### PR TITLE
ensure unit test install ABSPATH is a real path

### DIFF
--- a/plugins/woocommerce/changelog/fix-36638
+++ b/plugins/woocommerce/changelog/fix-36638
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix overlapping header elements on product page

--- a/plugins/woocommerce/changelog/fix-36638
+++ b/plugins/woocommerce/changelog/fix-36638
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Fix overlapping header elements on product page
+Fix WordPress unit tests libraries being installed in a symlinked folder structure

--- a/plugins/woocommerce/tests/bin/install.sh
+++ b/plugins/woocommerce/tests/bin/install.sh
@@ -126,7 +126,7 @@ install_test_suite() {
 	if [ ! -f wp-tests-config.php ]; then
 		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR"/wp-tests-config.php
 		# remove all forward slashes in the end
-		WP_CORE_DIR=$(echo $WP_CORE_DIR | sed "s:/\+$::")
+		WP_CORE_DIR=$(realpath $(echo $WP_CORE_DIR | sed "s:/\+$::"))
 		sed $ioption -E "s:(__DIR__ . '/src/'|dirname\( __FILE__ \) . '/src/'):'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR passes the unit test root directory through `realpath` when setting `ABSPATH` in `wp-tests-config.php`.

Closes #36638 .

### How to test the changes in this Pull Request:

1. Run `tests/bin/install.sh` from in the `woocommerce/plugins/woocommerce` folder
2. If unit tests are already installed this will error and output the wordpress unit test folder (eg. `/var/folders/8l/pm1lvhbd7zl5fl81yxf6bbr80000gn/T`)
3. In that case delete the `wordpress` and `wordpress-tests-lib` folders then retry step 1
4. Run `vendor/bin/phpunit`
5. Unit tests should run

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
