### PR TITLE
Fix: can't apply or remove a coupon whose code is "0".

### DIFF
--- a/plugins/woocommerce/changelog/fix-cant-apply-coupon-0
+++ b/plugins/woocommerce/changelog/fix-cant-apply-coupon-0
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the inability to apply a coupon whose code is "0"

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -10,8 +10,10 @@ use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Internal\Orders\CouponsController;
 use Automattic\WooCommerce\Internal\Orders\TaxesController;
 use Automattic\WooCommerce\Internal\Admin\Orders\MetaBoxes\CustomMetaBox;
+use Automattic\WooCommerce\Utilities\ArrayUtil;
 use Automattic\WooCommerce\Utilities\NumberUtil;
 use Automattic\WooCommerce\Utilities\OrderUtil;
+use Automattic\WooCommerce\Utilities\StringUtil;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -224,8 +226,9 @@ class WC_AJAX {
 
 		check_ajax_referer( 'apply-coupon', 'security' );
 
-		if ( ! empty( $_POST['coupon_code'] ) ) {
-			WC()->cart->add_discount( wc_format_coupon_code( wp_unslash( $_POST['coupon_code'] ) ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$coupon_code = ArrayUtil::get_value_or_default( $_POST, 'coupon_code' );
+		if ( ! StringUtil::is_null_or_whitespace( $coupon_code ) ) {
+			WC()->cart->add_discount( wc_format_coupon_code( wp_unslash( $coupon_code ) ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		} else {
 			wc_add_notice( WC_Coupon::get_generic_coupon_error( WC_Coupon::E_WC_COUPON_PLEASE_ENTER ), 'error' );
 		}
@@ -242,7 +245,7 @@ class WC_AJAX {
 
 		$coupon = isset( $_POST['coupon'] ) ? wc_format_coupon_code( wp_unslash( $_POST['coupon'] ) ) : false; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
-		if ( empty( $coupon ) ) {
+		if ( StringUtil::is_null_or_whitespace( $coupon ) ) {
 			wc_add_notice( __( 'Sorry there was a problem removing this coupon.', 'woocommerce' ), 'error' );
 		} else {
 			WC()->cart->remove_coupon( $coupon );
@@ -1199,11 +1202,12 @@ class WC_AJAX {
 				throw new Exception( __( 'Invalid order', 'woocommerce' ) );
 			}
 
-			if ( empty( $_POST['coupon'] ) ) {
+			$coupon = ArrayUtil::get_value_or_default( $_POST, 'coupon' );
+			if ( StringUtil::is_null_or_whitespace( $coupon ) ) {
 				throw new Exception( __( 'Invalid coupon', 'woocommerce' ) );
 			}
 
-			$order->remove_coupon( wc_format_coupon_code( wp_unslash( $_POST['coupon'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			$order->remove_coupon( wc_format_coupon_code( wp_unslash( $coupon ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			$order->calculate_taxes( $calculate_tax_args );
 			$order->calculate_totals( false );
 

--- a/plugins/woocommerce/includes/class-wc-coupon.php
+++ b/plugins/woocommerce/includes/class-wc-coupon.php
@@ -9,6 +9,7 @@
  */
 
 use Automattic\WooCommerce\Utilities\NumberUtil;
+use Automattic\WooCommerce\Utilities\StringUtil;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -106,7 +107,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 		// Try to load coupon using ID or code.
 		if ( is_int( $data ) && 'shop_coupon' === get_post_type( $data ) ) {
 			$this->set_id( $data );
-		} elseif ( ! empty( $data ) ) {
+		} elseif ( is_string( $data ) && ! StringUtil::is_null_or_whitespace( $data ) ) {
 			$id = wc_get_coupon_id_by_code( $data );
 			// Need to support numeric strings for backwards compatibility.
 			if ( ! $id && 'shop_coupon' === get_post_type( $data ) ) {

--- a/plugins/woocommerce/includes/class-wc-discounts.php
+++ b/plugins/woocommerce/includes/class-wc-discounts.php
@@ -7,6 +7,7 @@
  */
 
 use Automattic\WooCommerce\Utilities\NumberUtil;
+use Automattic\WooCommerce\Utilities\StringUtil;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -255,8 +256,9 @@ class WC_Discounts {
 			return $is_coupon_valid;
 		}
 
-		if ( ! isset( $this->discounts[ $coupon->get_code() ] ) ) {
-			$this->discounts[ $coupon->get_code() ] = array_fill_keys( array_keys( $this->items ), 0 );
+		$coupon_code = $coupon->get_code();
+		if ( StringUtil::is_null_or_whitespace( $this->discounts[ $coupon_code ] ) ) {
+			$this->discounts[ $coupon_code ] = array_fill_keys( array_keys( $this->items ), 0 );
 		}
 
 		$items_to_apply = $this->get_items_to_apply_coupon( $coupon );

--- a/plugins/woocommerce/includes/class-wc-discounts.php
+++ b/plugins/woocommerce/includes/class-wc-discounts.php
@@ -257,7 +257,7 @@ class WC_Discounts {
 		}
 
 		$coupon_code = $coupon->get_code();
-		if ( StringUtil::is_null_or_whitespace( $this->discounts[ $coupon_code ] ) ) {
+		if ( StringUtil::is_null_or_whitespace( $this->discounts[ $coupon_code ] ?? null ) ) {
 			$this->discounts[ $coupon_code ] = array_fill_keys( array_keys( $this->items ), 0 );
 		}
 

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-coupons-v1-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-coupons-v1-controller.php
@@ -10,7 +10,6 @@
  * @since    3.0.0
  */
 
-use Automattic\WooCommerce\Utilities\ArrayUtil;
 use Automattic\WooCommerce\Utilities\StringUtil;
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-coupons-v1-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-coupons-v1-controller.php
@@ -133,8 +133,9 @@ class WC_REST_Coupons_V1_Controller extends WC_REST_Posts_Controller {
 	 * @return array
 	 */
 	public function query_args( $args, $request ) {
-		if ( ! empty( $request['code'] ) ) {
-			$id = wc_get_coupon_id_by_code( $request['code'] );
+		$coupon_code = $request['code'] ?? null;
+		if ( ! StringUtil::is_null_or_whitespace( $coupon_code ) ) {
+			$id               = wc_get_coupon_id_by_code( $coupon_code );
 			$args['post__in'] = array( $id );
 		}
 

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-coupons-v1-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-coupons-v1-controller.php
@@ -10,6 +10,9 @@
  * @since    3.0.0
  */
 
+use Automattic\WooCommerce\Utilities\ArrayUtil;
+use Automattic\WooCommerce\Utilities\StringUtil;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -249,7 +252,7 @@ class WC_REST_Coupons_V1_Controller extends WC_REST_Posts_Controller {
 
 		// Validate required POST fields.
 		if ( 'POST' === $request->get_method() && 0 === $coupon->get_id() ) {
-			if ( empty( $request['code'] ) ) {
+			if ( StringUtil::is_null_or_whitespace( $request['code'] ?? null ) ) {
 				return new WP_Error( 'woocommerce_rest_empty_coupon_code', sprintf( __( 'The coupon code cannot be empty.', 'woocommerce' ), 'code' ), array( 'status' => 400 ) );
 			}
 		}

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-orders-v1-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-orders-v1-controller.php
@@ -10,6 +10,9 @@
  * @since    3.0.0
  */
 
+use Automattic\WooCommerce\Utilities\ArrayUtil;
+use Automattic\WooCommerce\Utilities\StringUtil;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -737,7 +740,8 @@ class WC_REST_Orders_V1_Controller extends WC_REST_Posts_Controller {
 		$item = new WC_Order_Item_Coupon( ! empty( $posted['id'] ) ? $posted['id'] : '' );
 
 		if ( 'create' === $action ) {
-			if ( empty( $posted['code'] ) ) {
+			$coupon_code = ArrayUtil::get_value_or_default( $posted, 'code' );
+			if ( StringUtil::is_null_or_whitespace( $coupon_code ) ) {
 				throw new WC_REST_Exception( 'woocommerce_rest_invalid_coupon_coupon', __( 'Coupon code is required.', 'woocommerce' ), 400 );
 			}
 		}

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-coupons-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-coupons-v2-controller.php
@@ -8,6 +8,9 @@
  * @since   2.6.0
  */
 
+use Automattic\WooCommerce\Utilities\ArrayUtil;
+use Automattic\WooCommerce\Utilities\StringUtil;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -268,7 +271,7 @@ class WC_REST_Coupons_V2_Controller extends WC_REST_CRUD_Controller {
 		$data_keys = array_keys( array_filter( $schema['properties'], array( $this, 'filter_writable_props' ) ) );
 
 		// Validate required POST fields.
-		if ( $creating && empty( $request['code'] ) ) {
+		if ( $creating && StringUtil::is_null_or_whitespace( $request['code'] ?? null ) ) {
 			return new WP_Error( 'woocommerce_rest_empty_coupon_code', sprintf( __( 'The coupon code cannot be empty.', 'woocommerce' ), 'code' ), array( 'status' => 400 ) );
 		}
 

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-coupons-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-coupons-v2-controller.php
@@ -235,8 +235,9 @@ class WC_REST_Coupons_V2_Controller extends WC_REST_CRUD_Controller {
 	protected function prepare_objects_query( $request ) {
 		$args = parent::prepare_objects_query( $request );
 
-		if ( ! empty( $request['code'] ) ) {
-			$id               = wc_get_coupon_id_by_code( $request['code'] );
+		$coupon_code = $request['code'] ?? null;
+		if ( ! StringUtil::is_null_or_whitespace( $coupon_code ) ) {
+			$id               = wc_get_coupon_id_by_code( $coupon_code );
 			$args['post__in'] = array( $id );
 		}
 

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-coupons-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-coupons-v2-controller.php
@@ -8,7 +8,6 @@
  * @since   2.6.0
  */
 
-use Automattic\WooCommerce\Utilities\ArrayUtil;
 use Automattic\WooCommerce\Utilities\StringUtil;
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -10,7 +10,9 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Utilities\ArrayUtil;
 use Automattic\WooCommerce\Utilities\OrderUtil;
+use Automattic\WooCommerce\Utilities\StringUtil;
 
 // phpcs:disable Squiz.Classes.ClassFileName.NoMatch, Squiz.Classes.ValidClassName.NotCamelCaps -- Legacy class name, can't change without breaking backward compat.
 /**
@@ -944,7 +946,8 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 		$item = is_null( $item ) ? new WC_Order_Item_Coupon( ! empty( $posted['id'] ) ? $posted['id'] : '' ) : $item;
 
 		if ( 'create' === $action ) {
-			if ( empty( $posted['code'] ) ) {
+			$coupon_code = ArrayUtil::get_value_or_default( $posted, 'code' );
+			if ( StringUtil::is_null_or_whitespace( $coupon_code ) ) {
 				throw new WC_REST_Exception( 'woocommerce_rest_invalid_coupon_coupon', __( 'Coupon code is required.', 'woocommerce' ), 400 );
 			}
 		}

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
@@ -8,7 +8,9 @@
  * @since    2.6.0
  */
 
+use Automattic\WooCommerce\Utilities\ArrayUtil;
 use Automattic\WooCommerce\Utilities\OrderUtil;
+use Automattic\WooCommerce\Utilities\StringUtil;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -58,11 +60,12 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 				throw new WC_REST_Exception( 'woocommerce_rest_coupon_item_id_readonly', __( 'Coupon item ID is readonly.', 'woocommerce' ), 400 );
 			}
 
-			if ( empty( $item['code'] ) ) {
+			$coupon_code = ArrayUtil::get_value_or_default( $item, 'code' );
+			if ( StringUtil::is_null_or_whitespace( $coupon_code ) ) {
 				throw new WC_REST_Exception( 'woocommerce_rest_invalid_coupon', __( 'Coupon code is required.', 'woocommerce' ), 400 );
 			}
 
-			$coupon_code = wc_format_coupon_code( wc_clean( $item['code'] ) );
+			$coupon_code = wc_format_coupon_code( wc_clean( $coupon_code ) );
 			$coupon      = new WC_Coupon( $coupon_code );
 
 			// Skip check if the coupon is already applied to the order, as this could wrongly throw an error for single-use coupons.

--- a/plugins/woocommerce/includes/wc-coupon-functions.php
+++ b/plugins/woocommerce/includes/wc-coupon-functions.php
@@ -10,6 +10,8 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Utilities\StringUtil;
+
 /**
  * Get coupon types.
  *
@@ -91,7 +93,7 @@ function wc_get_coupon_code_by_id( $id ) {
  */
 function wc_get_coupon_id_by_code( $code, $exclude = 0 ) {
 
-	if ( empty( $code ) ) {
+	if ( StringUtil::is_null_or_whitespace( $code ) ) {
 		return 0;
 	}
 

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -9,6 +9,7 @@
  */
 
 use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer;
+use Automattic\WooCommerce\Utilities\StringUtil;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -926,7 +927,7 @@ function wc_update_coupon_usage_counts( $order_id ) {
 
 	if ( count( $order->get_coupon_codes() ) > 0 ) {
 		foreach ( $order->get_coupon_codes() as $code ) {
-			if ( ! $code ) {
+			if ( StringUtil::is_null_or_whitespace( $code ) ) {
 				continue;
 			}
 

--- a/plugins/woocommerce/src/Internal/Orders/CouponsController.php
+++ b/plugins/woocommerce/src/Internal/Orders/CouponsController.php
@@ -2,6 +2,8 @@
 
 namespace Automattic\WooCommerce\Internal\Orders;
 
+use Automattic\WooCommerce\Utilities\ArrayUtil;
+use Automattic\WooCommerce\Utilities\StringUtil;
 use Exception;
 
 /**
@@ -58,7 +60,8 @@ class CouponsController {
 			throw new Exception( __( 'Invalid order', 'woocommerce' ) );
 		}
 
-		if ( empty( $post_variables['coupon'] ) ) {
+		$coupon = ArrayUtil::get_value_or_default( $post_variables, 'coupon' );
+		if ( StringUtil::is_null_or_whitespace( $coupon ) ) {
 			throw new Exception( __( 'Invalid coupon', 'woocommerce' ) );
 		}
 
@@ -76,7 +79,7 @@ class CouponsController {
 		$order->calculate_taxes( $calculate_tax_args );
 		$order->calculate_totals( false );
 
-		$result = $order->apply_coupon( wc_format_coupon_code( wp_unslash( $post_variables['coupon'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$result = $order->apply_coupon( wc_format_coupon_code( wp_unslash( $coupon ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		if ( is_wp_error( $result ) ) {
 			throw new Exception( html_entity_decode( wp_strip_all_tags( $result->get_error_message() ) ) );

--- a/plugins/woocommerce/src/Utilities/StringUtil.php
+++ b/plugins/woocommerce/src/Utilities/StringUtil.php
@@ -83,4 +83,25 @@ final class StringUtil {
 	public static function plugin_name_from_plugin_file( string $plugin_file_path ): string {
 		return basename( dirname( $plugin_file_path ) ) . DIRECTORY_SEPARATOR . basename( $plugin_file_path );
 	}
+
+	/**
+	 * Check if a string is null or is empty.
+	 *
+	 * @param string|null $value The string to check.
+	 * @return bool True if the string is null or is empty.
+	 */
+	public static function is_null_or_empty( ?string $value ) {
+		return is_null( $value ) || '' === $value;
+	}
+
+	/**
+	 * Check if a string is null, is empty, or has only whitespace characters
+	 * (space, tab, vertical tab, form feed, carriage return, new line)
+	 *
+	 * @param string|null $value The string to check.
+	 * @return bool True if the string is null, is empty, or contains only whitespace characters.
+	 */
+	public static function is_null_or_whitespace( ?string $value ) {
+		return is_null( $value ) || '' === $value || ctype_space( $value );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Utilities/StringUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Utilities/StringUtilTest.php
@@ -74,4 +74,40 @@ class StringUtilTest extends \WC_Unit_Test_Case {
 		$expected  = 'foobar/fizzbuzz.php';
 		$this->assertEquals( $expected, $result );
 	}
+
+	/**
+	 * @testDox 'is_null_or_empty' should return true only if the value is null or an empty string.
+	 *
+	 * @testWith [null, true]
+	 *           ["", true]
+	 *           ["  ", false]
+	 *           ["0", false]
+	 *           ["foo", false]
+	 *           ["  foo  ", false]
+	 *
+	 * @param string $value Value to test.
+	 * @param bool   $expected Expected result from the method.
+	 */
+	public function test_is_null_or_empty( $value, $expected ) {
+		$result = StringUtil::is_null_or_empty( $value );
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * @testDox 'is_null_or_empty' should return true only if the value is null, an empty string, or consists of only whitespace characters.
+	 *
+	 * @testWith [null, true]
+	 *           ["", true]
+	 *           [" \n\r\t\f ", true]
+	 *           ["0", false]
+	 *           ["foo", false]
+	 *           ["  foo  ", false]
+	 *
+	 * @param string $value Value to test.
+	 * @param bool   $expected Expected result from the method.
+	 */
+	public function test_is_null_or_whitespace( $value, $expected ) {
+		$result = StringUtil::is_null_or_whitespace( $value );
+		$this->assertEquals( $expected, $result );
+	}
 }


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fixes a bug that allowed to create a coupon with code "0" but prevented if from being actually used. With the fix a coupon with code "0" can be used as any other coupon.

Also adds two new methods to the `StringUtil` class: `is_null_or_empty` and `is_null_or_whitespace`.

Closes #35210.

- [ ] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).

### How to test the changes in this Pull Request:

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Go to Marketing - Coupons and click "Add coupon".
2. Give the coupon the code `0` and an amount of 1 (Coupon data - General - Coupon amount), leave it as type "Fixed cart discount" and save it.
3. Go to the shop and add any product to the cart, then go to the cart.
4. Type `0 ` in "Coupon code", then click "Apply coupon". The coupon should be applied successfully and appear listed in "Cart totals".
5. Click the "Remove" link next to the coupon amount in "Cart totals", the coupon should be successfully removed.
6. Click "Proceed to checkout" and click on "Have a coupon? Click here to enter your code".
7. Enter the coupon code `0` and click "Apply coupon", the coupon should be applied successfully and appear listed in "Your order".
8. Click the "Remove" link next to the coupon amount in "Your order", the coupon should be successfully removed.
9. Apply the coupon again and complete the order.
10. Go to Marketing - Coupons in the admin area and verify that the coupon usage has been increased.
11. Go to the admin area and open the order details (WooCommerce - Orders). Verify that the coupon is listed under "Coupon(s)" and that its value is discounted from the order total.
12. Remove the coupon by clicking the "x" in the coupon name, verify that the operation succeeds and the coupon value is no longer discounted from the order total.
13. Go to Marketing - Coupons in the admin area and verify that the coupon usage has been decreased.
14. Add the coupon again by clickin "Add coupon", verify that the operation succeeds and the coupon value is discounted again from the order total.
15. Edit the coupon so that it has a maximum allowed usage (Usage limits - Usage limit per coupon) equal to the current usage count.
16. Try to apply the coupon again to a different order, you should get an error now.

### Testing with REST API

Verify that the coupon "0" can be created and applied via REST API too.

Example request to create (try `v1`, `v2` and `v3`):

```
curl --request POST \
  --url http://localhost/wp-json/wc/v3/coupons \
  --header 'Authorization: Basic {your app password}' \
  --header 'Content-Type: multipart/form-data' \
  --form code=0 \
  --form discount_type=percent \
  --form amount=1
```

Example request to apply to a new order:

```
curl --request POST \
  --url http://localhost/wp-json/wc/v3/orders \
  --header 'Authorization: Basic {your app password}' \
  --header 'Content-Type: application/json' \
  --data '{
	"line_items": [
    {
      "product_id": 95,
      "quantity": 1
    }
  ],
	"coupon_lines": [
		{
			"code": "0"
		}
	],
	"payment_method": "cod"
}'
```

Also verify that a `GET` request to the coupons endpoint with `code=0`  returns just the coupon with code `0` instead of all the existing coupons:

```
curl --request GET --url 'http://localhost/wp-json/wc/v3/coupons?code=0' --header 'Authorization: Basic {your app password}'
```

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [ ] Have you included testing instructions?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
