### PR TITLE
Add context to the credit card names used for translators.

### DIFF
--- a/plugins/woocommerce/changelog/add-credit-card-i18n-context
+++ b/plugins/woocommerce/changelog/add-credit-card-i18n-context
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Add context to translatable strings for credit card labels.

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1560,12 +1560,12 @@ function wc_get_credit_card_type_label( $type ) {
 	$labels = apply_filters(
 		'woocommerce_credit_card_type_labels',
 		array(
-			'mastercard'       => __( 'MasterCard', 'woocommerce' ),
-			'visa'             => __( 'Visa', 'woocommerce' ),
-			'discover'         => __( 'Discover', 'woocommerce' ),
-			'american express' => __( 'American Express', 'woocommerce' ),
-			'diners'           => __( 'Diners', 'woocommerce' ),
-			'jcb'              => __( 'JCB', 'woocommerce' ),
+			'mastercard'       => _x( 'MasterCard', 'Name of credit card', 'woocommerce' ),
+			'visa'             => _x( 'Visa', 'Name of credit card', 'woocommerce' ),
+			'discover'         => _x( 'Discover', 'Name of credit card', 'woocommerce' ),
+			'american express' => _x( 'American Express', 'Name of credit card', 'woocommerce' ),
+			'diners'           => _x( 'Diners', 'Name of credit card', 'woocommerce' ),
+			'jcb'              => _x( 'JCB', 'Name of credit card', 'woocommerce' ),
 		)
 	);
 


### PR DESCRIPTION
Some of the card brand names aren't extremely clear that they're a brand and not representing another concept, e.g. Visa, Discover.  Providing context would simplify translation.

Related # 533-gh-Automattic/i18n-issues

### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adding `Name of credit card` as context to Credit Card labels.


- [x] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
