### PR TITLE
Fix tax task showing as not completed after setting up tax

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/fills/tax/index.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/tax/index.tsx
@@ -92,20 +92,34 @@ const Tax: React.FC< TaxProps > = ( { onComplete, query, task } ) => {
 		}
 	}, [] );
 
-	const onAutomate = useCallback( () => {
+	const onAutomate = useCallback( async () => {
 		setIsPending( true );
-		updateAndPersistSettingsForGroup( 'tax', {
-			tax: {
-				...taxSettings,
-				wc_connect_taxes_enabled: 'yes',
-			},
-		} );
-		updateAndPersistSettingsForGroup( 'general', {
-			general: {
-				...generalSettings,
-				woocommerce_calc_taxes: 'yes',
-			},
-		} );
+		try {
+			await Promise.all( [
+				updateAndPersistSettingsForGroup( 'tax', {
+					tax: {
+						...taxSettings,
+						wc_connect_taxes_enabled: 'yes',
+					},
+				} ),
+				updateAndPersistSettingsForGroup( 'general', {
+					general: {
+						...generalSettings,
+						woocommerce_calc_taxes: 'yes',
+					},
+				} ),
+			] );
+		} catch ( error: unknown ) {
+			setIsPending( false );
+			createNotice(
+				'error',
+				__(
+					'There was a problem setting up automated taxes. Please try again.',
+					'woocommerce'
+				)
+			);
+			return;
+		}
 
 		createNotice(
 			'success',

--- a/plugins/woocommerce/changelog/fix-tax-task-not-completed
+++ b/plugins/woocommerce/changelog/fix-tax-task-not-completed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix tax task showing as not completed after setting up tax


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #35745.

Wait for requests to finish before redirecting to make sure the [wc_connect_taxes_enabled](https://github.com/woocommerce/woocommerce/blob/9fabda744ae49099a525c8e54632adfe91f22f61/plugins/woocommerce-admin/client/tasks/fills/tax/index.tsx#L100) option is set synchronously.

Ideally, we should also add a test for it, but it's a bit challenging because it requires a Jetpack connection to complete the flow. I think we can tackle this problem when we start to work on the e2e project.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. In a new site, skip OBW
2. Go to `WooCommerce > Home > Add tax rates`
3. Do all the steps and connect the site
4. Click on "Yes please" button when seeing "Jetpack and WooCommerce Tax can automate your sales tax calculations" texts.
5. Observe that the tax task is marked as completed

<!-- End testing instructions -->

You can use this [release zip file](https://github.com/woocommerce/woocommerce/actions/runs/3937194291) for testing.


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.


https://user-images.githubusercontent.com/4344253/212846119-801bdddd-2e08-4943-bb3b-e2798fde7b41.mov


