### PR TITLE
Update action dependencies to remove set-output and save-state warnings

### DIFF
--- a/.github/actions/setup-woocommerce-monorepo/action.yml
+++ b/.github/actions/setup-woocommerce-monorepo/action.yml
@@ -46,7 +46,7 @@ runs:
               tools: phpcs, sirbrillig/phpcs-changed
 
         - name: Cache Composer Dependencies
-          uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77
+          uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12
           with:
               path: ~/.cache/composer/files
               key: ${{ runner.os }}-php-${{ inputs.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -59,7 +59,7 @@ runs:
               pnpm install ${{ steps.parse-input.outputs.INSTALL_FILTERS }}
 
         - name: Cache Build Output
-          uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77
+          uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12
           with:
               path: node_modules/.cache/turbo
               key: ${{ runner.os }}-build-output-${{ hashFiles('node_modules/.cache/turbo/*-meta.json') }}

--- a/.github/actions/setup-woocommerce-monorepo/action.yml
+++ b/.github/actions/setup-woocommerce-monorepo/action.yml
@@ -32,14 +32,14 @@ runs:
               version: '^7.13.3'
 
         - name: Setup Node
-          uses: actions/setup-node@2fddd8803e2f5c9604345a0b591c3020ee971a93
+          uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
           with:
               node-version-file: .nvmrc
               cache: pnpm
               registry-url: 'https://registry.npmjs.org'
 
         - name: Setup PHP
-          uses: shivammathur/setup-php@e04e1d97f0c0481c6e1ba40f8a538454fe5d7709
+          uses: shivammathur/setup-php@8e2ac35f639d3e794c1da1f28999385ab6fdf0fc
           with:
               php-version: ${{ inputs.php-version }}
               coverage: none

--- a/.github/actions/setup-woocommerce-monorepo/action.yml
+++ b/.github/actions/setup-woocommerce-monorepo/action.yml
@@ -27,7 +27,7 @@ runs:
               echo "BUILD_FILTERS=$(node ./.github/actions/setup-woocommerce-monorepo/scripts/parse-input-filter.js '${{ inputs.build-filters }}')" >> $GITHUB_OUTPUT
 
         - name: Setup PNPM
-          uses: pnpm/action-setup@10693b3829bf86eb2572aef5f3571dcf5ca9287d
+          uses: pnpm/action-setup@c3b53f6a16e57305370b4ae5a540c2077a1d50dd
           with:
               version: '^7.13.3'
 

--- a/.github/workflows/community-label.yml
+++ b/.github/workflows/community-label.yml
@@ -17,14 +17,14 @@ jobs:
         name: Verify
         runs-on: ubuntu-20.04
         permissions:
-          contents: read
-          pull-requests: write
-          issues: write
+            contents: read
+            pull-requests: write
+            issues: write
         steps:
             - uses: actions/checkout@v3
 
             - name: Setup Node.js
-              uses: actions/setup-node@2fddd8803e2f5c9604345a0b591c3020ee971a93
+              uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
 
             - name: Install Octokit
               run: npm --prefix .github/workflows/scripts install @octokit/action

--- a/.github/workflows/pull-request-post-merge-processing.yml
+++ b/.github/workflows/pull-request-post-merge-processing.yml
@@ -1,43 +1,43 @@
-name: "Pull request post-merge processing"
+name: 'Pull request post-merge processing'
 on:
-  pull_request_target:
-    types: [closed]
+    pull_request_target:
+        types: [closed]
 
 permissions: {}
 
 jobs:
-  process-pull-request-after-merge:
-    name: "Process a pull request after it's merged"
-    if: github.event.pull_request.merged == true
-    runs-on: ubuntu-20.04
-    permissions:
-      pull-requests: write
-    steps:
-      - name: "Get the action scripts"
-        run: |
-          scripts="assign-milestone-to-merged-pr.php add-post-merge-comment.php post-request-shared.php"
-          for script in $scripts
-          do
-            curl \
-            --silent \
-            --fail \
-            --header 'Authorization: bearer ${{ secrets.GITHUB_TOKEN }}' \
-            --header 'User-Agent: GitHub action to set the milestone for a pull request' \
-            --header 'Accept: application/vnd.github.v3.raw' \
-            --output $script \
-            --location "$GITHUB_API_URL/repos/${{ github.repository }}/contents/.github/workflows/scripts/$script?ref=${{ github.event.pull_request.base.ref }}"
-          done
-        env:
-          GITHUB_API_URL: ${{ env.GITHUB_API_URL }}
-      - name: "Install PHP"
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '7.4'
-      - name: "Run the script to assign a milestone"
-        if: |
-          !github.event.pull_request.milestone &&
-          github.event.pull_request.base.ref == 'trunk'
-        run: php assign-milestone-to-merged-pr.php
-        env:
-          PULL_REQUEST_ID: ${{ github.event.pull_request.node_id }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    process-pull-request-after-merge:
+        name: "Process a pull request after it's merged"
+        if: github.event.pull_request.merged == true
+        runs-on: ubuntu-20.04
+        permissions:
+            pull-requests: write
+        steps:
+            - name: 'Get the action scripts'
+              run: |
+                  scripts="assign-milestone-to-merged-pr.php add-post-merge-comment.php post-request-shared.php"
+                  for script in $scripts
+                  do
+                    curl \
+                    --silent \
+                    --fail \
+                    --header 'Authorization: bearer ${{ secrets.GITHUB_TOKEN }}' \
+                    --header 'User-Agent: GitHub action to set the milestone for a pull request' \
+                    --header 'Accept: application/vnd.github.v3.raw' \
+                    --output $script \
+                    --location "$GITHUB_API_URL/repos/${{ github.repository }}/contents/.github/workflows/scripts/$script?ref=${{ github.event.pull_request.base.ref }}"
+                  done
+              env:
+                  GITHUB_API_URL: ${{ env.GITHUB_API_URL }}
+            - name: 'Install PHP'
+              uses: shivammathur/setup-php@8e2ac35f639d3e794c1da1f28999385ab6fdf0fc
+              with:
+                  php-version: '7.4'
+            - name: 'Run the script to assign a milestone'
+              if: |
+                  !github.event.pull_request.milestone &&
+                  github.event.pull_request.base.ref == 'trunk'
+              run: php assign-milestone-to-merged-pr.php
+              env:
+                  PULL_REQUEST_ID: ${{ github.event.pull_request.node_id }}
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -30,7 +30,7 @@ jobs:
             freeze: ${{ steps.check-freeze.outputs.freeze }}
         steps:
             - name: 'Install PHP'
-              uses: shivammathur/setup-php@v2
+              uses: shivammathur/setup-php@8e2ac35f639d3e794c1da1f28999385ab6fdf0fc
               with:
                   php-version: '7.4'
 

--- a/.github/workflows/syncpack.yml
+++ b/.github/workflows/syncpack.yml
@@ -1,37 +1,37 @@
 name: Synchronize Dependencies with syncpack
 on:
-  # Run whenever a pull request is updated
-  pull_request:
-    branches:
-      - trunk
-    paths:
-      - '**/package.json'
+    # Run whenever a pull request is updated
+    pull_request:
+        branches:
+            - trunk
+        paths:
+            - '**/package.json'
 
 permissions: {}
 
 jobs:
-  syncpack:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    name: syncpack
-    steps:
-      - name: 'Checkout'
-        uses: actions/checkout@v3
-      
-      - name: 'Setup node'
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
+    syncpack:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        name: syncpack
+        steps:
+            - name: 'Checkout'
+              uses: actions/checkout@v3
 
-      - name: 'Install Syncpack'
-        run: npm install -g syncpack@^8.2.4
-        
-      - name: 'List Mismatches'
-        run: syncpack list-mismatches
-        
-      - name: 'Explain Remedy'
-        if: failure()
-        run: |
-          echo "Dependency version mismatch detected. This can usually be fixed automatically by updating the pinned version in \`.syncpackrc\` and then running: \`pnpm run sync-dependencies\`"
-          exit 1
+            - name: 'Setup node'
+              uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
+              with:
+                  node-version: 16
+
+            - name: 'Install Syncpack'
+              run: npm install -g syncpack@^8.2.4
+
+            - name: 'List Mismatches'
+              run: syncpack list-mismatches
+
+            - name: 'Explain Remedy'
+              if: failure()
+              run: |
+                  echo "Dependency version mismatch detected. This can usually be fixed automatically by updating the pinned version in \`.syncpackrc\` and then running: \`pnpm run sync-dependencies\`"
+                  exit 1


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

A few core actions we depend on were pulling quite old versions which caused them to still report `save-state` and `set-output` deprecation warnings.

This updates those actions where possible those to remove the warnings.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

You can check the CI output for most actions that run "WooCommerce Monorepo setup" step. In the past these generate many set-output / save-state deprecation warnings (compare to some older PRs in the repo). You should see this step no longer generates any warnings.

**Note**, I don't think its necessary to test any manually run workflows because these are minor updates to the actions and also because as long as every other CI check passes I think the risk is pretty low here. 

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
