### PR TITLE
Fix the filter "woocommerce_{order_type}_list_table_prepare_items_query_args"

### DIFF
--- a/plugins/woocommerce/changelog/fix-orders-list-query-arg-filter
+++ b/plugins/woocommerce/changelog/fix-orders-list-query-arg-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure changes made via the `woocommerce_order_list_table_prepare_items_query_args` are observed.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -325,7 +325,7 @@ class ListTable extends WP_List_Table {
 		 *
 		 * @since 7.3.0
 		 */
-		$order_query_args = apply_filters( 'woocommerce_' . $this->order_type . '_list_table_prepare_items_query_args', $this->order_query_args );
+		$order_query_args = apply_filters( 'woocommerce_' . $this->order_type . '_list_table_prepare_items_query_args', $order_query_args );
 
 		// We must ensure the 'paginate' argument is set.
 		$order_query_args['paginate'] = true;


### PR DESCRIPTION
The filter `woocommerce_order_list_table_prepare_items_query_args` (1) was useless because its result was not used by the next filter, `woocommerce_{order_type}_list_table_prepare_items_query_args` (2).
By doing so, the result of (1) was overwritten by (2).

### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR proposes to replace the class property by the temporary var in the filter `woocommerce_{order_type}_list_table_prepare_items_query_args`.

- [x] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
