### PR TITLE
Upstream changes from experimental-select-control back to @woocommerce/components

### DIFF
--- a/packages/js/components/changelog/update-experimental-select-control
+++ b/packages/js/components/changelog/update-experimental-select-control
@@ -1,4 +1,4 @@
 Significance: minor
 Type: update
 
-Apply wccom experimenta select control changes
+Apply wccom experimental select control changes

--- a/packages/js/components/changelog/update-experimental-select-control
+++ b/packages/js/components/changelog/update-experimental-select-control
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Apply wccom experimenta select control changes

--- a/packages/js/components/src/experimental-select-control/combo-box.scss
+++ b/packages/js/components/src/experimental-select-control/combo-box.scss
@@ -44,3 +44,18 @@
 .woocommerce-experimental-select-control__suffix {
 	align-self: stretch;
 }
+
+.woocommerce-experimental-select-control__combox-box-icon {
+	all: unset;
+	position: absolute;
+	right: 6px;
+	top: 50%;
+	transform: translateY( -50% );
+	> svg {
+		margin-top: 4px;
+	}
+}
+
+.woocommerce-experimental-select-control:not( .is-focused ) .woocommerce-experimental-select-control__combox-box-icon {
+	pointer-events: none; // Prevents the icon from being clickable when the combobox is not focused, because otherwise we get a race condition when clicking on the icon, because focussing the combobox opens the menu, then sequentially the icon toggles it back closed
+}

--- a/packages/js/components/src/experimental-select-control/combo-box.scss
+++ b/packages/js/components/src/experimental-select-control/combo-box.scss
@@ -45,7 +45,7 @@
 	align-self: stretch;
 }
 
-.woocommerce-experimental-select-control__combox-box-icon {
+.woocommerce-experimental-select-control__combox-box-toggle-button {
 	all: unset;
 	position: absolute;
 	right: 6px;
@@ -56,6 +56,6 @@
 	}
 }
 
