### PR TITLE
Update WooCommerce Blocks to 9.1.5

### DIFF
--- a/plugins/woocommerce/changelog/update-wc-blocks-9.1.5
+++ b/plugins/woocommerce/changelog/update-wc-blocks-9.1.5
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update WooCommerce Blocks to 9.1.5

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -21,7 +21,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.4.2",
-		"woocommerce/woocommerce-blocks": "9.1.4"
+		"woocommerce/woocommerce-blocks": "9.1.5"
 	},
 	"require-dev": {
 		"bamarni/composer-bin-plugin": "^1.4",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5d6aa45a4ccd532e09383828f396c06d",
+    "content-hash": "d6b2e5e6edd15bf8dfddfcc0d4d645b6",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -628,16 +628,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "v9.1.4",
+            "version": "v9.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "03d5efd33206aa11684dee2c493bbbe9a4e417c8"
+                "reference": "5438fbb8ba195e92e265e1fcef880171f31ae52f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/03d5efd33206aa11684dee2c493bbbe9a4e417c8",
-                "reference": "03d5efd33206aa11684dee2c493bbbe9a4e417c8",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/5438fbb8ba195e92e265e1fcef880171f31ae52f",
+                "reference": "5438fbb8ba195e92e265e1fcef880171f31ae52f",
                 "shasum": ""
             },
             "require": {
@@ -683,9 +683,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v9.1.4"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v9.1.5"
             },
-            "time": "2023-01-05T23:41:26+00:00"
+            "time": "2023-01-10T11:03:07+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull request updates the WooCommerce Blocks plugin to 9.1.5. 

It contains a critical fix for the Cart and Checkout blocks in < WP 5.9 and also a fix for the All Products block that could not be customised in the editor.

## Blocks 9.1.5

* [Release PR](https://github.com/woocommerce/woocommerce-blocks/pull/8138)
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/5c157d2514f83cfcb2f98e67c0f2eeca1eb47a38/docs/internal-developers/testing/releases/915.md)

---

### Changelog entry

#### Bug fixes

- Add thunk support for < WP 5.9 ([#8136](https://github.com/woocommerce/woocommerce-blocks/pull/8136))
- Fix: All Products block customization issue. ([#8140](https://github.com/woocommerce/woocommerce-blocks/pull/8140))