### PR TITLE
Update the release date for code freeze action readme generation

### DIFF
--- a/.github/workflows/scripts/release-changelog.php
+++ b/.github/workflows/scripts/release-changelog.php
@@ -10,8 +10,8 @@ if ( getenv( 'TIME_OVERRIDE' ) ) {
 
 $base_dir = dirname( dirname( dirname( __DIR__ ) ) );
 
-// The release date is 26 days after the code freeze.
-$release_time = strtotime( '+26 days', $now );
+// The release date is 22 days after the code freeze.
+$release_time = strtotime( '+22 days', $now );
 $release_date = date( 'Y-m-d', $release_time );
 
 $readme_file    = $base_dir . '/plugins/woocommerce/readme.txt';


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR follows on to the change made in #36023, which moved the code freeze to 22 days prior to the release. When making that update, we missed the piece that generated the readme file, which caused an incorrect value to be used for the release date.

This was noted in p1676540794430159-slack-C0741730R

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Fork this repository.
1. Enable issues in your fork from https://github.com/YOURORG/woocommerce/settings
1. Enable actions in your fork from https://github.com/YOURORG/woocommerce/settings/actions. Also, make sure workflows have read and write permissions and the ability to create and approve PRs.
1. Enable the scheduled workflow from https://github.com/YOURORG/woocommerce/actions/workflows/release-code-freeze.yml.
1. Merge this PR into trunk of your new fork.
1. Make sure that you've first created an existing release in your fork (for example, `7.3.0`). Also create a `7.4.0` milestone.
1. Run the action manually from https://github.com/YOURORG/woocommerce/actions/workflows/release-code-freeze.yml with "2023-01-23" as the value for time override. This is the Monday that comes 22 days prior to 2023-02-14 (the 7.4 release date). The code freeze action should now run.
1. Verify that the generated readme file created by the action contains a release date of "2023-02-14".

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
