### PR TITLE
Move clearQueue call to inside an useEffect

### DIFF
--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-tracks-container.js
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-tracks-container.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { useEffect } from 'react';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { OPTIONS_STORE_NAME } from '@woocommerce/data';
@@ -29,6 +30,12 @@ function CustomerEffortScoreTracksContainer( {
 	resolving,
 	clearQueue,
 } ) {
+	useEffect( () => {
+		if ( queueForPage.length ) {
+			clearQueue();
+		}
+	}, [] );
+
 	if ( resolving ) {
 		return null;
 	}
@@ -38,10 +45,6 @@ function CustomerEffortScoreTracksContainer( {
 			item.pagenow === window.pagenow &&
 			item.adminpage === window.adminpage
 	);
-
-	if ( queueForPage.length ) {
-		clearQueue();
-	}
 
 	return (
 		<>

--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-tracks-container.js
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-tracks-container.js
@@ -30,21 +30,20 @@ function CustomerEffortScoreTracksContainer( {
 	resolving,
 	clearQueue,
 } ) {
-	useEffect( () => {
-		if ( queueForPage.length ) {
-			clearQueue();
-		}
-	}, [] );
-
-	if ( resolving ) {
-		return null;
-	}
-
 	const queueForPage = queue.filter(
 		( item ) =>
 			item.pagenow === window.pagenow &&
 			item.adminpage === window.adminpage
 	);
+	useEffect( () => {
+		if ( queueForPage.length ) {
+			clearQueue();
+		}
+	}, [ queueForPage ] );
+
+	if ( resolving ) {
+		return null;
+	}
 
 	return (
 		<>

--- a/plugins/woocommerce/changelog/fix-setstate-diff-component2
+++ b/plugins/woocommerce/changelog/fix-setstate-diff-component2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Move clearQueue call to inside an useEffect since it was updating a component while rendering another component
+
+


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Move clearQueue call to inside an useEffect
That call was causing a React error (Cannot update a component while rendering a different component)

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Using WCA Test Helper, clear the option `woocommerce_ces_shown_for_actions`.
2. Open the new product form.
3. Fill something in the Summary.
4. Refresh the page.
5. Confirm in the browser dialog that you want to refresh
6. Check console if there are no errors (There would be an error in trunk, when clearQueue is called)
7. Check if `How is your experience with creating products?` snack bar appears. 

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
