### PR TITLE
Add slot for ProgressHeader and ProgressTitle

### DIFF
--- a/plugins/woocommerce-admin/client/task-lists/progress-header/default-progress-header.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/progress-header/default-progress-header.tsx
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { getVisibleTasks, ONBOARDING_STORE_NAME } from '@woocommerce/data';
+
+/**
+ * Internal dependencies
+ */
+import './progress-header.scss';
+import { TaskListMenu } from '~/tasks/task-list-menu';
+
+export type DefaultProgressHeaderProps = {
+	taskListId: string;
+};
+
+export const DefaultProgressHeader: React.FC< DefaultProgressHeaderProps > = ( {
+	taskListId,
+} ) => {
+	const { loading, tasksCount, completedCount } = useSelect( ( select ) => {
+		const taskList = select( ONBOARDING_STORE_NAME ).getTaskList(
+			taskListId
+		);
+		const finishedResolution = select(
+			ONBOARDING_STORE_NAME
+		).hasFinishedResolution( 'getTaskList', [ taskListId ] );
+		const visibleTasks = getVisibleTasks( taskList?.tasks || [] );
+
+		return {
+			loading: ! finishedResolution,
+			tasksCount: visibleTasks?.length,
+			completedCount: visibleTasks?.filter( ( task ) => task.isComplete )
+				.length,
+		};
+	} );
+
+	if ( loading ) {
+		return null;
+	}
+
+	return (
+		<div className="woocommerce-task-progress-header">
+			<TaskListMenu
+				id={ taskListId }
+				hideTaskListText={ __( 'Hide setup list', 'woocommerce' ) }
+			/>
+			<div className="woocommerce-task-progress-header__contents">
+				{ completedCount !== tasksCount ? (
+					<>
+						<p>
+							{ sprintf(
+								/* translators: 1: completed tasks, 2: total tasks */
+								__(
+									'Follow these steps to start selling quickly. %1$d out of %2$d complete.',
+									'woocommerce'
+								),
+								completedCount,
+								tasksCount
+							) }
+						</p>
+						<progress
+							className="woocommerce-task-progress-header__progress-bar"
+							max={ tasksCount }
+							value={ completedCount || 0 }
+						/>
+					</>
+				) : null }
+			</div>
+		</div>
+	);
+};

