### PR TITLE
Improve order email layouts (responsive and mobile email clients)

### DIFF
--- a/plugins/woocommerce/changelog/fix-36893-responsive-ltr-rtl-emails
+++ b/plugins/woocommerce/changelog/fix-36893-responsive-ltr-rtl-emails
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Further improvements to order emails (specifically in relation to mobile email clients).

--- a/plugins/woocommerce/templates/emails/email-styles.php
+++ b/plugins/woocommerce/templates/emails/email-styles.php
@@ -237,17 +237,55 @@ img {
  * Gmail clients and can help us achieve better consistency there.
  */
 @media screen and (max-width: 600px) {
+	* {
+		font-size: 8px !important;
+	}
+
+	body {
+		padding: 0 !important;
+	}
+
+	#template_container {
+		margin: 0 !important;
+	}
+
+	h1 {
+		font-size: 18px !important;
+		margin: 14px 0 !important;
+	}
+
+	h2, h3, h2 a, h3 a {
+		font-size: 12px !important;
+		margin: 12px 0 !important;
+	}
+
 	#header_wrapper {
-		padding: 27px 36px !important;
-		font-size: 24px;
+		padding: 18px 27px !important;
+	}
+
+	#header_wrapper h1 {
+		margin: 0 !important;
 	}
 
 	#body_content table > tbody > tr > td {
-		padding: 10px !important;
+		padding: 14px 25px !important;
+	}
+
+	#body_content table table.td th,
+	#body_content table table.td td {
+		padding: 4px 7px !important;
+	}
+
+	#body_content table#addresses > tbody > tr > td {
+		padding: 0 !important;
 	}
 
 	#body_content_inner {
 		font-size: 10px !important;
+	}
+
+	#body_content_inner > div {
+		margin-bottom: 10px !important;
 	}
 }
 <?php

--- a/plugins/woocommerce/templates/emails/email-styles.php
+++ b/plugins/woocommerce/templates/emails/email-styles.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 7.4.0
+ * @version 7.7.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/plugins/woocommerce/tests/legacy/data/sample-email.html
+++ b/plugins/woocommerce/tests/legacy/data/sample-email.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">\n
-<style type="text/css">@media screen and (max-width: 600px){*{font-size: 8px !important;}body{padding: 0 !important;}}</style>\n
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<style type="text/css">@media screen and (max-width: 600px){*{font-size: 8px !important;}body{padding: 0 !important;}}</style>
 </head>
 <body style="background-color: #f7f7f7; padding: 0; text-align: center;" bgcolor="#f7f7f7"><p class="text" style='color: #3c3c3c; font-family: "Helvetica Neue",Helvetica,Roboto,Arial,sans-serif;'>Hello World!</p></body>
 </html>

--- a/plugins/woocommerce/tests/legacy/data/sample-email.html
+++ b/plugins/woocommerce/tests/legacy/data/sample-email.html
@@ -1,5 +1,8 @@
 <!DOCTYPE html>
 <html>
-<head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">\n
+<style type="text/css">@media screen and (max-width: 600px){*{font-size: 8px !important;}body{padding: 0 !important;}}</style>\n
+</head>
 <body style="background-color: #f7f7f7; padding: 0; text-align: center;" bgcolor="#f7f7f7"><p class="text" style='color: #3c3c3c; font-family: "Helvetica Neue",Helvetica,Roboto,Arial,sans-serif;'>Hello World!</p></body>
 </html>


### PR DESCRIPTION
Attempts to get order emails closer to the pre-7.4.0 responsive layout, but maintaining the RTL improvements introduced in https://github.com/woocommerce/woocommerce/pull/36310. There should be no significant changes re desktop and non-responsive web clients. To add a little more context:

- Before 7.4.0, emails were unresponsive for RTL languages, and often would render with much of the content being cut-off [(screenshot)](https://user-images.githubusercontent.com/3594411/210817426-3137eeb2-97c4-4d16-8ee1-d65854bf7bbc.png).
- In 7.4.0, we addressed the above problem: however, those changes also altered the way mobile emails rendered for other users (some fonts became slightly larger, and the layout was spaced out more than might be optimal).
- In this change, we're trying to reconcile those things and regain something reasonably close to the 7.4.0 layout, without regressing in relation to RTL languages.

Screenshots show how order emails currently look (as of 7.4.0) when viewed in a mobile email client, then how things looked *before* 7.4.0 (smaller fonts, tighter spacing), and then how things look with this branch. Notice how much closer this branch is to the pre-7.4.0 layouts in terms of font sizing, spacing, etc, to the pre-7.4.0 branch.

| | iPhone 14 | Pixel Gmail |
| --- | --- | --- |
| Current (7.4.0) | ![current--iphone-14](https://user-images.githubusercontent.com/3594411/222019694-d0cc3c50-77c1-4240-aa81-b3cb5e968ab1.png) | ![current--pixel-gmail](https://user-images.githubusercontent.com/3594411/222020071-c4e3ab60-68cd-4d91-9793-d0a3bd5b83a4.png) |
| Pre-7.4.0 | ![pre740--iphone-14](https://user-images.githubusercontent.com/3594411/222019516-cda081f7-d41a-40df-9e27-f3b9db589d91.png) | ![pre740--pixel-gmail](https://user-images.githubusercontent.com/3594411/222019990-e8922b1a-7643-4a1f-964b-cc3a2836d4d7.png) |
| Branch | ![branch--iphone-14](https://user-images.githubusercontent.com/3594411/222019725-b1cae82b-387c-48bb-b08e-dddc158c7b43.png) | ![branch--pixel-gmail](https://user-images.githubusercontent.com/3594411/222020160-045515e2-2ed5-473c-a421-a66b5edac92e.png) |

Closes #36893.

---

### Testing instructions

Setup:

- To see how things look across multiple email clients, I recommend using a tool such as [Email on Acid](https://app.emailonacid.com).
- You will need an email catcher of some sort. This could be [MailHog](https://github.com/mailhog/MailHog), an [email-logging WordPress plugin](https://wordpress.org/plugins/wp-mail-log/), or some other solution: but whatever you use, you will need to be able to extract the email's HTML so you can supply it to Email on Acid (or other testing platform).

You also need to test with RTL as well as LTR languages, because it is important we don't re-introduce the problem with RTL languages solved by https://github.com/woocommerce/woocommerce/pull/36310. In these testing instructions, I alternate between US English and Arabic. To install Arabic via WP CLI:

```sh
wp language core install ar; \
wp language plugin install woocommerce ar
```

Next, identify an existing order (create one if necessary) and capture the order ID. In the instructions below, we'll assume the ID is `123`. Then, use WP CLI to generate order emails in both languages:

```sh
wp option set WPLANG ""; \
wp eval "add_filter( 'woocommerce_new_order_email_allows_resend', '__return_true' ); ( new WC_Email_New_Order )->trigger( 123 );"
```

```sh
wp option set WPLANG "ar"; \
wp eval "add_filter( 'woocommerce_new_order_email_allows_resend', '__return_true' ); ( new WC_Email_New_Order )->trigger( 123 );"
```

Repeat this process with WooCommerce 7.3.0, with WooCommerce 7.5.1 (or current `trunk` branch at time of writing), and with this branch. Then, simply copy and paste the HTML for the generated emails into your email testing platform of choice. Key points:

- Spacing, font-size, etc should all be much closer with this branch to what we had before 7.4.0.
- The improvements for RTL languages like Arabic, specifically when viewed in mobile email clients, should not have been lost.
