### PR TITLE
Fix dynamic property creation warning in `class-woocommerce.php`

### DIFF
--- a/plugins/woocommerce/changelog/fix-35763-dynamic-property-creation-in-woocommerce-class
+++ b/plugins/woocommerce/changelog/fix-35763-dynamic-property-creation-in-woocommerce-class
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Define a public `api` property in the WooCommerce class that was previously being dynamically created
+Define a public `api` property in the WooCommerce class to prevent to prevent a PHP deprecation warning

--- a/plugins/woocommerce/changelog/fix-35763-dynamic-property-creation-in-woocommerce-class
+++ b/plugins/woocommerce/changelog/fix-35763-dynamic-property-creation-in-woocommerce-class
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Define a public `api` property in the WooCommerce class that was previously being dynamically created

--- a/plugins/woocommerce/changelog/fix-35763-dynamic-property-creation-in-woocommerce-class
+++ b/plugins/woocommerce/changelog/fix-35763-dynamic-property-creation-in-woocommerce-class
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Define a public `api` property in the WooCommerce class to prevent to prevent a PHP deprecation warning
+Define a public `api` property in the WooCommerce class to prevent a PHP deprecation warning

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -66,6 +66,13 @@ final class WooCommerce {
 	public $query = null;
 
 	/**
+	 * API instance
+	 *
+	 * @var WC_API
+	 */
+	public $api;
+
+	/**
 	 * Product factory instance.
 	 *
 	 * @var WC_Product_Factory

--- a/plugins/woocommerce/tests/php/includes/class-woocommerce-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-woocommerce-test.php
@@ -9,9 +9,9 @@ class WooCommerce_Test extends \WC_Unit_Test_Case {
 	 * Test that the $api property is defined, public and initialized correctly.
 	 */
 	public function test_api_property() {
-		$property = new ReflectionProperty(WooCommerce::class, 'api');
+		$property = new ReflectionProperty( WooCommerce::class, 'api' );
 
-		$this->assertTrue($property->isPublic());
-		$this->assertInstanceOf(WC_API::class, $property->getValue(WC()));
+		$this->assertTrue( $property->isPublic() );
+		$this->assertInstanceOf( WC_API::class, $property->getValue( WC() ) );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-woocommerce-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-woocommerce-test.php
@@ -8,7 +8,7 @@ class WooCommerce_Test extends \WC_Unit_Test_Case {
 	/**
 	 * Test that the $api property is defined, public and initialized correctly.
 	 */
-	public function test_api_property() {
+	public function test_api_property(): void {
 		$property = new ReflectionProperty( WooCommerce::class, 'api' );
 
 		$this->assertTrue( $property->isPublic() );

--- a/plugins/woocommerce/tests/php/includes/class-woocommerce-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-woocommerce-test.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * Unit tests for the WooCommerce class.
+ */
+class WooCommerce_Test extends \WC_Unit_Test_Case {
+
+	/**
+	 * Test that the $api property is defined, public and initialized correctly.
+	 */
+	public function test_api_property() {
+		$property = new ReflectionProperty(WooCommerce::class, 'api');
+
+		$this->assertTrue($property->isPublic());
+		$this->assertInstanceOf(WC_API::class, $property->getValue(WC()));
+	}
+}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Declares `$api` public property to the `WooCommerce` class. The property is [already being dynamically created whenever the WooCommerce is instantiated](https://github.com/woocommerce/woocommerce/blob/71a7bd4360c8802a6d61a50b1c5d3b7885392a69/plugins/woocommerce/includes/class-woocommerce.php#L556-L557). Without a property declaration, the current behavior triggers a deprecation notice in PHP 8.2 and will become a fatal error in PHP 9.

This PR is related to issue #35763 but it doesn't fix all the problems described there.

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

The `WooCommerce` class is instantiated every time the plugin is loaded, so a quick smoke test can confirm that it can still be instantiated and that the `api` property is accessible.

#### PHP 7.4

Start a new environment:

```
WP_ENV_PHP_VERSION=7.4 pnpm -- wp-env start
```

Open a shell session to run a snippet:

```
pnpm -- wp-env run cli shell
```

Run the following snippet to confirm the property is defined, has the correct value and is public:

```php
get_class(WC()->api);
```

- [ ] The snippets outputs: `string(6) "WC_API"`

Now, visit the admin dashboard on your development site.

Then, open a bash session to inspect the WordPress debug logs:

```
pnpm -- wp-env run cli bash
```

Inside the new bash session, tail the `debug.log` file:

```
tail -f wp-content/debug.log
```

Then, visit WooCommerce > Settings in the admin dashboard of your development site

- [ ] The logs don't show any errors or notices

⚠️ I did get some errors, likely because `pnpm run build --filter=woocommerce` kept failing for me, even on `trunk` on a fresh clone. I think that's a separate issue.

Expand the details to see the errors that I was getting:

<details>
<pre><code>
[22-Jan-2023 17:40:10 UTC] PHP Warning:  filemtime(): stat failed for /var/www/html/wp-content/plugins/woocommerce/assets/client/admin/ in /var/www/html/wp-content/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php on line 100
[22-Jan-2023 17:40:10 UTC] Exception caught in Automattic\WooCommerce\Internal\Admin\WCAdminAssets::register_scripts. Could not find asset registry for explat. Args: explat..
[22-Jan-2023 17:40:10 UTC] Exception caught in Automattic\WooCommerce\Internal\Admin\WCAdminAssets::register_scripts. Could not find asset registry for experimental. Args: experimental..
[22-Jan-2023 17:40:10 UTC] Exception caught in Automattic\WooCommerce\Internal\Admin\WCAdminAssets::register_scripts. Could not find asset registry for customer-effort-score. Args: customer-effort-score..
[22-Jan-2023 17:40:10 UTC] Exception caught in Automattic\WooCommerce\Internal\Admin\WCAdminAssets::register_scripts. Could not find asset registry for notices. Args: notices..
[22-Jan-2023 17:40:10 UTC] Exception caught in Automattic\WooCommerce\Internal\Admin\WCAdminAssets::register_scripts. Could not find asset registry for number. Args: number..
[22-Jan-2023 17:40:10 UTC] Exception caught in Automattic\WooCommerce\Internal\Admin\WCAdminAssets::register_scripts. Could not find asset registry for tracks. Args: tracks..
[22-Jan-2023 17:40:10 UTC] Exception caught in Automattic\WooCommerce\Internal\Admin\WCAdminAssets::register_scripts. Could not find asset registry for date. Args: date..
[22-Jan-2023 17:40:10 UTC] Exception caught in Automattic\WooCommerce\Internal\Admin\WCAdminAssets::register_scripts. Could not find asset registry for components. Args: components..
[22-Jan-2023 17:40:10 UTC] Exception caught in Automattic\WooCommerce\Internal\Admin\WCAdminAssets::register_scripts. Could not find asset registry for app. Args: app..
[22-Jan-2023 17:40:10 UTC] Exception caught in Automattic\WooCommerce\Internal\Admin\WCAdminAssets::register_scripts. Could not find asset registry for csv-export. Args: csv-export..
[22-Jan-2023 17:40:10 UTC] Exception caught in Automattic\WooCommerce\Internal\Admin\WCAdminAssets::register_scripts. Could not find asset registry for data. Args: data..
[22-Jan-2023 17:40:10 UTC] Exception caught in Automattic\WooCommerce\Internal\Admin\WCAdminAssets::register_scripts. Could not find asset registry for currency. Args: currency..
[22-Jan-2023 17:40:10 UTC] Exception caught in Automattic\WooCommerce\Internal\Admin\WCAdminAssets::register_scripts. Could not find asset registry for navigation. Args: navigation..
[22-Jan-2023 17:41:16 UTC] PHP Warning:  filemtime(): stat failed for /var/www/html/wp-content/plugins/woocommerce/assets/client/admin/ in /var/www/html/wp-content/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php on line 100
[22-Jan-2023 17:41:16 UTC] PHP Fatal error:  Uncaught Exception: Could not find asset registry for wp-admin-scripts in /var/www/html/wp-content/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php:128
Stack trace:
#0 /var/www/html/wp-content/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php(391): Automattic\WooCommerce\Internal\Admin\WCAdminAssets::get_script_asset_filename('wp-admin-script...', 'payment-method-...')
#1 /var/www/html/wp-content/plugins/woocommerce/src/Internal/Admin/WCPayPromotion/Init.php(45): Automattic\WooCommerce\Internal\Admin\WCAdminAssets::register_script('wp-admin-script...', 'payment-method-...', true)
#2 /var/www/html/wp-content/plugins/woocommerce/src/Admin/Features/Features.php(141): Automattic\WooCommerce\Internal\Admin\WCPayPromotion\Init->__construct()
#3 /var/www/html/wp-includes/class-wp-hook.php(308): Automattic\WooCommerce\Admin\Features\Features::load_features('')
#4 /var/www/html/wp-includes/class-wp-hook.php(332): WP_Hook->apply_filters(NULL, Array)
#5 /var/www/html/wp-includes/plugin.php(517): WP_Hook-> in /var/www/html/wp-content/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php on line 128
</code></pre>
</details>

#### PHP 8.0

Repeat the steps for PHP 7.4, but create the environment using PHP 8.0:

```
WP_ENV_PHP_VERSION=8.0 pnpm -- wp-env start
```

#### PHP 8.1

Repeat the steps for PHP 7.4, but create the environment using PHP 8.1:

```
WP_ENV_PHP_VERSION=8.1 pnpm -- wp-env start
```

#### PHP 8.2

Create the environment using PHP 8.2:

```
WP_ENV_PHP_VERSION=8.2 pnpm -- wp-env start
```

Open a shell session to run a snippet:

```
pnpm -- wp-env run cli shell
```

Run the following snippet to confirm the property is defined, has the correct value and is public:

```php
get_class(WC()->api);
```

- [ ] The snippets outputs: `string(6) "WC_API"`

Now, visit the admin dashboard on your development site.

Then, open a bash session to inspect the WordPress debug logs:

```
pnpm -- wp-env run cli bash
```

Inside the new bash session, delete the `debug.log` file to start with a clean slate:

```
rm wp-content/debug.log
```

Then, tail the `debug.log` file:

```
tail -f wp-content/debug.log
```

After that, visit WooCommerce > Settings in the admin dashboard of your development site

- [ ] The logs DO NOT include `PHP Deprecated:  Creation of dynamic property WooCommerce::$api is deprecated`

In PHP 8.2 the logs will be filled with many `PHP Deprecated:  Creation of dynamic property` entries. We want to make sure that the one fixed in this PR no longer shows up.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
