### PR TITLE
Fix/36530 settings tables styles

### DIFF
--- a/plugins/woocommerce/changelog/fix-36530_settings_tables_styles
+++ b/plugins/woocommerce/changelog/fix-36530_settings_tables_styles
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix settings tables styles

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -4375,11 +4375,6 @@ img.help_tip {
 			top: 20px;
 		}
 
-		td.help-tooltip {
-			white-space: nowrap;
-			width: 8px;
-		}
-
 		.select2-container {
 			vertical-align: top;
 			margin-bottom: 3px;
@@ -4412,6 +4407,17 @@ img.help_tip {
 
 			&:first-child {
 				margin-top: 0;
+			}
+		}
+
+		td.with-tooltip {
+			> fieldset {
+				margin-top: 0;
+			}
+			span.help-tooltip {
+				position: absolute;
+				margin-left: -30px;
+				margin-top: 7px;
 			}
 		}
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
@@ -489,11 +489,15 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						}
 
 						if ( ! isset( $value['checkboxgroup'] ) || 'start' === $value['checkboxgroup'] ) {
+							$has_tooltip = isset( $value['tooltip'] ) && '' !== $value['tooltip'];
+							$tooltip_container_class = $has_tooltip ? esc_html('with-tooltip') : '';
 							?>
 								<tr valign="top" class="<?php echo esc_attr( implode( ' ', $visibility_class ) ); ?>">
 									<th scope="row" class="titledesc"><?php echo esc_html( $value['title'] ); ?></th>
-									<td class="help-tooltip"><?php echo isset( $value['tooltip'] ) && '' !== $value['tooltip'] ? wc_help_tip( esc_html( $value['tooltip'] ) ) : ''; ?></td>
-									<td class="forminp forminp-checkbox">
+									<td class="forminp forminp-checkbox <?php echo $tooltip_container_class; ?>">
+										<?php if ( $has_tooltip ) : ?>
+											<span class="help-tooltip"><?php echo wc_help_tip( esc_html( $value['tooltip'] ) ); ?></span>
+										<?php endif; ?>
 										<fieldset>
 							<?php
 						} else {

--- a/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
@@ -489,12 +489,12 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						}
 
 						if ( ! isset( $value['checkboxgroup'] ) || 'start' === $value['checkboxgroup'] ) {
-							$has_tooltip = isset( $value['tooltip'] ) && '' !== $value['tooltip'];
-							$tooltip_container_class = $has_tooltip ? esc_html('with-tooltip') : '';
+							$has_tooltip             = isset( $value['tooltip'] ) && '' !== $value['tooltip'];
+							$tooltip_container_class = $has_tooltip ? 'with-tooltip' : '';
 							?>
 								<tr valign="top" class="<?php echo esc_attr( implode( ' ', $visibility_class ) ); ?>">
 									<th scope="row" class="titledesc"><?php echo esc_html( $value['title'] ); ?></th>
-									<td class="forminp forminp-checkbox <?php echo $tooltip_container_class; ?>">
+									<td class="forminp forminp-checkbox <?php echo esc_html( $tooltip_container_class ); ?>">
 										<?php if ( $has_tooltip ) : ?>
 											<span class="help-tooltip"><?php echo wc_help_tip( esc_html( $value['tooltip'] ) ); ?></span>
 										<?php endif; ?>


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR adds the changes to add a tooltip to the advanced settings tables without breaking other settings tables.

![Screenshot 2023-01-20 at 15 04 13](https://user-images.githubusercontent.com/1314156/213774058-3c634bd1-dec1-4f61-b38e-2d05d6d4852f.png)

Closes #36530 .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Install a plugin that adds new settings like WooCommerce Payments
2. Go to WooCommerce > Settings > Subscriptions
3. Verify that the table looks ok.

**New**
![Screenshot 2023-01-20 at 13 27 43](https://user-images.githubusercontent.com/1314156/213751747-49af51f0-57b8-4ed8-b7e1-0965f00ecec6.png)

**Broken**
![Screenshot 2023-01-20 at 13 27 04](https://user-images.githubusercontent.com/1314156/213751597-60ed2b2b-f458-42bf-bb3a-a195971d85d7.png)

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
