### PR TITLE
Add an admin notice about the upcoming change in PHP requirements (PHP 7.3)

### DIFF
--- a/plugins/woocommerce/changelog/add-php-73-version-bump-notice
+++ b/plugins/woocommerce/changelog/add-php-73-version-bump-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add an admin notice about the upcoming PHP version requirement change for PHP 7.2 users

--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -123,6 +123,8 @@ class WC_Admin_Notices {
 		self::maybe_add_php73_required_notice();
 	}
 
+	// phpcs:disable Generic.Commenting.Todo.TaskFound
+
 	/**
 	 * Add an admin notice about the bump of the required PHP version in WooCommerce 7.7
 	 * if the current PHP version is too old.
@@ -151,6 +153,8 @@ class WC_Admin_Notices {
 			self::remove_notice( 'php73_required_in_woo_77' );
 		}
 	}
+
+	// phpcs:enable Generic.Commenting.Todo.TaskFound
 
 	/**
 	 * Show a notice.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -8,6 +8,7 @@
 
 use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Internal\Utilities\Users;
+use Automattic\WooCommerce\Internal\Traits\AccessiblePrivateMethods;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -15,6 +16,8 @@ defined( 'ABSPATH' ) || exit;
  * WC_Admin_Notices Class.
  */
 class WC_Admin_Notices {
+
+	use AccessiblePrivateMethods;
 
 	/**
 	 * Stores notices.
@@ -54,6 +57,7 @@ class WC_Admin_Notices {
 		add_action( 'woocommerce_installed', array( __CLASS__, 'reset_admin_notices' ) );
 		add_action( 'wp_loaded', array( __CLASS__, 'add_redirect_download_method_notice' ) );
 		add_action( 'admin_init', array( __CLASS__, 'hide_notices' ), 20 );
+		self::add_action( 'admin_init', array( __CLASS__, 'maybe_remove_php73_required_notice' ) );
 
 		// @TODO: This prevents Action Scheduler async jobs from storing empty list of notices during WC installation.
 		// That could lead to OBW not starting and 'Run setup wizard' notice not appearing in WP admin, which we want
@@ -116,6 +120,36 @@ class WC_Admin_Notices {
 		self::add_notice( 'template_files' );
 		self::add_min_version_notice();
 		self::add_maxmind_missing_license_key_notice();
+		self::maybe_add_php73_required_notice();
+	}
+
+	/**
+	 * Add an admin notice about the bump of the required PHP version in WooCommerce 7.7
+	 * if the current PHP version is too old.
+	 *
+	 * TODO: Remove this method in WooCommerce 7.7.
+	 */
+	private static function maybe_add_php73_required_notice() {
+		if ( version_compare( phpversion(), '7.3', '>=' ) ) {
+			return;
+		}
+
+		self::add_custom_notice(
+			'php73_required_in_woo_77',
+			__( '<h4>PHP version requirements will change soon</h4><p>WooCommerce 7.7, scheduled for <b>May 2023</b>, will require PHP 7.3 or newer to work. Your server is currently running an older version of PHP, so this change will impact your store. Upgrading to at least PHP 8.0 is recommended. <b><a href="https://developer.woocommerce.com/2023/01/10/new-requirement-for-woocommerce-7-7-php-7-3/">Learn more about this change.</a></b></p>', 'woocommerce' )
+		);
+	}
+
+	/**
+	 * Remove the admin notice about the bump of the required PHP version in WooCommerce 7.7
+	 * if the current PHP version is good.
+	 *
+	 * TODO: Remove this method in WooCommerce 7.7.
+	 */
+	private static function maybe_remove_php73_required_notice() {
+		if ( version_compare( phpversion(), '7.3', '>=' ) && self::has_notice( 'php73_required_in_woo_77' ) ) {
+			self::remove_notice( 'php73_required_in_woo_77' );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -145,6 +145,7 @@ class WC_Admin_Notices {
 					esc_html__( 'PHP version requirements will change soon', 'woocommerce' )
 				),
 				sprintf(
+					// translators: Placeholder is a URL.
 					wpautop( wp_kses_data( __( 'WooCommerce 7.7, scheduled for <b>May 2023</b>, will require PHP 7.3 or newer to work. Your server is currently running an older version of PHP, so this change will impact your store. Upgrading to at least PHP 8.0 is recommended. <b><a href="%s">Learn more about this change.</a></b>', 'woocommerce' ) ) ),
 					'https://developer.woocommerce.com/2023/01/10/new-requirement-for-woocommerce-7-7-php-7-3/'
 				)

--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -138,7 +138,17 @@ class WC_Admin_Notices {
 
 		self::add_custom_notice(
 			'php73_required_in_woo_77',
-			__( '<h4>PHP version requirements will change soon</h4><p>WooCommerce 7.7, scheduled for <b>May 2023</b>, will require PHP 7.3 or newer to work. Your server is currently running an older version of PHP, so this change will impact your store. Upgrading to at least PHP 8.0 is recommended. <b><a href="https://developer.woocommerce.com/2023/01/10/new-requirement-for-woocommerce-7-7-php-7-3/">Learn more about this change.</a></b></p>', 'woocommerce' )
+			sprintf(
+				'%s%s',
+				sprintf(
+					'<h4>%s</h4>',
+					esc_html__( 'PHP version requirements will change soon', 'woocommerce' )
+				),
+				sprintf(
+					wpautop( wp_kses_data( __( 'WooCommerce 7.7, scheduled for <b>May 2023</b>, will require PHP 7.3 or newer to work. Your server is currently running an older version of PHP, so this change will impact your store. Upgrading to at least PHP 8.0 is recommended. <b><a href="%s">Learn more about this change.</a></b>', 'woocommerce' ) ) ),
+					'https://developer.woocommerce.com/2023/01/10/new-requirement-for-woocommerce-7-7-php-7-3/'
+				)
+			)
 		);
 	}
 


### PR DESCRIPTION
-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

The minimum required PHP version will be 7.3 as of WooCommerce 7.7. This pull request adds a dismissable admin notice visible when PHP 7.2 is used:

![image](https://user-images.githubusercontent.com/937723/212655186-99145617-490f-46b6-a060-2357f28ec9d2.png)

The notice is created (if needed) when the theme is switched or a new version of WooCommerce is installed.

This pull request is a re-edition of https://github.com/woocommerce/woocommerce/pull/31557.

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Run the following in command line to simulate a new WooCommerce version installed, this will also attempt to clear some user meta that doesn't exist yet:

```
wp eval 'WC_Admin_Notices::reset_admin_notices(); delete_user_meta(get_current_user_id(), "dismissed_php73_required_in_woo_77_notice");' --user=<your WP user name or id>
```

2. Switch to PHP 7.3 and load any admin page, e.g. orders. You shouldn't see any notice.

3. Switch to PHP 7.2, repeat step 1, and load the admin page again. You should see the notice.

4. Switch to PHP 7.3, reload the admin page (DON'T repeat step 1 this time), and you should see that the notice has disappeared.

5. Switch to PHP 7.2, repeat step 1, reload the admin page, and click the "Dismiss" button. The notice shouldn't appear anymore unless you repeat step 1.

1+2 simulates a user that was already on PHP 7.3+ at the time of upgrading to the WooCommerce release that includes this pull request, nothing will happen for these users; 3+4 simulates a user that upgrades his PHP without dismissing the notice; and 3+5 simulates a user that dismisses the notice without (or before) upgrading his PHP. 


### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
