### PR TITLE
Fix one last case of not skipping hooks when cloning in code analyzer

### DIFF
--- a/tools/code-analyzer/src/lib/scan-changes.ts
+++ b/tools/code-analyzer/src/lib/scan-changes.ts
@@ -50,9 +50,12 @@ export const scanForChanges = async (
 
 	// Only checkout the compare version if we're in CLI mode.
 	if ( outputStyle === 'cli' ) {
-		execSync( `cd ${ tmpRepoPath } && git checkout ${ compareVersion }`, {
-			stdio: 'pipe',
-		} );
+		execSync(
+			`cd ${ tmpRepoPath } && git -c core.hooksPath=/dev/null checkout ${ compareVersion }`,
+			{
+				stdio: 'pipe',
+			}
+		);
 	}
 
 	const pluginPath = join( tmpRepoPath, 'plugins/woocommerce' );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

I stumbled on one more instance where hooks try to run in Code Analyzer, this fixes that issue.

<!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Otherwise, please include detailed instructions on how these changes can be tested. Please, make sure to review and follow the guide for writing high-quality testing instructions below. -->

1. Run a code analyzer command successfully e.g. `pnpm run analyzer -- lint release/7.5 "7.5.0" -b release/7.4`

(Before this PR it would fail trying to run husky hooks).

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
