### PR TITLE
Add feedback modal and product mvp feedback modal components

### DIFF
--- a/packages/js/customer-effort-score/changelog/add-36324_survey_after_disabling_new_exp
+++ b/packages/js/customer-effort-score/changelog/add-36324_survey_after_disabling_new_exp
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add FeedbackModal and ProductMVPFeedbackModal components

--- a/packages/js/customer-effort-score/src/feedback-modal/feedback-modal.scss
+++ b/packages/js/customer-effort-score/src/feedback-modal/feedback-modal.scss
@@ -6,7 +6,7 @@
 	}
 }
 
-.woocommerce-feedback-modal .woocommerce-feedback-modal__intro {
+.woocommerce-feedback-modal .woocommerce-feedback-modal__description {
 	max-width: 550px;
 	margin: 0 0 1.5em 0;
 }

--- a/packages/js/customer-effort-score/src/feedback-modal/feedback-modal.scss
+++ b/packages/js/customer-effort-score/src/feedback-modal/feedback-modal.scss
@@ -1,0 +1,12 @@
+.woocommerce-feedback-modal__buttons {
+	text-align: right;
+
+	.components-button {
+		margin-left: 1em;
+	}
+}
+
+.woocommerce-feedback-modal .woocommerce-feedback-modal__intro {
+	max-width: 550px;
+	margin: 0 0 1.5em 0;
+}

--- a/packages/js/customer-effort-score/src/feedback-modal/feedback-modal.tsx
+++ b/packages/js/customer-effort-score/src/feedback-modal/feedback-modal.tsx
@@ -1,0 +1,106 @@
+/**
+ * External dependencies
+ */
+import { createElement, useState } from '@wordpress/element';
+import PropTypes from 'prop-types';
+import { Button, Modal } from '@wordpress/components';
+import { Text } from '@woocommerce/experimental';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Provides a modal requesting customer feedback.
+ *
+ * Answers and comments are sent to a callback function.
+ *
+ * @param {Object}   props                      Component props.
+ * @param {Function} props.onSendFeedback       Function to call when the results are sent.
+ * @param {string}   props.title                Title displayed in the modal.
+ * @param {string}   props.description          Description displayed in the modal.
+ * @param {string}   props.isSendButtonDisabled Boolean to enable/disable the send button.
+ * @param {string}   props.sendButtonLabel      Label for the send button.
+ * @param {string}   props.cancelButtonLabel    Label for the cancel button.
+ * @param {Function} props.onCloseModal         Callback for when user closes modal by clicking cancel.
+ * @param {Function} props.children             Children to be rendered.
+ */
+function FeedbackModal( {
+	onSendFeedback,
+	title,
+	description,
+	onCloseModal,
+	children,
+	isSendButtonDisabled,
+	sendButtonLabel,
+	cancelButtonLabel,
+}: {
+	onSendFeedback: () => void;
+	title: string;
+	description?: string;
+	onCloseModal?: () => void;
+	children?: JSX.Element;
+	isSendButtonDisabled?: boolean;
+	sendButtonLabel?: string;
+	cancelButtonLabel?: string;
+} ): JSX.Element | null {
+	const [ isOpen, setOpen ] = useState( true );
+
+	const closeModal = () => {
+		setOpen( false );
+		if ( onCloseModal ) {
+			onCloseModal();
+		}
+	};
+
+	if ( ! isOpen ) {
+		return null;
+	}
+
+	return (
+		<Modal
+			className="woocommerce-feedback-modal"
+			title={ title }
+			onRequestClose={ closeModal }
+			shouldCloseOnClickOutside={ false }
+		>
+			<Text
+				variant="body"
+				as="p"
+				className="woocommerce-feedback-modal__intro"
+				size={ 14 }
+				lineHeight="20px"
+				marginBottom="1.5em"
+			>
+				{ description }
+			</Text>
+			{ children }
+			<div className="woocommerce-feedback-modal__buttons">
+				<Button isTertiary onClick={ closeModal } name="cancel">
+					{ cancelButtonLabel }
+				</Button>
+				<Button
+					isPrimary
+					onClick={ () => {
+						onSendFeedback();
+						setOpen( false );
+					} }
+					name="send"
+					disabled={ isSendButtonDisabled }
+				>
+					{ sendButtonLabel }
+				</Button>
+			</div>
+		</Modal>
+	);
+}
+
+FeedbackModal.propTypes = {
+	onSendFeedback: PropTypes.func.isRequired,
+	title: PropTypes.string,
+	description: PropTypes.string,
+	defaultScore: PropTypes.number,
+	onCloseModal: PropTypes.func,
+	isSendButtonDisabled: PropTypes.bool,
+	sendButtonLabel: PropTypes.string,
+	cancelButtonLabel: PropTypes.string,
+};
+
+export { FeedbackModal };

--- a/packages/js/customer-effort-score/src/feedback-modal/feedback-modal.tsx
+++ b/packages/js/customer-effort-score/src/feedback-modal/feedback-modal.tsx
@@ -77,7 +77,8 @@ function FeedbackModal( {
 					{ cancelButtonLabel }
 				</Button>
 				<Button
-					isPrimary
+					isPrimary={ ! isSendButtonDisabled }
+					isSecondary={ isSendButtonDisabled }
 					onClick={ () => {
 						onSendFeedback();
 						setOpen( false );

--- a/packages/js/customer-effort-score/src/feedback-modal/feedback-modal.tsx
+++ b/packages/js/customer-effort-score/src/feedback-modal/feedback-modal.tsx
@@ -12,41 +12,41 @@ import { __ } from '@wordpress/i18n';
  *
  * Answers and comments are sent to a callback function.
  *
- * @param {Object}   props                      Component props.
- * @param {Function} props.onSendFeedback       Function to call when the results are sent.
- * @param {string}   props.title                Title displayed in the modal.
- * @param {string}   props.description          Description displayed in the modal.
- * @param {string}   props.isSendButtonDisabled Boolean to enable/disable the send button.
- * @param {string}   props.sendButtonLabel      Label for the send button.
- * @param {string}   props.cancelButtonLabel    Label for the cancel button.
- * @param {Function} props.onCloseModal         Callback for when user closes modal by clicking cancel.
- * @param {Function} props.children             Children to be rendered.
+ * @param {Object}   props                        Component props.
+ * @param {Function} props.onSubmit               Function to call when the results are sent.
+ * @param {string}   props.title                  Title displayed in the modal.
+ * @param {string}   props.description            Description displayed in the modal.
+ * @param {string}   props.isSubmitButtonDisabled Boolean to enable/disable the send button.
+ * @param {string}   props.submitButtonLabel      Label for the send button.
+ * @param {string}   props.cancelButtonLabel      Label for the cancel button.
+ * @param {Function} props.onModalClose           Callback for when user closes modal by clicking cancel.
+ * @param {Function} props.children               Children to be rendered.
  */
 function FeedbackModal( {
-	onSendFeedback,
+	onSubmit,
 	title,
 	description,
-	onCloseModal,
+	onModalClose,
 	children,
-	isSendButtonDisabled,
-	sendButtonLabel,
+	isSubmitButtonDisabled,
+	submitButtonLabel,
 	cancelButtonLabel,
 }: {
-	onSendFeedback: () => void;
+	onSubmit: () => void;
 	title: string;
 	description?: string;
-	onCloseModal?: () => void;
+	onModalClose?: () => void;
 	children?: JSX.Element;
-	isSendButtonDisabled?: boolean;
-	sendButtonLabel?: string;
+	isSubmitButtonDisabled?: boolean;
+	submitButtonLabel?: string;
 	cancelButtonLabel?: string;
 } ): JSX.Element | null {
 	const [ isOpen, setOpen ] = useState( true );
 
 	const closeModal = () => {
 		setOpen( false );
-		if ( onCloseModal ) {
-			onCloseModal();
+		if ( onModalClose ) {
+			onModalClose();
 		}
 	};
 
@@ -64,7 +64,7 @@ function FeedbackModal( {
 			<Text
 				variant="body"
 				as="p"
-				className="woocommerce-feedback-modal__intro"
+				className="woocommerce-feedback-modal__description"
 				size={ 14 }
 				lineHeight="20px"
 				marginBottom="1.5em"
@@ -77,16 +77,16 @@ function FeedbackModal( {
 					{ cancelButtonLabel }
 				</Button>
 				<Button
-					isPrimary={ ! isSendButtonDisabled }
-					isSecondary={ isSendButtonDisabled }
+					isPrimary={ ! isSubmitButtonDisabled }
+					isSecondary={ isSubmitButtonDisabled }
 					onClick={ () => {
-						onSendFeedback();
+						onSubmit();
 						setOpen( false );
 					} }
 					name="send"
-					disabled={ isSendButtonDisabled }
+					disabled={ isSubmitButtonDisabled }
 				>
-					{ sendButtonLabel }
+					{ submitButtonLabel }
 				</Button>
 			</div>
 		</Modal>
@@ -94,13 +94,12 @@ function FeedbackModal( {
 }
 
 FeedbackModal.propTypes = {
-	onSendFeedback: PropTypes.func.isRequired,
+	onSubmit: PropTypes.func.isRequired,
 	title: PropTypes.string,
 	description: PropTypes.string,
-	defaultScore: PropTypes.number,
-	onCloseModal: PropTypes.func,
-	isSendButtonDisabled: PropTypes.bool,
-	sendButtonLabel: PropTypes.string,
+	onModalClose: PropTypes.func,
+	isSubmitButtonDisabled: PropTypes.bool,
+	submitButtonLabel: PropTypes.string,
 	cancelButtonLabel: PropTypes.string,
 };
 

--- a/packages/js/customer-effort-score/src/feedback-modal/index.ts
+++ b/packages/js/customer-effort-score/src/feedback-modal/index.ts
@@ -1,0 +1,1 @@
+export * from './feedback-modal';

--- a/packages/js/customer-effort-score/src/feedback-modal/test/index.tsx
+++ b/packages/js/customer-effort-score/src/feedback-modal/test/index.tsx
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { createElement } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { FeedbackModal } from '../index';
+
+const mockRecordScoreCallback = jest.fn();
+
+describe( 'FeedbackModal', () => {
+	it( 'should render a modal', async () => {
+		render(
+			<FeedbackModal
+				onSendFeedback={ mockRecordScoreCallback }
+				title="Testing"
+				sendButtonLabel="Send"
+				cancelButtonLabel="Cancel"
+			/>
+		);
+
+		// Wait for the modal to render.
+		await screen.findByRole( 'dialog' );
+
+		expect(
+			screen.getByRole( 'button', { name: /Send/i } )
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole( 'button', { name: /Cancel/i } )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should close modal when cancel button pressed', async () => {
+		render(
+			<FeedbackModal
+				onSendFeedback={ mockRecordScoreCallback }
+				title="Testing"
+				sendButtonLabel="Send"
+				cancelButtonLabel="Cancel"
+			/>
+		);
+
+		// Wait for the modal to render.
+		await screen.findByRole( 'dialog' );
+
+		// Press cancel button.
+		fireEvent.click( screen.getByRole( 'button', { name: /Cancel/i } ) );
+
+		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/packages/js/customer-effort-score/src/feedback-modal/test/index.tsx
+++ b/packages/js/customer-effort-score/src/feedback-modal/test/index.tsx
@@ -15,9 +15,9 @@ describe( 'FeedbackModal', () => {
 	it( 'should render a modal', async () => {
 		render(
 			<FeedbackModal
-				onSendFeedback={ mockRecordScoreCallback }
+				onSubmit={ mockRecordScoreCallback }
 				title="Testing"
-				sendButtonLabel="Send"
+				submitButtonLabel="Send"
 				cancelButtonLabel="Cancel"
 			/>
 		);
@@ -36,9 +36,9 @@ describe( 'FeedbackModal', () => {
 	it( 'should close modal when cancel button pressed', async () => {
 		render(
 			<FeedbackModal
-				onSendFeedback={ mockRecordScoreCallback }
+				onSubmit={ mockRecordScoreCallback }
 				title="Testing"
-				sendButtonLabel="Send"
+				submitButtonLabel="Send"
 				cancelButtonLabel="Cancel"
 			/>
 		);

--- a/packages/js/customer-effort-score/src/index.ts
+++ b/packages/js/customer-effort-score/src/index.ts
@@ -1,3 +1,5 @@
 export * from './customer-effort-score';
 export * from './customer-feedback-simple';
 export * from './customer-feedback-modal';
+export * from './product-mvp-feedback-modal';
+export * from './feedback-modal';

--- a/packages/js/customer-effort-score/src/product-mvp-feedback-modal/index.ts
+++ b/packages/js/customer-effort-score/src/product-mvp-feedback-modal/index.ts
@@ -1,0 +1,1 @@
+export * from './product-mvp-feedback-modal';

--- a/packages/js/customer-effort-score/src/product-mvp-feedback-modal/product-mvp-feedback-modal.scss
+++ b/packages/js/customer-effort-score/src/product-mvp-feedback-modal/product-mvp-feedback-modal.scss
@@ -1,0 +1,23 @@
+.woocommerce-product-mvp-feedback-modal {
+	&__subtitle {
+		margin-top: $gap-smaller !important;
+	}
+	&__checkboxes {
+		margin: $gap-small 0;
+	}
+	&__comments {
+		margin-top: 2em;
+		margin-bottom: 1.5em;
+
+		label {
+			display: block;
+			font-weight: bold;
+			text-transform: none;
+			font-size: 14px;
+		}
+
+		textarea {
+			width: 100%;
+		}
+	}
+}

--- a/packages/js/customer-effort-score/src/product-mvp-feedback-modal/product-mvp-feedback-modal.tsx
+++ b/packages/js/customer-effort-score/src/product-mvp-feedback-modal/product-mvp-feedback-modal.tsx
@@ -91,10 +91,10 @@ function ProductMVPFeedbackModal( {
 				'We’re working on making it better, and your feedback will help improve the experience for thousands of merchants like you.',
 				'woocommerce'
 			) }
-			onSendFeedback={ onSendFeedback }
-			onCloseModal={ onCloseModal }
-			isSendButtonDisabled={ isSendButtonDisabled }
-			sendButtonLabel={ __( 'Send feedback', 'woocommerce' ) }
+			onSubmit={ onSendFeedback }
+			onModalClose={ onCloseModal }
+			isSubmitButtonDisabled={ isSendButtonDisabled }
+			submitButtonLabel={ __( 'Send feedback', 'woocommerce' ) }
 			cancelButtonLabel={ __( 'Skip', 'woocommerce' ) }
 		>
 			<>

--- a/packages/js/customer-effort-score/src/product-mvp-feedback-modal/product-mvp-feedback-modal.tsx
+++ b/packages/js/customer-effort-score/src/product-mvp-feedback-modal/product-mvp-feedback-modal.tsx
@@ -1,0 +1,156 @@
+/**
+ * External dependencies
+ */
+import { createElement, Fragment, useState } from '@wordpress/element';
+import PropTypes from 'prop-types';
+import { CheckboxControl, TextareaControl } from '@wordpress/components';
+import { Text } from '@woocommerce/experimental';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { FeedbackModal } from '../feedback-modal';
+
+/**
+ * Provides a modal requesting customer feedback.
+ *
+ *
+ * @param {Object}   props                     Component props.
+ * @param {Function} props.recordScoreCallback Function to call when the results are sent.
+ * @param {Function} props.onCloseModal        Callback for when user closes modal by clicking cancel.
+ */
+function ProductMVPFeedbackModal( {
+	recordScoreCallback,
+	onCloseModal,
+}: {
+	recordScoreCallback: ( checked: string[], comments: string ) => void;
+	onCloseModal?: () => void;
+} ): JSX.Element | null {
+	const [ missingFeatures, setMissingFeatures ] = useState( false );
+	const [ missingPlugins, setMissingPlugins ] = useState( false );
+	const [ difficultToUse, setDifficultToUse ] = useState( false );
+	const [ slowBuggyOrBroken, setSlowBuggyOrBroken ] = useState( false );
+	const [ other, setOther ] = useState( false );
+	const checkboxes = [
+		{
+			key: 'missing-features',
+			label: __( 'Missing features', 'woocommerce' ),
+			checked: missingFeatures,
+			onChange: setMissingFeatures,
+		},
+		{
+			key: 'missing-plugins',
+			label: __( 'Missing plugins', 'woocommerce' ),
+			checked: missingPlugins,
+			onChange: setMissingPlugins,
+		},
+		{
+			key: 'difficult-to-use',
+			label: __( 'It is difficult to use', 'woocommerce' ),
+			checked: difficultToUse,
+			onChange: setDifficultToUse,
+		},
+		{
+			key: 'slow-buggy-or-broken',
+			label: __( 'It is slow, buggy, or broken', 'woocommerce' ),
+			checked: slowBuggyOrBroken,
+			onChange: setSlowBuggyOrBroken,
+		},
+		{
+			key: 'other',
+			label: __( 'Other (describe below)', 'woocommerce' ),
+			checked: other,
+			onChange: setOther,
+		},
+	];
+	const [ comments, setComments ] = useState( '' );
+
+	const onSendFeedback = () => {
+		const checked = checkboxes
+			.filter( ( checkbox ) => checkbox.checked )
+			.map( ( checkbox ) => checkbox.key );
+		recordScoreCallback( checked, comments );
+	};
+
+	const isSendButtonDisabled =
+		! comments &&
+		! missingFeatures &&
+		! missingPlugins &&
+		! difficultToUse &&
+		! slowBuggyOrBroken &&
+		! other;
+
+	return (
+		<FeedbackModal
+			title={ __(
+				'Thanks for trying out the new product editor!',
+				'woocommerce'
+			) }
+			description={ __(
+				'We’re working on making it better, and your feedback will help improve the experience for thousands of merchants like you.',
+				'woocommerce'
+			) }
+			onSendFeedback={ onSendFeedback }
+			onCloseModal={ onCloseModal }
+			isSendButtonDisabled={ isSendButtonDisabled }
+			sendButtonLabel={ __( 'Send feedback', 'woocommerce' ) }
+			cancelButtonLabel={ __( 'Skip', 'woocommerce' ) }
+		>
+			<>
+				<Text
+					variant="subtitle.small"
+					as="p"
+					weight="600"
+					size="14"
+					lineHeight="20px"
+				>
+					{ __(
+						'What made you switch back to the classic product editor?',
+						'woocommerce'
+					) }
+				</Text>
+				<Text
+					weight="400"
+					size="12"
+					as="p"
+					lineHeight="16px"
+					color="#757575"
+					className="woocommerce-product-mvp-feedback-modal__subtitle"
+				>
+					{ __( '(Check all that apply)', 'woocommerce' ) }
+				</Text>
+				<div className="woocommerce-product-mvp-feedback-modal__checkboxes">
+					{ checkboxes.map( ( checkbox, index ) => (
+						<CheckboxControl
+							key={ index }
+							label={ checkbox.label }
+							name={ checkbox.key }
+							checked={ checkbox.checked }
+							onChange={ checkbox.onChange }
+						/>
+					) ) }
+				</div>
+				<div className="woocommerce-product-mvp-feedback-modal__comments">
+					<TextareaControl
+						label={ __( 'Additional comments', 'woocommerce' ) }
+						value={ comments }
+						placeholder={ __(
+							'Optional, but much apprecated. We love reading your feedback!',
+							'woocommerce'
+						) }
+						onChange={ ( value: string ) => setComments( value ) }
+						rows={ 5 }
+					/>
+				</div>
+			</>
+		</FeedbackModal>
+	);
+}
+
+ProductMVPFeedbackModal.propTypes = {
+	recordScoreCallback: PropTypes.func.isRequired,
+	onCloseModal: PropTypes.func,
+};
+
+export { ProductMVPFeedbackModal };

--- a/packages/js/customer-effort-score/src/product-mvp-feedback-modal/test/index.tsx
+++ b/packages/js/customer-effort-score/src/product-mvp-feedback-modal/test/index.tsx
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { createElement } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { ProductMVPFeedbackModal } from '../index';
+
+const mockRecordScoreCallback = jest.fn();
+
+describe( 'ProductMVPFeedbackModal', () => {
+	it( 'should close the ProductMVPFeedback modal when skip button pressed', async () => {
+		render(
+			<ProductMVPFeedbackModal
+				recordScoreCallback={ mockRecordScoreCallback }
+			/>
+		);
+		// Wait for the modal to render.
+		await screen.findByRole( 'dialog' );
+		// Press cancel button.
+		fireEvent.click( screen.getByRole( 'button', { name: /Skip/i } ) );
+		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+	} );
+	it( 'should enable Send button when an option is checked', async () => {
+		render(
+			<ProductMVPFeedbackModal
+				recordScoreCallback={ mockRecordScoreCallback }
+			/>
+		);
+		// Wait for the modal to render.
+		await screen.findByRole( 'dialog' );
+		fireEvent.click( screen.getByRole( 'checkbox', { name: /other/i } ) );
+		fireEvent.click(
+			screen.getByRole( 'button', { name: /Send feedback/i } )
+		);
+	} );
+	it( 'should call the function sent as recordScoreCallback with the checked options', async () => {
+		render(
+			<ProductMVPFeedbackModal
+				recordScoreCallback={ mockRecordScoreCallback }
+			/>
+		);
+		// Wait for the modal to render.
+		await screen.findByRole( 'dialog' );
+		fireEvent.click( screen.getByRole( 'checkbox', { name: /other/i } ) );
+		expect( mockRecordScoreCallback ).toHaveBeenCalledWith(
+			[ 'other' ],
+			''
+		);
+	} );
+} );

--- a/packages/js/customer-effort-score/src/style.scss
+++ b/packages/js/customer-effort-score/src/style.scss
@@ -1,4 +1,6 @@
 @import 'customer-feedback-simple/customer-feedback-simple.scss';
+@import 'product-mvp-feedback-modal/product-mvp-feedback-modal.scss';
+@import 'feedback-modal/feedback-modal.scss';
 
 .woocommerce-customer-effort-score__selection {
 	margin: 1em 0 1.5em 0;


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR adds the components FeedbackModal and ProductMVPFeedbackModal to the package `customer-effort-score`.

I think that it would be a good follow-up for this PR to add the storybooks for both components.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

To test the changes added in this PR you can follow the steps described on [this PR](https://github.com/woocommerce/woocommerce/pull/36544).

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
