### PR TITLE
Enable new experience when new user selects "Physical product"

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/fills/products/use-create-product-by-type.ts
+++ b/plugins/woocommerce-admin/client/tasks/fills/products/use-create-product-by-type.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useDispatch } from '@wordpress/data';
-import { ITEMS_STORE_NAME } from '@woocommerce/data';
+import { ITEMS_STORE_NAME, OPTIONS_STORE_NAME } from '@woocommerce/data';
 import { getAdminLink } from '@woocommerce/settings';
 import { getNewPath, navigateTo } from '@woocommerce/navigation';
 import { loadExperimentAssignment } from '@woocommerce/explat';
@@ -15,9 +15,12 @@ import { useState } from '@wordpress/element';
 import { ProductTypeKey } from './constants';
 import { createNoticesFromResponse } from '../../../lib/notices';
 
+const NEW_PRODUCT_MANAGEMENT = 'woocommerce_new_product_management_enabled';
+
 export const useCreateProductByType = () => {
 	const { createProductFromTemplate } = useDispatch( ITEMS_STORE_NAME );
 	const [ isRequesting, setIsRequesting ] = useState< boolean >( false );
+	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
 
 	const createProductByType = async ( type: ProductTypeKey ) => {
 		if ( type === 'subscription' ) {
@@ -38,6 +41,9 @@ export const useCreateProductByType = () => {
 			);
 
 			if ( assignment.variationName === 'treatment' ) {
+				updateOptions( {
+					[ NEW_PRODUCT_MANAGEMENT ]: 'yes',
+				} );
 				navigateTo( { url: getNewPath( {}, '/add-product', {} ) } );
 				return;
 			}

--- a/plugins/woocommerce-admin/client/tasks/fills/products/use-create-product-by-type.ts
+++ b/plugins/woocommerce-admin/client/tasks/fills/products/use-create-product-by-type.ts
@@ -4,7 +4,6 @@
 import { useDispatch } from '@wordpress/data';
 import { ITEMS_STORE_NAME, OPTIONS_STORE_NAME } from '@woocommerce/data';
 import { getAdminLink } from '@woocommerce/settings';
-import { getNewPath, navigateTo } from '@woocommerce/navigation';
 import { loadExperimentAssignment } from '@woocommerce/explat';
 import moment from 'moment';
 import { useState } from '@wordpress/element';
@@ -41,10 +40,12 @@ export const useCreateProductByType = () => {
 			);
 
 			if ( assignment.variationName === 'treatment' ) {
-				updateOptions( {
+				await updateOptions( {
 					[ NEW_PRODUCT_MANAGEMENT ]: 'yes',
 				} );
-				navigateTo( { url: getNewPath( {}, '/add-product', {} ) } );
+				window.location.href = getAdminLink(
+					'admin.php?page=wc-admin&path=/add-product'
+				);
 				return;
 			}
 		}

--- a/plugins/woocommerce-admin/client/tasks/fills/products/use-create-product-by-type.ts
+++ b/plugins/woocommerce-admin/client/tasks/fills/products/use-create-product-by-type.ts
@@ -42,17 +42,17 @@ export const useCreateProductByType = () => {
 				`woocommerce_product_creation_experience_${ year }${ month }_v1`
 			);
 
+			if ( isNewExperienceEnabled ) {
+				navigateTo( { url: getNewPath( {}, '/add-product', {} ) } );
+				return;
+			}
 			if ( assignment.variationName === 'treatment' ) {
-				if ( isNewExperienceEnabled ) {
-					navigateTo( { url: getNewPath( {}, '/add-product', {} ) } );
-				} else {
-					await updateOptions( {
-						[ NEW_PRODUCT_MANAGEMENT ]: 'yes',
-					} );
-					window.location.href = getAdminLink(
-						'admin.php?page=wc-admin&path=/add-product'
-					);
-				}
+				await updateOptions( {
+					[ NEW_PRODUCT_MANAGEMENT ]: 'yes',
+				} );
+				window.location.href = getAdminLink(
+					'admin.php?page=wc-admin&path=/add-product'
+				);
 				return;
 			}
 		}

--- a/plugins/woocommerce-admin/client/tasks/fills/products/use-create-product-by-type.ts
+++ b/plugins/woocommerce-admin/client/tasks/fills/products/use-create-product-by-type.ts
@@ -3,6 +3,7 @@
  */
 import { useDispatch } from '@wordpress/data';
 import { ITEMS_STORE_NAME, OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { getNewPath, navigateTo } from '@woocommerce/navigation';
 import { getAdminLink } from '@woocommerce/settings';
 import { loadExperimentAssignment } from '@woocommerce/explat';
 import moment from 'moment';
@@ -20,6 +21,8 @@ export const useCreateProductByType = () => {
 	const { createProductFromTemplate } = useDispatch( ITEMS_STORE_NAME );
 	const [ isRequesting, setIsRequesting ] = useState< boolean >( false );
 	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
+	const isNewExperienceEnabled =
+		window.wcAdminFeatures[ 'new-product-management-experience' ];
 
 	const createProductByType = async ( type: ProductTypeKey ) => {
 		if ( type === 'subscription' ) {
@@ -40,12 +43,16 @@ export const useCreateProductByType = () => {
 			);
 
 			if ( assignment.variationName === 'treatment' ) {
-				await updateOptions( {
-					[ NEW_PRODUCT_MANAGEMENT ]: 'yes',
-				} );
-				window.location.href = getAdminLink(
-					'admin.php?page=wc-admin&path=/add-product'
-				);
+				if ( isNewExperienceEnabled ) {
+					navigateTo( { url: getNewPath( {}, '/add-product', {} ) } );
+				} else {
+					await updateOptions( {
+						[ NEW_PRODUCT_MANAGEMENT ]: 'yes',
+					} );
+					window.location.href = getAdminLink(
+						'admin.php?page=wc-admin&path=/add-product'
+					);
+				}
 				return;
 			}
 		}

--- a/plugins/woocommerce/changelog/add-36319_enable_new_experience_when_simple_product
+++ b/plugins/woocommerce/changelog/add-36319_enable_new_experience_when_simple_product
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Enable new experience when new user selects "Physical product".


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR enables the new experience when a user selects "Physical product" in the setup task list (`/wp-admin/admin.php?page=wc-admin&task=products`).

![Screenshot 2023-01-12 at 19 07 33](https://user-images.githubusercontent.com/1314156/212191569-065253f9-accd-414f-b795-8bc233ebb100.png)

Closes #36319.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. To make this PR easier to test, I created the branch `add/36319_enable_new_experience_when_simple_product_test`that [adds the code](https://github.com/woocommerce/woocommerce/compare/add/36319_enable_new_experience_when_simple_product...add/36319_enable_new_experience_when_simple_product_test?expand=1) to be always `treatment`.
2. Go to `Settings` > `Advanced` > `Features` and disable the new experience. 
3. Go to the setup task list `/wp-admin/admin.php?page=wc-admin&task=products` and select  "Physical product" under the `Add product` task.
4. You should see the new experience after selecting "Physical product". 

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
