### PR TITLE
Remove opinionated styles from buttons in block themes so they inherit theme styles more accurately

### DIFF
--- a/plugins/woocommerce/changelog/remove-block-themes-button-constrains
+++ b/plugins/woocommerce/changelog/remove-block-themes-button-constrains
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Remove opinionated styles from buttons in block themes so they inherit theme styles more accurately

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -336,12 +336,6 @@
 			margin-top: var(--wp--style--block-gap);
 		}
 
-		button[name="add-to-cart"],
-		button.single_add_to_cart_button {
-			margin-top: 0.5rem;
-			margin-bottom: var(--wp--style--block-gap);
-		}
-
 		ol.flex-control-thumbs {
 			padding-left: 0;
 			float: left;

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -315,10 +315,6 @@
 					font-size: 1em;
 				}
 			}
-
-			.quantity {
-				display: inline-block;
-			}
 		}
 
 		table.variations tr {

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
@@ -120,7 +120,6 @@ $tt2-gray: #f7f7f7;
 		background-color: var(--wp--preset--color--primary);
 		color: #fff;
 		border: 1px solid var(--wp--preset--color--black);
-		padding: 1rem 2rem;
 		margin-top: 1rem;
 		text-decoration: none;
 		font-size: medium;
@@ -186,7 +185,6 @@ $tt2-gray: #f7f7f7;
 	button.single_add_to_cart_button,
 	a.checkout-button {
 		font-size: 18px;
-		padding: 1.5rem 3.5rem;
 	}
 
 	// Moved from blockthemes.css to make sure TT2 won't be changed.
@@ -328,12 +326,6 @@ $tt2-gray: #f7f7f7;
 					font-size: 1em;
 				}
 			}
-		}
-
-		button[name="add-to-cart"],
-		button.single_add_to_cart_button {
-			margin-top: 0.5rem;
-			margin-bottom: var(--wp--style--block-gap);
 		}
 
 		ol.flex-control-thumbs {

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
@@ -328,6 +328,12 @@ $tt2-gray: #f7f7f7;
 			}
 		}
 
+		button[name="add-to-cart"],
+		button.single_add_to_cart_button {
+			margin-top: 0.5rem;
+			margin-bottom: var(--wp--style--block-gap);
+		}
+
 		ol.flex-control-thumbs {
 			padding-left: 0;
 			float: left;

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
@@ -328,8 +328,9 @@ $tt2-gray: #f7f7f7;
 			}
 		}
 
-		button[name="add-to-cart"],
-		button.single_add_to_cart_button {
+		form.cart button[name="add-to-cart"],
+		form.cart button.single_add_to_cart_button {
+			display: block;
 			margin-top: 0.5rem;
 			margin-bottom: var(--wp--style--block-gap);
 		}

--- a/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
@@ -26,19 +26,6 @@
 * General
 */
 .woocommerce {
-
-	/**
-	* Buttons
-	*/
-	a.button,
-	button[name="add-to-cart"],
-	input[name="submit"],
-	button.single_add_to_cart_button,
-	button[type="submit"]:not(.wp-block-search__button) {
-		// Slightly increase CTA size across the board.
-		padding: 0.9rem 1.1rem;
-	}
-
 	button.button,
 	a.button {
 

--- a/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
@@ -291,23 +291,18 @@
 			}
 		}
 
+		.coupon {
+			display: flex;
+			align-items: center;
+		}
+
 		#coupon_code {
 			// Allow sufficient space for the coupon code.
 			width: auto;
 			margin-right: 0.8rem;
-		}
-
-		#coupon_code,
-		.actions .button {
 			height: 50px;
 			font-size: var(--wp--preset--font-size--small);
-			padding-left: 1.1rem;
-			padding-right: 1.1rem;
-			// We need to remove top and bottom padding because we are setting a fixed
-			// height. This is to prevent the button from being cut off. !important is
-			// needed to override the Elements API styles, which also use !important.
-			padding-top: 0 !important;
-			padding-bottom: 0 !important;
+			padding: 0 1.1rem;
 		}
 
 		@media only screen and ( max-width: 768px ) {

--- a/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
@@ -100,22 +100,26 @@
 			}
 		}
 
