### PR TITLE
Add unique sku option to error data when setting product sku

### DIFF
--- a/plugins/woocommerce/changelog/add-36589
+++ b/plugins/woocommerce/changelog/add-36589
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add unique sku option to error data when setting product sku

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
@@ -820,7 +820,15 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 		if ( $this->get_object_read() && ! empty( $sku ) && ! wc_product_has_unique_sku( $this->get_id(), $sku ) ) {
 			$sku_found = wc_get_product_id_by_sku( $sku );
 
-			$this->error( 'product_invalid_sku', __( 'Invalid or duplicated SKU.', 'woocommerce' ), 400, array( 'resource_id' => $sku_found ) );
+			$this->error(
+				'product_invalid_sku',
+				__( 'Invalid or duplicated SKU.', 'woocommerce' ),
+				400,
+				array(
+					'resource_id' => $sku_found,
+					'unique_sku'  => wc_product_generate_unique_sku( $this->get_id(), $sku ),
+				)
+			);
 		}
 		$this->set_prop( 'sku', $sku );
 	}

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
@@ -818,18 +818,13 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	public function set_sku( $sku ) {
 		$sku = (string) $sku;
 		if ( $this->get_object_read() && ! empty( $sku ) && ! wc_product_has_unique_sku( $this->get_id(), $sku ) ) {
-			if ( ! function_exists( 'get_sample_permalink' ) ) {
-				require_once ABSPATH . 'wp-admin/includes/post.php';
-			}
-			$sku_found        = wc_get_product_id_by_sku( $sku );
-			$sample_permalink = get_sample_permalink( $this->get_id(), $this->get_name(), '' );
+			$sku_found = wc_get_product_id_by_sku( $sku );
 
 			$this->error(
 				'product_invalid_sku',
 				__( 'Invalid or duplicated SKU.', 'woocommerce' ),
 				400,
 				array(
-					'permalink_template' => $sample_permalink[0],
 					'resource_id' => $sku_found,
 					'unique_sku'  => wc_product_generate_unique_sku( $this->get_id(), $sku ),
 				)

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
@@ -818,13 +818,18 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	public function set_sku( $sku ) {
 		$sku = (string) $sku;
 		if ( $this->get_object_read() && ! empty( $sku ) && ! wc_product_has_unique_sku( $this->get_id(), $sku ) ) {
-			$sku_found = wc_get_product_id_by_sku( $sku );
+			if ( ! function_exists( 'get_sample_permalink' ) ) {
+				require_once ABSPATH . 'wp-admin/includes/post.php';
+			}
+			$sku_found        = wc_get_product_id_by_sku( $sku );
+			$sample_permalink = get_sample_permalink( $this->get_id(), $this->get_name(), '' );
 
 			$this->error(
 				'product_invalid_sku',
 				__( 'Invalid or duplicated SKU.', 'woocommerce' ),
 				400,
 				array(
+					'permalink_template' => $sample_permalink[0],
 					'resource_id' => $sku_found,
 					'unique_sku'  => wc_product_generate_unique_sku( $this->get_id(), $sku ),
 				)


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a unique sku to the error response in the products REST API.

Instead of creating a new (non-RESTful) endpoint purely for slugs, we can piggyback on the existing create/update endpoints and append a unique slug for our case.

This will allow us to catch the errors going forward and suggest or automatically replace the sku for new products.  For new products, we'll use auto-drafts so that we can still hit these endpoints and validate the product.

Closes #36589  .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Using a tool like Postman, make a POST request to `wp-json/wc/v3/products` with the following data as the body:
```
{
  "sku": "already-used-sku",
  "name": "My new post"
}
```
2. Make sure that you get an error response and `unique_sku` is contained within that data
3. Verify that `unique_sku` has not yet been used
4. Make a POST request to `wp-json/wc/v3/products/{product_id} with the same JSON data as above
5. Verify that the error also contains a unique sku.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
