### PR TITLE
[COT] Fix inappropriate deletion of order from posts with sync off

### DIFF
--- a/plugins/woocommerce/changelog/fix-order_delete_from_posts_with_sync_off
+++ b/plugins/woocommerce/changelog/fix-order_delete_from_posts_with_sync_off
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Don't delete order from posts table when deleted from orders table if the later is authoritative and sync is off

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1766,14 +1766,14 @@ FROM $order_meta_table
 
 			$order->set_id( 0 );
 
-			// If this datastore method is called while the posts table is authoritative, refrain from deleting post data.
-			if ( $order->get_data_store()->get_current_class_name() !== self::class ) {
-				return;
+			// If this datastore method is called while the posts table is authoritative, or if data synchronization is disabled,
+			// refrain from deleting post data.
+			$data_synchronizer = wc_get_container()->get( DataSynchronizer::class );
+			if ( $data_synchronizer->data_sync_is_enabled() && $order->get_data_store()->get_current_class_name() === self::class ) {
+				// Delete the associated post, which in turn deletes order items, etc. through {@see WC_Post_Data}.
+				// Once we stop creating posts for orders, we should do the cleanup here instead.
+				wp_delete_post( $order_id );
 			}
-
-			// Delete the associated post, which in turn deletes order items, etc. through {@see WC_Post_Data}.
-			// Once we stop creating posts for orders, we should do the cleanup here instead.
-			wp_delete_post( $order_id );
 
 			do_action( 'woocommerce_delete_order', $order_id ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		} else {

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1767,8 +1767,7 @@ FROM $order_meta_table
 
 			$order->set_id( 0 );
 
-			// If this datastore method is called while the posts table is authoritative, or if data synchronization is disabled,
-			// refrain from deleting post data.
+			// Only delete post data if the posts table is authoritative and synchronization is enabled.
 			$data_synchronizer = wc_get_container()->get( DataSynchronizer::class );
 			if ( $data_synchronizer->data_sync_is_enabled() && $order->get_data_store()->get_current_class_name() === self::class ) {
 				// Delete the associated post, which in turn deletes order items, etc. through {@see WC_Post_Data}.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1763,7 +1763,7 @@ FROM $order_meta_table
 
 			$this->upshift_child_orders( $order );
 			$this->delete_order_data_from_custom_order_tables( $order_id );
-			$this->delete_order_data_from_shared_tables( $order_id );
+			$this->delete_items( $order );
 
 			$order->set_id( 0 );
 
@@ -1985,28 +1985,6 @@ FROM $order_meta_table
 				array( '%d' )
 			);
 		}
-	}
-
-	/**
-	 * Deletes shared order data (created with and without custom order tables in use).
-	 *
-	 * @param int $order_id The order ID.
-	 * @return void
-	 */
-	private function delete_order_data_from_shared_tables( $order_id ) {
-		global $wpdb;
-
-		// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.MissingReplacements
-		$sql = $wpdb->prepare(
-			"DELETE FROM {$wpdb->prefix}woocommerce_order_itemmeta WHERE order_item_id IN
-			(SELECT order_id FROM {$wpdb->prefix}woocommerce_order_items WHERE order_id = %d)",
-			$order_id
-		);
-
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-		$wpdb->query( $sql );
-
-		$wpdb->delete( "{$wpdb->prefix}woocommerce_order_items", array( 'order_id' => $order_id ) );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1763,6 +1763,7 @@ FROM $order_meta_table
 
 			$this->upshift_child_orders( $order );
 			$this->delete_order_data_from_custom_order_tables( $order_id );
+			$this->delete_order_data_from_shared_tables( $order_id );
 
 			$order->set_id( 0 );
 
@@ -1985,6 +1986,28 @@ FROM $order_meta_table
 				array( '%d' )
 			);
 		}
+	}
+
+	/**
+	 * Deletes shared order data (created with and without custom order tables in use).
+	 *
+	 * @param int $order_id The order ID.
+	 * @return void
+	 */
+	private function delete_order_data_from_shared_tables( $order_id ) {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.MissingReplacements
+		$sql = $wpdb->prepare(
+			"DELETE FROM {$wpdb->prefix}woocommerce_order_itemmeta WHERE order_item_id IN
+			(SELECT order_id FROM {$wpdb->prefix}woocommerce_order_items WHERE order_id = %d)",
+			$order_id
+		);
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query( $sql );
+
+		$wpdb->delete( "{$wpdb->prefix}woocommerce_order_items", array( 'order_id' => $order_id ) );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -8,6 +8,8 @@ use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableQuery;
 use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
 use Automattic\WooCommerce\RestApi\UnitTests\HPOSToggleTrait;
 
+require_once __DIR__ . '/../../../../helpers/HPOSToggleTrait.php';
+
 /**
  * Class OrdersTableDataStoreTests.
  *


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

When the orders table is authoritative and sync is off, deleting and order is deleting the order record from the posts table, which is something that shouldn't happen. This commit changes that for consistency with the case when the posts table is authoritative (deleting an order from posts doesn't delete it from the orders table when sync is off).

Additionally, `OrdersTableDataStore::delete` will now trigger the `woocommerce_delete_order` action in all cases, even when the
method is called while the posts table is authoritative.

Closes #36579.

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

### How to test the changes in this Pull Request:

1. Set the orders table as authoritative and enable sync (Settings - Advanced - Custom data stores).
2. Create an order and verify that records are created in both the orders table and the posts table.
3. Now disably sync.
4. Trash the order, then delete it.
5. Verify that the order has been deleted in the orders table **and** in the posts table (the later isn't true without this fix).
6. Repeat leaving sync on when deleting the order, verify that the order is still deleted from both tables.

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
