### PR TITLE
Prevent stores from calling helper API when local cache is not functioning

### DIFF
--- a/plugins/woocommerce/changelog/fix-helper-api-usage-when-cache-is-not-working
+++ b/plugins/woocommerce/changelog/fix-helper-api-usage-when-cache-is-not-working
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix the issue of stores sending frequent Helper API requests when site cache is not functioning properly.

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
@@ -270,7 +270,7 @@ class WC_Helper_Updater {
 		$raw_response = wp_remote_post(
 			'https://translate.wordpress.com/api/translations-updates/woocommerce',
 			array(
-				'body'    => json_encode( $request_body ),
+				'body'    => wp_json_encode( $request_body ),
 				'headers' => array( 'Content-Type: application/json' ),
 				'timeout' => $timeout,
 			)

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
@@ -77,7 +77,7 @@ class WC_Helper_Updater {
 			}
 		}
 
-		$translations = self::get_translations_update_data();
+		$translations            = self::get_translations_update_data();
 		$transient->translations = array_merge( isset( $transient->translations ) ? $transient->translations : array(), $translations );
 
 		return $transient;
@@ -232,8 +232,8 @@ class WC_Helper_Updater {
 		}
 
 		// Scan local plugins which may or may not have a subscription.
-		$plugins                 = WC_Helper::get_local_woo_plugins();
-		$active_woo_plugins      = array_intersect( array_keys( $plugins ), get_option( 'active_plugins', array() ) );
+		$plugins            = WC_Helper::get_local_woo_plugins();
+		$active_woo_plugins = array_intersect( array_keys( $plugins ), get_option( 'active_plugins', array() ) );
 
 		/*
 		* Use only plugins that are subscribed to the automatic translations updates.
@@ -263,16 +263,16 @@ class WC_Helper_Updater {
 		);
 
 		foreach ( $active_for_translations as $active_plugin ) {
-			$plugin = $plugins[ $active_plugin ];
+			$plugin                                     = $plugins[ $active_plugin ];
 			$request_body['plugins'][ $plugin['slug'] ] = array( 'version' => $plugin['Version'] );
 		}
 
 		$raw_response = wp_remote_post(
 			'https://translate.wordpress.com/api/translations-updates/woocommerce',
 			array(
-				'body'        => json_encode( $request_body ),
-				'headers'     => array( 'Content-Type: application/json' ),
-				'timeout'     => $timeout,
+				'body'    => json_encode( $request_body ),
+				'headers' => array( 'Content-Type: application/json' ),
+				'timeout' => $timeout,
 			)
 		);
 
@@ -336,6 +336,11 @@ class WC_Helper_Updater {
 			if ( hash_equals( $hash, $data['hash'] ) ) {
 				return $data['products'];
 			}
+		}
+
+		if ( false === WC_Helper::verify_site_cache_status() ) {
+			WC_Helper::log( 'Could not perform update-check due to dysfunctional site cache. This could be due to a misconfigured object cache or database not having enough space.' );
+			return array();
 		}
 
 		$data = array(

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-updater.php
@@ -338,7 +338,7 @@ class WC_Helper_Updater {
 			}
 		}
 
-		if ( false === WC_Helper::verify_site_cache_status() ) {
+		if ( false === wc_is_transient_functional() ) {
 			WC_Helper::log( 'Could not perform update-check due to dysfunctional site cache. This could be due to a misconfigured object cache or database not having enough space.' );
 			return array();
 		}

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -1270,6 +1270,11 @@ class WC_Helper {
 			return $data;
 		}
 
+		if ( false === self::verify_site_cache_status() ) {
+			self::log( 'Could not fetch subscription data due to dysfunctional site cache. This could be due to a misconfigured object cache or database not having enough space.' );
+			return array();
+		}
+
 		$request_uri = wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$source      = '';
 		if ( stripos( $request_uri, 'wc-addons' ) ) :
@@ -1769,6 +1774,24 @@ class WC_Helper {
 
 		self::_flush_subscriptions_cache();
 		self::_flush_updates_cache();
+	}
+
+	/**
+	 * Verify if the cache is working properly.
+	 *
+	 * @return bool
+	 */
+	public static function verify_site_cache_status(): bool {
+		$current_timestamp_cache_key = '_wc_helper_api_cache_test';
+		$current_timestamp           = time();
+		set_transient( $current_timestamp_cache_key, $current_timestamp );
+		$cached_timestamp = get_transient( '_wc_helper_api_cache_test' );
+		// To avoid a potential race condition where the transient is updated with a new timestamp
+		if ( $current_timestamp <= (int) $cached_timestamp ) {
+			return true;
+		}
+
+		return false;
 	}
 }
 

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -1270,7 +1270,7 @@ class WC_Helper {
 			return $data;
 		}
 
