### PR TITLE
Experimental SlotContext for managing slot fill interactions

### DIFF
--- a/packages/js/components/changelog/try-product-mvp-slotfill-experiments
+++ b/packages/js/components/changelog/try-product-mvp-slotfill-experiments
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Adding experimental component SlotContext

--- a/packages/js/components/src/index.ts
+++ b/packages/js/components/src/index.ts
@@ -92,3 +92,9 @@ export {
 	ProductFieldSection as __experimentalProductFieldSection,
 } from './product-section-layout';
 export * from './product-fields';
+export {
+	SlotContextProvider,
+	useSlotContext,
+	SlotContextType,
+	SlotContextHelpersType,
+} from './slot-context';

--- a/packages/js/components/src/slot-context/index.ts
+++ b/packages/js/components/src/slot-context/index.ts
@@ -1,0 +1,1 @@
+export * from './slot-context';

--- a/packages/js/components/src/slot-context/slot-context.tsx
+++ b/packages/js/components/src/slot-context/slot-context.tsx
@@ -1,0 +1,104 @@
+/**
+ * External dependencies
+ */
+import {
+	createElement,
+	createContext,
+	useContext,
+	useCallback,
+	useReducer,
+} from '@wordpress/element';
+
+type FillConfigType = {
+	visible: boolean;
+};
+
+type FillType = Record< string, FillConfigType >;
+
+type FillCollection = readonly ( readonly JSX.Element[] )[];
+
+export type SlotContextHelpersType = {
+	hideFill: ( id: string ) => void;
+	showFill: ( id: string ) => void;
+	getFills: () => FillType;
+};
+
+export type SlotContextType = {
+	fills: FillType;
+	getFillHelpers: () => SlotContextHelpersType;
+	registerFill: ( id: string ) => void;
+	filterRegisteredFills: ( fillsArrays: FillCollection ) => FillCollection;
+};
+
+const SlotContext = createContext< SlotContextType | undefined >( undefined );
+
+export const SlotContextProvider: React.FC = ( { children } ) => {
+	const [ fills, updateFills ] = useReducer(
+		( data: FillType, updates: FillType ) => ( { ...data, ...updates } ),
+		{}
+	);
+
+	const updateFillConfig = (
+		id: string,
+		update: Partial< FillConfigType >
+	) => {
+		if ( ! fills[ id ] ) {
+			throw new Error( `No fill found with ID: ${ id }` );
+		}
+		updateFills( { [ id ]: { ...fills[ id ], ...update } } );
+	};
+
+	const registerFill = useCallback(
+		( id: string ) => {
+			if ( fills[ id ] ) {
+				return;
+			}
+			updateFills( { [ id ]: { visible: true } } );
+		},
+		[ fills ]
+	);
+
+	const hideFill = useCallback(
+		( id: string ) => updateFillConfig( id, { visible: false } ),
+		[ fills ]
+	);
+
+	const showFill = useCallback(
+		( id: string ) => updateFillConfig( id, { visible: true } ),
+		[ fills ]
+	);
+
+	const getFills = useCallback( () => ( { ...fills } ), [ fills ] );
+
+	return (
+		<SlotContext.Provider
+			value={ {
+				registerFill,
+				getFillHelpers() {
+					return { hideFill, showFill, getFills };
+				},
+				filterRegisteredFills( fillsArrays: FillCollection ) {
+					return fillsArrays.filter(
+						( arr ) =>
+							fills[ arr[ 0 ].props._id ]?.visible !== false
+					);
+				},
+				fills,
+			} }
+		>
+			{ children }
+		</SlotContext.Provider>
+	);
+};
+
+export const useSlotContext = () => {
+	const slotContext = useContext( SlotContext );
+
+	if ( slotContext === undefined ) {
+		throw new Error(
+			'useSlotContext must be used within a SlotContextProvider'
+		);
+	}
+
+	return slotContext;
+};

--- a/packages/js/components/src/utils.tsx
+++ b/packages/js/components/src/utils.tsx
@@ -22,7 +22,7 @@ function createOrderedChildren< T = Fill.Props, S = Record< string, unknown > >(
 	if ( typeof children === 'function' ) {
 		return cloneElement( children( props ), { order, ...injectProps } );
 	} else if ( isValidElement( children ) ) {
-		return cloneElement( children, { ...props, order } );
+		return cloneElement( children, { ...props, order, ...injectProps } );
 	}
 	throw Error( 'Invalid children type' );
 }

--- a/packages/js/components/src/utils.tsx
+++ b/packages/js/components/src/utils.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { isValidElement, Fragment } from 'react';
+import { isValidElement, Fragment } from 'react';
 import { Slot, Fill } from '@wordpress/components';
 import { cloneElement, createElement } from '@wordpress/element';
 
