### PR TITLE
[36257 redux] Add `menu_order` sorting option to products widget

### DIFF
--- a/plugins/woocommerce/changelog/36257-redux
+++ b/plugins/woocommerce/changelog/36257-redux
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Allow sorting by menu_order in products widget.

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-products.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-products.php
@@ -50,11 +50,11 @@ class WC_Widget_Products extends WC_Widget {
 				'std'     => 'date',
 				'label'   => __( 'Order by', 'woocommerce' ),
 				'options' => array(
-					'menu_order'  => __( 'Menu order', 'woocommerce' ),
-					'date'  => __( 'Date', 'woocommerce' ),
-					'price' => __( 'Price', 'woocommerce' ),
-					'rand'  => __( 'Random', 'woocommerce' ),
-					'sales' => __( 'Sales', 'woocommerce' ),
+					'menu_order' => __( 'Menu order', 'woocommerce' ),
+					'date'       => __( 'Date', 'woocommerce' ),
+					'price'      => __( 'Price', 'woocommerce' ),
+					'rand'       => __( 'Random', 'woocommerce' ),
+					'sales'      => __( 'Sales', 'woocommerce' ),
 				),
 			),
 			'order'       => array(
@@ -155,7 +155,7 @@ class WC_Widget_Products extends WC_Widget {
 
 		switch ( $orderby ) {
 			case 'menu_order':
-				$query_args['orderby']  = 'menu_order';
+				$query_args['orderby'] = 'menu_order';
 				break;
 			case 'price':
 				$query_args['meta_key'] = '_price'; // WPCS: slow query ok.

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-products.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-products.php
@@ -50,6 +50,7 @@ class WC_Widget_Products extends WC_Widget {
 				'std'     => 'date',
 				'label'   => __( 'Order by', 'woocommerce' ),
 				'options' => array(
+					'menu_order'  => __( 'Menu order', 'woocommerce' ),
 					'date'  => __( 'Date', 'woocommerce' ),
 					'price' => __( 'Price', 'woocommerce' ),
 					'rand'  => __( 'Random', 'woocommerce' ),
@@ -153,6 +154,9 @@ class WC_Widget_Products extends WC_Widget {
 		}
 
 		switch ( $orderby ) {
+			case 'menu_order':
+				$query_args['orderby']  = 'menu_order';
+				break;
 			case 'price':
 				$query_args['meta_key'] = '_price'; // WPCS: slow query ok.
 				$query_args['orderby']  = 'meta_value_num';


### PR DESCRIPTION
From https://github.com/woocommerce/woocommerce/pull/36257:

> Option for sorting by menu order in widget products.
> 
> ### All Submissions:
> 
> -   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
> -   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
> -   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?
> 
> <!-- Mark completed items with an [x] -->
> 
> <!-- You can erase any parts of this template not applicable to your Pull Request. -->
> 
> ### Changes proposed in this Pull Request:
> 
> <!-- Describe the changes made to this Pull Request and the reason for such changes. -->
> 
> Closes # .
> 
> <!-- The next section is mandatory. If your PR doesn't require testing, please indicate that you are purposefully omitting instructions. -->
> 
> - [x] This PR is a very minor change/addition and does not require testing instructions (if checked you can ignore/remove the next section).
> 
> <!-- Begin testing instructions -->
> 
> ### How to test the changes in this Pull Request:
> 
<!-- Otherwise, please include detailed instructions on how these changes can be tested (including pre-conditions, configuration, steps to take and expected results). It may help to write your instructions > using pseudocode -- as if you're telling a computer how to execute the test. -->
> 
> 1.
> 2.
> 3.
> 
> <!-- End testing instructions -->
> 
> ### Other information:
> 
> -   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
> -   [ ] Have you written new tests for your changes, as applicable?
> -   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
> 
> <!-- Mark completed items with an [x] -->
> 
> ### FOR PR REVIEWER ONLY:
> 
> -   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
