### PR TITLE
Fix inconsistent colors products task icons

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/fills/import-products/style.scss
+++ b/plugins/woocommerce-admin/client/tasks/fills/import-products/style.scss
@@ -48,12 +48,6 @@
 		.woocommerce-list__item-before {
 			border: 0;
 			background: none;
-			svg {
-				fill: #bbb;
-				rect {
-					fill: #bbb;
-				}
-			}
 		}
 	}
 }

--- a/plugins/woocommerce-admin/client/tasks/fills/products/icon/link_24px.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/products/icon/link_24px.js
@@ -24,7 +24,7 @@ const Link = () => {
 				/>
 			</mask>
 			<g mask="url(#mask0_1133_132681)">
-				<rect x="0.5" width="24" height="24" fill="#007CBA" />
+				<rect x="0.5" width="24" height="24" />
 			</g>
 		</svg>
 	);

--- a/plugins/woocommerce-admin/client/tasks/fills/products/icon/widgets_24px.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/products/icon/widgets_24px.js
@@ -24,7 +24,7 @@ const Widget = () => {
 				/>
 			</mask>
 			<g mask="url(#mask0_1133_132667)">
-				<rect x="0.5" width="24" height="24" fill="#007CBA" />
+				<rect x="0.5" width="24" height="24" />
 			</g>
 		</svg>
 	);

--- a/plugins/woocommerce/changelog/fix-36829-inconsistent-colors-products-task-icons
+++ b/plugins/woocommerce/changelog/fix-36829-inconsistent-colors-products-task-icons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix inconsitent product task icon colors


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fix inconsistent product task icon colors

Closes #36829.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

### Testing add products
1. In a fresh site, set the user's profile color in Users > Profile to something vastly different like orange or red
1. Go to WooCommerce > Home > Add products task
1. Extend `View more product types` accordion
1. Observe the `Grouped` and `External` product icons follow WP theme color

### Testing import products
1. Go to Setup Wizard > Business Details
1. Select "Yes, on another platform and in person at physical stores and/or events" and fill up other required fields and save
1. Go to WooCommerce > Home > Add products task
1. Extend `Or add your products from scratch` accordion
1. Observe the `Grouped` and `External` product icons follow WP theme color

<img width="700" alt="image" src="https://user-images.githubusercontent.com/3747241/220020115-ccbe599c-9808-45cd-b60a-a7fb7e697d95.png">

<img width="700" alt="image" src="https://user-images.githubusercontent.com/3747241/220020223-9149864b-9be5-4a9d-b4f9-b940084a54e6.png">
