### PR TITLE
Use dbDelta and truncate to manage attribute lookup tables

### DIFF
--- a/plugins/woocommerce/changelog/fix-use-dbdelta-and-truncate-to-manage-attribute-lookup-tables
+++ b/plugins/woocommerce/changelog/fix-use-dbdelta-and-truncate-to-manage-attribute-lookup-tables
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Switch wc_product_attributes_lookup table management to use truncate and dbDelta over drop table

--- a/plugins/woocommerce/src/Internal/ProductAttributesLookup/DataRegenerator.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributesLookup/DataRegenerator.php
@@ -104,7 +104,7 @@ class DataRegenerator {
 		$this->data_store->unset_regeneration_in_progress_flag();
 
 		if ( $this->data_store->check_lookup_table_exists() ) {
-			$wpdb->query( "TRUNCATE TABLE {$this->lookup_table_name}" );
+			$wpdb->query( "TRUNCATE TABLE {$this->lookup_table_name}" ); // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		}
 	}
 

--- a/plugins/woocommerce/src/Internal/ProductAttributesLookup/DataRegenerator.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributesLookup/DataRegenerator.php
@@ -104,7 +104,7 @@ class DataRegenerator {
 		$this->data_store->unset_regeneration_in_progress_flag();
 
 		if ( $this->data_store->check_lookup_table_exists() ) {
-			$wpdb->query( $wpdb->prepare( 'TRUNCATE TABLE %s', $this->lookup_table_name ) );
+			$wpdb->query( "TRUNCATE TABLE {$this->lookup_table_name}" );
 		}
 	}
 

--- a/plugins/woocommerce/src/Internal/ProductAttributesLookup/DataRegenerator.php
+++ b/plugins/woocommerce/src/Internal/ProductAttributesLookup/DataRegenerator.php
@@ -103,8 +103,9 @@ class DataRegenerator {
 		delete_option( 'woocommerce_attribute_lookup_processed_count' );
 		$this->data_store->unset_regeneration_in_progress_flag();
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-		$wpdb->query( 'DROP TABLE IF EXISTS ' . $this->lookup_table_name );
+		if ( $this->data_store->check_lookup_table_exists() ) {
+			$wpdb->query( $wpdb->prepare( 'TRUNCATE TABLE %s', $this->lookup_table_name ) );
+		}
 	}
 
 	/**
@@ -114,10 +115,8 @@ class DataRegenerator {
 	 * @return bool True if there's any product at all in the database, false otherwise.
 	 */
 	private function initialize_table_and_data() {
-		global $wpdb;
-
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-		$wpdb->query( $this->get_table_creation_sql() );
+		$database_util = wc_get_container()->get( DatabaseUtil::class );
+		$database_util->dbdelta( $this->get_table_creation_sql() );
 
 		$last_existing_product_id = $this->get_last_existing_product_id();
 		if ( ! $last_existing_product_id ) {

--- a/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/DataRegeneratorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/DataRegeneratorTest.php
@@ -81,7 +81,7 @@ class DataRegeneratorTest extends \WC_Unit_Test_Case {
 	 *
 	 * @param bool $previously_existing True to create a lookup table beforehand.
 	 */
-	public function test_initiate_regeneration_creates_looukp_table( $previously_existing ) {
+	public function test_initiate_regeneration_creates_lookup_table( $previously_existing ) {
 		global $wpdb;
 
 		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
@@ -96,9 +96,10 @@ class DataRegeneratorTest extends \WC_Unit_Test_Case {
 
 		// Try to insert a row to verify that the table exists.
 		// We can't use the regular table existence detection mechanisms because PHPUnit creates all tables as temporary.
-		$wpdb->query( 'INSERT INTO ' . $this->lookup_table_name .
-		              '( product_id, product_or_parent_id, taxonomy, term_id, is_variation_attribute, in_stock)' .
-		              " VALUES (1, 1, 'taxonomy', 1, 1, 1 )"
+		$wpdb->query(
+			'INSERT INTO ' . $this->lookup_table_name .
+			'( product_id, product_or_parent_id, taxonomy, term_id, is_variation_attribute, in_stock)' .
+			" VALUES (1, 1, 'taxonomy', 1, 1, 1 )"
 		);
 		$value = $wpdb->get_var( 'SELECT product_id FROM ' . $this->lookup_table_name . ' LIMIT 1' );
 		$this->assertEquals( 1, $value );

--- a/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/DataRegeneratorTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/DataRegeneratorTest.php
@@ -96,7 +96,10 @@ class DataRegeneratorTest extends \WC_Unit_Test_Case {
 
 		// Try to insert a row to verify that the table exists.
 		// We can't use the regular table existence detection mechanisms because PHPUnit creates all tables as temporary.
-		$wpdb->query( 'INSERT INTO ' . $this->lookup_table_name . " VALUES (1, 1, 'taxonomy', 1, 1, 1 )" );
+		$wpdb->query( 'INSERT INTO ' . $this->lookup_table_name .
+		              '( product_id, product_or_parent_id, taxonomy, term_id, is_variation_attribute, in_stock)' .
+		              " VALUES (1, 1, 'taxonomy', 1, 1, 1 )"
+		);
 		$value = $wpdb->get_var( 'SELECT product_id FROM ' . $this->lookup_table_name . ' LIMIT 1' );
 		$this->assertEquals( 1, $value );
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

The use of `DROP TABLE` can be problematic in some hosting environments and may be blocked for security and performance reasons. Dropping a table can also cause quite a bit of replication lag in multi-database setups.

This PR proposes switching from the use of DROP/CREATE table for the `wc_product_attributes_lookup` table to use `TRUNCATE` and `dbDelta()` to manage it's lifecycle.  This also brings it more in line with the lifecycle of other tables managed by WooCommerce.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Install WooCommerce, and setup some products with attributes.
2. In the WP-Admin, go to WooCommerce - Settings - Products - Advanced. Make sure Product attributes lookup table - Enable table usage is checked.  If it doesn't yet show, make sure to run any pending or past due actions scheduler actions to allow the generation to complete.
3. Apply this patch.
4. In the WP-Admin, go to WooCommerce - Status - Tools and Regenerate the product attributes lookup table.  This should go through the new TRUNCATE -> dbDelta() process for that table.
5.  Allow any pending/past due scheduled actions to run so generation can complete.
6.  In the WP-Admin, go back to WooCommerce - Settings - Products - Advanced. Make sure Product attributes lookup table - Enable table usage is checked.
7. Query the `wp_wc_product_attributes_lookup` to verify that data exists.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?


### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
