### PR TITLE
Add check to line item refund quantity

### DIFF
--- a/plugins/woocommerce/changelog/fix-31738
+++ b/plugins/woocommerce/changelog/fix-31738
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Add check to line item refund quantity

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
@@ -1062,7 +1062,7 @@ jQuery( function ( $ ) {
 					format:    woocommerce_admin_meta_boxes.currency_format
 				} ) );
 			},
-
+ 
 			// When the refund qty is changed, increase or decrease costs
 			refund_quantity_changed: function() {
 				var $row              = $( this ).closest( 'tr.item' );
@@ -1070,6 +1070,11 @@ jQuery( function ( $ ) {
 				var refund_qty        = $( this ).val();
 				var line_total        = $( 'input.line_total', $row );
 				var refund_line_total = $( 'input.refund_line_total', $row );
+
+				if( refund_qty > qty ) {
+					window.alert( woocommerce_admin_meta_boxes.i18n_refund_invalid_item_qty );
+					return;
+				}
 
 				// Totals
 				var unit_total = accounting.unformat( line_total.attr( 'data-total' ), woocommerce_admin.mon_decimal_point ) / qty;

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
@@ -1062,7 +1062,7 @@ jQuery( function ( $ ) {
 					format:    woocommerce_admin_meta_boxes.currency_format
 				} ) );
 			},
- 
+
 			// When the refund qty is changed, increase or decrease costs
 			refund_quantity_changed: function() {
 				var $row              = $( this ).closest( 'tr.item' );

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -356,6 +356,8 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					'remove_fee_notice'                  => $remove_fee_notice,
 					'remove_shipping_notice'             => $remove_shipping_notice,
 					'i18n_select_items'                  => __( 'Please select some items.', 'woocommerce' ),
+					'i18n_refund_invalid_item_amount'	 => __( 'Invalid line item amount to refund', 'woocommerce' ),
+					'i18n_refund_invalid_item_qty'		 => __( 'Invalid line item quantity to refund', 'woocommerce' ),
 					'i18n_do_refund'                     => __( 'Are you sure you wish to process this refund? This action cannot be undone.', 'woocommerce' ),
 					'i18n_delete_refund'                 => __( 'Are you sure you wish to delete this refund? This action cannot be undone.', 'woocommerce' ),
 					'i18n_delete_tax'                    => __( 'Are you sure you wish to delete this tax column? This action cannot be undone.', 'woocommerce' ),

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -356,7 +356,6 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					'remove_fee_notice'                  => $remove_fee_notice,
 					'remove_shipping_notice'             => $remove_shipping_notice,
 					'i18n_select_items'                  => __( 'Please select some items.', 'woocommerce' ),
-					'i18n_refund_invalid_item_amount'	 => __( 'Invalid line item amount to refund', 'woocommerce' ),
 					'i18n_refund_invalid_item_qty'		 => __( 'Invalid line item quantity to refund', 'woocommerce' ),
 					'i18n_do_refund'                     => __( 'Are you sure you wish to process this refund? This action cannot be undone.', 'woocommerce' ),
 					'i18n_delete_refund'                 => __( 'Are you sure you wish to delete this refund? This action cannot be undone.', 'woocommerce' ),

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -1982,8 +1982,9 @@ class WC_AJAX {
 		$response               = array();
 
 		try {
-			$order      = wc_get_order( $order_id );
-			$max_refund = wc_format_decimal( $order->get_total() - $order->get_total_refunded(), wc_get_price_decimals() );
+			$order            = wc_get_order( $order_id );
+			$order_line_items = $order->get_items();
+			$max_refund       = wc_format_decimal( $order->get_total() - $order->get_total_refunded(), wc_get_price_decimals() );
 
 			if ( ( ! $refund_amount && ( wc_format_decimal( 0, wc_get_price_decimals() ) !== $refund_amount ) ) || $max_refund < $refund_amount || 0 > $refund_amount ) {
 				throw new Exception( __( 'Invalid refund amount', 'woocommerce' ) );
@@ -2006,6 +2007,15 @@ class WC_AJAX {
 			}
 			foreach ( $line_item_qtys as $item_id => $qty ) {
 				$line_items[ $item_id ]['qty'] = max( $qty, 0 );
+				if ( isset($order_line_items[ $item_id ]) && $line_items[ $item_id ]['qty'] > $order_line_items[ $item_id ]->get_quantity() ) {
+					throw new Exception(
+						sprintf(
+						/* translators: %1s: order item name;  */
+							__( 'Invalid refund quantity for item: %1s.', 'woocommerce' ),
+							$order_line_items[ $item_id ]->get_name(),
+						)
+					);
+				}
 			}
 			foreach ( $line_item_totals as $item_id => $total ) {
 				$line_items[ $item_id ]['refund_total'] = wc_format_decimal( $total );

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -2012,7 +2012,7 @@ class WC_AJAX {
 						sprintf(
 						/* translators: %1s: order item name;  */
 							__( 'Invalid refund quantity for item: %1s.', 'woocommerce' ),
-							$order_line_items[ $item_id ]->get_name(),
+							$order_line_items[ $item_id ]->get_name()
 						)
 					);
 				}

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -2007,7 +2007,7 @@ class WC_AJAX {
 			}
 			foreach ( $line_item_qtys as $item_id => $qty ) {
 				$line_items[ $item_id ]['qty'] = max( $qty, 0 );
-				if ( isset($order_line_items[ $item_id ]) && $line_items[ $item_id ]['qty'] > $order_line_items[ $item_id ]->get_quantity() ) {
+				if ( isset( $order_line_items[ $item_id ] ) && $line_items[ $item_id ]['qty'] > $order_line_items[ $item_id ]->get_quantity() ) {
 					throw new Exception(
 						sprintf(
 						/* translators: %1s: order item name;  */

--- a/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
@@ -193,8 +193,13 @@ class WC_AJAX_Test extends \WP_Ajax_UnitTestCase {
 		$this->assertEquals( 108, $order->get_total() );
 	}
 
+	/**
+	 * Tests if an error is generated when trying to refund too many of a product
+	 *
+	 * @return void
+	 */
 	public function test_refund_too_many() {
-		// Create order with products
+		// Create order with products.
 		$product1 = WC_Helper_Product::create_simple_product();
 		$product1->set_regular_price( 10 );
 		$product1->save();
@@ -212,18 +217,16 @@ class WC_AJAX_Test extends \WP_Ajax_UnitTestCase {
 		$item    = current( $order->get_items() );
 		$item_id = $item->get_id();
 
-		// Loggin as admin
 		$this->_setRole( 'administrator' );
 
-		// Try to refund too many items
-
-		$_REQUEST = $_POST = array(
+		// Try to refund too many items.
+		$_REQUEST = array(
 			'order_id'               => $order->get_id(),
 			'refund_amount'          => 20.00,
 			'refunded_amount'        => 0,
 			'refund_reason'          => '',
-			'line_item_qtys'         => json_encode( array( $item_id => '2' ) ),
-			'line_item_totals'       => json_encode(
+			'line_item_qtys'         => wp_json_encode( array( $item_id => '2' ) ),
+			'line_item_totals'       => wp_json_encode(
 				array(
 					$item_id => 20,
 				)
@@ -232,6 +235,8 @@ class WC_AJAX_Test extends \WP_Ajax_UnitTestCase {
 			'restock_refunded_items' => true,
 			'security'               => wp_create_nonce( 'order-item' ),
 		);
+
+		$_POST = $_REQUEST;
 
 		try {
 			$this->_handleAjax( 'woocommerce_refund_line_items' );

--- a/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-ajax-test.php
@@ -236,6 +236,7 @@ class WC_AJAX_Test extends \WP_Ajax_UnitTestCase {
 			'security'               => wp_create_nonce( 'order-item' ),
 		);
 
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		$_POST = $_REQUEST;
 
 		try {


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:
This PR adds a check on the frontend and backend to prevent refunding more than the product quantity bought by the customer.

Closes #31738
### How to test the changes in this Pull Request:
1. As a Shopper create an order with at least 2 products with the same price
2. As a Merchant go to \wp-admin > WooCommerce > Orders click Refund
3. Enter "2" (typing, not clicking the up-arrow) as refund quantity for one of the order items
4. Click "Refund manually"
5. The message `Invalid line item quantity to refund` should show up and the order not be refunded
6. Comment out this JS code and repeat the steps above. This will allow us to test the backend checks. This time the message `Invalid refund quantity for item: <line item name>` should show up

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
