### PR TITLE
Make order updated messages to be compatible with both posts and HPOS

### DIFF
--- a/plugins/woocommerce/changelog/fix-36841
+++ b/plugins/woocommerce/changelog/fix-36841
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make order edit messages compatible with both posts and theorder object.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php
@@ -41,6 +41,7 @@ class WC_Admin_Post_Types {
 
 		// Admin notices.
 		add_filter( 'post_updated_messages', array( $this, 'post_updated_messages' ) );
+		add_filter( 'woocommerce_order_updated_messages', array( $this, 'order_updated_messages' ) );
 		add_filter( 'bulk_post_updated_messages', array( $this, 'bulk_post_updated_messages' ), 10, 2 );
 
 		// Disable Auto Save.
@@ -145,24 +146,7 @@ class WC_Admin_Post_Types {
 			10 => sprintf( __( 'Product draft updated. <a target="_blank" href="%s">Preview product</a>', 'woocommerce' ), esc_url( add_query_arg( 'preview', 'true', get_permalink( $post->ID ) ) ) ),
 		);
 
-		$messages['shop_order'] = array(
-			0  => '', // Unused. Messages start at index 1.
-			1  => __( 'Order updated.', 'woocommerce' ),
-			2  => __( 'Custom field updated.', 'woocommerce' ),
-			3  => __( 'Custom field deleted.', 'woocommerce' ),
-			4  => __( 'Order updated.', 'woocommerce' ),
-			5  => __( 'Revision restored.', 'woocommerce' ),
-			6  => __( 'Order updated.', 'woocommerce' ),
-			7  => __( 'Order saved.', 'woocommerce' ),
-			8  => __( 'Order submitted.', 'woocommerce' ),
-			9  => sprintf(
-				/* translators: %s: date */
-				__( 'Order scheduled for: %s.', 'woocommerce' ),
-				'<strong>' . date_i18n( __( 'M j, Y @ G:i', 'woocommerce' ), strtotime( $post->post_date ) ) . '</strong>'
-			),
-			10 => __( 'Order draft updated.', 'woocommerce' ),
-			11 => __( 'Order updated and sent.', 'woocommerce' ),
-		);
+		$messages = $this->order_updated_messages( $messages );
 
 		$messages['shop_coupon'] = array(
 			0  => '', // Unused. Messages start at index 1.
@@ -180,6 +164,46 @@ class WC_Admin_Post_Types {
 				'<strong>' . date_i18n( __( 'M j, Y @ G:i', 'woocommerce' ), strtotime( $post->post_date ) ) . '</strong>'
 			),
 			10 => __( 'Coupon draft updated.', 'woocommerce' ),
+		);
+
+		return $messages;
+	}
+
+	/**
+	 * Add messages when an order is updated.
+	 *
+	 * @param array $messages Array of messages.
+	 *
+	 * @return array
+	 */
+	public function order_updated_messages( array $messages ) {
+		global $post, $theorder;
+
+		if ( ! isset( $theorder ) || ! $theorder instanceof WC_Abstract_Order ) {
+			if ( ! isset( $post ) || 'shop_order' !== $post->post_type ) {
+				return $messages;
+			} else {
+				\Automattic\WooCommerce\Utilities\OrderUtil::init_theorder_object( $post );
+			}
+		}
+
+		$messages['shop_order'] = array(
+			0  => '', // Unused. Messages start at index 1.
+			1  => __( 'Order updated.', 'woocommerce' ),
+			2  => __( 'Custom field updated.', 'woocommerce' ),
+			3  => __( 'Custom field deleted.', 'woocommerce' ),
+			4  => __( 'Order updated.', 'woocommerce' ),
+			5  => __( 'Revision restored.', 'woocommerce' ),
+			6  => __( 'Order updated.', 'woocommerce' ),
+			7  => __( 'Order saved.', 'woocommerce' ),
+			8  => __( 'Order submitted.', 'woocommerce' ),
+			9  => sprintf(
+			/* translators: %s: date */
+				__( 'Order scheduled for: %s.', 'woocommerce' ),
+				'<strong>' . date_i18n( __( 'M j, Y @ G:i', 'woocommerce' ), strtotime( $theorder->get_date_created() ) ) . '</strong>'
+			),
+			10 => __( 'Order draft updated.', 'woocommerce' ),
+			11 => __( 'Order updated and sent.', 'woocommerce' ),
 		);
 
 		return $messages;

--- a/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
@@ -230,13 +230,6 @@ class Edit {
 		 */
 		$messages = apply_filters( 'woocommerce_order_updated_messages', array() );
 
-		/**
-		 * Backward compatibility for displaying messages using the post fields.
-		 *
-		 * @since 7.4.0. (Although available earlier by the posts based screen).
-		 */
-		$messages = apply_filters( 'post_updated_messages', $messages );
-
 		$message = $this->message;
 		if ( isset( $_GET['message'] ) ) {
 			$message = absint( $_GET['message'] );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR has two changes:

1. [Remove post_updated_messages filter since the hooks will be expecting global $post to be set](https://github.com/woocommerce/woocommerce/pull/36485/commits/cee68e2543ec647471f85dc6333e8275de4a5c54): We are calling `post_updated_messages` filter when displaying order edit screen in HPOS. However, this is a post based filter, which means that functions hooked to it might be expecting the global $post object to already be set. This unfortunately may cause warnings or fatals, so we remove this filter call from HPOS page.

2. [Make order updated messages to be compatible with both posts and HPOS] (https://github.com/woocommerce/woocommerce/pull/36485/commits/32cbd6ca403815d7b4535c17824085aac3ea8ffc): Updates references of $post to use the global $theorder object instead.

Closes #36481.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [x] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

Repeat for both HPOS and posts as authoritative

1. Open the edit order screen for any order.
2. Update the status. Check that the "Order updated" notification is displayed. Check that there are no notices or warnings in the debug log.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
