### PR TITLE
Update/use theme color for completed task strikethrough

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/tasks.scss
+++ b/plugins/woocommerce-admin/client/tasks/tasks.scss
@@ -53,7 +53,7 @@
 }
 
 .components-modal__screen-overlay {
-	background: rgba( 43, 45, 47, 0.4 );
+	background: rgba(43, 45, 47, 0.4);
 }
 
 .components-modal__frame {
@@ -240,12 +240,12 @@
 
 .woocommerce-task-list__setup {
 	.woocommerce-experimental-list
-		.woocommerce-experimental-list__item.complete {
+	.woocommerce-experimental-list__item.complete {
 		text-decoration: line-through;
-		color: var( --wp-admin-theme-color );
+		color: var(--wp-admin-theme-color);
 
 		.woocommerce-task-list__item-title {
-			color: var( --wp-admin-theme-color );
+			color: var(--wp-admin-theme-color);
 		}
 	}
 }

--- a/plugins/woocommerce-admin/client/tasks/tasks.scss
+++ b/plugins/woocommerce-admin/client/tasks/tasks.scss
@@ -53,7 +53,7 @@
 }
 
 .components-modal__screen-overlay {
-	background: rgba(43, 45, 47, 0.4);
+	background: rgba( 43, 45, 47, 0.4 );
 }
 
 .components-modal__frame {
@@ -239,11 +239,13 @@
 }
 
 .woocommerce-task-list__setup {
-	.woocommerce-experimental-list .woocommerce-experimental-list__item.complete {
+	.woocommerce-experimental-list
+		.woocommerce-experimental-list__item.complete {
 		text-decoration: line-through;
+		color: var( --wp-admin-theme-color );
 
 		.woocommerce-task-list__item-title {
-			color: var(--wp-admin-theme-color);
+			color: var( --wp-admin-theme-color );
 		}
 	}
 }

--- a/plugins/woocommerce/changelog/update-use-theme-color-for-completed-task-strikethrough
+++ b/plugins/woocommerce/changelog/update-use-theme-color-for-completed-task-strikethrough
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Use the currently activated theme color for completed tasks strikethough


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/Automattic/wc-calypso-bridge/issues/1000

This PR uses the theme color for completed tasks strikethrough.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:


1. Checkout this branch and build the assets.
2. Navigate to `WooCommerce -> Home`
3. Complete a task.
4. Confirm the strikethrough color is the same as currently activated theme color.

<!-- End testing instructions -->

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [ ] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
