### PR TITLE
Initial product form field store

### DIFF
--- a/packages/js/components/changelog/add-36074_product_form_field_registry
+++ b/packages/js/components/changelog/add-36074_product_form_field_registry
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add product field store and helper functions for rendering fields from config.

--- a/packages/js/components/src/product-fields/README.md
+++ b/packages/js/components/src/product-fields/README.md
@@ -1,0 +1,45 @@
+# Product Fields
+
+Product Fields are used within the WooCommerce Admin product editor, for rendering new fields using PHP.
+
+## Example
+
+```js
+// block.js
+( function ( element ) {
+	var el = element.createElement;
+
+	registerProductField( 'number', {
+		name: 'number',
+		edit: () => {
+			return <InputControl type="number" />;
+		},
+	} );
+} )( window.wp.element );
+```
+
+## API
+
+### registerProductField
+
+Registers a new product field provided a unique name and an object defining its
+behavior.
+
+_Usage_
+
+```js
+import { __ } from '@wordpress/i18n';
+import { registerProductField } from '@woocommerce/components';
+
+registerProductField( 'number', {
+	name: 'number',
+	edit: () => {
+		return <InputControl type="number" />;
+	},
+} );
+```
+
+_Parameters_
+
+-   _fieldName_ `string`: Field name.
+-   _settings_ `Object`: Field settings.

