### PR TITLE
Add tree-control expand/collapse on click the expander button or by a custom logic

### DIFF
--- a/packages/js/components/changelog/add-35851-tree-control-expander
+++ b/packages/js/components/changelog/add-35851-tree-control-expander
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add tree-control expand/collapse on click the expander button or by a custom logic

--- a/packages/js/components/changelog/add-35851-tree-control-expander
+++ b/packages/js/components/changelog/add-35851-tree-control-expander
@@ -1,4 +1,4 @@
 Significance: minor
 Type: dev
 
-Add tree-control expand/collapse on click the expander button or by a custom logic
+Add TreeControl expand/collapse functionality.

--- a/packages/js/components/src/experimental-tree-control/hooks/use-expander.ts
+++ b/packages/js/components/src/experimental-tree-control/hooks/use-expander.ts
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { useEffect, useState } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { TreeItemProps } from '../types';
+
+export function useExpander( {
+	isExpanded,
+	item,
+}: Pick< TreeItemProps, 'isExpanded' | 'item' > ) {
+	const [ expanded, setExpanded ] = useState( false );
+
+	useEffect( () => {
+		if ( item.children?.length && typeof isExpanded === 'function' ) {
+			setExpanded( isExpanded( item ) );
+		}
+	}, [ item, isExpanded ] );
+
+	function onToggleExpand() {
+		setExpanded( ( prev ) => ! prev );
+	}
+
+	return { expanded, onToggleExpand };
+}

--- a/packages/js/components/src/experimental-tree-control/hooks/use-expander.ts
+++ b/packages/js/components/src/experimental-tree-control/hooks/use-expander.ts
@@ -9,20 +9,23 @@ import { useEffect, useState } from 'react';
 import { TreeItemProps } from '../types';
 
 export function useExpander( {
-	isExpanded,
+	shouldItemBeExpanded,
 	item,
-}: Pick< TreeItemProps, 'isExpanded' | 'item' > ) {
-	const [ expanded, setExpanded ] = useState( false );
+}: Pick< TreeItemProps, 'shouldItemBeExpanded' | 'item' > ) {
+	const [ isExpanded, setExpanded ] = useState( false );
 
 	useEffect( () => {
-		if ( item.children?.length && typeof isExpanded === 'function' ) {
-			setExpanded( isExpanded( item ) );
+		if (
+			item.children?.length &&
+			typeof shouldItemBeExpanded === 'function'
+		) {
+			setExpanded( shouldItemBeExpanded( item ) );
 		}
-	}, [ item, isExpanded ] );
+	}, [ item, shouldItemBeExpanded ] );
 
 	function onToggleExpand() {
 		setExpanded( ( prev ) => ! prev );
 	}
 
-	return { expanded, onToggleExpand };
+	return { isExpanded, onToggleExpand };
 }

--- a/packages/js/components/src/experimental-tree-control/hooks/use-tree-item.ts
+++ b/packages/js/components/src/experimental-tree-control/hooks/use-tree-item.ts
@@ -7,13 +7,25 @@ import React from 'react';
  * Internal dependencies
  */
 import { TreeItemProps } from '../types';
+import { useExpander } from './use-expander';
 
