### PR TITLE
Fix inconsistencies on Analytics > Orders table when using date_paid or date_completed

### DIFF
--- a/plugins/woocommerce-admin/client/analytics/report/orders/table.js
+++ b/plugins/woocommerce-admin/client/analytics/report/orders/table.js
@@ -116,7 +116,7 @@ class OrdersReportTable extends Component {
 		return map( tableData, ( row ) => {
 			const {
 				currency,
-				date_created: dateCreated,
+				date,
 				net_total: netTotal,
 				num_items_sold: numItemsSold,
 				order_id: orderId,
@@ -150,12 +150,9 @@ class OrdersReportTable extends Component {
 			return [
 				{
 					display: (
-						<Date
-							date={ dateCreated }
-							visibleFormat={ dateFormat }
-						/>
+						<Date date={ date } visibleFormat={ dateFormat } />
 					),
-					value: dateCreated,
+					value: date,
 				},
 				{
 					display: (

--- a/plugins/woocommerce/changelog/fix-analytics-orders-dates-inconsistencies
+++ b/plugins/woocommerce/changelog/fix-analytics-orders-dates-inconsistencies
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Comment: Fix inconsistencies on Analytics > Orders table when using date_paid or date_completed

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
@@ -75,9 +75,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$this->report_columns = array(
 			'order_id'         => "DISTINCT {$table_name}.order_id",
 			'parent_id'        => "{$table_name}.parent_id",
-			/**
-			 * add 'date' field based on date type setting
-			 */
+			// Add 'date' field based on date type setting.
 			'date'             => "{$table_name}.{$this->date_column_name} AS date",
 			'date_created'     => "{$table_name}.date_created",
 			'date_created_gmt' => "{$table_name}.date_created_gmt",

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
@@ -20,6 +20,14 @@ use \Automattic\WooCommerce\Admin\API\Reports\TimeInterval;
 class DataStore extends ReportsDataStore implements DataStoreInterface {
 
 	/**
+	 * Dynamically sets the date column name based on configuration
+	 */
+	public function __construct() {
+		$this->date_column_name = get_option( 'woocommerce_date_type', 'date_created' );
+		parent::__construct();
+	}
+
+	/**
 	 * Table used to get the data.
 	 *
 	 * @var string
@@ -67,6 +75,10 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$this->report_columns = array(
 			'order_id'         => "DISTINCT {$table_name}.order_id",
 			'parent_id'        => "{$table_name}.parent_id",
+			/**
+			 * add 'date' field based on date type setting
+			 */
+			'date'             => "{$table_name}.{$this->date_column_name} AS date",
 			'date_created'     => "{$table_name}.date_created",
 			'date_created_gmt' => "{$table_name}.date_created_gmt",
 			'status'           => "REPLACE({$table_name}.status, 'wc-', '') as status",
@@ -207,14 +219,12 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	public function get_data( $query_args ) {
 		global $wpdb;
 
-		$table_name = self::get_db_table_name();
-
 		// These defaults are only partially applied when used via REST API, as that has its own defaults.
 		$defaults   = array(
 			'per_page'          => get_option( 'posts_per_page' ),
 			'page'              => 1,
 			'order'             => 'DESC',
-			'orderby'           => 'date_created',
+			'orderby'           => $this->date_column_name,
 			'before'            => TimeInterval::default_before(),
 			'after'             => TimeInterval::default_after(),
 			'fields'            => '*',
@@ -317,7 +327,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 */
 	protected function normalize_order_by( $order_by ) {
 		if ( 'date' === $order_by ) {
-			return 'date_created';
+			return $this->date_column_name;
 		}
 
 		return $order_by;

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php
@@ -73,8 +73,8 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 * Dynamically sets the date column name based on configuration
 	 */
 	public function __construct() {
-		parent::__construct();
 		$this->date_column_name = get_option( 'woocommerce_date_type', 'date_created' );
+		parent::__construct();
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders.php
@@ -94,6 +94,7 @@ class WC_Admin_Tests_Reports_Orders extends WC_Unit_Test_Case {
 					'customer_type'    => 'new',
 					'date_created'     => $data->data[0]['date_created'], // Not under test.
 					'date_created_gmt' => $data->data[0]['date_created_gmt'], // Not under test.
+					'date'             => $data->data[0]['date'], // Not under test.
 					'extended_info'    => array(
 						'products' => array(
 							array(


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

After merging #36492 today, I decided to test some more and found issues in the Analytics > Orders table. This fixes the issues.

Sample with date_paid configured as the sort date, before this fix, for an order created on February 08th and paid on February 14th:

<img width="1614" alt="image" src="https://user-images.githubusercontent.com/13437655/219755018-4b5e754b-41b5-45a5-b6d8-56298bde9051.png">

After the fix:
<img width="1607" alt="image" src="https://user-images.githubusercontent.com/13437655/219755836-7a4f4762-b376-4d2e-be2c-e405c004f5da.png">




<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Disable cache by going to the file `plugins/woocommerce/src/Admin/API/Reports/DataStore.php` and edit the following method to disable cache:
```php
protected function should_use_cache() {
		/**
		 * Determines if a report will utilize caching.
		 *
		 * @param bool $use_cache Whether or not to use cache.
		 * @param string $cache_key The report's cache key. Used to identify the report.
		 */
		return false;
	}
```
2. Have some orders that were paid and created on different dates. You can use wc-smooth-generator and change completed order dates manually afterward, as an example.
4. Go to Analytics > Settings.
5. Change "Date type" to "Date paid" and Save.
6. Go to Analytics > Orders.
7. Check for inconsistencies between the chart and the table. Look for your order and see if the date being represented is actually the date paid.
6. Go to Analytics > Revenue.
7. Check for inconsistencies between the chart and the table. Check if the revenue is correctly represented by the paid dates.

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
