### PR TITLE
Use products data store for getPermalinkParts selector

### DIFF
--- a/packages/js/data/changelog/update-get-permalinks-parts-selector
+++ b/packages/js/data/changelog/update-get-permalinks-parts-selector
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Use products data store for getPermalinkParts selector.

--- a/packages/js/data/src/products/index.ts
+++ b/packages/js/data/src/products/index.ts
@@ -19,7 +19,6 @@ registerStore< State >( STORE_NAME, {
 	reducer: reducer as Reducer< ProductState >,
 	actions,
 	controls,
-	// @ts-expect-error as the registerStore type is not allowing the createRegistrySelector selector.
 	selectors,
 	resolvers,
 } );

--- a/packages/js/data/src/products/resolvers.ts
+++ b/packages/js/data/src/products/resolvers.ts
@@ -2,12 +2,17 @@
  * External dependencies
  */
 import { addQueryArgs } from '@wordpress/url';
-import { apiFetch } from '@wordpress/data-controls';
+import {
+	apiFetch,
+	dispatch as deprecatedDispatch,
+	select,
+} from '@wordpress/data-controls';
+import { controls } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import { WC_PRODUCT_NAMESPACE } from './constants';
+import { STORE_NAME, WC_PRODUCT_NAMESPACE } from './constants';
 import { Product, ProductQuery } from './types';
 import {
 	getProductError,
@@ -18,6 +23,11 @@ import {
 	getProductSuccess,
 } from './actions';
 import { request } from '../utils';
+
+const dispatch =
+	controls && controls.dispatch ? controls.dispatch : deprecatedDispatch;
+const resolveSelect =
+	controls && controls.resolveSelect ? controls.resolveSelect : select;
 
 export function* getProducts( query: Partial< ProductQuery > ) {
 	// id is always required.
@@ -56,6 +66,11 @@ export function* getProduct( productId: number ) {
 		} );
 
 		yield getProductSuccess( productId, product );
+
+		yield dispatch( STORE_NAME, 'finishResolution', 'getPermalinkParts', [
+			productId,
+		] );
+
 		return product;
 	} catch ( error ) {
 		yield getProductError( productId, error );
@@ -80,4 +95,8 @@ export function* getProductsTotalCount( query: Partial< ProductQuery > ) {
 		yield getProductsTotalCountError( query, error );
 		throw error;
 	}
+}
+
+export function* getPermalinkParts( productId: number ) {
+	yield resolveSelect( STORE_NAME, 'getProduct', [ productId ] );
 }

--- a/packages/js/data/src/products/selectors.ts
+++ b/packages/js/data/src/products/selectors.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import createSelector from 'rememo';
-import { createRegistrySelector } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -122,38 +121,24 @@ export const isPending = (
 	return false;
 };
 
-export const getPermalinkParts = createRegistrySelector(
-	( select ) => ( state: ProductState, productId: number ) => {
-		const product = select( 'core' ).getEntityRecord(
-			'postType',
-			'product',
-			productId,
-			// @ts-expect-error query object is not part of the @wordpress/core-data types yet.
-			{
-				_fields: [
-					'id',
-					'permalink_template',
-					'slug',
-					'generated_slug',
-				],
-			}
+export const getPermalinkParts = ( state: ProductState, productId: number ) => {
+	const product = state.data[ productId ];
+
+	if ( product && product.permalink_template ) {
+		const postName = product.slug || product.generated_slug;
+
+		const [ prefix, suffix ] = product.permalink_template.split(
+			PERMALINK_PRODUCT_REGEX
 		);
-		if ( product && product.permalink_template ) {
-			const postName = product.slug || product.generated_slug;
 
-			const [ prefix, suffix ] = product.permalink_template.split(
-				PERMALINK_PRODUCT_REGEX
-			);
-
-			return {
-				prefix,
-				postName,
-				suffix,
-			};
-		}
-		return null;
+		return {
+			prefix,
+			postName,
+			suffix,
+		};
 	}
-);
+	return null;
+};
 
 export type ProductsSelectors = {
 	getCreateProductError: WPDataSelector< typeof getCreateProductError >;
@@ -162,7 +147,5 @@ export type ProductsSelectors = {
 	getProductsTotalCount: WPDataSelector< typeof getProductsTotalCount >;
 	getProductsError: WPDataSelector< typeof getProductsError >;
 	isPending: WPDataSelector< typeof isPending >;
-	getPermalinkParts: (
-		productId: number
-	) => { prefix: string; postName: string; suffix: string } | null;
+	getPermalinkParts: WPDataSelector< typeof getPermalinkParts >;
 } & WPDataSelectors;

--- a/packages/js/data/src/products/types.ts
+++ b/packages/js/data/src/products/types.ts
@@ -66,6 +66,7 @@ export type Product< Status = ProductStatus, Type = ProductType > = Omit<
 	downloads: ProductDownload[];
 	external_url: string;
 	featured: boolean;
+	generated_slug: string;
 	id: number;
 	low_stock_amount: number;
 	manage_stock: boolean;
@@ -73,6 +74,7 @@ export type Product< Status = ProductStatus, Type = ProductType > = Omit<
 	name: string;
 	on_sale: boolean;
 	permalink: string;
+	permalink_template: string;
 	price: string;
 	price_html: string;
 	purchasable: boolean;
@@ -108,9 +110,11 @@ export const productReadOnlyProperties = [
 	'date_created_gmt',
 	'date_modified',
 	'date_modified_gmt',
+	'generated_slug',
 	'id',
 	'on_sale',
 	'permalink',
+	'permalink_template',
 	'price',
 	'price_html',
 	'purchasable',


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR changes the `getPermalinkParts` selector to use the products data store instead of making a separate HTTP request to the server.

This results in one less network request when a product draft is saved.

Closes #34312 .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

Using the new product editor (enable in WooCommerce > Settings > Advanced > Features)...

1. In the Network tab of the browser developer tools, filter for `permalink`
2. Create a new Product (Products > Add New) and save it as a draft.
3. Verify that no requests matching `permalink` show up in the Network tab.

To test the resolver:

1. In the browser dev tools console...

```
wp.data.select('wc/admin/products').getPermalinkParts({PRODUCT_ID})
```

2. In the network tab, verify only a single `GET` to `/wp-json/wc/v3/products/{PRODUCT_ID}` is made.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
