### PR TITLE
Restore pre-7.2.0 quantity selector behavior

### DIFF
--- a/plugins/woocommerce/changelog/fix-36007-quantity-selector
+++ b/plugins/woocommerce/changelog/fix-36007-quantity-selector
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Restore the pre-7.2.0 behavior for single product quantity inputs.

--- a/plugins/woocommerce/changelog/fix-36007-sold-individually
+++ b/plugins/woocommerce/changelog/fix-36007-sold-individually
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-By default, hide the quantity selector within the single product page if a product is sold individually.

--- a/plugins/woocommerce/changelog/fix-36007-sold-individually-amendment
+++ b/plugins/woocommerce/changelog/fix-36007-sold-individually-amendment
@@ -1,5 +1,0 @@
-Significance: patch
-Type: tweak
-Comment: We're tweaking an unreleased change which is already covered by a changelog entry added in PR#36350.
-
-

--- a/plugins/woocommerce/client/legacy/css/_common.scss
+++ b/plugins/woocommerce/client/legacy/css/_common.scss
@@ -1,8 +1,0 @@
-/**
- * Contains rules common to all supported frontend themes.
- */
-
-/* We do not wish to display the quantity selector (within single product pages) if the product is sold individually. */
-.woocommerce.single-product .product.sold-individually .quantity {
-	display: none;
-}

--- a/plugins/woocommerce/client/legacy/css/twenty-nineteen.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-nineteen.scss
@@ -1,4 +1,3 @@
-@import "common";
 @import 'mixins';
 
 /**

--- a/plugins/woocommerce/client/legacy/css/twenty-seventeen.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-seventeen.scss
@@ -1,7 +1,6 @@
 /**
  * Twenty Seventeen integration styles
  */
-@import "common";
 @import "mixins";
 @import "animation";
 

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-one.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-one.scss
@@ -1,4 +1,3 @@
-@import "common";
 @import "mixins";
 
 /**

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -25,7 +25,6 @@
 	font-style: normal;
 }
 
-@import "common";
 @import "mixins";
 @import "animation";
 

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
@@ -25,7 +25,6 @@
 	font-style: normal;
 }
 
-@import "common";
 @import "mixins";
 @import "animation";
 @import "variables";

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty.scss
@@ -1,4 +1,3 @@
-@import "common";
 @import "mixins";
 
 /**

--- a/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
@@ -2,7 +2,6 @@
 * woocommerce-blocktheme.scss
 * Block theme default styles to ensure WooCommerce looks better out of the box with block themes that are not optimised for WooCommerce specifically.
 */
-@import "common";
 @import "fonts";
 @import "variables";
 

--- a/plugins/woocommerce/client/legacy/css/woocommerce.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce.scss
@@ -7,7 +7,6 @@
 /**
  * Imports
  */
-@import "common";
 @import "mixins";
 @import "variables";
 @import "animation";

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -1797,6 +1797,7 @@ if ( ! function_exists( 'woocommerce_quantity_input' ) ) {
 			// When autocomplete is enabled in firefox, it will overwrite actual value with what user entered last. So we default to off.
 			// See @link https://github.com/woocommerce/woocommerce/issues/30733.
 			'autocomplete' => apply_filters( 'woocommerce_quantity_input_autocomplete', 'off', $product ),
+			'readonly'     => false,
 		);
 
 		$args = apply_filters( 'woocommerce_quantity_input_args', wp_parse_args( $args, $defaults ), $product );
@@ -1810,8 +1811,25 @@ if ( ! function_exists( 'woocommerce_quantity_input' ) ) {
 			$args['max_value'] = $args['min_value'];
 		}
 
-		ob_start();
+		/**
+		 * The input type attribute will generally be 'number' unless the quantity cannot be changed, in which case
+		 * it will be set to 'hidden'. An exception is made for non-hidden readonly inputs: in this case we set the
+		 * type to 'text' (this prevents most browsers from rendering increment/decrement arrows, which are useless
+		 * and/or confusing in this context).
+		 */
+		$type = $args['min_value']  > 0 && $args['min_value'] === $args['max_value'] ? 'hidden' : 'number';
+		$type = $args['readonly'] && $type !== 'hidden' ? 'text' : $type;
 