-		.cart {
-			display: flex;
-			align-items: center;
-		}
-
-		.quantity {
-			// Adjust positioning of quantity selector and button.
-			.qty {
-				margin-right: 0.5rem;
+		form.cart {
+			div.quantity {
+				display: inline-block;
+				float: none; // Remove float set by WC core.
+				vertical-align: middle;
+	
+				// Adjust positioning of quantity selector and button.
+				.qty {
+					margin-right: 0.5rem;
+				}
 			}
-		}
-
-		button[name="add-to-cart"],
-		button.single_add_to_cart_button {
-			margin-top: 0;
-			margin-bottom: 0;
+	
+			button[name="add-to-cart"],
+			button.single_add_to_cart_button {
+				display: inline-block;
+				float: none; // Remove float set by WC core.
+				margin-top: 0;
+				margin-bottom: 0;
+				vertical-align: middle;
+			}
 		}
 
 		.related.products {

--- a/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
@@ -113,20 +113,22 @@
 			}
 		}
 
+		.cart {
+			display: flex;
+			align-items: center;
+		}
+
 		.quantity {
 			// Adjust positioning of quantity selector and button.
 			.qty {
 				margin-right: 0.5rem;
 			}
+		}
 
-			+ .single_add_to_cart_button {
-				min-height: 51px;
-				// We need to remove top and bottom padding because we are setting a fixed
-				// height. This is to prevent the button from being cut off. !important is
-				// needed to override the Elements API styles, which also use !important.
-				padding-top: 0 !important;
-				padding-bottom: 0 !important;
-			}
+		button[name="add-to-cart"],
+		button.single_add_to_cart_button {
+			margin-top: 0;
+			margin-bottom: 0;
 		}
 
 		.related.products {


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR removes several CSS lines that were enforcing specific styles (mostly padding) to buttons. This is in order to better inherit the styles provided by the theme. In some cases, I made the container of the buttons a flex wrapper, so items could be vertically aligned (see screenshots below).

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Enable [Tenty Tewnty-Three](https://wordpress.org/themes/twentytwentythree/).
2. In the frontend, go to one of the product pages (ie: Beanie).
3. Verify the Add to Cart button and the input field are vertically aligned, even though they might have different height:

Type | Before | After
--- | --- | ---
Simple Product | ![imatge](https://user-images.githubusercontent.com/3616980/215092948-c123aba2-a29e-420e-9880-e506c6da3fe8.png) | ![imatge](https://user-images.githubusercontent.com/3616980/215092732-cda0b051-92fe-4fe8-86be-ecddc415fbd6.png)
Variable Product | ![imatge](https://user-images.githubusercontent.com/3616980/216571476-7f196a1c-f700-41f0-adca-fcb29fbe5d4c.png) | ![imatge](https://user-images.githubusercontent.com/3616980/216571444-c0fc7523-9302-4085-83e5-f21e4eac0b8f.png)


4. Go to the Cart page (with the Cart shortcode) and verify the Coupon code is properly aligned as well.

Before | After
--- | ---
![imatge](https://user-images.githubusercontent.com/3616980/215093453-15d16ee5-c934-47a8-91de-d9e613ea77e2.png)| ![imatge](https://user-images.githubusercontent.com/3616980/215093101-d8e75fc1-3fdf-43c1-923e-db3d8d7db68c.png)

5. Do some smoke testing in some other pages (ie: Shop, My Account...) and verify no button looks broken.
6. Change your theme to [Twenty Twenty-Two](https://wordpress.org/themes/twentytwentytwo/) and repeat the process.
7. Feel free to test it with other block themes and in all of them verify buttons are displayed correctly:

_Pixl:_

![imatge](https://user-images.githubusercontent.com/3616980/215096789-3d2205fa-f0e8-4353-ac65-fe63b8cf2946.png)

_Oaknut:_

![imatge](https://user-images.githubusercontent.com/3616980/215096911-fafb42d8-d6ca-4edd-9b32-8920ea4ebb6b.png)


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
