### PR TITLE
Eliminate duplicate HPOS internal meta keys

### DIFF
--- a/plugins/woocommerce/changelog/fix-36473-HPOS-internal-meta-keys
+++ b/plugins/woocommerce/changelog/fix-36473-HPOS-internal-meta-keys
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Eliminate data store internal meta keys duplicates

--- a/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-data-store-wp.php
@@ -108,7 +108,15 @@ class WC_Data_Store_WP {
 	 * @return mixed|void
 	 */
 	public function filter_raw_meta_data( &$object, $raw_meta_data ) {
-		$this->internal_meta_keys = array_merge( array_map( array( $this, 'prefix_key' ), $object->get_data_keys() ), $this->internal_meta_keys );
+		$this->internal_meta_keys = array_unique(
+			array_merge(
+				array_map(
+					array( $this, 'prefix_key' ),
+					$object->get_data_keys()
+				),
+				$this->internal_meta_keys
+			)
+		);
 		$meta_data                = array_filter( $raw_meta_data, array( $this, 'exclude_internal_meta_keys' ) );
 		return apply_filters( "woocommerce_data_store_wp_{$this->meta_type}_read_meta", $meta_data, $object, $this );
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR wraps the merge of data store internal meta key with `array_unique` to eliminate duplicate keys.

Closes #36473 .

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Create two orders
2. Run these commands in a terminal in a folder in your development install that has HPOS enabled where `$id1` and `$id2` are the two order IDs
```
 wp shell
$ds = WC_Data_Store::load( 'order' );
wc_get_order( $id1 );
count( $ds->get_internal_meta_keys() ); // 70
wc_get_order( $id2 );
count( $ds->get_internal_meta_keys() ); // 70
```
3. You should get a count of 70 after loading each of the orders

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 