### PR TITLE
Initial e2e tests for new product editor (form-based)

### DIFF
--- a/plugins/woocommerce/changelog/add-new-product-editor-e2e
+++ b/plugins/woocommerce/changelog/add-new-product-editor-e2e
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Initial e2e tests for new product editor.

--- a/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
+++ b/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
@@ -2,6 +2,7 @@
 
 ENABLE_HPOS="${ENABLE_HPOS:-0}"
 ENABLE_NEW_PRODUCT_EDITOR="${ENABLE_NEW_PRODUCT_EDITOR:-0}"
+ENABLE_TRACKING="${ENABLE_TRACKING:-0}"
 
 wp-env run tests-cli "wp theme install twentynineteen --activate"
 
@@ -33,4 +34,9 @@ fi
 if [ $ENABLE_NEW_PRODUCT_EDITOR == 1 ]; then
 	echo 'Enable the new product editor feature'
 	wp-env run tests-cli "wp plugin install https://github.com/woocommerce/woocommerce-experimental-enable-new-product-editor/releases/download/0.1.0/woocommerce-experimental-enable-new-product-editor.zip --activate"
+fi
+
+if [ $ENABLE_TRACKING == 1 ]; then
+	echo 'Enable tracking'
+	wp-env run tests-cli "wp option update woocommerce_allow_tracking 'yes'"
 fi

--- a/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
+++ b/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 ENABLE_HPOS="${ENABLE_HPOS:-0}"
+ENABLE_NEW_PRODUCT_EDITOR="${ENABLE_NEW_PRODUCT_EDITOR:-0}"
 
 wp-env run tests-cli "wp theme install twentynineteen --activate"
 
@@ -27,4 +28,9 @@ wp-env run tests-cli 'wp option update blogname "WooCommerce Core E2E Test Suite
 if [ $ENABLE_HPOS == 1 ]; then
 	echo 'Enable the COT feature'
 	wp-env run tests-cli "wp plugin install https://gist.github.com/vedanshujain/564afec8f5e9235a1257994ed39b1449/archive/b031465052fc3e04b17624acbeeb2569ef4d5301.zip --activate"
+fi
+
+if [ $ENABLE_NEW_PRODUCT_EDITOR == 1 ]; then
+	echo 'Enable the new product editor feature'
+	wp-env run tests-cli "wp plugin install https://github.com/woocommerce/woocommerce-experimental-enable-new-product-editor/releases/download/0.1.0/woocommerce-experimental-enable-new-product-editor.zip --activate"
 fi