--- a/plugins/woocommerce-admin/client/task-lists/progress-header/progress-header.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/progress-header/progress-header.tsx
@@ -8,7 +8,7 @@ import { useSlot } from '@woocommerce/experimental';
  */
 import './progress-header.scss';
 import {
-	WC_TASKLIST_PROGRESS_HEADER_SLOT_NAME,
+	WC_TASKLIST_EXPERIMENTAL_PROGRESS_HEADER_SLOT_NAME,
 	WooTaskListProgressHeaderItem,
 } from './utils';
 import {
@@ -19,7 +19,7 @@ import {
 export const ProgressHeader: React.FC< DefaultProgressHeaderProps > = ( {
 	taskListId,
 } ) => {
-	const slot = useSlot( WC_TASKLIST_PROGRESS_HEADER_SLOT_NAME );
+	const slot = useSlot( WC_TASKLIST_EXPERIMENTAL_PROGRESS_HEADER_SLOT_NAME );
 
 	return Boolean( slot?.fills?.length ) ? (
 		<WooTaskListProgressHeaderItem.Slot fillProps={ { taskListId } } />

--- a/plugins/woocommerce-admin/client/task-lists/progress-header/progress-header.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/progress-header/progress-header.tsx
@@ -1,72 +1,29 @@
 /**
  * External dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
-import { useSelect } from '@wordpress/data';
-import { getVisibleTasks, ONBOARDING_STORE_NAME } from '@woocommerce/data';
+import { useSlot } from '@woocommerce/experimental';
 
 /**
  * Internal dependencies
  */
 import './progress-header.scss';
-import { TaskListMenu } from '~/tasks/task-list-menu';
+import {
+	WC_TASKLIST_PROGRESS_HEADER_SLOT_NAME,
+	WooTaskListProgressHeaderItem,
+} from './utils';
+import {
+	DefaultProgressHeader,
+	DefaultProgressHeaderProps,
+} from './default-progress-header';
 
-type ProgressHeaderProps = {
-	taskListId: string;
-};
-
-export const ProgressHeader: React.FC< ProgressHeaderProps > = ( {
+export const ProgressHeader: React.FC< DefaultProgressHeaderProps > = ( {
 	taskListId,
 } ) => {
-	const { loading, tasksCount, completedCount } = useSelect( ( select ) => {
-		const taskList = select( ONBOARDING_STORE_NAME ).getTaskList(
-			taskListId
-		);
-		const finishedResolution = select(
-			ONBOARDING_STORE_NAME
-		).hasFinishedResolution( 'getTaskList', [ taskListId ] );
-		const visibleTasks = getVisibleTasks( taskList?.tasks || [] );
+	const slot = useSlot( WC_TASKLIST_PROGRESS_HEADER_SLOT_NAME );
 
-		return {
-			loading: ! finishedResolution,
-			tasksCount: visibleTasks?.length,
-			completedCount: visibleTasks?.filter( ( task ) => task.isComplete )
-				.length,
-		};
-	} );
-
-	if ( loading ) {
-		return null;
-	}
-
-	return (
-		<div className="woocommerce-task-progress-header">
-			<TaskListMenu
-				id={ taskListId }
-				hideTaskListText={ __( 'Hide setup list', 'woocommerce' ) }
-			/>
-			<div className="woocommerce-task-progress-header__contents">
-				{ completedCount !== tasksCount ? (
-					<>
-						<p>
-							{ sprintf(
-								/* translators: 1: completed tasks, 2: total tasks */
-								__(
-									'Follow these steps to start selling quickly. %1$d out of %2$d complete.',
-									'woocommerce'
-								),
-								completedCount,
-								tasksCount
-							) }
-						</p>
-						<progress
-							className="woocommerce-task-progress-header__progress-bar"
-							max={ tasksCount }
-							value={ completedCount || 0 }
-						/>
-					</>
-				) : null }
-			</div>
-		</div>
+	return Boolean( slot?.fills?.length ) ? (
+		<WooTaskListProgressHeaderItem.Slot fillProps={ { taskListId } } />
+	) : (
+		<DefaultProgressHeader taskListId={ taskListId } />
 	);
 };

--- a/plugins/woocommerce-admin/client/task-lists/progress-header/utils.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/progress-header/utils.tsx
@@ -9,8 +9,8 @@ import { Slot, Fill } from '@wordpress/components';
  */
 import { createOrderedChildren, sortFillsByOrder } from '../../utils';
 
-export const WC_TASKLIST_PROGRESS_HEADER_SLOT_NAME =
-	'woocommerce_tasklist_progress_header_item';
+export const WC_TASKLIST_EXPERIMENTAL_PROGRESS_HEADER_SLOT_NAME =
+	'woocommerce_tasklist_experimental_progress_header_item';
 
 export const WooTaskListProgressHeaderItem: React.FC< {
 	order?: number;
@@ -18,7 +18,7 @@ export const WooTaskListProgressHeaderItem: React.FC< {
 	Slot: React.FC< Slot.Props >;
 } = ( { children, order = 1 } ) => {
 	return (
-		<Fill name={ WC_TASKLIST_PROGRESS_HEADER_SLOT_NAME }>
+		<Fill name={ WC_TASKLIST_EXPERIMENTAL_PROGRESS_HEADER_SLOT_NAME }>
 			{ ( fillProps: Fill.Props ) => {
 				return createOrderedChildren( children, order, fillProps );
 			} }
@@ -29,7 +29,7 @@ export const WooTaskListProgressHeaderItem: React.FC< {
 WooTaskListProgressHeaderItem.Slot = ( { fillProps } ) => {
 	return (
 		<Slot
-			name={ WC_TASKLIST_PROGRESS_HEADER_SLOT_NAME }
+			name={ WC_TASKLIST_EXPERIMENTAL_PROGRESS_HEADER_SLOT_NAME }
 			fillProps={ fillProps }
 		>
 			{ sortFillsByOrder }

--- a/plugins/woocommerce-admin/client/task-lists/progress-header/utils.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/progress-header/utils.tsx
@@ -1,0 +1,38 @@
+/* eslint-disable no-console */
+/**
+ * External dependencies
+ */
+import { Slot, Fill } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { createOrderedChildren, sortFillsByOrder } from '../../utils';
+
+export const WC_TASKLIST_PROGRESS_HEADER_SLOT_NAME =
+	'woocommerce_tasklist_progress_header_item';
+
+export const WooTaskListProgressHeaderItem: React.FC< {
+	order?: number;
+} > & {
+	Slot: React.FC< Slot.Props >;
+} = ( { children, order = 1 } ) => {
+	return (
+		<Fill name={ WC_TASKLIST_PROGRESS_HEADER_SLOT_NAME }>
+			{ ( fillProps: Fill.Props ) => {
+				return createOrderedChildren( children, order, fillProps );
+			} }
+		</Fill>
+	);
+};
+
+WooTaskListProgressHeaderItem.Slot = ( { fillProps } ) => {
+	return (
+		<Slot
+			name={ WC_TASKLIST_PROGRESS_HEADER_SLOT_NAME }
+			fillProps={ fillProps }
+		>
+			{ sortFillsByOrder }
+		</Slot>
+	);
+};

--- a/plugins/woocommerce-admin/client/task-lists/progress-title/default-progress-title.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/progress-title/default-progress-title.tsx
@@ -1,0 +1,69 @@
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { useMemo } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { getVisibleTasks, ONBOARDING_STORE_NAME } from '@woocommerce/data';
+import { getSetting } from '@woocommerce/settings';
+
+export type DefaultProgressTitleProps = {
+	taskListId: string;
+};
+
+export const DefaultProgressTitle: React.FC< DefaultProgressTitleProps > = ( {
+	taskListId,
+} ) => {
+	const { loading, tasksCount, completedCount, hasVisitedTasks } = useSelect(
+		( select ) => {
+			const taskList = select( ONBOARDING_STORE_NAME ).getTaskList(
+				taskListId
+			);
+			const finishedResolution = select(
+				ONBOARDING_STORE_NAME
+			).hasFinishedResolution( 'getTaskList', [ taskListId ] );
+			const visibleTasks = getVisibleTasks( taskList?.tasks || [] );
+
+			return {
+				loading: ! finishedResolution,
+				tasksCount: visibleTasks?.length,
+				completedCount: visibleTasks?.filter(
+					( task ) => task.isComplete
+				).length,
+				hasVisitedTasks:
+					visibleTasks?.filter(
+						( task ) =>
+							task.isVisited && task.id !== 'store_details'
+					).length > 0,
+			};
+		}
+	);
+
+	const title = useMemo( () => {
+		if ( ! hasVisitedTasks || completedCount === tasksCount ) {
+			const siteTitle = getSetting( 'siteTitle' );
+			return siteTitle
+				? sprintf(
+						/* translators: %s = site title */
+						__( 'Welcome to %s', 'woocommerce' ),
+						siteTitle
+				  )
+				: __( 'Welcome to your store', 'woocommerce' );
+		}
+		if ( completedCount > 0 && completedCount < 4 ) {
+			return __( "Let's get you started", 'woocommerce' ) + '   🚀';
+		}
+		if ( completedCount > 3 && completedCount < 6 ) {
+			return __( 'You are on the right track', 'woocommerce' );
+		}
+		return __( 'You are almost there', 'woocommerce' );
+	}, [ completedCount, hasVisitedTasks, tasksCount ] );
+
+	if ( loading ) {
+		return null;
+	}
+
+	return (
+		<h1 className="woocommerce-task-progress-header__title">{ title }</h1>
+	);
+};

--- a/plugins/woocommerce-admin/client/task-lists/progress-title/progress-title.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/progress-title/progress-title.tsx
@@ -1,69 +1,29 @@
 /**
  * External dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
-import { useMemo } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
-import { getVisibleTasks, ONBOARDING_STORE_NAME } from '@woocommerce/data';
-import { getSetting } from '@woocommerce/settings';
+import { useSlot } from '@woocommerce/experimental';
 
-type ProgressTitleProps = {
-	taskListId: string;
-};
+/**
+ * Internal dependencies
+ */
+import {
+	WC_TASKLIST_PROGRESS_TITLE_SLOT_NAME,
+	WooTaskListProgressTitleItem,
+} from './utils';
 
-export const ProgressTitle: React.FC< ProgressTitleProps > = ( {
+import {
+	DefaultProgressTitle,
+	DefaultProgressTitleProps,
+} from './default-progress-title';
+
+export const ProgressTitle: React.FC< DefaultProgressTitleProps > = ( {
 	taskListId,
 } ) => {
-	const { loading, tasksCount, completedCount, hasVisitedTasks } = useSelect(
-		( select ) => {
-			const taskList = select( ONBOARDING_STORE_NAME ).getTaskList(
-				taskListId
-			);
-			const finishedResolution = select(
-				ONBOARDING_STORE_NAME
-			).hasFinishedResolution( 'getTaskList', [ taskListId ] );
-			const visibleTasks = getVisibleTasks( taskList?.tasks || [] );
+	const slot = useSlot( WC_TASKLIST_PROGRESS_TITLE_SLOT_NAME );
 
-			return {
-				loading: ! finishedResolution,
-				tasksCount: visibleTasks?.length,
-				completedCount: visibleTasks?.filter(
-					( task ) => task.isComplete
-				).length,
-				hasVisitedTasks:
-					visibleTasks?.filter(
-						( task ) =>
-							task.isVisited && task.id !== 'store_details'
-					).length > 0,
-			};
-		}
-	);
-
-	const title = useMemo( () => {
-		if ( ! hasVisitedTasks || completedCount === tasksCount ) {
-			const siteTitle = getSetting( 'siteTitle' );
-			return siteTitle
-				? sprintf(
-						/* translators: %s = site title */
-						__( 'Welcome to %s', 'woocommerce' ),
-						siteTitle
-				  )
-				: __( 'Welcome to your store', 'woocommerce' );
-		}
-		if ( completedCount > 0 && completedCount < 4 ) {
-			return __( "Let's get you started", 'woocommerce' ) + '   🚀';
-		}
-		if ( completedCount > 3 && completedCount < 6 ) {
-			return __( 'You are on the right track', 'woocommerce' );
-		}
-		return __( 'You are almost there', 'woocommerce' );
-	}, [ completedCount, hasVisitedTasks, tasksCount ] );
-
-	if ( loading ) {
-		return null;
-	}
-
-	return (
-		<h1 className="woocommerce-task-progress-header__title">{ title }</h1>
+	return Boolean( slot?.fills?.length ) ? (
+		<WooTaskListProgressTitleItem.Slot fillProps={ { taskListId } } />
+	) : (
+		<DefaultProgressTitle taskListId={ taskListId } />
 	);
 };

--- a/plugins/woocommerce-admin/client/task-lists/progress-title/progress-title.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/progress-title/progress-title.tsx
@@ -7,7 +7,7 @@ import { useSlot } from '@woocommerce/experimental';
  * Internal dependencies
  */
 import {
-	WC_TASKLIST_PROGRESS_TITLE_SLOT_NAME,
+	WC_TASKLIST_EXPERIMENTAL_PROGRESS_TITLE_SLOT_NAME,
 	WooTaskListProgressTitleItem,
 } from './utils';
 
@@ -19,7 +19,7 @@ import {
 export const ProgressTitle: React.FC< DefaultProgressTitleProps > = ( {
 	taskListId,
 } ) => {
-	const slot = useSlot( WC_TASKLIST_PROGRESS_TITLE_SLOT_NAME );
+	const slot = useSlot( WC_TASKLIST_EXPERIMENTAL_PROGRESS_TITLE_SLOT_NAME );
 
 	return Boolean( slot?.fills?.length ) ? (
 		<WooTaskListProgressTitleItem.Slot fillProps={ { taskListId } } />

--- a/plugins/woocommerce-admin/client/task-lists/progress-title/utils.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/progress-title/utils.tsx
@@ -9,8 +9,8 @@ import { Slot, Fill } from '@wordpress/components';
  */
 import { createOrderedChildren, sortFillsByOrder } from '../../utils';
 
-export const WC_TASKLIST_PROGRESS_TITLE_SLOT_NAME =
-	'woocommerce_tasklist_progress_title_item';
+export const WC_TASKLIST_EXPERIMENTAL_PROGRESS_TITLE_SLOT_NAME =
+	'woocommerce_tasklist_experimental_progress_title_item';
 
 export const WooTaskListProgressTitleItem: React.FC< {
 	order?: number;
@@ -18,7 +18,7 @@ export const WooTaskListProgressTitleItem: React.FC< {
 	Slot: React.FC< Slot.Props >;
 } = ( { children, order = 1 } ) => {
 	return (
-		<Fill name={ WC_TASKLIST_PROGRESS_TITLE_SLOT_NAME }>
+		<Fill name={ WC_TASKLIST_EXPERIMENTAL_PROGRESS_TITLE_SLOT_NAME }>
 			{ ( fillProps: Fill.Props ) => {
 				return createOrderedChildren( children, order, fillProps );
 			} }
@@ -29,7 +29,7 @@ export const WooTaskListProgressTitleItem: React.FC< {
 WooTaskListProgressTitleItem.Slot = ( { fillProps } ) => {
 	return (
 		<Slot
-			name={ WC_TASKLIST_PROGRESS_TITLE_SLOT_NAME }
+			name={ WC_TASKLIST_EXPERIMENTAL_PROGRESS_TITLE_SLOT_NAME }
 			fillProps={ fillProps }
 		>
 			{ sortFillsByOrder }

--- a/plugins/woocommerce-admin/client/task-lists/progress-title/utils.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/progress-title/utils.tsx
@@ -1,0 +1,38 @@
+/* eslint-disable no-console */
+/**
+ * External dependencies
+ */
+import { Slot, Fill } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { createOrderedChildren, sortFillsByOrder } from '../../utils';
+
+export const WC_TASKLIST_PROGRESS_TITLE_SLOT_NAME =
+	'woocommerce_tasklist_progress_title_item';
+
+export const WooTaskListProgressTitleItem: React.FC< {
+	order?: number;
+} > & {
+	Slot: React.FC< Slot.Props >;
+} = ( { children, order = 1 } ) => {
+	return (
+		<Fill name={ WC_TASKLIST_PROGRESS_TITLE_SLOT_NAME }>
+			{ ( fillProps: Fill.Props ) => {
+				return createOrderedChildren( children, order, fillProps );
+			} }
+		</Fill>
+	);
+};
+
+WooTaskListProgressTitleItem.Slot = ( { fillProps } ) => {
+	return (
+		<Slot
+			name={ WC_TASKLIST_PROGRESS_TITLE_SLOT_NAME }
+			fillProps={ fillProps }
+		>
+			{ sortFillsByOrder }
+		</Slot>
+	);
+};

--- a/plugins/woocommerce/changelog/add-wcadmin-progress-header-and-title-slot
+++ b/plugins/woocommerce/changelog/add-wcadmin-progress-header-and-title-slot
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Added a slot for ProgressHeader and ProgressTitle component


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?


### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #36463 .

Added slot for [ProgressTitle](https://github.com/woocommerce/woocommerce/blob/c3d62f113addbbf820ed5e8103a0a052092efc00/plugins/woocommerce-admin/client/task-lists/progress-title/progress-title.tsx) and [Progressheader](https://github.com/woocommerce/woocommerce/blob/c3d62f113addbbf820ed5e8103a0a052092efc00/plugins/woocommerce-admin/client/task-lists/progress-header/progress-header.tsx) components.


### How to test the changes in this Pull Request:


1. Checkout this branch. 
2. [demo/homescreen-welcome-text-slot](https://github.com/woocommerce/woocommerce/tree/demo/homescreen-welcome-text-slot) branch to include examples. This branch adds `example-fills.tsx` in `progress-header` and `progress-title` directories.
3. Navigate to `WooCommerce -> Home`. You should see the following progress title and header.

![Screen Shot 2023-01-17 at 11 57 35 AM](https://user-images.githubusercontent.com/4723145/212999164-32174d58-4ea1-4268-9573-5c3e1b9884b9.jpg)

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
