### PR TITLE
Update tree select control

### DIFF
--- a/packages/js/components/changelog/update-34885_category_field_in_product_editor
+++ b/packages/js/components/changelog/update-34885_category_field_in_product_editor
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Export TreeSelectControl component and add additional props: onInputChange, alwaysShowPlaceholder, includeParent.

--- a/packages/js/components/src/index.ts
+++ b/packages/js/components/src/index.ts
@@ -95,6 +95,8 @@ export {
 	SlotContextType,
 	SlotContextHelpersType,
 } from './slot-context';
+export { TreeControl as __experimentalTreeControl } from './experimental-tree-control';
+export { default as TreeSelectControl } from './tree-select-control';
 
 // Exports below can be removed once the @woocommerce/product-editor package is released.
 export {

--- a/packages/js/components/src/style.scss
+++ b/packages/js/components/src/style.scss
@@ -57,3 +57,4 @@
 @import 'form/style.scss';
 @import 'experimental-tree-control/tree.scss';
 @import 'product-section-layout/style.scss';
+@import 'tree-select-control/index.scss';

--- a/packages/js/components/src/tree-select-control/control.js
+++ b/packages/js/components/src/tree-select-control/control.js
@@ -20,6 +20,7 @@ import { BACKSPACE } from './constants';
  * @param {string}   props.instanceId       Id of the component
  * @param {string}   props.placeholder      Placeholder of the search input
  * @param {boolean}  props.isExpanded       True if the tree is expanded
+ * @param {boolean}  props.alwaysShowPlaceholder  Will always show placeholder (default: false)
  * @param {boolean}  props.disabled         True if the component is disabled
  * @param {number}   props.maxVisibleTags   The maximum number of tags to show. Undefined, 0 or less than 0 evaluates to "Show All".
  * @param {string}   props.value            The current input value
@@ -43,11 +44,14 @@ const Control = forwardRef(
 			onTagsChange = () => {},
 			onInputChange = () => {},
 			onControlClick = noop,
+			alwaysShowPlaceholder = false,
 		},
 		ref
 	) => {
 		const hasTags = tags.length > 0;
-		const showPlaceholder = ! hasTags && ! isExpanded;
+		const showPlaceholder = alwaysShowPlaceholder
+			? true
+			: ! hasTags && ! isExpanded;
 
 		/**
 		 * Handles keydown event

--- a/packages/js/components/src/tree-select-control/index.js
+++ b/packages/js/components/src/tree-select-control/index.js
@@ -209,7 +209,12 @@ const TreeSelectControl = ( {
 						return [];
 					}
 					return this.children.flatMap( ( option ) => {
-						return option.hasChildren ? option.leaves : option;
+						if ( option.hasChildren ) {
+							return includeParent && option.value !== ROOT_VALUE
+								? [ option, ...option.leaves ]
+								: option.leaves;
+						}
+						return option;
 					} );
 				},
 			},
@@ -222,7 +227,10 @@ const TreeSelectControl = ( {
 				 * @return {boolean} True if checked, false otherwise.
 				 */
 				get() {
-					if ( this.hasChildren && ! includeParent ) {
+					if ( includeParent && this.value !== ROOT_VALUE ) {
+						return cache.selectedValues.includes( this.value );
+					}
+					if ( this.hasChildren ) {
 						return this.leaves.every( ( opt ) => opt.checked );
 					}
 					return cache.selectedValues.includes( this.value );
@@ -413,10 +421,12 @@ const TreeSelectControl = ( {
 		if (
 			includeParent &&
 			parent &&
+			parent.value !== ROOT_VALUE &&
 			parent.children &&
 			parent.children.every( ( child ) =>
 				newValue.includes( child.value )
-			)
+			) &&
+			! newValue.includes( parent.value )
 		) {
 			newValue.push( parent.value );
 		}
@@ -434,7 +444,7 @@ const TreeSelectControl = ( {
 		const changedValues = option.leaves
 			.filter( ( opt ) => opt.checked !== checked )
 			.map( ( opt ) => opt.value );
-		if ( includeParent ) {
+		if ( includeParent && option.value !== ROOT_VALUE ) {
 			changedValues.push( option.value );
 		}
 		if ( checked ) {

--- a/packages/js/components/src/tree-select-control/index.js
+++ b/packages/js/components/src/tree-select-control/index.js
@@ -23,7 +23,6 @@ import {
 import useIsEqualRefValue from './useIsEqualRefValue';
 import Control from './control';
 import Options from './options';
-import './index.scss';
 import { ARROW_DOWN, ARROW_UP, ENTER, ESCAPE, ROOT_VALUE } from './constants';
 
 /**
@@ -64,11 +63,14 @@ import { ARROW_DOWN, ARROW_UP, ENTER, ESCAPE, ROOT_VALUE } from './constants';
  * @param {string}                     [props.placeholder]                Placeholder for the search control input
  * @param {string}                     [props.className]                  The class name for this component
  * @param {boolean}                    [props.disabled]                   Disables the component
+ * @param {boolean}                    [props.includeParent]              Includes parent with selection.
+ * @param {boolean}                    [props.alwaysShowPlaceholder]      Will always show placeholder (default: false)
  * @param {Option[]}                   [props.options]                    Options to show in the component
  * @param {string[]}                   [props.value]                      Selected values
  * @param {number}                     [props.maxVisibleTags]             The maximum number of tags to show. Undefined, 0 or less than 0 evaluates to "Show All".
  * @param {Function}                   [props.onChange]                   Callback when the selector changes
  * @param {(visible: boolean) => void} [props.onDropdownVisibilityChange] Callback when the visibility of the dropdown options is changed.
+ * @param {Function}                   [props.onInputChange]                   Callback when the selector changes
  * @return {JSX.Element} The component
  */
 const TreeSelectControl = ( {
@@ -84,6 +86,9 @@ const TreeSelectControl = ( {
 	maxVisibleTags,
 	onChange = () => {},
 	onDropdownVisibilityChange = noop,
+	onInputChange = noop,
+	includeParent = false,
+	alwaysShowPlaceholder = false,
 } ) => {
 	let instanceId = useInstanceId( TreeSelectControl );
 	instanceId = id ?? instanceId;
@@ -217,7 +222,7 @@ const TreeSelectControl = ( {
 				 * @return {boolean} True if checked, false otherwise.
 				 */
 				get() {
-					if ( this.hasChildren ) {
+					if ( this.hasChildren && ! includeParent ) {
 						return this.leaves.every( ( opt ) => opt.checked );
 					}
 					return cache.selectedValues.includes( this.value );
@@ -378,14 +383,16 @@ const TreeSelectControl = ( {
 	 *
 	 * @param {boolean}     checked Indicates if the item should be checked
 	 * @param {InnerOption} option  The option to change
+	 * @param {InnerOption} parent  The options parent (could be null)
 	 */
-	const handleOptionsChange = ( checked, option ) => {
+	const handleOptionsChange = ( checked, option, parent ) => {
 		if ( option.hasChildren ) {
 			handleParentChange( checked, option );
 		} else {
-			handleSingleChange( checked, option );
+			handleSingleChange( checked, option, parent );
 		}
 
+		onInputChange( '' );
 		setInputControlValue( '' );
 		if ( ! nodesExpanded.includes( option.parent ) ) {
 			controlRef.current.focus();
@@ -397,12 +404,22 @@ const TreeSelectControl = ( {
 	 *
 	 * @param {boolean}     checked Indicates if the item should be checked
 	 * @param {InnerOption} option  The option to change
+	 * @param {InnerOption} parent  The options parent (could be null)
 	 */
-	const handleSingleChange = ( checked, option ) => {
+	const handleSingleChange = ( checked, option, parent ) => {
 		const newValue = checked
 			? [ ...value, option.value ]
 			: value.filter( ( el ) => el !== option.value );
-
+		if (
+			includeParent &&
+			parent &&
+			parent.children &&
+			parent.children.every( ( child ) =>
+				newValue.includes( child.value )
+			)
+		) {
+			newValue.push( parent.value );
+		}
 		onChange( newValue );
 	};
 
@@ -417,7 +434,9 @@ const TreeSelectControl = ( {
 		const changedValues = option.leaves
 			.filter( ( opt ) => opt.checked !== checked )
 			.map( ( opt ) => opt.value );
-
+		if ( includeParent ) {
+			changedValues.push( option.value );
+		}
 		if ( checked ) {
 			if ( ! option.expanded ) {
 				handleToggleExpanded( option );
@@ -446,6 +465,7 @@ const TreeSelectControl = ( {
 	 * @param {Event} e Event returned by the On Change function in the Input control
 	 */
 	const handleOnInputChange = ( e ) => {
+		onInputChange( e.target.value );
 		setInputControlValue( e.target.value );
 	};
 
@@ -486,6 +506,7 @@ const TreeSelectControl = ( {
 				value={ inputControlValue }
 				onTagsChange={ handleTagsChange }
 				onInputChange={ handleOnInputChange }
+				alwaysShowPlaceholder={ alwaysShowPlaceholder }
 			/>
 			{ showTree && (
 				<div

--- a/packages/js/components/src/tree-select-control/options.js
+++ b/packages/js/components/src/tree-select-control/options.js
@@ -22,6 +22,7 @@ import Checkbox from './checkbox';
  *
  * @param {Object}                        props                    Component parameters
  * @param {InnerOption[]}                 props.options            List of options to be rendered
+ * @param {InnerOption}                   props.parent             Parent option
  * @param {Function}                      props.onChange           Callback when an option changes
  * @param {Function}                      [props.onExpanderClick]  Callback when an expander is clicked.
  * @param {(option: InnerOption) => void} [props.onToggleExpanded] Callback when requesting an expander to be toggled.
@@ -31,6 +32,7 @@ const Options = ( {
 	onChange = () => {},
 	onExpanderClick = noop,
 	onToggleExpanded = noop,
+	parent = null,
 } ) => {
 	/**
 	 * Alters the node with some keys for accessibility
@@ -76,6 +78,7 @@ const Options = ( {
 							) }
 							tabIndex="-1"
 							onClick={ ( e ) => {
+								e.preventDefault();
 								onExpanderClick( e );
 								onToggleExpanded( option );
 							} }
@@ -93,7 +96,7 @@ const Options = ( {
 						option={ option }
 						checked={ checked }
 						onChange={ ( e ) => {
-							onChange( e.target.checked, option );
+							onChange( e.target.checked, option, parent );
 						} }
 						onKeyDown={ ( e ) => {
 							handleKeyDown( e, option );
@@ -113,6 +116,7 @@ const Options = ( {
 							onChange={ onChange }
 							onExpanderClick={ onExpanderClick }
 							onToggleExpanded={ onToggleExpanded }
+							parent={ option }
 						/>
 					</div>
 				) }

--- a/packages/js/components/src/tree-select-control/stories/index.js
+++ b/packages/js/components/src/tree-select-control/stories/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -15,7 +15,7 @@ const treeSelectControlOptions = [
 		children: [
 			{ value: 'ES', label: 'Spain' },
 			{ value: 'FR', label: 'France' },
-			{ key: 'FR-Colonies', value: 'FR', label: 'France (Colonies)' },
+			{ key: 'FR-Colonies', value: 'FR-C', label: 'France (Colonies)' },
 		],
 	},
 	{
@@ -69,6 +69,12 @@ const treeSelectControlOptions = [
 const Template = ( args ) => {
 	const [ selected, setSelected ] = useState( [ 'ES' ] );
 
+	useEffect( () => {
+		if ( args.onChange ) {
+			args.onChange( selected );
+		}
+	}, [ selected ] );
+
 	return (
 		<TreeSelectControl
 			{ ...args }
@@ -94,6 +100,7 @@ Base.args = {
 
 Base.argTypes = {
 	onInputChange: { action: 'onInputChange' },
+	onChange: { action: 'onChange' },
 };
 
 export default {

--- a/packages/js/components/src/tree-select-control/stories/index.js
+++ b/packages/js/components/src/tree-select-control/stories/index.js
@@ -88,6 +88,12 @@ Base.args = {
 	options: treeSelectControlOptions,
 	maxVisibleTags: 3,
 	selectAllLabel: 'All countries',
+	includeParent: false,
+	alwaysShowPlaceholder: false,
+};
+
+Base.argTypes = {
+	onInputChange: { action: 'onInputChange' },
 };
 
 export default {

--- a/packages/js/components/src/tree-select-control/test/control.test.js
+++ b/packages/js/components/src/tree-select-control/test/control.test.js
@@ -110,4 +110,36 @@ describe( 'TreeSelectControl - Control Component', () => {
 		placeholder = input.getAttribute( 'placeholder' );
 		expect( placeholder ).toBeFalsy();
 	} );
+
+	it( 'Renders placeholder when alwaysShowPlaceholder is true with tags or expanded', () => {
+		const { rerender } = render(
+			<Control placeholder="Select" alwaysShowPlaceholder={ true } />
+		);
+		let input = screen.queryByRole( 'combobox' );
+		let placeholder = input.getAttribute( 'placeholder' );
+		expect( placeholder ).toBe( 'Select' );
+
+		rerender(
+			<Control
+				placeholder="Select"
+				alwaysShowPlaceholder={ true }
+				tags={ [ { id: 'es', label: 'Spain' } ] }
+			/>
+		);
+
+		input = screen.queryByRole( 'combobox' );
+		placeholder = input.getAttribute( 'placeholder' );
+		expect( placeholder ).toBeTruthy();
+
+		rerender(
+			<Control
+				placeholder="Select"
+				isExpanded={ true }
+				alwaysShowPlaceholder={ true }
+			/>
+		);
+		input = screen.queryByRole( 'combobox' );
+		placeholder = input.getAttribute( 'placeholder' );
+		expect( placeholder ).toBeTruthy();
+	} );
 } );

--- a/packages/js/components/src/tree-select-control/test/index.test.js
+++ b/packages/js/components/src/tree-select-control/test/index.test.js
@@ -71,6 +71,25 @@ describe( 'TreeSelectControl Component', () => {
 		expect( onChange ).toHaveBeenCalledWith( [ 'ES', 'AS' ] );
 	} );
 
+	it( 'Should include parent in onChange value when includeParent is truthy', () => {
+		const onChange = jest.fn().mockName( 'onChange' );
+
+		const { queryByLabelText, queryByRole } = render(
+			<TreeSelectControl
+				options={ options }
+				value={ [] }
+				onChange={ onChange }
+				includeParent={ true }
+			/>
+		);
+
+		const control = queryByRole( 'combobox' );
+		fireEvent.click( control );
+		const checkbox = queryByLabelText( 'Europe' );
+		fireEvent.click( checkbox );
+		expect( onChange ).toHaveBeenCalledWith( [ 'ES', 'FR', 'IT', 'EU' ] );
+	} );
+
 	it( 'Renders the label', () => {
 		const { queryByLabelText } = render(
 			<TreeSelectControl options={ options } label="Select" />
@@ -147,5 +166,26 @@ describe( 'TreeSelectControl Component', () => {
 		expect( queryByLabelText( 'Spain' ) ).toBeTruthy(); // match pain
 		expect( queryByLabelText( 'France' ) ).toBeFalsy(); // doesn't match pain
 		expect( queryByLabelText( 'Asia' ) ).toBeFalsy(); // doesn't match pain
+	} );
+
+	it( 'should call onInputChange when input field changed', () => {
+		const onInputChangeMock = jest.fn();
+		const { queryByRole } = render(
+			<TreeSelectControl
+				options={ options }
+				onInputChange={ onInputChangeMock }
+			/>
+		);
+
+		const control = queryByRole( 'combobox' );
+		fireEvent.click( control );
+		fireEvent.change( control, { target: { value: 'Asi' } } );
+		expect( onInputChangeMock ).toHaveBeenCalledWith( 'Asi' );
+
+		fireEvent.change( control, { target: { value: 'As' } } );
+		expect( onInputChangeMock ).toHaveBeenCalledWith( 'As' );
+
+		fireEvent.change( control, { target: { value: 'pain' } } );
+		expect( onInputChangeMock ).toHaveBeenCalledWith( 'pain' );
 	} );
 } );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This exports the TreeSelectControl component from the component package and adds 3 additional props:
- `onInputChange` a callback for when a user types
- `alwaysShowPlaceholder` an option to always show the placeholder.
- `includeParent` this will include the parent id to the `onChange` array if a parent is selected.

This is related to the work done as part of #36869

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. On this branch load up the storybook: `pnpm --filter=storybook storybook` 
2. Go to the `TreeSelectControl`
3. Start typing something, this should be outputted in the `actions` tab
4. In the control tab toggle the `alwaysShowPlaceholder` and `includeParent` to `true`
5. Make sure the placeholder always shows when the input field is blank and a parent is also showing up when selecting a parent, like `Tokio` for example.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
