### PR TITLE
Synchronize order meta data (between HPOS and CPT stores)

### DIFF
--- a/plugins/woocommerce/changelog/fix-35703-order-meta-backfill
+++ b/plugins/woocommerce/changelog/fix-35703-order-meta-backfill
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+When order meta data is saved via HPOS, it should be backfilled to the CPT data store.

--- a/plugins/woocommerce/src/Internal/DataStores/CustomMetaDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/CustomMetaDataStore.php
@@ -78,6 +78,8 @@ abstract class CustomMetaDataStore {
 	 *
 	 * @param  WC_Data  $object WC_Data object.
 	 * @param  stdClass $meta (containing at least ->id).
+	 *
+	 * @return bool
 	 */
 	public function delete_meta( &$object, $meta ) {
 		global $wpdb;
@@ -127,6 +129,8 @@ abstract class CustomMetaDataStore {
 	 *
 	 * @param  WC_Data  $object WC_Data object.
 	 * @param  stdClass $meta (containing ->id, ->key and ->value).
+	 *
+	 * @return bool
 	 */
 	public function update_meta( &$object, $meta ) {
 		global $wpdb;

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1964,21 +1964,6 @@ FROM $order_meta_table
 			$order->delete_meta_data( '_wp_trash_meta_comments_status' );
 			$order->save_meta_data();
 
-			$data_synchronizer = wc_get_container()->get( DataSynchronizer::class );
-			if ( $data_synchronizer->data_sync_is_enabled() ) {
-				// The previous $order->save() will have forced a sync to the posts table,
-				// this implies that the post status is not "trash" anymore, and thus
-				// wp_untrash_post would do nothing.
-				wp_update_post(
-					array(
-						'ID'          => $id,
-						'post_status' => 'trash',
-					)
-				);
-
-				wp_untrash_post( $id );
-			}
-
 			return true;
 		}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -11,6 +11,7 @@ use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
 use Automattic\WooCommerce\Utilities\ArrayUtil;
 use Exception;
+use WC_Abstract_Order;
 use WC_Data;
 use WC_Order;
 
@@ -2457,9 +2458,17 @@ CREATE TABLE $meta_table (
 	 *
 	 * @param  WC_Data  $object WC_Data object.
 	 * @param  stdClass $meta (containing at least ->id).
+	 *
+	 * @return bool
 	 */
 	public function delete_meta( &$object, $meta ) {
-		return $this->data_store_meta->delete_meta( $object, $meta );
+		$delete_meta = $this->data_store_meta->delete_meta( $object, $meta );
+
+		if ( $object instanceof WC_Abstract_Order ) {
+			$this->maybe_backfill_post_record( $object );
+		}
+
+		return $delete_meta;
 	}
 
 	/**
@@ -2467,10 +2476,17 @@ CREATE TABLE $meta_table (
 	 *
 	 * @param  WC_Data  $object WC_Data object.
 	 * @param  stdClass $meta (containing ->key and ->value).
-	 * @return int meta ID
+	 *
+	 * @return int|bool  meta ID or false on failure
 	 */
 	public function add_meta( &$object, $meta ) {
-		return $this->data_store_meta->add_meta( $object, $meta );
+		$add_meta = $this->data_store_meta->add_meta( $object, $meta );
+
+		if ( $object instanceof WC_Abstract_Order ) {
+			$this->maybe_backfill_post_record( $object );
+		}
+
+		return $add_meta;
 	}
 
 	/**
@@ -2478,8 +2494,16 @@ CREATE TABLE $meta_table (
 	 *
 	 * @param  WC_Data  $object WC_Data object.
 	 * @param  stdClass $meta (containing ->id, ->key and ->value).
+	 *
+	 * @return bool
 	 */
 	public function update_meta( &$object, $meta ) {
-		return $this->data_store_meta->update_meta( $object, $meta );
+		$update_meta = $this->data_store_meta->update_meta( $object, $meta );
+
+		if ( $object instanceof WC_Abstract_Order ) {
+			$this->maybe_backfill_post_record( $object );
+		}
+
+		return $update_meta;
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
@@ -237,6 +237,10 @@ class DataSynchronizerTests extends WC_Unit_Test_Case {
 
 		$order = OrderHelper::create_order();
 		$order->add_meta_data( 'foo', 'bar' );
+		$order->add_meta_data( 'bar', 'baz' );
+		$order->save_meta_data();
+
+		$order->delete_meta_data( 'bar' );
 		$order->save_meta_data();
 
 		update_option( CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, 'no' );
@@ -245,7 +249,13 @@ class DataSynchronizerTests extends WC_Unit_Test_Case {
 		$this->assertEquals(
 			$refreshed_order->get_meta( 'foo' ),
 			'bar',
-			'Meta data persisted via the HPOS datastore is accessible via the CPT datastore'
+			'Meta data persisted via the HPOS datastore is accessible via the CPT datastore.'
+		);
+
+		$this->assertEquals(
+			$refreshed_order->get_meta( 'bar' ),
+			'',
+			'Meta data deleted from the HPOS datastore should also be deleted from the CPT datastore.'
 		);
 	}
 
@@ -262,6 +272,10 @@ class DataSynchronizerTests extends WC_Unit_Test_Case {
 
 		$order = OrderHelper::create_order();
 		$order->add_meta_data( 'foo', 'bar' );
+		$order->add_meta_data( 'bar', 'baz' );
+		$order->save_meta_data();
+
+		$order->delete_meta_data( 'bar' );
 		$order->save_meta_data();
 
 		update_option( CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, 'yes' );
@@ -270,7 +284,13 @@ class DataSynchronizerTests extends WC_Unit_Test_Case {
 		$this->assertEquals(
 			$refreshed_order->get_meta( 'foo' ),
 			'bar',
-			'Meta data persisted via the CPT datastore is accessible via the HPOS datastore'
+			'Meta data persisted via the CPT datastore is accessible via the HPOS datastore.'
+		);
+
+		$this->assertEquals(
+			$refreshed_order->get_meta( 'bar' ),
+			'',
+			'Meta data deleted from the CPT datastore should also be deleted from the HPOS datastore.'
 		);
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
@@ -225,7 +225,7 @@ class DataSynchronizerTests extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * When sync is enabled, changes to meta data should propoagate from the Custom Orders Table to
+	 * When sync is enabled, changes to meta data should propagate from the Custom Orders Table to
 	 * the post meta table whenever the order object's save_meta_data() method is called.
 	 *
 	 * @return void
@@ -250,13 +250,13 @@ class DataSynchronizerTests extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * When sync is enabled, changes to meta data should propoagate from the post meta table to
+	 * When sync is enabled, changes to meta data should propagate from the post meta table to
 	 * the Custom Orders Table whenever the order object's save_meta_data() method is called.
 	 *
 	 * @return void
 	 */
 	public function test_meta_data_changes_propagate_from_cpt_to_cot(): void {
-		// Sync enabled and COT authoritative.
+		// Sync enabled and CPT authoritative.
 		update_option( $this->sut::ORDERS_DATA_SYNC_ENABLED_OPTION, 'yes' );
 		update_option( CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, 'no' );
 


### PR DESCRIPTION
When HPOS is enabled and authoritative, and sync is enabled, a call to `$order->save_meta_data()` should be sufficient to cause the meta data to be persisted in both stores.

Closes #35703.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Review of the code and corresponding tests should be sufficient, however via WP CLI (or by running snippets of custom code) you can also verify the change manually.

1. Start by enabling HPOS, making custom order tables authoritative, and enabling sync. Reminder of how to do this:
    - Visit **WooCommerce ▸ Status ▸ Tools** and create the custom order tables (if you don't see a tool for this, that means they already exist).
    - Next, visit **WooCommerce ▸ Settings ▸ Advanced ▸ Custom Data Stores** and enable **Use the WooCommerce orders tables** as well as **Keep the posts table and the orders tables synchronized**.
    - If there are any unsynchronized orders, you can run `wp wc cot sync` to process them.
2. Select an existing order, or create a new one, and note the order ID. I'm going to use `123` to represent that ID in the following snippets.
3. List the post meta data for the corresponding post record: `wp post meta list 123` and think of a new meta key that is not currently contained in that list (I will use `foo` in the following instructions).
4. Using the order API (remembering here the HPOS data-store is authoritative), create a new piece of meta data: `wp eval "$order = wc_get_order( 123 ); $order->add_meta_data( 'foo', 1 ); $order->save_meta_data();"` (remember to modify the order ID and meta key string if needed; depending on your shell you may also need to escape the sigils, ie `\$order`).
5. Verify that the new piece of meta data is available via the post meta table: `wp post meta get 123 foo` (the response should be `1`—whereas, without this change, you will get back an empty result).

You can also refer to the [linked issue](https://github.com/woocommerce/woocommerce/issues/35703) and use the testing instructions noted there.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

✍🏽  *Note that, in an ideal world, one could test this through the admin UI by adding, updating and deleting custom fields via the HPOS order editor. This will not work, however, possibly because of an order-of-operations issue (I'll log a follow-up issue for that). To satisfy the original bug report, though, this change should be sufficient.*

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
