### PR TITLE
Fix missing padding in some buttons in TT2 with WP 5.9 and 6.0

### DIFF
--- a/plugins/woocommerce/changelog/fix-tt2-wp60-missing-padding-in-some-buttons
+++ b/plugins/woocommerce/changelog/fix-tt2-wp60-missing-padding-in-some-buttons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add default button padding to TT2 stylesheet to fix some visual issues in WP 5.9 and 6.0

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
@@ -120,6 +120,7 @@ $tt2-gray: #f7f7f7;
 		background-color: var(--wp--preset--color--primary);
 		color: #fff;
 		border: 1px solid var(--wp--preset--color--black);
+		padding: 1rem 2rem;
 		margin-top: 1rem;
 		text-decoration: none;
 		font-size: medium;
@@ -185,6 +186,7 @@ $tt2-gray: #f7f7f7;
 	button.single_add_to_cart_button,
 	a.checkout-button {
 		font-size: 18px;
+		padding: 1.5rem 3.5rem;
 	}
 
 	// Moved from blockthemes.css to make sure TT2 won't be changed.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes a WC 7.5 regression only reproducible in WP 5.9 and 6.0 where some buttons didn't have the correct padding when using theme Twenty Twenty-Two.

The regression was introduced in #36651. That PR removed the [button paddings](https://github.com/woocommerce/woocommerce/pull/36651/files#diff-25bcda4a934f188daa9d7ff8746a2c877f0e2d3dd853ca53cd230f2cfae6ece9L123) to let the store inherit those from global styles (or from the child theme). In order to accomplish that, it relied on the styles provided by WordPress using the `wp-element-button` class. However, that class and its associated styles are not present in WP 5.9 and 6.0, so the buttons rendered without padding.

This PR is adding that padding back.

### How to test the changes in this Pull Request:

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

With WP 5.9 (or 6.0) and theme [TT2](https://github.com/wordpress/twentytwentytwo):
1. Make sure you have at least one variable product and one product collection.
2. Go to the Shop page.
3. Verify all buttons are sized correctly.

Before | After
--- | ---
![imatge](https://user-images.githubusercontent.com/3616980/222209049-b1e2a699-4d4c-416d-a275-d812433f8588.png) | ![imatge](https://user-images.githubusercontent.com/3616980/222208944-0d8d631d-c62c-4910-a67c-ce2d19a33780.png)

4. Go to the Cart page (with the Cart shortcode).
5. Verify the button has a big padding.

Before | After
--- | ---
![imatge](https://user-images.githubusercontent.com/3616980/222211498-06a7b74a-89a2-4e05-abba-a7013aa40a31.png) | ![imatge](https://user-images.githubusercontent.com/3616980/222211437-abd33eb2-8493-4245-93b0-33d288d6c31c.png)

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
