### PR TITLE
Hide product attribute selector when adding the first local attribute

### DIFF
--- a/plugins/woocommerce/changelog/add-product-attribute-selector
+++ b/plugins/woocommerce/changelog/add-product-attribute-selector
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Hide product attribute selector when adding the first local attribute

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -57,6 +57,10 @@ jQuery( function ( $ ) {
 		} );
 	} );
 
+	$( document.body ).on( 'woocommerce_attributes_saved', function () {
+		$( '#product_attributes_actions' ).removeClass( 'hidden' );
+	} );
+
 	$( function () {
 		if ( ! woocommerce_admin_meta_boxes.has_attributes ) {
 			$( 'button.add_attribute' ).trigger( 'click' );
@@ -467,11 +471,18 @@ jQuery( function ( $ ) {
 
 			attribute_row_indexes();
 
-			$attributes
+			const lastAttribute = $attributes
 				.find( '.woocommerce_attribute' )
-				.last()
-				.find( 'h3' )
-				.trigger( 'click' );
+				.last();
+
+			lastAttribute.find( 'h3' ).trigger( 'click' );
+
+			if ( $attributes.length === 1 ) {
+				// if there is only one attribute, show the actions that were hidden when user finishes typing attribute value to avoid a roundtrip
+				lastAttribute.find( '[name^="attribute_values"]' ).on( 'blur', function () {
+					$( '#product_attributes_actions' ).removeClass( 'hidden' );
+				} );
+			}
 
 			$wrapper.unblock();
 
@@ -799,7 +810,6 @@ jQuery( function ( $ ) {
 				);
 
 				$( document.body ).trigger( 'woocommerce_attributes_saved' );
-
 			}
 		} );
 	} );
@@ -1047,7 +1057,6 @@ jQuery( function ( $ ) {
 			delay: 200,
 			keepAlive: true,
 		} );
-
 
 	// add a tooltip to the right of the product image meta box "Set product image" and "Add product gallery images"
 	const setProductImageLink = $( '#set-post-thumbnail' );

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
@@ -12,7 +12,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 		// Product attributes - taxonomies and custom, ordered, with visibility and variation attributes set.
 		$product_attributes = $product_object->get_attributes( 'edit' );
 
-		if ( empty( $attribute_taxonomies ) && empty( $product_attributes ) ) :
+		$is_empty = empty( $attribute_taxonomies ) && empty( $product_attributes );
+
+		if ( $is_empty ) :
 			?>
 			<div id="message" class="inline notice woocommerce-message">
 				<p>
@@ -25,10 +27,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 				</p>
 			</div>
 		<?php endif; ?>
-		<span class="expand-close">
-			<a href="#" class="expand_all"><?php esc_html_e( 'Expand', 'woocommerce' ); ?></a> / <a href="#" class="close_all"><?php esc_html_e( 'Close', 'woocommerce' ); ?></a>
-		</span>
-
+		<div id="product_attributes_actions" class="<?php echo $is_empty ? 'hidden' : ''; ?>">
+			<span class="expand-close">
+				<a href="#" class="expand_all"><?php esc_html_e( 'Expand', 'woocommerce' ); ?></a> / <a href="#" class="close_all"><?php esc_html_e( 'Close', 'woocommerce' ); ?></a>
+			</span>
 		<?php
 		/**
 		 * Filter for the attribute taxonomy filter dropdown threshold.
@@ -56,6 +58,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<select class="wc-attribute-search attribute_taxonomy" id="attribute_taxonomy" name="attribute_taxonomy" data-placeholder="<?php esc_attr_e( 'Add existing attribute', 'woocommerce' ); ?>" data-minimum-input-length="0">
 			</select>
 		<?php endif; ?>
+		</div>
 	</div>
 	<div class="product_attributes wc-metaboxes">
 		<?php

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
@@ -63,6 +63,9 @@ test.describe.serial( 'Add New Variable Product Page', () => {
 				`textarea[name="attribute_values[${ i }]"]`,
 				'val1 | val2'
 			);
+			await page
+				.locator( `textarea[name="attribute_values[${ i }]"]` )
+				.blur();
 		}
 		await page.click( 'text=Save attributes' );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
@@ -214,6 +214,9 @@ test.describe.serial( 'Add New Variable Product Page', () => {
 				`textarea[name="attribute_values[${ i }]"]`,
 				'val1 | val2'
 			);
+			await page
+				.locator( `textarea[name="attribute_values[${ i }]"]` )
+				.blur();
 			await page.click( 'text=Save attributes' );
 			await expect(
 				page


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Hide product attribute selector when adding the first local attribute.

I decided to use jQuery to show the selector when the first value blurs to avoid making the user click on "Save attributes" twice. 

https://user-images.githubusercontent.com/13437655/221646376-6cab865b-862b-45d9-97a7-c179dbf18379.mov


<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #36665 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Have no global attributes at your Woo installation (the ones created at Products > Attributes)
2. Go to Products > Add
3. Go to the Attributes tab
4. Check if the message appears and the product selector is hidden
5. Fill the first attribute
6. Check if the selector appears

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [ ] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