--- a/plugins/woocommerce/tests/e2e-pw/tests/new-product-editor/new-product-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/new-product-editor/new-product-editor.spec.js
@@ -1,0 +1,125 @@
+const { test, expect } = require( '@playwright/test' );
+
+const EXPERIMENTAL_FEATURES_SETTINGS_URL =
+	'wp-admin/admin.php?page=wc-settings&tab=advanced&section=features';
+const EDIT_PRODUCT_URL = 'wp-admin/edit.php?post_type=product';
+const NEW_PRODUCT_URL = 'wp-admin/post-new.php?post_type=product';
+
+const NEW_PRODUCT_EDITOR_EXPERIMENTAL_FEATURE_SELECTOR =
+	'#woocommerce_new_product_management_enabled';
+
+async function expectExperimentalFeatureExists( page ) {
+	// make sure the Advanced tab is active
+	await expect( page.locator( 'a.nav-tab-active' ) ).toContainText(
+		'Advanced'
+	);
+
+	// make sure the Features sub-tab is active
+	await expect(
+		page.locator( 'ul.subsubsub > li > a.current' )
+	).toContainText( 'Features' );
+
+	// make sure the new product editor experimental feature is shown
+	await expect(
+		page.locator( NEW_PRODUCT_EDITOR_EXPERIMENTAL_FEATURE_SELECTOR )
+	).toBeVisible();
+}
+
+async function clickAddNewMenuItem( page ) {
+	await page
+		.locator( '#menu-posts-product' )
+		.getByRole( 'link', { name: 'Add New' } )
+		.click();
+}
+
+test.describe( 'New Product Editor', () => {
+	test.use( { storageState: process.env.ADMINSTATE } );
+
+	test( 'is disabled by default', async ( { page } ) => {
+		await page.goto( EXPERIMENTAL_FEATURES_SETTINGS_URL );
+
+		await expectExperimentalFeatureExists( page );
+
+		// make sure the new product editor is unchecked
+		await expect(
+			page.locator( NEW_PRODUCT_EDITOR_EXPERIMENTAL_FEATURE_SELECTOR )
+		).not.toBeChecked();
+	} );
+
+	test( 'is not used when disabled by default', async ( { page } ) => {
+		await page.goto( EDIT_PRODUCT_URL );
+
+		await clickAddNewMenuItem( page );
+
+		// make sure the old product editor is shown
+		await expect(
+			page.locator( '#woocommerce-product-data h2' )
+		).toContainText( 'Product data' );
+	} );
+
+	test( 'can be enabled', async ( { page } ) => {
+		await page.goto( EXPERIMENTAL_FEATURES_SETTINGS_URL );
+
+		await expectExperimentalFeatureExists( page );
+
+		// enable the new product editor
+		await page.check( NEW_PRODUCT_EDITOR_EXPERIMENTAL_FEATURE_SELECTOR );
+
+		// save changes
+		await page.click( 'text=Save changes' );
+
+		// make sure settings have been saved
+		await expect( page.locator( 'div.updated.inline' ) ).toContainText(
+			'Your settings have been saved'
+		);
+
+		// make sure the new product editor is enabled
+		await expect(
+			page.locator( NEW_PRODUCT_EDITOR_EXPERIMENTAL_FEATURE_SELECTOR )
+		).toBeChecked();
+	} );
+
+	test( 'is used when enabled', async ( { page } ) => {
+		await page.goto( EDIT_PRODUCT_URL );
+
+		await clickAddNewMenuItem( page );
+
+		// make sure the new product editor is shown
+		await expect(
+			page.locator( '.woocommerce-product-title__wrapper' )
+		).toContainText( 'New product' );
+	} );
+
+	test( 'can be disabled', async ( { page } ) => {
+		await page.goto( EXPERIMENTAL_FEATURES_SETTINGS_URL );
+
+		await expectExperimentalFeatureExists( page );
+
+		// disable the new product editor
+		await page.uncheck( NEW_PRODUCT_EDITOR_EXPERIMENTAL_FEATURE_SELECTOR );
+
+		// save changes
+		await page.click( 'text=Save changes' );
+
+		// make sure settings have been saved
+		await expect( page.locator( 'div.updated.inline' ) ).toContainText(
+			'Your settings have been saved'
+		);
+
+		// make sure the new product editor is disabled
+		await expect(
+			page.locator( NEW_PRODUCT_EDITOR_EXPERIMENTAL_FEATURE_SELECTOR )
+		).not.toBeChecked();
+	} );
+
+	test( 'is not used when disabled', async ( { page } ) => {
+		await page.goto( EDIT_PRODUCT_URL );
+
+		await clickAddNewMenuItem( page );
+
+		// make sure the old product editor is shown
+		await expect(
+			page.locator( '#woocommerce-product-data h2' )
+		).toContainText( 'Product data' );
+	} );
+} );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds initial e2e tests for the new product editor (form-based). These tests focus solely on:

* verifying whether the new product editor is enabled or not (based on e2e configuration options detailed below)
* whether new product editor can be disabled 
* serving as a base from which future e2e testing can be built from.

Future issues/PRs will add additional functionality, such as:

* enable and verify new block-based product editor
* add simple products
* edit simple products

Closes #36588 .

#### New e2e configuration options:

* `ENABLE_NEW_PRODUCT_EDITOR` - if set to `1`, the new product editor will be enabled in the e2e tests (via a plugin: https://github.com/woocommerce/woocommerce-experimental-enable-new-product-editor)
* `ENABLE_TRACKING` - if set to `1`, tracking will be enabled and the e2e tests for the new product editor will take that into account

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

#### Run just the new product editor e2e tests with the new product editor enabled

```
ENABLE_NEW_PRODUCT_EDITOR=1 pnpm env:restart
ENABLE_NEW_PRODUCT_EDITOR=1 USE_WP_ENV=1 pnpm playwright test --config=tests/e2e-pw/playwright.config.js ./tests/e2e-pw/tests/new-product-editor/new-product-editor.spec.js
```

- Verify all tests pass
- Also try these with `ENABLE_TRACKING=1`

#### Run just the new product editor e2e tests without the new product editor enabled

```
pnpm env:restart
USE_WP_ENV=1 pnpm playwright test --config=tests/e2e-pw/playwright.config.js ./tests/e2e-pw/tests/new-product-editor/new-product-editor.spec.js
```

- Verify all tests pass
- Also try these with `ENABLE_TRACKING=1`

#### Verify full e2e tests pass

- Just look at the checks run for this PR.

See full documentation for e2e testing for more details: https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/tests/e2e-pw/README.md

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
