### PR TITLE
get_index_columns using SHOW INDEX FROM query instead of information_schema

### DIFF
--- a/plugins/woocommerce/changelog/fix-36374-use-show-index-instead-of-db-schema
+++ b/plugins/woocommerce/changelog/fix-36374-use-show-index-instead-of-db-schema
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Convert DatabaseUtil::get_index_columns() to use SHOW INDEX FROM instead of INFORMATION_SCHEMA query

--- a/plugins/woocommerce/src/Internal/Utilities/DatabaseUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/DatabaseUtil.php
@@ -126,6 +126,7 @@ class DatabaseUtil {
 			$index_name = 'PRIMARY';
 		}
 
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$results = $wpdb->get_results( $wpdb->prepare( "SHOW INDEX FROM $table_name WHERE Key_name = %s", $index_name ) );
 
 		if ( empty( $results ) ) {

--- a/plugins/woocommerce/src/Internal/Utilities/DatabaseUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/DatabaseUtil.php
@@ -126,15 +126,13 @@ class DatabaseUtil {
 			$index_name = 'PRIMARY';
 		}
 
-		// phpcs:disable WordPress.DB.PreparedSQL
-		return $wpdb->get_col(
-			"
-SELECT column_name FROM INFORMATION_SCHEMA.STATISTICS
-WHERE table_name='$table_name'
-AND table_schema='" . DB_NAME . "'
-AND index_name='$index_name'"
-		);
-		// phpcs:enable WordPress.DB.PreparedSQL
+		$results = $wpdb->get_results( $wpdb->prepare( "SHOW INDEX FROM $table_name WHERE Key_name = %s", $index_name ) );
+
+		if ( empty( $results ) ) {
+			return $results;
+		}
+
+		return array_column( $results, 'Column_name' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Utilities/DatabaseUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/DatabaseUtil.php
@@ -129,7 +129,7 @@ class DatabaseUtil {
 		$results = $wpdb->get_results( $wpdb->prepare( "SHOW INDEX FROM $table_name WHERE Key_name = %s", $index_name ) );
 
 		if ( empty( $results ) ) {
-			return $results;
+			return array();
 		}
 
 		return array_column( $results, 'Column_name' );

--- a/plugins/woocommerce/tests/php/src/Internal/Utilities/DatabaseUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Utilities/DatabaseUtilTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Tests for the DatabaseUtil utility.
+ */
+
+use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
+
+/**
+ * Tests relating to DatabaseUtil.
+ */
+class DatabaseUtilTest extends WC_Unit_Test_Case {
+
+	/**
+	 * @var DatabaseUtil
+	 */
+	private $sut;
+
+	/**
+	 * Set-up subject under test.
+	 */
+	public function set_up() {
+		$this->sut = wc_get_container()->get( DatabaseUtil::class );
+		parent::set_up();
+	}
+
+	/**
+	 * @testdox Test that get_index_columns() will default to return the primary key index columns.
+	 */
+	public function test_get_index_columns_returns_primary_index_by_default() {
+		global $wpdb;
+
+		$this->assertEquals(
+			array( 'product_id' ),
+			$this->sut->get_index_columns( $wpdb->prefix . 'wc_product_meta_lookup' )
+		);
+	}
+
+	/**
+	 * @testdox Test that get_index_columns() will return an array containing all columns of a multi-column index.
+	 */
+	public function test_get_index_columns_returns_multicolumn_index() {
+		global $wpdb;
+
+		$this->assertEquals(
+			array( 'min_price', 'max_price' ),
+			$this->sut->get_index_columns( $wpdb->prefix . 'wc_product_meta_lookup', 'min_max_price' )
+		);
+	}
+
+	/**
+	 * @testdox Test that giving a non-existent index name to get_index_columns() will return an empty array.
+	 */
+	public function test_get_index_columns_returns_empty_for_invalid_index() {
+		global $wpdb;
+
+		$this->assertEmpty(
+			$this->sut->get_index_columns( $wpdb->prefix . 'wc_product_meta_lookup', 'invalid_index_name' )
+		);
+	}
+}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

This switches from the use of a INFORMATION_SCHEMA query, which requires that the `DB_NAME` constant be defined to a `SHOW INDEX FROM` query when getting the index columns within the DatabaseUtil class.

Closes #36374.

Also fixes #37276 in-part.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

New unit tests covering the change `::get_index_columns()` method were added.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
