### PR TITLE
Update product editor packages

### DIFF
--- a/packages/js/components/changelog/update-product_editor_packages
+++ b/packages/js/components/changelog/update-product_editor_packages
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Add deprecated message to packages moved to product-editor package.

--- a/packages/js/components/src/index.ts
+++ b/packages/js/components/src/index.ts
@@ -88,10 +88,6 @@ export { createOrderedChildren, sortFillsByOrder } from './utils';
 export { WooProductFieldItem as __experimentalWooProductFieldItem } from './woo-product-field-item';
 export { WooProductSectionItem as __experimentalWooProductSectionItem } from './woo-product-section-item';
 export { WooProductTabItem as __experimentalWooProductTabItem } from './woo-product-tab-item';
-export {
-	ProductSectionLayout as __experimentalProductSectionLayout,
-	ProductFieldSection as __experimentalProductFieldSection,
-} from './product-section-layout';
 export * from './product-fields';
 export {
 	SlotContextProvider,
@@ -99,3 +95,9 @@ export {
 	SlotContextType,
 	SlotContextHelpersType,
 } from './slot-context';
+
+// Exports below can be removed once the @woocommerce/product-editor package is released.
+export {
+	ProductSectionLayout as __experimentalProductSectionLayout,
+	ProductFieldSection as __experimentalProductFieldSection,
+} from './product-section-layout';

--- a/packages/js/components/src/index.ts
+++ b/packages/js/components/src/index.ts
@@ -88,6 +88,10 @@ export { createOrderedChildren, sortFillsByOrder } from './utils';
 export { WooProductFieldItem as __experimentalWooProductFieldItem } from './woo-product-field-item';
 export { WooProductSectionItem as __experimentalWooProductSectionItem } from './woo-product-section-item';
 export { WooProductTabItem as __experimentalWooProductTabItem } from './woo-product-tab-item';
+export {
+	ProductSectionLayout as __experimentalProductSectionLayout,
+	ProductFieldSection as __experimentalProductFieldSection,
+} from './product-section-layout';
 export * from './product-fields';
 export {
 	SlotContextProvider,

--- a/packages/js/components/src/product-section-layout/index.ts
+++ b/packages/js/components/src/product-section-layout/index.ts
@@ -1,0 +1,2 @@
+export * from './product-section-layout';
+export * from './product-field-section';

--- a/packages/js/components/src/product-section-layout/product-field-section.tsx
+++ b/packages/js/components/src/product-section-layout/product-field-section.tsx
@@ -3,6 +3,7 @@
  */
 import { createElement } from '@wordpress/element';
 import { Card, CardBody } from '@wordpress/components';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -23,17 +24,24 @@ export const ProductFieldSection: React.FC< ProductFieldSectionProps > = ( {
 	description,
 	className,
 	children,
-} ) => (
-	<ProductSectionLayout
-		title={ title }
-		description={ description }
-		className={ className }
-	>
-		<Card>
-			<CardBody>
-				{ children }
-				<WooProductFieldItem.Slot section={ id } />
-			</CardBody>
-		</Card>
-	</ProductSectionLayout>
-);
+} ) => {
+	deprecated( `__experimentalProductFieldSection`, {
+		version: '13.0.0',
+		plugin: '@woocommerce/components',
+		hint: 'Moved to @woocommerce/product-editor package: import { __experimentalProductFieldSection } from @woocommerce/product-editor',
+	} );
+	return (
+		<ProductSectionLayout
+			title={ title }
+			description={ description }
+			className={ className }
+		>
+			<Card>
+				<CardBody>
+					{ children }
+					<WooProductFieldItem.Slot section={ id } />
+				</CardBody>
+			</Card>
+		</ProductSectionLayout>
+	);
+};

--- a/packages/js/components/src/product-section-layout/product-field-section.tsx
+++ b/packages/js/components/src/product-section-layout/product-field-section.tsx
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { createElement } from '@wordpress/element';
+import { Card, CardBody } from '@wordpress/components';
+import { __experimentalWooProductFieldItem as WooProductFieldItem } from '@woocommerce/components';
+
+/**
+ * Internal dependencies
+ */
+import { ProductSectionLayout } from './product-section-layout';
+
+type ProductFieldSectionProps = {
+	id: string;
+	title: string;
+	description: string | JSX.Element;
+	className?: string;
+};
+
+export const ProductFieldSection: React.FC< ProductFieldSectionProps > = ( {
+	id,
+	title,
+	description,
+	className,
+	children,
+} ) => (
+	<ProductSectionLayout
+		title={ title }
+		description={ description }
+		className={ className }
+	>
+		<Card>
+			<CardBody>
+				{ children }
+				<WooProductFieldItem.Slot section={ id } />
+			</CardBody>
+		</Card>
+	</ProductSectionLayout>
+);

--- a/packages/js/components/src/product-section-layout/product-field-section.tsx
+++ b/packages/js/components/src/product-section-layout/product-field-section.tsx
@@ -3,12 +3,12 @@
  */
 import { createElement } from '@wordpress/element';
 import { Card, CardBody } from '@wordpress/components';
-import { __experimentalWooProductFieldItem as WooProductFieldItem } from '@woocommerce/components';
 
 /**
  * Internal dependencies
  */
 import { ProductSectionLayout } from './product-section-layout';
