### PR TITLE
Fix create ordered children helper function

### DIFF
--- a/packages/js/components/changelog/fix-create_ordered_children
+++ b/packages/js/components/changelog/fix-create_ordered_children
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix issue were Options tab was not showing up anymore in new product management screen.

--- a/packages/js/components/src/utils.tsx
+++ b/packages/js/components/src/utils.tsx
@@ -44,7 +44,7 @@ function getChildrenAndProps< T = Fill.Props, S = Record< string, unknown > >(
 		}
 		return {
 			children: children as React.ReactElement< ChildrenProps >,
-			props: { order },
+			props: { order, ...injectProps },
 		};
 	}
 	throw Error( 'Invalid children type' );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Small fix that still passes in the `injectProps` that are needed for the tab specific data.
Without this it caused some tabs not to show up that made use of either Fragments or html elements as there first child (this makes the `Options` tab show up again.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Create a test field like this (in `details-section-fills`?)
```js
<WooProductFieldItem
	id="my-field-item"
	sections={ [ { name: DETAILS_SECTION_ID, order: 2 } ] }
	pluginId={ PLUGIN_ID }
>
	<div className="my-class">Test field</div>
</WooProductFieldItem>
```
2. Open the browser console and go to `Products` > `Add New`.
3. Verify that the console has no error (or warning).
4. Verify that the field is rendered in the right order.
5. Enable the `product-variation-management` feature flag and go to **Products > Add New** and make sure the **Options** tab shows up correctly and contains the necessary fields.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
