### PR TITLE
Add advanced setting option

### DIFF
--- a/plugins/woocommerce/changelog/add-36163_advanced_setting_option
+++ b/plugins/woocommerce/changelog/add-36163_advanced_setting_option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add advanced setting option

--- a/plugins/woocommerce/client/admin/config/core.json
+++ b/plugins/woocommerce/client/admin/config/core.json
@@ -14,7 +14,7 @@
 		"minified-js": false,
 		"mobile-app-banner": true,
 		"navigation": true,
-		"new-product-management-experience": false,
+		"new-product-management-experience": true,
 		"onboarding": true,
 		"onboarding-tasks": true,
 		"product-variation-management": false,

--- a/plugins/woocommerce/client/admin/config/development.json
+++ b/plugins/woocommerce/client/admin/config/development.json
@@ -14,7 +14,7 @@
 		"minified-js": true,
 		"mobile-app-banner": true,
 		"navigation": true,
-		"new-product-management-experience": false,
+		"new-product-management-experience": true,
 		"onboarding": true,
 		"onboarding-tasks": true,
 		"payment-gateway-suggestions": true,

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -4375,6 +4375,11 @@ img.help_tip {
 			top: 20px;
 		}
 
+		td.help-tooltip {
+			white-space: nowrap;
+			width: 8px;
+		}
+
 		.select2-container {
 			vertical-align: top;
 			margin-bottom: 3px;

--- a/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
@@ -489,11 +489,10 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						}
 
 						if ( ! isset( $value['checkboxgroup'] ) || 'start' === $value['checkboxgroup'] ) {
-							$maybe_add_wc_help_tip = isset( $value['tooltip'] ) && '' !== $value['tooltip'] ? wc_help_tip( $value['tooltip'] ) : '';
 							?>
 								<tr valign="top" class="<?php echo esc_attr( implode( ' ', $visibility_class ) ); ?>">
 									<th scope="row" class="titledesc"><?php echo esc_html( $value['title'] ); ?></th>
-									<td class="help-tooltip"><?php echo esc_html( $maybe_add_wc_help_tip ); ?></td>
+									<td class="help-tooltip"><?php echo isset( $value['tooltip'] ) && '' !== $value['tooltip'] ? wc_help_tip( esc_html( $value['tooltip'] ) ) : ''; ?></td>
 									<td class="forminp forminp-checkbox">
 										<fieldset>
 							<?php

--- a/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
@@ -489,9 +489,11 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						}
 
 						if ( ! isset( $value['checkboxgroup'] ) || 'start' === $value['checkboxgroup'] ) {
+							$maybe_add_wc_help_tip = isset( $value['tooltip'] ) && '' !== $value['tooltip'] ? wc_help_tip( esc_html( $value['tooltip'] ) ) : '';
 							?>
 								<tr valign="top" class="<?php echo esc_attr( implode( ' ', $visibility_class ) ); ?>">
 									<th scope="row" class="titledesc"><?php echo esc_html( $value['title'] ); ?></th>
+									<td class="help-tooltip"><?php echo $maybe_add_wc_help_tip; ?></td>
 									<td class="forminp forminp-checkbox">
 										<fieldset>
 							<?php

--- a/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
@@ -489,11 +489,11 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						}
 
 						if ( ! isset( $value['checkboxgroup'] ) || 'start' === $value['checkboxgroup'] ) {
-							$maybe_add_wc_help_tip = isset( $value['tooltip'] ) && '' !== $value['tooltip'] ? wc_help_tip( esc_html( $value['tooltip'] ) ) : '';
+							$maybe_add_wc_help_tip = isset( $value['tooltip'] ) && '' !== $value['tooltip'] ? wc_help_tip( $value['tooltip'] ) : '';
 							?>
 								<tr valign="top" class="<?php echo esc_attr( implode( ' ', $visibility_class ) ); ?>">
 									<th scope="row" class="titledesc"><?php echo esc_html( $value['title'] ); ?></th>
-									<td class="help-tooltip"><?php echo $maybe_add_wc_help_tip; ?></td>
+									<td class="help-tooltip"><?php echo esc_html( $maybe_add_wc_help_tip ); ?></td>
 									<td class="forminp forminp-checkbox">
 										<fieldset>
 							<?php

--- a/plugins/woocommerce/src/Admin/Features/Features.php
+++ b/plugins/woocommerce/src/Admin/Features/Features.php
@@ -26,11 +26,12 @@ class Features {
 	 * @var array
 	 */
 	protected static $optional_features = array(
-		'multichannel-marketing'     => array( 'default' => 'no' ),
-		'navigation'                 => array( 'default' => 'no' ),
-		'settings'                   => array( 'default' => 'no' ),
-		'analytics'                  => array( 'default' => 'yes' ),
-		'remote-inbox-notifications' => array( 'default' => 'yes' ),
+		'multichannel-marketing'            => array( 'default' => 'no' ),
+		'navigation'                        => array( 'default' => 'no' ),
+		'settings'                          => array( 'default' => 'no' ),
+		'new-product-management-experience' => array( 'default' => 'no' ),
+		'analytics'                         => array( 'default' => 'yes' ),
+		'remote-inbox-notifications'         => array( 'default' => 'yes' ),
 	);
 
 	/**
@@ -41,6 +42,7 @@ class Features {
 	protected static $beta_features = array(
 		'multichannel-marketing',
 		'navigation',
+		'new-product-management-experience',
 		'settings',
 	);
 

--- a/plugins/woocommerce/src/Admin/Features/Features.php
+++ b/plugins/woocommerce/src/Admin/Features/Features.php
@@ -31,7 +31,7 @@ class Features {
 		'settings'                          => array( 'default' => 'no' ),
 		'new-product-management-experience' => array( 'default' => 'no' ),
 		'analytics'                         => array( 'default' => 'yes' ),
-		'remote-inbox-notifications'         => array( 'default' => 'yes' ),
+		'remote-inbox-notifications'        => array( 'default' => 'yes' ),
 	);
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/NewProductManagementExperience.php
+++ b/plugins/woocommerce/src/Admin/Features/NewProductManagementExperience.php
@@ -14,6 +14,11 @@ use \Automattic\WooCommerce\Internal\Admin\Loader;
 class NewProductManagementExperience {
 
 	/**
+	 * Option name used to toggle this feature.
+	 */
+	const TOGGLE_OPTION_NAME = 'woocommerce_new_product_management_enabled';
+
+	/**
 	 * Constructor
 	 */
 	public function __construct() {

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -90,13 +90,13 @@ class FeaturesController {
 	 */
 	public function __construct() {
 		$features = array(
-			'analytics'           => array(
+			'analytics'              => array(
 				'name'               => __( 'Analytics', 'woocommerce' ),
 				'description'        => __( 'Enables WooCommerce Analytics', 'woocommerce' ),
 				'is_experimental'    => false,
 				'enabled_by_default' => true,
 			),
-			'new_navigation'      => array(
+			'new_navigation'         => array(
 				'name'            => __( 'Navigation', 'woocommerce' ),
 				'description'     => __( 'Adds the new WooCommerce navigation experience to the dashboard', 'woocommerce' ),
 				'is_experimental' => false,
@@ -107,7 +107,7 @@ class FeaturesController {
 				'tooltip'         => __( 'Enable to try the new, simplified product editor (currently in development and only available for simple products). No extension support yet.', 'woocommerce' ),
 				'is_experimental' => false,
 			),
-			'custom_order_tables' => array(
+			'custom_order_tables'    => array(
 				'name'            => __( 'High-Performance order storage (COT)', 'woocommerce' ),
 				'description'     => __( 'Enable the high performance order storage feature.', 'woocommerce' ),
 				'is_experimental' => true,
@@ -601,7 +601,7 @@ class FeaturesController {
 		$description = $feature['description'];
 		$disabled    = false;
 		$desc_tip    = '';
-		$tooltip         = isset( $feature['tooltip'] ) ? $feature['tooltip'] : '';
+		$tooltip     = isset( $feature['tooltip'] ) ? $feature['tooltip'] : '';
 
 		if ( ( 'analytics' === $feature_id || 'new_navigation' === $feature_id ) && $admin_features_disabled ) {
 			$disabled = true;

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -114,7 +114,7 @@ class FeaturesController {
 			),
 		);
 
-		$this->legacy_feature_ids = array( 'analytics', 'new_navigation' );
+		$this->legacy_feature_ids = array( 'analytics', 'new_navigation', 'new_product_management' );
 
 		$this->init_features( $features );
 

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -8,6 +8,7 @@ namespace Automattic\WooCommerce\Internal\Features;
 use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Internal\Admin\Analytics;
 use Automattic\WooCommerce\Admin\Features\Navigation\Init;
+use Automattic\WooCommerce\Admin\Features\NewProductManagementExperience;
 use Automattic\WooCommerce\Internal\Traits\AccessiblePrivateMethods;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
 use Automattic\WooCommerce\Utilities\ArrayUtil;
@@ -98,6 +99,12 @@ class FeaturesController {
 			'new_navigation'      => array(
 				'name'            => __( 'Navigation', 'woocommerce' ),
 				'description'     => __( 'Adds the new WooCommerce navigation experience to the dashboard', 'woocommerce' ),
+				'is_experimental' => false,
+			),
+			'new_product_management' => array(
+				'name'            => __( 'New product editor', 'woocommerce' ),
+				'description'     => __( 'Try the new product editor (Beta)', 'woocommerce' ),
+				'tooltip'         => __( 'Enable to try the new, simplified product editor (currently in development and only available for simple products). No extension support yet.', 'woocommerce' ),
 				'is_experimental' => false,
 			),
 			'custom_order_tables' => array(
@@ -393,6 +400,8 @@ class FeaturesController {
 			return Analytics::TOGGLE_OPTION_NAME;
 		} elseif ( 'new_navigation' === $feature_id ) {
 			return Init::TOGGLE_OPTION_NAME;
+		} elseif ( 'new_product_management' === $feature_id ) {
+			return NewProductManagementExperience::TOGGLE_OPTION_NAME;
 		}
 
 		return "woocommerce_feature_${feature_id}_enabled";
@@ -450,7 +459,7 @@ class FeaturesController {
 		$matches = array();
 		$success = preg_match( '/^woocommerce_feature_([a-zA-Z0-9_]+)_enabled$/', $option, $matches );
 
-		if ( ! $success && Analytics::TOGGLE_OPTION_NAME !== $option && Init::TOGGLE_OPTION_NAME !== $option ) {
+		if ( ! $success && Analytics::TOGGLE_OPTION_NAME !== $option && Init::TOGGLE_OPTION_NAME !== $option && NewProductManagementExperience::TOGGLE_OPTION_NAME !== $option ) {
 			return;
 		}
 
@@ -462,6 +471,8 @@ class FeaturesController {
 			$feature_id = 'analytics';
 		} elseif ( Init::TOGGLE_OPTION_NAME === $option ) {
 			$feature_id = 'new_navigation';
+		} elseif ( NewProductManagementExperience::TOGGLE_OPTION_NAME === $option ) {
+			$feature_id = 'new_product_management';
 		} else {
 			$feature_id = $matches[1];
 		}
@@ -590,6 +601,7 @@ class FeaturesController {
 		$description = $feature['description'];
 		$disabled    = false;
 		$desc_tip    = '';
+		$tooltip         = isset( $feature['tooltip'] ) ? $feature['tooltip'] : '';
 
 		if ( ( 'analytics' === $feature_id || 'new_navigation' === $feature_id ) && $admin_features_disabled ) {
 			$disabled = true;
@@ -675,6 +687,7 @@ class FeaturesController {
 			'id'       => $this->feature_enable_option_name( $feature_id ),
 			'disabled' => $disabled && ! $this->force_allow_enabling_features,
 			'desc_tip' => $desc_tip,
+			'tooltip'  => $tooltip,
 			'default'  => $this->feature_is_enabled_by_default( $feature_id ) ? 'yes' : 'no',
 		);
 	}

--- a/plugins/woocommerce/tests/e2e-pw/tests/admin-analytics/analytics.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/admin-analytics/analytics.spec.js
@@ -23,7 +23,9 @@ test.describe( 'Analytics pages', () => {
 			await page.goto(
 				`/wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2F${ urlTitle }`
 			);
-			const pageTitle = page.locator( 'h1' );
+			const pageTitle = page.locator(
+				'.woocommerce-layout__header-wrapper > h1'
+			);
 			await expect( pageTitle ).toContainText( aPages );
 			await expect(
 				page.locator( '#woocommerce-layout__primary' )

--- a/plugins/woocommerce/tests/e2e-pw/tests/admin-tasks/payment.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/admin-tasks/payment.spec.js
@@ -1,85 +1,91 @@
-const { test, expect } = require('@playwright/test');
-const wcApi = require('@woocommerce/woocommerce-rest-api').default;
+const { test, expect } = require( '@playwright/test' );
+const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
-test.describe('Payment setup task', () => {
-	test.use({ storageState: process.env.ADMINSTATE });
+test.describe( 'Payment setup task', () => {
+	test.use( { storageState: process.env.ADMINSTATE } );
 
-	test.beforeEach(async ({ page }) => {
-		await page.goto('wp-admin/admin.php?page=wc-admin&path=/setup-wizard');
-		await page.click('text=Skip setup store details');
-		await page.click('text=No thanks');
-		await page.waitForLoadState('networkidle');
-	});
+	test.beforeEach( async ( { page } ) => {
+		await page.goto(
+			'wp-admin/admin.php?page=wc-admin&path=/setup-wizard'
+		);
+		await page.click( 'text=Skip setup store details' );
+		await page.click( 'text=No thanks' );
+		await page.waitForLoadState( 'networkidle' );
+	} );
 
-	test.afterAll(async ({ baseURL }) => {
-		const api = new wcApi({
+	test.afterAll( async ( { baseURL } ) => {
+		const api = new wcApi( {
 			url: baseURL,
 			consumerKey: process.env.CONSUMER_KEY,
 			consumerSecret: process.env.CONSUMER_SECRET,
 			version: 'wc/v3',
-		});
-		await api.put('payment_gateways/bacs', {
+		} );
+		await api.put( 'payment_gateways/bacs', {
 			enabled: false,
-		});
-		await api.put('payment_gateways/cod', {
+		} );
+		await api.put( 'payment_gateways/cod', {
 			enabled: false,
-		});
-	});
+		} );
+	} );
 
-	test('Can visit the payment setup task from the homescreen if the setup wizard has been skipped', async ({
+	test( 'Can visit the payment setup task from the homescreen if the setup wizard has been skipped', async ( {
 		page,
-	}) => {
-		await page.goto('wp-admin/admin.php?page=wc-admin');
-		await page.click('text=Set up payments');
-		await expect(page.locator('h1')).toHaveText('Set up payments');
-	});
+	} ) => {
+		await page.goto( 'wp-admin/admin.php?page=wc-admin' );
+		await page.click( 'text=Set up payments' );
+		await expect(
+			page.locator( '.woocommerce-layout__header-wrapper > h1' )
+		).toHaveText( 'Set up payments' );
+	} );
 
-	test('Saving valid bank account transfer details enables the payment method', async ({
+	test( 'Saving valid bank account transfer details enables the payment method', async ( {
 		page,
-	}) => {
+	} ) => {
 		// load the bank transfer page
 		await page.goto(
 			'wp-admin/admin.php?page=wc-admin&task=payments&id=bacs'
 		);
 		// purposely no await -- close the help dialog if/when it appears
-		page.locator('.components-button.is-small.has-icon')
+		page.locator( '.components-button.is-small.has-icon' )
 			.click()
-			.catch(() => {});
+			.catch( () => {} );
 
 		// fill in bank transfer form
-		await page.fill('//input[@placeholder="Account name"]', 'Savings');
-		await page.fill('//input[@placeholder="Account number"]', '1234');
-		await page.fill('//input[@placeholder="Bank name"]', 'Test Bank');
-		await page.fill('//input[@placeholder="Sort code"]', '12');
-		await page.fill('//input[@placeholder="IBAN"]', '12 3456 7890');
-		await page.fill('//input[@placeholder="BIC / Swift"]', 'ABBA');
-		await page.click('text=Save');
+		await page.fill( '//input[@placeholder="Account name"]', 'Savings' );
+		await page.fill( '//input[@placeholder="Account number"]', '1234' );
+		await page.fill( '//input[@placeholder="Bank name"]', 'Test Bank' );
+		await page.fill( '//input[@placeholder="Sort code"]', '12' );
+		await page.fill( '//input[@placeholder="IBAN"]', '12 3456 7890' );
+		await page.fill( '//input[@placeholder="BIC / Swift"]', 'ABBA' );
+		await page.click( 'text=Save' );
 
 		// check that bank transfers were set up
 		await expect(
-			page.locator('div.components-snackbar__content')
-		).toContainText('Direct bank transfer details added successfully');
+			page.locator( 'div.components-snackbar__content' )
+		).toContainText( 'Direct bank transfer details added successfully' );
 
-		await page.goto('wp-admin/admin.php?page=wc-settings&tab=checkout');
+		await page.goto( 'wp-admin/admin.php?page=wc-settings&tab=checkout' );
 
 		await expect(
-			page.locator('//tr[@data-gateway_id="bacs"]/td[@class="status"]/a')
-		).toHaveClass('wc-payment-gateway-method-toggle-enabled');
-	});
+			page.locator(
+				'//tr[@data-gateway_id="bacs"]/td[@class="status"]/a'
+			)
+		).toHaveClass( 'wc-payment-gateway-method-toggle-enabled' );
+	} );
 
-	test('Enabling cash on delivery enables the payment method', async ({
+	test( 'Enabling cash on delivery enables the payment method', async ( {
 		page,
 		baseURL,
-	}) => {
+	} ) => {
 		// Payments page differs if located outside of a WCPay-supported country, so make sure we aren't.
-		const api = new wcApi({
+		const api = new wcApi( {
 			url: baseURL,
 			consumerKey: process.env.CONSUMER_KEY,
 			consumerSecret: process.env.CONSUMER_SECRET,
 			version: 'wc/v3',
-		});
+		} );
 		// ensure store address is US
-		await api.post('settings/general/batch', {
+		await api.post( 'settings/general/batch', {
 			update: [
 				{
 					id: 'woocommerce_store_address',
@@ -98,28 +104,28 @@ test.describe('Payment setup task', () => {
 					value: '94107',
 				},
 			],
-		});
-		await page.goto('wp-admin/admin.php?page=wc-admin&task=payments');
+		} );
+		await page.goto( 'wp-admin/admin.php?page=wc-admin&task=payments' );
 
 		// purposely no await -- close the help dialog if/when it appears
-		page.locator('.components-button.is-small.has-icon')
+		page.locator( '.components-button.is-small.has-icon' )
 			.click()
-			.catch(() => {});
-		await page.waitForLoadState('networkidle');
+			.catch( () => {} );
+		await page.waitForLoadState( 'networkidle' );
 
 		// purposely no await again
-		page.click('button.toggle-button');
+		page.click( 'button.toggle-button' );
 
 		// enable COD payment option
 		await page.click(
 			'div.woocommerce-task-payment-cod > div.woocommerce-task-payment__footer > button'
 		);
-		await page.waitForLoadState('networkidle');
+		await page.waitForLoadState( 'networkidle' );
 
-		await page.goto('wp-admin/admin.php?page=wc-settings&tab=checkout');
+		await page.goto( 'wp-admin/admin.php?page=wc-settings&tab=checkout' );
 
 		await expect(
-			page.locator('//tr[@data-gateway_id="cod"]/td[@class="status"]/a')
-		).toHaveClass('wc-payment-gateway-method-toggle-enabled');
-	});
-});
+			page.locator( '//tr[@data-gateway_id="cod"]/td[@class="status"]/a' )
+		).toHaveClass( 'wc-payment-gateway-method-toggle-enabled' );
+	} );
+} );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds a new setting in `Settings` > `Advanced` > `Features`.
The setting should be disabled by default unless it was enabled through the flows described in #36161 and #36162
Include a tooltip to describe the new exp briefly.

Closes #36163.


<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Go to `WooCommerce` > `Settings` > `Advanced` > `Features`.
2. Verify the option `New product editor` is available to toggle. The description is: "Try the new product editor (Beta)" and the tooltip text says: "Enable to try the new, simplified product editor (currently in development and only available for simple products). No extension support yet."
![Screenshot 2023-01-11 at 16 57 53](https://user-images.githubusercontent.com/1314156/211905510-1874968c-21ef-4cec-9997-f0f5c1e37da2.png)

3. Enable the `New product editor` and verify that the new experience is turned on.
4. Verify that the toggle works correctly.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
