### PR TITLE
Fix docblock type annotation for return value of `::process_refund`.

### DIFF
--- a/plugins/woocommerce/changelog/fix-docblock-type-annotation-process-refund
+++ b/plugins/woocommerce/changelog/fix-docblock-type-annotation-process-refund
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Add correct type annotation for the return type of `::process_refund`.

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-payment-gateway.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-payment-gateway.php
@@ -376,7 +376,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	 * @param  int        $order_id Order ID.
 	 * @param  float|null $amount Refund amount.
 	 * @param  string     $reason Refund reason.
-	 * @return boolean True or false based on success, or a WP_Error object.
+	 * @return bool|\WP_Error True or false based on success, or a WP_Error object.
 	 */
 	public function process_refund( $order_id, $amount = null, $reason = '' ) {
 		return false;


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add correct type annotation for the return type of `::process_refund`.

- [x] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
