### PR TITLE
Add a unit test for `woocommerce_admin_experimental_onboarding_tasklists` filter

### DIFF
--- a/plugins/woocommerce/changelog/add-36536-unit-test-for-onboarding-filter
+++ b/plugins/woocommerce/changelog/add-36536-unit-test-for-onboarding-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add a unit test for woocommerce_admin_experimental_onboarding_tasklists filter

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/task-lists.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/task-lists.php
@@ -26,7 +26,7 @@ class WC_Tests_OnboardingTasks_TaskLists extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Tests that the "woocommerce_admin_experimental_onboarding_tasklists" filter is able to override tasklists.
+	 * Tests that the "woocommerce_admin_experimental_onboarding_tasklists" filter is able to append tasks to any tasklist.
 	 */
 	public function test_default_tasklists_can_be_add_by_onboarding_filter() {
 		// Filter the default task lists.

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/task-lists.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/task-lists.php
@@ -30,22 +30,25 @@ class WC_Tests_OnboardingTasks_TaskLists extends WC_Unit_Test_Case {
 	 */
 	public function test_default_tasklists_can_be_add_by_onboarding_filter() {
 		// Filter the default task lists.
-		add_filter( 'woocommerce_admin_experimental_onboarding_tasklists', function(
+		add_filter(
+			'woocommerce_admin_experimental_onboarding_tasklists',
+			function(
 			$task_lists
-		) {
-			$this->assertIsArray( $task_lists );
+			) {
+				$this->assertIsArray( $task_lists );
 
-			// Add a new task list.
-			$task_lists[ 'test' ] = new TaskList(
-				array(
-					'id'       => 'test',
-					'title'    => 'Test',
-					'tasks'    => array(),
-					'isHidden' => false,
-				)
-			);
-			return $task_lists;
-		} );
+				// Add a new task list.
+				$task_lists['test'] = new TaskList(
+					array(
+						'id'       => 'test',
+						'title'    => 'Test',
+						'tasks'    => array(),
+						'isHidden' => false,
+					)
+				);
+				return $task_lists;
+			}
+		);
 
 		// Initialize the default task lists.
 		TaskLists::init_default_lists();

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/task-lists.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/task-lists.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Test the TaskLists class.
+ *
+ * @package WooCommerce\Admin\Tests\OnboardingTasks
+ */
+
+/**
+ * Test task fixture.
+ */
+require_once __DIR__ . '/test-task.php';
+
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskList;
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists;
+
+/**
+ * Class WC_Tests_OnboardingTasks_TaskLists
+ */
+class WC_Tests_OnboardingTasks_TaskLists extends WC_Unit_Test_Case {
+	/**
+	 * Setup test data. Called before every test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		TaskLists::clear_lists();
+	}
+
+	/**
+	 * Tests that the "woocommerce_admin_experimental_onboarding_tasklists" filter is able to override tasklists.
+	 */
+	public function test_default_tasklists_can_be_add_by_onboarding_filter() {
+		// Filter the default task lists.
+		add_filter( 'woocommerce_admin_experimental_onboarding_tasklists', function(
+			$task_lists
+		) {
+			$this->assertIsArray( $task_lists );
+
+			// Add a new task list.
+			$task_lists[ 'test' ] = new TaskList(
+				array(
+					'id'       => 'test',
+					'title'    => 'Test',
+					'tasks'    => array(),
+					'isHidden' => false,
+				)
+			);
+			return $task_lists;
+		} );
+
+		// Initialize the default task lists.
+		TaskLists::init_default_lists();
+
+		// Assert that the new task list is added.
+		$this->assertNotEmpty( TaskLists::get_list( 'test' ) );
+	}
+}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/36536.

Add a unit test for `woocommerce_admin_experimental_onboarding_tasklists` filter to to ensure the filter is able to add/replace tasklists at will.

One reviewer should be enough.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [x] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Review the changes and the CI should pass

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
