### PR TITLE
Add SlotFill for marketing overview screen

### DIFF
--- a/plugins/woocommerce-admin/client/marketing/overview/index.js
+++ b/plugins/woocommerce-admin/client/marketing/overview/index.js
@@ -12,11 +12,11 @@ import RecommendedExtensions from '../components/recommended-extensions';
 import KnowledgeBase from '../components/knowledge-base';
 import WelcomeCard from './welcome-card';
 import { getAdminSetting } from '~/utils/admin-settings';
+import { MarketingOverviewSectionSlot } from './section-slot';
 import '../data';
 
 const MarketingOverview = () => {
 	const { currentUserCan } = useUser();
-
 	const shouldShowExtensions =
 		getAdminSetting( 'allowMarketplaceSuggestions', false ) &&
 		currentUserCan( 'install_plugins' );
@@ -25,6 +25,7 @@ const MarketingOverview = () => {
 		<div className="woocommerce-marketing-overview">
 			<WelcomeCard />
 			<InstalledExtensions />
+			<MarketingOverviewSectionSlot />
 			{ shouldShowExtensions && (
 				<RecommendedExtensions category="marketing" />
 			) }

--- a/plugins/woocommerce-admin/client/marketing/overview/index.js
+++ b/plugins/woocommerce-admin/client/marketing/overview/index.js
@@ -17,6 +17,7 @@ import '../data';
 
 const MarketingOverview = () => {
 	const { currentUserCan } = useUser();
+
 	const shouldShowExtensions =
 		getAdminSetting( 'allowMarketplaceSuggestions', false ) &&
 		currentUserCan( 'install_plugins' );

--- a/plugins/woocommerce-admin/client/marketing/overview/section-slot/index.ts
+++ b/plugins/woocommerce-admin/client/marketing/overview/section-slot/index.ts
@@ -1,0 +1,2 @@
+export * from './section-slot';
+export * from './utils';

--- a/plugins/woocommerce-admin/client/marketing/overview/section-slot/section-slot.tsx
+++ b/plugins/woocommerce-admin/client/marketing/overview/section-slot/section-slot.tsx
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import { useSlot } from '@woocommerce/experimental';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import {
+	EXPERIMENTAL_WC_MARKETING_OVERVIEW_SECTION_SLOT_NAME,
+	WooMarketingOverviewSection,
+} from './utils';
+
+export const MarketingOverviewSectionSlot = ( {
+	className,
+}: {
+	className: string;
+} ) => {
+	const slot = useSlot(
+		EXPERIMENTAL_WC_MARKETING_OVERVIEW_SECTION_SLOT_NAME
+	);
+	const hasFills = Boolean( slot?.fills?.length );
+
+	if ( ! hasFills ) {
+		return null;
+	}
+	return (
+		<div
+			className={ classnames(
+				'woocommerce-marketing-overview__section',
+				className
+			) }
+		>
+			<WooMarketingOverviewSection.Slot />
+		</div>
+	);
+};

--- a/plugins/woocommerce-admin/client/marketing/overview/section-slot/utils.tsx
+++ b/plugins/woocommerce-admin/client/marketing/overview/section-slot/utils.tsx
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import { Slot, Fill } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { createOrderedChildren, sortFillsByOrder } from '../../../utils';
+
+export const EXPERIMENTAL_WC_MARKETING_OVERVIEW_SECTION_SLOT_NAME =
+	'experimental_woocommerce_marketing_overview_section';
+/**
+ * Create a Fill for extensions to add a section to the Marketing Overview page.
+ *
+ * @slotFill WooMarketingOverviewSection
+ * @scope woocommerce-admin
+ * @example
+ * const MySection = () => (
+ * 	<Fill name="experimental_woocommerce_marketing_overview_section">
+ * 		<div className="woocommerce-experiments-placeholder-slotfill">
+ * 			<div className="placeholder-slotfill-content">
+ * 				Slotfill goes in here!
+ * 			</div>
+ * 		</div>
+ * 	</Fill>
+ * );
+ *
+ * registerPlugin( 'my-extension', {
+ * render: MySection,
+ * scope: 'woocommerce-admin',
+ * } );
+ * @param {Object} param0
+ * @param {Array}  param0.children - Node children.
+ * @param {Array}  param0.order    - Node order.
+ */
+export const WooMarketingOverviewSection = ( {
+	children,
+	order = 1,
+}: {
+	children: React.ReactNode;
+	order?: number;
+} ) => {
+	return (
+		<Fill name={ EXPERIMENTAL_WC_MARKETING_OVERVIEW_SECTION_SLOT_NAME }>
+			{ ( fillProps: Fill.Props ) => {
+				return createOrderedChildren( children, order, fillProps );
+			} }
+		</Fill>
+	);
+};
+
+WooMarketingOverviewSection.Slot = ( {
+	fillProps,
+}: {
+	fillProps?: Slot.Props;
+} ) => (
+	<Slot
+		name={ EXPERIMENTAL_WC_MARKETING_OVERVIEW_SECTION_SLOT_NAME }
+		fillProps={ fillProps }
+	>
+		{ sortFillsByOrder }
+	</Slot>
+);

--- a/plugins/woocommerce/changelog/add-36615-marketing-overview-section-slot
+++ b/plugins/woocommerce/changelog/add-36615-marketing-overview-section-slot
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add an experimental slot for marketing overview extensibility

--- a/plugins/woocommerce/changelog/p
+++ b/plugins/woocommerce/changelog/p
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add a experimental slot for marketing overview extensibility

--- a/plugins/woocommerce/changelog/p
+++ b/plugins/woocommerce/changelog/p
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a experimental slot for marketing overview extensibility


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/36615.

A SlotFill extensibility point is added below the `Installed marketing extensions` section on the marketing overview page to allow appending a component.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Checkout this branch first
2. Rebase `demo/example-marketing-section-fill` on top or cherry pick the relevant [commit](https://github.com/woocommerce/woocommerce/commit/8f0e81813c06dd533e4d94f1a80fa8a3686326b0) for the demo marketing section fill
3. Install marketing plugins such as [Google Listings & Ads](https://woocommerce.com/products/google-listings-and-ads/)
4. Go to `WooCommmerce > Marketing > Overview`
5. Observe the demo fill should look like the above screencap

https://user-images.githubusercontent.com/4344253/218641327-2c9c0f85-7565-4857-93c2-291207bd8c51.mov

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
