### PR TITLE
add: slot for tasklist completion component slotfill

### DIFF
--- a/plugins/woocommerce-admin/client/two-column-tasks/task-list-completion-slot/index.ts
+++ b/plugins/woocommerce-admin/client/two-column-tasks/task-list-completion-slot/index.ts
@@ -1,0 +1,2 @@
+export * from './task-list-completion-slot';
+export * from './utils';

--- a/plugins/woocommerce-admin/client/two-column-tasks/task-list-completion-slot/task-list-completion-slot.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/task-list-completion-slot/task-list-completion-slot.tsx
@@ -9,17 +9,19 @@ import classNames from 'classnames';
  */
 import {
 	EXPERIMENTAL_WC_TASK_LIST_COMPLETION_SLOT_NAME,
-	WooTaskListCompletionItem,
+	WooTaskListCompletion,
+	WooTaskListCompletionFillProps,
 } from './utils';
 
 export const TaskListCompletionSlot = ( {
 	className,
+	fillProps,
 }: {
 	className?: string;
+	fillProps: WooTaskListCompletionFillProps;
 } ) => {
 	const slot = useSlot( EXPERIMENTAL_WC_TASK_LIST_COMPLETION_SLOT_NAME );
 	const hasFills = Boolean( slot?.fills?.length );
-
 	if ( ! hasFills ) {
 		return null;
 	}
@@ -30,7 +32,7 @@ export const TaskListCompletionSlot = ( {
 				className
 			) }
 		>
-			<WooTaskListCompletionItem.Slot />
+			<WooTaskListCompletion.Slot fillProps={ fillProps } />
 		</div>
 	);
 };

--- a/plugins/woocommerce-admin/client/two-column-tasks/task-list-completion-slot/task-list-completion-slot.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/task-list-completion-slot/task-list-completion-slot.tsx
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import { useSlot } from '@woocommerce/experimental';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import {
+	EXPERIMENTAL_WC_TASK_LIST_COMPLETION_SLOT_NAME,
+	WooTaskListCompletionItem,
+} from './utils';
+
+export const TaskListCompletionSlot = ( {
+	className,
+}: {
+	className?: string;
+} ) => {
+	const slot = useSlot( EXPERIMENTAL_WC_TASK_LIST_COMPLETION_SLOT_NAME );
+	const hasFills = Boolean( slot?.fills?.length );
+
+	if ( ! hasFills ) {
+		return null;
+	}
+	return (
+		<div
+			className={ classNames(
+				'woocommerce-tasklist-completion-slot',
+				className
+			) }
+		>
+			<WooTaskListCompletionItem.Slot />
+		</div>
+	);
+};

--- a/plugins/woocommerce-admin/client/two-column-tasks/task-list-completion-slot/utils.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/task-list-completion-slot/utils.tsx
@@ -8,21 +8,21 @@ import { Slot, Fill } from '@wordpress/components';
  */
 import { createOrderedChildren, sortFillsByOrder } from '../../utils';
 
