### PR TITLE
Fix Typo in Variable Name on line 342

### DIFF
--- a/plugins/woocommerce/changelog/pr-36759
+++ b/plugins/woocommerce/changelog/pr-36759
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix typo in variable name

--- a/plugins/woocommerce/includes/wc-product-functions.php
+++ b/plugins/woocommerce/includes/wc-product-functions.php
@@ -339,10 +339,10 @@ function wc_placeholder_img( $size = 'woocommerce_thumbnail', $attr = '' ) {
 		$attributes = array();
 
 		foreach ( $attr as $name => $value ) {
-			$attribute[] = esc_attr( $name ) . '="' . esc_attr( $value ) . '"';
+			$attributes[] = esc_attr( $name ) . '="' . esc_attr( $value ) . '"';
 		}
 
-		$image_html = '<img src="' . esc_url( $image ) . '" ' . $hwstring . implode( ' ', $attribute ) . '/>';
+		$image_html = '<img src="' . esc_url( $image ) . '" ' . $hwstring . implode( ' ', $attributes ) . '/>';
 	}
 
 	return apply_filters( 'woocommerce_placeholder_img', $image_html, $size, $dimensions );


### PR DESCRIPTION
I've noticed on line 339 has an empty array ($attributes) which might be intended to use as a fallback variable for line 345. The array ($attributes) is then extended on line 342, but the variable name at this point is $attribute instead $attributes