### PR TITLE
Add HPOS compat to meta and CRUD unit tests.

### DIFF
--- a/plugins/woocommerce/changelog/fix-36682
+++ b/plugins/woocommerce/changelog/fix-36682
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Changes are only in unit tests, no functionality is affected.
+
+

--- a/plugins/woocommerce/tests/legacy/unit-tests/crud/meta.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/crud/meta.php
@@ -1,4 +1,7 @@
 <?php
+
+use Automattic\WooCommerce\Utilities\OrderUtil;
+
 /**
  * Test meta for https://github.com/woocommerce/woocommerce/issues/13533.
  *
@@ -106,11 +109,14 @@ class WC_Tests_CRUD_Meta_Data extends WC_Unit_Test_Case {
 		$this->assertCount( 1, $order->get_meta_data() );
 		$this->assertTrue( in_array( 'random', wp_list_pluck( $order->get_meta_data(), 'key' ) ) );
 
-		// The new $order should have 3 items of meta since it's freshly loaded.
-		$this->assertCount( 3, $new_order->get_meta_data() );
+		$expected_count = OrderUtil::custom_orders_table_usage_is_enabled() ? 2 : 3;
+		// The new $order should have 3 items (or 2 in case of HPOS since direct post updates are not read) of meta since it's freshly loaded.
+		$this->assertCount( $expected_count, $new_order->get_meta_data() );
 		$this->assertTrue( in_array( 'random', wp_list_pluck( $new_order->get_meta_data(), 'key' ) ) );
 		$this->assertTrue( in_array( 'random_other', wp_list_pluck( $new_order->get_meta_data(), 'key' ) ) );
-		$this->assertTrue( in_array( 'random_other_pre_crud', wp_list_pluck( $new_order->get_meta_data(), 'key' ) ) );
+		if ( ! OrderUtil::custom_orders_table_usage_is_enabled() ) {
+			$this->assertTrue( in_array( 'random_other_pre_crud', wp_list_pluck( $new_order->get_meta_data(), 'key' ) ) );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/crud/meta.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/crud/meta.php
@@ -115,7 +115,7 @@ class WC_Tests_CRUD_Meta_Data extends WC_Unit_Test_Case {
 		$this->assertTrue( in_array( 'random', wp_list_pluck( $new_order->get_meta_data(), 'key' ) ) );
 		$this->assertTrue( in_array( 'random_other', wp_list_pluck( $new_order->get_meta_data(), 'key' ) ) );
 		if ( ! OrderUtil::custom_orders_table_usage_is_enabled() ) {
-			$this->assertTrue( in_array( 'random_other_pre_crud', wp_list_pluck( $new_order->get_meta_data(), 'key' ) ) );
+			$this->assertTrue( in_array( 'random_other_pre_crud', wp_list_pluck( $new_order->get_meta_data(), 'key' ), true ) );
 		}
 	}
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-crud-orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-crud-orders.php
@@ -884,8 +884,8 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 		// Save + create.
 		$save_id = $object->save();
 		$post    = get_post( $save_id );
-		$this->assertEquals( 'shop_order', $post->post_type );
-		$this->assertEquals( 'shop_order', $post->post_type );
+		$expected_post_type = \Automattic\WooCommerce\Utilities\OrderUtil::custom_orders_table_usage_is_enabled() ? 'shop_order_placehold' : 'shop_order';
+		$this->assertEquals( $expected_post_type, $post->post_type );
 
 		// Update.
 		$update_id = $object->save();

--- a/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-crud-orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-crud-orders.php
@@ -5,6 +5,8 @@
  * @package WooCommerce\Tests\CRUD
  */
 
+use Automattic\WooCommerce\Utilities\OrderUtil;
+
 /**
  * Meta
  *
@@ -882,9 +884,9 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 		$object = new WC_Order();
 
 		// Save + create.
-		$save_id = $object->save();
-		$post    = get_post( $save_id );
-		$expected_post_type = \Automattic\WooCommerce\Utilities\OrderUtil::custom_orders_table_usage_is_enabled() ? 'shop_order_placehold' : 'shop_order';
+		$save_id            = $object->save();
+		$post               = get_post( $save_id );
+		$expected_post_type = OrderUtil::custom_orders_table_usage_is_enabled() ? 'shop_order_placehold' : 'shop_order';
 		$this->assertEquals( $expected_post_type, $post->post_type );
 
 		// Update.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #36682 
Targets #36905 

Adds HPOS compatibility to unit tests in `WC_Tests_CRUD_Meta_Data` and `WC_Tests_CRUD_Orders` by adopting code for HPOS as needed.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [x] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

Since changes are only in unit tests, verifying that tests pass is enough. For HPOS tests, make sure that test for `WC_Tests_CRUD_Meta_Data` and `WC_Tests_CRUD_Orders` pass.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
