### PR TITLE
Translate the labels for units of measure

### DIFF
--- a/plugins/woocommerce/changelog/fix-31486-unit-i18n
+++ b/plugins/woocommerce/changelog/fix-31486-unit-i18n
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Translate the labels for units of measure.

--- a/plugins/woocommerce/i18n/units.php
+++ b/plugins/woocommerce/i18n/units.php
@@ -13,16 +13,16 @@ defined( 'ABSPATH' ) || exit;
 
 return array(
 	'weight'     => array(
-		'kg'  => _x( 'kg', 'weight unit kilograms', 'woocommerce' ),
-		'g'   => _x( 'g', 'weight unit grams', 'woocommerce' ),
-		'lbs' => _x( 'lbs', 'weight unit pounds', 'woocommerce' ),
-		'oz'  => _x( 'oz', 'weight unit ounces', 'woocommerce' ),
+		'kg'  => __( 'kg', 'woocommerce' ),
+		'g'   => __( 'g', 'woocommerce' ),
+		'lbs' => __( 'lbs', 'woocommerce' ),
+		'oz'  => __( 'oz', 'woocommerce' ),
 	),
 	'dimensions' => array(
-		'm'  => _x( 'm', 'dimensions unit meters', 'woocommerce' ),
-		'cm' => _x( 'cm', 'dimensions unit centimeters', 'woocommerce' ),
-		'mm' => _x( 'mm', 'dimensions unit millimeters', 'woocommerce' ),
-		'in' => _x( 'in', 'dimensions unit inches', 'woocommerce' ),
-		'yd' => _x( 'yd', 'dimensions unit yards', 'woocommerce' ),
+		'm'  => __( 'm', 'woocommerce' ),
+		'cm' => __( 'cm', 'woocommerce' ),
+		'mm' => __( 'mm', 'woocommerce' ),
+		'in' => __( 'in', 'woocommerce' ),
+		'yd' => __( 'yd', 'woocommerce' ),
 	),
 );

--- a/plugins/woocommerce/i18n/units.php
+++ b/plugins/woocommerce/i18n/units.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Units
+ *
+ * Returns a multidimensional array of measurement units and their labels.
+ * Unit labels should be defined in English and translated native through localization files.
+ *
+ * @package WooCommerce\i18n
+ * @version
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+return array(
+	'weight'     => array(
+		'kg'  => _x( 'kg', 'weight unit kilograms', 'woocommerce' ),
+		'g'   => _x( 'g', 'weight unit grams', 'woocommerce' ),
+		'lbs' => _x( 'lbs', 'weight unit pounds', 'woocommerce' ),
+		'oz'  => _x( 'oz', 'weight unit ounces', 'woocommerce' ),
+	),
+	'dimensions' => array(
+		'm'  => _x( 'm', 'dimensions unit meters', 'woocommerce' ),
+		'cm' => _x( 'cm', 'dimensions unit centimeters', 'woocommerce' ),
+		'mm' => _x( 'mm', 'dimensions unit millimeters', 'woocommerce' ),
+		'in' => _x( 'in', 'dimensions unit inches', 'woocommerce' ),
+		'yd' => _x( 'yd', 'dimensions unit yards', 'woocommerce' ),
+	),
+);

--- a/plugins/woocommerce/includes/admin/importers/class-wc-product-csv-importer-controller.php
+++ b/plugins/woocommerce/includes/admin/importers/class-wc-product-csv-importer-controller.php
@@ -5,6 +5,8 @@
  * @package WooCommerce\Admin\Importers
  */
 
