### PR TITLE
Add missing woocommerce_run_on_woocommerce_admin_updated hook for RemoteInboxNotificationsEngine scheduled action

### DIFF
--- a/plugins/woocommerce/changelog/fix-36767-add-woocommerce_run_on_woocommerce_admin_updated-hook
+++ b/plugins/woocommerce/changelog/fix-36767-add-woocommerce_run_on_woocommerce_admin_updated-hook
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add missing woocommerce_run_on_woocommerce_admin_updated hook for the scheduled action registered in RemoteInboxNotificationsEngine

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
@@ -46,7 +46,7 @@ class RemoteInboxNotificationsEngine {
 			array( __CLASS__, 'run_on_woocommerce_admin_updated' ),
 			'woocommerce-remote-inbox-engine'
 		);
-		
+
 		add_filter( 'woocommerce_get_note_from_db', array( __CLASS__, 'get_note_from_db' ), 10, 1 );
 	}
 

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
@@ -40,19 +40,20 @@ class RemoteInboxNotificationsEngine {
 
 		// Hook into WCA updated. This is hooked up here rather than in
 		// on_admin_init because that runs too late to hook into the action.
+		add_action( 'woocommerce_run_on_woocommerce_admin_updated' , array( __CLASS__, 'run_on_woocommerce_admin_updated' ) );
 		add_action(
 			'woocommerce_updated',
 			function() {
 				$next_hook = WC()->queue()->get_next(
 					'woocommerce_run_on_woocommerce_admin_updated',
-					array( __CLASS__, 'run_on_woocommerce_admin_updated' ),
+					array(),
 					'woocommerce-remote-inbox-engine'
 				);
 				if ( $next_hook === null ) {
 					WC()->queue()->schedule_single(
 						time(),
 						'woocommerce_run_on_woocommerce_admin_updated',
-						array( __CLASS__, 'run_on_woocommerce_admin_updated' ),
+						array(),
 						'woocommerce-remote-inbox-engine'
 					);
 				}

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
@@ -40,26 +40,13 @@ class RemoteInboxNotificationsEngine {
 
 		// Hook into WCA updated. This is hooked up here rather than in
 		// on_admin_init because that runs too late to hook into the action.
-		add_action( 'woocommerce_run_on_woocommerce_admin_updated' , array( __CLASS__, 'run_on_woocommerce_admin_updated' ) );
-		add_action(
+		WC()->queue()->schedule_single(
+			time(),
 			'woocommerce_updated',
-			function() {
-				$next_hook = WC()->queue()->get_next(
-					'woocommerce_run_on_woocommerce_admin_updated',
-					array(),
-					'woocommerce-remote-inbox-engine'
-				);
-				if ( $next_hook === null ) {
-					WC()->queue()->schedule_single(
-						time(),
-						'woocommerce_run_on_woocommerce_admin_updated',
-						array(),
-						'woocommerce-remote-inbox-engine'
-					);
-				}
-			}
+			array( __CLASS__, 'run_on_woocommerce_admin_updated' ),
+			'woocommerce-remote-inbox-engine'
 		);
-
+		
 		add_filter( 'woocommerce_get_note_from_db', array( __CLASS__, 'get_note_from_db' ), 10, 1 );
 	}
 


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds missing `woocommerce_run_on_woocommerce_admin_updated` hook to fix scheduled action error.
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #36767 .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions using pseudocode -- as if you're telling a computer how to execute the test. -->

1. Go to `WooCommerce -> Status -> Scheduled Actions` and search for `woocommerce_run_on_woocommerce_admin_updated` then delete it
2. Open `wp_options` table and search for `woocommerce_version`
3. Update `woocommerce_version` to a lower number.
4. Go to any WooCommerce Admin page and refresh.
5. Confirm `woocommerce_version` has been updated to the latest number.
6. Go to `WooCommerce -> Status -> Scheduled Actions` and search for `woocommerce_run_on_woocommerce_admin_updated`. 
7. Confirm the action executed.

<!-- End testing instructions -->

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