@@ -13,13 +13,14 @@ import { cloneElement, createElement } from '@wordpress/element';
  * @param {Array}  props    - Fill props.
  * @return {Node} Node.
  */
-function createOrderedChildren< T = Fill.Props >(
+function createOrderedChildren< T = Fill.Props, S = Record< string, unknown > >(
 	children: React.ReactNode,
 	order: number,
-	props: T
+	props: T,
+	injectProps?: S
 ) {
 	if ( typeof children === 'function' ) {
-		return cloneElement( children( props ), { order } );
+		return cloneElement( children( props ), { order, ...injectProps } );
 	} else if ( isValidElement( children ) ) {
 		return cloneElement( children, { ...props, order } );
 	}

--- a/packages/js/components/src/woo-product-field-item/woo-product-field-item.tsx
+++ b/packages/js/components/src/woo-product-field-item/woo-product-field-item.tsx
@@ -9,6 +9,7 @@ import { createElement, Children } from '@wordpress/element';
  * Internal dependencies
  */
 import { createOrderedChildren, sortFillsByOrder } from '../utils';
+import { useSlotContext, SlotContextHelpersType } from '../slot-context';
 
 type WooProductFieldItemProps = {
 	id: string;
@@ -23,36 +24,55 @@ type WooProductFieldSlotProps = {
 
 export const WooProductFieldItem: React.FC< WooProductFieldItemProps > & {
 	Slot: React.FC< Slot.Props & WooProductFieldSlotProps >;
-} = ( { children, order = 20, section } ) => (
-	<Fill name={ `woocommerce_product_field_${ section }` }>
-		{ ( fillProps: Fill.Props ) => {
-			return createOrderedChildren< Fill.Props >(
-				children,
-				order,
-				fillProps
-			);
-		} }
-	</Fill>
-);
+} = ( { children, order = 20, section, id } ) => {
+	const { registerFill, getFillHelpers } = useSlotContext();
 
-WooProductFieldItem.Slot = ( { fillProps, section } ) => (
-	<Slot
-		name={ `woocommerce_product_field_${ section }` }
-		fillProps={ fillProps }
-	>
-		{ ( fills ) => {
-			if ( ! sortFillsByOrder ) {
-				return null;
-			}
+	registerFill( id );
 
-			return Children.map(
-				sortFillsByOrder( fills )?.props.children,
-				( child ) => (
-					<div className="woocommerce-product-form__field">
-						{ child }
-					</div>
-				)
-			);
-		} }
-	</Slot>
-);
+	return (
+		<Fill name={ `woocommerce_product_field_${ section }` }>
+			{ ( fillProps: Fill.Props ) => {
+				return createOrderedChildren<
+					Fill.Props & SlotContextHelpersType,
+					{ _id: string }
+				>(
+					children,
+					order,
+					{
+						...fillProps,
+						...getFillHelpers(),
+					},
+					{ _id: id }
+				);
+			} }
+		</Fill>
+	);
+};
+
+WooProductFieldItem.Slot = ( { fillProps, section } ) => {
+	// eslint-disable-next-line react-hooks/rules-of-hooks
+	const { filterRegisteredFills } = useSlotContext();
+
+	return (
+		<Slot
+			name={ `woocommerce_product_field_${ section }` }
+			fillProps={ fillProps }
+		>
+			{ ( fills ) => {
+				if ( ! sortFillsByOrder ) {
+					return null;
+				}
+
+				return Children.map(
+					sortFillsByOrder( filterRegisteredFills( fills ) )?.props
+						.children,
+					( child ) => (
+						<div className="woocommerce-product-form__field">
+							{ child }
+						</div>
+					)
+				);
+			} }
+		</Slot>
+	);
+};

--- a/plugins/woocommerce-admin/client/products/fills/details-section/details-section-fills.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/details-section/details-section-fills.tsx
@@ -84,7 +84,5 @@ const DetailsSection = () => (
 registerPlugin( 'wc-admin-product-editor-details-section', {
 	// @ts-expect-error 'scope' does exist. @types/wordpress__plugins is outdated.
 	scope: 'woocommerce-product-editor',
-	render: () => {
-		return <DetailsSection />;
-	},
+	render: () => <DetailsSection />,
 } );

--- a/plugins/woocommerce-admin/client/products/product-form.tsx
+++ b/plugins/woocommerce-admin/client/products/product-form.tsx
@@ -5,6 +5,7 @@ import {
 	Form,
 	FormRef,
 	__experimentalWooProductSectionItem as WooProductSectionItem,
+	SlotContextProvider,
 } from '@woocommerce/components';
 import { PartialProduct, Product } from '@woocommerce/data';
 import { Ref } from 'react';
@@ -33,60 +34,64 @@ export const ProductForm: React.FC< {
 	formRef?: Ref< FormRef< Partial< Product > > >;
 } > = ( { product, formRef } ) => {
 	return (
-		<Form< Partial< Product > >
-			initialValues={
-				product || {
-					reviews_allowed: true,
-					name: '',
-					sku: '',
-					stock_quantity: 0,
-					stock_status: 'instock',
+		<SlotContextProvider>
+			<Form< Partial< Product > >
+				initialValues={
+					product || {
+						reviews_allowed: true,
+						name: '',
+						sku: '',
+						stock_quantity: 0,
+						stock_status: 'instock',
+					}
 				}
-			}
-			ref={ formRef }
-			errors={ {} }
-			validate={ validate }
-		>
-			<ProductFormHeader />
-			<ProductFormLayout>
-				<ProductFormTab name="general" title="General">
-					<WooProductSectionItem.Slot location="tab/general" />
-					<ImagesSection />
-					<AttributesSection />
-				</ProductFormTab>
-				<ProductFormTab
-					name="pricing"
-					title="Pricing"
-					disabled={ !! product?.variations?.length }
-				>
-					<PricingSection />
-				</ProductFormTab>
-				<ProductFormTab
-					name="inventory"
-					title="Inventory"
-					disabled={ !! product?.variations?.length }
-				>
-					<ProductInventorySection />
-				</ProductFormTab>
-				<ProductFormTab
-					name="shipping"
-					title="Shipping"
-					disabled={ !! product?.variations?.length }
-				>
-					<ProductShippingSection product={ product } />
-				</ProductFormTab>
-				{ window.wcAdminFeatures[ 'product-variation-management' ] ? (
-					<ProductFormTab name="options" title="Options">
-						<OptionsSection />
-						<ProductVariationsSection />
+				ref={ formRef }
+				errors={ {} }
+				validate={ validate }
+			>
+				<ProductFormHeader />
+				<ProductFormLayout>
+					<ProductFormTab name="general" title="General">
+						<WooProductSectionItem.Slot location="tab/general" />
+						<ImagesSection />
+						<AttributesSection />
 					</ProductFormTab>
-				) : (
-					<></>
-				) }
-			</ProductFormLayout>
-			<ProductFormFooter />
-			{ /* @ts-expect-error 'scope' does exist. @types/wordpress__plugins is outdated. */ }
-			<PluginArea scope="woocommerce-product-editor" />
-		</Form>
+					<ProductFormTab
+						name="pricing"
+						title="Pricing"
+						disabled={ !! product?.variations?.length }
+					>
+						<PricingSection />
+					</ProductFormTab>
+					<ProductFormTab
+						name="inventory"
+						title="Inventory"
+						disabled={ !! product?.variations?.length }
+					>
+						<ProductInventorySection />
+					</ProductFormTab>
+					<ProductFormTab
+						name="shipping"
+						title="Shipping"
+						disabled={ !! product?.variations?.length }
+					>
+						<ProductShippingSection product={ product } />
+					</ProductFormTab>
+					{ window.wcAdminFeatures[
+						'product-variation-management'
+					] ? (
+						<ProductFormTab name="options" title="Options">
+							<OptionsSection />
+							<ProductVariationsSection />
+						</ProductFormTab>
+					) : (
+						<></>
+					) }
+				</ProductFormLayout>
+				<ProductFormFooter />
+				{ /* @ts-expect-error 'scope' does exist. @types/wordpress__plugins is outdated. */ }
+				<PluginArea scope="woocommerce-product-editor" />
+			</Form>
+		</SlotContextProvider>
 	);
 };

--- a/plugins/woocommerce/changelog/try-product-mvp-slotfill-experiments
+++ b/plugins/woocommerce/changelog/try-product-mvp-slotfill-experiments
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Trying experimental slot context with product editor fills.


### PR DESCRIPTION
This is an experimental PoC regarding using a context to allow fills to interact with each other in a simple fashion. This is meant to make it easy for 3PD to perform requested interactions such as hiding other fields/etc. 

This currently allows to hide or show another fill within the same `<SlotContext />` using helpers functions passed as fill props.

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Checkout branch
2. Enable new product MVP feature flag
3. Navigate to the new product editor.
4. Notice the duplicate `Name` field at the bottom of the details section. There are actually 2 fills, including the "other" field fill, but it's currently hidden.
5. Go to the `details-name-field.tsx` file and comment out the `hideField()` line. 
6. The other field will show up on refresh.

![image](https://user-images.githubusercontent.com/444632/211429124-4ed21500-7de7-4e56-94c5-99e57b66647f.png)

