### PR TITLE
Fix k6 baseline load imports

### DIFF
--- a/plugins/woocommerce/changelog/fix-k6-baseline-imports
+++ b/plugins/woocommerce/changelog/fix-k6-baseline-imports
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+add wpLogin import to wc-baseline-load.js

--- a/plugins/woocommerce/tests/performance/tests/wc-baseline-load.js
+++ b/plugins/woocommerce/tests/performance/tests/wc-baseline-load.js
@@ -23,6 +23,7 @@ import { ordersFilter } from '../requests/merchant/orders-filter.js';
 import { addOrder } from '../requests/merchant/add-order.js';
 import { homeWCAdmin } from '../requests/merchant/home-wc-admin.js';
 import { myAccountMerchantLogin } from '../requests/merchant/my-account-merchant.js';
+import { wpLogin } from '../requests/merchant/wp-login.js';
 import { ordersAPI } from '../requests/api/orders.js';
 import { admin_acc_login } from '../config.js';
 


### PR DESCRIPTION
### All Submissions:

The `wc-baseline-load.js` test file logs a good number of `wpLogin is undefined` messages. This PR adds the import for the function.

### How to test the changes in this Pull Request:

1. Run `pnpm run env:dev --filter=woocommerce`
2. Run `pnpm run env:performance-init --filter=woocommerce`
3. Run `k6 run tests/performance/tests/wc-baseline-load.js`
4. The tests should run successfully without lagging any errors.

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
