### PR TITLE
Switched matching of screen ID with the untranslated string.

### DIFF
--- a/plugins/woocommerce/changelog/fix-36474
+++ b/plugins/woocommerce/changelog/fix-36474
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Screen ID matching switched to untranslated 'woocommerce' sctrings.
+Screen ID matching switched to untranslated 'woocommerce' strings.

--- a/plugins/woocommerce/changelog/fix-36474
+++ b/plugins/woocommerce/changelog/fix-36474
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Screen ID matching switched to untranslated 'woocommerce' sctrings.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -106,11 +106,11 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 		 * Enqueue scripts.
 		 */
 		public function admin_scripts() {
-			global $wp_query, $post, $theorder;
+			global $wp_query, $post, $theorder, $admin_page_hooks;
 
 			$screen       = get_current_screen();
 			$screen_id    = $screen ? $screen->id : '';
-			$wc_screen_id = sanitize_title( __( 'WooCommerce', 'woocommerce' ) );
+			$wc_screen_id = $admin_page_hooks['woocommerce'];
 			$suffix       = Constants::is_true( 'SCRIPT_DEBUG' ) ? '' : '.min';
 			$version      = Constants::get_constant( 'WC_VERSION' );
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -106,11 +106,11 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 		 * Enqueue scripts.
 		 */
 		public function admin_scripts() {
-			global $wp_query, $post, $theorder, $admin_page_hooks;
+			global $wp_query, $post, $theorder;
 
 			$screen       = get_current_screen();
 			$screen_id    = $screen ? $screen->id : '';
-			$wc_screen_id = $admin_page_hooks['woocommerce'];
+			$wc_screen_id = 'woocommerce';
 			$suffix       = Constants::is_true( 'SCRIPT_DEBUG' ) ? '' : '.min';
 			$version      = Constants::get_constant( 'WC_VERSION' );
 

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -504,11 +504,9 @@ class WC_Helper {
 	 * Enqueue admin scripts and styles.
 	 */
 	public static function admin_enqueue_scripts() {
-		global $admin_page_hooks;
-
 		$screen       = get_current_screen();
 		$screen_id    = $screen ? $screen->id : '';
-		$wc_screen_id = $admin_page_hooks['woocommerce'];
+		$wc_screen_id = 'woocommerce';
 
 		if ( $wc_screen_id . '_page_wc-addons' === $screen_id && isset( $_GET['section'] ) && 'helper' === $_GET['section'] ) {
 			wp_enqueue_style( 'woocommerce-helper', WC()->plugin_url() . '/assets/css/helper.css', array(), Constants::get_constant( 'WC_VERSION' ) );
@@ -663,9 +661,7 @@ class WC_Helper {
 	 * @param object $screen WP screen object.
 	 */
 	public static function current_screen( $screen ) {
-		global $admin_page_hooks;
-
-		$wc_screen_id = $admin_page_hooks['woocommerce'];
+		$wc_screen_id = 'woocommerce';
 
 		if ( $wc_screen_id . '_page_wc-addons' !== $screen->id ) {
 			return;

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -504,9 +504,11 @@ class WC_Helper {
 	 * Enqueue admin scripts and styles.
 	 */
 	public static function admin_enqueue_scripts() {
+		global $admin_page_hooks;
+
 		$screen       = get_current_screen();
 		$screen_id    = $screen ? $screen->id : '';
-		$wc_screen_id = sanitize_title( __( 'WooCommerce', 'woocommerce' ) );
+		$wc_screen_id = $admin_page_hooks['woocommerce'];
 
 		if ( $wc_screen_id . '_page_wc-addons' === $screen_id && isset( $_GET['section'] ) && 'helper' === $_GET['section'] ) {
 			wp_enqueue_style( 'woocommerce-helper', WC()->plugin_url() . '/assets/css/helper.css', array(), Constants::get_constant( 'WC_VERSION' ) );
@@ -661,7 +663,9 @@ class WC_Helper {
 	 * @param object $screen WP screen object.
 	 */
 	public static function current_screen( $screen ) {
-		$wc_screen_id = sanitize_title( __( 'WooCommerce', 'woocommerce' ) );
+		global $admin_page_hooks;
+
+		$wc_screen_id = $admin_page_hooks['woocommerce'];
 
 		if ( $wc_screen_id . '_page_wc-addons' !== $screen->id ) {
 			return;

--- a/plugins/woocommerce/includes/admin/wc-admin-functions.php
+++ b/plugins/woocommerce/includes/admin/wc-admin-functions.php
@@ -18,9 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return array
  */
 function wc_get_screen_ids() {
-	global $admin_page_hooks;
-
-	$wc_screen_id = $admin_page_hooks['woocommerce'];
+	$wc_screen_id = 'woocommerce';
 	$screen_ids   = array(
 		'toplevel_page_' . $wc_screen_id,
 		$wc_screen_id . '_page_wc-orders',

--- a/plugins/woocommerce/includes/admin/wc-admin-functions.php
+++ b/plugins/woocommerce/includes/admin/wc-admin-functions.php
@@ -18,8 +18,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return array
  */
 function wc_get_screen_ids() {
+	global $admin_page_hooks;
 
-	$wc_screen_id = sanitize_title( __( 'WooCommerce', 'woocommerce' ) );
+	$wc_screen_id = $admin_page_hooks['woocommerce'];
 	$screen_ids   = array(
 		'toplevel_page_' . $wc_screen_id,
 		$wc_screen_id . '_page_wc-orders',


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/36474 .

The change proposed here, along with earlier PR from 7.3 (https://github.com/woocommerce/woocommerce/pull/35695) might be worth mentioning in a dev advisory, as (strictly speaking) it breaks backward compatibility.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

Side note: We should also ensure previous problems won't reappear, so testing instructions for issues https://github.com/woocommerce/woocommerce/issues/4788 and https://github.com/woocommerce/woocommerce/issues/16043 have been included as well.


1. Start with a fresh WC 7.3 site set to the English language.
2. Add at least one shipping zone via WooCommerce > Settings > Shipping > Shipping Zones > Add Shipping Zone, e.g. Europe, Flat Rate 10 pounds/euros/dollars/pesos.
3. Confirm the Shipping zones section contains added shipping zones:
![Screenshot 2023-02-16 at 14 41 38](https://user-images.githubusercontent.com/2207451/219380666-c7164785-6026-492e-b8de-7c28e11e30a1.png)
4. Switch the language of the Admin to Farsi (فارسی) via Settings > General > Site Language, then click on the button Save Changes further down.
5. Go to core updates page and make sure to download translations for WC for Farsi language.
![Screenshot 2023-02-16 at 14 45 26](https://user-images.githubusercontent.com/2207451/219381646-ee329013-1a63-49c9-a8d6-eb7222637c40.png)
6. The very last section on the page should show a button that updates the translations (you can use Google Translate to translate the interface). Click the button to update the translations and then reload. (Example shows translation for different language since I already downloaded the Farsi one).
![Screenshot 2023-02-16 at 14 49 29](https://user-images.githubusercontent.com/2207451/219382602-ef148c44-f0d3-4ebc-ab14-f6b612f5572d.png)
7. Check the translations were loaded correctly by looking at the WP Admin menu. If the WooCommerce items (WooCommerce, Products, Analytics, etc) are no longer in English, then you succeeded. 
8. Now navigate to WooCommerce > Settings > Shipping.
9. You should see an empty list of Shipping zones (only the row for "Other zones" should be visible)
![Screenshot 2023-02-16 at 14 54 00](https://user-images.githubusercontent.com/2207451/219383622-2c5ee195-fe8a-4c58-833a-a1ec16de4c74.png)

11. Now apply the changes from this branch.
12. Reload the page, you should see all the shipping zones:
![Screenshot 2023-02-16 at 14 56 00](https://user-images.githubusercontent.com/2207451/219384097-955862b4-4b4c-4334-8f98-a525f5f19675.png)
13. Now test that you can create a new REST API key:
14. Go to WC > Settings > Advanced > REST API
15. Click Add key (افزودن کلید)
16. Set the description for the new key, e.g. `test-123` and click `Generate API key` (ساخت کلید API ) button. 
17. You should be able to see a new set of keys, a QR code and a message that the keys were generated successfully.
![Screenshot 2023-02-16 at 15 00 14](https://user-images.githubusercontent.com/2207451/219385169-63a4deac-0d3d-4ee8-865b-b94f2643fe2e.png)

19. Go to WC > Settings > Advanced > REST API to make sure the new key is listed in the list of REST API keys.
20. Go to WC > Settings > Payments and make sure the activation and ordering works: Try to activate Payment by check and change the ordering via the arrows, then Save changes:
![Screenshot 2023-02-16 at 15 03 29](https://user-images.githubusercontent.com/2207451/219385942-96886c61-9230-443f-b72d-b21fc5ac380b.png)
21. Make sure you can see tooltips and can change settings for selectWoo dropdowns (to make sure there's no regression for #4788):
22. Go to WC > Settings > General
23. Examine the tooltips and try to change the country of the Store to something else (e.g. I picked UK in the onboarding and changed it to Argentina --- Ciudad Autonoma de Buenos Aires)
24. Now we need to test the connection to WC.COM still works fine (to ensure there's no regression for https://github.com/woocommerce/woocommerce/issues/16043):
25. Go to WC > Extensions > My subscriptions
26. Click on the Connection button.
27. It should initiate the connection correctly (and hopefully finish it as well)
28. Once done, you should see Connected to WooCommerce.com in the left upper corner
![Screenshot 2023-02-16 at 15 10 08](https://user-images.githubusercontent.com/2207451/219387607-61fbba93-c94f-4206-89fb-3c230d73a58a.png)


<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