-type WooTaskListCompletionItemProps = {
+type WooTaskListCompletionProps = {
 	children: React.ReactNode;
 	order?: number;
 };
 
 export const EXPERIMENTAL_WC_TASK_LIST_COMPLETION_SLOT_NAME =
-	'woocommerce_task_list-completion_item';
+	'woocommerce_experimental_task_list_completion';
 /**
  * Create a Fill for extensions to add items to the WooCommerce Admin Task List completion component slot.
  *
- * @slotFill WooTaskListCompletionItem
+ * @slotFill WooTaskListCompletion
  * @scope woocommerce-admin
  * @example
  * const MyTasklistCompletionItem = () => (
- * <WooTaskListCompletionItem>My Task List completion item</WooTaskListCompletionItem>
+ * <WooTaskListCompletion>My Task List completion item</WooTaskListCompletion>
  * );
  *
  * registerPlugin( 'my-extension', {
@@ -33,10 +33,10 @@ export const EXPERIMENTAL_WC_TASK_LIST_COMPLETION_SLOT_NAME =
  * @param {Array}  param0.children - Node children.
  * @param {Array}  param0.order    - Node order.
  */
-export const WooTaskListCompletionItem = ( {
+export const WooTaskListCompletion = ( {
 	children,
 	order = 1,
-}: WooTaskListCompletionItemProps ) => {
+}: WooTaskListCompletionProps ) => {
 	return (
 		<Fill name={ EXPERIMENTAL_WC_TASK_LIST_COMPLETION_SLOT_NAME }>
 			{ ( fillProps: Fill.Props ) => {
@@ -46,10 +46,19 @@ export const WooTaskListCompletionItem = ( {
 	);
 };
 
-WooTaskListCompletionItem.Slot = ( {
+export type WooTaskListCompletionFillProps = {
+	/** Call this function to hide this Task List completion component completely, without any replacement component */
+	hideTasks: () => void;
+	/** Call this function to show the completed Task List items instead of this TaskList completion component */
+	keepTasks: () => void;
+	/** To show the CES component or not */
+	customerEffortScore: boolean;
+};
+
+WooTaskListCompletion.Slot = ( {
 	fillProps,
 }: {
-	fillProps?: Slot.Props;
+	fillProps: Slot.Props & WooTaskListCompletionFillProps;
 } ) => (
 	<Slot
 		name={ EXPERIMENTAL_WC_TASK_LIST_COMPLETION_SLOT_NAME }

--- a/plugins/woocommerce-admin/client/two-column-tasks/task-list-completion-slot/utils.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/task-list-completion-slot/utils.tsx
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import { Slot, Fill } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { createOrderedChildren, sortFillsByOrder } from '../../utils';
+
+type WooTaskListCompletionItemProps = {
+	children: React.ReactNode;
+	order?: number;
+};
+
+export const EXPERIMENTAL_WC_TASK_LIST_COMPLETION_SLOT_NAME =
+	'woocommerce_task_list-completion_item';
+/**
+ * Create a Fill for extensions to add items to the WooCommerce Admin Task List completion component slot.
+ *
+ * @slotFill WooTaskListCompletionItem
+ * @scope woocommerce-admin
+ * @example
+ * const MyTasklistCompletionItem = () => (
+ * <WooTaskListCompletionItem>My Task List completion item</WooTaskListCompletionItem>
+ * );
+ *
+ * registerPlugin( 'my-extension', {
+ * render: MyTasklistCompletionItem,
+ * scope: 'woocommerce-admin',
+ * } );
+ * @param {Object} param0
+ * @param {Array}  param0.children - Node children.
+ * @param {Array}  param0.order    - Node order.
+ */
+export const WooTaskListCompletionItem = ( {
+	children,
+	order = 1,
+}: WooTaskListCompletionItemProps ) => {
+	return (
+		<Fill name={ EXPERIMENTAL_WC_TASK_LIST_COMPLETION_SLOT_NAME }>
+			{ ( fillProps: Fill.Props ) => {
+				return createOrderedChildren( children, order, fillProps );
+			} }
+		</Fill>
+	);
+};
+
+WooTaskListCompletionItem.Slot = ( {
+	fillProps,
+}: {
+	fillProps?: Slot.Props;
+} ) => (
+	<Slot
+		name={ EXPERIMENTAL_WC_TASK_LIST_COMPLETION_SLOT_NAME }
+		fillProps={ fillProps }
+	>
+		{ sortFillsByOrder }
+	</Slot>
+);

--- a/plugins/woocommerce-admin/client/two-column-tasks/task-list.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/task-list.tsx
@@ -22,7 +22,7 @@ import {
 	WCDataSelector,
 } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
-import { List } from '@woocommerce/experimental';
+import { List, useSlot } from '@woocommerce/experimental';
 import classnames from 'classnames';
 
 /**
@@ -36,6 +36,10 @@ import { ProgressHeader } from '~/task-lists/progress-header';
 import { TaskListItemTwoColumn } from './task-list-item-two-column';
 import { TaskListCompletedHeader } from './completed-header';
 import { LayoutContext } from '~/layout';
+import {
+	TaskListCompletionSlot,
+	EXPERIMENTAL_WC_TASK_LIST_COMPLETION_SLOT_NAME,
+} from './task-list-completion-slot';
 
 export type TaskListProps = TaskListType & {
 	eventName?: string;
@@ -98,6 +102,10 @@ export const TaskList: React.FC< TaskListProps > = ( {
 	useEffect( () => {
 		recordTaskListView();
 	}, [] );
+
+	const taskListCompletionSlot = useSlot(
+		EXPERIMENTAL_WC_TASK_LIST_COMPLETION_SLOT_NAME
+	);
 
 	useEffect( () => {
 		const { task: prevTask } = prevQueryRef.current;
@@ -229,7 +237,14 @@ export const TaskList: React.FC< TaskListProps > = ( {
 		return <div className="woocommerce-task-dashboard__container"></div>;
 	}
 
+	const hasTaskListCompletionSlotFills = Boolean(
+		taskListCompletionSlot?.fills?.length
+	);
+
 	if ( isComplete && keepCompletedTaskList !== 'yes' ) {
+		if ( hasTaskListCompletionSlotFills ) {
+			return <TaskListCompletionSlot />;
+		}
 		return (
 			<>
 				{ cesHeader ? (

--- a/plugins/woocommerce-admin/client/two-column-tasks/task-list.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/task-list.tsx
@@ -243,7 +243,15 @@ export const TaskList: React.FC< TaskListProps > = ( {
 
 	if ( isComplete && keepCompletedTaskList !== 'yes' ) {
 		if ( hasTaskListCompletionSlotFills ) {
-			return <TaskListCompletionSlot />;
+			return (
+				<TaskListCompletionSlot
+					fillProps={ {
+						hideTasks,
+						keepTasks,
+						customerEffortScore: cesHeader,
+					} }
+				/>
+			);
 		}
 		return (
 			<>

--- a/plugins/woocommerce/changelog/add-tasklist-completion-slotfill
+++ b/plugins/woocommerce/changelog/add-tasklist-completion-slotfill
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Added slot for tasklist completion slotfill


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Added slot for task list completion component to be replaced, for extensibility reasons.

Note that in the code there exists two variants of the task list completion component, one with CES and one without. I assume the latter has been deprecated because it doesn't look possible to toggle it on.

Regardless, neither will show up if a Fill is registered for the task list completion slotfill.

Closes #36464.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

https://user-images.githubusercontent.com/27843274/213117755-2b0c091a-4712-4fe8-b493-8ffad16bed66.mp4


1. Checkout this branch and run woocommerce-admin, complete all the items in the tasklist
2. Observe that the default task list completion component with CES shows up. (see second part of screen capture after refresh)
3. Checkout the demo branch (`demo/example-tasklist-completion-slotfill`) or [commit](https://github.com/woocommerce/woocommerce/commit/5b83d820e7a94230123ab9f2181d1be30516c4d1)
4. Observe that the task list completion component has been replaced by the demo slot fill.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
