### PR TITLE
Update the pnpm setup action in workflows to remove Node.js 12 deprecation warnings

### DIFF
--- a/.github/actions/setup-woocommerce-monorepo/action.yml
+++ b/.github/actions/setup-woocommerce-monorepo/action.yml
@@ -27,9 +27,9 @@ runs:
               echo "BUILD_FILTERS=$(node ./.github/actions/setup-woocommerce-monorepo/scripts/parse-input-filter.js '${{ inputs.build-filters }}')" >> $GITHUB_OUTPUT
 
         - name: Setup PNPM
-          uses: pnpm/action-setup@10693b3829bf86eb2572aef5f3571dcf5ca9287d
+          uses: pnpm/action-setup@c3b53f6a16e57305370b4ae5a540c2077a1d50dd
           with:
-              version: '^7.13.3'
+              version: '^7.22.0'
 
         - name: Setup Node
           uses: actions/setup-node@2fddd8803e2f5c9604345a0b591c3020ee971a93


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In Summer 2023 Github will [remove support for Node.js 12 in GH actions](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/). Right now we have some warnings in our GH workflows for this issue due to the pnpm action.

This updates the action to latest version which will eliminate those warnings. I also updated pnpm to `7.22` to reflect the version being used in most development environments.


<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [x] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:=

1.  Have a look at some previous PRs, in the action output you will see Node.js 12 warnings emitted from pnpm setup
2. Check the output of CI for this PR, the warnings should be gone for Node.js 12

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
