### PR TITLE
Update WooCommerce Blocks plugin to 9.4.4

### DIFF
--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-9.4.4
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-9.4.4
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Woo Blocks 9.4.4

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -21,7 +21,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.5.4",
-		"woocommerce/woocommerce-blocks": "9.4.3"
+		"woocommerce/woocommerce-blocks": "9.4.4"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.3.0",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1c61abfc7c6c9b7795d2c18201e29f08",
+    "content-hash": "2382206bf8387e0c58e5b1a36602dce6",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -628,16 +628,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "v9.4.3",
+            "version": "v9.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "26feae05d65ff38f0277bdb0c19f9d293d3cbfc4"
+                "reference": "3b399c8327fe4dc862038a20fc9439fa5533f147"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/26feae05d65ff38f0277bdb0c19f9d293d3cbfc4",
-                "reference": "26feae05d65ff38f0277bdb0c19f9d293d3cbfc4",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/3b399c8327fe4dc862038a20fc9439fa5533f147",
+                "reference": "3b399c8327fe4dc862038a20fc9439fa5533f147",
                 "shasum": ""
             },
             "require": {
@@ -683,9 +683,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v9.4.3"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v9.4.4"
             },
-            "time": "2023-02-02T10:50:45+00:00"
+            "time": "2023-02-27T15:57:57+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 9.4.4. 
## Blocks 9.4.4

* [Release PR](https://github.com/woocommerce/woocommerce-blocks/pull/8551)
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/944.md)



### Changelog entry

#### Bug Fixes

- Check if session is set before returing updated customer address. ([8537](https://github.com/woocommerce/woocommerce-blocks/pull/8537))