-.woocommerce-experimental-select-control:not( .is-focused ) .woocommerce-experimental-select-control__combox-box-icon {
+.woocommerce-experimental-select-control:not( .is-focused ) .woocommerce-experimental-select-control__combox-box-toggle-button {
 	pointer-events: none; // Prevents the icon from being clickable when the combobox is not focused, because otherwise we get a race condition when clicking on the icon, because focussing the combobox opens the menu, then sequentially the icon toggles it back closed
 }

--- a/packages/js/components/src/experimental-select-control/combo-box.tsx
+++ b/packages/js/components/src/experimental-select-control/combo-box.tsx
@@ -1,21 +1,42 @@
 /**
  * External dependencies
  */
-import { createElement, MouseEvent, useRef } from 'react';
+import { createElement, MouseEvent, useRef, forwardRef } from 'react';
 import classNames from 'classnames';
+import { Icon, chevronDown } from '@wordpress/icons';
 
 type ComboBoxProps = {
 	children?: JSX.Element | JSX.Element[] | null;
 	comboBoxProps: JSX.IntrinsicElements[ 'div' ];
 	inputProps: JSX.IntrinsicElements[ 'input' ];
+	getToggleButtonProps: () => Omit<
+		JSX.IntrinsicElements[ 'button' ],
+		'ref'
+	>;
 	suffix?: JSX.Element | null;
+	showToggleButton?: boolean;
 };
+
+const ToggleButton = forwardRef< HTMLButtonElement >( ( props, ref ) => {
+	// using forwardRef here because getToggleButtonProps injects a ref prop
+	return (
+		<button
+			className="woocommerce-experimental-select-control__combox-box-icon"
+			{ ...props }
+			ref={ ref }
+		>
+			<Icon icon={ chevronDown } />
+		</button>
+	);
+} );
 
 export const ComboBox = ( {
 	children,
 	comboBoxProps,
+	getToggleButtonProps,
 	inputProps,
 	suffix,
+	showToggleButton,
 }: ComboBoxProps ) => {
 	const inputRef = useRef< HTMLInputElement | null >( null );
 
@@ -71,6 +92,9 @@ export const ComboBox = ( {
 				<div className="woocommerce-experimental-select-control__suffix">
 					{ suffix }
 				</div>
+			) }
+			{ showToggleButton && (
+				<ToggleButton { ...getToggleButtonProps() } />
 			) }
 		</div>
 	);

--- a/packages/js/components/src/experimental-select-control/combo-box.tsx
+++ b/packages/js/components/src/experimental-select-control/combo-box.tsx
@@ -9,7 +9,7 @@ type ComboBoxProps = {
 	children?: JSX.Element | JSX.Element[] | null;
 	comboBoxProps: JSX.IntrinsicElements[ 'div' ];
 	inputProps: JSX.IntrinsicElements[ 'input' ];
-	getToggleButtonProps: () => Omit<
+	getToggleButtonProps?: () => Omit<
 		JSX.IntrinsicElements[ 'button' ],
 		'ref'
 	>;
@@ -33,7 +33,7 @@ const ToggleButton = forwardRef< HTMLButtonElement >( ( props, ref ) => {
 export const ComboBox = ( {
 	children,
 	comboBoxProps,
-	getToggleButtonProps,
+	getToggleButtonProps = () => ( {} ),
 	inputProps,
 	suffix,
 	showToggleButton,

--- a/packages/js/components/src/experimental-select-control/combo-box.tsx
+++ b/packages/js/components/src/experimental-select-control/combo-box.tsx
@@ -21,7 +21,7 @@ const ToggleButton = forwardRef< HTMLButtonElement >( ( props, ref ) => {
 	// using forwardRef here because getToggleButtonProps injects a ref prop
 	return (
 		<button
-			className="woocommerce-experimental-select-control__combox-box-icon"
+			className="woocommerce-experimental-select-control__combox-box-toggle-button"
 			{ ...props }
 			ref={ ref }
 		>

--- a/packages/js/components/src/experimental-select-control/menu-item.tsx
+++ b/packages/js/components/src/experimental-select-control/menu-item.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { createElement, ReactElement } from 'react';
+import { createElement, CSSProperties, ReactElement } from 'react';
 
 /**
  * Internal dependencies
@@ -14,6 +14,7 @@ export type MenuItemProps< ItemType > = {
 	item: ItemType;
 	children: ReactElement | string;
 	getItemProps: getItemPropsType< ItemType >;
+	activeStyle?: CSSProperties;
 };
 
 export const MenuItem = < ItemType, >( {
@@ -21,11 +22,12 @@ export const MenuItem = < ItemType, >( {
 	getItemProps,
 	index,
 	isActive,
+	activeStyle = { backgroundColor: '#bde4ff' },
 	item,
 }: MenuItemProps< ItemType > ) => {
 	return (
 		<li
-			style={ isActive ? { backgroundColor: '#bde4ff' } : {} }
+			style={ isActive ? activeStyle : {} }
 			{ ...getItemProps( { item, index } ) }
 			className="woocommerce-experimental-select-control__menu-item"
 		>

--- a/packages/js/components/src/experimental-select-control/menu.tsx
+++ b/packages/js/components/src/experimental-select-control/menu.tsx
@@ -22,6 +22,8 @@ type MenuProps = {
 	getMenuProps: getMenuPropsType;
 	isOpen: boolean;
 	className?: string;
+	position?: Popover.Position;
+	scrollIntoViewOnOpen?: boolean;
 };
 
 export const Menu = ( {
@@ -29,6 +31,8 @@ export const Menu = ( {
 	getMenuProps,
 	isOpen,
 	className,
+	position = 'bottom center',
+	scrollIntoViewOnOpen = false,
 }: MenuProps ) => {
 	const [ boundingRect, setBoundingRect ] = useState< DOMRect >();
 	const selectControlMenuRef = useRef< HTMLDivElement >( null );
@@ -40,6 +44,13 @@ export const Menu = ( {
 			);
 		}
 	}, [ selectControlMenuRef.current ] );
+
+	// Scroll the selected item into view when the menu opens.
+	useEffect( () => {
+		if ( isOpen && scrollIntoViewOnOpen ) {
+			selectControlMenuRef.current?.scrollIntoView();
+		}
+	}, [ isOpen, scrollIntoViewOnOpen ] );
 
 	/* eslint-disable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events */
 	/* Disabled because of the onmouseup on the ul element below. */
@@ -60,7 +71,7 @@ export const Menu = ( {
 							'has-results': Children.count( children ) > 0,
 						}
 					) }
-					position="bottom right"
+					position={ position }
 					animate={ false }
 				>
 					<ul

--- a/packages/js/components/src/experimental-select-control/menu.tsx
+++ b/packages/js/components/src/experimental-select-control/menu.tsx
@@ -31,7 +31,7 @@ export const Menu = ( {
 	getMenuProps,
 	isOpen,
 	className,
-	position = 'bottom center',
+	position = 'bottom right',
 	scrollIntoViewOnOpen = false,
 }: MenuProps ) => {
 	const [ boundingRect, setBoundingRect ] = useState< DOMRect >();

--- a/packages/js/components/src/experimental-select-control/select-control.tsx
+++ b/packages/js/components/src/experimental-select-control/select-control.tsx
@@ -68,6 +68,7 @@ export type SelectControlProps< ItemType > = {
 	disabled?: boolean;
 	inputProps?: GetInputPropsOptions;
 	suffix?: JSX.Element | null;
+	showToggleButton?: boolean;
 	/**
 	 * This is a feature already implemented in downshift@7.0.0 through the
 	 * reducer. In order for us to use it this prop is added temporarily until
@@ -123,6 +124,7 @@ function SelectControl< ItemType = DefaultItemType >( {
 	disabled,
 	inputProps = {},
 	suffix = <SuffixIcon icon={ search } />,
+	showToggleButton = false,
 	__experimentalOpenMenuOnFocus = false,
 }: SelectControlProps< ItemType > ) {
 	const [ isFocused, setIsFocused ] = useState( false );
@@ -154,12 +156,13 @@ function SelectControl< ItemType = DefaultItemType >( {
 		}
 
 		setInputValue( getItemLabel( singleSelectedItem ) );
-	}, [ singleSelectedItem ] );
+	}, [ getItemLabel, multiple, singleSelectedItem ] );
 
 	const {
 		isOpen,
 		getLabelProps,
 		getMenuProps,
+		getToggleButtonProps,
 		getInputProps,
 		getComboboxProps,
 		highlightedIndex,
@@ -256,6 +259,7 @@ function SelectControl< ItemType = DefaultItemType >( {
 			{ /* eslint-enable jsx-a11y/label-has-for */ }
 			<ComboBox
 				comboBoxProps={ getComboboxProps() }
+				getToggleButtonProps={ getToggleButtonProps }
 				inputProps={ getInputProps( {
 					...getDropdownProps( {
 						preventKeyAction: isOpen,
@@ -274,6 +278,7 @@ function SelectControl< ItemType = DefaultItemType >( {
 					...inputProps,
 				} ) }
 				suffix={ suffix }
+				showToggleButton={ showToggleButton }
 			>
 				<>
 					{ children( {

--- a/packages/js/components/src/experimental-select-control/stories/index.tsx
+++ b/packages/js/components/src/experimental-select-control/stories/index.tsx
@@ -573,6 +573,24 @@ export const CustomSuffix: React.FC = () => {
 	);
 };
 
+export const ToggleButton: React.FC = () => {
+	const [ selected, setSelected ] = useState<
+		SelectedType< DefaultItemType >
+	>( sampleItems[ 1 ] );
+
+	return (
+		<SelectControl
+			items={ sampleItems }
+			label="Has toggle button"
+			selected={ selected }
+			onSelect={ ( item ) => item && setSelected( item ) }
+			onRemove={ () => setSelected( null ) }
+			suffix={ null }
+			showToggleButton={ true }
+		/>
+	);
+};
+
 export default {
 	title: 'WooCommerce Admin/experimental/SelectControl',
 	component: SelectControl,

--- a/packages/js/components/src/experimental-select-control/stories/index.tsx
+++ b/packages/js/components/src/experimental-select-control/stories/index.tsx
@@ -574,9 +574,8 @@ export const CustomSuffix: React.FC = () => {
 };
 
 export const ToggleButton: React.FC = () => {
-	const [ selected, setSelected ] = useState<
-		SelectedType< DefaultItemType >
-	>( sampleItems[ 1 ] );
+	const [ selected, setSelected ] =
+		useState< SelectedType< DefaultItemType > >();
 
 	return (
 		<SelectControl
@@ -587,6 +586,7 @@ export const ToggleButton: React.FC = () => {
 			onRemove={ () => setSelected( null ) }
 			suffix={ null }
 			showToggleButton={ true }
+			__experimentalOpenMenuOnFocus={ true }
 		/>
 	);
 };


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/team-ghidorah/issues/148.

This PR applies the following changes from the WCCOM experimental select control fork.

1. Add a toggle button
2. Add the ability to customize menu item active style
3. Add `scrollIntoViewOnOpen` feature and `position` prop to the Menu component



<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Run `pnpm --filter=@woocommerce/storybook run storybook`
2. Go to http://localhost:6007/?path=/story/woocommerce-admin-experimental-selectcontrol--toggle-button
3. Observe that a toggle button is displayed on the right of the input box.
4  Click on the toggle button
5. Observe that the menu is opened.
6. Make sure other story examples still work as expected

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
