### PR TITLE
Fix SelectControl and TreeControl styles

### DIFF
--- a/packages/js/components/changelog/fix-select-control-style
+++ b/packages/js/components/changelog/fix-select-control-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix SelectControl and TreeControl styles.

--- a/packages/js/components/src/experimental-tree-control/tree-item.scss
+++ b/packages/js/components/src/experimental-tree-control/tree-item.scss
@@ -17,7 +17,7 @@
 
 		&:hover,
 		&:focus-within {
-			background-color: $gray-0;
+			background-color: $gray-100;
 		}
 	}
 	&__label {

--- a/packages/js/components/src/style.scss
+++ b/packages/js/components/src/style.scss
@@ -1,7 +1,6 @@
 /**
 * External Dependencies
 */
-@import 'node_modules/@wordpress/base-styles/colors.native';
 @import '@automattic/tour-kit/dist/esm/styles.scss';
 
 /**


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes the styling of the `SelectControl` and `TreeControl`. The `SelectControl` styling was broken in #36517.

Before:

![Image](https://user-images.githubusercontent.com/2098816/216082479-4d17ffa9-2420-4a9f-b956-51209feeda5b.png)

After:

![Image](https://user-images.githubusercontent.com/2098816/216082513-c06925be-a45d-412e-95ab-0e677f88623a.png)

Closes #36712.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

#### Verify `SelectControl` is styled properly

Using the new product editor (enable in WooCommerce > Settings > Advanced > Features)...

1. Create a new Product (Products > Add New).
2. Assign it a category.
3. Verify the styling of the category field is as shown above.

#### Verify `TreeControl` is styled properly

0. Build storybook (`pnpm --filter=@woocommerce/storybook build-storybook`)
1. Run storybook (`pnpm --filter=@woocommerce/storybook storybook`)
4. Visit `http://localhost:6007/?path=/story/woocommerce-admin-experimental-treecontrol--simple-tree`
5. A basic tree control should be shown.
6. Verify the CSS is included and the tree looks as shown in the screenshot above.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
