### PR TITLE
Show attribute creation form when there are no attributes

### DIFF
--- a/plugins/woocommerce/changelog/dev-35115_show_attribute_creation_form
+++ b/plugins/woocommerce/changelog/dev-35115_show_attribute_creation_form
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add attribute creation form when there are no attributes

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -57,6 +57,12 @@ jQuery( function ( $ ) {
 		} );
 	} );
 
+	$( function () {
+		if ( ! woocommerce_admin_meta_boxes.has_attributes ) {
+			$( 'button.add_attribute' ).trigger( 'click' );
+		}
+	} );
+
 	// Catalog Visibility.
 	$( '#catalog-visibility' )
 		.find( '.edit-catalog-visibility' )

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -403,6 +403,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					'rounding_precision'                 => wc_get_rounding_precision(),
 					'tax_rounding_mode'                  => wc_get_tax_rounding_mode(),
 					'product_types'                      => array_unique( array_merge( array( 'simple', 'grouped', 'variable', 'external' ), array_keys( wc_get_product_types() ) ) ),
+					'has_attributes'                     => ! empty( wc_get_attribute_taxonomies() ),
 					'i18n_download_permission_fail'      => __( 'Could not grant access - the user may already have permission for this file or billing email is not set. Ensure the billing email is set, and the order has been saved.', 'woocommerce' ),
 					'i18n_permission_revoke'             => __( 'Are you sure you want to revoke access to this download?', 'woocommerce' ),
 					'i18n_tax_rate_already_exists'       => __( 'You cannot add the same tax rate twice!', 'woocommerce' ),

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -339,6 +339,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 				$remove_item_notice     = __( 'Are you sure you want to remove the selected items?', 'woocommerce' );
 				$remove_fee_notice      = __( 'Are you sure you want to remove the selected fees?', 'woocommerce' );
 				$remove_shipping_notice = __( 'Are you sure you want to remove the selected shipping?', 'woocommerce' );
+				$product                = wc_get_product( $post_id );
 
 				// Eventually this will become wc_data_or_post object as we implement more custom tables.
 				$order_or_post_object = $post;
@@ -403,7 +404,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					'rounding_precision'                 => wc_get_rounding_precision(),
 					'tax_rounding_mode'                  => wc_get_tax_rounding_mode(),
 					'product_types'                      => array_unique( array_merge( array( 'simple', 'grouped', 'variable', 'external' ), array_keys( wc_get_product_types() ) ) ),
-					'has_attributes'                     => ! empty( wc_get_attribute_taxonomies() ) || ! empty( wc_get_product( $post_id ) ? wc_get_product( $post_id )->get_attributes( 'edit' ) : array() ),
+					'has_attributes'                     => ! empty( wc_get_attribute_taxonomies() ) || ! empty( $product ? $product->get_attributes( 'edit' ) : array() ),
 					'i18n_download_permission_fail'      => __( 'Could not grant access - the user may already have permission for this file or billing email is not set. Ensure the billing email is set, and the order has been saved.', 'woocommerce' ),
 					'i18n_permission_revoke'             => __( 'Are you sure you want to revoke access to this download?', 'woocommerce' ),
 					'i18n_tax_rate_already_exists'       => __( 'You cannot add the same tax rate twice!', 'woocommerce' ),

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -403,7 +403,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					'rounding_precision'                 => wc_get_rounding_precision(),
 					'tax_rounding_mode'                  => wc_get_tax_rounding_mode(),
 					'product_types'                      => array_unique( array_merge( array( 'simple', 'grouped', 'variable', 'external' ), array_keys( wc_get_product_types() ) ) ),
-					'has_attributes'                     => ! empty( wc_get_attribute_taxonomies() ) || ! empty( wc_get_product( $post_id )->get_attributes( 'edit' ) ),
+					'has_attributes'                     => ! empty( wc_get_attribute_taxonomies() ) || ! empty( wc_get_product( $post_id ) ? wc_get_product( $post_id )->get_attributes( 'edit' ) : array() ),
 					'i18n_download_permission_fail'      => __( 'Could not grant access - the user may already have permission for this file or billing email is not set. Ensure the billing email is set, and the order has been saved.', 'woocommerce' ),
 					'i18n_permission_revoke'             => __( 'Are you sure you want to revoke access to this download?', 'woocommerce' ),
 					'i18n_tax_rate_already_exists'       => __( 'You cannot add the same tax rate twice!', 'woocommerce' ),

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -403,7 +403,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					'rounding_precision'                 => wc_get_rounding_precision(),
 					'tax_rounding_mode'                  => wc_get_tax_rounding_mode(),
 					'product_types'                      => array_unique( array_merge( array( 'simple', 'grouped', 'variable', 'external' ), array_keys( wc_get_product_types() ) ) ),
