### PR TITLE
fixing typo in name of country in states(i18n) file

### DIFF
--- a/plugins/woocommerce/changelog/fix-i18n-states-comment-typo
+++ b/plugins/woocommerce/changelog/fix-i18n-states-comment-typo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Corrects a typo in the i18n/states.php file, relating to our list of Iranian states.

--- a/plugins/woocommerce/i18n/states.php
+++ b/plugins/woocommerce/i18n/states.php
@@ -815,7 +815,7 @@ return array(
 		'LD' => __( 'Lakshadeep', 'woocommerce' ),
 		'PY' => __( 'Pondicherry (Puducherry)', 'woocommerce' ),
 	),
-	'IR' => array( // Irania states.
+	'IR' => array( // Iranian states.
 		'KHZ' => __( 'Khuzestan (خوزستان)', 'woocommerce' ),
 		'THR' => __( 'Tehran (تهران)', 'woocommerce' ),
 		'ILM' => __( 'Ilaam (ایلام)', 'woocommerce' ),


### PR DESCRIPTION
### All Submissions:

-   [x ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

this is just a simple typo fix in name of Iran country in the comments of the states.php file in i18n 

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [x ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).