### PR TITLE
[COT] Allow to filter orders query

### DIFF
--- a/plugins/woocommerce/changelog/hpos-filter-query-clauses
+++ b/plugins/woocommerce/changelog/hpos-filter-query-clauses
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Allow filtering HPOS order queries.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -706,7 +706,7 @@ class OrdersTableQuery {
 		 * Filters all query clauses at once.
 		 * Covers the fields (SELECT), JOIN, WHERE, GROUP BY, ORDER BY, and LIMIT clauses.
 		 *
-		 * @since 7.4.0
+		 * @since 7.9.0
 		 *
 		 * @param string[]         $clauses {
 		 *     Associative array of the clauses for the query.
@@ -720,7 +720,7 @@ class OrdersTableQuery {
 		 * }
 		 * @param OrdersTableQuery $query   The OrdersTableQuery instance (passed by reference).
 		 */
-		$clauses = (array) apply_filters_ref_array( 'woocommerce_order_table_orders_clauses', array( $pieces, &$this ) );
+		$clauses = (array) apply_filters_ref_array( 'woocommerce_orders_table_query_clauses', array( $pieces, &$this ) );
 
 		$fields  = $clauses['fields'] ?? '';
 		$join    = $clauses['join'] ?? '';
@@ -734,12 +734,12 @@ class OrdersTableQuery {
 		/**
 		 * Filters the completed SQL query.
 		 *
-		 * @since 7.4.0
+		 * @since 7.9.0
 		 *
 		 * @param string           $sql   The complete SQL query.
 		 * @param OrdersTableQuery $query The OrdersTableQuery instance (passed by reference).
 		 */
-		$this->sql = apply_filters_ref_array( 'woocommerce_order_table_orders_request', array( $this->sql, &$this ) );
+		$this->sql = apply_filters_ref_array( 'woocommerce_orders_table_query_sql', array( $this->sql, &$this ) );
 
 		$this->build_count_query( $fields, $join, $where, $groupby );
 	}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -730,6 +730,7 @@ class OrdersTableQuery {
 			 *     @type string $limits  The LIMIT clause of the query.
 			 * }
 			 * @param OrdersTableQuery $query   The OrdersTableQuery instance (passed by reference).
+			 * @param array            $args    Query args.
 			 */
 			$clauses = (array) apply_filters_ref_array( 'woocommerce_orders_table_query_clauses', array( $pieces, &$this, $this->args ) );
 
@@ -754,6 +755,7 @@ class OrdersTableQuery {
 			 *
 			 * @param string           $sql   The complete SQL query.
 			 * @param OrdersTableQuery $query The OrdersTableQuery instance (passed by reference).
+			 * @param array            $args  Query args.
 			 */
 			$this->sql = apply_filters_ref_array( 'woocommerce_orders_table_query_sql', array( $this->sql, &$this, $this->args ) );
 		}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -700,7 +700,47 @@ class OrdersTableQuery {
 		// GROUP BY.
 		$groupby = $this->groupby ? 'GROUP BY ' . implode( ', ', (array) $this->groupby ) : '';
 
+		$pieces = compact( 'fields', 'join', 'where', 'groupby', 'orderby', 'limits' );
+
+		/**
+		 * Filters all query clauses at once.
+		 * Covers the fields (SELECT), JOIN, WHERE, GROUP BY, ORDER BY, and LIMIT clauses.
+		 *
+		 * @since 7.4.0
+		 *
+		 * @param string[]         $clauses {
+		 *     Associative array of the clauses for the query.
+		 *
+		 *     @type string $fields  The SELECT clause of the query.
+		 *     @type string $join    The JOIN clause of the query.
+		 *     @type string $where   The WHERE clause of the query.
+		 *     @type string $groupby The GROUP BY clause of the query.
+		 *     @type string $orderby The ORDER BY clause of the query.
+		 *     @type string $limits  The LIMIT clause of the query.
+		 * }
+		 * @param OrdersTableQuery $query   The OrdersTableQuery instance (passed by reference).
+		 */
+		$clauses = (array) apply_filters_ref_array( 'woocommerce_order_table_orders_clauses', array( $pieces, &$this ) );
+
+		$fields  = $clauses['fields'] ?? '';
+		$join    = $clauses['join'] ?? '';
+		$where   = $clauses['where'] ?? '';
+		$groupby = $clauses['groupby'] ?? '';
+		$orderby = $clauses['orderby'] ?? '';
+		$limits  = $clauses['limits'] ?? '';
+
 		$this->sql = "SELECT $fields FROM $orders_table $join WHERE $where $groupby $orderby $limits";
+
+		/**
+		 * Filters the completed SQL query.
+		 *
+		 * @since 7.4.0
+		 *
+		 * @param string           $sql   The complete SQL query.
+		 * @param OrdersTableQuery $query The OrdersTableQuery instance (passed by reference).
+		 */
+		$this->sql = apply_filters_ref_array( 'woocommerce_order_table_orders_request', array( $this->sql, &$this ) );
+
 		$this->build_count_query( $fields, $join, $where, $groupby );
 	}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -171,6 +171,11 @@ class OrdersTableQuery {
 	 */
 	private $order_datastore = null;
 
+	/**
+	 * Whether to run filters to modify the query or not.
+	 *
+	 * @var boolean
+	 */
 	private $suppress_filters = false;
 
 	/**
@@ -770,8 +775,6 @@ class OrdersTableQuery {
 		}
 		$orders_table    = $this->tables['orders'];
 		$this->count_sql = "SELECT COUNT(DISTINCT $fields) FROM  $orders_table $join WHERE $where";
-
-		//date ASC
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
@@ -143,7 +143,7 @@ class OrdersTableQueryTests extends WC_Unit_Test_Case {
 			'woocommerce_orders_table_query_sql',
 		);
 
-		$filters_called = 0;
+		$filters_called  = 0;
 		$filter_callback = function ( $arg ) use ( &$filters_called ) {
 			$filters_called++;
 			return $arg;
@@ -153,19 +153,19 @@ class OrdersTableQueryTests extends WC_Unit_Test_Case {
 			add_filter( $hook, $filter_callback );
 		}
 
-		// suppress_filters = false
+		// Check that suppress_filters = false is honored.
 		foreach ( $hooks as $hook ) {
 			wc_get_orders( array() );
 		}
 
 		$this->assertNotEquals( $filters_called, 0 );
 
-		// suppress_filters = true
+		// Check that suppress_filters = true is honored.
 		$filters_called = 0;
 		foreach ( $hooks as $hook ) {
 			wc_get_orders(
 				array(
-					'suppress_filters' => true
+					'suppress_filters' => true,
 				)
 			);
 		}
@@ -233,19 +233,5 @@ class OrdersTableQueryTests extends WC_Unit_Test_Case {
 		);
 		remove_all_filters( 'woocommerce_orders_table_query_clauses' );
 	}
-
-		// $logged_messages = array();
-
-		// $log_watcher = function ( string $logged_message ) use ( &$logged_messages ) {
-		// 	$logged_messages[] = $logged_message;
-		// };
-
-		// add_filter( 'woocommerce_logger_log_message', $log_watcher );
-
-		// suppress_filters.
-		// $this->database_service = $this->getMockBuilder( 'WC_Integration_maxMind_Database_Service' )
-		// 	->disableOriginalConstructor()
-		// 	->getMock();
-		// add_filter( 'woocommerce_maxmind_geolocation_database_service', array( $this, 'override_integration_service' ) );
 
 }


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

This introduces 2 filters: `woocommerce_order_table_orders_clauses` and `woocommerce_order_table_orders_request`. They mimic the ones found in `WP_Query::get_posts()`.

They allow to modify the query's clauses for orders when using the custom orders table.

#### About how I intend to use these filters:
I'm one of the developers of Polylang, and we assign a language (taxonomy term) to orders for several reasons. One of them is to send emails to customers in the right language for example.
We would like to use the first filter (the clauses) to be able to filter the orders lists by language: in the "Orders" admin page and in the REST API for example.

- [ ] This PR is a very minor change/addition and does not require testing instructions.

A basic example of how we could use it:
```php
add_filter(
	'woocommerce_order_table_orders_clauses',
	function ( $clauses, $query ) {
		global $wpdb;

		$languages = $query->get( 'lang' );

		if ( empty( $languages ) ) {
			return $clauses;
		}

		if ( is_string( $languages ) ) {
			$languages = explode( ',', $languages );
		} elseif ( ! is_array( $languages ) ) {
			return $clauses;
		}

		$languages = array_map( array( PLL()->model, 'get_language' ), $languages );
		$languages = array_filter( $languages );

		if ( empty( $languages ) ) {
			return $clauses;
		}

		$tt_ids = array();
		$alias  = $query->get_core_mapping_alias( 'orders' );

		foreach ( $languages as $language ) {
			$tt_ids[] = (int) $language->term_taxonomy_id;
		}

		$clauses['join']  .= " INNER JOIN {$wpdb->term_relationships} AS pll_tr ON pll_tr.object_id = {$alias}.id";
		$clauses['where'] .= ' AND pll_tr.term_taxonomy_id IN ( ' . implode( ',', $tt_ids ) . ' )';

		return $clauses;
	},
	10,
	2
);

$query = new OrdersTableQuery(
	array(
		'lang' => 'fr',
	)
);
```

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