+use Automattic\WooCommerce\Utilities\I18nUtil;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -482,8 +484,8 @@ class WC_Product_CSV_Importer_Controller {
 	 * @return array
 	 */
 	protected function auto_map_columns( $raw_headers, $num_indexes = true ) {
-		$weight_unit    = get_option( 'woocommerce_weight_unit' );
-		$dimension_unit = get_option( 'woocommerce_dimension_unit' );
+		$weight_unit_label    = I18nUtil::get_weight_unit_label( get_option( 'woocommerce_weight_unit', 'kg' ) );
+		$dimension_unit_label = I18nUtil::get_dimensions_unit_label( get_option( 'woocommerce_dimension_unit', 'cm' ) );
 
 		/*
 		 * @hooked wc_importer_generic_mappings - 10
@@ -513,13 +515,13 @@ class WC_Product_CSV_Importer_Controller {
 					__( 'Low stock amount', 'woocommerce' ) => 'low_stock_amount',
 					__( 'Sold individually?', 'woocommerce' ) => 'sold_individually',
 					/* translators: %s: Weight unit */
-					sprintf( __( 'Weight (%s)', 'woocommerce' ), $weight_unit ) => 'weight',
+					sprintf( __( 'Weight (%s)', 'woocommerce' ), $weight_unit_label ) => 'weight',
 					/* translators: %s: Length unit */
-					sprintf( __( 'Length (%s)', 'woocommerce' ), $dimension_unit ) => 'length',
+					sprintf( __( 'Length (%s)', 'woocommerce' ), $dimension_unit_label ) => 'length',
 					/* translators: %s: Width unit */
-					sprintf( __( 'Width (%s)', 'woocommerce' ), $dimension_unit ) => 'width',
+					sprintf( __( 'Width (%s)', 'woocommerce' ), $dimension_unit_label ) => 'width',
 					/* translators: %s: Height unit */
-					sprintf( __( 'Height (%s)', 'woocommerce' ), $dimension_unit ) => 'height',
+					sprintf( __( 'Height (%s)', 'woocommerce' ), $dimension_unit_label ) => 'height',
 					__( 'Allow customer reviews?', 'woocommerce' ) => 'reviews_allowed',
 					__( 'Purchase note', 'woocommerce' )  => 'purchase_note',
 					__( 'Sale price', 'woocommerce' )     => 'sale_price',
@@ -655,9 +657,9 @@ class WC_Product_CSV_Importer_Controller {
 		$meta = str_replace( 'meta:', '', $item );
 
 		// Available options.
-		$weight_unit    = get_option( 'woocommerce_weight_unit' );
-		$dimension_unit = get_option( 'woocommerce_dimension_unit' );
-		$options        = array(
+		$weight_unit_label    = I18nUtil::get_weight_unit_label( get_option( 'woocommerce_weight_unit', 'kg' ) );
+		$dimension_unit_label = I18nUtil::get_dimensions_unit_label( get_option( 'woocommerce_dimension_unit', 'cm' ) );
+		$options              = array(
 			'id'                 => __( 'ID', 'woocommerce' ),
 			'type'               => __( 'Type', 'woocommerce' ),
 			'sku'                => __( 'SKU', 'woocommerce' ),
@@ -684,16 +686,16 @@ class WC_Product_CSV_Importer_Controller {
 			'low_stock_amount'   => __( 'Low stock amount', 'woocommerce' ),
 			'sold_individually'  => __( 'Sold individually?', 'woocommerce' ),
 			/* translators: %s: weight unit */
-			'weight'             => sprintf( __( 'Weight (%s)', 'woocommerce' ), $weight_unit ),
+			'weight'             => sprintf( __( 'Weight (%s)', 'woocommerce' ), $weight_unit_label ),
 			'dimensions'         => array(
 				'name'    => __( 'Dimensions', 'woocommerce' ),
 				'options' => array(
 					/* translators: %s: dimension unit */
-					'length' => sprintf( __( 'Length (%s)', 'woocommerce' ), $dimension_unit ),
+					'length' => sprintf( __( 'Length (%s)', 'woocommerce' ), $dimension_unit_label ),
 					/* translators: %s: dimension unit */
-					'width'  => sprintf( __( 'Width (%s)', 'woocommerce' ), $dimension_unit ),
+					'width'  => sprintf( __( 'Width (%s)', 'woocommerce' ), $dimension_unit_label ),
 					/* translators: %s: dimension unit */
-					'height' => sprintf( __( 'Height (%s)', 'woocommerce' ), $dimension_unit ),
+					'height' => sprintf( __( 'Height (%s)', 'woocommerce' ), $dimension_unit_label ),
 				),
 			),
 			'category_ids'       => __( 'Categories', 'woocommerce' ),

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-shipping.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-shipping.php
@@ -30,8 +30,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 		if ( wc_product_dimensions_enabled() ) {
 			?>
 			<p class="form-field dimensions_field">
-				<?php /* translators: WooCommerce dimension unit*/ ?>
-				<label for="product_length"><?php printf( __( 'Dimensions (%s)', 'woocommerce' ), get_option( 'woocommerce_dimension_unit' ) ); ?></label>
+				<label for="product_length">
+					<?php
+					printf(
+						/* translators: WooCommerce dimension unit */
+						esc_html__( 'Dimensions (%s)', 'woocommerce' ),
+						esc_html( I18nUtil::get_dimensions_unit_label( get_option( 'woocommerce_dimension_unit' ) ) )
+					);
+					?>
+				</label>
 				<span class="wrap">
 					<input id="product_length" placeholder="<?php esc_attr_e( 'Length', 'woocommerce' ); ?>" class="input-text wc_input_decimal" size="6" type="text" name="_length" value="<?php echo esc_attr( wc_format_localized_decimal( $product_object->get_length( 'edit' ) ) ); ?>" />
 					<input id="product_width" placeholder="<?php esc_attr_e( 'Width', 'woocommerce' ); ?>" class="input-text wc_input_decimal" size="6" type="text" name="_width" value="<?php echo esc_attr( wc_format_localized_decimal( $product_object->get_width( 'edit' ) ) ); ?>" />

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-shipping.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-shipping.php
@@ -1,4 +1,6 @@
 <?php
+use Automattic\WooCommerce\Utilities\I18nUtil;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -11,7 +13,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 				array(
 					'id'          => '_weight',
 					'value'       => $product_object->get_weight( 'edit' ),
-					'label'       => __( 'Weight', 'woocommerce' ) . ' (' . get_option( 'woocommerce_weight_unit' ) . ')',
+					'label'       => sprintf(
+						/* translators: %s: Weight unit */
+						__( 'Weight (%s)', 'woocommerce' ),
+						I18nUtil::get_weight_unit_label( get_option( 'woocommerce_weight_unit', 'kg' ) )
+					),
 					'placeholder' => wc_format_localized_decimal( 0 ),
 					'desc_tip'    => true,
 					'description' => __( 'Weight in decimal form', 'woocommerce' ),

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-variation-admin.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-variation-admin.php
@@ -9,6 +9,8 @@
  * @var array $variation_data array of variation data @deprecated 4.4.0.
  */
 
+use Automattic\WooCommerce\Utilities\I18nUtil;
+
 defined( 'ABSPATH' ) || exit;
 
 ?>
@@ -279,9 +281,9 @@ defined( 'ABSPATH' ) || exit;
 
 				if ( wc_product_weight_enabled() ) {
 					$label = sprintf(
-						/* translators: %s: weight unit */
+						/* translators: %s: Weight unit */
 						__( 'Weight (%s)', 'woocommerce' ),
-						esc_html( get_option( 'woocommerce_weight_unit' ) )
+						I18nUtil::get_weight_unit_label( get_option( 'woocommerce_weight_unit', 'kg' ) )
 					);
 
 					woocommerce_wp_text_input(

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-variation-admin.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-variation-admin.php
@@ -312,9 +312,9 @@ defined( 'ABSPATH' ) || exit;
 						<label for="product_length">
 							<?php
 							printf(
-								/* translators: %s: dimension unit */
+								/* translators: %s dimension unit */
 								esc_html__( 'Dimensions (L&times;W&times;H) (%s)', 'woocommerce' ),
-								esc_html( get_option( 'woocommerce_dimension_unit' ) )
+								esc_html( I18nUtil::get_dimensions_unit_label( get_option( 'woocommerce_dimension_unit' ) ) )
 							);
 							?>
 						</label>

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-products.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-products.php
@@ -6,6 +6,8 @@
  * @version 2.4.0
  */
 
+use Automattic\WooCommerce\Utilities\I18nUtil;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -112,10 +114,10 @@ class WC_Settings_Products extends WC_Settings_Page {
 					'default'  => 'kg',
 					'type'     => 'select',
 					'options'  => array(
-						'kg'  => __( 'kg', 'woocommerce' ),
-						'g'   => __( 'g', 'woocommerce' ),
-						'lbs' => __( 'lbs', 'woocommerce' ),
-						'oz'  => __( 'oz', 'woocommerce' ),
+						'kg'  => I18nUtil::get_weight_unit_label( 'kg' ),
+						'g'   => I18nUtil::get_weight_unit_label( 'g' ),
+						'lbs' => I18nUtil::get_weight_unit_label( 'lbs' ),
+						'oz'  => I18nUtil::get_weight_unit_label( 'oz' ),
 					),
 					'desc_tip' => true,
 				),
@@ -129,11 +131,11 @@ class WC_Settings_Products extends WC_Settings_Page {
 					'default'  => 'cm',
 					'type'     => 'select',
 					'options'  => array(
-						'm'  => __( 'm', 'woocommerce' ),
-						'cm' => __( 'cm', 'woocommerce' ),
-						'mm' => __( 'mm', 'woocommerce' ),
-						'in' => __( 'in', 'woocommerce' ),
-						'yd' => __( 'yd', 'woocommerce' ),
+						'm'  => I18nUtil::get_dimensions_unit_label( 'm' ),
+						'cm' => I18nUtil::get_dimensions_unit_label( 'cm' ),
+						'mm' => I18nUtil::get_dimensions_unit_label( 'mm' ),
+						'in' => I18nUtil::get_dimensions_unit_label( 'in' ),
+						'yd' => I18nUtil::get_dimensions_unit_label( 'yd' ),
 					),
 					'desc_tip' => true,
 				),

--- a/plugins/woocommerce/includes/admin/views/html-bulk-edit-product.php
+++ b/plugins/woocommerce/includes/admin/views/html-bulk-edit-product.php
@@ -179,7 +179,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 						name="_length"
 						class="text length"
 						<?php /* translators: %s is dimension unit label */ ?>
-						placeholder="<?php printf( esc_attr__( 'Length (%s)', 'woocommerce' ), $dimension_unit_label ); ?>"
+						placeholder="<?php printf( esc_attr__( 'Length (%s)', 'woocommerce' ), esc_html( $dimension_unit_label ) ); ?>"
 						value=""
 					>
 					<input
@@ -187,7 +187,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 						name="_width"
 						class="text width"
 						<?php /* translators: %s is dimension unit label */ ?>
-						placeholder="<?php printf( esc_attr__( 'Width (%s)', 'woocommerce' ), $dimension_unit_label ); ?>"
+						placeholder="<?php printf( esc_attr__( 'Width (%s)', 'woocommerce' ), esc_html( $dimension_unit_label ) ); ?>"
 						value=""
 					>
 					<input
@@ -195,7 +195,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 						name="_height"
 						class="text height"
 						<?php /* translators: %s is dimension unit label */ ?>
-						placeholder="<?php printf( esc_attr__( 'Height (%s)', 'woocommerce' ), $dimension_unit_label ); ?>"
+						placeholder="<?php printf( esc_attr__( 'Height (%s)', 'woocommerce' ), esc_html( $dimension_unit_label ) ); ?>"
 						value=""
 					>
 				</label>

--- a/plugins/woocommerce/includes/admin/views/html-bulk-edit-product.php
+++ b/plugins/woocommerce/includes/admin/views/html-bulk-edit-product.php
@@ -171,9 +171,33 @@ if ( ! defined( 'ABSPATH' ) ) {
 					</span>
 				</label>
 				<label class="change-input">
-					<input type="text" name="_length" class="text length" placeholder="<?php printf( esc_attr__( 'Length (%s)', 'woocommerce' ), get_option( 'woocommerce_dimension_unit' ) ); ?>" value="">
-					<input type="text" name="_width" class="text width" placeholder="<?php printf( esc_attr__( 'Width (%s)', 'woocommerce' ), get_option( 'woocommerce_dimension_unit' ) ); ?>" value="">
-					<input type="text" name="_height" class="text height" placeholder="<?php printf( esc_attr__( 'Height (%s)', 'woocommerce' ), get_option( 'woocommerce_dimension_unit' ) ); ?>" value="">
+					<?php
+					$dimension_unit_label = I18nUtil::get_dimensions_unit_label( get_option( 'woocommerce_dimension_unit', 'cm' ) );
+					?>
+					<input
+						type="text"
+						name="_length"
+						class="text length"
+						<?php /* translators: %s is dimension unit label */ ?>
+						placeholder="<?php printf( esc_attr__( 'Length (%s)', 'woocommerce' ), $dimension_unit_label ); ?>"
+						value=""
+					>
+					<input
+						type="text"
+						name="_width"
+						class="text width"
+						<?php /* translators: %s is dimension unit label */ ?>
+						placeholder="<?php printf( esc_attr__( 'Width (%s)', 'woocommerce' ), $dimension_unit_label ); ?>"
+						value=""
+					>
+					<input
+						type="text"
+						name="_height"
+						class="text height"
+						<?php /* translators: %s is dimension unit label */ ?>
+						placeholder="<?php printf( esc_attr__( 'Height (%s)', 'woocommerce' ), $dimension_unit_label ); ?>"
+						value=""
+					>
 				</label>
 			</div>
 		<?php endif; ?>

--- a/plugins/woocommerce/includes/admin/views/html-bulk-edit-product.php
+++ b/plugins/woocommerce/includes/admin/views/html-bulk-edit-product.php
@@ -3,6 +3,8 @@
  * Admin View: Bulk Edit Products
  */
 
+use Automattic\WooCommerce\Utilities\I18nUtil;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
@@ -131,7 +133,21 @@ if ( ! defined( 'ABSPATH' ) ) {
 					</span>
 				</label>
 				<label class="change-input">
-					<input type="text" name="_weight" class="text weight" placeholder="<?php printf( esc_attr__( '%1$s (%2$s)', 'woocommerce' ), wc_format_localized_decimal( 0 ), get_option( 'woocommerce_weight_unit' ) ); ?>" value="">
+					<?php
+					$placeholder = sprintf(
+						/* translators: 1. Weight number; 2. Weight unit; E.g. 2 kg */
+						__( '%1$s (%2$s)', 'woocommerce' ),
+						wc_format_localized_decimal( 0 ),
+						I18nUtil::get_weight_unit_label( get_option( 'woocommerce_weight_unit', 'kg' ) )
+					);
+					?>
+					<input
+						type="text"
+						name="_weight"
+						class="text weight"
+						placeholder="<?php echo esc_attr( $placeholder ); ?>"
+						value=""
+					>
 				</label>
 			</div>
 		<?php endif; ?>

--- a/plugins/woocommerce/includes/export/class-wc-product-csv-exporter.php
+++ b/plugins/woocommerce/includes/export/class-wc-product-csv-exporter.php
@@ -6,6 +6,8 @@
  * @version 3.1.0
  */
 
+use Automattic\WooCommerce\Utilities\I18nUtil;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -99,6 +101,9 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	 * @return array
 	 */
 	public function get_default_column_names() {
+		$weight_unit_label    = I18nUtil::get_weight_unit_label( get_option( 'woocommerce_weight_unit', 'kg' ) );
+		$dimension_unit_label = I18nUtil::get_dimensions_unit_label( get_option( 'woocommerce_dimension_unit', 'cm' ) );
+
 		return apply_filters(
 			"woocommerce_product_export_{$this->export_type}_default_columns",
 			array(
@@ -121,13 +126,13 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 				'backorders'         => __( 'Backorders allowed?', 'woocommerce' ),
 				'sold_individually'  => __( 'Sold individually?', 'woocommerce' ),
 				/* translators: %s: weight */
-				'weight'             => sprintf( __( 'Weight (%s)', 'woocommerce' ), get_option( 'woocommerce_weight_unit' ) ),
+				'weight'             => sprintf( __( 'Weight (%s)', 'woocommerce' ), $weight_unit_label ),
 				/* translators: %s: length */
-				'length'             => sprintf( __( 'Length (%s)', 'woocommerce' ), get_option( 'woocommerce_dimension_unit' ) ),
+				'length'             => sprintf( __( 'Length (%s)', 'woocommerce' ), $dimension_unit_label ),
 				/* translators: %s: width */
-				'width'              => sprintf( __( 'Width (%s)', 'woocommerce' ), get_option( 'woocommerce_dimension_unit' ) ),
+				'width'              => sprintf( __( 'Width (%s)', 'woocommerce' ), $dimension_unit_label ),
 				/* translators: %s: Height */
-				'height'             => sprintf( __( 'Height (%s)', 'woocommerce' ), get_option( 'woocommerce_dimension_unit' ) ),
+				'height'             => sprintf( __( 'Height (%s)', 'woocommerce' ), $dimension_unit_label ),
 				'reviews_allowed'    => __( 'Allow customer reviews?', 'woocommerce' ),
 				'purchase_note'      => __( 'Purchase note', 'woocommerce' ),
 				'sale_price'         => __( 'Sale price', 'woocommerce' ),

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-products-v1-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-products-v1-controller.php
@@ -1732,7 +1732,7 @@ class WC_REST_Products_V1_Controller extends WC_REST_Posts_Controller {
 	public function get_item_schema() {
 		$weight_unit_label    = I18nUtil::get_weight_unit_label( get_option( 'woocommerce_weight_unit', 'kg' ) );
 		$dimension_unit_label = I18nUtil::get_dimensions_unit_label( get_option( 'woocommerce_dimension_unit', 'cm' ) );
-		$schema         = array(
+		$schema               = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
 			'title'      => $this->post_type,
 			'type'       => 'object',

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-products-v1-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-products-v1-controller.php
@@ -10,6 +10,8 @@
  * @since    3.0.0
  */
 
+use Automattic\WooCommerce\Utilities\I18nUtil;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -1728,8 +1730,8 @@ class WC_REST_Products_V1_Controller extends WC_REST_Posts_Controller {
 	 * @return array
 	 */
 	public function get_item_schema() {
-		$weight_unit    = get_option( 'woocommerce_weight_unit' );
-		$dimension_unit = get_option( 'woocommerce_dimension_unit' );
+		$weight_unit_label    = I18nUtil::get_weight_unit_label( get_option( 'woocommerce_weight_unit', 'kg' ) );
+		$dimension_unit_label = I18nUtil::get_dimensions_unit_label( get_option( 'woocommerce_dimension_unit', 'cm' ) );
 		$schema         = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
 			'title'      => $this->post_type,
@@ -1985,7 +1987,7 @@ class WC_REST_Products_V1_Controller extends WC_REST_Posts_Controller {
 				),
 				'weight' => array(
 					/* translators: %s: weight unit */
-					'description' => sprintf( __( 'Product weight (%s).', 'woocommerce' ), $weight_unit ),
+					'description' => sprintf( __( 'Product weight (%s).', 'woocommerce' ), $weight_unit_label ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 				),
@@ -1996,19 +1998,19 @@ class WC_REST_Products_V1_Controller extends WC_REST_Posts_Controller {
 					'properties'  => array(
 						'length' => array(
 							/* translators: %s: dimension unit */
-							'description' => sprintf( __( 'Product length (%s).', 'woocommerce' ), $dimension_unit ),
+							'description' => sprintf( __( 'Product length (%s).', 'woocommerce' ), $dimension_unit_label ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),
 						'width' => array(
 							/* translators: %s: dimension unit */
-							'description' => sprintf( __( 'Product width (%s).', 'woocommerce' ), $dimension_unit ),
+							'description' => sprintf( __( 'Product width (%s).', 'woocommerce' ), $dimension_unit_label ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),
 						'height' => array(
 							/* translators: %s: dimension unit */
-							'description' => sprintf( __( 'Product height (%s).', 'woocommerce' ), $dimension_unit ),
+							'description' => sprintf( __( 'Product height (%s).', 'woocommerce' ), $dimension_unit_label ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),
@@ -2438,7 +2440,7 @@ class WC_REST_Products_V1_Controller extends WC_REST_Posts_Controller {
 							),
 							'weight' => array(
 								/* translators: %s: weight unit */
-								'description' => sprintf( __( 'Variation weight (%s).', 'woocommerce' ), $weight_unit ),
+								'description' => sprintf( __( 'Variation weight (%s).', 'woocommerce' ), $weight_unit_label ),
 								'type'        => 'string',
 								'context'     => array( 'view', 'edit' ),
 							),
@@ -2449,19 +2451,19 @@ class WC_REST_Products_V1_Controller extends WC_REST_Posts_Controller {
 								'properties'  => array(
 									'length' => array(
 										/* translators: %s: dimension unit */
-										'description' => sprintf( __( 'Variation length (%s).', 'woocommerce' ), $dimension_unit ),
+										'description' => sprintf( __( 'Variation length (%s).', 'woocommerce' ), $dimension_unit_label ),
 										'type'        => 'string',
 										'context'     => array( 'view', 'edit' ),
 									),
 									'width' => array(
 										/* translators: %s: dimension unit */
-										'description' => sprintf( __( 'Variation width (%s).', 'woocommerce' ), $dimension_unit ),
+										'description' => sprintf( __( 'Variation width (%s).', 'woocommerce' ), $dimension_unit_label ),
 										'type'        => 'string',
 										'context'     => array( 'view', 'edit' ),
 									),
 									'height' => array(
 										/* translators: %s: dimension unit */
-										'description' => sprintf( __( 'Variation height (%s).', 'woocommerce' ), $dimension_unit ),
+										'description' => sprintf( __( 'Variation height (%s).', 'woocommerce' ), $dimension_unit_label ),
 										'type'        => 'string',
 										'context'     => array( 'view', 'edit' ),
 									),

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-product-variations-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-product-variations-v2-controller.php
@@ -8,6 +8,8 @@
  * @since   3.0.0
  */
 
+use Automattic\WooCommerce\Utilities\I18nUtil;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -640,8 +642,8 @@ class WC_REST_Product_Variations_V2_Controller extends WC_REST_Products_V2_Contr
 	 * @return array
 	 */
 	public function get_item_schema() {
-		$weight_unit    = get_option( 'woocommerce_weight_unit' );
-		$dimension_unit = get_option( 'woocommerce_dimension_unit' );
+		$weight_unit_label    = I18nUtil::get_weight_unit_label( get_option( 'woocommerce_weight_unit', 'kg' ) );
+		$dimension_unit_label = I18nUtil::get_dimensions_unit_label( get_option( 'woocommerce_dimension_unit', 'cm' ) );
 		$schema         = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
 			'title'      => $this->post_type,
@@ -835,7 +837,7 @@ class WC_REST_Product_Variations_V2_Controller extends WC_REST_Products_V2_Contr
 				),
 				'weight'                => array(
 					/* translators: %s: weight unit */
-					'description' => sprintf( __( 'Variation weight (%s).', 'woocommerce' ), $weight_unit ),
+					'description' => sprintf( __( 'Variation weight (%s).', 'woocommerce' ), $weight_unit_label ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 				),
@@ -846,19 +848,19 @@ class WC_REST_Product_Variations_V2_Controller extends WC_REST_Products_V2_Contr
 					'properties'  => array(
 						'length' => array(
 							/* translators: %s: dimension unit */
-							'description' => sprintf( __( 'Variation length (%s).', 'woocommerce' ), $dimension_unit ),
+							'description' => sprintf( __( 'Variation length (%s).', 'woocommerce' ), $dimension_unit_label ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),
 						'width'  => array(
 							/* translators: %s: dimension unit */
-							'description' => sprintf( __( 'Variation width (%s).', 'woocommerce' ), $dimension_unit ),
+							'description' => sprintf( __( 'Variation width (%s).', 'woocommerce' ), $dimension_unit_label ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),
 						'height' => array(
 							/* translators: %s: dimension unit */
-							'description' => sprintf( __( 'Variation height (%s).', 'woocommerce' ), $dimension_unit ),
+							'description' => sprintf( __( 'Variation height (%s).', 'woocommerce' ), $dimension_unit_label ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-product-variations-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-product-variations-v2-controller.php
@@ -644,7 +644,7 @@ class WC_REST_Product_Variations_V2_Controller extends WC_REST_Products_V2_Contr
 	public function get_item_schema() {
 		$weight_unit_label    = I18nUtil::get_weight_unit_label( get_option( 'woocommerce_weight_unit', 'kg' ) );
 		$dimension_unit_label = I18nUtil::get_dimensions_unit_label( get_option( 'woocommerce_dimension_unit', 'cm' ) );
-		$schema         = array(
+		$schema               = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
 			'title'      => $this->post_type,
 			'type'       => 'object',

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
@@ -1667,7 +1667,7 @@ class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {
 	public function get_item_schema() {
 		$weight_unit_label    = I18nUtil::get_weight_unit_label( get_option( 'woocommerce_weight_unit', 'kg' ) );
 		$dimension_unit_label = I18nUtil::get_dimensions_unit_label( get_option( 'woocommerce_dimension_unit', 'cm' ) );
-		$schema         = array(
+		$schema               = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
 			'title'      => $this->post_type,
 			'type'       => 'object',

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
@@ -8,6 +8,8 @@
  * @since   2.6.0
  */
 
+use Automattic\WooCommerce\Utilities\I18nUtil;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -1663,8 +1665,8 @@ class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {
 	 * @return array
 	 */
 	public function get_item_schema() {
-		$weight_unit    = get_option( 'woocommerce_weight_unit' );
-		$dimension_unit = get_option( 'woocommerce_dimension_unit' );
+		$weight_unit_label    = I18nUtil::get_weight_unit_label( get_option( 'woocommerce_weight_unit', 'kg' ) );
+		$dimension_unit_label = I18nUtil::get_dimensions_unit_label( get_option( 'woocommerce_dimension_unit', 'cm' ) );
 		$schema         = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
 			'title'      => $this->post_type,
@@ -1935,7 +1937,7 @@ class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {
 				),
 				'weight'                => array(
 					/* translators: %s: weight unit */
-					'description' => sprintf( __( 'Product weight (%s).', 'woocommerce' ), $weight_unit ),
+					'description' => sprintf( __( 'Product weight (%s).', 'woocommerce' ), $weight_unit_label ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 				),
@@ -1946,19 +1948,19 @@ class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {
 					'properties'  => array(
 						'length' => array(
 							/* translators: %s: dimension unit */
-							'description' => sprintf( __( 'Product length (%s).', 'woocommerce' ), $dimension_unit ),
+							'description' => sprintf( __( 'Product length (%s).', 'woocommerce' ), $dimension_unit_label ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),
 						'width'  => array(
 							/* translators: %s: dimension unit */
-							'description' => sprintf( __( 'Product width (%s).', 'woocommerce' ), $dimension_unit ),
+							'description' => sprintf( __( 'Product width (%s).', 'woocommerce' ), $dimension_unit_label ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),
 						'height' => array(
 							/* translators: %s: dimension unit */
-							'description' => sprintf( __( 'Product height (%s).', 'woocommerce' ), $dimension_unit ),
+							'description' => sprintf( __( 'Product height (%s).', 'woocommerce' ), $dimension_unit_label ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
@@ -445,7 +445,7 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 	public function get_item_schema() {
 		$weight_unit_label    = I18nUtil::get_weight_unit_label( get_option( 'woocommerce_weight_unit', 'kg' ) );
 		$dimension_unit_label = I18nUtil::get_dimensions_unit_label( get_option( 'woocommerce_dimension_unit', 'cm' ) );
-		$schema         = array(
+		$schema               = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
 			'title'      => $this->post_type,
 			'type'       => 'object',

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
@@ -8,6 +8,8 @@
  * @since   3.0.0
  */
 
+use Automattic\WooCommerce\Utilities\I18nUtil;
+
 defined( 'ABSPATH' ) || exit;
 
 use Automattic\Jetpack\Constants;
@@ -441,8 +443,8 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 	 * @return array
 	 */
 	public function get_item_schema() {
-		$weight_unit    = get_option( 'woocommerce_weight_unit' );
-		$dimension_unit = get_option( 'woocommerce_dimension_unit' );
+		$weight_unit_label    = I18nUtil::get_weight_unit_label( get_option( 'woocommerce_weight_unit', 'kg' ) );
+		$dimension_unit_label = I18nUtil::get_dimensions_unit_label( get_option( 'woocommerce_dimension_unit', 'cm' ) );
 		$schema         = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
 			'title'      => $this->post_type,
@@ -643,7 +645,7 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 				),
 				'weight'                => array(
 					/* translators: %s: weight unit */
-					'description' => sprintf( __( 'Variation weight (%s).', 'woocommerce' ), $weight_unit ),
+					'description' => sprintf( __( 'Variation weight (%s).', 'woocommerce' ), $weight_unit_label ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 				),
@@ -654,19 +656,19 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 					'properties'  => array(
 						'length' => array(
 							/* translators: %s: dimension unit */
-							'description' => sprintf( __( 'Variation length (%s).', 'woocommerce' ), $dimension_unit ),
+							'description' => sprintf( __( 'Variation length (%s).', 'woocommerce' ), $dimension_unit_label ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),
 						'width'  => array(
 							/* translators: %s: dimension unit */
-							'description' => sprintf( __( 'Variation width (%s).', 'woocommerce' ), $dimension_unit ),
+							'description' => sprintf( __( 'Variation width (%s).', 'woocommerce' ), $dimension_unit_label ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),
 						'height' => array(
 							/* translators: %s: dimension unit */
-							'description' => sprintf( __( 'Variation height (%s).', 'woocommerce' ), $dimension_unit ),
+							'description' => sprintf( __( 'Variation height (%s).', 'woocommerce' ), $dimension_unit_label ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -808,7 +808,7 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 	public function get_item_schema() {
 		$weight_unit_label    = I18nUtil::get_weight_unit_label( get_option( 'woocommerce_weight_unit', 'kg' ) );
 		$dimension_unit_label = I18nUtil::get_dimensions_unit_label( get_option( 'woocommerce_dimension_unit', 'cm' ) );
-		$schema         = array(
+		$schema               = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
 			'title'      => $this->post_type,
 			'type'       => 'object',

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -8,6 +8,8 @@
  * @since   2.6.0
  */
 
+use Automattic\WooCommerce\Utilities\I18nUtil;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -804,8 +806,8 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 	 * @return array
 	 */
 	public function get_item_schema() {
-		$weight_unit    = get_option( 'woocommerce_weight_unit' );
-		$dimension_unit = get_option( 'woocommerce_dimension_unit' );
+		$weight_unit_label    = I18nUtil::get_weight_unit_label( get_option( 'woocommerce_weight_unit', 'kg' ) );
+		$dimension_unit_label = I18nUtil::get_dimensions_unit_label( get_option( 'woocommerce_dimension_unit', 'cm' ) );
 		$schema         = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
 			'title'      => $this->post_type,
@@ -1080,7 +1082,7 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 				),
 				'weight'                => array(
 					/* translators: %s: weight unit */
-					'description' => sprintf( __( 'Product weight (%s).', 'woocommerce' ), $weight_unit ),
+					'description' => sprintf( __( 'Product weight (%s).', 'woocommerce' ), $weight_unit_label ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 				),
@@ -1091,19 +1093,19 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 					'properties'  => array(
 						'length' => array(
 							/* translators: %s: dimension unit */
-							'description' => sprintf( __( 'Product length (%s).', 'woocommerce' ), $dimension_unit ),
+							'description' => sprintf( __( 'Product length (%s).', 'woocommerce' ), $dimension_unit_label ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),
 						'width'  => array(
 							/* translators: %s: dimension unit */
-							'description' => sprintf( __( 'Product width (%s).', 'woocommerce' ), $dimension_unit ),
+							'description' => sprintf( __( 'Product width (%s).', 'woocommerce' ), $dimension_unit_label ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),
 						'height' => array(
 							/* translators: %s: dimension unit */
-							'description' => sprintf( __( 'Product height (%s).', 'woocommerce' ), $dimension_unit ),
+							'description' => sprintf( __( 'Product height (%s).', 'woocommerce' ), $dimension_unit_label ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),

--- a/plugins/woocommerce/includes/wc-formatting-functions.php
+++ b/plugins/woocommerce/includes/wc-formatting-functions.php
@@ -8,6 +8,7 @@
  * @version 2.1.0
  */
 
+use Automattic\WooCommerce\Utilities\I18nUtil;
 use Automattic\WooCommerce\Utilities\NumberUtil;
 
 defined( 'ABSPATH' ) || exit;
@@ -1303,7 +1304,14 @@ function wc_format_weight( $weight ) {
 	$weight_string = wc_format_localized_decimal( $weight );
 
 	if ( ! empty( $weight_string ) ) {
-		$weight_string .= ' ' . get_option( 'woocommerce_weight_unit' );
+		$weight_label = I18nUtil::get_weight_unit_label( get_option( 'woocommerce_weight_unit' ) );
+
+		$weight_string = sprintf(
+			// translators: 1. A formatted number; 2. A label for a weight unit of measure. E.g. 2.72 kg
+			_x( '%1$s %2$s', 'formatted weight', 'woocommerce' ),
+			$weight_string,
+			$weight_label
+		);
 	} else {
 		$weight_string = __( 'N/A', 'woocommerce' );
 	}
@@ -1322,7 +1330,14 @@ function wc_format_dimensions( $dimensions ) {
 	$dimension_string = implode( ' &times; ', array_filter( array_map( 'wc_format_localized_decimal', $dimensions ) ) );
 
 	if ( ! empty( $dimension_string ) ) {
-		$dimension_string .= ' ' . get_option( 'woocommerce_dimension_unit' );
+		$dimension_label = I18nUtil::get_dimensions_unit_label( get_option( 'woocommerce_dimension_unit' ) );
+
+		$dimension_string = sprintf(
+			// translators: 1. A formatted number; 2. A label for a dimensions unit of measure. E.g. 3.14 cm
+			_x( '%1$s %2$s', 'formatted dimensions', 'woocommerce' ),
+			$dimension_string,
+			$dimension_label
+		);
 	} else {
 		$dimension_string = __( 'N/A', 'woocommerce' );
 	}

--- a/plugins/woocommerce/includes/wc-formatting-functions.php
+++ b/plugins/woocommerce/includes/wc-formatting-functions.php
@@ -1307,7 +1307,7 @@ function wc_format_weight( $weight ) {
 		$weight_label = I18nUtil::get_weight_unit_label( get_option( 'woocommerce_weight_unit' ) );
 
 		$weight_string = sprintf(
-			// translators: 1. A formatted number; 2. A label for a weight unit of measure. E.g. 2.72 kg
+			// translators: 1. A formatted number; 2. A label for a weight unit of measure. E.g. 2.72 kg.
 			_x( '%1$s %2$s', 'formatted weight', 'woocommerce' ),
 			$weight_string,
 			$weight_label
@@ -1333,7 +1333,7 @@ function wc_format_dimensions( $dimensions ) {
 		$dimension_label = I18nUtil::get_dimensions_unit_label( get_option( 'woocommerce_dimension_unit' ) );
 
 		$dimension_string = sprintf(
-			// translators: 1. A formatted number; 2. A label for a dimensions unit of measure. E.g. 3.14 cm
+			// translators: 1. A formatted number; 2. A label for a dimensions unit of measure. E.g. 3.14 cm.
 			_x( '%1$s %2$s', 'formatted dimensions', 'woocommerce' ),
 			$dimension_string,
 			$dimension_label

--- a/plugins/woocommerce/src/Utilities/I18nUtil.php
+++ b/plugins/woocommerce/src/Utilities/I18nUtil.php
@@ -19,6 +19,9 @@ final class I18nUtil {
 	/**
 	 * Get the translated label for a weight unit of measure.
 	 *
+	 * This will return the original input string if it isn't found in the units array. This way a custom unit of
+	 * measure can be used even if its' not getting translated.
+	 *
 	 * @param string $weight_unit The abbreviated weight unit in English, e.g. kg.
 	 *
 	 * @return string
@@ -28,7 +31,7 @@ final class I18nUtil {
 			self::$units = include WC()->plugin_path() . '/i18n/units.php';
 		}
 
-		$label = '';
+		$label = $weight_unit;
 
 		if ( ! empty( self::$units['weight'][ $weight_unit ] ) ) {
 			$label = self::$units['weight'][ $weight_unit ];
@@ -40,6 +43,9 @@ final class I18nUtil {
 	/**
 	 * Get the translated label for a dimensions unit of measure.
 	 *
+	 * This will return the original input string if it isn't found in the units array. This way a custom unit of
+	 * measure can be used even if its' not getting translated.
+	 *
 	 * @param string $dimensions_unit The abbreviated dimension unit in English, e.g. cm.
 	 *
 	 * @return string
@@ -49,7 +55,7 @@ final class I18nUtil {
 			self::$units = include WC()->plugin_path() . '/i18n/units.php';
 		}
 
-		$label = '';
+		$label = $dimensions_unit;
 
 		if ( ! empty( self::$units['dimensions'][ $dimensions_unit ] ) ) {
 			$label = self::$units['dimensions'][ $dimensions_unit ];

--- a/plugins/woocommerce/src/Utilities/I18nUtil.php
+++ b/plugins/woocommerce/src/Utilities/I18nUtil.php
@@ -5,8 +5,13 @@
 
 namespace Automattic\WooCommerce\Utilities;
 
+/**
+ * A class of utilities for dealing with internationalization.
+ */
 final class I18nUtil {
 	/**
+	 * A cache for the i18n units data.
+	 *
 	 * @var array $units
 	 */
 	private static $units;
@@ -14,7 +19,7 @@ final class I18nUtil {
 	/**
 	 * Get the translated label for a weight unit of measure.
 	 *
-	 * @param string $weight_unit
+	 * @param string $weight_unit The abbreviated weight unit in English, e.g. kg.
 	 *
 	 * @return string
 	 */
@@ -35,7 +40,7 @@ final class I18nUtil {
 	/**
 	 * Get the translated label for a dimensions unit of measure.
 	 *
-	 * @param string $dimensions_unit
+	 * @param string $dimensions_unit The abbreviated dimension unit in English, e.g. cm.
 	 *
 	 * @return string
 	 */

--- a/plugins/woocommerce/src/Utilities/I18nUtil.php
+++ b/plugins/woocommerce/src/Utilities/I18nUtil.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * A class of utilities for dealing with internationalization.
+ */
+
+namespace Automattic\WooCommerce\Utilities;
+
+final class I18nUtil {
+	/**
+	 * @var array $units
+	 */
+	private static $units;
+
+	/**
+	 * Get the translated label for a weight unit of measure.
+	 *
+	 * @param string $weight_unit
+	 *
+	 * @return string
+	 */
+	public static function get_weight_unit_label( $weight_unit ) {
+		if ( empty( self::$units ) ) {
+			self::$units = include WC()->plugin_path() . '/i18n/units.php';
+		}
+
+		$label = '';
+
+		if ( ! empty( self::$units['weight'][ $weight_unit ] ) ) {
+			$label = self::$units['weight'][ $weight_unit ];
+		}
+
+		return $label;
+	}
+
+	/**
+	 * Get the translated label for a dimensions unit of measure.
+	 *
+	 * @param string $dimensions_unit
+	 *
+	 * @return string
+	 */
+	public static function get_dimensions_unit_label( $dimensions_unit ) {
+		if ( empty( self::$units ) ) {
+			self::$units = include WC()->plugin_path() . '/i18n/units.php';
+		}
+
+		$label = '';
+
+		if ( ! empty( self::$units['dimensions'][ $dimensions_unit ] ) ) {
+			$label = self::$units['dimensions'][ $dimensions_unit ];
+		}
+
+		return $label;
+	}
+}

--- a/plugins/woocommerce/src/Utilities/I18nUtil.php
+++ b/plugins/woocommerce/src/Utilities/I18nUtil.php
@@ -44,7 +44,7 @@ final class I18nUtil {
 	 * Get the translated label for a dimensions unit of measure.
 	 *
 	 * This will return the original input string if it isn't found in the units array. This way a custom unit of
-	 * measure can be used even if its' not getting translated.
+	 * measure can be used even if it's not getting translated.
 	 *
 	 * @param string $dimensions_unit The abbreviated dimension unit in English, e.g. cm.
 	 *

--- a/plugins/woocommerce/src/Utilities/I18nUtil.php
+++ b/plugins/woocommerce/src/Utilities/I18nUtil.php
@@ -20,7 +20,7 @@ final class I18nUtil {
 	 * Get the translated label for a weight unit of measure.
 	 *
 	 * This will return the original input string if it isn't found in the units array. This way a custom unit of
-	 * measure can be used even if its' not getting translated.
+	 * measure can be used even if it's not getting translated.
 	 *
 	 * @param string $weight_unit The abbreviated weight unit in English, e.g. kg.
 	 *

--- a/plugins/woocommerce/tests/php/src/Utilities/I18nUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Utilities/I18nUtilTest.php
@@ -28,7 +28,7 @@ class I18nUtilTest extends \WC_Unit_Test_Case {
 	 * Do before each test in this class.
 	 *
 	 * @return void
-	 * @throws \ReflectionException
+	 * @throws \ReflectionException If the units property does not exist on the class.
 	 */
 	public function set_up() {
 		parent::set_up();
@@ -55,7 +55,7 @@ class I18nUtilTest extends \WC_Unit_Test_Case {
 	/**
 	 * Simulate a string getting translated.
 	 *
-	 * @param string $translated
+	 * @param string $translated The "translated" string before we modify it.
 	 *
 	 * @return string
 	 */

--- a/plugins/woocommerce/tests/php/src/Utilities/I18nUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Utilities/I18nUtilTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Automattic\WooCommerce\Tests\Utilities;
+
+use Automattic\WooCommerce\Utilities\I18nUtil;
+
+/**
+ * A collection of tests for the internationalization utility class.
+ */
+class I18nUtilTest extends \WC_Unit_Test_Case {
+
+	/**
+	 * @testdox `get_weight_unit_label` should return the input when it's a valid weight unit and the locale is en_US.
+	 */
+	public function test_get_valid_weight_unit_label() {
+		$actual   = I18nUtil::get_weight_unit_label( 'oz' );
+		$expected = 'oz';
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * @testdox `get_weight_unit_label` should return an empty string when the input is an invalid weight unit.
+	 */
+	public function test_get_invalid_weight_unit_label() {
+		$actual   = I18nUtil::get_weight_unit_label( 'chz' ); // Cheezeburgers.
+		$expected = '';
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * @testdox `get_dimensions_unit_label` should return the input when it's a valid dimensions unit and the locale is en_US.
+	 */
+	public function test_get_valid_dimensions_unit_label() {
+		$actual   = I18nUtil::get_dimensions_unit_label( 'yd' );
+		$expected = 'yd';
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * @testdox `get_dimensions_unit_label` should return an empty string when the input is an invalid dimensions unit.
+	 */
+	public function test_get_invalid_dimensions_unit_label() {
+		$actual   = I18nUtil::get_weight_unit_label( 'pc' ); // Parsecs.
+		$expected = '';
+
+		$this->assertEquals( $expected, $actual );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Utilities/I18nUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Utilities/I18nUtilTest.php
@@ -8,43 +8,97 @@ use Automattic\WooCommerce\Utilities\I18nUtil;
  * A collection of tests for the internationalization utility class.
  */
 class I18nUtilTest extends \WC_Unit_Test_Case {
+	/**
+	 * A reflected instance of I18nUtil that can be manipulated for testing.
+	 *
+	 * @var \ReflectionClass
+	 */
+	private static $reflection;
 
 	/**
-	 * @testdox `get_weight_unit_label` should return the input when it's a valid weight unit and the locale is en_US.
+	 * Do once before all the tests in this class.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		self::$reflection = new \ReflectionClass( I18nUtil::class );
+	}
+
+	/**
+	 * Do before each test in this class.
+	 *
+	 * @return void
+	 * @throws \ReflectionException
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		// Ensure unit strings are not already cached before the gettext filter gets added.
+		$units_prop = self::$reflection->getProperty( 'units' );
+		$units_prop->setAccessible( true );
+		$units_prop->setValue( I18nUtil::class, null );
+
+		add_filter( 'gettext', array( __CLASS__, 'filter_gettext' ) );
+	}
+
+	/**
+	 * Do after each test in this class.
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+		remove_filter( 'gettext', array( __CLASS__, 'filter_gettext' ) );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Simulate a string getting translated.
+	 *
+	 * @param string $translated
+	 *
+	 * @return string
+	 */
+	public static function filter_gettext( $translated ): string {
+		return sprintf( '%s (translated)', $translated );
+	}
+
+	/**
+	 * @testdox `get_weight_unit_label` should return a translated string when it's a valid weight unit.
 	 */
 	public function test_get_valid_weight_unit_label() {
 		$actual   = I18nUtil::get_weight_unit_label( 'oz' );
-		$expected = 'oz';
+		$expected = 'oz (translated)';
 
 		$this->assertEquals( $expected, $actual );
 	}
 
 	/**
-	 * @testdox `get_weight_unit_label` should return an empty string when the input is an invalid weight unit.
+	 * @testdox `get_weight_unit_label` should return the original input string when the input is not a recognized weight unit.
 	 */
 	public function test_get_invalid_weight_unit_label() {
 		$actual   = I18nUtil::get_weight_unit_label( 'chz' ); // Cheezeburgers.
-		$expected = '';
+		$expected = 'chz';
 
 		$this->assertEquals( $expected, $actual );
 	}
 
 	/**
-	 * @testdox `get_dimensions_unit_label` should return the input when it's a valid dimensions unit and the locale is en_US.
+	 * @testdox `get_dimensions_unit_label` should return a translated string when it's a valid dimensions unit.
 	 */
 	public function test_get_valid_dimensions_unit_label() {
 		$actual   = I18nUtil::get_dimensions_unit_label( 'yd' );
-		$expected = 'yd';
+		$expected = 'yd (translated)';
 
 		$this->assertEquals( $expected, $actual );
 	}
 
 	/**
-	 * @testdox `get_dimensions_unit_label` should return an empty string when the input is an invalid dimensions unit.
+	 * @testdox `get_dimensions_unit_label` should return the original input string when the input is not a recognized dimensions unit.
 	 */
 	public function test_get_invalid_dimensions_unit_label() {
 		$actual   = I18nUtil::get_weight_unit_label( 'pc' ); // Parsecs.
-		$expected = '';
+		$expected = 'pc';
 
 		$this->assertEquals( $expected, $actual );
 	}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Introduces data and methods for localizing the labels on units of measure, e.g. `kg` or `cm`, and ensures they are utilized wherever those labels are output on the front end and in the admin UI.

Closes #31486

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

### How to test the changes in this Pull Request:

Testing this involves looking through the UI (front end and admin) to see if there is anywhere that still shows untranslated unit measure labels. In order to differentiate from labels that _have_ been translated, you can add this snippet as an mu-plugin on your test site:

```php
<?php

add_filter(
	'gettext',
	function( $translated, $original ) {
		$weight_units    = array( 'kg', 'g', 'lbs', 'oz' );
		$dimension_units = array( 'm', 'cm', 'mm', 'in', 'yd' );

		$new_string = $original;

		if ( in_array( $new_string, $weight_units, true ) ) {
			$new_string = "💰";
		} else if ( in_array( $new_string, $dimension_units, true ) ) {
			$new_string = "🦄";
		}

		return $new_string;
	},
	99,
	2
);
```

This will make it so any abbreviated weight unit label that's successfully being translated will show as 💰 and any translated dimensions label will show as 🦄.

Some places to check:
* Single product views
* Product management screens
* Product import/export
* Shipping management screens
* WooCommerce settings

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