-					'has_attributes'                     => ! empty( wc_get_attribute_taxonomies() ),
+					'has_attributes'                     => ! empty( wc_get_attribute_taxonomies() ) || ! empty( wc_get_product( $post_id )->get_attributes( 'edit' ) ),
 					'i18n_download_permission_fail'      => __( 'Could not grant access - the user may already have permission for this file or billing email is not set. Ensure the billing email is set, and the order has been saved.', 'woocommerce' ),
 					'i18n_permission_revoke'             => __( 'Are you sure you want to revoke access to this download?', 'woocommerce' ),
 					'i18n_tax_rate_already_exists'       => __( 'You cannot add the same tax rate twice!', 'woocommerce' ),

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
@@ -15,7 +15,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 		if ( empty( $attribute_taxonomies ) && empty( $product_attributes ) ) :
 			?>
 			<div id="message" class="inline notice woocommerce-message">
-				<p><?php echo esc_html_e( __( 'Add descriptive pieces of information that customers can use to search for this product on your store, such as “Material” or “Brand”.', 'woocommerce' ) ); ?></p>
+				<p>
+					<?php
+					esc_html_e(
+						'Add descriptive pieces of information that customers can use to search for this product on your store, such as “Material” or “Brand”.',
+						'woocommerce'
+					);
+					?>
+				</p>
 			</div>
 		<?php endif; ?>
 		<span class="expand-close">

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
@@ -9,8 +9,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 		global $wc_product_attributes;
 		// Array of defined attribute taxonomies.
 		$attribute_taxonomies = wc_get_attribute_taxonomies();
+		// Product attributes - taxonomies and custom, ordered, with visibility and variation attributes set.
+		$product_attributes = $product_object->get_attributes( 'edit' );
 
-		if ( empty( $attribute_taxonomies ) ) :
+		if ( empty( $attribute_taxonomies ) && empty( $product_attributes ) ) :
 			?>
 			<div id="message" class="inline notice woocommerce-message">
 				<p><?php echo wp_kses_post( __( 'Add descriptive pieces of information that customers can use to search for this product on your store, such as “Material” or “Brand”.', 'woocommerce' ) ); ?></p>
@@ -50,11 +52,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</div>
 	<div class="product_attributes wc-metaboxes">
 		<?php
-		// Product attributes - taxonomies and custom, ordered, with visibility and variation attributes set.
-		$attributes = $product_object->get_attributes( 'edit' );
 		$i          = -1;
 
