### PR TITLE
Add permalink_template and generated_slug to products REST API response

### DIFF
--- a/plugins/woocommerce/changelog/add-product-permalink-template-rest-api
+++ b/plugins/woocommerce/changelog/add-product-permalink-template-rest-api
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Add permalink_template and generated_slug to products REST API response.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -1421,6 +1421,24 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 				),
 			),
 		);
+
+		$post_type_obj = get_post_type_object( $this->post_type );
+		if ( is_post_type_viewable( $post_type_obj ) && $post_type_obj->public ) {
+			$schema['properties']['permalink_template'] = array(
+				'description' => __( 'Permalink template for the product.' ),
+				'type'        => 'string',
+				'context'     => array( 'edit' ),
+				'readonly'    => true,
+			);
+
+			$schema['properties']['generated_slug'] = array(
+				'description' => __( 'Slug automatically generated from the product name.' ),
+				'type'        => 'string',
+				'context'     => array( 'edit' ),
+				'readonly'    => true,
+			);
+		}
+
 		return $this->add_additional_fields_schema( $schema );
 	}
 
@@ -1462,16 +1480,45 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 	 */
 	protected function get_product_data( $product, $context = 'view' ) {
 		$data = parent::get_product_data( ...func_get_args() );
-		// Add stock_status if needed.
+
 		if ( isset( $this->request ) ) {
 			$fields = $this->get_fields_for_response( $this->request );
+
+			// Add stock_status if needed.
 			if ( in_array( 'stock_status', $fields ) ) {
 				$data['stock_status'] = $product->get_stock_status( $context );
 			}
+
+			// Add has_options if needed.
 			if ( in_array( 'has_options', $fields ) ) {
 				$data['has_options'] = $product->has_options( $context );
 			}
+
+			$post_type_obj = get_post_type_object( $this->post_type );
+			if ( is_post_type_viewable( $post_type_obj ) && $post_type_obj->public ) {
+				$permalink_template_requested = in_array( 'permalink_template', $fields );
+				$generated_slug_requested = in_array( 'generated_slug', $fields );
+
+				if ( $permalink_template_requested || $generated_slug_requested ) {
+					if ( ! function_exists( 'get_sample_permalink' ) ) {
+						require_once ABSPATH . 'wp-admin/includes/post.php';
+					}
+
+					$sample_permalink = get_sample_permalink( $product->get_id(), $product->get_name(), '' );
+
+					// Add permalink_template if needed.
+					if ( $permalink_template_requested ) {
+						$data['permalink_template'] = $sample_permalink[0];
+					}
+
+					// Add generated_slug if needed.
+					if ( $generated_slug_requested ) {
+						$data['generated_slug'] = $sample_permalink[1];
+					}
+				}
+			}
 		}
+
 		return $data;
 	}
 }

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -1497,7 +1497,7 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 			$post_type_obj = get_post_type_object( $this->post_type );
 			if ( is_post_type_viewable( $post_type_obj ) && $post_type_obj->public ) {
 				$permalink_template_requested = in_array( 'permalink_template', $fields, true );
-				$generated_slug_requested = in_array( 'generated_slug', $fields, true );
+				$generated_slug_requested     = in_array( 'generated_slug', $fields, true );
 
 				if ( $permalink_template_requested || $generated_slug_requested ) {
 					if ( ! function_exists( 'get_sample_permalink' ) ) {

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -1485,19 +1485,19 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 			$fields = $this->get_fields_for_response( $this->request );
 
 			// Add stock_status if needed.
-			if ( in_array( 'stock_status', $fields ) ) {
+			if ( in_array( 'stock_status', $fields, true ) ) {
 				$data['stock_status'] = $product->get_stock_status( $context );
 			}
 
 			// Add has_options if needed.
-			if ( in_array( 'has_options', $fields ) ) {
+			if ( in_array( 'has_options', $fields, true ) ) {
 				$data['has_options'] = $product->has_options( $context );
 			}
 
 			$post_type_obj = get_post_type_object( $this->post_type );
 			if ( is_post_type_viewable( $post_type_obj ) && $post_type_obj->public ) {
-				$permalink_template_requested = in_array( 'permalink_template', $fields );
-				$generated_slug_requested = in_array( 'generated_slug', $fields );
+				$permalink_template_requested = in_array( 'permalink_template', $fields, true );
+				$generated_slug_requested = in_array( 'generated_slug', $fields, true );
 
 				if ( $permalink_template_requested || $generated_slug_requested ) {
 					if ( ! function_exists( 'get_sample_permalink' ) ) {

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -1425,14 +1425,14 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 		$post_type_obj = get_post_type_object( $this->post_type );
 		if ( is_post_type_viewable( $post_type_obj ) && $post_type_obj->public ) {
 			$schema['properties']['permalink_template'] = array(
-				'description' => __( 'Permalink template for the product.' ),
+				'description' => __( 'Permalink template for the product.', 'woocommerce' ),
 				'type'        => 'string',
 				'context'     => array( 'edit' ),
 				'readonly'    => true,
 			);
 
 			$schema['properties']['generated_slug'] = array(
-				'description' => __( 'Slug automatically generated from the product name.' ),
+				'description' => __( 'Slug automatically generated from the product name.', 'woocommerce' ),
 				'type'        => 'string',
 				'context'     => array( 'edit' ),
 				'readonly'    => true,

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/products.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/products.php
@@ -646,7 +646,7 @@ class WC_Tests_API_Product extends WC_REST_Unit_Test_Case {
 		$response   = $this->server->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertEquals( 67, count( $properties ) );
+		$this->assertEquals( 69, count( $properties ) );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds the `permalink_template` and `generated_slug` fields to the products REST API response. These fields will be used by the new product management experience UI to show a sample permalink for products that are still in draft.

I did not add anything to the tests at `/plugins/woocommerce/tests/api-core-tests/tests/products/products-crud.test.js` because the `can add a simple product` test does not test for the existence of most properties, so it felt out of place to add in specific tests for these two properties. In addition, the test for both properties would really just be testing built-in WordPress Core functionality (`get_sample_permalink`) being used to get those values. But, I can add something to the tests if others feel there should be.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Part of #34312.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

Using Postman or some other tool, where `{ID}` is the post ID of an existing product...

1. Make a GET request to `/wp-json/wc/v3/products/{ID}` and verify that `permalink_template` and `generated_slug` do not appear in the response.
2. Make a GET request to `/wp-json/wc/v3/products/{ID}?context=edit` and verify that `permalink_template` and `generated_slug` do appear in the response.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
