### PR TITLE
Add `fills` prop to `useSlot` return object to fix task list bugs in WP 6.2

### DIFF
--- a/packages/js/experimental/changelog/fix-slot-fills-for-wp-6_2
+++ b/packages/js/experimental/changelog/fix-slot-fills-for-wp-6_2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix missing fills prop in useSlotFills return object for wp.components >= 21.2.0

--- a/packages/js/experimental/src/index.js
+++ b/packages/js/experimental/src/index.js
@@ -9,6 +9,7 @@ import {
 	__experimentalNavigationItem,
 	__experimentalText,
 	__experimentalUseSlot,
+	__experimentalUseSlotFills as useSlotFillsHook,
 	Navigation as NavigationComponent,
 	NavigationBackButton as NavigationBackButtonComponent,
 	NavigationGroup as NavigationGroupComponent,
@@ -31,7 +32,28 @@ export const NavigationMenu =
 export const NavigationItem =
 	NavigationItemComponent || __experimentalNavigationItem;
 export const Text = TextComponent || __experimentalText;
-export const useSlot = useSlotHook || __experimentalUseSlot;
+
+// Add a fallback for useSlotFills hook to not break in older versions of wp.components.
+// This hook was introduced in wp.components@21.2.0.
+const useSlotFills = useSlotFillsHook || ( () => null );
+
+export const useSlot = ( name ) => {
+	const _useSlot = useSlotHook || __experimentalUseSlot;
+	const slot = _useSlot( name );
+	const fills = useSlotFills( name );
+
+	/*
+	 * Since wp.components@21.2.0, the slot object no longer contains the fills prop.
+	 * Add fills prop to the slot object for backward compatibility.
+	 */
+	if ( typeof useSlotFillsHook === 'function' ) {
+		return {
+			...slot,
+			fills,
+		};
+	}
+	return slot;
+};
 
 export { ExperimentalListItem as ListItem } from './experimental-list/experimental-list-item';
 export { ExperimentalList as List } from './experimental-list/experimental-list';


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #36841, #36793, #36842.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

Since `wp.components@21.2.0`, the slot object no longer contains the fills prop, it introduced a new hook `useSlotFills` to access fills. (See https://github.com/WordPress/gutenberg/pull/44642/files#diff-c39400fce05d8a8375c1b8060163ac57a8ace79e56f7e356adb8279525546876 and https://github.com/WordPress/gutenberg/pull/44642/files#diff-4933aeec78367ba34617ac25fa043ec87ce4ad908b6b0625b6759fed36655597L51). 

For backward compatibility, I wrap the `useSlot` in a customized function and add a "fills" prop if useSlotFillsHook exists.


- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Use WP 6.1.1.
2. Start with OBW.
3. Go to the "Product Types" step.
4. Select all Product Type and Click Continue.
5. Complete OBW.
6. Go to `Woocommerce > Home` page
7. Click on "Add <Paid Product Type> to my store" option from Task list.
8. Observe that it pops up a `Would you like to add the following paid features to your store now?` modal, instead of showing a blank page.
9. Navigate to `wp-admin/admin.php?page=wc-admin&task=payments&id=bacs`
10. Observe that the page shows the "Add your bank details" form.
11. Go to `WooCommerce > Home`
12. In the Home task list, click "Set up payments".
13. Notice that the "Back" button text is "Set up payments".
14. Observe that the button beside "Direct bank transfer" is labeled "Get started".
15. Please tests the same steps (2-14) on a WP 6.2 site (currently in Beta 2) https://wordpress.org/wordpress-6.2-beta2.zip


![Screenshot 2023-02-20 at 11 22 15](https://user-images.githubusercontent.com/4344253/220003351-d7fc5d6e-0dd7-4dec-b841-13935dc787b1.png)

![Screenshot 2023-02-20 at 11 33 14](https://user-images.githubusercontent.com/4344253/220003466-f2bb40ca-0ac0-4666-a945-194634384be6.png)


![Screenshot 2023-02-20 at 11 15 29](https://user-images.githubusercontent.com/4344253/220003334-1e1d633f-b1a6-458c-9450-b3a2d7216db0.png)


<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
