### PR TITLE
Move registerFill call to inside an useEffect

### DIFF
--- a/packages/js/components/changelog/fix-setstate-diff-component
+++ b/packages/js/components/changelog/fix-setstate-diff-component
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Move registerFill call to inside an useEffect since it was updating a component while rendering another component
+
+

--- a/packages/js/components/src/woo-product-field-item/woo-product-field-item.tsx
+++ b/packages/js/components/src/woo-product-field-item/woo-product-field-item.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Slot, Fill } from '@wordpress/components';
 import { createElement, Children } from '@wordpress/element';
 
@@ -27,7 +27,9 @@ export const WooProductFieldItem: React.FC< WooProductFieldItemProps > & {
 } = ( { children, order = 20, section, id } ) => {
 	const { registerFill, getFillHelpers } = useSlotContext();
 
-	registerFill( id );
+	useEffect( () => {
+		registerFill( id );
+	}, [] );
 
 	return (
 		<Fill name={ `woocommerce_product_field_${ section }` }>


### PR DESCRIPTION
That call was causing a React error (Cannot update a component while rendering a different component)

### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Move registerFill call to inside an useEffect since it was updating a component while rendering another component

Closes #36621.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Open the new add product page
2. Check if no regressions occur
3. Check if there are no related errors in the console

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