-		foreach ( $attributes as $attribute ) {
+		foreach ( $product_attributes as $attribute ) {
 			$i++;
 			$metabox_class = array();
 

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
@@ -5,6 +5,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <div id="product_attributes" class="panel wc-metaboxes-wrapper hidden">
 	<div class="toolbar toolbar-top">
+		<?php
+		global $wc_product_attributes;
+		// Array of defined attribute taxonomies.
+		$attribute_taxonomies = wc_get_attribute_taxonomies();
+
+		if ( empty( $attribute_taxonomies ) ) :
+		?>
+			<div id="message" class="inline notice woocommerce-message">
+				<p><?php echo wp_kses_post( __( 'Add descriptive pieces of information that customers can use to search for this product on your store, such as “Material” or “Brand”.', 'woocommerce' ) ); ?></p>
+			</div>
+		<?php endif; ?>
 		<span class="expand-close">
 			<a href="#" class="expand_all"><?php esc_html_e( 'Expand', 'woocommerce' ); ?></a> / <a href="#" class="close_all"><?php esc_html_e( 'Close', 'woocommerce' ); ?></a>
 		</span>
@@ -16,15 +27,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 		 * @since 7.0.0
 		 * @param number $threshold The threshold for showing the simple dropdown.
 		 */
-		if ( count( wc_get_attribute_taxonomies() ) <= apply_filters( 'woocommerce_attribute_taxonomy_filter_threshold', 20 ) ) :
+		if ( count( $attribute_taxonomies ) <= apply_filters( 'woocommerce_attribute_taxonomy_filter_threshold', 20 ) ) :
 			?>
 			<select name="attribute_taxonomy" class="attribute_taxonomy">
 				<option value=""><?php esc_html_e( 'Custom product attribute', 'woocommerce' ); ?></option>
 				<?php
-				global $wc_product_attributes;
-				// Array of defined attribute taxonomies.
-				$attribute_taxonomies = wc_get_attribute_taxonomies();
-
 				if ( ! empty( $attribute_taxonomies ) ) {
 					foreach ( $attribute_taxonomies as $attr_taxonomy ) {
 						$attribute_taxonomy_name = wc_attribute_taxonomy_name( $attr_taxonomy->attribute_name );

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		if ( empty( $attribute_taxonomies ) && empty( $product_attributes ) ) :
 			?>
 			<div id="message" class="inline notice woocommerce-message">
-				<p><?php echo wp_kses_post( __( 'Add descriptive pieces of information that customers can use to search for this product on your store, such as “Material” or “Brand”.', 'woocommerce' ) ); ?></p>
+				<p><?php echo esc_html_e( __( 'Add descriptive pieces of information that customers can use to search for this product on your store, such as “Material” or “Brand”.', 'woocommerce' ) ); ?></p>
 			</div>
 		<?php endif; ?>
 		<span class="expand-close">

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		$attribute_taxonomies = wc_get_attribute_taxonomies();
 
 		if ( empty( $attribute_taxonomies ) ) :
-		?>
+			?>
 			<div id="message" class="inline notice woocommerce-message">
 				<p><?php echo wp_kses_post( __( 'Add descriptive pieces of information that customers can use to search for this product on your store, such as “Material” or “Brand”.', 'woocommerce' ) ); ?></p>
 			</div>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
@@ -52,7 +52,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</div>
 	<div class="product_attributes wc-metaboxes">
 		<?php
-		$i          = -1;
+		$i = -1;
 
 		foreach ( $product_attributes as $attribute ) {
 			$i++;

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -591,7 +591,7 @@ class WC_AJAX {
 		$attribute->set_id( wc_attribute_taxonomy_id_by_name( sanitize_text_field( wp_unslash( $_POST['taxonomy'] ) ) ) );
 		$attribute->set_name( sanitize_text_field( wp_unslash( $_POST['taxonomy'] ) ) );
 		$attribute->set_visible( apply_filters( 'woocommerce_attribute_default_visibility', 1 ) );
-		$attribute->set_variation( apply_filters( 'woocommerce_attribute_default_is_variation', 0 ) );
+		$attribute->set_variation( apply_filters( 'woocommerce_attribute_default_is_variation', 1 ) );
 
 		if ( $attribute->is_taxonomy() ) {
 			$metabox_class[] = 'taxonomy';

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -590,8 +590,10 @@ class WC_AJAX {
 
 		$attribute->set_id( wc_attribute_taxonomy_id_by_name( sanitize_text_field( wp_unslash( $_POST['taxonomy'] ) ) ) );
 		$attribute->set_name( sanitize_text_field( wp_unslash( $_POST['taxonomy'] ) ) );
+		/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
 		$attribute->set_visible( apply_filters( 'woocommerce_attribute_default_visibility', 1 ) );
 		$attribute->set_variation( apply_filters( 'woocommerce_attribute_default_is_variation', 1 ) );
+		/* phpcs: enable */
 
 		if ( $attribute->is_taxonomy() ) {
 			$metabox_class[] = 'taxonomy';

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
@@ -52,7 +52,9 @@ test.describe.serial( 'Add New Variable Product Page', () => {
 
 		// add 3 attributes
 		for ( let i = 0; i < 3; i++ ) {
-			await page.click( 'button.add_attribute' );
+			if ( i > 0 ) {
+				await page.click( 'button.add_attribute' );
+			}
 			await page.fill(
 				`input[name="attribute_names[${ i }]"]`,
 				`attr #${ i + 1 }`
@@ -61,7 +63,6 @@ test.describe.serial( 'Add New Variable Product Page', () => {
 				`textarea[name="attribute_values[${ i }]"]`,
 				'val1 | val2'
 			);
-			await page.click( `input[name="attribute_variation[${ i }]"]` );
 		}
 		await page.click( 'text=Save attributes' );
 
@@ -199,7 +200,9 @@ test.describe.serial( 'Add New Variable Product Page', () => {
 		await page.click( 'a[href="#product_attributes"]' );
 		// add 3 attributes
 		for ( let i = 0; i < 3; i++ ) {
-			await page.click( 'button.add_attribute' );
+			if ( i > 0 ) {
+				await page.click( 'button.add_attribute' );
+			}
 			await page.fill(
 				`input[name="attribute_names[${ i }]"]`,
 				`attr #${ i + 1 }`
@@ -208,7 +211,6 @@ test.describe.serial( 'Add New Variable Product Page', () => {
 				`textarea[name="attribute_values[${ i }]"]`,
 				'val1 | val2'
 			);
-			await page.click( `input[name="attribute_variation[${ i }]"]` );
 			await page.click( 'text=Save attributes' );
 			await expect(
 				page


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR adds the code to show the add attribute form by default when there are no attributes in the store.

A warning will be shown with the text
```
Add descriptive pieces of information that customers can use to search for this product on your store, such as “Material” or “Brand”.
```

The `Used for variations` checkbox will be checked by default.

Fixes partially [35115](https://github.com/woocommerce/woocommerce/issues/35115).

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Go to `Products > Add New` in a store without attributes.
2. Under `Product data` press `Attributes`.
3. The warning and the form should be visible
![Screenshot 2023-01-25 at 16 12 19](https://user-images.githubusercontent.com/1314156/214661809-7198bcf0-d3f2-4079-b95e-c226d79fe257.png)

4. Create an attribute and try again. The warning won't be visible by default either the form.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
