### PR TITLE
Update product links when new product management experience is enabled

### DIFF
--- a/plugins/woocommerce/changelog/update-36363
+++ b/plugins/woocommerce/changelog/update-36363
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Update product links when new product management experience is enabled

--- a/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
+++ b/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
@@ -11,6 +11,11 @@
 			$blankslate = $product_screen.find( '.woocommerce-BlankState' );
 
 		if ( 0 === $blankslate.length ) {
+			if ( woocommerce_admin.urls.add_product ) {
+				$title_action
+					.first()
+					.attr( 'href', woocommerce_admin.urls.add_product );
+			}
 			if ( woocommerce_admin.urls.export_products ) {
 				$title_action.after(
 					'<a href="' +

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -7,6 +7,7 @@
  */
 
 use Automattic\Jetpack\Constants;
+use Automattic\WooCommerce\Admin\Features\Features;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -214,6 +215,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 						'gateway_toggle' => wp_create_nonce( 'woocommerce-toggle-payment-gateway-enabled' ),
 					),
 					'urls'                              => array(
+						'add_product'     => Features::is_enabled( 'new-product-management-experience' ) ? esc_url_raw( admin_url( 'admin.php?page=wc-admin&path=/add-product' ) ) : false,
 						'import_products' => current_user_can( 'import' ) ? esc_url_raw( admin_url( 'edit.php?post_type=product&page=product_importer' ) ) : null,
 						'export_products' => current_user_can( 'export' ) ? esc_url_raw( admin_url( 'edit.php?post_type=product&page=product_exporter' ) ) : null,
 					),

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -215,7 +215,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 						'gateway_toggle' => wp_create_nonce( 'woocommerce-toggle-payment-gateway-enabled' ),
 					),
 					'urls'                              => array(
-						'add_product'     => Features::is_enabled( 'new-product-management-experience' ) ? esc_url_raw( admin_url( 'admin.php?page=wc-admin&path=/add-product' ) ) : false,
+						'add_product'     => Features::is_enabled( 'new-product-management-experience' ) ? esc_url_raw( admin_url( 'admin.php?page=wc-admin&path=/add-product' ) ) : null,
 						'import_products' => current_user_can( 'import' ) ? esc_url_raw( admin_url( 'edit.php?post_type=product&page=product_importer' ) ) : null,
 						'export_products' => current_user_can( 'export' ) ? esc_url_raw( admin_url( 'edit.php?post_type=product&page=product_exporter' ) ) : null,
 					),

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -425,7 +425,14 @@ class WC_Admin_Menus {
 	 */
 	public function maybe_add_new_product_management_experience() {
 		if ( Features::is_enabled( 'new-product-management-experience' ) ) {
-			add_submenu_page( 'edit.php?post_type=product', __( 'Add New', 'woocommerce' ), __( 'Add New (MVP)', 'woocommerce' ), 'manage_woocommerce', 'admin.php?page=wc-admin&path=/add-product', '', 2 );
+			global $submenu;
+			if ( isset( $submenu['edit.php?post_type=product'][10] ) ) {
+				// Disable phpcs since we need to override submenu classes.
+				// Note that `phpcs:ignore WordPress.Variables.GlobalVariables.OverrideProhibited` does not work to disable this check.
+				// phpcs:disable
+				$submenu['edit.php?post_type=product'][10][2] = 'admin.php?page=wc-admin&path=/add-product';
+				// phps:enableWordPress.Variables.GlobalVariables.OverrideProhibited
+			}
 		}
 	}
 }

--- a/plugins/woocommerce/src/Admin/Features/NewProductManagementExperience.php
+++ b/plugins/woocommerce/src/Admin/Features/NewProductManagementExperience.php
@@ -51,7 +51,7 @@ class NewProductManagementExperience {
 	 * @return string
 	 */
 	public function update_edit_product_link( $link, $post_id ) {
-		$product  = wc_get_product( $post_id );
+		$product = wc_get_product( $post_id );
 
 		if ( ! $product ) {
 			return $link;

--- a/plugins/woocommerce/src/Admin/Features/NewProductManagementExperience.php
+++ b/plugins/woocommerce/src/Admin/Features/NewProductManagementExperience.php
@@ -17,7 +17,12 @@ class NewProductManagementExperience {
 	 * Constructor
 	 */
 	public function __construct() {
+		if ( ! Features::is_enabled( 'new-product-management-experience' ) ) {
+			return;
+		}
+
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_styles' ) );
+		add_action( 'get_edit_post_link', array( $this, 'update_edit_product_link' ), 10, 2 );
 	}
 
 	/**
@@ -36,6 +41,27 @@ class NewProductManagementExperience {
 		 * @since 7.1.0
 		*/
 		do_action( 'enqueue_block_editor_assets' );
+	}
+
+	/**
+	 * Update the edit product links when the new experience is enabled.
+	 *
+	 * @param string $link    The edit link.
+	 * @param int    $post_id Post ID.
+	 * @return string
+	 */
+	public function update_edit_product_link( $link, $post_id ) {
+		$product  = wc_get_product( $post_id );
+
+		if ( ! $product ) {
+			return $link;
+		}
+
+		if ( $product->get_type() === 'simple' ) {
+			return admin_url( 'admin.php?page=wc-admin&path=/product/' . $product->get_id() );
+		}
+
+		return $link;
 	}
 
 }


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Updates add product and edit product links to point to the new experience when enabled.

<img width="594" alt="Screen Shot 2023-01-11 at 1 21 05 PM" src="https://user-images.githubusercontent.com/10561050/211920247-a0a42f4d-0b4d-46a3-ad77-74c3b5fce5bd.png">


Closes #36363  .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Before checking out this branch, create a simple product and variable product
2. Under WooCommerce -> Settings -> Advanced, toggle on the "New product editor"
3. After saving, click on Products -> Add new
4. Make sure you are directed to the new experience
5. Navigate to Products -> All products
6. Click on the simple product and make sure you are directed to the new product experience
7. Make sure the same is true when clicking on "Edit" when hovering a simple product on the All products page
8. Click on the variable product links and make sure you are directed to the old experience
9. Turn off the "New product editor" feature under WooCommerce -> Settings -> Advanced
10. Make sure all inks take you to the old experience

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
