### PR TITLE
Redirect to new product experience when in experiment group

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/fills/products/use-create-product-by-type.ts
+++ b/plugins/woocommerce-admin/client/tasks/fills/products/use-create-product-by-type.ts
@@ -4,6 +4,9 @@
 import { useDispatch } from '@wordpress/data';
 import { ITEMS_STORE_NAME } from '@woocommerce/data';
 import { getAdminLink } from '@woocommerce/settings';
+import { getNewPath, navigateTo } from '@woocommerce/navigation';
+import { loadExperimentAssignment } from '@woocommerce/explat';
+import moment from 'moment';
 import { useState } from '@wordpress/element';
 
 /**
@@ -25,6 +28,21 @@ export const useCreateProductByType = () => {
 		}
 
 		setIsRequesting( true );
+
+		if ( type === 'physical' ) {
+			const momentDate = moment().utc();
+			const year = momentDate.format( 'YYYY' );
+			const month = momentDate.format( 'MM' );
+			const assignment = await loadExperimentAssignment(
+				`woocommerce_product_creation_experience_${ year }${ month }_v1`
+			);
+
+			if ( assignment.variationName === 'treatment' ) {
+				navigateTo( { url: getNewPath( {}, '/add-product', {} ) } );
+				return;
+			}
+		}
+
 		try {
 			const data: {
 				id?: number;

--- a/plugins/woocommerce/changelog/add-76-product-creation-experiment
+++ b/plugins/woocommerce/changelog/add-76-product-creation-experiment
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Redirect to new product experience when in experiment group


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Redirects to the new product experience when in the experiment treatment group and clicking "Physical product" in the task list product task.

I think the list here could use some busy/disabled states, but I believe that's pre-existing and beyond the scope of this PR.

<img width="596" alt="Screen Shot 2023-01-11 at 12 01 42 PM" src="https://user-images.githubusercontent.com/10561050/211907289-c75b761e-e835-4c5b-ba39-06845b83cfff.png">


<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Set your computer's datetime to any time in February, 2023 or change `const month = momentDate.format( 'MM' );` to `const month = '02';`
2. Navigate to the products task `wp-admin/admin.php?page=wc-admin&task=products`
3. Use the bookmarklet's from the [abicus experiment](21000-explat-experiment) to put yourself in the treatment group.  You may need to refresh for this to take effect.
4. Click on "Physical product"
5. Make sure you are taken to the new product creation experience
6. Use the control bookmarklet from the abicus experiment page. You may need to refresh for this to take effect.
7. Click "Physical product"
8. Make sure you are taken to the legacy experiement

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.