### PR TITLE
Bump stable tag and update changelog for 7.2.3 release.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,13 @@
 == Changelog ==
 
+= 7.2.3 2023-1-9
+
+**WooCommerce Blocks 8.9.4**
+
+* Fix - fatal error in WordPress 5.8 when creating a post or page. #7496
+* Fix - hangs in the block editor with WordPress 5.8. #8095
+* Fix - Filter by Attribute block crashing in the editor of WordPress 5.8. #8101
+
 = 7.2.2 2022-12-21 =
 
 ** WooCommerce**

--- a/plugins/woocommerce/changelog/dev-bump-stable-tag
+++ b/plugins/woocommerce/changelog/dev-bump-stable-tag
@@ -1,4 +1,3 @@
-Significance: minor
+Significance: patch
 Type: dev
-
-Update stable tag to latest fix release 7.2.3
+Comment: Stable tag bump

--- a/plugins/woocommerce/changelog/dev-bump-stable-tag
+++ b/plugins/woocommerce/changelog/dev-bump-stable-tag
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Update stable tag to latest fix release 7.2.3

--- a/plugins/woocommerce/readme.txt
+++ b/plugins/woocommerce/readme.txt
@@ -1,7 +1,7 @@
 === WooCommerce ===
 Contributors: automattic, mikejolley, jameskoster, claudiosanches, rodrigosprimo, peterfabian1000, vedjain, jamosova, obliviousharmony, konamiman, sadowski, wpmuguru, royho, barryhughes-1
 Tags: online store, ecommerce, shop, shopping cart, sell online, storefront, checkout, payments, woo, woo commerce, e-commerce, store
-Requires at least: 5.9
+Requires at least: 5.5
 Tested up to: 6.1
 Requires PHP: 7.2
 Stable tag: 7.1.1

--- a/plugins/woocommerce/readme.txt
+++ b/plugins/woocommerce/readme.txt
@@ -1,10 +1,10 @@
 === WooCommerce ===
 Contributors: automattic, mikejolley, jameskoster, claudiosanches, rodrigosprimo, peterfabian1000, vedjain, jamosova, obliviousharmony, konamiman, sadowski, wpmuguru, royho, barryhughes-1
 Tags: online store, ecommerce, shop, shopping cart, sell online, storefront, checkout, payments, woo, woo commerce, e-commerce, store
-Requires at least: 5.5
+Requires at least: 5.9
 Tested up to: 6.1
 Requires PHP: 7.2
-Stable tag: 7.1.1
+Stable tag: 7.2.3
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This updates the stable tag to match the latest fix release of WooCommerce and updates the changelog as well.

