### PR TITLE
Support opening direction prop for ExperimentalCollapsibleList component

### DIFF
--- a/packages/js/experimental/changelog/update-36805-support-direction-prop
+++ b/packages/js/experimental/changelog/update-36805-support-direction-prop
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+
+Support direction prop to control which direction hidden items open.
+

--- a/packages/js/experimental/src/experimental-list/collapsible-list/index.tsx
+++ b/packages/js/experimental/src/experimental-list/collapsible-list/index.tsx
@@ -32,6 +32,7 @@ type CollapsibleListProps = {
 	show?: number;
 	onCollapse?: () => void;
 	onExpand?: () => void;
+	direction?: 'top' | 'bottom';
 } & ListProps;
 
 const defaultStyle = {
@@ -126,6 +127,7 @@ export const ExperimentalCollapsibleList: React.FC< CollapsibleListProps > = ( {
 	show = 0,
 	onCollapse,
 	onExpand,
+	direction = 'top',
 	...listProps
 } ): JSX.Element => {
 	const [ isCollapsed, setCollapsed ] = useState( collapsed );
@@ -225,9 +227,33 @@ export const ExperimentalCollapsibleList: React.FC< CollapsibleListProps > = ( {
 		'woocommerce-experimental-list-wrapper': ! isCollapsed,
 	} );
 
+	const hiddenChildren =
+		displayedChildren.hidden.length > 0 ? (
+			<ExperimentalListItem
+				key="collapse-item"
+				className="list-item-collapse"
+				onClick={ clickHandler }
+				animation="none"
+				disableGutters
+			>
+				<p>
+					{ isCollapsed
+						? footerLabels.expand
+						: footerLabels.collapse }
+				</p>
+
+				<Icon
+					className="list-item-collapse__icon"
+					size={ 30 }
+					icon={ isCollapsed ? chevronDown : chevronUp }
+				/>
+			</ExperimentalListItem>
+		) : null;
+
 	return (
 		<ExperimentalList { ...listProps } className={ listClasses }>
 			{ [
+				direction === 'bottom' && hiddenChildren,
 				...displayedChildren.shown,
 				<Transition
 					key="remaining-children"
@@ -288,27 +314,7 @@ export const ExperimentalCollapsibleList: React.FC< CollapsibleListProps > = ( {
 						);
 					} }
 				</Transition>,
-				displayedChildren.hidden.length > 0 ? (
-					<ExperimentalListItem
-						key="collapse-item"
-						className="list-item-collapse"
-						onClick={ clickHandler }
-						animation="none"
-						disableGutters
-					>
-						<p>
-							{ isCollapsed
-								? footerLabels.expand
-								: footerLabels.collapse }
-						</p>
-
-						<Icon
-							className="list-item-collapse__icon"
-							size={ 30 }
-							icon={ isCollapsed ? chevronDown : chevronUp }
-						/>
-					</ExperimentalListItem>
-				) : null,
+				direction === 'top' && hiddenChildren,
 			] }
 		</ExperimentalList>
 	);

--- a/packages/js/experimental/src/experimental-list/collapsible-list/index.tsx
+++ b/packages/js/experimental/src/experimental-list/collapsible-list/index.tsx
@@ -32,7 +32,7 @@ type CollapsibleListProps = {
 	show?: number;
 	onCollapse?: () => void;
 	onExpand?: () => void;
-	direction?: 'top' | 'bottom';
+	direction?: 'up' | 'down';
 } & ListProps;
 
 const defaultStyle = {
@@ -127,7 +127,7 @@ export const ExperimentalCollapsibleList: React.FC< CollapsibleListProps > = ( {
 	show = 0,
 	onCollapse,
 	onExpand,
-	direction = 'top',
+	direction = 'up',
 	...listProps
 } ): JSX.Element => {
 	const [ isCollapsed, setCollapsed ] = useState( collapsed );
@@ -253,7 +253,7 @@ export const ExperimentalCollapsibleList: React.FC< CollapsibleListProps > = ( {
 	return (
 		<ExperimentalList { ...listProps } className={ listClasses }>
 			{ [
-				direction === 'bottom' && hiddenChildren,
+				direction === 'down' && hiddenChildren,
 				...displayedChildren.shown,
 				<Transition
 					key="remaining-children"
@@ -314,7 +314,7 @@ export const ExperimentalCollapsibleList: React.FC< CollapsibleListProps > = ( {
 						);
 					} }
 				</Transition>,
-				direction === 'top' && hiddenChildren,
+				direction === 'up' && hiddenChildren,
 			] }
 		</ExperimentalList>
 	);

--- a/packages/js/experimental/src/experimental-list/stories/index.tsx
+++ b/packages/js/experimental/src/experimental-list/stories/index.tsx
@@ -16,6 +16,14 @@ export default {
 	title: 'WooCommerce Admin/experimental/List',
 	component: List,
 	decorators: [ ( storyFn, context ) => withConsole()( storyFn )( context ) ],
+	argTypes: {
+		direction: {
+			control: {
+				type: 'select',
+				options: [ 'top', 'bottom' ],
+			},
+		},
+	},
 } as Meta;
 
 const Template: Story< ListProps > = ( args ) => (
@@ -40,9 +48,10 @@ export const Primary = Template.bind( { onClick: () => {} } );
 Primary.args = {
 	listType: 'ul',
 	animation: 'slide-right',
+	direction: 'top',
 };
 
-export const CollapsibleListExample: Story = () => {
+export const CollapsibleListExample: Story = ( args ) => {
 	return (
 		<CollapsibleList
 			collapseLabel="Show less"
@@ -56,6 +65,8 @@ export const CollapsibleListExample: Story = () => {
 				// eslint-disable-next-line no-console
 				console.log( 'expanded' );
 			} }
+			direction="top"
+			{ ...args }
 		>
 			<ListItem onClick={ () => {} }>
 				<div>Any markup can go here.</div>

--- a/packages/js/experimental/src/experimental-list/stories/index.tsx
+++ b/packages/js/experimental/src/experimental-list/stories/index.tsx
@@ -20,7 +20,7 @@ export default {
 		direction: {
 			control: {
 				type: 'select',
-				options: [ 'top', 'bottom' ],
+				options: [ 'up', 'down' ],
 			},
 		},
 	},


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #36805  .

This PR adds `direction` props to control which direction hidden items open.

![Screen Shot 2023-02-09 at 11 20 28 AM](https://user-images.githubusercontent.com/4723145/217915838-e1d38a05-79f6-4bc4-a9d1-af63efc3242d.jpg)



### How to test the changes in this Pull Request:

1. Build the change `pnpm --filter=@woocommerce/experimental start`
2. Run `pnpm --filter=@woocommerce/storybook run storybook` 
3. Click `experimental -> List -> List with CollapsibleListItem`
4. Change `direction` control to `bottom.
5. Confirm it works as expected.

<!-- End testing instructions -->

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
