### PR TITLE
Have "Grow your store" appear first in marketing task by default

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/fills/Marketing/index.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/Marketing/index.tsx
@@ -27,6 +27,7 @@ import { PluginProps } from './Plugin';
 import { getPluginSlug } from '../../../utils';
 
 const ALLOWED_PLUGIN_LISTS = [ 'task-list/reach', 'task-list/grow' ];
+const PLUGIN_LIST_DISPLAY_ORDER = [ 'task-list/grow', 'task-list/reach' ];
 
 export const transformExtensionToPlugin = (
 	extension: Extension,
@@ -55,39 +56,43 @@ export const getMarketingExtensionLists = (
 ): [ PluginProps[], PluginListProps[] ] => {
 	const installed: PluginProps[] = [];
 	const lists: PluginListProps[] = [];
-	const freeExtensionsRandomized: ExtensionList[] = freeExtensions.sort(
-		() => Math.random() - 0.5
-	); // Randomize the order sections appear.
 
-	freeExtensionsRandomized.forEach( ( list ) => {
-		if ( ! ALLOWED_PLUGIN_LISTS.includes( list.key ) ) {
-			return;
-		}
-
-		const listPlugins: PluginProps[] = [];
-		list.plugins.forEach( ( extension ) => {
-			const plugin = transformExtensionToPlugin(
-				extension,
-				activePlugins,
-				installedPlugins
+	freeExtensions
+		.sort( ( a: ExtensionList, b: ExtensionList ) => {
+			return (
+				PLUGIN_LIST_DISPLAY_ORDER.indexOf( a.key ) -
+				PLUGIN_LIST_DISPLAY_ORDER.indexOf( b.key )
 			);
-			if ( plugin.isInstalled ) {
-				installed.push( plugin );
+		} )
+		.forEach( ( list ) => {
+			if ( ! ALLOWED_PLUGIN_LISTS.includes( list.key ) ) {
 				return;
 			}
-			listPlugins.push( plugin );
+
+			const listPlugins: PluginProps[] = [];
+			list.plugins.forEach( ( extension ) => {
+				const plugin = transformExtensionToPlugin(
+					extension,
+					activePlugins,
+					installedPlugins
+				);
+				if ( plugin.isInstalled ) {
+					installed.push( plugin );
+					return;
+				}
+				listPlugins.push( plugin );
+			} );
+
+			if ( ! listPlugins.length ) {
+				return;
+			}
+
+			const transformedList: PluginListProps = {
+				...list,
+				plugins: listPlugins,
+			};
+			lists.push( transformedList );
 		} );
-
-		if ( ! listPlugins.length ) {
-			return;
-		}
-
-		const transformedList: PluginListProps = {
-			...list,
-			plugins: listPlugins,
-		};
-		lists.push( transformedList );
-	} );
 
 	return [ installed, lists ];
 };

--- a/plugins/woocommerce-admin/client/tasks/fills/Marketing/index.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/Marketing/index.tsx
@@ -26,8 +26,8 @@ import { PluginList, PluginListProps } from './PluginList';
 import { PluginProps } from './Plugin';
 import { getPluginSlug } from '../../../utils';
 
-const ALLOWED_PLUGIN_LISTS = [ 'task-list/reach', 'task-list/grow' ];
-const PLUGIN_LIST_DISPLAY_ORDER = [ 'task-list/grow', 'task-list/reach' ];
+// We display the list of plugins ordered by this list.
+const ALLOWED_PLUGIN_LISTS = [ 'task-list/grow', 'task-list/reach' ];
 
 export const transformExtensionToPlugin = (
 	extension: Extension,
@@ -60,8 +60,8 @@ export const getMarketingExtensionLists = (
 	freeExtensions
 		.sort( ( a: ExtensionList, b: ExtensionList ) => {
 			return (
-				PLUGIN_LIST_DISPLAY_ORDER.indexOf( a.key ) -
-				PLUGIN_LIST_DISPLAY_ORDER.indexOf( b.key )
+				ALLOWED_PLUGIN_LISTS.indexOf( a.key ) -
+				ALLOWED_PLUGIN_LISTS.indexOf( b.key )
 			);
 		} )
 		.forEach( ( list ) => {

--- a/plugins/woocommerce-admin/client/tasks/fills/Marketing/test/index.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/Marketing/test/index.tsx
@@ -117,11 +117,10 @@ describe( 'getMarketingExtensionLists', () => {
 			[],
 			[]
 		);
-		const listKeys = lists.map( ( list ) => list.key );
 
 		expect( lists.length ).toBe( 2 );
-		expect( listKeys ).toContain( 'task-list/reach' );
-		expect( listKeys ).toContain( 'task-list/grow' );
+		expect( lists[ 0 ].key ).toBe( 'task-list/grow' );
+		expect( lists[ 1 ].key ).toBe( 'task-list/reach' );
 	} );
 
 	test( 'should separate installed plugins', () => {

--- a/plugins/woocommerce/changelog/update-marketing-task-section-order
+++ b/plugins/woocommerce/changelog/update-marketing-task-section-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Have "Grow your store" appear first in marketing task by default


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/team-ghidorah/issues/132.

Update the marketing task to display "Grow your store" section first by default.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. On a fresh site
2. Go to `WooCommmerce > Home`
3. Either skip or complete OBW 
4. Go to `WooCommmerce > Home`
5. Click on the Marketing Task (`Get more sales`).
6. Refresh the Marketing Task page a few times. The "Grow your store" should always be displayed first before the "Reach out to customers" section.

<img src="https://user-images.githubusercontent.com/9312929/178734168-02c20631-87d5-4fd7-a51d-c49262d4d4c0.png" />

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
