### PR TITLE
Refactor product tabs and add product tab slot fills

### DIFF
--- a/packages/js/components/changelog/refactor-36446_product_tabs
+++ b/packages/js/components/changelog/refactor-36446_product_tabs
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add new WooProductTabItem component for slot filling tab items.

--- a/packages/js/components/src/index.ts
+++ b/packages/js/components/src/index.ts
@@ -87,6 +87,7 @@ export { CollapsibleContent } from './collapsible-content';
 export { createOrderedChildren, sortFillsByOrder } from './utils';
 export { WooProductFieldItem as __experimentalWooProductFieldItem } from './woo-product-field-item';
 export { WooProductSectionItem as __experimentalWooProductSectionItem } from './woo-product-section-item';
+export { WooProductTabItem as __experimentalWooProductTabItem } from './woo-product-tab-item';
 export {
 	ProductSectionLayout as __experimentalProductSectionLayout,
 	ProductFieldSection as __experimentalProductFieldSection,

--- a/packages/js/components/src/utils.tsx
+++ b/packages/js/components/src/utils.tsx
@@ -19,6 +19,7 @@ function createOrderedChildren< T = Fill.Props, S = Record< string, unknown > >(
 	props: T,
 	injectProps?: S
 ) {
+	console.log( 'create ordered' );
 	if ( typeof children === 'function' ) {
 		return cloneElement( children( props ), { order, ...injectProps } );
 	} else if ( isValidElement( children ) ) {

--- a/packages/js/components/src/utils.tsx
+++ b/packages/js/components/src/utils.tsx
@@ -20,7 +20,10 @@ function createOrderedChildren< T = Fill.Props, S = Record< string, unknown > >(
 	injectProps?: S
 ) {
 	if ( typeof children === 'function' ) {
-		return cloneElement( children( props ), { order, ...injectProps } );
+		return cloneElement( children( { ...props, order, ...injectProps } ), {
+			order,
+			...injectProps,
+		} );
 	} else if ( isValidElement( children ) ) {
 		return cloneElement( children, { ...props, order, ...injectProps } );
 	}

--- a/packages/js/components/src/utils.tsx
+++ b/packages/js/components/src/utils.tsx
@@ -19,7 +19,6 @@ function createOrderedChildren< T = Fill.Props, S = Record< string, unknown > >(
 	props: T,
 	injectProps?: S
 ) {
-	console.log( 'create ordered' );
 	if ( typeof children === 'function' ) {
 		return cloneElement( children( props ), { order, ...injectProps } );
 	} else if ( isValidElement( children ) ) {

--- a/packages/js/components/src/woo-product-tab-item/README.md
+++ b/packages/js/components/src/woo-product-tab-item/README.md
@@ -1,46 +1,35 @@
-# WooProductSectionItem Slot & Fill
+# WooProductTabItem Slot & Fill
 
-A Slotfill component that will allow you to add a new section to the product editor.
+A Slotfill component that will allow you to add a new tab to the product editor.
 
 ## Usage
 
 ```jsx
-<WooProductSectionItem id={ key } location="tab/general" order={ 2 } pluginId="test-plugin" >
-  { () => {
-    return (
-      <ProductSectionLayout
-        title={ __( 'Product test section', 'woocommerce' ) }
-        description={ __(
-          'In this area you can describe the section.',
-          'woocommerce'
-        ) }
-      >
+<WooProductTabItem id={ key } location="tab/general" order={ 2 } pluginId="test-plugin" tabProps={ { title: 'New tab', name: 'new-tab' } } >
         <Card>
-          <CardBody>{ /* Section content */ }</CardBody>
+          <CardBody>{ /* Tab content */ }</CardBody>
         </Card>
-		  </ProductSectionLayout>
-    );
-} }
-</WooProductSectionItem>
+</WooProductTabItem>
 
-<WooProductSectionItem.Slot location="tab/general" />
+<WooProductTabItem.Slot location="tab/general" />
 ```
 
-### WooProductSectionItem (fill)
+### WooProductTabItem (fill)
 
 This is the fill component. You must provide the `id` prop to identify your section fill with a unique string. This component will accept a series of props:
 
-| Prop         | Type     | Description                                                                                                              |
-| -------------| -------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `id`         | String   | A unique string to identify your fill. Used for configuiration management.                                               |
-| `location`   | String   | The string used to identify the particular location that you want to render your section.                                |
-| `pluginId`   | String   | A unique plugin ID to identify the plugin/extension that this fill is associated with.                                   |
-| `order`      | Number   | (optional) This number will dictate the order that the sections rendered by a Slot will be appear.                       |
+| Prop       | Type   | Description                                                                                                    |
+| ---------- | ------ | -------------------------------------------------------------------------------------------------------------- |
+| `id`       | String | A unique string to identify your fill. Used for configuiration management.                                     |
+| `location` | String | The string used to identify the particular location that you want to render your section.                      |
+| `pluginId` | String | A unique plugin ID to identify the plugin/extension that this fill is associated with.                         |
+| `tabProps` | Object | An object containing tab props: name, title, className, disabled (see TabPanel.Tab from @wordpress/components) |
+| `order`    | Number | (optional) This number will dictate the order that the sections rendered by a Slot will be appear.             |
 
-### WooProductSectionItem.Slot (slot)
+### WooProductTabItem.Slot (slot)
 
 This is the slot component, and will not be used as frequently. It must also receive the required `location` prop that will be identical to the fill `location`.
 
-| Name        | Type   | Description                                                                                          |
-| ----------- | ------ | ---------------------------------------------------------------------------------------------------- |
-| `location`  | String | Unique to the location that the Slot appears, and must be the same as the one provided to any fills. |
+| Name       | Type   | Description                                                                                          |
+| ---------- | ------ | ---------------------------------------------------------------------------------------------------- |
+| `location` | String | Unique to the location that the Slot appears, and must be the same as the one provided to any fills. |

--- a/packages/js/components/src/woo-product-tab-item/README.md
+++ b/packages/js/components/src/woo-product-tab-item/README.md
@@ -1,0 +1,46 @@
+# WooProductSectionItem Slot & Fill
+
+A Slotfill component that will allow you to add a new section to the product editor.
+
+## Usage
+
+```jsx
+<WooProductSectionItem id={ key } location="tab/general" order={ 2 } pluginId="test-plugin" >
+  { () => {
+    return (
+      <ProductSectionLayout
+        title={ __( 'Product test section', 'woocommerce' ) }
+        description={ __(
+          'In this area you can describe the section.',
+          'woocommerce'
+        ) }
+      >
+        <Card>
+          <CardBody>{ /* Section content */ }</CardBody>
+        </Card>
+		  </ProductSectionLayout>
+    );
+} }
+</WooProductSectionItem>
+
+<WooProductSectionItem.Slot location="tab/general" />
+```
+
+### WooProductSectionItem (fill)
+
+This is the fill component. You must provide the `id` prop to identify your section fill with a unique string. This component will accept a series of props:
+
+| Prop         | Type     | Description                                                                                                              |
+| -------------| -------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `id`         | String   | A unique string to identify your fill. Used for configuiration management.                                               |
+| `location`   | String   | The string used to identify the particular location that you want to render your section.                                |
+| `pluginId`   | String   | A unique plugin ID to identify the plugin/extension that this fill is associated with.                                   |
+| `order`      | Number   | (optional) This number will dictate the order that the sections rendered by a Slot will be appear.                       |
+
+### WooProductSectionItem.Slot (slot)
+
+This is the slot component, and will not be used as frequently. It must also receive the required `location` prop that will be identical to the fill `location`.
+
+| Name        | Type   | Description                                                                                          |
+| ----------- | ------ | ---------------------------------------------------------------------------------------------------- |
+| `location`  | String | Unique to the location that the Slot appears, and must be the same as the one provided to any fills. |

--- a/packages/js/components/src/woo-product-tab-item/index.ts
+++ b/packages/js/components/src/woo-product-tab-item/index.ts
@@ -1,0 +1,1 @@
+export * from './woo-product-tab-item';

--- a/packages/js/components/src/woo-product-tab-item/woo-product-tab-item.tsx
+++ b/packages/js/components/src/woo-product-tab-item/woo-product-tab-item.tsx
@@ -15,7 +15,10 @@ type WooProductTabItemProps = {
 	pluginId: string;
 	template?: string;
 	order?: number;
-	tabProps: TabPanel.Tab;
+	tabProps:
+		| TabPanel.Tab
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		| ( ( fillProps: Record< string, any > | undefined ) => TabPanel.Tab );
 	templates?: Array< { name: string; order?: number } >;
 };
 
@@ -49,11 +52,9 @@ export const WooProductTabItem: React.FC< WooProductTabItemProps > & {
 				>
 					{ ( fillProps: Fill.Props ) => {
 						return createOrderedChildren< Fill.Props >(
-							typeof children === 'function'
-								? children( templateData )
-								: children,
+							children,
 							templateData.order || 20,
-							fillProps,
+							{ ...templateData, ...fillProps },
 							{ tabProps }
 						);
 					} }
@@ -74,8 +75,12 @@ WooProductTabItem.Slot = ( { fillProps, template, children } ) => (
 					const props: WooProductTabItemProps = fill[ 0 ].props;
 					if ( props && props.tabProps ) {
 						childrenMap[ props.tabProps.name ] = fill[ 0 ];
+						const tabProps =
+							typeof props.tabProps === 'function'
+								? props.tabProps( fillProps )
+								: props.tabProps;
 						tabs.push( {
-							...props.tabProps,
+							...tabProps,
 							order: props.order ?? 20,
 						} );
 					}

--- a/packages/js/components/src/woo-product-tab-item/woo-product-tab-item.tsx
+++ b/packages/js/components/src/woo-product-tab-item/woo-product-tab-item.tsx
@@ -54,8 +54,13 @@ export const WooProductTabItem: React.FC< WooProductTabItemProps > & {
 						return createOrderedChildren< Fill.Props >(
 							children,
 							templateData.order || 20,
-							{ ...templateData, ...fillProps },
-							{ tabProps }
+							{},
+							{
+								tabProps,
+								templateName: templateData.name,
+								order: templateData.order || 20,
+								...fillProps,
+							}
 						);
 					} }
 				</Fill>

--- a/packages/js/components/src/woo-product-tab-item/woo-product-tab-item.tsx
+++ b/packages/js/components/src/woo-product-tab-item/woo-product-tab-item.tsx
@@ -12,14 +12,15 @@ import { createOrderedChildren } from '../utils';
 
 type WooProductTabItemProps = {
 	id: string;
-	location: string;
 	pluginId: string;
+	template?: string;
 	order?: number;
 	tabProps: TabPanel.Tab;
+	templates?: Array< { name: string; order?: number } >;
 };
 
 type WooProductFieldSlotProps = {
-	location: string;
+	template: string;
 	children: (
 		tabs: TabPanel.Tab[],
 		tabChildren: Record< string, ReactNode >
@@ -30,24 +31,41 @@ export const WooProductTabItem: React.FC< WooProductTabItemProps > & {
 	Slot: React.VFC<
 		Omit< Slot.Props, 'children' > & WooProductFieldSlotProps
 	>;
-} = ( { children, order = 20, location, tabProps } ) => {
+} = ( { children, order, template, tabProps, templates } ) => {
+	if ( ! template && ! templates ) {
+		// eslint-disable-next-line no-console
+		console.warn(
+			'WooProductTabItem fill is missing template or templates property.'
+		);
+		return null;
+	}
+	templates = templates || [ { name: template as string, order } ];
 	return (
-		<Fill name={ `woocommerce_product_tab_${ location }` }>
-			{ ( fillProps: Fill.Props ) => {
-				return createOrderedChildren< Fill.Props >(
-					children,
-					order,
-					fillProps,
-					{ tabProps }
-				);
-			} }
-		</Fill>
+		<>
+			{ templates.map( ( templateData ) => (
+				<Fill
+					name={ `woocommerce_product_tab_${ templateData.name }` }
+					key={ templateData.name }
+				>
+					{ ( fillProps: Fill.Props ) => {
+						return createOrderedChildren< Fill.Props >(
+							typeof children === 'function'
+								? children( templateData )
+								: children,
+							templateData.order || 20,
+							fillProps,
+							{ tabProps }
+						);
+					} }
+				</Fill>
+			) ) }
+		</>
 	);
 };
 
-WooProductTabItem.Slot = ( { fillProps, location, children } ) => (
+WooProductTabItem.Slot = ( { fillProps, template, children } ) => (
 	<Slot
-		name={ `woocommerce_product_tab_${ location }` }
+		name={ `woocommerce_product_tab_${ template }` }
 		fillProps={ fillProps }
 	>
 		{ ( fills ) => {

--- a/packages/js/components/src/woo-product-tab-item/woo-product-tab-item.tsx
+++ b/packages/js/components/src/woo-product-tab-item/woo-product-tab-item.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { ReactElement } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 import { Slot, Fill, TabPanel } from '@wordpress/components';
 import { createElement, Fragment } from '@wordpress/element';
 
@@ -22,7 +22,7 @@ type WooProductFieldSlotProps = {
 	location: string;
 	children: (
 		tabs: TabPanel.Tab[],
-		tabChildren: Record< string, ReactElement >
+		tabChildren: Record< string, ReactNode >
 	) => ReactElement | null;
 };
 
@@ -75,7 +75,6 @@ WooProductTabItem.Slot = ( { fillProps, location, children } ) => (
 				return a.order - b.order;
 			} );
 
-			console.log( tabData );
 			return children( orderedTabs, tabData.childrenMap );
 		} }
 	</Slot>

--- a/packages/js/components/src/woo-product-tab-item/woo-product-tab-item.tsx
+++ b/packages/js/components/src/woo-product-tab-item/woo-product-tab-item.tsx
@@ -1,0 +1,82 @@
+/**
+ * External dependencies
+ */
+import React, { ReactElement } from 'react';
+import { Slot, Fill, TabPanel } from '@wordpress/components';
+import { createElement, Fragment } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { createOrderedChildren } from '../utils';
+
+type WooProductTabItemProps = {
+	id: string;
+	location: string;
+	pluginId: string;
+	order?: number;
+	tabProps: TabPanel.Tab;
+};
+
+type WooProductFieldSlotProps = {
+	location: string;
+	children: (
+		tabs: TabPanel.Tab[],
+		tabChildren: Record< string, ReactElement >
+	) => ReactElement | null;
+};
+
+export const WooProductTabItem: React.FC< WooProductTabItemProps > & {
+	Slot: React.VFC<
+		Omit< Slot.Props, 'children' > & WooProductFieldSlotProps
+	>;
+} = ( { children, order = 20, location, tabProps } ) => {
+	return (
+		<Fill name={ `woocommerce_product_tab_${ location }` }>
+			{ ( fillProps: Fill.Props ) => {
+				return createOrderedChildren< Fill.Props >(
+					children,
+					order,
+					fillProps,
+					{ tabProps }
+				);
+			} }
+		</Fill>
+	);
+};
+
+WooProductTabItem.Slot = ( { fillProps, location, children } ) => (
+	<Slot
+		name={ `woocommerce_product_tab_${ location }` }
+		fillProps={ fillProps }
+	>
+		{ ( fills ) => {
+			const tabData = fills.reduce(
+				( { childrenMap, tabs }, fill ) => {
+					const props: WooProductTabItemProps = fill[ 0 ].props;
+					if ( props && props.tabProps ) {
+						childrenMap[ props.tabProps.name ] = fill[ 0 ];
+						tabs.push( {
+							...props.tabProps,
+							order: props.order ?? 20,
+						} );
+					}
+					return {
+						childrenMap,
+						tabs,
+					};
+				},
+				{ childrenMap: {}, tabs: [] } as {
+					childrenMap: Record< string, ReactElement >;
+					tabs: Array< TabPanel.Tab & { order: number } >;
+				}
+			);
+			const orderedTabs = tabData.tabs.sort( ( a, b ) => {
+				return a.order - b.order;
+			} );
+
+			console.log( tabData );
+			return children( orderedTabs, tabData.childrenMap );
+		} }
+	</Slot>
+);

--- a/plugins/woocommerce-admin/client/products/edit-product-page.tsx
+++ b/plugins/woocommerce-admin/client/products/edit-product-page.tsx
@@ -126,7 +126,7 @@ const EditProductPage: React.FC = () => {
 				product.status === 'trash' &&
 				! isPendingAction &&
 				! wasDeletedUsingAction && (
-					<ProductFormLayout>
+					<ProductFormLayout id="error">
 						<div className="woocommerce-edit-product__error">
 							{ __(
 								'You cannot edit this item because it is in the Trash. Please restore it and try again.',

--- a/plugins/woocommerce-admin/client/products/fills/index.ts
+++ b/plugins/woocommerce-admin/client/products/fills/index.ts
@@ -3,6 +3,7 @@
  */
 import './product-form-fills';
 import './product-form-tab-fills';
+import './product-form-variation-tab-fills';
 
 export * from './shipping-section/shipping-section-fills';
 export * from './details-section/details-section-fills';

--- a/plugins/woocommerce-admin/client/products/fills/index.ts
+++ b/plugins/woocommerce-admin/client/products/fills/index.ts
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import './product-form-fills';
+import './product-form-tab-fills';
 
 export * from './shipping-section/shipping-section-fills';
 export * from './details-section/details-section-fills';

--- a/plugins/woocommerce-admin/client/products/fills/product-form-tab-fills.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/product-form-tab-fills.tsx
@@ -56,7 +56,7 @@ const Tabs = () => {
 	return (
 		<>
 			<WooProductTabItem
-				id={ 'new-tab-id' }
+				id="tab/general"
 				template="tab/general"
 				pluginId="core"
 				order={ 1 }
@@ -65,7 +65,7 @@ const Tabs = () => {
 				<WooProductSectionItem.Slot location={ TAB_GENERAL_ID } />
 			</WooProductTabItem>
 			<WooProductTabItem
-				id={ 'tab/pricing' }
+				id="tab/pricing"
 				template="tab/general"
 				pluginId="core"
 				order={ 3 }
@@ -74,7 +74,7 @@ const Tabs = () => {
 				<WooProductSectionItem.Slot location={ TAB_PRICING_ID } />
 			</WooProductTabItem>
 			<WooProductTabItem
-				id={ 'tab/inventory' }
+				id="tab/inventory"
 				template="tab/general"
 				pluginId="core"
 				order={ 5 }
@@ -83,7 +83,7 @@ const Tabs = () => {
 				<WooProductSectionItem.Slot location={ TAB_INVENTORY_ID } />
 			</WooProductTabItem>
 			<WooProductTabItem
-				id={ 'tab/shipping' }
+				id="tab/shipping"
 				template="tab/general"
 				pluginId="core"
 				order={ 7 }
@@ -96,7 +96,7 @@ const Tabs = () => {
 			</WooProductTabItem>
 			{ window.wcAdminFeatures[ 'product-variation-management' ] ? (
 				<WooProductTabItem
-					id={ 'tab/options' }
+					id="tab/options"
 					template="tab/general"
 					pluginId="core"
 					order={ 9 }

--- a/plugins/woocommerce-admin/client/products/fills/product-form-tab-fills.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/product-form-tab-fills.tsx
@@ -1,0 +1,126 @@
+/**
+ * External dependencies
+ */
+import { registerPlugin } from '@wordpress/plugins';
+import {
+	__experimentalWooProductTabItem as WooProductTabItem,
+	__experimentalWooProductSectionItem as WooProductSectionItem,
+	useFormContext,
+} from '@woocommerce/components';
+import { Product } from '@woocommerce/data';
+import { useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { OptionsSection } from '../sections/options-section';
+import { ProductVariationsSection } from '../sections/product-variations-section';
+import {
+	TAB_GENERAL_ID,
+	TAB_SHIPPING_ID,
+	TAB_INVENTORY_ID,
+	TAB_PRICING_ID,
+} from './fills/constants';
+
+const Tabs = () => {
+	const { values: product } = useFormContext< Product >();
+	const tabPropData = useMemo(
+		() => ( {
+			general: {
+				name: 'general',
+				title: 'General',
+			},
+			pricing: {
+				name: 'pricing',
+				title: 'Pricing',
+				disabled: !! product?.variations?.length,
+			},
+			inventory: {
+				name: 'inventory',
+				title: 'Inventory',
+				disabled: !! product?.variations?.length,
+			},
+			shipping: {
+				name: 'shipping',
+				title: 'Shipping',
+				disabled: !! product?.variations?.length,
+			},
+			options: {
+				name: 'options',
+				title: 'Options',
+			},
+		} ),
+		[]
+	);
+	return (
+		<>
+			<WooProductTabItem
+				id={ 'new-tab-id' }
+				location="tab/general"
+				pluginId="core"
+				order={ 1 }
+				tabProps={ tabPropData.general }
+			>
+				<WooProductSectionItem.Slot location={ TAB_GENERAL_ID } />
+			</WooProductTabItem>
+			<WooProductTabItem
+				id={ 'tab/pricing' }
+				location="tab/general"
+				pluginId="core"
+				order={ 3 }
+				tabProps={ tabPropData.pricing }
+			>
+				<WooProductSectionItem.Slot location={ TAB_PRICING_ID } />
+			</WooProductTabItem>
+			<WooProductTabItem
+				id={ 'tab/inventory' }
+				location="tab/general"
+				pluginId="core"
+				order={ 5 }
+				tabProps={ tabPropData.inventory }
+			>
+				<WooProductSectionItem.Slot location={ TAB_INVENTORY_ID } />
+			</WooProductTabItem>
+			<WooProductTabItem
+				id={ 'tab/shipping' }
+				location="tab/general"
+				pluginId="core"
+				order={ 7 }
+				tabProps={ tabPropData.shipping }
+			>
+				<WooProductSectionItem.Slot
+					location={ TAB_SHIPPING_ID }
+					fillProps={ { product } }
+				/>
+			</WooProductTabItem>
+			{ window.wcAdminFeatures[ 'product-variation-management' ] ? (
+				<WooProductTabItem
+					id={ 'tab/options' }
+					location="tab/general"
+					pluginId="core"
+					order={ 9 }
+					tabProps={ tabPropData.options }
+				>
+					<>
+						<OptionsSection />
+						<ProductVariationsSection />
+					</>
+				</WooProductTabItem>
+			) : (
+				<></>
+			) }
+		</>
+	);
+};
+
+/**
+ * Preloading product form data, as product pages are waiting on this to be resolved.
+ * The above Form component won't get rendered until the getProductForm is resolved.
+ */
+registerPlugin( 'wc-admin-product-editor-form-tab-fills', {
+	// @ts-expect-error 'scope' does exist. @types/wordpress__plugins is outdated.
+	scope: 'woocommerce-product-editor',
+	render: () => {
+		return <Tabs />;
+	},
+} );

--- a/plugins/woocommerce-admin/client/products/fills/product-form-tab-fills.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/product-form-tab-fills.tsx
@@ -106,9 +106,7 @@ const Tabs = () => {
 						<ProductVariationsSection />
 					</>
 				</WooProductTabItem>
-			) : (
-				<></>
-			) }
+			) : null }
 		</>
 	);
 };

--- a/plugins/woocommerce-admin/client/products/fills/product-form-tab-fills.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/product-form-tab-fills.tsx
@@ -21,7 +21,7 @@ import {
 	TAB_SHIPPING_ID,
 	TAB_INVENTORY_ID,
 	TAB_PRICING_ID,
-} from './fills/constants';
+} from './constants';
 
 const Tabs = () => {
 	const { values: product } = useFormContext< Product >();
@@ -57,7 +57,7 @@ const Tabs = () => {
 		<>
 			<WooProductTabItem
 				id={ 'new-tab-id' }
-				location="tab/general"
+				template="tab/general"
 				pluginId="core"
 				order={ 1 }
 				tabProps={ tabPropData.general }
@@ -66,7 +66,7 @@ const Tabs = () => {
 			</WooProductTabItem>
 			<WooProductTabItem
 				id={ 'tab/pricing' }
-				location="tab/general"
+				template="tab/general"
 				pluginId="core"
 				order={ 3 }
 				tabProps={ tabPropData.pricing }
@@ -75,7 +75,7 @@ const Tabs = () => {
 			</WooProductTabItem>
 			<WooProductTabItem
 				id={ 'tab/inventory' }
-				location="tab/general"
+				template="tab/general"
 				pluginId="core"
 				order={ 5 }
 				tabProps={ tabPropData.inventory }
@@ -84,7 +84,7 @@ const Tabs = () => {
 			</WooProductTabItem>
 			<WooProductTabItem
 				id={ 'tab/shipping' }
-				location="tab/general"
+				template="tab/general"
 				pluginId="core"
 				order={ 7 }
 				tabProps={ tabPropData.shipping }
@@ -97,7 +97,7 @@ const Tabs = () => {
 			{ window.wcAdminFeatures[ 'product-variation-management' ] ? (
 				<WooProductTabItem
 					id={ 'tab/options' }
-					location="tab/general"
+					template="tab/general"
 					pluginId="core"
 					order={ 9 }
 					tabProps={ tabPropData.options }
@@ -112,10 +112,6 @@ const Tabs = () => {
 	);
 };
 
-/**
- * Preloading product form data, as product pages are waiting on this to be resolved.
- * The above Form component won't get rendered until the getProductForm is resolved.
- */
 registerPlugin( 'wc-admin-product-editor-form-tab-fills', {
 	// @ts-expect-error 'scope' does exist. @types/wordpress__plugins is outdated.
 	scope: 'woocommerce-product-editor',

--- a/plugins/woocommerce-admin/client/products/fills/product-form-tab-fills.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/product-form-tab-fills.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
 import {
 	__experimentalWooProductTabItem as WooProductTabItem,
@@ -28,29 +29,29 @@ const Tabs = () => {
 		() => ( {
 			general: {
 				name: 'general',
-				title: 'General',
+				title: __( 'General', 'woocommerce' ),
 			},
 			pricing: {
 				name: 'pricing',
-				title: 'Pricing',
+				title: __( 'Pricing', 'woocommerce' ),
 				disabled: !! product?.variations?.length,
 			},
 			inventory: {
 				name: 'inventory',
-				title: 'Inventory',
+				title: __( 'Inventory', 'woocommerce' ),
 				disabled: !! product?.variations?.length,
 			},
 			shipping: {
 				name: 'shipping',
-				title: 'Shipping',
+				title: __( 'Shipping', 'woocommerce' ),
 				disabled: !! product?.variations?.length,
 			},
 			options: {
 				name: 'options',
-				title: 'Options',
+				title: __( 'Options', 'woocommerce' ),
 			},
 		} ),
-		[]
+		[ product.variations ]
 	);
 	return (
 		<>

--- a/plugins/woocommerce-admin/client/products/fills/product-form-variation-tab-fills.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/product-form-variation-tab-fills.tsx
@@ -1,0 +1,102 @@
+/**
+ * External dependencies
+ */
+import { registerPlugin } from '@wordpress/plugins';
+import {
+	__experimentalWooProductTabItem as WooProductTabItem,
+	__experimentalWooProductSectionItem as WooProductSectionItem,
+} from '@woocommerce/components';
+import { PartialProduct } from '@woocommerce/data';
+
+/**
+ * Internal dependencies
+ */
+import { ProductVariationDetailsSection } from '../sections/product-variation-details-section';
+import {
+	TAB_INVENTORY_ID,
+	TAB_SHIPPING_ID,
+	TAB_PRICING_ID,
+} from './fills/constants';
+
+const tabPropData = {
+	general: {
+		name: 'general',
+		title: 'General',
+	},
+	pricing: {
+		name: 'pricing',
+		title: 'Pricing',
+	},
+	inventory: {
+		name: 'inventory',
+		title: 'Inventory',
+	},
+	shipping: {
+		name: 'shipping',
+		title: 'Shipping',
+	},
+	options: {
+		name: 'options',
+		title: 'Options',
+	},
+};
+
+const Tabs = () => {
+	return (
+		<>
+			<WooProductTabItem
+				id={ 'new-tab-id' }
+				location="tab/variation"
+				pluginId="core"
+				order={ 1 }
+				tabProps={ tabPropData.general }
+			>
+				<ProductVariationDetailsSection />
+			</WooProductTabItem>
+			<WooProductTabItem
+				id={ 'tab/pricing' }
+				location="tab/variation"
+				pluginId="core"
+				order={ 3 }
+				tabProps={ tabPropData.pricing }
+			>
+				<WooProductSectionItem.Slot location={ TAB_PRICING_ID } />
+			</WooProductTabItem>
+			<WooProductTabItem
+				id={ 'tab/inventory' }
+				location="tab/variation"
+				pluginId="core"
+				order={ 5 }
+				tabProps={ tabPropData.inventory }
+			>
+				<WooProductSectionItem.Slot location={ TAB_INVENTORY_ID } />
+			</WooProductTabItem>
+			<WooProductTabItem
+				id={ 'tab/shipping' }
+				location="tab/variation"
+				pluginId="core"
+				order={ 7 }
+				tabProps={ tabPropData.shipping }
+			>
+				{ ( product: PartialProduct ) => (
+					<WooProductSectionItem.Slot
+						location={ TAB_SHIPPING_ID }
+						fillProps={ { product } }
+					/>
+				) }
+			</WooProductTabItem>
+		</>
+	);
+};
+
+/**
+ * Preloading product form data, as product pages are waiting on this to be resolved.
+ * The above Form component won't get rendered until the getProductForm is resolved.
+ */
+registerPlugin( 'wc-admin-product-editor-form-variation-tab-fills', {
+	// @ts-expect-error 'scope' does exist. @types/wordpress__plugins is outdated.
+	scope: 'woocommerce-product-editor',
+	render: () => {
+		return <Tabs />;
+	},
+} );

--- a/plugins/woocommerce-admin/client/products/fills/product-form-variation-tab-fills.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/product-form-variation-tab-fills.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
 import {
 	__experimentalWooProductTabItem as WooProductTabItem,
@@ -21,23 +22,23 @@ import {
 const tabPropData = {
 	general: {
 		name: 'general',
-		title: 'General',
+		title: __( 'General', 'woocommerce' ),
 	},
 	pricing: {
 		name: 'pricing',
-		title: 'Pricing',
+		title: __( 'Pricing', 'woocommerce' ),
 	},
 	inventory: {
 		name: 'inventory',
-		title: 'Inventory',
+		title: __( 'Inventory', 'woocommerce' ),
 	},
 	shipping: {
 		name: 'shipping',
-		title: 'Shipping',
+		title: __( 'Shipping', 'woocommerce' ),
 	},
 	options: {
 		name: 'options',
-		title: 'Options',
+		title: __( 'Options', 'woocommerce' ),
 	},
 };
 

--- a/plugins/woocommerce-admin/client/products/fills/product-form-variation-tab-fills.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/product-form-variation-tab-fills.tsx
@@ -42,7 +42,7 @@ const Tabs = () => {
 	return (
 		<>
 			<WooProductTabItem
-				id={ 'new-tab-id' }
+				id="tab/general/variation"
 				template="tab/variation"
 				pluginId="core"
 				order={ 1 }
@@ -51,7 +51,7 @@ const Tabs = () => {
 				<ProductVariationDetailsSection />
 			</WooProductTabItem>
 			<WooProductTabItem
-				id={ 'tab/pricing' }
+				id="tab/pricing"
 				template="tab/variation"
 				pluginId="core"
 				order={ 3 }
@@ -60,7 +60,7 @@ const Tabs = () => {
 				<WooProductSectionItem.Slot location={ TAB_PRICING_ID } />
 			</WooProductTabItem>
 			<WooProductTabItem
-				id={ 'tab/inventory' }
+				id="tab/inventory"
 				template="tab/variation"
 				pluginId="core"
 				order={ 5 }
@@ -69,7 +69,7 @@ const Tabs = () => {
 				<WooProductSectionItem.Slot location={ TAB_INVENTORY_ID } />
 			</WooProductTabItem>
 			<WooProductTabItem
-				id={ 'tab/shipping' }
+				id="tab/shipping"
 				template="tab/variation"
 				pluginId="core"
 				order={ 7 }

--- a/plugins/woocommerce-admin/client/products/fills/product-form-variation-tab-fills.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/product-form-variation-tab-fills.tsx
@@ -13,11 +13,7 @@ import { PartialProduct } from '@woocommerce/data';
  * Internal dependencies
  */
 import { ProductVariationDetailsSection } from '../sections/product-variation-details-section';
-import {
-	TAB_INVENTORY_ID,
-	TAB_SHIPPING_ID,
-	TAB_PRICING_ID,
-} from './fills/constants';
+import { TAB_INVENTORY_ID, TAB_SHIPPING_ID, TAB_PRICING_ID } from './constants';
 
 const tabPropData = {
 	general: {
@@ -47,7 +43,7 @@ const Tabs = () => {
 		<>
 			<WooProductTabItem
 				id={ 'new-tab-id' }
-				location="tab/variation"
+				template="tab/variation"
 				pluginId="core"
 				order={ 1 }
 				tabProps={ tabPropData.general }
@@ -56,7 +52,7 @@ const Tabs = () => {
 			</WooProductTabItem>
 			<WooProductTabItem
 				id={ 'tab/pricing' }
-				location="tab/variation"
+				template="tab/variation"
 				pluginId="core"
 				order={ 3 }
 				tabProps={ tabPropData.pricing }
@@ -65,7 +61,7 @@ const Tabs = () => {
 			</WooProductTabItem>
 			<WooProductTabItem
 				id={ 'tab/inventory' }
-				location="tab/variation"
+				template="tab/variation"
 				pluginId="core"
 				order={ 5 }
 				tabProps={ tabPropData.inventory }
@@ -74,7 +70,7 @@ const Tabs = () => {
 			</WooProductTabItem>
 			<WooProductTabItem
 				id={ 'tab/shipping' }
-				location="tab/variation"
+				template="tab/variation"
 				pluginId="core"
 				order={ 7 }
 				tabProps={ tabPropData.shipping }

--- a/plugins/woocommerce-admin/client/products/fills/product-form-variation-tab-fills.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/product-form-variation-tab-fills.tsx
@@ -75,7 +75,7 @@ const Tabs = () => {
 				order={ 7 }
 				tabProps={ tabPropData.shipping }
 			>
-				{ ( product: PartialProduct ) => (
+				{ ( { product }: { product: PartialProduct } ) => (
 					<WooProductSectionItem.Slot
 						location={ TAB_SHIPPING_ID }
 						fillProps={ { product } }

--- a/plugins/woocommerce-admin/client/products/layout/product-form-layout.tsx
+++ b/plugins/woocommerce-admin/client/products/layout/product-form-layout.tsx
@@ -6,6 +6,7 @@ import { useEffect } from '@wordpress/element';
 import { TabPanel, Tooltip } from '@wordpress/components';
 import { navigateTo, getNewPath, getQuery } from '@woocommerce/navigation';
 import { __experimentalWooProductTabItem as WooProductTabItem } from '@woocommerce/components';
+import { PartialProduct } from '@woocommerce/data';
 import classnames from 'classnames';
 
 /**
@@ -15,7 +16,15 @@ import './product-form-layout.scss';
 import { ProductFormTab } from '../product-form-tab';
 import { useHeaderHeight } from '~/header/use-header-height';
 
-export const ProductFormLayout: React.FC = () => {
+type ProductFormLayoutProps = {
+	id: string;
+	product?: PartialProduct;
+};
+
+export const ProductFormLayout: React.FC< ProductFormLayoutProps > = ( {
+	id,
+	product,
+} ) => {
 	const query = getQuery() as Record< string, string >;
 
 	useEffect( () => {
@@ -68,7 +77,7 @@ export const ProductFormLayout: React.FC = () => {
 
 	return (
 		<>
-			<WooProductTabItem.Slot location="tab/general">
+			<WooProductTabItem.Slot location={ 'tab/' + id }>
 				{ ( tabs, childrenMap ) =>
 					tabs.length > 0 ? (
 						<TabPanel
@@ -90,9 +99,12 @@ export const ProductFormLayout: React.FC = () => {
 									'woocommerce-product-form-tab',
 									'woocommerce-product-form-tab__' + tab.name
 								);
+								const child = childrenMap[ tab.name ];
 								return (
 									<div className={ classes } key={ tab.name }>
-										{ childrenMap[ tab.name ] }
+										{ typeof child === 'function'
+											? child( product )
+											: child }
 									</div>
 								);
 							} }

--- a/plugins/woocommerce-admin/client/products/layout/product-form-layout.tsx
+++ b/plugins/woocommerce-admin/client/products/layout/product-form-layout.tsx
@@ -13,7 +13,6 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import './product-form-layout.scss';
-import { ProductFormTab } from '../product-form-tab';
 import { useHeaderHeight } from '~/header/use-header-height';
 
 type ProductFormLayoutProps = {
@@ -45,7 +44,9 @@ export const ProductFormLayout: React.FC< ProductFormLayoutProps > = ( {
 		const tabPanelTabs = document.querySelector(
 			'.product-form-layout .components-tab-panel__tabs'
 		) as HTMLElement;
-		tabPanelTabs.style.top = adminBarHeight + headerHeight + 'px';
+		if ( tabPanelTabs ) {
+			tabPanelTabs.style.top = adminBarHeight + headerHeight + 'px';
+		}
 	}, [ adminBarHeight, headerHeight ] );
 
 	const getTooltipTabs = ( tabs: TabPanel.Tab[] ) => {
@@ -77,7 +78,7 @@ export const ProductFormLayout: React.FC< ProductFormLayoutProps > = ( {
 
 	return (
 		<>
-			<WooProductTabItem.Slot location={ 'tab/' + id }>
+			<WooProductTabItem.Slot template={ 'tab/' + id }>
 				{ ( tabs, childrenMap ) =>
 					tabs.length > 0 ? (
 						<TabPanel

--- a/plugins/woocommerce-admin/client/products/layout/product-form-layout.tsx
+++ b/plugins/woocommerce-admin/client/products/layout/product-form-layout.tsx
@@ -2,9 +2,11 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Children, useEffect } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 import { TabPanel, Tooltip } from '@wordpress/components';
 import { navigateTo, getNewPath, getQuery } from '@woocommerce/navigation';
+import { __experimentalWooProductTabItem as WooProductTabItem } from '@woocommerce/components';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -13,9 +15,7 @@ import './product-form-layout.scss';
 import { ProductFormTab } from '../product-form-tab';
 import { useHeaderHeight } from '~/header/use-header-height';
 
-export const ProductFormLayout: React.FC< {
-	children: JSX.Element | JSX.Element[];
-} > = ( { children } ) => {
+export const ProductFormLayout: React.FC = () => {
 	const query = getQuery() as Record< string, string >;
 
 	useEffect( () => {
@@ -39,13 +39,10 @@ export const ProductFormLayout: React.FC< {
 		tabPanelTabs.style.top = adminBarHeight + headerHeight + 'px';
 	}, [ adminBarHeight, headerHeight ] );
 
-	const tabs = Children.map( children, ( child: JSX.Element ) => {
-		if ( child.type !== ProductFormTab ) {
-			return null;
-		}
-		return {
-			name: child.props.name,
-			title: child.props.disabled ? (
+	const getTooltipTabs = ( tabs: TabPanel.Tab[] ) => {
+		return tabs.map( ( tab ) => ( {
+			name: tab.name,
+			title: tab.disabled ? (
 				<Tooltip
 					text={ __(
 						'Manage individual variation details in the Options tab.',
@@ -54,49 +51,55 @@ export const ProductFormLayout: React.FC< {
 				>
 					<span className="woocommerce-product-form-tab__item-inner">
 						<span className="woocommerce-product-form-tab__item-inner-text">
-							{ child.props.title }
+							{ tab.title }
 						</span>
 					</span>
 				</Tooltip>
 			) : (
 				<span className="woocommerce-product-form-tab__item-inner">
 					<span className="woocommerce-product-form-tab__item-inner-text">
-						{ child.props.title }
+						{ tab.title }
 					</span>
 				</span>
 			),
-			disabled: child.props.disabled,
-		};
-	} );
+			disabled: tab.disabled,
+		} ) );
+	};
 
 	return (
-		<TabPanel
-			className="product-form-layout"
-			activeClass="is-active"
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-			// @ts-ignore Disabled properties will be included in newer versions of Gutenberg.
-			tabs={ tabs }
-			initialTabName={ query.tab ?? tabs[ 0 ].name }
-			onSelect={ ( tabName: string ) => {
-				window.document.documentElement.scrollTop = 0;
-				navigateTo( {
-					url: getNewPath( { tab: tabName } ),
-				} );
-			} }
-		>
-			{ ( tab ) => (
-				<>
-					{ Children.map( children, ( child: JSX.Element ) => {
-						if (
-							child.type !== ProductFormTab ||
-							child.props.name !== tab.name
-						) {
-							return null;
-						}
-						return child;
-					} ) }
-				</>
-			) }
-		</TabPanel>
+		<>
+			<WooProductTabItem.Slot location="tab/general">
+				{ ( tabs, childrenMap ) =>
+					tabs.length > 0 ? (
+						<TabPanel
+							className="product-form-layout"
+							activeClass="is-active"
+							// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+							// @ts-ignore Disabled properties will be included in newer versions of Gutenberg.
+							tabs={ getTooltipTabs( tabs ) }
+							initialTabName={ query.tab ?? tabs[ 0 ].name }
+							onSelect={ ( tabName: string ) => {
+								window.document.documentElement.scrollTop = 0;
+								navigateTo( {
+									url: getNewPath( { tab: tabName } ),
+								} );
+							} }
+						>
+							{ ( tab ) => {
+								const classes = classnames(
+									'woocommerce-product-form-tab',
+									'woocommerce-product-form-tab__' + tab.name
+								);
+								return (
+									<div className={ classes } key={ tab.name }>
+										{ childrenMap[ tab.name ] }
+									</div>
+								);
+							} }
+						</TabPanel>
+					) : null
+				}
+			</WooProductTabItem.Slot>
+		</>
 	);
 };

--- a/plugins/woocommerce-admin/client/products/layout/product-form-layout.tsx
+++ b/plugins/woocommerce-admin/client/products/layout/product-form-layout.tsx
@@ -78,7 +78,10 @@ export const ProductFormLayout: React.FC< ProductFormLayoutProps > = ( {
 
 	return (
 		<>
-			<WooProductTabItem.Slot template={ 'tab/' + id }>
+			<WooProductTabItem.Slot
+				template={ 'tab/' + id }
+				fillProps={ { product } }
+			>
 				{ ( tabs, childrenMap ) =>
 					tabs.length > 0 ? (
 						<TabPanel

--- a/plugins/woocommerce-admin/client/products/product-form.tsx
+++ b/plugins/woocommerce-admin/client/products/product-form.tsx
@@ -35,7 +35,7 @@ export const ProductForm: React.FC< {
 				validate={ validate }
 			>
 				<ProductFormHeader />
-				<ProductFormLayout />
+				<ProductFormLayout id="general" product={ product } />
 				<ProductFormFooter />
 				{ /* @ts-expect-error 'scope' does exist. @types/wordpress__plugins is outdated. */ }
 				<PluginArea scope="woocommerce-product-editor" />

--- a/plugins/woocommerce-admin/client/products/product-form.tsx
+++ b/plugins/woocommerce-admin/client/products/product-form.tsx
@@ -1,12 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	Form,
-	FormRef,
-	__experimentalWooProductSectionItem as WooProductSectionItem,
-	SlotContextProvider,
-} from '@woocommerce/components';
+import { Form, FormRef, SlotContextProvider } from '@woocommerce/components';
 import { PartialProduct, Product } from '@woocommerce/data';
 import { PluginArea } from '@wordpress/plugins';
 import { Ref } from 'react';
@@ -16,17 +11,8 @@ import { Ref } from 'react';
  */
 import { ProductFormHeader } from './layout/product-form-header';
 import { ProductFormLayout } from './layout/product-form-layout';
-import { ProductVariationsSection } from './sections/product-variations-section';
 import { validate } from './product-validation';
-import { OptionsSection } from './sections/options-section';
 import { ProductFormFooter } from './layout/product-form-footer';
-import { ProductFormTab } from './product-form-tab';
-import {
-	TAB_GENERAL_ID,
-	TAB_SHIPPING_ID,
-	TAB_INVENTORY_ID,
-	TAB_PRICING_ID,
-} from './fills/constants';
 
 export const ProductForm: React.FC< {
 	product?: PartialProduct;
@@ -49,51 +35,7 @@ export const ProductForm: React.FC< {
 				validate={ validate }
 			>
 				<ProductFormHeader />
-				<ProductFormLayout>
-					<ProductFormTab name="general" title="General">
-						<WooProductSectionItem.Slot
-							location={ TAB_GENERAL_ID }
-						/>
-					</ProductFormTab>
-					<ProductFormTab
-						name="pricing"
-						title="Pricing"
-						disabled={ !! product?.variations?.length }
-					>
-						<WooProductSectionItem.Slot
-							location={ TAB_PRICING_ID }
-						/>
-					</ProductFormTab>
-					<ProductFormTab
-						name="inventory"
-						title="Inventory"
-						disabled={ !! product?.variations?.length }
-					>
-						<WooProductSectionItem.Slot
-							location={ TAB_INVENTORY_ID }
-						/>
-					</ProductFormTab>
-					<ProductFormTab
-						name="shipping"
-						title="Shipping"
-						disabled={ !! product?.variations?.length }
-					>
-						<WooProductSectionItem.Slot
-							location={ TAB_SHIPPING_ID }
-							fillProps={ { product } }
-						/>
-					</ProductFormTab>
-					{ window.wcAdminFeatures[
-						'product-variation-management'
-					] ? (
-						<ProductFormTab name="options" title="Options">
-							<OptionsSection />
-							<ProductVariationsSection />
-						</ProductFormTab>
-					) : (
-						<></>
-					) }
-				</ProductFormLayout>
+				<ProductFormLayout />
 				<ProductFormFooter />
 				{ /* @ts-expect-error 'scope' does exist. @types/wordpress__plugins is outdated. */ }
 				<PluginArea scope="woocommerce-product-editor" />

--- a/plugins/woocommerce-admin/client/products/product-variation-form.tsx
+++ b/plugins/woocommerce-admin/client/products/product-variation-form.tsx
@@ -3,12 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useEffect, useRef } from '@wordpress/element';
-import {
-	Form,
-	FormRef,
-	__experimentalWooProductSectionItem as WooProductSectionItem,
-	SlotContextProvider,
-} from '@woocommerce/components';
+import { Form, FormRef, SlotContextProvider } from '@woocommerce/components';
+import { PluginArea } from '@wordpress/plugins';
 import { PartialProduct, ProductVariation } from '@woocommerce/data';
 import { PluginArea } from '@wordpress/plugins';
 
@@ -60,27 +56,11 @@ export const ProductVariationForm: React.FC< {
 				ref={ formRef }
 			>
 				<ProductVariationFormHeader />
-				<ProductFormLayout key={ productVariation.id }>
-					<ProductFormTab name="general" title="General">
-						<ProductVariationDetailsSection />
-					</ProductFormTab>
-					<ProductFormTab name="pricing" title="Pricing">
-						<WooProductSectionItem.Slot
-							location={ TAB_PRICING_ID }
-						/>
-					</ProductFormTab>
-					<ProductFormTab name="inventory" title="Inventory">
-						<WooProductSectionItem.Slot
-							location={ TAB_INVENTORY_ID }
-						/>
-					</ProductFormTab>
-					<ProductFormTab name="shipping" title="Shipping">
-						<WooProductSectionItem.Slot
-							location={ TAB_SHIPPING_ID }
-							fillProps={ { product } }
-						/>
-					</ProductFormTab>
-				</ProductFormLayout>
+				<ProductFormLayout
+					key={ productVariation.id }
+					id="variation"
+					product={ productVariation as PartialProduct }
+				/>
 				<ProductFormFooter />
 
 				<div className="product-variation-form__navigation">

--- a/plugins/woocommerce-admin/client/products/product-variation-form.tsx
+++ b/plugins/woocommerce-admin/client/products/product-variation-form.tsx
@@ -6,7 +6,6 @@ import { useEffect, useRef } from '@wordpress/element';
 import { Form, FormRef, SlotContextProvider } from '@woocommerce/components';
 import { PluginArea } from '@wordpress/plugins';
 import { PartialProduct, ProductVariation } from '@woocommerce/data';
-import { PluginArea } from '@wordpress/plugins';
 
 /**
  * Internal dependencies
@@ -14,15 +13,8 @@ import { PluginArea } from '@wordpress/plugins';
 import PostsNavigation from './shared/posts-navigation';
 import { ProductFormLayout } from './layout/product-form-layout';
 import { ProductFormFooter } from './layout/product-form-footer';
-import { ProductFormTab } from './product-form-tab';
-import { ProductVariationDetailsSection } from './sections/product-variation-details-section';
 import { ProductVariationFormHeader } from './layout/product-variation-form-header';
 import useProductVariationNavigation from './hooks/use-product-variation-navigation';
-import {
-	TAB_INVENTORY_ID,
-	TAB_SHIPPING_ID,
-	TAB_PRICING_ID,
-} from './fills/constants';
 
 import './product-variation-form.scss';
 

--- a/plugins/woocommerce/changelog/refactor-36446_product_tabs
+++ b/plugins/woocommerce/changelog/refactor-36446_product_tabs
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add slot fill support for tabs for the new product management MVP.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #36446 and #36394  .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Checkout branch.
2. Enable product editor at WooCommerce -> Settings -> Advanced -> Features -> Try the new product editor
3. Go to product editor at Products -> Add new (MVP)
4. Do an overall smoke test of the tabs and sections within each tab
5. Make sure to enable the `product-variation-management` feature flag and add some options and click `edit` on one of the option/variations, as this uses a different set of tabs.
6. You may also want to test the slot fill by adding this code somewhere in the app or in your mu-plugin:
```
import {
	__experimentalWooProductTabItem as WooProductTabItem,
} from '@woocommerce/components';

function Tabs() {
  return <WooProductTabItem
				id={ 'tab/new-tab' }
				location="tab/general"
				pluginId="test-plugin"
				order={ 3 }
				tabProps={ { name: 'new-tab', title: 'New Tab' } }
			>
	<div>Hi this is the content of this new slot filled tab.</div>
  </WooProductTabItem>
}

registerPlugin( 'wc-admin-product-editor-form-extra-tab-fills', {
	scope: 'woocommerce-product-editor',
	render: () => {
		return <Tabs />;
	},
} );
```

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
