### PR TITLE
Update the stable tag to 7.4.1

### DIFF
--- a/plugins/woocommerce/changelog/update-stable-tag
+++ b/plugins/woocommerce/changelog/update-stable-tag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: This PR updates the stable tag. No changelog entry is required.
+

--- a/plugins/woocommerce/readme.txt
+++ b/plugins/woocommerce/readme.txt
@@ -4,7 +4,7 @@ Tags: online store, ecommerce, shop, shopping cart, sell online, storefront, che
 Requires at least: 5.9
 Tested up to: 6.1
 Requires PHP: 7.2
-Stable tag: 7.4.0
+Stable tag: 7.4.1
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 


### PR DESCRIPTION
With [7.4.1 being released](https://developer.woocommerce.com/2023/02/28/woocommerce-7-4-1-fix-release/), this PR updates the stable tag.