+		/**
+		 * Controls the quantity input's type attribute.
+		 *
+		 * @since 7.4.0
+		 *
+		 * @param string $type A valid input type attribute value, usually 'number' or 'hidden'.
+		 */
+		$args['type'] = apply_filters( 'woocommerce_quantity_input_type', $type );
+
+		ob_start();
 		wc_get_template( 'global/quantity-input.php', $args );
 
 		if ( $echo ) {

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -1817,8 +1817,8 @@ if ( ! function_exists( 'woocommerce_quantity_input' ) ) {
 		 * type to 'text' (this prevents most browsers from rendering increment/decrement arrows, which are useless
 		 * and/or confusing in this context).
 		 */
-		$type = $args['min_value']  > 0 && $args['min_value'] === $args['max_value'] ? 'hidden' : 'number';
-		$type = $args['readonly'] && $type !== 'hidden' ? 'text' : $type;
+		$type = $args['min_value'] > 0 && $args['min_value'] === $args['max_value'] ? 'hidden' : 'number';
+		$type = $args['readonly'] && 'hidden' !== $type ? 'text' : $type;
 
 		/**
 		 * Controls the quantity input's type attribute.

--- a/plugins/woocommerce/templates/global/quantity-input.php
+++ b/plugins/woocommerce/templates/global/quantity-input.php
@@ -45,7 +45,7 @@ $label = ! empty( $args['product_name'] ) ? sprintf( esc_html__( '%s quantity', 
 		size="4"
 		min="<?php echo esc_attr( $min_value ); ?>"
 		max="<?php echo esc_attr( 0 < $max_value ? $max_value : '' ); ?>"
-		<?php if ( ! $readonly ): ?>
+		<?php if ( ! $readonly ) : ?>
 			step="<?php echo esc_attr( $step ); ?>"
 			placeholder="<?php echo esc_attr( $placeholder ); ?>"
 			inputmode="<?php echo esc_attr( $inputmode ); ?>"

--- a/plugins/woocommerce/templates/global/quantity-input.php
+++ b/plugins/woocommerce/templates/global/quantity-input.php
@@ -12,7 +12,10 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.2.1
+ * @version 7.4.0
+ *
+ * @var bool   $readonly If the input should be set to readonly mode.
+ * @var string $type     The input type attribute.
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -20,13 +23,6 @@ defined( 'ABSPATH' ) || exit;
 /* translators: %s: Quantity. */
 $label = ! empty( $args['product_name'] ) ? sprintf( esc_html__( '%s quantity', 'woocommerce' ), wp_strip_all_tags( $args['product_name'] ) ) : esc_html__( 'Quantity', 'woocommerce' );
 
-// In some cases we wish to display the quantity but not allow for it to be changed.
-if ( $max_value && $min_value === $max_value ) {
-	$is_readonly = true;
-	$input_value = $min_value;
-} else {
-	$is_readonly = false;
-}
 ?>
 <div class="quantity">
 	<?php
@@ -39,8 +35,8 @@ if ( $max_value && $min_value === $max_value ) {
 	?>
 	<label class="screen-reader-text" for="<?php echo esc_attr( $input_id ); ?>"><?php echo esc_attr( $label ); ?></label>
 	<input
-		type="<?php echo $is_readonly ? 'text' : 'number'; ?>"
-		<?php echo $is_readonly ? 'readonly="readonly"' : ''; ?>
+		type="<?php echo esc_attr( $type ); ?>"
+		<?php echo $readonly ? 'readonly="readonly"' : ''; ?>
 		id="<?php echo esc_attr( $input_id ); ?>"
 		class="<?php echo esc_attr( join( ' ', (array) $classes ) ); ?>"
 		name="<?php echo esc_attr( $input_name ); ?>"
@@ -49,7 +45,7 @@ if ( $max_value && $min_value === $max_value ) {
 		size="4"
 		min="<?php echo esc_attr( $min_value ); ?>"
 		max="<?php echo esc_attr( 0 < $max_value ? $max_value : '' ); ?>"
-		<?php if ( ! $is_readonly ): ?>
+		<?php if ( ! $readonly ): ?>
 			step="<?php echo esc_attr( $step ); ?>"
 			placeholder="<?php echo esc_attr( $placeholder ); ?>"
 			inputmode="<?php echo esc_attr( $inputmode ); ?>"


### PR DESCRIPTION
The product quantity selector has gone through a number of changes. To understand this latest PR, I want to start by summarizing its recent history:

- Prior to 7.2.0, if the product quantity selector's min and max values were the same (ie, it could not be modified), it would render as a hidden input. Otherwise, it rendered as a regular number input.
- In 7.2.0 we merged a change making it so the selector would render even when the [min and max values are the same (but in readonly mode)](https://github.com/woocommerce/woocommerce/pull/34282). The idea was to make the UI consistent across products, and make the purchase quantity obvious to customers.
- This [met with resistance](https://github.com/woocommerce/woocommerce/issues/36007), with many users reporting they preferred the previous behaviour.
- CSS based attempts at a compromise [[1]](https://github.com/woocommerce/woocommerce/pull/36350) [[2]](https://github.com/woocommerce/woocommerce/pull/36384) in which we would hide the input if the product was sold individually were attempted, but also proved to be problematic. 

So, in this change, we essentially restore the behavior we had before the 7.2.0 release. However, we are also tweaking an existing filter hook and adding one more, making it possible to achieve the objectives of the [original PR](https://github.com/woocommerce/woocommerce/pull/34282) without implementing a template override.

Updates #36007.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Ensure you have one product that is sold individually, and another regular product.
2. Visit the single product page of each:
    - For the sold individually product, the quantity input should be hidden.
    - For the regular product, the quantity input should be visible.
3. Add each item to the cart. Within the cart page:
    - The sold individually product quantity selector should be hidden.
    - The regular product should have a visible quantity selector.

<img width="1061" alt="restored-pre-720-behavior" src="https://user-images.githubusercontent.com/3594411/212782683-daeef9e2-cfd9-452f-b7b6-3fbb4200a327.png">

Let's now test that we can achieve the goals of [PR#34282](https://github.com/woocommerce/woocommerce/pull/34282) by adding the following code to an appropriate location (such as `wp-content/mu-plugins/test-quantity-selectors.php`):

```php
<?php
/**
 * This snippet can be used to force the quantity input to display in cases where
 * the input value cannot be changed (which is when the product is set to be sold
 * individually, or when the min and max values are identical).
 */
add_filter( 'woocommerce_quantity_input_args', function ( array $args ) {
	// Only modify inputs where the max value is set and is equal to the min value.
	if ( $args['max_value'] < 1 || $args['min_value'] !== $args['max_value'] ) {
		return $args;
	}

	// Convert into a text input.
	add_filter( 'woocommerce_quantity_input_type', function () {
		return 'text';
	} );

	// Set to readonly.
	$args['readonly'] = true;
	return $args;
} );
```

Now, if you repeat the above tests, you should find the quantity selector **always** displays, even for products that are sold individually. However, in these cases it will be a readonly text input.
<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
