### PR TITLE
Update PayPal tests for HPOS compat.

### DIFF
--- a/plugins/woocommerce/changelog/fix-36680
+++ b/plugins/woocommerce/changelog/fix-36680
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Changes are only in unit tests (for HPOS compat).
+
+

--- a/plugins/woocommerce/tests/php/includes/gateways/paypal/class-wc-gateway-paypal-test.php
+++ b/plugins/woocommerce/tests/php/includes/gateways/paypal/class-wc-gateway-paypal-test.php
@@ -29,8 +29,8 @@ class WC_Gateway_Paypal_Test extends \WC_Unit_Test_Case {
 		$order = WC_Helper_Order::create_order();
 		$order->save();
 
-		update_post_meta( $order->get_id(), '_paypal_status', 'pending' );
-		update_post_meta( $order->get_id(), '_transaction_id', $this->transaction_id_26960 );
+		$order->update_meta_data( '_paypal_status', 'pending' );
+		$order->set_transaction_id( $this->transaction_id_26960 );
 		$order->set_payment_method( 'paypal' );
 		$order->save();
 
@@ -56,8 +56,8 @@ class WC_Gateway_Paypal_Test extends \WC_Unit_Test_Case {
 		$order = WC_Helper_Order::create_order();
 		$order->save();
 
-		update_post_meta( $order->get_id(), '_paypal_status', 'pending' );
-		update_post_meta( $order->get_id(), '_transaction_id', $this->transaction_id_26960 );
+		$order->update_meta_data( '_paypal_status', 'pending' );
+		$order->set_transaction_id( $this->transaction_id_26960 );
 		$order->set_payment_method( 'paypal' );
 		$order->save();
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #36680
Targets #36908

This PR fixes few PayPal unit tests by using CRUD APIs instead of doing direct DB access.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [x] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

Since changes are only in unit tests, make sure that test passes are enough for class `WC_Gateway_Paypal_Test`. 

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
