### PR TITLE
[HPOS] Add support for ordering by metadata in order queries

### DIFF
--- a/plugins/woocommerce/changelog/fix-35486
+++ b/plugins/woocommerce/changelog/fix-35486
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add support for sorting by order metadata in HPOS queries.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableMetaQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableMetaQuery.php
@@ -158,8 +158,8 @@ class OrdersTableMetaQuery {
 					unset( $arg['value'] );
 				}
 
-				$arg['compare']      = isset( $arg['compare'] ) ? strtoupper( $arg['compare'] ) : ( isset( $arg['value'] ) && is_array( $arg['value'] ) ? 'IN' : '=' );
-				$arg['compare_key']  = isset( $arg['compare_key'] ) ? strtoupper( $arg['compare_key'] ) : ( isset( $arg['key'] ) && is_array( $arg['key'] ) ? 'IN' : '=' );
+				$arg['compare']     = isset( $arg['compare'] ) ? strtoupper( $arg['compare'] ) : ( isset( $arg['value'] ) && is_array( $arg['value'] ) ? 'IN' : '=' );
+				$arg['compare_key'] = isset( $arg['compare_key'] ) ? strtoupper( $arg['compare_key'] ) : ( isset( $arg['key'] ) && is_array( $arg['key'] ) ? 'IN' : '=' );
 
 				if ( ! in_array( $arg['compare'], self::NON_NUMERIC_OPERATORS, true ) && ! in_array( $arg['compare'], self::NUMERIC_OPERATORS, true ) ) {
 					$arg['compare'] = '=';

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -723,6 +723,73 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testDox Tests queries involving 'orderby' and meta queries.
+	 */
+	public function test_cot_query_meta_orderby() {
+		$this->toggle_cot( true );
+
+		$order1 = new \WC_Order();
+		$order1->add_meta_data( 'color', 'red' );
+		$order1->add_meta_data( 'animal', 'lion' );
+		$order1->add_meta_data( 'numeric_meta', '1000' );
+		$order1->save();
+
+		$order2 = new \WC_Order();
+		$order2->add_meta_data( 'color', 'green' );
+		$order2->add_meta_data( 'animal', 'lion' );
+		$order2->add_meta_data( 'numeric_meta', '500' );
+		$order2->save();
+
+		$query_args = array(
+			'orderby'  => 'id',
+			'order'    => 'ASC',
+			'meta_key' => 'color',
+		);
+
+		// Check that orders are in order (when no meta ordering is involved).
+		$q = new OrdersTableQuery( $query_args );
+		$this->assertEquals( $q->orders, array( $order1->get_id(), $order2->get_id() ) );
+
+		// When ordering by color $order2 should come first.
+		// Also tests that the key name is a valid synonym for the primary meta query.
+		$query_args['orderby'] = 'color';
+		$q = new OrdersTableQuery( $query_args );
+		$this->assertEquals( $q->orders, array( $order2->get_id(), $order1->get_id() ) );
+
+		// When ordering by 'numeric_meta' 1000 < 500 (due to alphabetical sorting by default).
+		// Also tests that 'meta_value' is a valid synonym for the primary meta query.
+		$query_args['meta_key'] = 'numeric_meta';
+		$query_args['orderby']  = 'meta_value';
+		$q = new OrdersTableQuery( $query_args );
+		$this->assertEquals( $q->orders, array( $order1->get_id(), $order2->get_id() ) );
+
+		// Forcing numeric sorting with 'meta_value_num' reverses the order above.
+		$query_args['orderby']  = 'meta_value_num';
+		$q = new OrdersTableQuery( $query_args );
+		$this->assertEquals( $q->orders, array( $order2->get_id(), $order1->get_id() ) );
+
+		// Sorting by 'animal' meta is ambiguous. Test that we can order by various meta fields (and use the names in 'orderby').
+		unset( $query_args['meta_key'] );
+		$query_args['meta_query'] = array(
+			'animal_meta' => array(
+				'key' => 'animal',
+			),
+			'color_meta' => array(
+				'key' => 'color',
+			),
+		);
+		$query_args['orderby'] = array( 'animal_meta' => 'ASC', 'color_meta' => 'DESC' );
+		$q = new OrdersTableQuery( $query_args );
+		$this->assertEquals( $q->orders, array( $order1->get_id(), $order2->get_id() ) );
+
+		// Order is reversed when changing the sort order for 'color_meta'.
+		$query_args['orderby']['color_meta'] = 'ASC';
+		$q = new OrdersTableQuery( $query_args );
+		$this->assertEquals( $q->orders, array( $order2->get_id(), $order1->get_id() ) );
+
+	}
+
+	/**
 	 * @testDox Tests queries involving the 'customer' query var.
 	 *
 	 * @return void

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -743,7 +743,7 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 		$query_args = array(
 			'orderby'  => 'id',
 			'order'    => 'ASC',
-			'meta_key' => 'color',
+			'meta_key' => 'color', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 		);
 
 		// Check that orders are in order (when no meta ordering is involved).
@@ -753,38 +753,41 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 		// When ordering by color $order2 should come first.
 		// Also tests that the key name is a valid synonym for the primary meta query.
 		$query_args['orderby'] = 'color';
-		$q = new OrdersTableQuery( $query_args );
+		$q                     = new OrdersTableQuery( $query_args );
 		$this->assertEquals( $q->orders, array( $order2->get_id(), $order1->get_id() ) );
 
 		// When ordering by 'numeric_meta' 1000 < 500 (due to alphabetical sorting by default).
 		// Also tests that 'meta_value' is a valid synonym for the primary meta query.
-		$query_args['meta_key'] = 'numeric_meta';
+		$query_args['meta_key'] = 'numeric_meta'; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 		$query_args['orderby']  = 'meta_value';
-		$q = new OrdersTableQuery( $query_args );
+		$q                      = new OrdersTableQuery( $query_args );
 		$this->assertEquals( $q->orders, array( $order1->get_id(), $order2->get_id() ) );
 
 		// Forcing numeric sorting with 'meta_value_num' reverses the order above.
-		$query_args['orderby']  = 'meta_value_num';
-		$q = new OrdersTableQuery( $query_args );
+		$query_args['orderby'] = 'meta_value_num';
+		$q                     = new OrdersTableQuery( $query_args );
 		$this->assertEquals( $q->orders, array( $order2->get_id(), $order1->get_id() ) );
 
 		// Sorting by 'animal' meta is ambiguous. Test that we can order by various meta fields (and use the names in 'orderby').
 		unset( $query_args['meta_key'] );
-		$query_args['meta_query'] = array(
+		$query_args['meta_query'] = array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 			'animal_meta' => array(
 				'key' => 'animal',
 			),
-			'color_meta' => array(
+			'color_meta'  => array(
 				'key' => 'color',
 			),
 		);
-		$query_args['orderby'] = array( 'animal_meta' => 'ASC', 'color_meta' => 'DESC' );
-		$q = new OrdersTableQuery( $query_args );
+		$query_args['orderby']    = array(
+			'animal_meta' => 'ASC',
+			'color_meta'  => 'DESC',
+		);
+		$q                        = new OrdersTableQuery( $query_args );
 		$this->assertEquals( $q->orders, array( $order1->get_id(), $order2->get_id() ) );
 
 		// Order is reversed when changing the sort order for 'color_meta'.
 		$query_args['orderby']['color_meta'] = 'ASC';
-		$q = new OrdersTableQuery( $query_args );
+		$q                                   = new OrdersTableQuery( $query_args );
 		$this->assertEquals( $q->orders, array( $order2->get_id(), $order1->get_id() ) );
 
 	}


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR adds support for sorting results in HPOS order queries. Syntax and features are similar to what [`WP_Query` offers](http://developer.wordpress.org/reference/classes/WP_Query/#order-orderby-parameters):

- If `meta_key => $the_meta_key` is used in the query args, setting `orderby` to `meta_value` or `meta_value_num` sorts by `$the_meta_key` alphabetically or numerically.
- If non-numeric array keys are used in a `meta_query`, `orderby` can also be set to any of those indices to sort results by that particular meta key.
- The different meta-related keys can obviously be combined in more complex `orderby` clauses (see unit tests).

Closes #35486.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

Because there's currently no UI to take advantage of this functionality, the best way to test is to run the unit tests or manually create a few orders (with metadata) and try various possible meta queries. For example:

```php
$order = new \WC_Order();
$order->add_meta_data( 'color', 'green', true );
$order->save();

$order = new \WC_Order();
$order->add_meta_data( 'color', 'blue', true );
$order->save();

$results = wc_get_orders(
	array(
		'meta_key' => 'color',
		'orderby'  => 'meta_value',
		'order'    => 'ASC',
	)
);
```

<!-- End testing instructions -->

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [X] Have you written new tests for your changes, as applicable?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
