### PR TITLE
Allows developers to add their own filters to the active filters list

### DIFF
--- a/changelog/pr-36705
+++ b/changelog/pr-36705
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Added `woocommerce_widget_layered_nav_filters_start/end` hooks around layered nav filters widget

--- a/plugins/woocommerce/changelog/pr-36705
+++ b/plugins/woocommerce/changelog/pr-36705
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Added `woocommerce_widget_layered_nav_filters_start/end` hooks around layered nav filters widget

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-layered-nav-filters.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-layered-nav-filters.php
@@ -59,6 +59,8 @@ class WC_Widget_Layered_Nav_Filters extends WC_Widget {
 			/**
 			 * Allow 3rd party developers to add their own filters to start the Layered Navigation Filters Widget.
 			 *
+			 * @since 7.6.0
+			 *
 			 * @param array $args     Arguments.
 			 * @param array $instance Widget instance.
 			 */
@@ -115,6 +117,8 @@ class WC_Widget_Layered_Nav_Filters extends WC_Widget {
 
 			/**
 			 * Allow 3rd party developers to add their own filters to end the Layered Navigation Filters Widget.
+			 *
+			 * @since 7.6.0
 			 *
 			 * @param array $args     Arguments.
 			 * @param array $instance Widget instance.

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-layered-nav-filters.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-layered-nav-filters.php
@@ -55,6 +55,8 @@ class WC_Widget_Layered_Nav_Filters extends WC_Widget {
 			$this->widget_start( $args, $instance );
 
 			echo '<ul>';
+			
+			do_action( 'woocommerce_widget_layered_nav_filters_start' );
 
 			// Attributes.
 			if ( ! empty( $_chosen_attributes ) ) {
@@ -104,6 +106,8 @@ class WC_Widget_Layered_Nav_Filters extends WC_Widget {
 					echo '<li class="chosen"><a rel="nofollow" aria-label="' . esc_attr__( 'Remove filter', 'woocommerce' ) . '" href="' . esc_url( $link ) . '">' . sprintf( esc_html__( 'Rated %s out of 5', 'woocommerce' ), esc_html( $rating ) ) . '</a></li>';
 				}
 			}
+			
+			do_action( 'woocommerce_widget_layered_nav_filters_end' );
 
 			echo '</ul>';
 

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-layered-nav-filters.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-layered-nav-filters.php
@@ -55,8 +55,14 @@ class WC_Widget_Layered_Nav_Filters extends WC_Widget {
 			$this->widget_start( $args, $instance );
 
 			echo '<ul>';
-			
-			do_action( 'woocommerce_widget_layered_nav_filters_start' );
+
+			/**
+			 * Allow 3rd party developers to add their own filters to start the Layered Navigation Filters Widget.
+			 *
+			 * @param array $args     Arguments.
+			 * @param array $instance Widget instance.
+			 */
+			do_action( 'woocommerce_widget_layered_nav_filters_start', $args, $instance );
 
 			// Attributes.
 			if ( ! empty( $_chosen_attributes ) ) {
@@ -106,8 +112,14 @@ class WC_Widget_Layered_Nav_Filters extends WC_Widget {
 					echo '<li class="chosen"><a rel="nofollow" aria-label="' . esc_attr__( 'Remove filter', 'woocommerce' ) . '" href="' . esc_url( $link ) . '">' . sprintf( esc_html__( 'Rated %s out of 5', 'woocommerce' ), esc_html( $rating ) ) . '</a></li>';
 				}
 			}
-			
-			do_action( 'woocommerce_widget_layered_nav_filters_end' );
+
+			/**
+			 * Allow 3rd party developers to add their own filters to end the Layered Navigation Filters Widget.
+			 *
+			 * @param array $args     Arguments.
+			 * @param array $instance Widget instance.
+			 */
+			do_action( 'woocommerce_widget_layered_nav_filters_end', $args, $instance );
 
 			echo '</ul>';
 


### PR DESCRIPTION
Fixes #36704

### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #36704 allowing developers to add their own custom filters to the active filters widget

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [x] This PR is a very minor change/addition and does not require testing instructions

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