+import { WooProductFieldItem } from '../woo-product-field-item';
 
 type ProductFieldSectionProps = {
 	id: string;

--- a/packages/js/components/src/product-section-layout/product-section-layout.tsx
+++ b/packages/js/components/src/product-section-layout/product-section-layout.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { Children, isValidElement, createElement } from '@wordpress/element';
+import deprecated from '@wordpress/deprecated';
 /**
  * Internal dependencies
  */
@@ -18,17 +19,26 @@ export const ProductSectionLayout: React.FC< ProductSectionLayoutProps > = ( {
 	description,
 	className,
 	children,
-} ) => (
-	<FormSection
-		title={ title }
-		description={ description }
-		className={ className }
-	>
-		{ Children.map( children, ( child ) => {
-			if ( isValidElement( child ) && child.props.onChange ) {
-				return <div className="product-field-layout">{ child }</div>;
-			}
-			return child;
-		} ) }
-	</FormSection>
-);
+} ) => {
+	deprecated( `__experimentalProductSectionLayout`, {
+		version: '13.0.0',
+		plugin: '@woocommerce/components',
+		hint: 'Moved to @woocommerce/product-editor package: import { __experimentalProductSectionLayout } from @woocommerce/product-editor',
+	} );
+	return (
+		<FormSection
+			title={ title }
+			description={ description }
+			className={ className }
+		>
+			{ Children.map( children, ( child ) => {
+				if ( isValidElement( child ) && child.props.onChange ) {
+					return (
+						<div className="product-field-layout">{ child }</div>
+					);
+				}
+				return child;
+			} ) }
+		</FormSection>
+	);
+};

--- a/packages/js/components/src/product-section-layout/product-section-layout.tsx
+++ b/packages/js/components/src/product-section-layout/product-section-layout.tsx
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { Children, isValidElement, createElement } from '@wordpress/element';
+import { FormSection } from '@woocommerce/components';
+
+type ProductSectionLayoutProps = {
+	title: string;
+	description: string | JSX.Element;
+	className?: string;
+};
+
+export const ProductSectionLayout: React.FC< ProductSectionLayoutProps > = ( {
+	title,
+	description,
+	className,
+	children,
+} ) => (
+	<FormSection
+		title={ title }
+		description={ description }
+		className={ className }
+	>
+		{ Children.map( children, ( child ) => {
+			if ( isValidElement( child ) && child.props.onChange ) {
+				return <div className="product-field-layout">{ child }</div>;
+			}
+			return child;
+		} ) }
+	</FormSection>
+);

--- a/packages/js/components/src/product-section-layout/product-section-layout.tsx
+++ b/packages/js/components/src/product-section-layout/product-section-layout.tsx
@@ -2,7 +2,10 @@
  * External dependencies
  */
 import { Children, isValidElement, createElement } from '@wordpress/element';
-import { FormSection } from '@woocommerce/components';
+/**
+ * Internal dependencies
+ */
+import { FormSection } from '../form-section';
 
 type ProductSectionLayoutProps = {
 	title: string;

--- a/packages/js/components/src/product-section-layout/style.scss
+++ b/packages/js/components/src/product-section-layout/style.scss
@@ -1,0 +1,52 @@
+.woocommerce-form-section {
+	a {
+		text-decoration: none;
+	}
+
+	&__content {
+		.components-card {
+			border: 1px solid $gray-400;
+			border-radius: 2px;
+			box-shadow: none;
+			&__body {
+				padding: $gap-large;
+
+				.components-base-control,
+				.components-dropdown,
+				.woocommerce-rich-text-editor {
+					&:not(:first-child):not(.components-radio-control) {
+						margin-top: $gap-large - $gap-smaller;
+						margin-bottom: 0;
+					}
+				}
+			}
+		}
+
+		.woocommerce-product-form__field:not(:first-child) {
+			margin-top: $gap-large;
+
+			> .components-base-control {
+				margin-bottom: 0;
+			}
+		}
+
+		.components-radio-control .components-v-stack {
+			gap: $gap-small;
+		}
+
+		.woocommerce-collapsible-content {
+			margin-top: $gap-large;
+		}
+	}
+
+	&__header {
+		p > span {
+			display: block;
+			margin-bottom: $gap-smaller;
+		}
+	}
+
+	&:not(:first-child) {
+		margin-top: $gap-largest;
+	}
+}

--- a/packages/js/components/src/style.scss
+++ b/packages/js/components/src/style.scss
@@ -57,3 +57,4 @@
 @import 'collapsible-content/style.scss';
 @import 'form/style.scss';
 @import 'experimental-tree-control/tree.scss';
+@import 'product-section-layout/style.scss';


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Copied some of the `product-editor` components back to `@woocommerce/components` and added deprecated messages instead. This will still allow us to create sample plugins without breaking the build as `@woocommerce/product-editor` has not been released yet.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Run `pnpm run build` and make sure every thing builds correctly
2. Go to **WooCommerce > Products > Add New** with the feature flag enabled and make sure no `deprecated` messages show up and the form renders fine.
3. Create a JS file from [this gist](https://gist.github.com/louwie17/7564bb05cce17570fd8bba2d8734da97) and import it. Go to the new **Test tab** and make sure the deprecated warning shows up, but things still render correctly.


<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
