### PR TITLE
Fix: Ampersand changed to &amp on product attribute export #36520

### DIFF
--- a/plugins/woocommerce/changelog/update_36520
+++ b/plugins/woocommerce/changelog/update_36520
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Ampersand changed to &amp on product attribute export

--- a/plugins/woocommerce/includes/export/abstract-wc-csv-exporter.php
+++ b/plugins/woocommerce/includes/export/abstract-wc-csv-exporter.php
@@ -467,7 +467,7 @@ abstract class WC_CSV_Exporter {
 		$values_to_implode = array();
 
 		foreach ( $values as $value ) {
-			$value               = (string) is_scalar( $value ) ? $value : '';
+			$value               = (string) is_scalar( $value ) ? html_entity_decode( $value, ENT_QUOTES ) : '';
 			$values_to_implode[] = str_replace( ',', '\\,', $value );
 		}
 

--- a/plugins/woocommerce/includes/export/class-wc-product-csv-exporter.php
+++ b/plugins/woocommerce/includes/export/class-wc-product-csv-exporter.php
@@ -675,10 +675,10 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 
 						if ( 0 === strpos( $attribute_name, 'pa_' ) ) {
 							$option_term = get_term_by( 'slug', $attribute, $attribute_name ); // @codingStandardsIgnoreLine.
-							$row[ 'attributes:value' . $i ]    = $option_term && ! is_wp_error( $option_term ) ? str_replace( ',', '\\,', $option_term->name ) : str_replace( ',', '\\,', $attribute );
+							$row[ 'attributes:value' . $i ]    = $option_term && ! is_wp_error( $option_term ) ? html_entity_decode( str_replace( ',', '\\,', $option_term->name ), ENT_QUOTES ) : html_entity_decode( str_replace( ',', '\\,', $attribute ), ENT_QUOTES );
 							$row[ 'attributes:taxonomy' . $i ] = 1;
 						} else {
-							$row[ 'attributes:value' . $i ]    = str_replace( ',', '\\,', $attribute );
+							$row[ 'attributes:value' . $i ]    = html_entity_decode( str_replace( ',', '\\,', $attribute ), ENT_QUOTES );
 							$row[ 'attributes:taxonomy' . $i ] = 0;
 						}
 

--- a/plugins/woocommerce/includes/export/class-wc-product-csv-exporter.php
+++ b/plugins/woocommerce/includes/export/class-wc-product-csv-exporter.php
@@ -652,7 +652,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 					$this->column_names[ 'attributes:taxonomy' . $i ] = sprintf( __( 'Attribute %d global', 'woocommerce' ), $i );
 
 					if ( is_a( $attribute, 'WC_Product_Attribute' ) ) {
-						$row[ 'attributes:name' . $i ] = wc_attribute_label( $attribute->get_name(), $product );
+						$row[ 'attributes:name' . $i ] = html_entity_decode( wc_attribute_label( $attribute->get_name(), $product ), ENT_QUOTES );
 
 						if ( $attribute->is_taxonomy() ) {
 							$terms  = $attribute->get_terms();
@@ -671,7 +671,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 
 						$row[ 'attributes:visible' . $i ] = $attribute->get_visible();
 					} else {
-						$row[ 'attributes:name' . $i ] = wc_attribute_label( $attribute_name, $product );
+						$row[ 'attributes:name' . $i ] = html_entity_decode( wc_attribute_label( $attribute_name, $product ), ENT_QUOTES );
 
 						if ( 0 === strpos( $attribute_name, 'pa_' ) ) {
 							$option_term = get_term_by( 'slug', $attribute, $attribute_name ); // @codingStandardsIgnoreLine.

--- a/plugins/woocommerce/includes/wc-attribute-functions.php
+++ b/plugins/woocommerce/includes/wc-attribute-functions.php
@@ -207,6 +207,8 @@ function wc_attribute_label( $name, $product = '' ) {
 	} else {
 		$label = $name;
 	}
+	
+	$label = html_entity_decode( $label, ENT_QUOTES );
 
 	return apply_filters( 'woocommerce_attribute_label', $label, $name, $product );
 }

--- a/plugins/woocommerce/includes/wc-attribute-functions.php
+++ b/plugins/woocommerce/includes/wc-attribute-functions.php
@@ -207,8 +207,6 @@ function wc_attribute_label( $name, $product = '' ) {
 	} else {
 		$label = $name;
 	}
-	
-	$label = html_entity_decode( $label, ENT_QUOTES );
 
 	return apply_filters( 'woocommerce_attribute_label', $label, $name, $product );
 }


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Add one global attribute like "Test & ABC"
2. Use the above attribute in one of the product variations
3. Save Product
4. Navigate to the All Products
5. Click on the Export button at top of the page
6. Select the **Attributes** column in "Which columns should be exported?"
7. Click on Generate CSV button

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
