### PR TITLE
Use createSelector for getPermalinkParts selector to cache result

### DIFF
--- a/packages/js/data/changelog/update-get-permalink-parts-create-selector
+++ b/packages/js/data/changelog/update-get-permalink-parts-create-selector
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Use createSelector for getPermalinkParts selector, to cache result.

--- a/packages/js/data/src/products/selectors.ts
+++ b/packages/js/data/src/products/selectors.ts
@@ -121,24 +121,29 @@ export const isPending = (
 	return false;
 };
 
-export const getPermalinkParts = ( state: ProductState, productId: number ) => {
-	const product = state.data[ productId ];
+export const getPermalinkParts = createSelector(
+	( state: ProductState, productId: number ) => {
+		const product = state.data[ productId ];
 
-	if ( product && product.permalink_template ) {
-		const postName = product.slug || product.generated_slug;
+		if ( product && product.permalink_template ) {
+			const postName = product.slug || product.generated_slug;
 
-		const [ prefix, suffix ] = product.permalink_template.split(
-			PERMALINK_PRODUCT_REGEX
-		);
+			const [ prefix, suffix ] = product.permalink_template.split(
+				PERMALINK_PRODUCT_REGEX
+			);
 
-		return {
-			prefix,
-			postName,
-			suffix,
-		};
+			return {
+				prefix,
+				postName,
+				suffix,
+			};
+		}
+		return null;
+	},
+	( state, productId ) => {
+		return [ state.data[ productId ] ];
 	}
-	return null;
-};
+);
 
 export type ProductsSelectors = {
 	getCreateProductError: WPDataSelector< typeof getCreateProductError >;


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR is a follow up to #36706.

This uses `createSelector` for the `getPermalinkParts` selector, to cache the results and return the same object when the result hasn't changed.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

Using the new product editor (enable in WooCommerce > Settings > Advanced > Features)...

To test that the selector returns a cached result:

1. In the browser dev tools console...

```
let parts = wp.data.select('wc/admin/products').getPermalinkParts({PRODUCT_ID}); // call to kick off the request
let parts = wp.data.select('wc/admin/products').getPermalinkParts({PRODUCT_ID}); // call again to get the fulfilled result
wp.data.select('wc/admin/products').getPermalinkParts({PRODUCT_ID}) === parts // should return true
```

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
