### PR TITLE
Tweak product link description and display

### DIFF
--- a/plugins/woocommerce-admin/client/products/shared/edit-product-link-modal/edit-product-link-modal.scss
+++ b/plugins/woocommerce-admin/client/products/shared/edit-product-link-modal/edit-product-link-modal.scss
@@ -8,4 +8,12 @@
 		gap: 8px;
 		justify-content: flex-end;
 	}
+
+	.components-modal__header {
+		border-color: $gray-300;
+	}
+
+	.woocommerce-product-link-edit-modal__description {
+		margin: $gap-large 0;
+	}
 }

--- a/plugins/woocommerce-admin/client/products/shared/edit-product-link-modal/edit-product-link-modal.tsx
+++ b/plugins/woocommerce-admin/client/products/shared/edit-product-link-modal/edit-product-link-modal.tsx
@@ -6,6 +6,7 @@ import { Button, Modal, TextControl } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { cleanForSlug } from '@wordpress/url';
+import interpolateComponents from '@automattic/interpolate-components';
 import { Product } from '@woocommerce/data';
 import { Text } from '@woocommerce/experimental';
 import { useFormContext } from '@woocommerce/components';
@@ -95,18 +96,25 @@ export const EditProductLinkModal: React.FC< EditProductLinkModalProps > = ( {
 			className="woocommerce-product-link-edit-modal"
 		>
 			<div className="woocommerce-product-link-edit-modal__wrapper">
+				<p className="woocommerce-product-link-edit-modal__description">
+					{ __(
+						"Create a unique link for this product. Use simple, descriptive words and numbers. We'll replace spaces with hyphens (-).",
+						'woocommerce'
+					) }
+				</p>
 				<TextControl
-					label={ newProductLinkLabel }
+					label={ __( 'Product link', 'woocommerce' ) }
 					name="slug"
 					value={ slug }
 					onChange={ setSlug }
+					hideLabelFromVision
+					help={ interpolateComponents( {
+						mixedString: __( 'Preview: {{link/}}', 'woocommerce' ),
+						components: {
+							link: <strong>{ newProductLinkLabel }</strong>,
+						},
+					} ) }
 				/>
-				<Text size={ 12 }>
-					{ __(
-						"Use simple, descriptive words and numbers. We'll replace spaces with hyphens (-).",
-						'woocommerce'
-					) }
-				</Text>
 				<div className="woocommerce-product-link-edit-modal__buttons">
 					<Button isSecondary onClick={ () => onCancel() }>
 						{ __( 'Cancel', 'woocommerce' ) }

--- a/plugins/woocommerce-admin/client/products/shared/edit-product-link-modal/test/edit-product-link-modal.test.tsx
+++ b/plugins/woocommerce-admin/client/products/shared/edit-product-link-modal/test/edit-product-link-modal.test.tsx
@@ -51,7 +51,7 @@ describe( 'EditProductLinkModal', () => {
 			/>
 		);
 		userEvent.type(
-			getByLabelText( 'wootesting.com/product/test' ),
+			getByLabelText( 'Product link' ),
 			'{esc}{space}update',
 			{}
 		);
@@ -76,7 +76,7 @@ describe( 'EditProductLinkModal', () => {
 			/>
 		);
 		userEvent.type(
-			getByLabelText( 'wootesting.com/product/product' ),
+			getByLabelText( 'Product link' ),
 			'{esc}{space}update',
 			{}
 		);

--- a/plugins/woocommerce/changelog/update-36316
+++ b/plugins/woocommerce/changelog/update-36316
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Tweak product link description and display

--- a/plugins/woocommerce/changelog/update-36316
+++ b/plugins/woocommerce/changelog/update-36316
@@ -1,4 +1,4 @@
 Significance: minor
 Type: tweak
 
-Tweak product link description and display
+Tweak product link description and display in the new product management experience


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adjusts the description, link input label, and styling for the edit link modal in the new product management experience.

<img width="802" alt="Screen Shot 2023-01-24 at 3 33 23 PM" src="https://user-images.githubusercontent.com/10561050/214444997-35a935da-2644-48bf-a1ee-41042896f82f.png">


Closes #36316  .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Navigate to the new product experience and create a product.
2. After saving, click the "Edit" button next to the product link under the "General" tab.
3. Note that the text has been updated to that in the screenshot and the link preview is displayed below
4. Using a screen reader, note that the input still reads "Product link" when focused.

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
