### PR TITLE
Avoid calling-method-on-null/false errors

### DIFF
--- a/plugins/woocommerce/changelog/fix-36325-download-permissions
+++ b/plugins/woocommerce/changelog/fix-36325-download-permissions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+When adjusting download permissions, confirm the child products have not been removed.

--- a/plugins/woocommerce/src/Internal/DownloadPermissionsAdjuster.php
+++ b/plugins/woocommerce/src/Internal/DownloadPermissionsAdjuster.php
@@ -99,7 +99,21 @@ class DownloadPermissionsAdjuster {
 
 		$children_with_downloads = array();
 		foreach ( $children_ids as $child_id ) {
-			$child                                = wc_get_product( $child_id );
+			$child = wc_get_product( $child_id );
+
+			// Ensure we have a valid child product.
+			if ( ! $child ) {
+				wc_get_logger()->warning(
+					sprintf(
+						/* translators: 1: child product ID 2: parent product ID. */
+						__( 'Unable to load child product %1$d while adjusting download permissions for product %2$d.', 'woocommerce' ),
+						$child_id,
+						$product_id
+					)
+				);
+				continue;
+			}
+
 			$children_with_downloads[ $child_id ] = $this->get_download_files_and_permissions( $child );
 		}
 

--- a/plugins/woocommerce/src/Internal/DownloadPermissionsAdjuster.php
+++ b/plugins/woocommerce/src/Internal/DownloadPermissionsAdjuster.php
@@ -6,6 +6,7 @@
 namespace Automattic\WooCommerce\Internal;
 
 use Automattic\WooCommerce\Proxies\LegacyProxy;
+use WC_Product;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -102,7 +103,7 @@ class DownloadPermissionsAdjuster {
 			$child = wc_get_product( $child_id );
 
 			// Ensure we have a valid child product.
-			if ( ! $child ) {
+			if ( ! $child instanceof WC_Product ) {
 				wc_get_logger()->warning(
 					sprintf(
 						/* translators: 1: child product ID 2: parent product ID. */


### PR DESCRIPTION
Adds some defensive coding within the `DownloadPermissionsAdjuster` class, reducing the risk of us inadvertently calling a method on null (or on false) after loading a product via `wc_get_product()`.

Updates #36325 | #35916.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

The exact circumstances leading to this problem are not known (though see report #35916), but we can imagine some sort of race condition in which a child product is deleted by a concurrent request before the relevant code runs. This is hard to contrive, so, code review is probably sufficient here.

However, if desired, it is possible to simulate the issue by creating or using an existing variable product. Identify the product ID and one of the child IDs, and plug them into a snippet like the following (updating the IDs as needed):

```php
<?php

$parent_product = 123;
$child_product  = 456;

add_filter( 'woocommerce_product_class', function( $classname, $product_type, $type, $product_id ) use ( $child_product ) {
	return $product_id === $child_product ? '<NonExistentClass>' : $classname;
}, 10, 4 );

wc_get_container()->get( Automattic\WooCommerce\Internal\DownloadPermissionsAdjuster::class )->adjust_download_permissions( $parent_product );
```

Run the script via WP CLI (ie, `wp eval-file /path/to/snippet.php`). Without this change, you should see an error matching what was noted in the linked bug report:

```
PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Automattic\WooCommerce\Internal\DownloadPermissionsAdjuster::get_download_files_and_permissions() must be an instance of WC_Product, bool given
```

With this branch, there should be no error and if logging is enabled you should see a log message like the following in the **WooCommerce ▸ Status ▸ Logs** screen:

<img width="966" alt="log-entry" src="https://user-images.githubusercontent.com/3594411/212436703-52aa71ef-82d3-45ea-935a-5528824829f1.png">

<!-- End testing instructions -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
