### PR TITLE
Use NumberUtil::round() instead of number_format() in WC_Order::get_item_subtotal()

### DIFF
--- a/plugins/woocommerce/changelog/mahmoudsaeed-trunk
+++ b/plugins/woocommerce/changelog/mahmoudsaeed-trunk
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make `WC_Order::get_item_subtotal()` always return a float.

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -1889,7 +1889,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 				$subtotal = floatval( $item->get_subtotal() ) / $item->get_quantity();
 			}
 
-			$subtotal = $round ? number_format( (float) $subtotal, wc_get_price_decimals(), '.', '' ) : $subtotal;
+			$subtotal = $round ? NumberUtil::round( $subtotal, wc_get_price_decimals() ) : $subtotal;
 		}
 
 		return apply_filters( 'woocommerce_order_amount_item_subtotal', $subtotal, $this, $item, $inc_tax, $round );


### PR DESCRIPTION
Just like the other similar methods in the same class (`get_item_total()`, `get_line_total()`, and `get_line_subtotal()`), use `NumberUtil::round()` instead of `number_format()` to round `$subtotal` if needed. 

### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Using `number_format()` to round numbers is discouraged.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [x] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
