### PR TITLE
Assign milestone only if a PR touches WooCommerce Core

### DIFF
--- a/.github/workflows/pull-request-post-merge-processing.yml
+++ b/.github/workflows/pull-request-post-merge-processing.yml
@@ -2,6 +2,9 @@ name: 'Pull request post-merge processing'
 on:
     pull_request_target:
         types: [closed]
+        paths:
+            - 'packages/**'
+            - 'plugins/woocommerce/**'
 
 permissions: {}
 

--- a/.github/workflows/pull-request-post-merge-processing.yml
+++ b/.github/workflows/pull-request-post-merge-processing.yml
@@ -5,6 +5,7 @@ on:
         paths:
             - 'packages/**'
             - 'plugins/woocommerce/**'
+            - 'plugins/woocommerce-admin/**'
 
 permissions: {}
 


### PR DESCRIPTION
-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

One of our GitHub Actions assigns a WooCommerce milestone to every merged PR. The monorepo contains several other projects, though, so ideally we'd assign that milestone only to actual WooCommerce Core PRs -- those that touch at least one file we consider to be part of a WooCommerce release. 

E.g., right now WooCommerce Beta Tester PRs get assigned a WooCommerce Core milestone (https://github.com/woocommerce/woocommerce/pull/36072). 

This PR changes the Action to apply to certain paths only. 

### How to test the changes in this Pull Request:

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Fork the WooCommerce repo
2. Ensure Actions run in your fork
3. Merge this PR into trunk
4. Merge a few test PRs -- e.g., one that touches files that are part of WooCommerce Core, one that touches files only outside of those paths, and one that touches files in both areas

Note that I wasn't able to get Actions to run in my own fork, so I haven't been able to actually test this PR myself. This has been an issue previously and things ran well in others's forks, so this might also be the case here. 

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
