### PR TITLE
Bump WooCommerce blocks package to 9.6.2

### DIFF
--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-9.6.2
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-9.6.2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update WooCommerce Blocks to 9.6.2

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -21,7 +21,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.5.4",
-		"woocommerce/woocommerce-blocks": "9.6.1"
+		"woocommerce/woocommerce-blocks": "9.6.2"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.3.0",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "092f7722dc1ab046fc4204f3a8d6ef5e",
+    "content-hash": "3114b2ae01803fb5d37d2e848b566b8e",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -628,16 +628,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "v9.6.1",
+            "version": "v9.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "5fae67e162c5300ca5da5ebeb4403005492483ac"
+                "reference": "1eb30afa09310d0dcbe8be1222ac3e5214c60328"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/5fae67e162c5300ca5da5ebeb4403005492483ac",
-                "reference": "5fae67e162c5300ca5da5ebeb4403005492483ac",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/1eb30afa09310d0dcbe8be1222ac3e5214c60328",
+                "reference": "1eb30afa09310d0dcbe8be1222ac3e5214c60328",
                 "shasum": ""
             },
             "require": {
@@ -683,9 +683,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v9.6.1"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v9.6.2"
             },
-            "time": "2023-02-17T14:57:23+00:00"
+            "time": "2023-02-22T13:56:14+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 9.6.2. 
## Blocks 9.6.2

* [Release PR](https://github.com/woocommerce/woocommerce-blocks/pull/8506)
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/962.md)




### Changelog entry

### The following changelog entries are only those that impact existing blocks and functionality surfaced to users:

#### Bug Fixes

- Disable compatibility layer ([8507](https://github.com/woocommerce/woocommerce-blocks/pull/8507))