### PR TITLE
Add Tasklist extensibility and WooOnboardingTaskListHeader SlotFill

### DIFF
--- a/packages/js/onboarding/changelog/add-36465-tasklist-extensibility
+++ b/packages/js/onboarding/changelog/add-36465-tasklist-extensibility
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add WooOnboardingTaskListHeader component

--- a/packages/js/onboarding/src/components/WooOnboardingTaskListHeader/WooOnboardingTaskListHeader.tsx
+++ b/packages/js/onboarding/src/components/WooOnboardingTaskListHeader/WooOnboardingTaskListHeader.tsx
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { createElement } from '@wordpress/element';
+import { Slot, Fill } from '@wordpress/components';
+
+type WooOnboardingTaskListHeaderProps = {
+	id: string;
+};
+
+/**
+ * A Fill for adding Onboarding Task List items.
+ *
+ * @slotFill WooOnboardingTaskListHeader
+ * @scope woocommerce-tasks
+ * @param {Object} props    React props.
+ * @param {string} props.id Task id.
+ */
+export const WooOnboardingTaskListHeader: React.FC< WooOnboardingTaskListHeaderProps > & {
+	Slot: React.VFC< Slot.Props & { id: string } >;
+} = ( { id, ...props } ) => (
+	<Fill
+		name={ 'woocommerce_onboarding_task_list_header_' + id }
+		{ ...props }
+	/>
+);
+
+WooOnboardingTaskListHeader.Slot = ( { id, fillProps } ) => (
+	<Slot
+		name={ 'woocommerce_onboarding_task_list_header_' + id }
+		fillProps={ fillProps }
+	/>
+);

--- a/packages/js/onboarding/src/components/WooOnboardingTaskListHeader/WooOnboardingTaskListHeader.tsx
+++ b/packages/js/onboarding/src/components/WooOnboardingTaskListHeader/WooOnboardingTaskListHeader.tsx
@@ -9,7 +9,7 @@ type WooOnboardingTaskListHeaderProps = {
 };
 
 /**
- * A Fill for adding Onboarding Task List items.
+ * A Fill for adding Onboarding Task List headers.
  *
  * @slotFill WooOnboardingTaskListHeader
  * @scope woocommerce-tasks

--- a/packages/js/onboarding/src/components/WooOnboardingTaskListHeader/WooOnboardingTaskListHeader.tsx
+++ b/packages/js/onboarding/src/components/WooOnboardingTaskListHeader/WooOnboardingTaskListHeader.tsx
@@ -16,16 +16,20 @@ type WooOnboardingTaskListHeaderProps = {
  * @param {Object} props    React props.
  * @param {string} props.id Task id.
  */
