### PR TITLE
Revert/36294

### DIFF
--- a/packages/js/components/changelog/canceled
+++ b/packages/js/components/changelog/canceled
@@ -1,4 +1,0 @@
-Significance: minor
-Type: tweak
-
-Update spelling of Cancelled to Canceled for US English.

--- a/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-order-status-filters.test.js
+++ b/packages/js/e2e-core-tests/src/specs/merchant/wp-admin-order-status-filters.test.js
@@ -16,7 +16,7 @@ const orderStatus = [
 	[ 'Processing', 'wc-processing' ],
 	[ 'On hold', 'wc-on-hold' ],
 	[ 'Completed', 'wc-completed' ],
-	[ 'Canceled', 'wc-cancelled' ],
+	[ 'Cancelled', 'wc-cancelled' ],
 	[ 'Refunded', 'wc-refunded' ],
 	[ 'Failed', 'wc-failed' ],
 ];

--- a/plugins/woocommerce/changelog/revert-36294
+++ b/plugins/woocommerce/changelog/revert-36294
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: This is a revert: we don't need a further changelog entry and the existing entry should be removed by the revert itself.
+
+

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-accounts.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-accounts.php
@@ -203,8 +203,8 @@ class WC_Settings_Accounts extends WC_Settings_Page {
 				'autoload'    => false,
 			),
 			array(
-				'title'       => __( 'Retain canceled orders', 'woocommerce' ),
-				'desc_tip'    => __( 'Canceled orders are unpaid and may have been cancelled by the store owner or customer. They will be trashed after the specified duration.', 'woocommerce' ),
+				'title'       => __( 'Retain cancelled orders', 'woocommerce' ),
+				'desc_tip'    => __( 'Cancelled orders are unpaid and may have been cancelled by the store owner or customer. They will be trashed after the specified duration.', 'woocommerce' ),
 				'id'          => 'woocommerce_trash_cancelled_orders',
 				'type'        => 'relative_date_selector',
 				'placeholder' => __( 'N/A', 'woocommerce' ),

--- a/plugins/woocommerce/includes/class-wc-post-types.php
+++ b/plugins/woocommerce/includes/class-wc-post-types.php
@@ -598,13 +598,13 @@ class WC_Post_Types {
 					'label_count'               => _n_noop( 'Completed <span class="count">(%s)</span>', 'Completed <span class="count">(%s)</span>', 'woocommerce' ),
 				),
 				'wc-cancelled'  => array(
-					'label'                     => _x( 'Canceled', 'Order status', 'woocommerce' ),
+					'label'                     => _x( 'Cancelled', 'Order status', 'woocommerce' ),
 					'public'                    => false,
 					'exclude_from_search'       => false,
 					'show_in_admin_all_list'    => true,
 					'show_in_admin_status_list' => true,
 					/* translators: %s: number of orders */
-					'label_count'               => _n_noop( 'Canceled <span class="count">(%s)</span>', 'Canceled <span class="count">(%s)</span>', 'woocommerce' ),
+					'label_count'               => _n_noop( 'Cancelled <span class="count">(%s)</span>', 'Cancelled <span class="count">(%s)</span>', 'woocommerce' ),
 				),
 				'wc-refunded'   => array(
 					'label'                     => _x( 'Refunded', 'Order status', 'woocommerce' ),

--- a/plugins/woocommerce/includes/class-wc-regenerate-images.php
+++ b/plugins/woocommerce/includes/class-wc-regenerate-images.php
@@ -158,7 +158,7 @@ class WC_Regenerate_Images {
 
 			$log = wc_get_logger();
 			$log->info(
-				__( 'Canceled product image regeneration job.', 'woocommerce' ),
+				__( 'Cancelled product image regeneration job.', 'woocommerce' ),
 				array(
 					'source' => 'wc-image-regeneration',
 				)

--- a/plugins/woocommerce/includes/emails/class-wc-email-cancelled-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-cancelled-order.php
@@ -28,8 +28,8 @@ if ( ! class_exists( 'WC_Email_Cancelled_Order', false ) ) :
 		 */
 		public function __construct() {
 			$this->id             = 'cancelled_order';
-			$this->title          = __( 'Canceled order', 'woocommerce' );
-			$this->description    = __( 'Canceled order emails are sent to chosen recipient(s) when orders have been marked canceled (if they were previously processing or on-hold).', 'woocommerce' );
+			$this->title          = __( 'Cancelled order', 'woocommerce' );
+			$this->description    = __( 'Cancelled order emails are sent to chosen recipient(s) when orders have been marked cancelled (if they were previously processing or on-hold).', 'woocommerce' );
 			$this->template_html  = 'emails/admin-cancelled-order.php';
 			$this->template_plain = 'emails/plain/admin-cancelled-order.php';
 			$this->placeholders   = array(
@@ -66,7 +66,7 @@ if ( ! class_exists( 'WC_Email_Cancelled_Order', false ) ) :
 		 * @return string
 		 */
 		public function get_default_heading() {
-			return __( 'Order Canceled: #{order_number}', 'woocommerce' );
+			return __( 'Order Cancelled: #{order_number}', 'woocommerce' );
 		}
 
 		/**

--- a/plugins/woocommerce/includes/emails/class-wc-email-customer-on-hold-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-customer-on-hold-order.php
@@ -30,7 +30,7 @@ if ( ! class_exists( 'WC_Email_Customer_On_Hold_Order', false ) ) :
 			$this->id             = 'customer_on_hold_order';
 			$this->customer_email = true;
 			$this->title          = __( 'Order on-hold', 'woocommerce' );
-			$this->description    = __( 'This is an order notification sent to customers containing order details after an order is placed on-hold from Pending, Canceled or Failed order status.', 'woocommerce' );
+			$this->description    = __( 'This is an order notification sent to customers containing order details after an order is placed on-hold from Pending, Cancelled or Failed order status.', 'woocommerce' );
 			$this->template_html  = 'emails/customer-on-hold-order.php';
 			$this->template_plain = 'emails/plain/customer-on-hold-order.php';
 			$this->placeholders   = array(

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -98,7 +98,7 @@ function wc_get_order_statuses() {
 		'wc-processing' => _x( 'Processing', 'Order status', 'woocommerce' ),
 		'wc-on-hold'    => _x( 'On hold', 'Order status', 'woocommerce' ),
 		'wc-completed'  => _x( 'Completed', 'Order status', 'woocommerce' ),
-		'wc-cancelled'  => _x( 'Canceled', 'Order status', 'woocommerce' ),
+		'wc-cancelled'  => _x( 'Cancelled', 'Order status', 'woocommerce' ),
 		'wc-refunded'   => _x( 'Refunded', 'Order status', 'woocommerce' ),
 		'wc-failed'     => _x( 'Failed', 'Order status', 'woocommerce' ),
 	);

--- a/plugins/woocommerce/tests/api-core-tests/tests/reports/reports-crud.test.js
+++ b/plugins/woocommerce/tests/api-core-tests/tests/reports/reports-crud.test.js
@@ -281,7 +281,7 @@ test.describe('Reports API tests', () => {
 			expect.arrayContaining([
 				expect.objectContaining({
 					"slug": "cancelled",
-					"name": "Canceled",
+					"name": "Cancelled",
 					"total": expect.any(Number)
 				})
 			]));

--- a/plugins/woocommerce/tests/api-core-tests/tests/settings/settings-crud.test.js
+++ b/plugins/woocommerce/tests/api-core-tests/tests/settings/settings-crud.test.js
@@ -141,8 +141,8 @@ test.describe('Settings API tests: CRUD', () => {
 				expect.arrayContaining([
 					expect.objectContaining({
 						id: "email_cancelled_order",
-						label: "Canceled order",
-						description: "Canceled order emails are sent to chosen recipient(s) when orders have been marked canceled (if they were previously processing or on-hold).",
+						label: "Cancelled order",
+						description: "Cancelled order emails are sent to chosen recipient(s) when orders have been marked cancelled (if they were previously processing or on-hold).",
 						parent_id: "email",
 						"sub_groups": expect.arrayContaining([]),
 					})
@@ -162,7 +162,7 @@ test.describe('Settings API tests: CRUD', () => {
 					expect.objectContaining({
 						id: "email_customer_on_hold_order",
 						label: "Order on-hold",
-						description: "This is an order notification sent to customers containing order details after an order is placed on-hold from Pending, Canceled or Failed order status.",
+						description: "This is an order notification sent to customers containing order details after an order is placed on-hold from Pending, Cancelled or Failed order status.",
 						parent_id: "email",
 						"sub_groups": expect.arrayContaining([]),
 					})

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-status-filter.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-status-filter.spec.js
@@ -10,7 +10,7 @@ const orderStatus = [
 	[ 'Processing', 'wc-processing' ],
 	[ 'On hold', 'wc-on-hold' ],
 	[ 'Completed', 'wc-completed' ],
-	[ 'Canceled', 'wc-cancelled' ],
+	[ 'Cancelled', 'wc-cancelled' ],
 	[ 'Refunded', 'wc-refunded' ],
 	[ 'Failed', 'wc-failed' ],
 ];

--- a/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-order-functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-order-functions.php
@@ -29,7 +29,7 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 				'wc-processing' => _x( 'Processing', 'Order status', 'woocommerce' ),
 				'wc-on-hold'    => _x( 'On hold', 'Order status', 'woocommerce' ),
 				'wc-completed'  => _x( 'Completed', 'Order status', 'woocommerce' ),
-				'wc-cancelled'  => _x( 'Canceled', 'Order status', 'woocommerce' ),
+				'wc-cancelled'  => _x( 'Cancelled', 'Order status', 'woocommerce' ),
 				'wc-refunded'   => _x( 'Refunded', 'Order status', 'woocommerce' ),
 				'wc-failed'     => _x( 'Failed', 'Order status', 'woocommerce' ),
 			)


### PR DESCRIPTION
Reverts the change introduced in https://github.com/woocommerce/woocommerce/pull/36294: we have concerns about this, as we know of plugins that rely on the current formulation (therefore this change could lead to disruption for mutual users).

- Internal discussion: p1675247504094029-slack-C01DT6U03HC
- Code review should be sufficient: the only anomaly is the [original changelog file](https://github.com/woocommerce/woocommerce/pull/36294/files#diff-9b09e63c5a1f4b779dc178945777cb4cd8a460baaf36bcdaaf086be315b9a74e) ... that isn't included in the revert, but it also doesn't seem to be present in `trunk` any longer (for clarity: there were two changelog files—one for core, one for `packages/js/components`—the latter is included in this revert).

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.