### PR TITLE
Allow removing postcode and state from calculator even if required on checkout

### DIFF
--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -1566,10 +1566,10 @@ class WC_Cart extends WC_Legacy_Cart {
 				return false;
 			}
 			$country_fields = WC()->countries->get_address_fields( $country, 'shipping_' );
-			if ( isset( $country_fields['shipping_state'] ) && $country_fields['shipping_state']['required'] && ! $this->get_customer()->get_shipping_state() ) {
+			if ( apply_filters( 'woocommerce_shipping_calculator_enable_state', true ) && isset( $country_fields['shipping_state'] ) && $country_fields['shipping_state']['required'] && ! $this->get_customer()->get_shipping_state() ) {
 				return false;
 			}
-			if ( isset( $country_fields['shipping_postcode'] ) && $country_fields['shipping_postcode']['required'] && ! $this->get_customer()->get_shipping_postcode() ) {
+			if ( apply_filters( 'woocommerce_shipping_calculator_enable_postcode', true ) && isset( $country_fields['shipping_postcode'] ) && $country_fields['shipping_postcode']['required'] && ! $this->get_customer()->get_shipping_postcode() ) {
 				return false;
 			}
 		}

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -1566,6 +1566,12 @@ class WC_Cart extends WC_Legacy_Cart {
 				return false;
 			}
 			$country_fields = WC()->countries->get_address_fields( $country, 'shipping_' );
+			/**
+			 * Filter to not require shipping state for shipping calculation, even if its' required at checkout. This can be used to allow shipping calculations to be done without a state.
+			 *
+			 * @since 7.6.0
+			 * @param bool $show_state Whether to use the state field. Default true.
+			 */
 			if ( apply_filters( 'woocommerce_shipping_calculator_enable_state', true ) && isset( $country_fields['shipping_state'] ) && $country_fields['shipping_state']['required'] && ! $this->get_customer()->get_shipping_state() ) {
 				return false;
 			}

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -1569,6 +1569,12 @@ class WC_Cart extends WC_Legacy_Cart {
 			if ( apply_filters( 'woocommerce_shipping_calculator_enable_state', true ) && isset( $country_fields['shipping_state'] ) && $country_fields['shipping_state']['required'] && ! $this->get_customer()->get_shipping_state() ) {
 				return false;
 			}
+			/**
+			 * Filter to not require shipping postcode for shipping calculation, even if it's required at checkout. This can be used to allow shipping calculations to be done without a postcode.
+			 *
+			 * @since 7.6.0
+			 * @param bool $show_postcode Whether to use the postcode field. Default true.
+			 */
 			if ( apply_filters( 'woocommerce_shipping_calculator_enable_postcode', true ) && isset( $country_fields['shipping_postcode'] ) && $country_fields['shipping_postcode']['required'] && ! $this->get_customer()->get_shipping_postcode() ) {
 				return false;
 			}


### PR DESCRIPTION
Allow removing postcode and state fields from the shipping calculator, if they're not needed for calculation, even if they're required at the checkout. Fixes #28393

### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #28393 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Return false do `woocommerce_shipping_calculator_enable_postcode` or `woocommerce_shipping_calculator_enable_state` and have them as required fields for the checkout
2. If these changes are not live, the shipping calculator will fail
3. Apply the PR and the shipping calculator works

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
