### PR TITLE
Fixing issue preventing import products CES exit page from firing

### DIFF
--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-exit-page.ts
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-exit-page.ts
@@ -14,13 +14,11 @@ import { ALLOW_TRACKING_OPTION_NAME } from './constants';
 const CUSTOMER_EFFORT_SCORE_EXIT_PAGE_KEY = 'customer-effort-score-exit-page';
 
 let allowTracking = false;
-const trackingPromise = resolveSelect( OPTIONS_STORE_NAME ).getOption(
-	ALLOW_TRACKING_OPTION_NAME
-);
-
-trackingPromise.then( ( trackingOption ) => {
-	allowTracking = trackingOption === 'yes';
-} );
+const trackingPromise = resolveSelect( OPTIONS_STORE_NAME )
+	.getOption( ALLOW_TRACKING_OPTION_NAME )
+	.then( ( trackingOption ) => {
+		allowTracking = trackingOption === 'yes';
+	} );
 /**
  * Gets the list of exited pages from Localstorage.
  */

--- a/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-exit-page.ts
+++ b/plugins/woocommerce-admin/client/customer-effort-score-tracks/customer-effort-score-exit-page.ts
@@ -14,12 +14,13 @@ import { ALLOW_TRACKING_OPTION_NAME } from './constants';
 const CUSTOMER_EFFORT_SCORE_EXIT_PAGE_KEY = 'customer-effort-score-exit-page';
 
 let allowTracking = false;
-resolveSelect( OPTIONS_STORE_NAME )
-	.getOption( ALLOW_TRACKING_OPTION_NAME )
-	.then( ( trackingOption ) => {
-		allowTracking = trackingOption === 'yes';
-	} );
+const trackingPromise = resolveSelect( OPTIONS_STORE_NAME ).getOption(
+	ALLOW_TRACKING_OPTION_NAME
+);
 
+trackingPromise.then( ( trackingOption ) => {
+	allowTracking = trackingOption === 'yes';
+} );
 /**
  * Gets the list of exited pages from Localstorage.
  */
@@ -42,7 +43,8 @@ export const getExitPageData = () => {
  *
  * @param {string} pageId of page exited early.
  */
-export const addExitPage = ( pageId: string ) => {
+export const addExitPage = async ( pageId: string ) => {
+	await trackingPromise;
 	if ( ! ( window.localStorage && allowTracking ) ) {
 		return;
 	}

--- a/plugins/woocommerce/changelog/fix-36654-import-ces
+++ b/plugins/woocommerce/changelog/fix-36654-import-ces
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensuring that we know if allowTracking is true before adding exit page.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

There was a race condition present in which the allow tracking response, which defaulted to false, had not resolved before adding the exit page.

Closes #36654 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Enable tracking under WooCommerce > Settings > Advanced > Woocommerce.com
2. Go to Products -> All Products
3. Click "Import" button.
4. Without continuing the import, click back to Products -> All Products (or another page).
5. Observe the notice appear as seen in the screenshot:
![image](https://user-images.githubusercontent.com/444632/215180227-d45d8aa8-bb98-4e4f-9e9e-ba8eddce1f94.png)


<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
