### PR TITLE
Add codistoconnect to pluginNames

### DIFF
--- a/packages/js/data/changelog/fix-36765-add-codistoconnect-to-plugin-names
+++ b/packages/js/data/changelog/fix-36765-add-codistoconnect-to-plugin-names
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add codistoconnect to pluginNames

--- a/packages/js/data/src/plugins/constants.ts
+++ b/packages/js/data/src/plugins/constants.ts
@@ -60,4 +60,5 @@ export const pluginNames = {
 		'woocommerce'
 	),
 	'tiktok-for-business:alt': __( 'TikTok for WooCommerce', 'woocommerce' ),
+	codistoconnect: __( 'Omnichannel for WooCommerce', 'woocommerce' ),
 };


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds `codistoconnect` to the plugin names to correctly display its name.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #36765  .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Start OBW
2. Continue to Business Details step
3. Continue to Free features
4. Confirm `Omnichannel for WooCommerce` is in the plugin list

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
