### PR TITLE
Updating section and field product fills to support multiple slots

### DIFF
--- a/packages/js/components/changelog/try-support-multiple-fills
+++ b/packages/js/components/changelog/try-support-multiple-fills
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Updating the product editor fill components to support multiple targets.

--- a/packages/js/components/src/woo-product-field-item/woo-product-field-item.tsx
+++ b/packages/js/components/src/woo-product-field-item/woo-product-field-item.tsx
@@ -3,19 +3,19 @@
  */
 import React from 'react';
 import { Slot, Fill } from '@wordpress/components';
-import { createElement, Children } from '@wordpress/element';
+import { createElement, Children, Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { createOrderedChildren, sortFillsByOrder } from '../utils';
 import { useSlotContext, SlotContextHelpersType } from '../slot-context';
+import { ProductFillLocationType } from '../woo-product-tab-item';
 
 type WooProductFieldItemProps = {
 	id: string;
-	section: string;
+	sections: ProductFillLocationType[];
 	pluginId: string;
-	order?: number;
 };
 
 type WooProductFieldSlotProps = {
@@ -24,28 +24,35 @@ type WooProductFieldSlotProps = {
 
 export const WooProductFieldItem: React.FC< WooProductFieldItemProps > & {
 	Slot: React.FC< Slot.Props & WooProductFieldSlotProps >;
-} = ( { children, order = 20, section, id } ) => {
+} = ( { children, sections, id } ) => {
 	const { registerFill, getFillHelpers } = useSlotContext();
 
 	registerFill( id );
 
 	return (
-		<Fill name={ `woocommerce_product_field_${ section }` }>
-			{ ( fillProps: Fill.Props ) => {
-				return createOrderedChildren<
-					Fill.Props & SlotContextHelpersType,
-					{ _id: string }
-				>(
-					children,
-					order,
-					{
-						...fillProps,
-						...getFillHelpers(),
-					},
-					{ _id: id }
-				);
-			} }
-		</Fill>
+		<>
+			{ sections.map( ( { name: sectionName, order: sectionOrder } ) => (
+				<Fill
+					name={ `woocommerce_product_field_${ sectionName }` }
+					key={ sectionName }
+				>
+					{ ( fillProps: Fill.Props ) => {
+						return createOrderedChildren<
+							Fill.Props & SlotContextHelpersType,
+							{ _id: string }
+						>(
+							children,
+							sectionOrder || 20,
+							{
+								...fillProps,
+								...getFillHelpers(),
+							},
+							{ _id: id }
+						);
+					} }
+				</Fill>
+			) ) }
+		</>
 	);
 };
 

--- a/packages/js/components/src/woo-product-field-item/woo-product-field-item.tsx
+++ b/packages/js/components/src/woo-product-field-item/woo-product-field-item.tsx
@@ -38,12 +38,16 @@ export const WooProductFieldItem: React.FC< WooProductFieldItemProps > & {
 				>
 					{ ( fillProps: Fill.Props ) => {
 						return createOrderedChildren<
-							Fill.Props & SlotContextHelpersType,
+							Fill.Props &
+								SlotContextHelpersType & {
+									sectionName: string;
+								},
 							{ _id: string }
 						>(
 							children,
 							sectionOrder || 20,
 							{
+								sectionName,
 								...fillProps,
 								...getFillHelpers(),
 							},

--- a/packages/js/components/src/woo-product-section-item/woo-product-section-item.tsx
+++ b/packages/js/components/src/woo-product-section-item/woo-product-section-item.tsx
@@ -32,11 +32,12 @@ export const WooProductSectionItem: React.FC< WooProductSectionItemProps > & {
 					key={ tabName }
 				>
 					{ ( fillProps: Fill.Props ) => {
-						return createOrderedChildren< Fill.Props >(
-							children,
-							tabOrder || 20,
-							fillProps
-						);
+						return createOrderedChildren<
+							Fill.Props & { tabName: string }
+						>( children, tabOrder || 20, {
+							tabName,
+							...fillProps,
+						} );
 					} }
 				</Fill>
 			) ) }

--- a/packages/js/components/src/woo-product-section-item/woo-product-section-item.tsx
+++ b/packages/js/components/src/woo-product-section-item/woo-product-section-item.tsx
@@ -3,41 +3,50 @@
  */
 import React from 'react';
 import { Slot, Fill } from '@wordpress/components';
-import { createElement } from '@wordpress/element';
+import { createElement, Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { createOrderedChildren, sortFillsByOrder } from '../utils';
+import { ProductFillLocationType } from '../woo-product-tab-item';
 
 type WooProductSectionItemProps = {
 	id: string;
-	location: string;
+	tabs: ProductFillLocationType[];
 	pluginId: string;
-	order?: number;
 };
 
-type WooProductFieldSlotProps = {
-	location: string;
+type WooProductSectionSlotProps = {
+	tab: string;
 };
 
 export const WooProductSectionItem: React.FC< WooProductSectionItemProps > & {
-	Slot: React.FC< Slot.Props & WooProductFieldSlotProps >;
-} = ( { children, order = 20, location } ) => (
-	<Fill name={ `woocommerce_product_section_${ location }` }>
-		{ ( fillProps: Fill.Props ) => {
-			return createOrderedChildren< Fill.Props >(
-				children,
-				order,
-				fillProps
-			);
-		} }
-	</Fill>
-);
+	Slot: React.FC< Slot.Props & WooProductSectionSlotProps >;
+} = ( { children, tabs } ) => {
+	return (
+		<>
+			{ tabs.map( ( { name: tabName, order: tabOrder } ) => (
+				<Fill
+					name={ `woocommerce_product_section_${ tabName }` }
+					key={ tabName }
+				>
+					{ ( fillProps: Fill.Props ) => {
+						return createOrderedChildren< Fill.Props >(
+							children,
+							tabOrder || 20,
+							fillProps
+						);
+					} }
+				</Fill>
+			) ) }
+		</>
+	);
+};
 
-WooProductSectionItem.Slot = ( { fillProps, location } ) => (
+WooProductSectionItem.Slot = ( { fillProps, tab } ) => (
 	<Slot
-		name={ `woocommerce_product_section_${ location }` }
+		name={ `woocommerce_product_section_${ tab }` }
 		fillProps={ fillProps }
 	>
 		{ ( fills ) => {

--- a/packages/js/components/src/woo-product-tab-item/woo-product-tab-item.tsx
+++ b/packages/js/components/src/woo-product-tab-item/woo-product-tab-item.tsx
@@ -10,16 +10,16 @@ import { createElement, Fragment } from '@wordpress/element';
  */
 import { createOrderedChildren } from '../utils';
 
+export type ProductFillLocationType = { name: string; order?: number };
+
 type WooProductTabItemProps = {
 	id: string;
 	pluginId: string;
-	template?: string;
-	order?: number;
 	tabProps:
 		| TabPanel.Tab
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		| ( ( fillProps: Record< string, any > | undefined ) => TabPanel.Tab );
-	templates?: Array< { name: string; order?: number } >;
+	templates?: Array< ProductFillLocationType >;
 };
 
 type WooProductFieldSlotProps = {
@@ -34,15 +34,12 @@ export const WooProductTabItem: React.FC< WooProductTabItemProps > & {
 	Slot: React.VFC<
 		Omit< Slot.Props, 'children' > & WooProductFieldSlotProps
 	>;
-} = ( { children, order, template, tabProps, templates } ) => {
-	if ( ! template && ! templates ) {
+} = ( { children, tabProps, templates } ) => {
+	if ( ! templates ) {
 		// eslint-disable-next-line no-console
-		console.warn(
-			'WooProductTabItem fill is missing template or templates property.'
-		);
+		console.warn( 'WooProductTabItem fill is missing templates property.' );
 		return null;
 	}
-	templates = templates || [ { name: template as string, order } ];
 	return (
 		<>
 			{ templates.map( ( templateData ) => (
@@ -77,7 +74,8 @@ WooProductTabItem.Slot = ( { fillProps, template, children } ) => (
 		{ ( fills ) => {
 			const tabData = fills.reduce(
 				( { childrenMap, tabs }, fill ) => {
-					const props: WooProductTabItemProps = fill[ 0 ].props;
+					const props: WooProductTabItemProps & { order: number } =
+						fill[ 0 ].props;
 					if ( props && props.tabProps ) {
 						childrenMap[ props.tabProps.name ] = fill[ 0 ];
 						const tabProps =

--- a/packages/js/data/changelog/try-support-multiple-fills
+++ b/packages/js/data/changelog/try-support-multiple-fills
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Removing unused code from ProductForm data store.

--- a/packages/js/data/src/product-form/resolvers.ts
+++ b/packages/js/data/src/product-form/resolvers.ts
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import { apiFetch, select } from '@wordpress/data-controls';
-import { controls } from '@wordpress/data';
+import { apiFetch } from '@wordpress/data-controls';
 
 /**
  * Internal dependencies
@@ -15,10 +14,6 @@ import {
 } from './actions';
 import { WC_ADMIN_NAMESPACE } from '../constants';
 import { ProductFormField, ProductForm } from './types';
-import { STORE_NAME } from './constants';
-
-const resolveSelect =
-	controls && controls.resolveSelect ? controls.resolveSelect : select;
 
 export function* getFields() {
 	try {
@@ -32,10 +27,6 @@ export function* getFields() {
 	} catch ( error ) {
 		return getFieldsError( error );
 	}
-}
-
-export function* getCountry() {
-	yield resolveSelect( STORE_NAME, 'getProductForm' );
 }
 
 export function* getProductForm() {

--- a/plugins/woocommerce-admin/client/products/fills/attributes-section/attributes-section-fills.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/attributes-section/attributes-section-fills.tsx
@@ -23,9 +23,8 @@ const AttributesSection = () => (
 	<>
 		<WooProductSectionItem
 			id={ ATTRIBUTES_SECTION_ID }
-			location={ TAB_GENERAL_ID }
+			tabs={ [ { name: TAB_GENERAL_ID, order: 5 } ] }
 			pluginId={ PLUGIN_ID }
-			order={ 5 }
 		>
 			<ProductSectionLayout
 				title={ __( 'Attributes', 'woocommerce' ) }
@@ -62,9 +61,8 @@ const AttributesSection = () => (
 		</WooProductSectionItem>
 		<WooProductFieldItem
 			id="attributes/add"
-			section={ ATTRIBUTES_SECTION_ID }
+			sections={ [ { name: ATTRIBUTES_SECTION_ID, order: 1 } ] }
 			pluginId={ PLUGIN_ID }
-			order={ 1 }
 		>
 			<AttributesField />
 		</WooProductFieldItem>

--- a/plugins/woocommerce-admin/client/products/fills/details-section/details-section-fills.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/details-section/details-section-fills.tsx
@@ -28,9 +28,8 @@ const DetailsSection = () => (
 	<>
 		<WooProductSectionItem
 			id={ DETAILS_SECTION_ID }
-			location={ TAB_GENERAL_ID }
+			tabs={ [ { name: TAB_GENERAL_ID, order: 1 } ] }
 			pluginId={ PLUGIN_ID }
-			order={ 1 }
 		>
 			<ProductFieldSection
 				id={ DETAILS_SECTION_ID }
@@ -43,41 +42,36 @@ const DetailsSection = () => (
 		</WooProductSectionItem>
 		<WooProductFieldItem
 			id="details/name"
-			section={ DETAILS_SECTION_ID }
+			sections={ [ { name: DETAILS_SECTION_ID, order: 1 } ] }
 			pluginId={ PLUGIN_ID }
-			order={ 1 }
 		>
 			<DetailsNameField />
 		</WooProductFieldItem>
 		<WooProductFieldItem
 			id="details/categories"
-			section={ DETAILS_SECTION_ID }
+			sections={ [ { name: DETAILS_SECTION_ID, order: 3 } ] }
 			pluginId={ PLUGIN_ID }
-			order={ 3 }
 		>
 			<DetailsCategoriesField />
 		</WooProductFieldItem>
 		<WooProductFieldItem
 			id="details/feature"
-			section={ DETAILS_SECTION_ID }
+			sections={ [ { name: DETAILS_SECTION_ID, order: 5 } ] }
 			pluginId={ PLUGIN_ID }
-			order={ 5 }
 		>
 			<DetailsFeatureField />
 		</WooProductFieldItem>
 		<WooProductFieldItem
 			id="details/summary"
-			section={ DETAILS_SECTION_ID }
+			sections={ [ { name: DETAILS_SECTION_ID, order: 7 } ] }
 			pluginId={ PLUGIN_ID }
-			order={ 7 }
 		>
 			<DetailsSummaryField />
 		</WooProductFieldItem>
 		<WooProductFieldItem
 			id="details/description"
-			section={ DETAILS_SECTION_ID }
+			sections={ [ { name: DETAILS_SECTION_ID, order: 9 } ] }
 			pluginId={ PLUGIN_ID }
-			order={ 9 }
 		>
 			<DetailsDescriptionField />
 		</WooProductFieldItem>

--- a/plugins/woocommerce-admin/client/products/fills/images-section/images-section-fills.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/images-section/images-section-fills.tsx
@@ -23,9 +23,8 @@ const ImagesSection = () => (
 	<>
 		<WooProductSectionItem
 			id={ IMAGES_SECTION_ID }
-			location={ TAB_GENERAL_ID }
+			tabs={ [ { name: TAB_GENERAL_ID, order: 3 } ] }
 			pluginId={ PLUGIN_ID }
-			order={ 3 }
 		>
 			<ProductFieldSection
 				id={ IMAGES_SECTION_ID }
@@ -58,9 +57,8 @@ const ImagesSection = () => (
 		</WooProductSectionItem>
 		<WooProductFieldItem
 			id="images/gallery"
-			section={ IMAGES_SECTION_ID }
+			sections={ [ { name: IMAGES_SECTION_ID, order: 1 } ] }
 			pluginId={ PLUGIN_ID }
-			order={ 1 }
 		>
 			<ImagesGalleryField />
 		</WooProductFieldItem>

--- a/plugins/woocommerce-admin/client/products/fills/inventory-section/inventory-section-fills.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/inventory-section/inventory-section-fills.tsx
@@ -41,9 +41,8 @@ const InventorySection = () => {
 		<>
 			<WooProductSectionItem
 				id={ INVENTORY_SECTION_ID }
-				location={ TAB_INVENTORY_ID }
+				tabs={ [ { name: TAB_INVENTORY_ID, order: 1 } ] }
 				pluginId={ PLUGIN_ID }
-				order={ 1 }
 			>
 				<ProductSectionLayout
 					title={ __( 'Inventory', 'woocommerce' ) }
@@ -92,17 +91,15 @@ const InventorySection = () => {
 			</WooProductSectionItem>
 			<WooProductFieldItem
 				id="inventory/sku"
-				section={ INVENTORY_SECTION_ID }
+				sections={ [ { name: INVENTORY_SECTION_ID, order: 1 } ] }
 				pluginId={ PLUGIN_ID }
-				order={ 1 }
 			>
 				<InventorySkuField />
 			</WooProductFieldItem>
 			<WooProductFieldItem
 				id="inventory/track-quantity"
-				section={ INVENTORY_SECTION_ID }
+				sections={ [ { name: INVENTORY_SECTION_ID, order: 3 } ] }
 				pluginId={ PLUGIN_ID }
-				order={ 3 }
 			>
 				<InventoryTrackQuantityField />
 			</WooProductFieldItem>
@@ -110,18 +107,16 @@ const InventorySection = () => {
 			{ values.manage_stock ? (
 				<WooProductFieldItem
 					id="inventory/stock-manage"
-					section={ INVENTORY_SECTION_ID }
+					sections={ [ { name: INVENTORY_SECTION_ID, order: 5 } ] }
 					pluginId={ PLUGIN_ID }
-					order={ 5 }
 				>
 					<InventoryStockManageField />
 				</WooProductFieldItem>
 			) : (
 				<WooProductFieldItem
 					id="inventory/stock-manual"
-					section={ INVENTORY_SECTION_ID }
+					sections={ [ { name: INVENTORY_SECTION_ID, order: 5 } ] }
 					pluginId={ PLUGIN_ID }
-					order={ 5 }
 				>
 					<InventoryStockManualField />
 				</WooProductFieldItem>
@@ -130,9 +125,10 @@ const InventorySection = () => {
 			{ values.manage_stock && (
 				<WooProductFieldItem
 					id="inventory/advanced/stock-out"
-					section={ INVENTORY_SECTION_ADVANCED_ID }
+					sections={ [
+						{ name: INVENTORY_SECTION_ADVANCED_ID, order: 1 },
+					] }
 					pluginId={ PLUGIN_ID }
-					order={ 1 }
 				>
 					<InventoryStockOutField />
 				</WooProductFieldItem>
@@ -140,9 +136,10 @@ const InventorySection = () => {
 
 			<WooProductFieldItem
 				id="inventory/advanced/stock-limit"
-				section={ INVENTORY_SECTION_ADVANCED_ID }
+				sections={ [
+					{ name: INVENTORY_SECTION_ADVANCED_ID, order: 3 },
+				] }
 				pluginId={ PLUGIN_ID }
-				order={ 3 }
 			>
 				<InventoryStockLimitField />
 			</WooProductFieldItem>

--- a/plugins/woocommerce-admin/client/products/fills/pricing-section/pricing-section-fills.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/pricing-section/pricing-section-fills.tsx
@@ -97,9 +97,8 @@ const PricingSection = () => {
 		<>
 			<WooProductSectionItem
 				id={ PRICING_SECTION_BASIC_ID }
-				location={ TAB_PRICING_ID }
+				tabs={ [ { name: TAB_PRICING_ID, order: 1 } ] }
 				pluginId={ PLUGIN_ID }
-				order={ 1 }
 			>
 				<ProductSectionLayout
 					title={ __( 'Pricing', 'woocommerce' ) }
@@ -146,33 +145,29 @@ const PricingSection = () => {
 			</WooProductSectionItem>
 			<WooProductFieldItem
 				id="pricing/list"
-				section={ PRICING_SECTION_BASIC_ID }
+				sections={ [ { name: PRICING_SECTION_BASIC_ID, order: 1 } ] }
 				pluginId={ PLUGIN_ID }
-				order={ 1 }
 			>
 				<PricingListField currencyInputProps={ currencyInputProps } />
 			</WooProductFieldItem>
 			<WooProductFieldItem
 				id="pricing/sale"
-				section={ PRICING_SECTION_BASIC_ID }
+				sections={ [ { name: PRICING_SECTION_BASIC_ID, order: 3 } ] }
 				pluginId={ PLUGIN_ID }
-				order={ 3 }
 			>
 				<PricingSaleField currencyInputProps={ currencyInputProps } />
 			</WooProductFieldItem>
 			<WooProductFieldItem
 				id="pricing/taxes/charge"
-				section={ PRICING_SECTION_TAXES_ID }
+				sections={ [ { name: PRICING_SECTION_TAXES_ID, order: 1 } ] }
 				pluginId={ PLUGIN_ID }
-				order={ 1 }
 			>
 				<PricingTaxesChargeField />
 			</WooProductFieldItem>
 			<WooProductFieldItem
 				id="pricing/taxes/class"
-				section={ PRICING_SECTION_TAXES_ID }
+				sections={ [ { name: PRICING_SECTION_TAXES_ID, order: 3 } ] }
 				pluginId={ PLUGIN_ID }
-				order={ 3 }
 			>
 				<PricingTaxesClassField />
 			</WooProductFieldItem>

--- a/plugins/woocommerce-admin/client/products/fills/product-form-field-fills.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/product-form-field-fills.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
 import {
 	__experimentalWooProductFieldItem as WooProductFieldItem,
 	renderField,
@@ -20,9 +19,8 @@ export const Fields: React.FC< { fields: ProductFormField[] } > = ( {
 				<WooProductFieldItem
 					key={ field.properties.name }
 					id={ field.id }
-					section={ field.section }
+					sections={ [ { name: field.section, order: field.order } ] }
 					pluginId={ field.plugin_id }
-					order={ field.order }
 				>
 					<>
 						{ renderField( field.type, {

--- a/plugins/woocommerce-admin/client/products/fills/product-form-section-fills.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/product-form-section-fills.tsx
@@ -1,8 +1,6 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { Card, CardBody } from '@wordpress/components';
 import {
 	__experimentalWooProductSectionItem as WooProductSectionItem,
 	__experimentalProductFieldSection as ProductFieldSection,
@@ -18,9 +16,10 @@ export const Sections: React.FC< { sections: ProductFormSection[] } > = ( {
 				<WooProductSectionItem
 					key={ section.id }
 					id={ section.id }
-					location={ section.location }
+					tabs={ [
+						{ name: section.location, order: section.order },
+					] }
 					pluginId={ section.plugin_id }
-					order={ section.order }
 				>
 					<ProductFieldSection
 						id={ section.id }

--- a/plugins/woocommerce-admin/client/products/fills/product-form-tab-fills.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/product-form-tab-fills.tsx
@@ -57,49 +57,44 @@ const Tabs = () => {
 		<>
 			<WooProductTabItem
 				id="tab/general"
-				template="tab/general"
+				templates={ [ { name: 'tab/general', order: 1 } ] }
 				pluginId="core"
-				order={ 1 }
 				tabProps={ tabPropData.general }
 			>
-				<WooProductSectionItem.Slot location={ TAB_GENERAL_ID } />
+				<WooProductSectionItem.Slot tab={ TAB_GENERAL_ID } />
 			</WooProductTabItem>
 			<WooProductTabItem
 				id="tab/pricing"
-				template="tab/general"
+				templates={ [ { name: 'tab/general', order: 3 } ] }
 				pluginId="core"
-				order={ 3 }
 				tabProps={ tabPropData.pricing }
 			>
-				<WooProductSectionItem.Slot location={ TAB_PRICING_ID } />
+				<WooProductSectionItem.Slot tab={ TAB_PRICING_ID } />
 			</WooProductTabItem>
 			<WooProductTabItem
 				id="tab/inventory"
-				template="tab/general"
+				templates={ [ { name: 'tab/general', order: 5 } ] }
 				pluginId="core"
-				order={ 5 }
 				tabProps={ tabPropData.inventory }
 			>
-				<WooProductSectionItem.Slot location={ TAB_INVENTORY_ID } />
+				<WooProductSectionItem.Slot tab={ TAB_INVENTORY_ID } />
 			</WooProductTabItem>
 			<WooProductTabItem
 				id="tab/shipping"
-				template="tab/general"
+				templates={ [ { name: 'tab/general', order: 7 } ] }
 				pluginId="core"
-				order={ 7 }
 				tabProps={ tabPropData.shipping }
 			>
 				<WooProductSectionItem.Slot
-					location={ TAB_SHIPPING_ID }
+					tab={ TAB_SHIPPING_ID }
 					fillProps={ { product } }
 				/>
 			</WooProductTabItem>
 			{ window.wcAdminFeatures[ 'product-variation-management' ] ? (
 				<WooProductTabItem
 					id="tab/options"
-					template="tab/general"
+					templates={ [ { name: 'tab/general', order: 9 } ] }
 					pluginId="core"
-					order={ 9 }
 					tabProps={ tabPropData.options }
 				>
 					<>

--- a/plugins/woocommerce-admin/client/products/fills/product-form-variation-tab-fills.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/product-form-variation-tab-fills.tsx
@@ -43,41 +43,37 @@ const Tabs = () => {
 		<>
 			<WooProductTabItem
 				id="tab/general/variation"
-				template="tab/variation"
+				templates={ [ { name: 'tab/variation', order: 1 } ] }
 				pluginId="core"
-				order={ 1 }
 				tabProps={ tabPropData.general }
 			>
 				<ProductVariationDetailsSection />
 			</WooProductTabItem>
 			<WooProductTabItem
 				id="tab/pricing"
-				template="tab/variation"
+				templates={ [ { name: 'tab/variation', order: 3 } ] }
 				pluginId="core"
-				order={ 3 }
 				tabProps={ tabPropData.pricing }
 			>
-				<WooProductSectionItem.Slot location={ TAB_PRICING_ID } />
+				<WooProductSectionItem.Slot tab={ TAB_PRICING_ID } />
 			</WooProductTabItem>
 			<WooProductTabItem
 				id="tab/inventory"
-				template="tab/variation"
+				templates={ [ { name: 'tab/variation', order: 5 } ] }
 				pluginId="core"
-				order={ 5 }
 				tabProps={ tabPropData.inventory }
 			>
-				<WooProductSectionItem.Slot location={ TAB_INVENTORY_ID } />
+				<WooProductSectionItem.Slot tab={ TAB_INVENTORY_ID } />
 			</WooProductTabItem>
 			<WooProductTabItem
 				id="tab/shipping"
-				template="tab/variation"
+				templates={ [ { name: 'tab/variation', order: 7 } ] }
 				pluginId="core"
-				order={ 7 }
 				tabProps={ tabPropData.shipping }
 			>
 				{ ( { product }: { product: PartialProduct } ) => (
 					<WooProductSectionItem.Slot
-						location={ TAB_SHIPPING_ID }
+						tab={ TAB_SHIPPING_ID }
 						fillProps={ { product } }
 					/>
 				) }

--- a/plugins/woocommerce-admin/client/products/fills/shipping-section/shipping-section-fills.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/shipping-section/shipping-section-fills.tsx
@@ -74,9 +74,8 @@ const ShippingSection = () => {
 		<>
 			<WooProductSectionItem
 				id={ SHIPPING_SECTION_BASIC_ID }
-				location={ TAB_SHIPPING_ID }
+				tabs={ [ { name: TAB_SHIPPING_ID, order: 1 } ] }
 				pluginId={ PLUGIN_ID }
-				order={ 1 }
 			>
 				<ProductSectionLayout
 					title={ __( 'Shipping', 'woocommerce' ) }
@@ -130,9 +129,8 @@ const ShippingSection = () => {
 			</WooProductSectionItem>
 			<WooProductFieldItem
 				id="shipping/class"
-				section={ SHIPPING_SECTION_BASIC_ID }
+				sections={ [ { name: SHIPPING_SECTION_BASIC_ID, order: 1 } ] }
 				pluginId={ PLUGIN_ID }
-				order={ 1 }
 			>
 				{ ( { product }: ProductShippingSectionPropsType ) => (
 					<ShippingClassField product={ product } />
@@ -140,9 +138,10 @@ const ShippingSection = () => {
 			</WooProductFieldItem>
 			<WooProductFieldItem
 				id="shipping/dimensions/width"
-				section={ SHIPPING_SECTION_DIMENSIONS_ID }
+				sections={ [
+					{ name: SHIPPING_SECTION_DIMENSIONS_ID, order: 1 },
+				] }
 				pluginId={ PLUGIN_ID }
-				order={ 1 }
 			>
 				{ ( { ...props }: ShippingDimensionsPropsType ) => (
 					<ShippingDimensionsWidthField { ...props } />
@@ -150,9 +149,10 @@ const ShippingSection = () => {
 			</WooProductFieldItem>
 			<WooProductFieldItem
 				id="shipping/dimensions/length"
-				section={ SHIPPING_SECTION_DIMENSIONS_ID }
+				sections={ [
+					{ name: SHIPPING_SECTION_DIMENSIONS_ID, order: 3 },
+				] }
 				pluginId={ PLUGIN_ID }
-				order={ 3 }
 			>
 				{ ( { ...props }: ShippingDimensionsPropsType ) => (
 					<ShippingDimensionsLengthField { ...props } />
@@ -160,9 +160,10 @@ const ShippingSection = () => {
 			</WooProductFieldItem>
 			<WooProductFieldItem
 				id="shipping/dimensions/height"
-				section={ SHIPPING_SECTION_DIMENSIONS_ID }
+				sections={ [
+					{ name: SHIPPING_SECTION_DIMENSIONS_ID, order: 5 },
+				] }
 				pluginId={ PLUGIN_ID }
-				order={ 5 }
 			>
 				{ ( { ...props }: ShippingDimensionsPropsType ) => (
 					<ShippingDimensionsHeightField { ...props } />
@@ -170,9 +171,10 @@ const ShippingSection = () => {
 			</WooProductFieldItem>
 			<WooProductFieldItem
 				id="shipping/dimensions/weight"
-				section={ SHIPPING_SECTION_DIMENSIONS_ID }
+				sections={ [
+					{ name: SHIPPING_SECTION_DIMENSIONS_ID, order: 7 },
+				] }
 				pluginId={ PLUGIN_ID }
-				order={ 7 }
 			>
 				<ShippingDimensionsWeightField />
 			</WooProductFieldItem>

--- a/plugins/woocommerce/changelog/try-support-multiple-fills
+++ b/plugins/woocommerce/changelog/try-support-multiple-fills
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Updates to product editor fill to support new prop API.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?


### Changes proposed in this Pull Request:

Adding support to all product editor slot fills for multiple targets.

Closes #36609  .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Checkout branch.
2. Enable the `product-variation-management` feature flag using the WC Beta Tester Plugin
3. Enable the new product management experience using WooCommerce -> Settings -> Advanced -> Features -> Try the new product editor.
4. Go to Products -> Add New
5. Smoke test all tabs and fields.
6. Create an option on the Options tab, and then click edit
7. Ensure the tabs on the variant are working as expected

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
