### PR TITLE
Remove deprecated usage of `${var}` syntax in strings

### DIFF
--- a/plugins/woocommerce/changelog/fix-deprecated-usage-of-var-syntax-in-strings
+++ b/plugins/woocommerce/changelog/fix-deprecated-usage-of-var-syntax-in-strings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix deprecated usage of ${var} in strings

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-payment-gateways.php
@@ -267,7 +267,7 @@ class WC_Settings_Payment_Gateways extends WC_Settings_Page {
 								foreach ( $plugin_suggestions as $plugin_suggestion ) {
 									$alt = str_replace( '.png', '', basename( $plugin_suggestion->image_72x72 ) );
 									// phpcs:ignore
-									echo "<img src='{$plugin_suggestion->image_72x72}' alt='${alt}' width='24' height='24' style='vertical-align: middle; margin-right: 8px;'/>";
+									echo "<img src='{$plugin_suggestion->image_72x72}' alt='{$alt}' width='24' height='24' style='vertical-align: middle; margin-right: 8px;'/>";
 								}
 								echo '& more.';
 							}

--- a/plugins/woocommerce/includes/admin/views/html-admin-page-status-tools.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-page-status-tools.php
@@ -39,7 +39,7 @@ foreach ( $tools as $action_name => $tool ) {
 								echo wp_kses_post( $selector['description'] );
 							}
 							// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-							echo "&nbsp;&nbsp;<select style='width: 300px;' form='form_$action_name' id='selector_$action_name' data-allow_clear='true' class='${selector['class']}' name='${selector['name']}' data-placeholder='${selector['placeholder']}' data-action='${selector['search_action']}'></select>";
+							echo "&nbsp;&nbsp;<select style='width: 300px;' form='form_$action_name' id='selector_$action_name' data-allow_clear='true' class='{$selector['class']}' name='{$selector['name']}' data-placeholder='{$selector['placeholder']}' data-action='{$selector['search_action']}'></select>";
 						}
 						?>
 					</p>

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1701,8 +1701,11 @@ function wc_get_shipping_method_count( $include_legacy = false, $enabled_only = 
 		return absint( $transient_value['value'] );
 	}
 