-		if ( false === self::verify_site_cache_status() ) {
+		if ( false === wc_is_transient_functional() ) {
 			self::log( 'Could not fetch subscription data due to dysfunctional site cache. This could be due to a misconfigured object cache or database not having enough space.' );
 			return array();
 		}
@@ -1774,24 +1774,6 @@ class WC_Helper {
 
 		self::_flush_subscriptions_cache();
 		self::_flush_updates_cache();
-	}
-
-	/**
-	 * Verify if the cache is working properly.
-	 *
-	 * @return bool
-	 */
-	public static function verify_site_cache_status(): bool {
-		$current_timestamp_cache_key = '_wc_helper_api_cache_test';
-		$current_timestamp           = time();
-		set_transient( $current_timestamp_cache_key, $current_timestamp );
-		$cached_timestamp = get_transient( '_wc_helper_api_cache_test' );
-		// To avoid a potential race condition where the transient is updated with a new timestamp.
-		if ( $current_timestamp <= (int) $cached_timestamp ) {
-			return true;
-		}
-
-		return false;
 	}
 }
 

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -1786,7 +1786,7 @@ class WC_Helper {
 		$current_timestamp           = time();
 		set_transient( $current_timestamp_cache_key, $current_timestamp );
 		$cached_timestamp = get_transient( '_wc_helper_api_cache_test' );
-		// To avoid a potential race condition where the transient is updated with a new timestamp
+		// To avoid a potential race condition where the transient is updated with a new timestamp.
 		if ( $current_timestamp <= (int) $cached_timestamp ) {
 			return true;
 		}

--- a/plugins/woocommerce/includes/wc-conditional-functions.php
+++ b/plugins/woocommerce/includes/wc-conditional-functions.php
@@ -574,3 +574,25 @@ function wc_block_theme_has_styles_for_element( $element ) {
 
 	return false;
 }
+
+/**
+ * Verify if the transients can be saved and retrieved properly.
+ *
+ * If transients are not working properly,
+ * return false.
+ *
+ * @since 7.6.0
+ * @return bool
+ */
+function wc_is_transient_functional() {
+	$current_timestamp_cache_key = '_wc_transient_test';
+	$current_timestamp           = time();
+	set_transient( $current_timestamp_cache_key, $current_timestamp );
+	$cached_timestamp = get_transient( $current_timestamp_cache_key );
+	// To avoid a potential race condition where the transient is updated with a new timestamp.
+	if ( $current_timestamp <= (int) $cached_timestamp ) {
+		return true;
+	}
+
+	return false;
+}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Connected WooCommerce stores send requests to helper API for fetching details related to subscriptions and to get information about plugin updates. The responses from these API endpoints are cached to prevent stores from sending multiple requests frequently. 


For example, the `GET subscriptions` request is cached for  1 hour and `POST update-check` request is cached for 12 hours.

But for some stores, the cache can be completely broken due to DB having a full disk. This is because when `set_transient` is called if the object cache is not configured for the site wp options table will be used to store the transient value. (further discussions in this [P2 post](https://alphamattic.wordpress.com/2021/11/01/raising-spike-of-requests-to-woo-helper-api/#comment-12553) and the [issue](https://github.com/Automattic/woocommerce.com/issues/11649))

Since the response from Helper API `GET subscriptions` and `POST update-check` is not the cached store will keep sending these requests. Basically this PR will block stores from calling above two endpoints if site local cache is not functioning.

Find more details on this [P2 post](https://alphamattic.wordpress.com/2023/02/16/reducing-duplicate-traffic-on-helper-api/).

Closes # .

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Make sure the site is connected to WCCOM via <your test site root>wp-admin/admin.php?page=wc-addons&section=helper
2. Add the following code into a mu-plugin to trick helper API client to think that the cache is broken.
```
add_filter( 'pre_transient__wc_helper_api_cache_test', function() {
	return 0;
} );
```
3. Run `wp cache flush` to remove any previously stored subscription response.
4. Visit My subscriptions page `wp-admin/admin.php?page=wc-addons&section=helper`
5. There should be an error mentioning `Could not find any subscriptions on your WooCommerce.com account`
![Screenshot 2023-02-15 at 17 26 24](https://user-images.githubusercontent.com/1531403/219093847-5f8ddcce-68d3-4b76-8ee8-c3e20e62fe29.png)
6. Also there should be a log entry indicating the helper API request is skipped due to broken cache.
![Screenshot 2023-02-15 at 13 13 54](https://user-images.githubusercontent.com/1531403/219094309-d943bebf-eccd-4038-ab42-fb583bdd19ec.png)
7. Same should happen when pressing `Update` button under My Subscriptions.
8. `wp wc com extension list` command should be blocked from making getting the subscription list.
9. Now remove the hook added in step 2 and notice that the update check and subscription requests are working fine.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
