### PR TITLE
[HPOS] Add HPOS support for the reserved stock query

### DIFF
--- a/plugins/woocommerce/changelog/fix-36375-hpos-reserve-stock
+++ b/plugins/woocommerce/changelog/fix-36375-hpos-reserve-stock
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add HPOS support to the reserved stock query

--- a/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
+++ b/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
@@ -5,6 +5,8 @@
 
 namespace Automattic\WooCommerce\Checkout\Helpers;
 
+use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -34,6 +36,15 @@ final class ReserveStock {
 	 */
 	protected function is_enabled() {
 		return $this->enabled;
+	}
+
+	/**
+	 * Check if the usage of the custom orders table is enabled.
+	 *
+	 * @return bool
+	 */
+	protected function is_cot_in_use(): bool {
+		return wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled();
 	}
 
 	/**

--- a/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
+++ b/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
@@ -5,7 +5,7 @@
 
 namespace Automattic\WooCommerce\Checkout\Helpers;
 
-use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
+use Automattic\WooCommerce\Utilities\OrderUtil;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -36,15 +36,6 @@ final class ReserveStock {
 	 */
 	protected function is_enabled() {
 		return $this->enabled;
-	}
-
-	/**
-	 * Check if the usage of the custom orders table is enabled.
-	 *
-	 * @return bool
-	 */
-	protected function is_cot_in_use(): bool {
-		return wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled();
 	}
 
 	/**
@@ -216,7 +207,7 @@ final class ReserveStock {
 
 		$join         = "$wpdb->posts posts ON stock_table.`order_id` = posts.ID";
 		$where_status = "posts.post_status IN ( 'wc-checkout-draft', 'wc-pending' )";
-		if ( $this->is_cot_in_use() ) {
+		if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
 			$join         = "{$wpdb->prefix}wc_orders orders ON stock_table.`order_id` = orders.id";
 			$where_status = "orders.status IN ( 'wc-checkout-draft', 'wc-pending' )";
 		}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Enables the ReserveStock class to detect when HPOS tables are enabled and in use, and modify the query in `get_query_for_reserved_stock()` accordingly. Without this change, reserved stock is not correctly counted when using HPOS.

Closes #36375

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

This is tricky to test because when most orders are created, the stock gets reserved and then released within the space of the same HTTP request, so it's hard to isolate whether the reserved stock query is working or not.

To do it, we can use a simple mu-plugin:

```php
<?php

function test_stock_reserved() {
	$product_id = 119;
	$product = wc_get_product( $product_id );
	$reserved = wc_get_held_stock_quantity( $product );

	wc_get_logger()->debug( 'Reserved stock: ' . print_r( $reserved, true ) );
}
add_action( 'woocommerce_checkout_order_created', 'test_stock_reserved', 99 );
```

You'll need to add this code to your test site and change `119` to the ID of the product you'll be using in your test orders.

First observe the behavior before you check out this PR branch:

1. Ensure the product you're going to use for testing has inventory management enabled and enough stock available to make a few orders with.
1. Ensure your test site either has HPOS turned off (**WooCommerce > Settings > Advanced > Features**), or enabled but with the posts table selected as the data store, and with table synchronization enabled.
3. Turn on the COD payment method for easier testing.
4. Go through the front end checkout process to create an order containing the product whose ID you're using in the code snippet above.
5. After the checkout is complete, go to the logs screen (**WooCommerce > Status > Logs**). The most recent log should show `DEBUG Reserved stock: 1`
6. Now turn on HPOS, choose the WooCommerce orders tables as the data store, and turn off synchronization.
7. Make another order.
8. Now on the logs screen, there should be another entry, `DEBUG Reserved stock: 0`

The `0` in the second log entry indicates that no reserved stock was found during the request. This is the problem.

Now check out this branch and go back through the steps. This time, both logs should be `DEBUG Reserved stock: 1`, meaning that reserved stock was found even when using HPOS.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
