### PR TITLE
New product experience: Add error messages around duplicate or invalid skus

### DIFF
--- a/plugins/woocommerce-admin/client/products/fills/details-section/details-field-name.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/details-section/details-field-name.tsx
@@ -69,6 +69,7 @@ export const DetailsNameField = ( {} ) => {
 							{ permalinkSuffix }
 						</a>
 						<Button
+							id="wooocommerce-product-form__edit-product-link"
 							variant="link"
 							onClick={ () =>
 								setShowProductLinkEditModal( true )

--- a/plugins/woocommerce-admin/client/products/fills/details-section/details-field-name.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/details-section/details-field-name.tsx
@@ -2,16 +2,11 @@
  * External dependencies
  */
 import { Button, TextControl } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { cleanForSlug } from '@wordpress/url';
 import { useFormContext } from '@woocommerce/components';
 import interpolateComponents from '@automattic/interpolate-components';
-import {
-	Product,
-	PRODUCTS_STORE_NAME,
-	WCDataSelector,
-} from '@woocommerce/data';
+import { Product } from '@woocommerce/data';
 import { useState } from '@wordpress/element';
 
 /**
@@ -19,6 +14,7 @@ import { useState } from '@wordpress/element';
  */
 import { EditProductLinkModal } from '../../shared/edit-product-link-modal';
 import { PRODUCT_DETAILS_SLUG } from '../constants';
+import { getProductPermalinkParts } from '../../utils/get-product-permalink-parts';
 
 export const DetailsNameField = ( {} ) => {
 	const [ showProductLinkEditModal, setShowProductLinkEditModal ] =
@@ -26,19 +22,7 @@ export const DetailsNameField = ( {} ) => {
 	const { getInputProps, values, touched, errors, setValue } =
 		useFormContext< Product >();
 
-	const { permalinkPrefix, permalinkSuffix } = useSelect(
-		( select: WCDataSelector ) => {
-			const { getPermalinkParts } = select( PRODUCTS_STORE_NAME );
-			if ( values.id ) {
-				const parts = getPermalinkParts( values.id );
-				return {
-					permalinkPrefix: parts?.prefix,
-					permalinkSuffix: parts?.suffix,
-				};
-			}
-			return {};
-		}
-	);
+	const [ permalinkPrefix, permalinkSuffix ] = getProductPermalinkParts();
 
 	const hasNameError = () => {
 		return Boolean( touched.name ) && Boolean( errors.name );
@@ -69,27 +53,31 @@ export const DetailsNameField = ( {} ) => {
 					onBlur: setSkuIfEmpty,
 				} ) }
 			/>
-			{ values.id && ! hasNameError() && permalinkPrefix && (
-				<span className="woocommerce-product-form__secondary-text product-details-section__product-link">
-					{ __( 'Product link', 'woocommerce' ) }
-					:&nbsp;
-					<a
-						href={ values.permalink }
-						target="_blank"
-						rel="noreferrer"
-					>
-						{ permalinkPrefix }
-						{ values.slug || cleanForSlug( values.name ) }
-						{ permalinkSuffix }
-					</a>
-					<Button
-						variant="link"
-						onClick={ () => setShowProductLinkEditModal( true ) }
-					>
-						{ __( 'Edit', 'woocommerce' ) }
-					</Button>
-				</span>
-			) }
+			{ ( values.name || values.slug ) &&
+				! hasNameError() &&
+				permalinkPrefix && (
+					<span className="woocommerce-product-form__secondary-text product-details-section__product-link">
+						{ __( 'Product link', 'woocommerce' ) }
+						:&nbsp;
+						<a
+							href={ values.permalink }
+							target="_blank"
+							rel="noreferrer"
+						>
+							{ permalinkPrefix }
+							{ values.slug || cleanForSlug( values.name ) }
+							{ permalinkSuffix }
+						</a>
+						<Button
+							variant="link"
+							onClick={ () =>
+								setShowProductLinkEditModal( true )
+							}
+						>
+							{ __( 'Edit', 'woocommerce' ) }
+						</Button>
+					</span>
+				) }
 			{ showProductLinkEditModal && (
 				<EditProductLinkModal
 					permalinkPrefix={ permalinkPrefix || '' }

--- a/plugins/woocommerce-admin/client/products/shared/edit-product-link-modal/edit-product-link-modal.tsx
+++ b/plugins/woocommerce-admin/client/products/shared/edit-product-link-modal/edit-product-link-modal.tsx
@@ -33,8 +33,11 @@ export const EditProductLinkModal: React.FC< EditProductLinkModalProps > = ( {
 	onSaved,
 } ) => {
 	const { createNotice } = useDispatch( 'core/notices' );
-	const { updateProductWithStatus, isUpdatingDraft, isUpdatingPublished } =
-		useProductHelper();
+	const {
+		createOrUpdateProductWithStatus,
+		isUpdatingDraft,
+		isUpdatingPublished,
+	} = useProductHelper();
 	const [ slug, setSlug ] = useState(
 		product.slug || cleanForSlug( product.name )
 	);
@@ -46,12 +49,12 @@ export const EditProductLinkModal: React.FC< EditProductLinkModalProps > = ( {
 			product_id: product.id,
 			product_type: product.type,
 		} );
-		const updatedProduct = await updateProductWithStatus(
-			product.id,
+		const updatedProduct = await createOrUpdateProductWithStatus(
+			product.id || null,
 			{
 				slug,
 			},
-			product.status,
+			product.status || 'auto-draft',
 			true
 		);
 		if ( updatedProduct && updatedProduct.id ) {

--- a/plugins/woocommerce-admin/client/products/shared/edit-product-link-modal/edit-product-link-modal.tsx
+++ b/plugins/woocommerce-admin/client/products/shared/edit-product-link-modal/edit-product-link-modal.tsx
@@ -62,6 +62,7 @@ export const EditProductLinkModal: React.FC< EditProductLinkModalProps > = ( {
 			resetForm(
 				{
 					...product,
+					id: updatedProduct.id,
 					slug: updatedProduct.slug,
 					permalink: updatedProduct.permalink,
 				},

--- a/plugins/woocommerce-admin/client/products/use-product-helper.ts
+++ b/plugins/woocommerce-admin/client/products/use-product-helper.ts
@@ -23,6 +23,7 @@ import { recordEvent } from '@woocommerce/tracks';
 import { AUTO_DRAFT_NAME } from './utils/get-product-title';
 import { CurrencyContext } from '../lib/currency-context';
 import { getDerivedProductType } from './utils/get-derived-product-type';
+import { getProductError } from './utils/get-product-error';
 import {
 	NUMBERS_AND_DECIMAL_SEPARATOR,
 	ONLY_ONE_DECIMAL_SEPARATOR,
@@ -117,18 +118,12 @@ export function useProductHelper() {
 					return newProduct;
 				},
 				( error ) => {
+					const productError = getProductError( error, status );
 					if ( ! skipNotice ) {
 						createNotice(
 							'error',
-							status === 'publish'
-								? __(
-										'Failed to publish product.',
-										'woocommerce'
-								  )
-								: __(
-										'Failed to create product.',
-										'woocommerce'
-								  )
+							productError.content,
+							productError.options || {}
 						);
 					}
 					setUpdating( {

--- a/plugins/woocommerce-admin/client/products/use-product-helper.ts
+++ b/plugins/woocommerce-admin/client/products/use-product-helper.ts
@@ -243,6 +243,39 @@ export function useProductHelper() {
 	);
 
 	/**
+	 * Create or update product with status.
+	 *
+	 * @param {number}  productId  The product ID or null if not yet created.
+	 * @param {Product} product    The product data.
+	 * @param {string}  status     The product status.
+	 * @param {boolean} skipNotice Determines if the notice should be skipped (default: false).
+	 * @return {Promise<Product>} Returns a promise with the updated product.
+	 */
+	const createOrUpdateProductWithStatus = async (
+		productId: number | null,
+		product: Partial< Product >,
+		status: ProductStatus,
+		skipNotice = false
+	): Promise< Product > => {
+		if ( productId ) {
+			return updateProductWithStatus(
+				product.id,
+				product,
+				status,
+				skipNotice
+			);
+		}
+		return createProductWithStatus(
+			{
+				...product,
+				name: product.name || AUTO_DRAFT_NAME,
+			},
+			status,
+			skipNotice
+		);
+	};
+
+	/**
 	 * Creates a copy of the given product with the given status.
 	 *
 	 * @param {Product} product the product to be copied.
@@ -358,6 +391,7 @@ export function useProductHelper() {
 	);
 
 	return {
+		createOrUpdateProductWithStatus,
 		createProductWithStatus,
 		updateProductWithStatus,
 		copyProductWithStatus,

--- a/plugins/woocommerce-admin/client/products/use-product-helper.ts
+++ b/plugins/woocommerce-admin/client/products/use-product-helper.ts
@@ -30,9 +30,11 @@ import {
 import { ProductVariationsOrder } from './hooks/use-variations-order';
 
 function removeReadonlyProperties(
-	product: Product
-): Omit< Product, ReadOnlyProperties > {
-	productReadOnlyProperties.forEach( ( key ) => delete product[ key ] );
+	product: Partial< Product >
+): Omit< Partial< Product >, ReadOnlyProperties > {
+	productReadOnlyProperties.forEach(
+		( propertyName: keyof Product ) => delete product[ propertyName ]
+	);
 	return product;
 }
 
@@ -79,7 +81,7 @@ export function useProductHelper() {
 	 */
 	const createProductWithStatus = useCallback(
 		async (
-			product: Omit< Product, ReadOnlyProperties >,
+			product: Omit< Partial< Product >, ReadOnlyProperties >,
 			status: ProductStatus,
 			skipNotice = false
 		) => {
@@ -259,17 +261,17 @@ export function useProductHelper() {
 	): Promise< Product > => {
 		if ( productId ) {
 			return updateProductWithStatus(
-				product.id,
+				productId,
 				product,
 				status,
 				skipNotice
 			);
 		}
 		return createProductWithStatus(
-			{
+			removeReadonlyProperties( {
 				...product,
 				name: product.name || AUTO_DRAFT_NAME,
-			},
+			} ),
 			status,
 			skipNotice
 		);

--- a/plugins/woocommerce-admin/client/products/utils/get-product-error.ts
+++ b/plugins/woocommerce-admin/client/products/utils/get-product-error.ts
@@ -26,8 +26,18 @@ export const getProductError = (
 					{
 						label: __( 'Edit link', 'woocommerce' ),
 						onClick: () => {
-							// Navigate to general tab.
-							// Use context to open modal.
+							(
+								document.querySelector(
+									'#tab-panel-0-general'
+								) as HTMLElement
+							 )?.click();
+							setTimeout( () => {
+								(
+									document.querySelector(
+										'#wooocommerce-product-form__edit-product-link'
+									) as HTMLElement
+								 )?.click();
+							}, 0 );
 						},
 					},
 				],

--- a/plugins/woocommerce-admin/client/products/utils/get-product-error.ts
+++ b/plugins/woocommerce-admin/client/products/utils/get-product-error.ts
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { ProductStatus } from '@woocommerce/data';
+
+export type ProductError = {
+	code: string;
+	message: string;
+	data: Record< string, unknown >;
+};
+
+export const getProductError = (
+	error: ProductError,
+	status: ProductStatus
+) => {
+	if ( error.code === 'product_invalid_sku' ) {
+		return {
+			content: __(
+				'Product with this link already exists.',
+				'woocommerce'
+			),
+			options: {
+				explicitDismiss: true,
+				actions: [
+					{
+						label: __( 'Edit link', 'woocommerce' ),
+						onClick: () => {
+							// Navigate to general tab.
+							// Use context to open modal.
+						},
+					},
+				],
+			},
+		};
+	}
+
+	if ( status === 'publish' ) {
+		return {
+			content: __( 'Failed to publish product.', 'woocommerce' ),
+		};
+	}
+
+	return {
+		content: __( 'Failed to create product.', 'woocommerce' ),
+	};
+};

--- a/plugins/woocommerce-admin/client/products/utils/get-product-permalink-parts.ts
+++ b/plugins/woocommerce-admin/client/products/utils/get-product-permalink-parts.ts
@@ -1,0 +1,12 @@
+/**
+ * Internal dependencies
+ */
+import { getAdminSetting } from '~/utils/admin-settings';
+
+export const PERMALINK_PRODUCT_REGEX = /%(?:postname|pagename)%/;
+
+export const getProductPermalinkParts = () => {
+	return getAdminSetting( 'productPermalinkTemplate' ).split(
+		PERMALINK_PRODUCT_REGEX
+	);
+};

--- a/plugins/woocommerce/changelog/add-36317-draft-product-link
+++ b/plugins/woocommerce/changelog/add-36317-draft-product-link
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+New product experience: Allow unsaved products to edit product links


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds better error messages around duplicate or invalid SKUs.

Closes #36317  .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Navigate to the new product editor
2. Create a product with a sku that has already been used
3. Click "Publish"
4. Note the error message appears
5. Click "Edit link"
6. Make sure that the action opens the edit link modal

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
