### PR TITLE
Create a manually triggered workflow to release WooCommerce Beta Tester

### DIFF
--- a/.github/workflows/release-wc-beta-tester.yml
+++ b/.github/workflows/release-wc-beta-tester.yml
@@ -1,4 +1,5 @@
 name: WooCommerce Beta Tester Release
+permissions: {}
 
 on:
     workflow_dispatch:

--- a/.github/workflows/release-wc-beta-tester.yml
+++ b/.github/workflows/release-wc-beta-tester.yml
@@ -1,0 +1,33 @@
+name: WooCommerce Beta Tester Release
+
+on:
+    workflow_dispatch:
+        inputs:
+            version:
+                description: 'The version number for the release'
+                required: true
+
+jobs:
+    release:
+        name: Run release scripts
+        runs-on: ubuntu-20.04
+        permissions:
+            contents: write
+        steps:
+            - uses: actions/checkout@v3
+
+            - name: Setup WooCommerce Monorepo
+              uses: ./.github/actions/setup-woocommerce-monorepo
+
+            - name: Build WooCommerce Beta Tester Zip
+              working-directory: plugins/woocommerce-beta-tester
+              run: pnpm build:zip
+
+            - name: Create release
+              id: create_release
+              uses: softprops/action-gh-release@v1
+              with:
+                  tag_name: wc-beta-tester-${{ inputs.version }}
+                  name: WooCommerce Beta Tester Release ${{ inputs.version }}
+                  draft: false
+                  files: plugins/woocommerce-beta-tester/woocommerce-beta-tester.zip

--- a/.github/workflows/release-wc-beta-tester.yml
+++ b/.github/workflows/release-wc-beta-tester.yml
@@ -25,7 +25,7 @@ jobs:
 
             - name: Create release
               id: create_release
-              uses: samueljseay/action-gh-release@master
+              uses: woocommerce/action-gh-release@master
               with:
                   tag_name: wc-beta-tester-${{ inputs.version }}
                   name: WooCommerce Beta Tester Release ${{ inputs.version }}

--- a/.github/workflows/release-wc-beta-tester.yml
+++ b/.github/workflows/release-wc-beta-tester.yml
@@ -25,7 +25,7 @@ jobs:
 
             - name: Create release
               id: create_release
-              uses: softprops/action-gh-release@v1
+              uses: samueljseay/action-gh-release@master
               with:
                   tag_name: wc-beta-tester-${{ inputs.version }}
                   name: WooCommerce Beta Tester Release ${{ inputs.version }}

--- a/plugins/woocommerce/readme.txt
+++ b/plugins/woocommerce/readme.txt
@@ -1,7 +1,7 @@
 === WooCommerce ===
 Contributors: automattic, mikejolley, jameskoster, claudiosanches, rodrigosprimo, peterfabian1000, vedjain, jamosova, obliviousharmony, konamiman, sadowski, wpmuguru, royho, barryhughes-1
 Tags: online store, ecommerce, shop, shopping cart, sell online, storefront, checkout, payments, woo, woo commerce, e-commerce, store
-Requires at least: 5.5
+Requires at least: 5.9
 Tested up to: 6.1
 Requires PHP: 7.2
 Stable tag: 7.1.1

--- a/plugins/woocommerce/readme.txt
+++ b/plugins/woocommerce/readme.txt
@@ -1,7 +1,7 @@
 === WooCommerce ===
 Contributors: automattic, mikejolley, jameskoster, claudiosanches, rodrigosprimo, peterfabian1000, vedjain, jamosova, obliviousharmony, konamiman, sadowski, wpmuguru, royho, barryhughes-1
 Tags: online store, ecommerce, shop, shopping cart, sell online, storefront, checkout, payments, woo, woo commerce, e-commerce, store
-Requires at least: 5.9
+Requires at least: 5.5
 Tested up to: 6.1
 Requires PHP: 7.2
 Stable tag: 7.1.1


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This is a MVP workflow for releasing beta tester. It is fairly manual. Once we have done the version bumping and code edits we are happy with to perform a release of beta tester this workflow can be initiated. My thought is that in future we can automate things like version bumping etc if we need to.

You just choose a version number for the release manually and start the workflow. It will create a release a tagged release on the monorepo that has a name and version unique to WooCommerce Beta Tester. It will never set the release as latest since we should reserve that just for releasing the core plugin.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Fork woocommerce and enable actions
2. Merge this PR into your fork
3. Go to Actions tab on your fork -> Find the action and run it, choosing an arbitrary version (e.g. `2.1.0` which is what the plugin version is right now)
4. It should succeed.
5. It should create a release under your forks "Releases" section which includes the beta tester plugin zip file as well.
6. The release should not be marked "latest"

For reference here is a passing action run on my fork: https://github.com/samueljseay/woocommerce/actions/runs/3898558244

and the created release: https://github.com/samueljseay/woocommerce/releases/tag/wc-beta-tester-2.4.0

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
