### PR TITLE
Disable product info in Status Widget when stock management is disabled

### DIFF
--- a/plugins/woocommerce/changelog/fix-dashboard-sales-widget
+++ b/plugins/woocommerce/changelog/fix-dashboard-sales-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Do not display low/out-of-stock information in the dashboard status widget when stock management is disabled.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard.php
@@ -183,7 +183,9 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 			}
 
 			$this->status_widget_order_rows();
-			$this->status_widget_stock_rows( $is_wc_admin_disabled );
+			if ( get_option( 'woocommerce_manage_stock' ) === 'yes' ) {
+				$this->status_widget_stock_rows( $is_wc_admin_disabled );
+			}
 
 			do_action( 'woocommerce_after_dashboard_status_widget', $reports );
 			echo '</ul>';


### PR DESCRIPTION
There's no need to show the two products cells in Status Widget table when stock management is disabled, otherwise you'll get 2 links pointing nowhere (specific report pages are disabled and you'll get an "unauthorized" error)

### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Product's stock infos are always displayed in Status Widget, regardless of Stock Management option

When stock management is disabled, the two links contained in product cells of status widget table will point to disabled pages and give an "unauthorized error"

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Disable stock management
2. Go to dashboard home page
3. Check that no product cell is shown in Status widget

<img src="https://user-images.githubusercontent.com/3594411/215845918-83253f5b-8c34-42d2-b60e-7c85820e5b63.png" width="60%" />

☝🏽 Shows the low/out-of-stock warnings that currently render, even when stock management is disabled. Of course, you may need some products that are actually low inventory/out of stock to see something similar.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
