### PR TITLE
fix: Return type of some order shipping and discount amount getter methods made float

### DIFF
--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -370,40 +370,40 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * Get discount_total.
 	 *
 	 * @param  string $context View or edit context.
-	 * @return string
+	 * @return float
 	 */
 	public function get_discount_total( $context = 'view' ) {
-		return $this->get_prop( 'discount_total', $context );
+		return floatval( $this->get_prop( 'discount_total', $context ) );
 	}
 
 	/**
 	 * Get discount_tax.
 	 *
 	 * @param  string $context View or edit context.
-	 * @return string
+	 * @return float
 	 */
 	public function get_discount_tax( $context = 'view' ) {
-		return $this->get_prop( 'discount_tax', $context );
+		return floatval( $this->get_prop( 'discount_tax', $context ) );
 	}
 
 	/**
 	 * Get shipping_total.
 	 *
 	 * @param  string $context View or edit context.
-	 * @return string
+	 * @return float
 	 */
 	public function get_shipping_total( $context = 'view' ) {
-		return $this->get_prop( 'shipping_total', $context );
+		return floatval( $this->get_prop( 'shipping_total', $context ) );
 	}
 
 	/**
 	 * Get shipping_tax.
 	 *
 	 * @param  string $context View or edit context.
-	 * @return string
+	 * @return float
 	 */
 	public function get_shipping_tax( $context = 'view' ) {
-		return $this->get_prop( 'shipping_tax', $context );
+		return floatval( $this->get_prop( 'shipping_tax', $context ) );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Previously, the return type of some shipping and discount getter methods (`get_shipping_total()`, `get_shipping_tax()`, `get_discount_total()`, and `get_discount_tax()`) were not proper. So, those methods generate errors in some special cases. For example, if the `post_status` is `auto-draft`. Then, by using those methods throw fatal errors. The issue has been solved by updating the return type to `float` from `string`.

* Closes: #36762.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Go to `WooCommerce` > `Orders` > `Add Order`.
2. It will generate an order with an ID.
3. Leave the order creation page without clicking the `Create` button. So, the order's `post_status` will be `auto-draft`.
4. Now, get the order using the `wc_get_order()` method.
5. Try to do some calculations using any of the above-mentioned methods as per the below codes. It won't throw any fatal errors like previous.
```
$order   = wc_get_order( 1347 );
$earning = $order->get_total_shipping() - $order->get_total_shipping_refunded();

echo $earning;
```

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
