### PR TITLE
Making function more robust against wrong transients

### DIFF
--- a/plugins/woocommerce/changelog/patch-15
+++ b/plugins/woocommerce/changelog/patch-15
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Make related products check more robust against wrong transients.

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -915,7 +915,7 @@ function wc_get_related_products( $product_id, $limit = 5, $exclude_ids = array(
 	);
 
 	$transient     = get_transient( $transient_name );
-	$related_posts = $transient && isset( $transient[ $query_args ] ) ? $transient[ $query_args ] : false;
+	$related_posts = $transient && is_array( $transient ) && isset( $transient[ $query_args ] ) ? $transient[ $query_args ] : false;
 
 	// We want to query related posts if they are not cached, or we don't have enough.
 	if ( false === $related_posts || count( $related_posts ) < $limit ) {
@@ -931,7 +931,7 @@ function wc_get_related_products( $product_id, $limit = 5, $exclude_ids = array(
 			$related_posts = $data_store->get_related_products( $cats_array, $tags_array, $exclude_ids, $limit + 10, $product_id );
 		}
 
-		if ( $transient ) {
+		if ( $transient && is_array( $transient ) ) {
 			$transient[ $query_args ] = $related_posts;
 		} else {
 			$transient = array( $query_args => $related_posts );


### PR DESCRIPTION
This a re-doing of #34742, which confused CI because the remote branch was based on `master`.

> ### All Submissions:
> 
> -   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
> -   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
> -   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?
> 
> <!-- Mark completed items with an [x] -->
> 
> <!-- You can erase any parts of this template not applicable to your Pull Request. -->
> 
> ### Changes proposed in this Pull Request:
> 
> <!-- Describe the changes made to this Pull Request and the reason for such changes. -->
> 
This PR adds a pair of checks about the validity of a related-product transient, so if an invalid non-array value is found it is ignored and overwritten. It solves the warning that appears when any of these transients > ends up holding a string value instead of an array.
> 
> Closes #34741 .
> 
> ### How to test the changes in this Pull Request:
> 
> 1. Set a wrong string value in a related-products transient for a given product_id. For example, for the product with ID 470242 the transient name would be `wc_related_4270242`
> 2. Force a call of the function wc_get_related_products() with that same product id. You shouldn't get any warning message
> 
> ### Other information:
> 
> -   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
> -   [ ] Have you written new tests for your changes, as applicable?
> -   [x] Have you successfully run tests with your changes locally?
> -   [ ] Have you created a changelog file for each project being changed, ie `pnpm changelog add --filter=<project>`?
> 
> <!-- Mark completed items with an [x] -->
> 
> ### FOR PR REVIEWER ONLY:
> 
> -   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
