### PR TITLE
Fix overlapping header elements on product page

### DIFF
--- a/plugins/woocommerce-admin/client/header/use-header-height.ts
+++ b/plugins/woocommerce-admin/client/header/use-header-height.ts
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import { useEffect, useLayoutEffect, useState } from '@wordpress/element';
+
+export const useHeaderHeight = () => {
+	const [ headerHeight, setHeaderHeight ] = useState( 60 );
+	const [ adminBarHeight, setAdminBarHeight ] = useState( 32 );
+
+	useEffect( () => {
+		const wpbody = document.querySelector( '#wpbody' ) as Node;
+		const observer = new MutationObserver( () => {
+			setHeaderHeight(
+				parseInt( ( wpbody as HTMLElement ).style.marginTop, 10 )
+			);
+		} );
+		observer.observe( wpbody, {
+			attributes: true,
+		} );
+
+		return () => {
+			observer.disconnect();
+		};
+	}, [] );
+
+	useLayoutEffect( () => {
+		const handleResize = () => {
+			const adminBar = document.querySelector(
+				'#wpadminbar'
+			) as HTMLElement;
+			setAdminBarHeight( adminBar.clientHeight );
+		};
+		window.addEventListener( 'resize', handleResize );
+		return () => {
+			window.removeEventListener( 'resize', handleResize );
+		};
+	}, [] );
+
+	return {
+		adminBarHeight,
+		headerHeight,
+	};
+};

--- a/plugins/woocommerce-admin/client/products/layout/product-form-layout.scss
+++ b/plugins/woocommerce-admin/client/products/layout/product-form-layout.scss
@@ -30,7 +30,8 @@ $product-form-tabs-height: 56px;
 		left: $admin-menu-width;
 		width: calc(100% - $admin-menu-width);
 		background: $white;
-		z-index: 1001;
+		// This z-index is directly below the header of 1001.
+		z-index: 1000;
 		border-bottom: 1px solid $gray-400;
 		border-top: 1px solid $gray-400;
 		padding: 0 var(--large-gap) 0 var(--large-gap);
@@ -81,6 +82,16 @@ $product-form-tabs-height: 56px;
 	}
 }
 
-.woocommerce-admin-product-layout .woocommerce-layout__header {
-	min-height: $header-height + $product-form-tabs-height;
+.woocommerce-admin-product-layout {
+	.woocommerce-layout__primary {
+		padding-top: $product-form-tabs-height;
+	}
+
+	.woocommerce-layout__header.is-scrolled {
+		box-shadow: none;
+
+		~.woocommerce-layout__primary .product-form-layout .components-tab-panel__tabs {
+			box-shadow: $header-scroll-shadow;
+		}
+	}
 }

--- a/plugins/woocommerce-admin/client/products/layout/product-form-layout.tsx
+++ b/plugins/woocommerce-admin/client/products/layout/product-form-layout.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Children, useEffect } from '@wordpress/element';
+import { Children, useEffect, useLayoutEffect } from '@wordpress/element';
 import { TabPanel, Tooltip } from '@wordpress/components';
 import { navigateTo, getNewPath, getQuery } from '@woocommerce/navigation';
 
@@ -26,6 +26,27 @@ export const ProductFormLayout: React.FC< {
 			window.document.body.classList.remove(
 				'woocommerce-admin-product-layout'
 			);
+		};
+	}, [] );
+
+	const updateTabsPosition = () => {
+		const wpBody = document.querySelector( '#wpbody' ) as HTMLElement;
+		const top = parseInt( wpBody.style.marginTop, 10 );
+		const tabPanelTabs = document.querySelector(
+			'.product-form-layout .components-tab-panel__tabs'
+		) as HTMLElement;
+		tabPanelTabs.style.top = top + 32 + 'px';
+	};
+
+	useLayoutEffect( () => {
+		const wpbody = document.querySelector( '#wpbody' ) as Node;
+		const observer = new MutationObserver( updateTabsPosition );
+		observer.observe( wpbody, {
+			attributes: true,
+		} );
+
+		return () => {
+			observer.disconnect();
 		};
 	}, [] );
 

--- a/plugins/woocommerce-admin/client/products/layout/product-form-layout.tsx
+++ b/plugins/woocommerce-admin/client/products/layout/product-form-layout.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Children, useEffect, useLayoutEffect } from '@wordpress/element';
+import { Children, useEffect } from '@wordpress/element';
 import { TabPanel, Tooltip } from '@wordpress/components';
 import { navigateTo, getNewPath, getQuery } from '@woocommerce/navigation';
 
@@ -11,6 +11,7 @@ import { navigateTo, getNewPath, getQuery } from '@woocommerce/navigation';
  */
 import './product-form-layout.scss';
 import { ProductFormTab } from '../product-form-tab';
+import { useHeaderHeight } from '~/header/use-header-height';
 
 export const ProductFormLayout: React.FC< {
 	children: JSX.Element | JSX.Element[];
@@ -29,26 +30,14 @@ export const ProductFormLayout: React.FC< {
 		};
 	}, [] );
 
-	const updateTabsPosition = () => {
-		const wpBody = document.querySelector( '#wpbody' ) as HTMLElement;
-		const top = parseInt( wpBody.style.marginTop, 10 );
+	const { adminBarHeight, headerHeight } = useHeaderHeight();
+
+	useEffect( () => {
 		const tabPanelTabs = document.querySelector(
 			'.product-form-layout .components-tab-panel__tabs'
 		) as HTMLElement;
-		tabPanelTabs.style.top = top + 32 + 'px';
-	};
-
-	useLayoutEffect( () => {
-		const wpbody = document.querySelector( '#wpbody' ) as Node;
-		const observer = new MutationObserver( updateTabsPosition );
-		observer.observe( wpbody, {
-			attributes: true,
-		} );
-
-		return () => {
-			observer.disconnect();
-		};
-	}, [] );
+		tabPanelTabs.style.top = adminBarHeight + headerHeight + 'px';
+	}, [ adminBarHeight, headerHeight ] );
 
 	const tabs = Children.map( children, ( child: JSX.Element ) => {
 		if ( child.type !== ProductFormTab ) {

--- a/plugins/woocommerce/changelog/fix-36207
+++ b/plugins/woocommerce/changelog/fix-36207
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix overlapping header elements on product page


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes the product header overlapping the WC header and fixes positioning.

A better solution would be to use slotfill to place the tabs in the header, but the tabs themselves currently can't be isolated from the tab panel content, so we'll need to either update this in GB or come up with a our tab panels in WC.

<img width="627" alt="Screen Shot 2023-01-18 at 9 59 03 AM" src="https://user-images.githubusercontent.com/10561050/213258950-9889e940-ceff-4412-ba01-0df30137bb0e.png">
<img width="282" alt="Screen Shot 2023-01-18 at 9 58 53 AM" src="https://user-images.githubusercontent.com/10561050/213258956-0a8fdb58-623d-42d3-bc14-c4db2da8cb41.png">


Closes #36207  .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Navigate to the new product management experience
2. Click on the "more" menu in the top right of the header and make sure you can see and click the menu items
3. Narrow your viewport and make sure the header and tab panels are both in the correct positions
4. View the same page with the task reminder bar (by not having hidden it, having some incomplete tasks, and not having hidden the task list)
5. Make sure the header and tabs adjust their position from the top accordingly

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