-export function useTreeItem( { item, level, ...props }: TreeItemProps ) {
+export function useTreeItem( {
+	item,
+	level,
+	isExpanded,
+	...props
+}: TreeItemProps ) {
 	const nextLevel = level + 1;
+
+	const expander = useExpander( {
+		item,
+		isExpanded,
+	} );
 
 	return {
 		item,
 		level: nextLevel,
+		expander,
 		treeItemProps: {
 			...props,
 		},
@@ -25,6 +37,7 @@ export function useTreeItem( { item, level, ...props }: TreeItemProps ) {
 		treeProps: {
 			items: item.children,
 			level: nextLevel,
+			isItemExpanded: isExpanded,
 		},
 	};
 }

--- a/packages/js/components/src/experimental-tree-control/hooks/use-tree-item.ts
+++ b/packages/js/components/src/experimental-tree-control/hooks/use-tree-item.ts
@@ -12,14 +12,14 @@ import { useExpander } from './use-expander';
 export function useTreeItem( {
 	item,
 	level,
-	isExpanded,
+	shouldItemBeExpanded,
 	...props
 }: TreeItemProps ) {
 	const nextLevel = level + 1;
 
 	const expander = useExpander( {
 		item,
-		isExpanded,
+		shouldItemBeExpanded,
 	} );
 
 	return {
@@ -37,7 +37,7 @@ export function useTreeItem( {
 		treeProps: {
 			items: item.children,
 			level: nextLevel,
-			isItemExpanded: isExpanded,
+			shouldItemBeExpanded,
 		},
 	};
 }

--- a/packages/js/components/src/experimental-tree-control/hooks/use-tree.ts
+++ b/packages/js/components/src/experimental-tree-control/hooks/use-tree.ts
@@ -7,7 +7,13 @@
  */
 import { TreeProps } from '../types';
 
-export function useTree( { ref, items, level = 1, ...props }: TreeProps ) {
+export function useTree( {
+	ref,
+	items,
+	level = 1,
+	isItemExpanded,
+	...props
+}: TreeProps ) {
 	return {
 		level,
 		items,
@@ -16,6 +22,7 @@ export function useTree( { ref, items, level = 1, ...props }: TreeProps ) {
 		},
 		treeItemProps: {
 			level,
+			isExpanded: isItemExpanded,
 		},
 	};
 }

--- a/packages/js/components/src/experimental-tree-control/hooks/use-tree.ts
+++ b/packages/js/components/src/experimental-tree-control/hooks/use-tree.ts
@@ -11,7 +11,7 @@ export function useTree( {
 	ref,
 	items,
 	level = 1,
-	isItemExpanded,
+	shouldItemBeExpanded,
 	...props
 }: TreeProps ) {
 	return {
@@ -22,7 +22,7 @@ export function useTree( {
 		},
 		treeItemProps: {
 			level,
-			isExpanded: isItemExpanded,
+			shouldItemBeExpanded,
 		},
 	};
 }

--- a/packages/js/components/src/experimental-tree-control/stories/index.tsx
+++ b/packages/js/components/src/experimental-tree-control/stories/index.tsx
@@ -36,29 +36,29 @@ export const SimpleTree: React.FC = () => {
 	);
 };
 
-function isItemExpanded( item: LinkedTree, text: string ) {
-	if ( ! text || ! item.children?.length ) return false;
+function shouldItemBeExpanded( item: LinkedTree, filter: string ) {
+	if ( ! filter || ! item.children?.length ) return false;
 	return item.children.some( ( child ) => {
-		if ( new RegExp( text, 'ig' ).test( child.data.label ) ) {
+		if ( new RegExp( filter, 'ig' ).test( child.data.label ) ) {
 			return true;
 		}
-		return isItemExpanded( child, text );
+		return shouldItemBeExpanded( child, filter );
 	} );
 }
 
-export const ExpandOnSearch: React.FC = () => {
-	const [ text, setText ] = useState( '' );
+export const ExpandOnFilter: React.FC = () => {
+	const [ filter, setFilter ] = useState( '' );
 
 	return (
 		<>
-			<TextControl value={ text } onChange={ setText } />
-			<BaseControl label="Expand on search" id="expand-on-search">
+			<TextControl value={ filter } onChange={ setFilter } />
+			<BaseControl label="Expand on filter" id="expand-on-filter">
 				<TreeControl
-					id="expand-on-search"
+					id="expand-on-filter"
 					items={ listItems }
-					isItemExpanded={ useCallback(
-						( item ) => isItemExpanded( item, text ),
-						[ text ]
+					shouldItemBeExpanded={ useCallback(
+						( item ) => shouldItemBeExpanded( item, filter ),
+						[ filter ]
 					) }
 				/>
 			</BaseControl>

--- a/packages/js/components/src/experimental-tree-control/stories/index.tsx
+++ b/packages/js/components/src/experimental-tree-control/stories/index.tsx
@@ -1,14 +1,14 @@
 /**
  * External dependencies
  */
-import { BaseControl } from '@wordpress/components';
-import React, { createElement } from 'react';
+import { BaseControl, TextControl } from '@wordpress/components';
+import React, { createElement, useCallback, useState } from 'react';
 
 /**
  * Internal dependencies
  */
 import { TreeControl } from '../tree-control';
-import { Item } from '../types';
+import { Item, LinkedTree } from '../types';
 
 const listItems: Item[] = [
 	{ value: '1', label: 'Technology' },
@@ -33,6 +33,36 @@ export const SimpleTree: React.FC = () => {
 		<BaseControl label="Simple tree" id="simple-tree">
 			<TreeControl id="simple-tree" items={ listItems } />
 		</BaseControl>
+	);
+};
+
+function isItemExpanded( item: LinkedTree, text: string ) {
+	if ( ! text || ! item.children?.length ) return false;
+	return item.children.some( ( child ) => {
+		if ( new RegExp( text, 'ig' ).test( child.data.label ) ) {
+			return true;
+		}
+		return isItemExpanded( child, text );
+	} );
+}
+
+export const ExpandOnSearch: React.FC = () => {
+	const [ text, setText ] = useState( '' );
+
+	return (
+		<>
+			<TextControl value={ text } onChange={ setText } />
+			<BaseControl label="Expand on search" id="expand-on-search">
+				<TreeControl
+					id="expand-on-search"
+					items={ listItems }
+					isItemExpanded={ useCallback(
+						( item ) => isItemExpanded( item, text ),
+						[ text ]
+					) }
+				/>
+			</BaseControl>
+		</>
 	);
 };
 

--- a/packages/js/components/src/experimental-tree-control/stories/index.tsx
+++ b/packages/js/components/src/experimental-tree-control/stories/index.tsx
@@ -56,10 +56,9 @@ export const ExpandOnFilter: React.FC = () => {
 				<TreeControl
 					id="expand-on-filter"
 					items={ listItems }
-					shouldItemBeExpanded={ useCallback(
-						( item ) => shouldItemBeExpanded( item, filter ),
-						[ filter ]
-					) }
+					shouldItemBeExpanded={ ( item ) =>
+						shouldItemBeExpanded( item, filter )
+					}
 				/>
 			</BaseControl>
 		</>

--- a/packages/js/components/src/experimental-tree-control/tree-item.scss
+++ b/packages/js/components/src/experimental-tree-control/tree-item.scss
@@ -1,3 +1,5 @@
+$control-size: clac( $gap - $gap-smaller );
+
 .experimental-woocommerce-tree-item {
 	margin: 0;
 
@@ -29,6 +31,17 @@
 
 		> span {
 			display: block;
+		}
+	}
+	&__expander {
+		display: flex;
+		align-items: center;
+
+		.components-button {
+			padding: 0;
+			height: $control-size;
+			width: $control-size;
+			min-width: $control-size;
 		}
 	}
 }

--- a/packages/js/components/src/experimental-tree-control/tree-item.scss
+++ b/packages/js/components/src/experimental-tree-control/tree-item.scss
@@ -1,5 +1,3 @@
-$control-size: clac( $gap - $gap-smaller );
-
 .experimental-woocommerce-tree-item {
 	margin: 0;
 
@@ -39,9 +37,6 @@ $control-size: clac( $gap - $gap-smaller );
 
 		.components-button {
 			padding: 0;
-			height: $control-size;
-			width: $control-size;
-			min-width: $control-size;
 		}
 	}
 }

--- a/packages/js/components/src/experimental-tree-control/tree-item.tsx
+++ b/packages/js/components/src/experimental-tree-control/tree-item.tsx
@@ -43,11 +43,13 @@ export const TreeItem = forwardRef( function ForwardedTreeItem(
 				{ Boolean( item.children?.length ) && (
 					<div className="experimental-woocommerce-tree-item__expander">
 						<Button
-							icon={ expander.expanded ? chevronUp : chevronDown }
+							icon={
+								expander.isExpanded ? chevronUp : chevronDown
+							}
 							onClick={ expander.onToggleExpand }
 							className="experimental-woocommerce-tree-item__expander"
 							aria-label={
-								expander.expanded
+								expander.isExpanded
 									? __( 'Collapse', 'woocommerce' )
 									: __( 'Expand', 'woocommerce' )
 							}
@@ -56,7 +58,7 @@ export const TreeItem = forwardRef( function ForwardedTreeItem(
 				) }
 			</div>
 
-			{ Boolean( item.children.length ) && expander.expanded && (
+			{ Boolean( item.children.length ) && expander.isExpanded && (
 				<Tree { ...treeProps } />
 			) }
 		</li>

--- a/packages/js/components/src/experimental-tree-control/tree-item.tsx
+++ b/packages/js/components/src/experimental-tree-control/tree-item.tsx
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
+import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { chevronDown, chevronUp } from '@wordpress/icons';
 import classNames from 'classnames';
 import { createElement, forwardRef } from 'react';
 
@@ -16,10 +18,11 @@ export const TreeItem = forwardRef( function ForwardedTreeItem(
 	props: TreeItemProps,
 	ref: React.ForwardedRef< HTMLLIElement >
 ) {
-	const { item, treeItemProps, headingProps, treeProps } = useTreeItem( {
-		...props,
-		ref,
-	} );
+	const { item, treeItemProps, headingProps, treeProps, expander } =
+		useTreeItem( {
+			...props,
+			ref,
+		} );
 
 	return (
 		<li
@@ -36,9 +39,26 @@ export const TreeItem = forwardRef( function ForwardedTreeItem(
 				<div className="experimental-woocommerce-tree-item__label">
 					<span>{ item.data.label }</span>
 				</div>
+
+				{ Boolean( item.children?.length ) && (
+					<div className="experimental-woocommerce-tree-item__expander">
+						<Button
+							icon={ expander.expanded ? chevronUp : chevronDown }
+							onClick={ expander.onToggleExpand }
+							className="experimental-woocommerce-tree-item__expander"
+							aria-label={
+								expander.expanded
+									? __( 'Collapse', 'woocommerce' )
+									: __( 'Expand', 'woocommerce' )
+							}
+						/>
+					</div>
+				) }
 			</div>
 
-			{ Boolean( item.children.length ) && <Tree { ...treeProps } /> }
+			{ Boolean( item.children.length ) && expander.expanded && (
+				<Tree { ...treeProps } />
+			) }
 		</li>
 	);
 } );

--- a/packages/js/components/src/experimental-tree-control/tree-item.tsx
+++ b/packages/js/components/src/experimental-tree-control/tree-item.tsx
@@ -18,11 +18,16 @@ export const TreeItem = forwardRef( function ForwardedTreeItem(
 	props: TreeItemProps,
 	ref: React.ForwardedRef< HTMLLIElement >
 ) {
-	const { item, treeItemProps, headingProps, treeProps, expander } =
-		useTreeItem( {
-			...props,
-			ref,
-		} );
+	const {
+		item,
+		treeItemProps,
+		headingProps,
+		treeProps,
+		expander: { isExpanded, onToggleExpand },
+	} = useTreeItem( {
+		...props,
+		ref,
+	} );
 
 	return (
 		<li
@@ -43,13 +48,11 @@ export const TreeItem = forwardRef( function ForwardedTreeItem(
 				{ Boolean( item.children?.length ) && (
 					<div className="experimental-woocommerce-tree-item__expander">
 						<Button
-							icon={
-								expander.isExpanded ? chevronUp : chevronDown
-							}
-							onClick={ expander.onToggleExpand }
+							icon={ isExpanded ? chevronUp : chevronDown }
+							onClick={ onToggleExpand }
 							className="experimental-woocommerce-tree-item__expander"
 							aria-label={
-								expander.isExpanded
+								isExpanded
 									? __( 'Collapse', 'woocommerce' )
 									: __( 'Expand', 'woocommerce' )
 							}
@@ -58,7 +61,7 @@ export const TreeItem = forwardRef( function ForwardedTreeItem(
 				) }
 			</div>
 
-			{ Boolean( item.children.length ) && expander.isExpanded && (
+			{ Boolean( item.children.length ) && isExpanded && (
 				<Tree { ...treeProps } />
 			) }
 		</li>

--- a/packages/js/components/src/experimental-tree-control/types.ts
+++ b/packages/js/components/src/experimental-tree-control/types.ts
@@ -17,22 +17,22 @@ export type TreeProps = React.DetailedHTMLProps<
 	level?: number;
 	items: LinkedTree[];
 	/**
-	 * Control the tree item expand/collapse from outside the tree.
+	 * Control the tree item expand from outside the tree.
 	 * Cache the function to improve performance.
 	 *
 	 * @example
 	 * <Tree
-	 * 	isItemExpanded={ useCallback(
+	 * 	shouldItemBeExpanded={ useCallback(
 	 * 		( item ) => checkExpanded( item, text ),
 	 * 		[ text ]
 	 * 	) }
 	 * />
 	 *
-	 * @param  item The tree item to expand/collapse.
+	 * @param  item The tree item to check if should be expanded.
 	 *
 	 * @see {@link LinkedTree}
 	 */
-	isItemExpanded?( item: LinkedTree ): boolean;
+	shouldItemBeExpanded?( item: LinkedTree ): boolean;
 };
 
 export type TreeItemProps = React.DetailedHTMLProps<
@@ -41,7 +41,7 @@ export type TreeItemProps = React.DetailedHTMLProps<
 > & {
 	level: number;
 	item: LinkedTree;
-	isExpanded?( item: LinkedTree ): boolean;
+	shouldItemBeExpanded?( item: LinkedTree ): boolean;
 };
 
 export type TreeControlProps = Omit< TreeProps, 'items' | 'level' > & {

--- a/packages/js/components/src/experimental-tree-control/types.ts
+++ b/packages/js/components/src/experimental-tree-control/types.ts
@@ -17,9 +17,8 @@ export type TreeProps = React.DetailedHTMLProps<
 	level?: number;
 	items: LinkedTree[];
 	/**
-	 * It gives the possibility to control the tree item
-	 * expand/collapse on render from outside the tree.
-	 * Make sure to cache the function to improve performance.
+	 * Control the tree item expand/collapse from outside the tree.
+	 * Cache the function to improve performance.
 	 *
 	 * @example
 	 * <Tree
@@ -29,8 +28,7 @@ export type TreeProps = React.DetailedHTMLProps<
 	 * 	) }
 	 * />
 	 *
-	 * @param item The current linked tree item, useful to
-	 * traverse the entire linked tree from this item.
+	 * @param  item The tree item to expand/collapse.
 	 *
 	 * @see {@link LinkedTree}
 	 */

--- a/packages/js/components/src/experimental-tree-control/types.ts
+++ b/packages/js/components/src/experimental-tree-control/types.ts
@@ -16,6 +16,25 @@ export type TreeProps = React.DetailedHTMLProps<
 > & {
 	level?: number;
 	items: LinkedTree[];
+	/**
+	 * It gives the possibility to control the tree item
+	 * expand/collapse on render from outside the tree.
+	 * Make sure to cache the function to improve performance.
+	 *
+	 * @example
+	 * <Tree
+	 * 	isItemExpanded={ useCallback(
+	 * 		( item ) => checkExpanded( item, text ),
+	 * 		[ text ]
+	 * 	) }
+	 * />
+	 *
+	 * @param item The current linked tree item, useful to
+	 * traverse the entire linked tree from this item.
+	 *
+	 * @see {@link LinkedTree}
+	 */
+	isItemExpanded?( item: LinkedTree ): boolean;
 };
 
 export type TreeItemProps = React.DetailedHTMLProps<
@@ -24,6 +43,7 @@ export type TreeItemProps = React.DetailedHTMLProps<
 > & {
 	level: number;
 	item: LinkedTree;
+	isExpanded?( item: LinkedTree ): boolean;
 };
 
 export type TreeControlProps = Omit< TreeProps, 'items' | 'level' > & {

--- a/packages/js/components/src/experimental-tree-control/types.ts
+++ b/packages/js/components/src/experimental-tree-control/types.ts
@@ -17,7 +17,7 @@ export type TreeProps = React.DetailedHTMLProps<
 	level?: number;
 	items: LinkedTree[];
 	/**
-	 * Control the tree item expand from outside the tree.
+	 * Return if the tree item passed in should be expanded.
 	 * Cache the function to improve performance.
 	 *
 	 * @example
@@ -28,7 +28,7 @@ export type TreeProps = React.DetailedHTMLProps<
 	 * 	) }
 	 * />
 	 *
-	 * @param  item The tree item to check if should be expanded.
+	 * @param  item The tree item to determine if should be expanded.
 	 *
 	 * @see {@link LinkedTree}
 	 */

--- a/packages/js/components/src/experimental-tree-control/types.ts
+++ b/packages/js/components/src/experimental-tree-control/types.ts
@@ -18,14 +18,12 @@ export type TreeProps = React.DetailedHTMLProps<
 	items: LinkedTree[];
 	/**
 	 * Return if the tree item passed in should be expanded.
-	 * Cache the function to improve performance.
 	 *
 	 * @example
 	 * <Tree
-	 * 	shouldItemBeExpanded={ useCallback(
-	 * 		( item ) => checkExpanded( item, text ),
-	 * 		[ text ]
-	 * 	) }
+	 * 	shouldItemBeExpanded={
+	 * 		( item ) => checkExpanded( item, filter )
+	 * 	}
 	 * />
 	 *
 	 * @param  item The tree item to determine if should be expanded.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Depends on https://github.com/woocommerce/woocommerce/pull/36432
Partially addresses https://github.com/woocommerce/woocommerce/issues/35851

This PR adds expand/collapse functionality to the `TreeControl` component.

<img width="1025" alt="Screenshot 2023-01-27 at 11 55 53" src="https://user-images.githubusercontent.com/2098816/215147365-78ce215e-607c-45eb-8c00-cc470aeb79d1.png">

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

0. Build storybook (`pnpm --filter=@woocommerce/storybook build-storybook`)
1. Run storybook (`pnpm --filter=@woocommerce/storybook storybook`)
2. Visit `http://localhost:6007/?path=/story/woocommerce-admin-experimental-treecontrol--expand-on-search`
3. A basic tree control should be shown.
4. If you click the expander button at the end of the item the subtree should expand/collapse.
5. If you type in the text control above the tree should expand to show the matching children.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
