### PR TITLE
When product is sold individually, hide quantity selector

### DIFF
--- a/plugins/woocommerce/changelog/fix-36007-sold-individually
+++ b/plugins/woocommerce/changelog/fix-36007-sold-individually
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+By default, hide the quantity selector within the single product page if a product is sold individually.

--- a/plugins/woocommerce/client/legacy/css/_common.scss
+++ b/plugins/woocommerce/client/legacy/css/_common.scss
@@ -1,0 +1,8 @@
+/**
+ * Contains rules common to all supported frontend themes.
+ */
+
+/* We do not wish to display the quantity selector (within single product pages) if the product is sold individually. */
+.woocommerce.single-product .product.sold-individually input[name="quantity"] {
+	display: none;
+}

--- a/plugins/woocommerce/client/legacy/css/twenty-nineteen.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-nineteen.scss
@@ -1,3 +1,4 @@
+@import "common";
 @import 'mixins';
 
 /**

--- a/plugins/woocommerce/client/legacy/css/twenty-seventeen.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-seventeen.scss
@@ -1,6 +1,7 @@
 /**
  * Twenty Seventeen integration styles
  */
+@import "common";
 @import "mixins";
 @import "animation";
 

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-one.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-one.scss
@@ -1,3 +1,4 @@
+@import "common";
 @import "mixins";
 
 /**

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -25,6 +25,7 @@
 	font-style: normal;
 }
 
+@import "common";
 @import "mixins";
 @import "animation";
 
@@ -1130,7 +1131,7 @@
 		 list-style: none;
 		 font-size: var( --wp--preset--font-size--small );
 		 display: flow-root;
-	 
+
 		 &[role='alert']::before {
 			 background: #d5d5d5;
 			 color: black;
@@ -1140,10 +1141,10 @@
 			 padding-right: 3px;
 			 margin-right: 1rem;
 		 }
-	 
+
 		 a {
 			 color: var( --wp--preset--color--contrast );
-	 
+
 			 .button {
 				 margin-top: -0.5rem;
 				 border: none;
@@ -1151,24 +1152,24 @@
 			 }
 		 }
 	 }
-	 
+
 	 .woocommerce-error[role='alert'] {
 		 margin: 0;
-	 
+
 		 &::before {
 			 content: 'X';
 			 padding-right: 4px;
 			 padding-left: 4px;
 		 }
-	 
+
 		 li {
 			 display: inline-block;
 		 }
 	 }
-	 
+
 	 .woocommerce-message {
 		 &[role='alert']::before {
 			 content: '\2713';
 		 }
 	 }
-	 
+

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
@@ -25,6 +25,7 @@
 	font-style: normal;
 }
 
+@import "common";
 @import "mixins";
 @import "animation";
 @import "variables";

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty.scss
@@ -1,3 +1,4 @@
+@import "common";
 @import "mixins";
 
 /**

--- a/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
@@ -2,6 +2,7 @@
 * woocommerce-blocktheme.scss
 * Block theme default styles to ensure WooCommerce looks better out of the box with block themes that are not optimised for WooCommerce specifically.
 */
+@import "common";
 @import "fonts";
 @import "variables";
 

--- a/plugins/woocommerce/client/legacy/css/woocommerce.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce.scss
@@ -2333,4 +2333,3 @@ body:not(.search-results) .twentysixteen .entry-summary {
 	background: inherit;
 	color: inherit;
 }
-                  

--- a/plugins/woocommerce/client/legacy/css/woocommerce.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce.scss
@@ -7,6 +7,7 @@
 /**
  * Imports
  */
+@import "common";
 @import "mixins";
 @import "variables";
 @import "animation";
@@ -2332,3 +2333,4 @@ body:not(.search-results) .twentysixteen .entry-summary {
 	background: inherit;
 	color: inherit;
 }
+                  


### PR DESCRIPTION
Within the context of single product pages, and when a product is configured to be sold individually, let's hide the quantity selector. This partly restores the way the quantity selector worked within this page prior to the 7.2.0 release.

<img width="887" alt="no-qty-selector" src="https://user-images.githubusercontent.com/3594411/211402528-6e3286c1-1a06-4023-80cd-605ff0c773fb.png">

Closes #36007.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

You may wish to test this change alongside any of the default Twenty X themes (or indeed with a generic non-default theme, so long as it does not override and replace our stylesheets). Note that the change cannot currently be seen using Storefront, because that theme replaces our default styles (ie, we need to make a separate change within that product).

:bulb: After checking out this branch, rebuild the relevant stylesheets using `pnpm run --filter='woocommerce/client/legacy' build`. You may also need to clear your browser cache to see the change.

1. Configure a product such that it is sold individually.
2. Visit the single product page, confirm you do not see the quantity selector.
3. Configure it so it is **not** sold individually.
4. Visit the single product page, confirm you can now see the quantity selector.

This change should have no impact outside of single product pages.

<!-- End testing instructions -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
