### PR TITLE
[HPOS] wc_get_order() should use global post/order object if necessary

### DIFF
--- a/plugins/woocommerce/changelog/fix-35561-wc-get-order
+++ b/plugins/woocommerce/changelog/fix-35561-wc-get-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure wc_get_order() works without arguments when HPOS is enabled.

--- a/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-order-functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-order-functions.php
@@ -165,6 +165,7 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		global $post;
 		global $theorder;
 
+		// phpcs:disable WordPress.WP.GlobalVariablesOverride.Prohibited
 		$original_post     = $post;
 		$original_theorder = $theorder;
 
@@ -206,6 +207,7 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 
 		$post     = $original_post;
 		$theorder = $original_theorder;
+		// phpcs:enable WordPress.WP.GlobalVariablesOverride.Prohibited
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-order-functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-order-functions.php
@@ -162,6 +162,11 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 	 * @group test
 	 */
 	public function test_wc_get_order() {
+		global $post;
+		global $theorder;
+
+		$original_post     = $post;
+		$original_theorder = $theorder;
 
 		$order = WC_Helper_Order::create_order();
 
@@ -178,11 +183,29 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$post = $this->factory->post->create_and_get( array( 'post_type' => 'post' ) );
 		$this->assertFalse( wc_get_order( $post->ID ) );
 
+		// Assert the return when $the_order args is a random (incorrect) id.
+		$this->assertFalse( wc_get_order( 123456 ) );
+
 		// Assert the return when $the_order args is false.
 		$this->assertFalse( wc_get_order( false ) );
 
-		// Assert the return when $the_order args is a random (incorrect) id.
-		$this->assertFalse( wc_get_order( 123456 ) );
+		$post = get_post( $order->get_id() );
+		$this->assertInstanceOf(
+			'WC_Order',
+			wc_get_order(),
+			'If no order ID is specified, wc_get_order() will use the global $post object to try and determine the current order.'
+		);
+
+		unset( $post );
+		$theorder = $order;
+		$this->assertInstanceOf(
+			'WC_Order',
+			wc_get_order(),
+			'If no order ID is specified, wc_get_order() will use the global $theorder object to try and determine the current order.'
+		);
+
+		$post     = $original_post;
+		$theorder = $original_theorder;
 	}
 
 	/**


### PR DESCRIPTION
With the CPT data store for orders, calling `wc_get_order()` without passing an argument will still successfully return the current order object, so long as an order is referenced by the currently set global `$post` object.

In HPOS, it is desirable to have the same behavior since extension developers in particular rely on this to determine the current order object within the context of the admin order editor, and possibly other locations.

Closes #35561.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Add the following snippet to a suitable location, such as `wp-content/mu-plugins/test-35561.php`. Remove it when testing is complete.

```php
<?php

use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;

function add_wc_get_order_test_metabox() {
	$screen = wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled()
		? wc_get_page_screen_id( 'shop-order' )
		: 'shop_order';

	add_meta_box(
		'test-35561',
		'TEST #35561',
		'render_wc_get_order_test_metabox',
		$screen,
		'side',
		'high'
	);
}

function render_wc_get_order_test_metabox() {
	$order   = wc_get_order();

	print '<p><strong style="color: red; ">';
	print $order ? 'SUCCESS! ORDER ID #' . $order->get_id() : 'FAILURE';
	print '</strong></p>';
}

add_action( 'add_meta_boxes', 'add_wc_get_order_test_metabox' );
```

This change should be tested with and without HPOS, but the above snippet should be in place both times.

1. To test *with* HPOS, you should visit **WooCommerce ▸ Settings ▸ Advanced ▸ Custom Data Stores** and select **Use the WooCommerce Order Stores** (don't see this option, or can't enable it? Please refer to the notes in [this earlier PR](https://github.com/woocommerce/woocommerce/pull/35999)).
2. To test without HPOS, select **Use the WordPress Posts Table** from that same admin screen.

Then:

1. Visit the order editor for any existing order.
2. Look at the sidebar, you should see a meta box labelled `TEST #35561`.
3. If this change is successful, you should see a message within the meta box indicating success and echoing the current order ID.
4. If the change is not successful, or if you are testing without this change, you should see a message indicating failure.

Screenshots of meta box output:

| Success | Failure |
| --- | --- |
| ![35561-success](https://user-images.githubusercontent.com/3594411/213266658-220a1aa0-09e5-4cd8-b72a-1ca834cd6344.png) | ![35561-failure](https://user-images.githubusercontent.com/3594411/213266653-9efb721f-382a-4e92-9c57-38b507e3e559.png) |

<!-- End testing instructions -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
