### PR TITLE
Widen the selector used to hide the quantity input

### DIFF
--- a/plugins/woocommerce/changelog/fix-36007-sold-individually-amendment
+++ b/plugins/woocommerce/changelog/fix-36007-sold-individually-amendment
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: We're tweaking an unreleased change which is already covered by a changelog entry added in PR#36350.
+
+

--- a/plugins/woocommerce/client/legacy/css/_common.scss
+++ b/plugins/woocommerce/client/legacy/css/_common.scss
@@ -3,6 +3,6 @@
  */
 
 /* We do not wish to display the quantity selector (within single product pages) if the product is sold individually. */
-.woocommerce.single-product .product.sold-individually input[name="quantity"] {
+.woocommerce.single-product .product.sold-individually .quantity {
 	display: none;
 }


### PR DESCRIPTION
With reference to https://github.com/woocommerce/woocommerce/pull/36350, we just restored the default of hiding the quantity selector for any products that are sold individually.

Following some further feedback, this change adjusts the selector so it hides the entire `.quantity` div (important because some themes add their own increment/decrement buttons within the div, and we don't want those to remain visible when the input is hidden).

<!-- Mark completed items with an [x] -->

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->


Testing is as per earlier PR https://github.com/woocommerce/woocommerce/pull/36350 ... just as for that PR, you may wish to test this change alongside any of the default Twenty X themes (or indeed with a generic non-default theme, so long as it does not override and replace our stylesheets). Note that the change cannot currently be seen using Storefront, because that theme replaces our default styles (ie, we need to make a separate change within that product).

:bulb: After checking out this branch, rebuild the relevant stylesheets using `pnpm run --filter='woocommerce/client/legacy' build`. You may also need to clear your browser cache to see the change.

1. Configure a product such that it is sold individually.
2. Visit the single product page, confirm you do not see the quantity selector.
3. Configure it so it is **not** sold individually.
4. Visit the single product page, confirm you can now see the quantity selector.

This change should have no impact outside of single product pages.

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