-	$where_clause = $enabled_only ? 'WHERE is_enabled=1' : '';
-	$method_count = absint( $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}woocommerce_shipping_zone_methods {$where_clause}" ) );
+	if ( $enabled_only ) {
+		$method_count = absint( $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}woocommerce_shipping_zone_methods WHERE is_enabled=1" ) );
+	} else {
+		$method_count = absint( $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}woocommerce_shipping_zone_methods" ) );
+	}
 
 	if ( $include_legacy ) {
 		// Count activated methods that don't support shipping zones.

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1702,7 +1702,7 @@ function wc_get_shipping_method_count( $include_legacy = false, $enabled_only = 
 	}
 
 	$where_clause = $enabled_only ? 'WHERE is_enabled=1' : '';
-	$method_count = absint( $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}woocommerce_shipping_zone_methods ${where_clause}" ) );
+	$method_count = absint( $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}woocommerce_shipping_zone_methods {$where_clause}" ) );
 
 	if ( $include_legacy ) {
 		// Count activated methods that don't support shipping zones.

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
@@ -118,7 +118,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 
 		if ( $query_args['customer_type'] ) {
 			$returning_customer = 'returning' === $query_args['customer_type'] ? 1 : 0;
-			$where_subquery[]   = "{$order_stats_lookup_table}.returning_customer = ${returning_customer}";
+			$where_subquery[]   = "{$order_stats_lookup_table}.returning_customer = {$returning_customer}";
 		}
 
 		$refund_subquery = $this->get_refund_subquery( $query_args );

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
@@ -378,7 +378,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			$this->update_intervals_sql_params( $query_args, $db_interval_count, $expected_interval_count, $table_name );
 			$this->interval_query->add_sql_clause( 'order_by', $this->get_sql_clause( 'order_by' ) );
 			$this->interval_query->add_sql_clause( 'limit', $this->get_sql_clause( 'limit' ) );
-			$this->interval_query->add_sql_clause( 'select', ", MAX(${table_name}.date_created) AS datetime_anchor" );
+			$this->interval_query->add_sql_clause( 'select', ", MAX({$table_name}.date_created) AS datetime_anchor" );
 			if ( '' !== $selections ) {
 				$this->interval_query->add_sql_clause( 'select', ', ' . $selections );
 			}
@@ -697,7 +697,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 
 		$wpdb->query(
 			$wpdb->prepare(
-				"UPDATE ${orders_stats_table} SET returning_customer = CASE WHEN order_id = %d THEN false ELSE true END WHERE customer_id = %d",
+				"UPDATE {$orders_stats_table} SET returning_customer = CASE WHEN order_id = %d THEN false ELSE true END WHERE customer_id = %d",
 				$order_id,
 				$customer_id
 			)

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
@@ -697,6 +697,9 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 
 		$wpdb->query(
 			$wpdb->prepare(
+				// phpcs:ignore Generic.Commenting.Todo.TaskFound
+				// TODO: use the %i placeholder to prepare the table name when available in the the minimum required WordPress version.
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				"UPDATE {$orders_stats_table} SET returning_customer = CASE WHEN order_id = %d THEN false ELSE true END WHERE customer_id = %d",
 				$order_id,
 				$customer_id

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/DataStore.php
@@ -188,7 +188,7 @@ class DataStore extends ProductsDataStore implements DataStoreInterface {
 
 			$this->interval_query->add_sql_clause( 'order_by', $this->get_sql_clause( 'order_by' ) );
 			$this->interval_query->add_sql_clause( 'limit', $this->get_sql_clause( 'limit' ) );
-			$this->interval_query->add_sql_clause( 'select', ", MAX(${table_name}.date_created) AS datetime_anchor" );
+			$this->interval_query->add_sql_clause( 'select', ", MAX({$table_name}.date_created) AS datetime_anchor" );
 			if ( '' !== $selections ) {
 				$this->interval_query->add_sql_clause( 'select', ', ' . $selections );
 			}

--- a/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/DataStore.php
@@ -226,7 +226,7 @@ class DataStore extends VariationsDataStore implements DataStoreInterface {
 
 			$this->interval_query->add_sql_clause( 'order_by', $this->get_sql_clause( 'order_by' ) );
 			$this->interval_query->add_sql_clause( 'limit', $this->get_sql_clause( 'limit' ) );
-			$this->interval_query->add_sql_clause( 'select', ", MAX(${table_name}.date_created) AS datetime_anchor" );
+			$this->interval_query->add_sql_clause( 'select', ", MAX({$table_name}.date_created) AS datetime_anchor" );
 			if ( '' !== $selections ) {
 				$this->interval_query->add_sql_clause( 'select', ', ' . $selections );
 			}

--- a/plugins/woocommerce/src/Admin/Features/Navigation/Menu.php
+++ b/plugins/woocommerce/src/Admin/Features/Navigation/Menu.php
@@ -463,10 +463,10 @@ class Menu {
 			? "&post_type={$taxonomy_object->object_type[0]}"
 			: '';
 		$match_expression   = 'term.php';                               // Match term.php pages.
-		$match_expression  .= "(?=.*[?|&]taxonomy=${taxonomy}(&|$|#))"; // Lookahead to match a taxonomy URL param.
+		$match_expression  .= "(?=.*[?|&]taxonomy={$taxonomy}(&|$|#))"; // Lookahead to match a taxonomy URL param.
 		$match_expression  .= '|';                                      // Or.
 		$match_expression  .= 'edit-tags.php';                          // Match edit-tags.php pages.
-		$match_expression  .= "(?=.*[?|&]taxonomy=${taxonomy}(&|$|#))"; // Lookahead to match a taxonomy URL param.
+		$match_expression  .= "(?=.*[?|&]taxonomy={$taxonomy}(&|$|#))"; // Lookahead to match a taxonomy URL param.
 
 		return array(
 			'default' => array_merge(

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -147,7 +147,7 @@ class CustomOrdersTableController {
 		wc_doing_it_wrong(
 			$class_and_method,
 			sprintf(
-				// translators: %1$s the name of the class and method used
+				// translators: %1$s the name of the class and method used.
 				__( '%1$s: The visibility of the custom orders table feature is now handled by the WooCommerce features engine. See the FeaturesController class, or go to WooCommerce - Settings - Advanced - Features.', 'woocommerce' ),
 				$class_and_method
 			),
@@ -165,7 +165,7 @@ class CustomOrdersTableController {
 		wc_doing_it_wrong(
 			$class_and_method,
 			sprintf(
-				// translators: %1$s the name of the class and method used
+				// translators: %1$s the name of the class and method used.
 				__( '%1$s: The visibility of the custom orders table feature is now handled by the WooCommerce features engine. See the FeaturesController class, or go to WooCommerce - Settings - Advanced - Features.', 'woocommerce' ),
 				$class_and_method
 			),

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -146,7 +146,11 @@ class CustomOrdersTableController {
 		$class_and_method = ( new \ReflectionClass( $this ) )->getShortName() . '::' . __FUNCTION__;
 		wc_doing_it_wrong(
 			$class_and_method,
-			__( "{$class_and_method}: The visibility of the custom orders table feature is now handled by the WooCommerce features engine. See the FeaturesController class, or go to WooCommerce - Settings - Advanced - Features.", 'woocommerce' ),
+			sprintf(
+				// translators: %1$s the name of the class and method used
+				__( '%1$s: The visibility of the custom orders table feature is now handled by the WooCommerce features engine. See the FeaturesController class, or go to WooCommerce - Settings - Advanced - Features.', 'woocommerce' ),
+				$class_and_method
+			),
 			'7.0'
 		);
 	}
@@ -160,7 +164,11 @@ class CustomOrdersTableController {
 		$class_and_method = ( new \ReflectionClass( $this ) )->getShortName() . '::' . __FUNCTION__;
 		wc_doing_it_wrong(
 			$class_and_method,
-			__( "{$class_and_method}: The visibility of the custom orders table feature is now handled by the WooCommerce features engine. See the FeaturesController class, or go to WooCommerce - Settings - Advanced - Features.", 'woocommerce' ),
+			sprintf(
+				// translators: %1$s the name of the class and method used
+				__( '%1$s: The visibility of the custom orders table feature is now handled by the WooCommerce features engine. See the FeaturesController class, or go to WooCommerce - Settings - Advanced - Features.', 'woocommerce' ),
+				$class_and_method
+			),
 			'7.0'
 		);
 	}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -146,7 +146,7 @@ class CustomOrdersTableController {
 		$class_and_method = ( new \ReflectionClass( $this ) )->getShortName() . '::' . __FUNCTION__;
 		wc_doing_it_wrong(
 			$class_and_method,
-			__( "${class_and_method}: The visibility of the custom orders table feature is now handled by the WooCommerce features engine. See the FeaturesController class, or go to WooCommerce - Settings - Advanced - Features.", 'woocommerce' ),
+			__( "{$class_and_method}: The visibility of the custom orders table feature is now handled by the WooCommerce features engine. See the FeaturesController class, or go to WooCommerce - Settings - Advanced - Features.", 'woocommerce' ),
 			'7.0'
 		);
 	}
@@ -160,7 +160,7 @@ class CustomOrdersTableController {
 		$class_and_method = ( new \ReflectionClass( $this ) )->getShortName() . '::' . __FUNCTION__;
 		wc_doing_it_wrong(
 			$class_and_method,
-			__( "${class_and_method}: The visibility of the custom orders table feature is now handled by the WooCommerce features engine. See the FeaturesController class, or go to WooCommerce - Settings - Advanced - Features.", 'woocommerce' ),
+			__( "{$class_and_method}: The visibility of the custom orders table feature is now handled by the WooCommerce features engine. See the FeaturesController class, or go to WooCommerce - Settings - Advanced - Features.", 'woocommerce' ),
 			'7.0'
 		);
 	}

--- a/plugins/woocommerce/src/Internal/DownloadPermissionsAdjuster.php
+++ b/plugins/woocommerce/src/Internal/DownloadPermissionsAdjuster.php
@@ -154,7 +154,7 @@ class DownloadPermissionsAdjuster {
 					'file' => $file,
 					'data' => (array) $permission->data,
 				);
-				$result['permission_data_by_file_order_user'][ "${file}:${permission_data['user_id']}:${permission_data['order_id']}" ] = $data;
+				$result['permission_data_by_file_order_user'][ "{$file}:{$permission_data['user_id']}:{$permission_data['order_id']}" ] = $data;
 			}
 		}
 

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -395,7 +395,7 @@ class FeaturesController {
 			return Init::TOGGLE_OPTION_NAME;
 		}
 
-		return "woocommerce_feature_${feature_id}_enabled";
+		return "woocommerce_feature_{$feature_id}_enabled";
 	}
 
 	/**

--- a/plugins/woocommerce/src/Utilities/FeaturesUtil.php
+++ b/plugins/woocommerce/src/Utilities/FeaturesUtil.php
@@ -59,7 +59,7 @@ class FeaturesUtil {
 
 		if ( ! $plugin_id ) {
 			$logger = wc_get_logger();
-			$logger->error( "FeaturesUtil::declare_compatibility: ${plugin_file} is not a known WordPress plugin." );
+			$logger->error( "FeaturesUtil::declare_compatibility: {$plugin_file} is not a known WordPress plugin." );
 			return false;
 		}
 

--- a/plugins/woocommerce/tests/Tools/CodeHacking/Hacks/FunctionsMockerHack.php
+++ b/plugins/woocommerce/tests/Tools/CodeHacking/Hacks/FunctionsMockerHack.php
@@ -36,6 +36,13 @@ use ReflectionClass;
  */
 final class FunctionsMockerHack extends CodeHack {
 	/**
+	 * An array containing the names of the functions that will become mockable.
+	 *
+	 * @var array
+	 */
+	private $mockable_functions;
+
+	/**
 	 * Tokens that precede a non-standalone-function identifier.
 	 *
 	 * @var array

--- a/plugins/woocommerce/tests/Tools/CodeHacking/Hacks/StaticMockerHack.php
+++ b/plugins/woocommerce/tests/Tools/CodeHacking/Hacks/StaticMockerHack.php
@@ -35,6 +35,12 @@ namespace Automattic\WooCommerce\Testing\Tools\CodeHacking\Hacks;
  * executed inside tests (and thus the above example won't stack-overflow).
  */
 final class StaticMockerHack extends CodeHack {
+	/**
+	 * An associative array of class name => array of class methods.
+	 *
+	 * @var array
+	 */
+	private $mockable_classes;
 
 	/**
 	 * @var StaticMockerHack Holds the only existing instance of the class.

--- a/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-setup-test.php
+++ b/plugins/woocommerce/tests/php/includes/admin/class-wc-admin-dashboard-setup-test.php
@@ -165,7 +165,7 @@ class WC_Admin_Dashboard_Setup_Test extends WC_Unit_Test_Case {
 		);
 
 		foreach ( $required_strings as $required_string ) {
-			$this->assertRegexp( "/${required_string}/", $html );
+			$this->assertRegexp( "/{$required_string}/", $html );
 		}
 	}
 
@@ -191,7 +191,7 @@ class WC_Admin_Dashboard_Setup_Test extends WC_Unit_Test_Case {
 		if ( $completed_tasks_count === $tasks_count ) {
 			$this->assertEmpty( $this->get_widget_output() );
 		} else {
-			$this->assertRegexp( "/Step ${step_number} of 6/", $this->get_widget_output() );
+			$this->assertRegexp( "/Step {$step_number} of 6/", $this->get_widget_output() );
 		}
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-example.php
+++ b/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-example.php
@@ -26,7 +26,7 @@ class WC_Settings_Example extends WC_Settings_Page {
 	}
 
 	protected function get_settings_for_section_core( $section_id ) {
-		return array( "${section_id}_key" => "${section_id}_value" );
+		return array( "{$section_id}_key" => "{$section_id}_value" );
 	}
 
 	protected function get_own_sections() {

--- a/plugins/woocommerce/tests/php/src/Internal/Traits/AccessiblePrivateMethodsTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Traits/AccessiblePrivateMethodsTest.php
@@ -419,8 +419,8 @@ class AccessiblePrivateMethodsTest extends \WC_Unit_Test_Case {
 			use AccessiblePrivateMethods;
 		};
 
-		$method_name        = "add_${action_or_filter}";
-		$proper_method_name = "add_static_${action_or_filter}";
+		$method_name        = "add_{$action_or_filter}";
+		$proper_method_name = "add_static_{$action_or_filter}";
 
 		$this->expectException( \Error::class );
 		$this->expectExceptionMessage( get_class( $sut ) . '::' . "$method_name can't be called statically, did you mean '$proper_method_name'?" );

--- a/tools/monorepo/check-changelogger-use.php
+++ b/tools/monorepo/check-changelogger-use.php
@@ -70,9 +70,9 @@ if ( $verbose ) {
 	 */
 	function debug( ...$args ) {
 		if ( getenv( 'CI' ) ) {
-			$args[0] = "\e[34m${args[0]}\e[0m\n";
+			$args[0] = "\e[34m{$args[0]}\e[0m\n";
 		} else {
-			$args[0] = "\e[1;30m${args[0]}\e[0m\n";
+			$args[0] = "\e[1;30m{$args[0]}\e[0m\n";
 		}
 		fprintf( STDERR, ...$args );
 	}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

This Pull Request updates WooCommerce files to remove the deprecated usage of `${var}` syntax in string interpolation with the recommended `{$var}` syntax.

This PR also declares two properties that were being dynamically created in the `FunctionsMockerHack` and `StaticMockerHack` classes. Without those changes I was getting errors while running tests with PHP 8.2.

### Closes

This PR should fix some of the warnings/notices described in https://github.com/woocommerce/woocommerce/issues/35763 but doesn't cover them all. In particular, I believe that the `Creation of dynamic property ...` warnings described in that issue require separate PRs for each one of the affected classes. The solution approach and testing instructions can be different.

### How to test the changes in this Pull Request:

There are no application behavior modifications in this PR so I expect that automated tests and human code review are enough to confirm that the changes work.

If you think we should user test each of the modified files, then I can split the PR into smaller ones and try to come up with detailed instructions for the various areas.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
