### PR TITLE
Update default payment gateway list 

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/test/utils.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/test/utils.js
@@ -21,18 +21,28 @@ const paypal = {
 	id: 'paypal',
 	category_other: [ 'CA' ],
 	category_additional: [ 'CA' ],
+	recommendation_priority: 2,
 };
 
 const stripe = {
 	id: 'stripe',
 	category_other: [ 'US' ],
 	category_additional: [ 'US' ],
+	recommendation_priority: 1,
 };
 
 const klarna = {
 	id: 'klarna',
 	category_other: [ '' ],
 	category_additional: [ 'US' ],
+	recommendation_priority: 3,
+};
+
+const amazonPay = {
+	id: 'amazonPay',
+	category_other: [ '' ],
+	category_additional: [ 'US' ],
+	recommendation_priority: 4,
 };
 
 describe( 'getSplitGateways()', () => {
@@ -83,6 +93,19 @@ describe( 'getSplitGateways()', () => {
 			);
 			expect( additionalGateways ).toEqual( [ stripe, klarna ] );
 		} );
+		it( 'Returns "additional" category gateways in recommended order', () => {
+			const [ , , additionalGateways ] = getSplitGateways(
+				[ wcpay, cod, bacs, amazonPay, paypal, stripe, klarna ],
+				'US',
+				true,
+				true
+			);
+			expect( additionalGateways ).toEqual( [
+				stripe,
+				klarna,
+				amazonPay,
+			] );
+		} );
 	} );
 
 	describe( 'Additional gateways with ineligible WCPay', () => {
@@ -93,7 +116,7 @@ describe( 'getSplitGateways()', () => {
 				false,
 				false
 			);
-			expect( additionalGateways ).toEqual( [ paypal, stripe, klarna ] );
+			expect( additionalGateways ).toEqual( [ stripe, paypal, klarna ] );
 		} );
 		it( 'Returns only "additional" category gateways when "other" gateways is set up', () => {
 			const [ , , additionalGateways ] = getSplitGateways(

--- a/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/utils.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/utils.js
@@ -90,18 +90,7 @@ export const getSplitGateways = (
 	isWCPayOrOtherCategoryDoneSetup
 ) =>
 	Array.from( paymentGateways.values() )
-		.sort( ( a, b ) => {
-			if ( a.hasPlugins === b.hasPlugins ) {
-				return comparePaymentGatewaysByPriority( a, b );
-			}
-
-			// hasPlugins payment first
-			if ( a.hasPlugins ) {
-				return -1;
-			}
-
-			return 1;
-		} )
+		.sort( comparePaymentGatewaysByPriority )
 		.reduce(
 			( all, gateway ) => {
 				const [ wcPay, offline, additional ] = all;

--- a/plugins/woocommerce/changelog/update-payment-gateway-list
+++ b/plugins/woocommerce/changelog/update-payment-gateway-list
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update payment gateway list ordering priority and remove Klarna from North America

--- a/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
+++ b/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
@@ -420,7 +420,6 @@ class DefaultPaymentGateways {
 			),
 		);
 
-		// Add recommended priority attributes.
 		foreach ( $payment_gateways as $index => $payment_gateway ) {
 			$payment_gateways[ $index ]['recommendation_priority'] = self::get_recommendation_priority( $payment_gateway['id'] );
 		}

--- a/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
+++ b/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
@@ -7,12 +7,37 @@ namespace Automattic\WooCommerce\Admin\Features\PaymentGatewaySuggestions;
 
 defined( 'ABSPATH' ) || exit;
 
-use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Init as OnboardingTasks;
-
 /**
  * Default Payment Gateways
  */
 class DefaultPaymentGateways {
+	/**
+	 * Priority is used to determine which payment gateway to recommend first.
+	 * The lower the number, the higher the priority.
+	 *
+	 * @var array
+	 */
+	private static $recommendation_priority = array(
+		'woocommerce_payments'                            => 1,
+		'woocommerce_payments:with-in-person-payments'    => 1,
+		'woocommerce_payments:without-in-person-payments' => 1,
+		'stripe'                                          => 2,
+		'woo-mercado-pago-custom'                         => 3,
+		'paypal'                                          => 4,
+		'mollie_wc_gateway_banktransfer'                  => 5,
+		'razorpay'                                        => 5,
+		'payfast'                                         => 5,
+		'payubiz'                                         => 6,
+		'square_credit_card'                              => 6,
+		'klarna_payments'                                 => 6,
+		// Klarna Checkout.
+		'kco'                                             => 6,
+		'eway'                                            => 6,
+		'paystack'                                        => 6,
+		'amazon_payments_advanced'                        => 7,
+		'affirm'                                          => 8,
+		'afterpay'                                        => 9,
+	);
 
 	/**
 	 * Get default specs.
@@ -20,7 +45,7 @@ class DefaultPaymentGateways {
 	 * @return array Default specs.
 	 */
 	public static function get_all() {
-		return array(
+		$payment_gateways = array(
 			array(
 				'id'                  => 'payfast',
 				'title'               => __( 'PayFast', 'woocommerce' ),
@@ -36,22 +61,21 @@ class DefaultPaymentGateways {
 				'category_additional' => array(),
 			),
 			array(
-				'id'                      => 'stripe',
-				'title'                   => __( ' Stripe', 'woocommerce' ),
-				'content'                 => __( 'Accept debit and credit cards in 135+ currencies, methods such as Alipay, and one-touch checkout with Apple Pay.', 'woocommerce' ),
-				'image'                   => WC_ADMIN_IMAGES_FOLDER_URL . '/stripe.png',
-				'image_72x72'             => WC_ADMIN_IMAGES_FOLDER_URL . '/payment_methods/72x72/stripe.png',
-				'plugins'                 => array( 'woocommerce-gateway-stripe' ),
-				'is_visible'              => array(
+				'id'                  => 'stripe',
+				'title'               => __( ' Stripe', 'woocommerce' ),
+				'content'             => __( 'Accept debit and credit cards in 135+ currencies, methods such as Alipay, and one-touch checkout with Apple Pay.', 'woocommerce' ),
+				'image'               => WC_ADMIN_IMAGES_FOLDER_URL . '/stripe.png',
+				'image_72x72'         => WC_ADMIN_IMAGES_FOLDER_URL . '/payment_methods/72x72/stripe.png',
+				'plugins'             => array( 'woocommerce-gateway-stripe' ),
+				'is_visible'          => array(
 					// https://stripe.com/global.
 					self::get_rules_for_countries(
 						array( 'AU', 'AT', 'BE', 'BG', 'BR', 'CA', 'CY', 'CZ', 'DK', 'EE', 'FI', 'FR', 'DE', 'GR', 'HK', 'IN', 'IE', 'IT', 'JP', 'LV', 'LT', 'LU', 'MY', 'MT', 'MX', 'NL', 'NZ', 'NO', 'PL', 'PT', 'RO', 'SG', 'SK', 'SI', 'ES', 'SE', 'CH', 'GB', 'US', 'PR', 'HU', 'SL', 'ID', 'MY', 'SI', 'PR' )
 					),
 					self::get_rules_for_cbd( false ),
 				),
-				'category_other'          => array( 'AU', 'AT', 'BE', 'BG', 'BR', 'CA', 'CY', 'CZ', 'DK', 'EE', 'FI', 'FR', 'DE', 'GR', 'HK', 'IN', 'IE', 'IT', 'JP', 'LV', 'LT', 'LU', 'MY', 'MT', 'MX', 'NL', 'NZ', 'NO', 'PL', 'PT', 'RO', 'SG', 'SK', 'SI', 'ES', 'SE', 'CH', 'GB', 'US', 'PR', 'HU', 'SL', 'ID', 'MY', 'SI', 'PR' ),
-				'category_additional'     => array(),
-				'recommendation_priority' => 3,
+				'category_other'      => array( 'AU', 'AT', 'BE', 'BG', 'BR', 'CA', 'CY', 'CZ', 'DK', 'EE', 'FI', 'FR', 'DE', 'GR', 'HK', 'IN', 'IE', 'IT', 'JP', 'LV', 'LT', 'LU', 'MY', 'MT', 'MX', 'NL', 'NZ', 'NO', 'PL', 'PT', 'RO', 'SG', 'SK', 'SI', 'ES', 'SE', 'CH', 'GB', 'US', 'PR', 'HU', 'SL', 'ID', 'MY', 'SI', 'PR' ),
+				'category_additional' => array(),
 			),
 			array(
 				'id'                  => 'paystack',
@@ -113,19 +137,18 @@ class DefaultPaymentGateways {
 				'category_additional' => array(),
 			),
 			array(
-				'id'                      => 'woo-mercado-pago-custom',
-				'title'                   => __( 'Mercado Pago Checkout Pro & Custom', 'woocommerce' ),
-				'content'                 => __( 'Accept credit and debit cards, offline (cash or bank transfer) and logged-in payments with money in Mercado Pago. Safe and secure payments with the leading payment processor in LATAM.', 'woocommerce' ),
-				'image'                   => WC_ADMIN_IMAGES_FOLDER_URL . '/onboarding/mercadopago.png',
-				'image_72x72'             => WC_ADMIN_IMAGES_FOLDER_URL . '/payment_methods/72x72/mercadopago.png',
-				'plugins'                 => array( 'woocommerce-mercadopago' ),
-				'is_visible'              => array(
+				'id'                  => 'woo-mercado-pago-custom',
+				'title'               => __( 'Mercado Pago Checkout Pro & Custom', 'woocommerce' ),
+				'content'             => __( 'Accept credit and debit cards, offline (cash or bank transfer) and logged-in payments with money in Mercado Pago. Safe and secure payments with the leading payment processor in LATAM.', 'woocommerce' ),
+				'image'               => WC_ADMIN_IMAGES_FOLDER_URL . '/onboarding/mercadopago.png',
+				'image_72x72'         => WC_ADMIN_IMAGES_FOLDER_URL . '/payment_methods/72x72/mercadopago.png',
+				'plugins'             => array( 'woocommerce-mercadopago' ),
+				'is_visible'          => array(
 					self::get_rules_for_countries( array( 'AR', 'BR', 'CL', 'CO', 'MX', 'PE', 'UY' ) ),
 				),
-				'recommendation_priority' => 2,
-				'is_local_partner'        => true,
-				'category_other'          => array( 'AR', 'BR', 'CL', 'CO', 'MX', 'PE', 'UY' ),
-				'category_additional'     => array(),
+				'is_local_partner'    => true,
+				'category_other'      => array( 'AR', 'BR', 'CL', 'CO', 'MX', 'PE', 'UY' ),
+				'category_additional' => array(),
 			),
 			array(
 				'id'                  => 'ppcp-gateway',
@@ -169,17 +192,17 @@ class DefaultPaymentGateways {
 			),
 			// This is for backwards compatibility only (WC < 5.10.0-dev or WCA < 2.9.0-dev).
 			array(
-				'id'                      => 'woocommerce_payments',
-				'title'                   => __( 'WooCommerce Payments', 'woocommerce' ),
-				'content'                 => __(
+				'id'          => 'woocommerce_payments',
+				'title'       => __( 'WooCommerce Payments', 'woocommerce' ),
+				'content'     => __(
 					'Manage transactions without leaving your WordPress Dashboard. Only with WooCommerce Payments.',
 					'woocommerce'
 				),
-				'image'                   => WC_ADMIN_IMAGES_FOLDER_URL . '/onboarding/wcpay.svg',
-				'image_72x72'             => WC_ADMIN_IMAGES_FOLDER_URL . '/onboarding/wcpay.svg',
-				'plugins'                 => array( 'woocommerce-payments' ),
-				'description'             => __( 'With WooCommerce Payments, you can securely accept major cards, Apple Pay, and payments in over 100 currencies. Track cash flow and manage recurring revenue directly from your store’s dashboard - with no setup costs or monthly fees.', 'woocommerce' ),
-				'is_visible'              => array(
+				'image'       => WC_ADMIN_IMAGES_FOLDER_URL . '/onboarding/wcpay.svg',
+				'image_72x72' => WC_ADMIN_IMAGES_FOLDER_URL . '/onboarding/wcpay.svg',
+				'plugins'     => array( 'woocommerce-payments' ),
+				'description' => __( 'With WooCommerce Payments, you can securely accept major cards, Apple Pay, and payments in over 100 currencies. Track cash flow and manage recurring revenue directly from your store’s dashboard - with no setup costs or monthly fees.', 'woocommerce' ),
+				'is_visible'  => array(
 					self::get_rules_for_cbd( false ),
 					self::get_rules_for_countries( self::get_wcpay_countries() ),
 					(object) array(
@@ -209,20 +232,19 @@ class DefaultPaymentGateways {
 						),
 					),
 				),
-				'recommendation_priority' => 1,
 			),
 			array(
-				'id'                      => 'woocommerce_payments:without-in-person-payments',
-				'title'                   => __( 'WooCommerce Payments', 'woocommerce' ),
-				'content'                 => __(
+				'id'          => 'woocommerce_payments:without-in-person-payments',
+				'title'       => __( 'WooCommerce Payments', 'woocommerce' ),
+				'content'     => __(
 					'Manage transactions without leaving your WordPress Dashboard. Only with WooCommerce Payments.',
 					'woocommerce'
 				),
-				'image'                   => WC_ADMIN_IMAGES_FOLDER_URL . '/onboarding/wcpay.svg',
-				'image_72x72'             => WC_ADMIN_IMAGES_FOLDER_URL . '/onboarding/wcpay.svg',
-				'plugins'                 => array( 'woocommerce-payments' ),
-				'description'             => __( 'With WooCommerce Payments, you can securely accept major cards, Apple Pay, and payments in over 100 currencies. Track cash flow and manage recurring revenue directly from your store’s dashboard - with no setup costs or monthly fees.', 'woocommerce' ),
-				'is_visible'              => array(
+				'image'       => WC_ADMIN_IMAGES_FOLDER_URL . '/onboarding/wcpay.svg',
+				'image_72x72' => WC_ADMIN_IMAGES_FOLDER_URL . '/onboarding/wcpay.svg',
+				'plugins'     => array( 'woocommerce-payments' ),
+				'description' => __( 'With WooCommerce Payments, you can securely accept major cards, Apple Pay, and payments in over 100 currencies. Track cash flow and manage recurring revenue directly from your store’s dashboard - with no setup costs or monthly fees.', 'woocommerce' ),
+				'is_visible'  => array(
 					self::get_rules_for_cbd( false ),
 					self::get_rules_for_countries( array_diff( self::get_wcpay_countries(), array( 'US', 'CA' ) ) ),
 					(object) array(
@@ -244,21 +266,20 @@ class DefaultPaymentGateways {
 						),
 					),
 				),
-				'recommendation_priority' => 1,
 			),
 			// This is the same as the above, but with a different description for countries that support in-person payments such as US and CA.
 			array(
-				'id'                      => 'woocommerce_payments:with-in-person-payments',
-				'title'                   => __( 'WooCommerce Payments', 'woocommerce' ),
-				'content'                 => __(
+				'id'          => 'woocommerce_payments:with-in-person-payments',
+				'title'       => __( 'WooCommerce Payments', 'woocommerce' ),
+				'content'     => __(
 					'Manage transactions without leaving your WordPress Dashboard. Only with WooCommerce Payments.',
 					'woocommerce'
 				),
-				'image'                   => WC_ADMIN_IMAGES_FOLDER_URL . '/onboarding/wcpay.svg',
-				'image_72x72'             => WC_ADMIN_IMAGES_FOLDER_URL . '/onboarding/wcpay.svg',
-				'plugins'                 => array( 'woocommerce-payments' ),
-				'description'             => __( 'With WooCommerce Payments, you can securely accept major cards, Apple Pay, and payments in over 100 currencies – with no setup costs or monthly fees – and you can now accept in-person payments with the Woo mobile app.', 'woocommerce' ),
-				'is_visible'              => array(
+				'image'       => WC_ADMIN_IMAGES_FOLDER_URL . '/onboarding/wcpay.svg',
+				'image_72x72' => WC_ADMIN_IMAGES_FOLDER_URL . '/onboarding/wcpay.svg',
+				'plugins'     => array( 'woocommerce-payments' ),
+				'description' => __( 'With WooCommerce Payments, you can securely accept major cards, Apple Pay, and payments in over 100 currencies – with no setup costs or monthly fees – and you can now accept in-person payments with the Woo mobile app.', 'woocommerce' ),
+				'is_visible'  => array(
 					self::get_rules_for_cbd( false ),
 					self::get_rules_for_countries( array( 'US', 'CA' ) ),
 					(object) array(
@@ -280,7 +301,6 @@ class DefaultPaymentGateways {
 						),
 					),
 				),
-				'recommendation_priority' => 1,
 			),
 			array(
 				'id'                  => 'razorpay',
@@ -398,6 +418,13 @@ class DefaultPaymentGateways {
 				'category_additional' => array( 'US', 'CA' ),
 			),
 		);
+
+		// Add recommended priority attributes.
+		foreach ( $payment_gateways as $payment_gateway ) {
+			$payment_gateway['recommendation_priority'] = self::get_recommendation_priority( $payment_gateway['id'] );
+		}
+
+		return $payment_gateways;
 	}
 
 	/**
@@ -495,4 +522,18 @@ class DefaultPaymentGateways {
 		);
 	}
 
+	/**
+	 * Get recommendation priority for a given payment gateway by id.
+	 * If no priority is set, return null.
+	 * If the id is not found, return 1.
+	 *
+	 * @param string $id Payment gateway id.
+	 * @return int Priority.
+	 */
+	private static function get_recommendation_priority( $id ) {
+		if ( ! $id || ! array_key_exists( $id, self::$recommendation_priority ) ) {
+			return null;
+		}
+		return self::$recommendation_priority[ $id ];
+	}
 }

--- a/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
+++ b/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
@@ -23,7 +23,8 @@ class DefaultPaymentGateways {
 		'woocommerce_payments:without-in-person-payments' => 1,
 		'stripe'                                          => 2,
 		'woo-mercado-pago-custom'                         => 3,
-		'paypal'                                          => 4,
+		// PayPal Payments.
+		'ppcp-gateway'                                    => 4,
 		'mollie_wc_gateway_banktransfer'                  => 5,
 		'razorpay'                                        => 5,
 		'payfast'                                         => 5,
@@ -420,8 +421,8 @@ class DefaultPaymentGateways {
 		);
 
 		// Add recommended priority attributes.
-		foreach ( $payment_gateways as $payment_gateway ) {
-			$payment_gateway['recommendation_priority'] = self::get_recommendation_priority( $payment_gateway['id'] );
+		foreach ( $payment_gateways as $index => $payment_gateway ) {
+			$payment_gateways[ $index ]['recommendation_priority'] = self::get_recommendation_priority( $payment_gateway['id'] );
 		}
 
 		return $payment_gateways;
@@ -524,8 +525,7 @@ class DefaultPaymentGateways {
 
 	/**
 	 * Get recommendation priority for a given payment gateway by id.
-	 * If no priority is set, return null.
-	 * If the id is not found, return 1.
+	 * If no priority is set or the id is not found, return null.
 	 *
 	 * @param string $id Payment gateway id.
 	 * @return int Priority.

--- a/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
+++ b/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
@@ -90,12 +90,12 @@ class DefaultPaymentGateways {
 				'plugins'             => array( 'klarna-payments-for-woocommerce' ),
 				'is_visible'          => array(
 					self::get_rules_for_countries(
-						array( 'US', 'CA', 'DK', 'DE', 'AT', 'NL', 'CH', 'BE', 'SP', 'PL', 'FR', 'IT', 'GB', 'ES', 'FI', 'NO', 'SE', 'ES', 'FI', 'NO', 'SE' )
+						array( 'DK', 'DE', 'AT', 'NL', 'CH', 'BE', 'SP', 'PL', 'FR', 'IT', 'GB', 'ES', 'FI', 'NO', 'SE', 'ES', 'FI', 'NO', 'SE' )
 					),
 					self::get_rules_for_cbd( false ),
 				),
 				'category_other'      => array(),
-				'category_additional' => array( 'US', 'CA', 'DK', 'DE', 'AT', 'NL', 'CH', 'BE', 'SP', 'PL', 'FR', 'IT', 'GB', 'ES', 'FI', 'NO', 'SE', 'ES', 'FI', 'NO', 'SE' ),
+				'category_additional' => array( 'DK', 'DE', 'AT', 'NL', 'CH', 'BE', 'SP', 'PL', 'FR', 'IT', 'GB', 'ES', 'FI', 'NO', 'SE', 'ES', 'FI', 'NO', 'SE' ),
 			),
 			array(
 				'id'                  => 'mollie_wc_gateway_banktransfer',
@@ -378,10 +378,10 @@ class DefaultPaymentGateways {
 				'image_72x72'         => WC_ADMIN_IMAGES_FOLDER_URL . '/payment_methods/72x72/amazonpay.png',
 				'plugins'             => array( 'woocommerce-gateway-amazon-payments-advanced' ),
 				'is_visible'          => array(
-					self::get_rules_for_countries( array( 'US', 'CA', 'GB', 'JP', 'AT', 'BE', 'CY', 'DK', 'ES', 'FR', 'DE', 'HU', 'IE', 'IT', 'LU', 'NL', 'PT', 'SL', 'SE' ) ),
+					self::get_rules_for_countries( array( 'US', 'GB', 'JP', 'AT', 'BE', 'CY', 'DK', 'ES', 'FR', 'DE', 'HU', 'IE', 'IT', 'LU', 'NL', 'PT', 'SL', 'SE' ) ),
 				),
 				'category_other'      => array(),
-				'category_additional' => array( 'US', 'CA', 'GB', 'JP', 'AT', 'BE', 'CY', 'DK', 'ES', 'FR', 'DE', 'HU', 'IE', 'IT', 'LU', 'NL', 'PT', 'SL', 'SE' ),
+				'category_additional' => array( 'US', 'GB', 'JP', 'AT', 'BE', 'CY', 'DK', 'ES', 'FR', 'DE', 'HU', 'IE', 'IT', 'LU', 'NL', 'PT', 'SL', 'SE' ),
 			),
 			array(
 				'id'                  => 'affirm',

--- a/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
+++ b/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
@@ -33,8 +33,8 @@ class DefaultPaymentGateways {
 		'klarna_payments'                                 => 6,
 		// Klarna Checkout.
 		'kco'                                             => 6,
-		'eway'                                            => 6,
 		'paystack'                                        => 6,
+		'eway'                                            => 7,
 		'amazon_payments_advanced'                        => 7,
 		'affirm'                                          => 8,
 		'afterpay'                                        => 9,


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/team-ghidorah/issues/157.

1. Ensure payment gateway display order is as per shown in [Google sheet](https://docs.google.com/spreadsheets/d/1cb4M2oa9C6H6I287JSM_oc_s_IP8VzipnTb1TMI8FbY/edit#gid=0). The ordering would be descending (i.e: The top has the highest priority).
2. Remove Klarna Payments from North America
3. Remove Amazon Pay from CA

**Order**

Currently, the gateway's relative order is consistent in different countries, so I just use the existing `recommendation_priority` attribute for this.

```
WCPay > stripe > Mercado Pago >  Paypal > (Mollie, razorpay, payfast) > (payubiz, square, klarna payments, klarna checkout, eway, paystack) > Amazon Pay > affirm > afterpay
```

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Start with a fresh install
2. Go to OBW
3. Choose Canada as store country
4. Choose `Yes, in person at physical stores and/or events` in the business details step.
5. Complete OBW without installing any plugins in the business step.
6. Go to `WooCommerce > Settings > Advanced > WooCommerce.com` > Untick "Show Suggestions" checkbox
7. Go to `WooCommerce -> Home` and choose Set up payments task.
8. Click on `Other payment providers`
9. Observe that `Stripe`, `PayPal Payments`, and `Square` are displayed in order.
10. Go back to OBW
11. Install WCPay in the Business Details > free feature step.
12. Set up WCPay
13. Go to `Set up additional payment options` task
14. Observe that `PayPal Payments`, `Affirm` and `Afterpay` are displayed in order.
15. Go to WooCommerce > Settings, Change store country to United State
16. Go to `Set up additional payment options` task
17. Observe that `PayPal Payments`, `Amazon Pay`, `Affirm` and `Afterpay` are displayed in order.


Test the other countries and make sure the payment gateway display order is as shown in [Google sheet](https://docs.google.com/spreadsheets/d/1cb4M2oa9C6H6I287JSM_oc_s_IP8VzipnTb1TMI8FbY/edit#gid=0).

Canada

![Screenshot 2023-01-23 at 16 42 02](https://user-images.githubusercontent.com/4344253/213997212-fe9c9b00-efc0-4d09-bee4-a925ac21480b.png)

![Screenshot 2023-01-23 at 16 55 20](https://user-images.githubusercontent.com/4344253/213999786-e0738562-b949-4b3e-9a09-745b875ec945.png)

US

![Screenshot 2023-01-23 at 16 54 43](https://user-images.githubusercontent.com/4344253/213999774-92e3342b-1a5f-46f4-b997-0c2aaaf43d27.png)


<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
