### PR TITLE
Fix jQuery event being erased when element was replaced after saving attributes

### DIFF
--- a/plugins/woocommerce/changelog/fix-variations-dom-events
+++ b/plugins/woocommerce/changelog/fix-variations-dom-events
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: This fixes a bug which was introduced in a recent PR
+
+

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
@@ -33,7 +33,8 @@ jQuery( function ( $ ) {
 					'button.add_price_for_variations',
 					this.open_modal_to_set_variations_price
 				)
-				.on( 'reload', this.reload );
+				.on( 'reload', this.reload )
+				.on( 'click', 'button.create-variations', this.create_variations);
 
 			$(
 				'input.variable_is_downloadable, input.variable_is_virtual, input.variable_manage_stock'
@@ -49,78 +50,78 @@ jQuery( function ( $ ) {
 					'.wc_input_variations_price',
 					this.maybe_enable_button_to_add_price_to_variations
 				);
+		},
 
-			$( '.save-variations' ).on( 'click', function () {
-				var new_attribute_data = $(
-					'.woocommerce_variation_new_attribute_data'
-				);
-				var attribute_name = new_attribute_data.find( 'input[name^="attribute_names"]' ).val();
-				var attribute_value = new_attribute_data
-					.find( 'textarea[name^="attribute_values"]' )
-					.val();
+		create_variations: function() {
+			var new_attribute_data = $(
+				'.woocommerce_variation_new_attribute_data'
+			);
+			var attribute_name = new_attribute_data.find( 'input[name^="attribute_names"]' ).val();
+			var attribute_value = new_attribute_data
+				.find( 'textarea[name^="attribute_values"]' )
+				.val();
 
-				if ( ! attribute_name || ! attribute_value ) {
-					return;
-				}
+			if ( ! attribute_name || ! attribute_value ) {
+				return;
+			}
 
-				$( '#variable_product_options' ).block( {
-					message: null,
-					overlayCSS: {
-						background: '#fff',
-						opacity: 0.6,
-					},
-				} );
+			$( '#variable_product_options' ).block( {
+				message: null,
+				overlayCSS: {
+					background: '#fff',
+					opacity: 0.6,
+				},
+			} );
 
-				var original_data = new_attribute_data.find(
-					'input, select, textarea'
-				);
+			var original_data = new_attribute_data.find(
+				'input, select, textarea'
+			);
 
-				var data = {
-					post_id: woocommerce_admin_meta_boxes.post_id,
-					product_type: $( '#product-type' ).val(),
-					data: original_data.serialize(),
-					action: 'woocommerce_add_attributes_and_variations',
-					security:
-						woocommerce_admin_meta_boxes.add_attributes_and_variations,
-				};
+			var data = {
+				post_id: woocommerce_admin_meta_boxes.post_id,
+				product_type: $( '#product-type' ).val(),
+				data: original_data.serialize(),
+				action: 'woocommerce_add_attributes_and_variations',
+				security:
+					woocommerce_admin_meta_boxes.add_attributes_and_variations,
+			};
 
-				$.post( woocommerce_admin_meta_boxes.ajax_url, data, function (
-					response
-				) {
-					if ( response.error ) {
-						// Error.
-						window.alert( response.error );
+			$.post( woocommerce_admin_meta_boxes.ajax_url, data, function (
+				response
+			) {
+				if ( response.error ) {
+					// Error.
+					window.alert( response.error );
+					$( '#variable_product_options' ).unblock();
+				} else if ( response ) {
+					// Reload variations and attributes panel.
+					var this_page_url = window.location.toString();
+					this_page_url = this_page_url.replace(
+						'post-new.php?',
+						'post.php?post=' +
+							woocommerce_admin_meta_boxes.post_id +
+							'&action=edit&'
+					);
+
+					$.get( this_page_url, function ( response ) {
 						$( '#variable_product_options' ).unblock();
-					} else if ( response ) {
-						// Reload variations and attributes panel.
-						var this_page_url = window.location.toString();
-						this_page_url = this_page_url.replace(
-							'post-new.php?',
-							'post.php?post=' +
-								woocommerce_admin_meta_boxes.post_id +
-								'&action=edit&'
+						$( '#variable_product_options_inner' ).replaceWith(
+							$( response ).find(
+								'#variable_product_options_inner'
+							)
 						);
-
-						$.get( this_page_url, function ( response ) {
-							$( '#variable_product_options' ).unblock();
-							$( '#variable_product_options_inner' ).replaceWith(
-								$( response ).find(
-									'#variable_product_options_inner'
-								)
-							);
-							$( '#variable_product_options' ).trigger(
-								'reload'
-							);
-							$(
+						$( '#variable_product_options' ).trigger(
+							'reload'
+						);
+						$(
+							'#product_attributes > .product_attributes'
+						).replaceWith(
+							$( response ).find(
 								'#product_attributes > .product_attributes'
-							).replaceWith(
-								$( response ).find(
-									'#product_attributes > .product_attributes'
-								)
-							);
-						} );
-					}
-				} );
+							)
+						);
+					} );
+				}
 			} );
 		},
 

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
@@ -29,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				require __DIR__ . '/html-product-attribute-inner.php';
 			?>
 				<div class="toolbar">
-					<button type="button" class="button button-primary save-variations"><?php esc_html_e( 'Save variations', 'woocommerce' ); ?></button>
+					<button type="button" class="button button-primary create-variations"><?php esc_html_e( 'Create variations', 'woocommerce' ); ?></button>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This attaches the create_variations event to the parent to avoid erasing it when the DOM element is replaced.

Note: this is just a bug fix, but I think the acceptance criteria from #36657 are already met, so, note to the reviewer, please review against the #36657 acceptance criteria and comments.

Closes #36657.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Create a new product in the current product manager
2. Change Product type to 'Variable'
3. Go to Attributes tab, add a new attribute, fill name and values and uncheck the 'Used for variations' checkbox.
4. Click on 'Save attributes' (this will trigger the variations page reload and bug without this fix)
5. Go to 'Variations' tab, fill the name and values of the attributes.
6. Click on 'Create variations' (this would not work without this fix)
7. Check if the attributes and variations were created.

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [ ] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