-export const WooOnboardingTaskListHeader: React.FC< WooOnboardingTaskListHeaderProps > & {
-	Slot: React.VFC< Slot.Props & { id: string } >;
-} = ( { id, ...props } ) => (
+export const WooOnboardingTaskListHeader = ( {
+	id,
+	...props
+}: WooOnboardingTaskListHeaderProps & Slot.Props ) => (
 	<Fill
 		name={ 'woocommerce_onboarding_task_list_header_' + id }
 		{ ...props }
 	/>
 );
 
-WooOnboardingTaskListHeader.Slot = ( { id, fillProps } ) => (
+WooOnboardingTaskListHeader.Slot = ( {
+	id,
+	fillProps,
+}: WooOnboardingTaskListHeaderProps & Slot.Props ) => (
 	<Slot
 		name={ 'woocommerce_onboarding_task_list_header_' + id }
 		fillProps={ fillProps }

--- a/packages/js/onboarding/src/components/WooOnboardingTaskListHeader/index.ts
+++ b/packages/js/onboarding/src/components/WooOnboardingTaskListHeader/index.ts
@@ -1,0 +1,1 @@
+export * from './WooOnboardingTaskListHeader';

--- a/packages/js/onboarding/src/index.ts
+++ b/packages/js/onboarding/src/index.ts
@@ -13,4 +13,5 @@ export { default as WCPayLogo } from './images/wcpay-logo';
 export { WooPaymentGatewaySetup } from './components/WooPaymentGatewaySetup';
 export { WooPaymentGatewayConfigure } from './components/WooPaymentGatewayConfigure';
 export { WooOnboardingTaskListItem } from './components/WooOnboardingTaskListItem';
+export { WooOnboardingTaskListHeader } from './components/WooOnboardingTaskListHeader';
 export { WooOnboardingTask } from './components/WooOnboardingTask';

--- a/plugins/woocommerce-admin/client/two-column-tasks/task-list.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/task-list.tsx
@@ -13,6 +13,7 @@ import { Button, Card } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { EllipsisMenu } from '@woocommerce/components';
 import { navigateTo, getNewPath } from '@woocommerce/navigation';
+import { WooOnboardingTaskListHeader } from '@woocommerce/onboarding';
 import {
 	ONBOARDING_STORE_NAME,
 	TaskType,
@@ -22,7 +23,7 @@ import {
 	WCDataSelector,
 } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
-import { List } from '@woocommerce/experimental';
+import { List, useSlot } from '@woocommerce/experimental';
 import classnames from 'classnames';
 
 /**
@@ -98,6 +99,12 @@ export const TaskList: React.FC< TaskListProps > = ( {
 	useEffect( () => {
 		recordTaskListView();
 	}, [] );
+
+	const taskListHeaderSlot = useSlot(
+		`woocommerce_onboarding_task_list_header_${
+			headerData?.task?.id ?? ''
+		}`
+	);
 
 	useEffect( () => {
 		const { task: prevTask } = prevQueryRef.current;
@@ -229,6 +236,10 @@ export const TaskList: React.FC< TaskListProps > = ( {
 		return <div className="woocommerce-task-dashboard__container"></div>;
 	}
 
+	const hasTaskListHeaderSlotFills = Boolean(
+		taskListHeaderSlot?.fills?.length
+	);
+
 	if ( isComplete && keepCompletedTaskList !== 'yes' ) {
 		return (
 			<>
@@ -273,11 +284,18 @@ export const TaskList: React.FC< TaskListProps > = ( {
 				>
 					<div className="wooocommerce-task-card__header-container">
 						<div className="wooocommerce-task-card__header">
-							{ headerData?.task &&
+							{ hasTaskListHeaderSlotFills ? (
+								<WooOnboardingTaskListHeader.Slot
+									id={ selectedHeaderCard?.id }
+									fillProps={ headerData }
+								/>
+							) : (
+								headerData?.task &&
 								createElement(
 									taskHeaders[ headerData.task.id ],
 									headerData
-								) }
+								)
+							) }
 						</div>
 						{ ! displayProgressHeader && renderMenu() }
 					</div>

--- a/plugins/woocommerce-admin/client/two-column-tasks/task-list.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/task-list.tsx
@@ -100,12 +100,6 @@ export const TaskList: React.FC< TaskListProps > = ( {
 		recordTaskListView();
 	}, [] );
 
-	const taskListHeaderSlot = useSlot(
-		`woocommerce_onboarding_task_list_header_${
-			headerData?.task?.id ?? ''
-		}`
-	);
-
 	useEffect( () => {
 		const { task: prevTask } = prevQueryRef.current;
 		const { task } = query;
@@ -168,6 +162,15 @@ export const TaskList: React.FC< TaskListProps > = ( {
 		selectedHeaderCard = visibleTasks[ visibleTasks.length - 1 ];
 	}
 
+	const taskListHeaderSlot = useSlot(
+		`woocommerce_onboarding_task_list_header_${
+			headerData?.task?.id ?? selectedHeaderCard?.id
+		}`
+	);
+	const hasTaskListHeaderSlotFills = Boolean(
+		taskListHeaderSlot?.fills?.length
+	);
+
 	const getTaskStartedCount = ( taskId: string ) => {
 		const trackedStartedTasks =
 			userPreferences.task_list_tracked_started_tasks;
@@ -216,7 +219,7 @@ export const TaskList: React.FC< TaskListProps > = ( {
 	};
 
 	const showTaskHeader = ( task: TaskType ) => {
-		if ( taskHeaders[ task.id ] ) {
+		if ( taskHeaders[ task.id ] || hasTaskListHeaderSlotFills ) {
 			setHeaderData( {
 				task,
 				goToTask: () => goToTask( task ),
@@ -235,10 +238,6 @@ export const TaskList: React.FC< TaskListProps > = ( {
 	if ( ! visibleTasks.length ) {
 		return <div className="woocommerce-task-dashboard__container"></div>;
 	}
-
-	const hasTaskListHeaderSlotFills = Boolean(
-		taskListHeaderSlot?.fills?.length
-	);
 
 	if ( isComplete && keepCompletedTaskList !== 'yes' ) {
 		return (

--- a/plugins/woocommerce/changelog/add-36465-tasklist-extensibility
+++ b/plugins/woocommerce/changelog/add-36465-tasklist-extensibility
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-Add WooOnboardingTaskListHeader and woocommerce_onboarding_task_list_header Slot to task list
+Add WooOnboardingTaskListHeader, woocommerce_admin_experimental_onboarding_tasklists filter, and woocommerce_onboarding_task_list_header Slot to task list

--- a/plugins/woocommerce/changelog/add-36465-tasklist-extensibility
+++ b/plugins/woocommerce/changelog/add-36465-tasklist-extensibility
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add WooOnboardingTaskListHeader and woocommerce_onboarding_task_list_header Slot to task list

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
@@ -227,6 +227,16 @@ class TaskLists {
 			self::add_task( 'extended', $tour_task );
 			self::add_task( 'extended_two_column', $tour_task );
 		}
+
+		if ( has_filter( 'woocommerce_admin_experimental_onboarding_tasklists' ) ) {
+			/**
+			 * Filter to override default task lists.
+			 *
+			 * @since 7.4
+			 * @param array     $lists Array of tasklists.
+			 */
+			self::$lists = apply_filters( 'woocommerce_admin_experimental_onboarding_tasklists', self::$lists );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Closes #36465.

This PR:

1. Adds `woocommerce_admin_experimental_onboarding_tasklists` experimental filter for extension developers to be able to add or replace default tasks
2. Adds `WooOnboardingTaskListHeader` component which uses `woocommerce_onboarding_task_list_header_` Slotfill for extension developers to add or replace task headers

<img width="799" alt="image" src="https://user-images.githubusercontent.com/3747241/213616541-ad4fad24-0217-4bf3-98c4-4ff37fbea4c5.png">


### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Cherry-pick [this commit](https://github.com/woocommerce/woocommerce/commit/2420c3bc10a76f96aae34b9cd377228d346978d8)
4. Refresh WooCommerce > Home
5. Observe that the entire tasklist is replaced

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