--- a/packages/js/components/src/product-fields/README.md
+++ b/packages/js/components/src/product-fields/README.md
@@ -5,13 +5,13 @@ Product Fields are used within the WooCommerce Admin product editor, for renderi
 ## Example
 
 ```js
-// block.js
+// product-field.js
 ( function ( element ) {
-	var el = element.createElement;
+	const el = element.createElement;
 
 	registerProductField( 'number', {
 		name: 'number',
-		edit: () => {
+		render: () => {
 			return <InputControl type="number" />;
 		},
 	} );
@@ -33,7 +33,7 @@ import { registerProductField } from '@woocommerce/components';
 
 registerProductField( 'number', {
 	name: 'number',
-	edit: () => {
+	render: () => {
 		return <InputControl type="number" />;
 	},
 } );
@@ -43,3 +43,4 @@ _Parameters_
 
 -   _fieldName_ `string`: Field name.
 -   _settings_ `Object`: Field settings.
+    -   _render_ `ComponentType`: React functional component to be rendered.

--- a/packages/js/components/src/product-fields/api/index.ts
+++ b/packages/js/components/src/product-fields/api/index.ts
@@ -1,0 +1,2 @@
+export * from './registration';
+export * from './render';

--- a/packages/js/components/src/product-fields/api/registration.ts
+++ b/packages/js/components/src/product-fields/api/registration.ts
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import { select, dispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { store as productFieldStore } from '../store';
+import { ProductFieldDefinition } from '../store/types';
+
+/**
+ * Registers a new product field provided a unique name and an object defining its
+ * behavior. Once registered, the field is made available to use with the product form API.
+ *
+ * @param {string|Object} fieldName Field name.
+ * @param {Object}        settings  Field settings.
+ *
+ * @example
+ * ```js
+ * import { registerProductField } from '@woocommerce/components'
+ *
+ * registerProductFieldType( 'attributes-field', {
+ * } );
+ * ```
+ */
+export function registerProductField(
+	fieldName: string,
+	settings: ProductFieldDefinition
+) {
+	const name = fieldName;
+
+	if ( select( productFieldStore ).getProductField( name ) ) {
+		// eslint-disable-next-line no-console
+		console.error( 'Product Field "' + name + '" is already registered.' );
+		return;
+	}
+
+	const blockType = {
+		attributes: {},
+		...settings,
+	};
+
+	dispatch( productFieldStore ).registerProductField( blockType );
+
+	return select( productFieldStore ).getProductField( name );
+}

--- a/packages/js/components/src/product-fields/api/registration.ts
+++ b/packages/js/components/src/product-fields/api/registration.ts
@@ -28,20 +28,18 @@ export function registerProductField(
 	fieldName: string,
 	settings: ProductFieldDefinition
 ) {
-	const name = fieldName;
-
-	if ( select( productFieldStore ).getProductField( name ) ) {
+	if ( select( productFieldStore ).getProductField( fieldName ) ) {
 		// eslint-disable-next-line no-console
-		console.error( 'Product Field "' + name + '" is already registered.' );
+		console.error(
+			'Product Field "' + fieldName + '" is already registered.'
+		);
 		return;
 	}
 
-	const blockType = {
+	dispatch( productFieldStore ).registerProductField( {
 		attributes: {},
 		...settings,
-	};
+	} );
 
-	dispatch( productFieldStore ).registerProductField( blockType );
-
-	return select( productFieldStore ).getProductField( name );
+	return select( productFieldStore ).getProductField( fieldName );
 }

--- a/packages/js/components/src/product-fields/api/render.tsx
+++ b/packages/js/components/src/product-fields/api/render.tsx
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { select } from '@wordpress/data';
+import { createElement } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { store as productFieldStore } from '../store';
+import { ProductFieldDefinition } from '../store/types';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function renderField( name: string, props: Record< string, any > ) {
+	const fieldConfig: ProductFieldDefinition =
+		select( productFieldStore ).getProductField( name );
+
+	if ( fieldConfig.edit ) {
+		return <fieldConfig.edit { ...props } />;
+	}
+	if ( fieldConfig.type ) {
+		return createElement( 'input', {
+			type: fieldConfig.type,
+			...props,
+		} );
+	}
+	return null;
+}

--- a/packages/js/components/src/product-fields/api/render.tsx
+++ b/packages/js/components/src/product-fields/api/render.tsx
@@ -15,8 +15,8 @@ export function renderField( name: string, props: Record< string, any > ) {
 	const fieldConfig: ProductFieldDefinition =
 		select( productFieldStore ).getProductField( name );
 
-	if ( fieldConfig.edit ) {
-		return <fieldConfig.edit { ...props } />;
+	if ( fieldConfig.render ) {
+		return <fieldConfig.render { ...props } />;
 	}
 	if ( fieldConfig.type ) {
 		return createElement( 'input', {

--- a/packages/js/components/src/product-fields/index.ts
+++ b/packages/js/components/src/product-fields/index.ts
@@ -1,0 +1,2 @@
+export { store } from './store';
+export * from './api';

--- a/packages/js/components/src/product-fields/store/action-types.ts
+++ b/packages/js/components/src/product-fields/store/action-types.ts
@@ -1,0 +1,5 @@
+export enum TYPES {
+	REGISTER_FIELD = 'REGISTER_FIELD',
+}
+
+export default TYPES;

--- a/packages/js/components/src/product-fields/store/actions.ts
+++ b/packages/js/components/src/product-fields/store/actions.ts
@@ -1,0 +1,14 @@
+/**
+ * Internal dependencies
+ */
+import TYPES from './action-types';
+import { ProductFieldDefinition } from './types';
+
+export function registerProductField( field: ProductFieldDefinition ) {
+	return {
+		type: TYPES.REGISTER_FIELD as const,
+		field,
+	};
+}
+
+export type Actions = ReturnType< typeof registerProductField >;

--- a/packages/js/components/src/product-fields/store/constants.ts
+++ b/packages/js/components/src/product-fields/store/constants.ts
@@ -1,0 +1,1 @@
+export const STORE_NAME = 'wc/admin/product/fields';

--- a/packages/js/components/src/product-fields/store/index.ts
+++ b/packages/js/components/src/product-fields/store/index.ts
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { createReduxStore, register } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import reducer from './reducer';
+import * as selectors from './selectors';
+import * as actions from './actions';
+import { STORE_NAME } from './constants';
+
+export const store = createReduxStore( STORE_NAME, {
+	// @ts-expect-error reducer has correct format.
+	reducer,
+	selectors,
+	actions,
+} );
+
+register( store );

--- a/packages/js/components/src/product-fields/store/reducer.ts
+++ b/packages/js/components/src/product-fields/store/reducer.ts
@@ -1,0 +1,32 @@
+/**
+ * Internal dependencies
+ */
+import TYPES from './action-types';
+import { Actions } from './actions';
+import { ProductFieldState } from './types';
+
+const reducer = (
+	state: ProductFieldState = {
+		fields: {},
+	},
+	payload: Actions
+) => {
+	if ( payload && 'type' in payload ) {
+		switch ( payload.type ) {
+			case TYPES.REGISTER_FIELD:
+				return {
+					...state,
+					fields: {
+						...state.fields,
+						[ payload.field.name ]: payload.field,
+					},
+				};
+			default:
+				return state;
+		}
+	}
+	return state;
+};
+
+export type State = ReturnType< typeof reducer >;
+export default reducer;

--- a/packages/js/components/src/product-fields/store/selectors.ts
+++ b/packages/js/components/src/product-fields/store/selectors.ts
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import createSelector from 'rememo';
+
+/**
+ * Internal dependencies
+ */
+import { ProductFieldState } from './types';
+
+export function getProductField( state: ProductFieldState, name: string ) {
+	return state.fields[ name ] || null;
+}
+
+export const getRegisteredProductFields = createSelector(
+	( state: ProductFieldState ) => Object.keys( state.fields ),
+	( state ) => [ state.fields ]
+);

--- a/packages/js/components/src/product-fields/store/selectors.ts
+++ b/packages/js/components/src/product-fields/store/selectors.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import createSelector from 'rememo';
+import memoize from 'memoize-one';
 
 /**
  * Internal dependencies
@@ -12,7 +12,9 @@ export function getProductField( state: ProductFieldState, name: string ) {
 	return state.fields[ name ] || null;
 }
 
-export const getRegisteredProductFields = createSelector(
+export const getRegisteredProductFields = memoize(
 	( state: ProductFieldState ) => Object.keys( state.fields ),
-	( state ) => [ state.fields ]
+	( [ newState ], [ oldState ] ) => {
+		return newState.fields === oldState.fields;
+	}
 );

--- a/packages/js/components/src/product-fields/store/types.ts
+++ b/packages/js/components/src/product-fields/store/types.ts
@@ -1,8 +1,13 @@
+/**
+ * External dependencies
+ */
+import { ComponentType } from 'react';
+
 export type ProductFieldDefinition = {
 	name: string;
 	type?: string;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	edit?: ( props: Record< string, any > ) => JSX.Element;
+	render?: ComponentType;
 };
 
 export type ProductFieldState = {

--- a/packages/js/components/src/product-fields/store/types.ts
+++ b/packages/js/components/src/product-fields/store/types.ts
@@ -1,0 +1,10 @@
+export type ProductFieldDefinition = {
+	name: string;
+	type?: string;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	edit?: ( props: Record< string, any > ) => JSX.Element;
+};
+
+export type ProductFieldState = {
+	fields: Record< string, ProductFieldDefinition >;
+};

--- a/packages/js/components/src/product-fields/stories/index.tsx
+++ b/packages/js/components/src/product-fields/stories/index.tsx
@@ -22,22 +22,24 @@ registry.register( store );
 
 registerProductField( 'text', {
 	name: 'text',
-	edit: ( props ) => {
+	render: ( props ) => {
 		return <InputControl type="text" { ...props } />;
 	},
 } );
 
 registerProductField( 'number', {
 	name: 'number',
-	edit: () => {
+	render: () => {
 		return <InputControl type="number" />;
 	},
 } );
 
 const RenderField = () => {
-	const [ selectedField, setSelectedField ] = useState();
-
 	const fields: string[] = select( store ).getRegisteredProductFields();
+	const [ selectedField, setSelectedField ] = useState(
+		fields ? fields[ 0 ] : undefined
+	);
+
 	const handleChange = ( event ) => {
 		setSelectedField( event.target.value );
 	};
@@ -50,7 +52,7 @@ const RenderField = () => {
 					</option>
 				) ) }
 			</select>
-			{ renderField( selectedField || fields[ 0 ], { name: 'test' } ) }
+			{ selectedField && renderField( selectedField, { name: 'test' } ) }
 		</div>
 	);
 };

--- a/packages/js/components/src/product-fields/stories/index.tsx
+++ b/packages/js/components/src/product-fields/stories/index.tsx
@@ -1,0 +1,69 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useState, createElement } from '@wordpress/element';
+import { createRegistry, RegistryProvider, select } from '@wordpress/data';
+import {
+	// @ts-expect-error `__experimentalInputControl` does exist.
+	__experimentalInputControl as InputControl,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { store } from '../store';
+import { registerProductField, renderField } from '../api';
+
+const registry = createRegistry();
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore No types for this exist yet.
+registry.register( store );
+
+registerProductField( 'text', {
+	name: 'text',
+	edit: ( props ) => {
+		return <InputControl type="text" { ...props } />;
+	},
+} );
+
+registerProductField( 'number', {
+	name: 'number',
+	edit: () => {
+		return <InputControl type="number" />;
+	},
+} );
+
+const RenderField = () => {
+	const [ selectedField, setSelectedField ] = useState();
+
+	const fields: string[] = select( store ).getRegisteredProductFields();
+	const handleChange = ( event ) => {
+		setSelectedField( event.target.value );
+	};
+	return (
+		<div>
+			<select value={ selectedField } onChange={ handleChange }>
+				{ fields.map( ( field ) => (
+					<option key={ field } value={ field }>
+						{ field }
+					</option>
+				) ) }
+			</select>
+			{ renderField( selectedField || fields[ 0 ], { name: 'test' } ) }
+		</div>
+	);
+};
+
+export const Basic: React.FC = () => {
+	return (
+		<RegistryProvider value={ registry }>
+			<RenderField />
+		</RegistryProvider>
+	);
+};
+
+export default {
+	title: 'WooCommerce Admin/experimental/product-fields',
+	component: Basic,
+};


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This is a very barebones version of the initial field store/registry, that will allow us to register fields that will be available through the ProductForm fields API, this will also allow plugins to render their own fields to make use off.
I mimicked some of the design implementation from [registering new Gutenberg Blocks](https://github.com/WordPress/gutenberg/blob/trunk/packages/blocks/README.md), that way this stays somewhat consistent.
Again the above is very barebones for now and will likely be expanded on quite a bit as new requirements are needed.

Partially addresses #36074  .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Run storybook - `pnpm --filter=storybook storybook`
2. Go to the `product-fields` example -> `WooCommerce Admin/experimental/product-fields`
3. Change between the two fields that are registered and make sure they are updated correctly (again pretty simple)
4. Feel free to edit the storybook as well and add some more visually different fields.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
