### PR TITLE
Temporary remove free trial terms from Avalara tax task

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/fills/tax/avalara/card.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/tax/avalara/card.tsx
@@ -42,10 +42,7 @@ export const Card: React.FC< TaxChildProps > = ( { task } ) => {
 					'woocommerce'
 				),
 			] }
-			terms={ __(
-				'30-day free trial. No credit card needed.',
-				'woocommerce'
-			) }
+			terms={ '' }
 			actionText={
 				avalaraActivated
 					? __( 'Continue setup', 'woocommerce' )

--- a/plugins/woocommerce/changelog/tweak-36875-remove-free-trial-terms-avalara
+++ b/plugins/woocommerce/changelog/tweak-36875-remove-free-trial-terms-avalara
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Remove free trial terms from Avalara tax task


### PR DESCRIPTION
### All Submissions:

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/36875

<!-- Begin testing instructions -->

1. Go to WooCommerce > Home > Tax task
2. Observe there is no "30-day free trial. No credit card needed" copy under Avalara card

<img width="754" alt="image" src="https://user-images.githubusercontent.com/3747241/220005783-bb527cac-fb61-4e1a-ba17-1a69628e6052.png">

