### PR TITLE
add: slot for header banner slotfill

### DIFF
--- a/plugins/woocommerce-admin/client/homescreen/header-banner-slot/header-banner-slot.tsx
+++ b/plugins/woocommerce-admin/client/homescreen/header-banner-slot/header-banner-slot.tsx
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import { useSlot } from '@woocommerce/experimental';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import {
+	EXPERIMENTAL_WC_HOMESCREEN_HEADER_BANNER_SLOT_NAME,
+	WooHomescreenHeaderBannerItem,
+} from './utils';
+
+export const WooHomescreenHeaderBanner = ( {
+	className,
+}: {
+	className: string;
+} ) => {
+	const slot = useSlot( EXPERIMENTAL_WC_HOMESCREEN_HEADER_BANNER_SLOT_NAME );
+	const hasFills = Boolean( slot?.fills?.length );
+
+	if ( ! hasFills ) {
+		return null;
+	}
+	return (
+		<div
+			className={ classnames(
+				'woocommerce-homescreen__header',
+				className
+			) }
+		>
+			<WooHomescreenHeaderBannerItem.Slot />
+		</div>
+	);
+};

--- a/plugins/woocommerce-admin/client/homescreen/header-banner-slot/index.ts
+++ b/plugins/woocommerce-admin/client/homescreen/header-banner-slot/index.ts
@@ -1,0 +1,2 @@
+export * from './header-banner-slot';
+export * from './utils';

--- a/plugins/woocommerce-admin/client/homescreen/header-banner-slot/utils.tsx
+++ b/plugins/woocommerce-admin/client/homescreen/header-banner-slot/utils.tsx
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import { Slot, Fill } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { createOrderedChildren, sortFillsByOrder } from '../../utils';
+
+export const EXPERIMENTAL_WC_HOMESCREEN_HEADER_BANNER_SLOT_NAME =
+	'woocommerce_homescreen_experimental_header_banner_item';
+/**
+ * Create a Fill for extensions to add items to the WooCommerce Admin Homescreen header banner.
+ *
+ * @slotFill WooHomescreenHeaderBannerItem
+ * @scope woocommerce-admin
+ * @example
+ * const MyHeaderItem = () => (
+ * <WooHomescreenHeaderBannerItem>My header item</WooHomescreenHeaderBannerItem>
+ * );
+ *
+ * registerPlugin( 'my-extension', {
+ * render: MyHeaderItem,
+ * scope: 'woocommerce-admin',
+ * } );
+ * @param {Object} param0
+ * @param {Array}  param0.children - Node children.
+ * @param {Array}  param0.order    - Node order.
+ */
+export const WooHomescreenHeaderBannerItem = ( {
+	children,
+	order = 1,
+}: {
+	children: React.ReactNode;
+	order?: number;
+} ) => {
+	return (
+		<Fill name={ EXPERIMENTAL_WC_HOMESCREEN_HEADER_BANNER_SLOT_NAME }>
+			{ ( fillProps: Fill.Props ) => {
+				return createOrderedChildren( children, order, fillProps );
+			} }
+		</Fill>
+	);
+};
+
+WooHomescreenHeaderBannerItem.Slot = ( {
+	fillProps,
+}: {
+	fillProps?: Slot.Props;
+} ) => (
+	<Slot
+		name={ EXPERIMENTAL_WC_HOMESCREEN_HEADER_BANNER_SLOT_NAME }
+		fillProps={ fillProps }
+	>
+		{ sortFillsByOrder }
+	</Slot>
+);

--- a/plugins/woocommerce-admin/client/homescreen/layout.js
+++ b/plugins/woocommerce-admin/client/homescreen/layout.js
@@ -43,6 +43,7 @@ import './style.scss';
 import '../dashboard/style.scss';
 import { getAdminSetting } from '~/utils/admin-settings';
 import { ProgressTitle } from '../task-lists';
+import { WooHomescreenHeaderBanner } from './header-banner-slot';
 
 const Tasks = lazy( () =>
 	import( /* webpackChunkName: "tasks" */ '../tasks' ).then( ( module ) => ( {
@@ -126,7 +127,9 @@ export const Layout = ( {
 		return (
 			<Suspense fallback={ <TasksPlaceholder query={ query } /> }>
 				{ activeSetupTaskList && isDashboardShown && (
-					<ProgressTitle taskListId={ activeSetupTaskList } />
+					<>
+						<ProgressTitle taskListId={ activeSetupTaskList } />
+					</>
 				) }
 				<Tasks query={ query } />
 			</Suspense>
@@ -135,6 +138,13 @@ export const Layout = ( {
 
 	return (
 		<>
+			{ isDashboardShown && (
+				<WooHomescreenHeaderBanner
+					className={ classnames( 'woocommerce-homescreen', {
+						'woocommerce-homescreen-column': ! twoColumns,
+					} ) }
+				/>
+			) }
 			<div
 				className={ classnames( 'woocommerce-homescreen', {
 					'two-columns': twoColumns,

--- a/plugins/woocommerce/changelog/add-wcadmin-home-header-banner-slotfill
+++ b/plugins/woocommerce/changelog/add-wcadmin-home-header-banner-slotfill
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Added a slot for extending the app with a homescreen header banner


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Slot was added to the wcadmin homescreen in the header banner area, for extensibility reasons.

https://user-images.githubusercontent.com/27843274/212839628-37ec7841-9fbd-449a-b422-94711f80d7e9.mp4

Closes #36462.

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Checkout this branch first
2. Rebase `demo/example-header-banner-fill` on top or cherry pick the relevant [commit](https://github.com/woocommerce/woocommerce/commit/4bcab76840a242165327bc64e02e320f063e6b1e) for the demo header banner fill
3. Observe the demo fill should look like the above screencap

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
