### PR TITLE
Refactor createOrderedChildren

### DIFF
--- a/packages/js/components/changelog/fix-36614_refactor_create_ordered_children
+++ b/packages/js/components/changelog/fix-36614_refactor_create_ordered_children
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Refactor createOrderedChildren

--- a/packages/js/components/src/utils.tsx
+++ b/packages/js/components/src/utils.tsx
@@ -16,7 +16,7 @@ type ChildrenProps = {
  * @param {Node}   children    - Node children.
  * @param {number} order       - Node order.
  * @param {Array}  props       - Fill props.
- * @param {Object} injectProps - Injected props.
+ * @param {Object} injectProps - Props to inject.
  * @return {Object} Object with the keys: children and props.
  */
 function getChildrenAndProps< T = Fill.Props, S = Record< string, unknown > >(
@@ -55,7 +55,7 @@ function getChildrenAndProps< T = Fill.Props, S = Record< string, unknown > >(
  * @param {Node}   children    - Node children.
  * @param {number} order       - Node order.
  * @param {Array}  props       - Fill props.
- * @param {Object} injectProps - Injected props.
+ * @param {Object} injectProps - Props to inject.
  * @return {Node} Node.
  */
 function createOrderedChildren< T = Fill.Props, S = Record< string, unknown > >(

--- a/packages/js/components/src/utils.tsx
+++ b/packages/js/components/src/utils.tsx
@@ -31,6 +31,7 @@ function getChildrenAndProps< T = Fill.Props, S = Record< string, unknown > >(
 			props: { order, ...injectProps },
 		};
 	} else if ( isValidElement( children ) ) {
+		// This checks whether 'children' is a react element or a standard HTML element.
 		if ( typeof children?.type === 'function' ) {
 			return {
 				children,

--- a/packages/js/components/src/utils.tsx
+++ b/packages/js/components/src/utils.tsx
@@ -10,11 +10,51 @@ type ChildrenProps = {
 };
 
 /**
+ * Returns an object with the children and props that will be used by cloneElement.
+ *
+ * @param {Node}   children    - Node children.
+ * @param {number} order       - Node order.
+ * @param {Array}  props       - Fill props.
+ * @param {Object} injectProps - Injected props.
+ * @return {Node} Node.
+ */
+function getChildrenAndProps< T = Fill.Props, S = Record< string, unknown > >(
+	children: React.ReactNode,
+	order: number,
+	props: T,
+	injectProps?: S
+) {
+	if ( typeof children === 'function' ) {
+		return {
+			children: children( { ...props, order, ...injectProps } ),
+			props: { order, ...injectProps },
+		};
+	} else if ( isValidElement( children ) ) {
+		if ( typeof children?.type === 'function' ) {
+			return {
+				children,
+				props: {
+					...props,
+					order,
+					...injectProps,
+				},
+			};
+		}
+		return {
+			children: children as React.ReactElement< ChildrenProps >,
+			props: { order },
+		};
+	}
+	throw Error( 'Invalid children type' );
+}
+
+/**
  * Ordered fill item.
  *
- * @param {Node}   children - Node children.
- * @param {number} order    - Node order.
- * @param {Array}  props    - Fill props.
+ * @param {Node}   children    - Node children.
+ * @param {number} order       - Node order.
+ * @param {Array}  props       - Fill props.
+ * @param {Object} injectProps - Injected props.
  * @return {Node} Node.
  */
 function createOrderedChildren< T = Fill.Props, S = Record< string, unknown > >(
@@ -23,25 +63,9 @@ function createOrderedChildren< T = Fill.Props, S = Record< string, unknown > >(
 	props: T,
 	injectProps?: S
 ) {
-	if ( typeof children === 'function' ) {
-		return cloneElement( children( { ...props, order, ...injectProps } ), {
-			order,
-			...injectProps,
-		} );
-	} else if ( isValidElement( children ) ) {
-		if ( typeof children?.type === 'function' ) {
-			return cloneElement( children, {
-				...props,
-				order,
-				...injectProps,
-			} );
-		}
-		return cloneElement( children as React.ReactElement< ChildrenProps >, {
-			order,
-			...injectProps,
-		} );
-	}
-	throw Error( 'Invalid children type' );
+	const { children: childrenToRender, props: propsToRender } =
+		getChildrenAndProps( children, order, props, injectProps );
+	return cloneElement( childrenToRender, propsToRender );
 }
 export { createOrderedChildren };
 

--- a/packages/js/components/src/utils.tsx
+++ b/packages/js/components/src/utils.tsx
@@ -17,7 +17,7 @@ type ChildrenProps = {
  * @param {number} order       - Node order.
  * @param {Array}  props       - Fill props.
  * @param {Object} injectProps - Injected props.
- * @return {Node} Node.
+ * @return {Object} Object with the keys: children and props.
  */
 function getChildrenAndProps< T = Fill.Props, S = Record< string, unknown > >(
 	children: React.ReactNode,
@@ -56,7 +56,7 @@ function getChildrenAndProps< T = Fill.Props, S = Record< string, unknown > >(
  * @param {number} order       - Node order.
  * @param {Array}  props       - Fill props.
  * @param {Object} injectProps - Injected props.
- * @return {Object} Object with the keys: children and props.
+ * @return {Node} Node.
  */
 function createOrderedChildren< T = Fill.Props, S = Record< string, unknown > >(
 	children: React.ReactNode,

--- a/packages/js/components/src/utils.tsx
+++ b/packages/js/components/src/utils.tsx
@@ -10,7 +10,8 @@ type ChildrenProps = {
 };
 
 /**
- * Returns an object with the children and props that will be used by cloneElement.
+ * Returns an object with the children and props that will be used by `cloneElement`. They will change depending on the
+ * type of children passed in.
  *
  * @param {Node}   children    - Node children.
  * @param {number} order       - Node order.
@@ -55,7 +56,7 @@ function getChildrenAndProps< T = Fill.Props, S = Record< string, unknown > >(
  * @param {number} order       - Node order.
  * @param {Array}  props       - Fill props.
  * @param {Object} injectProps - Injected props.
- * @return {Node} Node.
+ * @return {Object} Object with the keys: children and props.
  */
 function createOrderedChildren< T = Fill.Props, S = Record< string, unknown > >(
 	children: React.ReactNode,

--- a/packages/js/components/src/utils.tsx
+++ b/packages/js/components/src/utils.tsx
@@ -5,6 +5,10 @@ import { isValidElement, Fragment } from 'react';
 import { Slot, Fill } from '@wordpress/components';
 import { cloneElement, createElement } from '@wordpress/element';
 
+type ChildrenProps = {
+	order: number;
+};
+
 /**
  * Ordered fill item.
  *
@@ -25,7 +29,17 @@ function createOrderedChildren< T = Fill.Props, S = Record< string, unknown > >(
 			...injectProps,
 		} );
 	} else if ( isValidElement( children ) ) {
-		return cloneElement( children, { ...props, order, ...injectProps } );
+		if ( typeof children?.type === 'function' ) {
+			return cloneElement( children, {
+				...props,
+				order,
+				...injectProps,
+			} );
+		}
+		return cloneElement( children as React.ReactElement< ChildrenProps >, {
+			order,
+			...injectProps,
+		} );
 	}
 	throw Error( 'Invalid children type' );
 }


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR adds the changes to let `createOrderedChildren` handle standard DOM elements like `<div />`.

In order to make the method clearer, I created the method `getChildrenAndProps` to get all the props and children that will be used by `cloneElement`.

Closes #36614.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Create a test field like this
```js
<WooProductFieldItem
	id="my-field-item"
	sections={ [ { name: DETAILS_SECTION_ID, order: 2 } ] }
	pluginId={ PLUGIN_ID }
>
	<div className="my-class">Test field</div>
</WooProductFieldItem>
```

Or checkout this test branch `fix/36614_refactor_create_ordered_children_test` (diff [here](https://github.com/woocommerce/woocommerce/compare/fix/36614_refactor_create_ordered_children...fix/36614_refactor_create_ordered_children_test?expand=1)).
2. Open the browser console and go to `Products` > `Add New`.
3. Verify that the console has no error (or warning).
4. Verify that the field is rendered in the right order.
5. Smoke test the home screen, task list, etc.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
