### PR TITLE
Fix blank screen is displayed during OBW when using WP5.9

### DIFF
--- a/plugins/woocommerce/changelog/fix-36711-obw-blank-screen-wp5_9
+++ b/plugins/woocommerce/changelog/fix-36711-obw-blank-screen-wp5_9
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix blank screen is displayed during OBW when using WP5.9

--- a/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingThemes.php
+++ b/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingThemes.php
@@ -124,8 +124,6 @@ class OnboardingThemes {
 			}
 
 			$installed_themes = wp_get_themes();
-			$active_theme     = get_option( 'stylesheet' );
-
 			foreach ( $installed_themes as $slug => $theme ) {
 				$theme_data = self::get_theme_data( $theme );
 				if ( isset( $themes[ $slug ] ) ) {
@@ -136,12 +134,21 @@ class OnboardingThemes {
 				}
 			}
 
-			// Add the WooCommerce support tag for default themes that don't explicitly declare support.
-			if ( function_exists( 'wc_is_wp_default_theme_active' ) && wc_is_wp_default_theme_active() ) {
-				$themes[ $active_theme ]['has_woocommerce_support'] = true;
+			$active_theme     = get_option( 'stylesheet' );
+
+			/**
+			 * The active theme may no be set if active_theme is not compatible with current version of WordPress.
+			 * In this case, we should not add active theme to onboarding themes.
+			 */
+			if ( isset( $themes[ $active_theme ] ) ) {
+				// Add the WooCommerce support tag for default themes that don't explicitly declare support.
+				if ( function_exists( 'wc_is_wp_default_theme_active' ) && wc_is_wp_default_theme_active() ) {
+					$themes[ $active_theme ]['has_woocommerce_support'] = true;
+				}
+
+				$themes = array( $active_theme => $themes[ $active_theme ] ) + $themes;
 			}
 
-			$themes = array( $active_theme => $themes[ $active_theme ] ) + $themes;
 
 			set_transient( self::THEMES_TRANSIENT, $themes, DAY_IN_SECONDS );
 		}

--- a/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingThemes.php
+++ b/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingThemes.php
@@ -134,7 +134,7 @@ class OnboardingThemes {
 				}
 			}
 
-			$active_theme     = get_option( 'stylesheet' );
+			$active_theme = get_option( 'stylesheet' );
 
 			/**
 			 * The active theme may no be set if active_theme is not compatible with current version of WordPress.
@@ -148,7 +148,6 @@ class OnboardingThemes {
 
 				$themes = array( $active_theme => $themes[ $active_theme ] ) + $themes;
 			}
-
 
 			set_transient( self::THEMES_TRANSIENT, $themes, DAY_IN_SECONDS );
 		}


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #36711.

When a site downgrades WP to a lower version with an incompatible active theme, it leads to a fatal error when clicking "Continue" on "Business Details" step because theme data is incomplete.

This PR adds a check to exclude the active theme from onboarding themes if it's incompatible.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Create a test site using Jurassic Ninja (ensure to check the box for WP Downgrade) or use a WP 6.1 site with `Twenty Twenty-Three` theme active.
2. Downgrade the version of WP to 5.9 PbPjnJ-1eN-p2
3. Start with OBW.
4. Go to Business Details > Free feature step.
5. Click Continue.
6. Observe that Blank Screen is NOT displayed, but a theme screen is shown.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.