### PR TITLE
Clone object array before iterating so that spliced array doesn't break iterator

### DIFF
--- a/plugins/woocommerce/client/legacy/js/frontend/cart.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/cart.js
@@ -85,7 +85,7 @@ jQuery( function( $ ) {
 	 */
 	var remove_duplicate_notices = function( notices ) {
 		var seen = [];
-		var new_notices = notices;
+		var new_notices = [...notices];
 
 		notices.each( function( index ) {
 			var text = $( this ).text();


### PR DESCRIPTION
When filtering an array the original can't be modified or else the iterator's cursor will get off and traverse into undefined territory
Instead, the modified array should be a clone

Fixes #35005

### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

This is a bug fix for a JS error caused when 2 identical notices exist on page and the duplicate is attempted to be removed.

Closes #35005

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

### How to test the changes in this Pull Request:

1. Using `wc_add_notice()` add 2 duplicate notices so they show up on shop pages (it may be helpful to create additional notices or multiple sets of duplicates)
2. Add an item to your cart and go to the cart page
3. Change the quantity of items in your cart to trigger an XHR call / JS update
4. Expected result:
    1. When broken, there will be an error in the JS console and the cart spinner will never close
    2. When working the quantity will update properly with no errors

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
