### PR TITLE
Show product CES footer on product tour close

### DIFF
--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/use-product-mvp-ces-footer.ts
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/use-product-mvp-ces-footer.ts
@@ -19,21 +19,23 @@ async function isProductMVPCESHidden(): Promise< boolean > {
 export const useProductMVPCESFooter = () => {
 	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
 
+	const showCesFooter = ( actionName = 'show' ) => {
+		updateOptions( {
+			[ PRODUCT_MVP_CES_ACTION_OPTION_NAME ]: actionName,
+		} );
+	};
+
 	const onSaveDraft = async () => {
 		if ( ( await isProductMVPCESHidden() ) === false ) {
-			updateOptions( {
-				[ PRODUCT_MVP_CES_ACTION_OPTION_NAME ]: 'new_product',
-			} );
+			showCesFooter( 'new_product' );
 		}
 	};
 
 	const onPublish = async () => {
 		if ( ( await isProductMVPCESHidden() ) === false ) {
-			updateOptions( {
-				[ PRODUCT_MVP_CES_ACTION_OPTION_NAME ]: 'new_product',
-			} );
+			showCesFooter( 'new_product' );
 		}
 	};
 
-	return { onSaveDraft, onPublish };
+	return { onSaveDraft, onPublish, showCesFooter };
 };

--- a/plugins/woocommerce-admin/client/products/tour/product-tour-container.tsx
+++ b/plugins/woocommerce-admin/client/products/tour/product-tour-container.tsx
@@ -1,10 +1,4 @@
 /**
- * External dependencies
- */
-import { useDispatch } from '@wordpress/data';
-import { OPTIONS_STORE_NAME } from '@woocommerce/data';
-
-/**
  * Internal dependencies
  */
 import { ProductTour } from './product-tour';
@@ -15,13 +9,7 @@ import { useProductTour } from './use-product-tour';
 export const ProductTourContainer: React.FC = () => {
 	const { dismissModal, endTour, isModalHidden, isTouring, startTour } =
 		useProductTour();
-	// const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
 	const { showCesFooter } = useProductMVPCESFooter();
-	// const showCesFooter = () => {
-	// 	updateOptions( {
-	// 		[ PRODUCT_MVP_CES_ACTION_OPTION_NAME ]: 'new_product',
-	// 	} );
-	// }
 
 	if ( isTouring ) {
 		return (

--- a/plugins/woocommerce-admin/client/products/tour/product-tour-container.tsx
+++ b/plugins/woocommerce-admin/client/products/tour/product-tour-container.tsx
@@ -1,21 +1,50 @@
 /**
+ * External dependencies
+ */
+import { useDispatch } from '@wordpress/data';
+import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+
+/**
  * Internal dependencies
  */
 import { ProductTour } from './product-tour';
 import { ProductTourModal } from './product-tour-modal';
+import { useProductMVPCESFooter } from '~/customer-effort-score-tracks/use-product-mvp-ces-footer';
 import { useProductTour } from './use-product-tour';
 
 export const ProductTourContainer: React.FC = () => {
 	const { dismissModal, endTour, isModalHidden, isTouring, startTour } =
 		useProductTour();
+	// const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
+	const { showCesFooter } = useProductMVPCESFooter();
+	// const showCesFooter = () => {
+	// 	updateOptions( {
+	// 		[ PRODUCT_MVP_CES_ACTION_OPTION_NAME ]: 'new_product',
+	// 	} );
+	// }
 
 	if ( isTouring ) {
-		return <ProductTour onClose={ endTour } />;
+		return (
+			<ProductTour
+				onClose={ () => {
+					endTour();
+					showCesFooter();
+				} }
+			/>
+		);
 	}
 
 	if ( isModalHidden ) {
 		return null;
 	}
 
-	return <ProductTourModal onClose={ dismissModal } onStart={ startTour } />;
+	return (
+		<ProductTourModal
+			onClose={ () => {
+				dismissModal();
+				showCesFooter();
+			} }
+			onStart={ startTour }
+		/>
+	);
 };

--- a/plugins/woocommerce/changelog/add-36322-ces-footer
+++ b/plugins/woocommerce/changelog/add-36322-ces-footer
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Show product CES footer on product tour close


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Shows the CES modal when the product tour is dismissed or closed.

<img width="889" alt="Screen Shot 2023-01-19 at 2 53 07 PM" src="https://user-images.githubusercontent.com/10561050/213580157-abe56727-8758-4451-87ac-f9b5a45b263b.png">

Closes #36322  .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Delete the `woocommerce_product_tour_modal_hidden` option from `wp_options` if you have previously dismissed it
2. Visit the new product management experience
3. Close the product tour modal without starting
4. You should see the product footer customer effort prompt at the bottom of the screen
5. Delete the `woocommerce_product_tour_modal_hidden` option.
6. Start the tour
7. Finish or close the tour
8. Make sure the product footer customer effort prompt is shown.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
