### PR TITLE
Prevent possible warning in `COTMigrationUtil::get_post_or_object_meta()`

### DIFF
--- a/plugins/woocommerce/changelog/fix-35543
+++ b/plugins/woocommerce/changelog/fix-35543
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent possible warning arising from use of woocommerce_wp_* family of functions.

--- a/plugins/woocommerce/src/Internal/Utilities/COTMigrationUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/COTMigrationUtil.php
@@ -96,7 +96,7 @@ class COTMigrationUtil {
 			}
 			return $data->get_meta( $key, $single );
 		} else {
-			return get_post_meta( $post->ID, $key, $single );
+			return isset( $post->ID ) ? get_post_meta( $post->ID, $key, $single ) : false;
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR makes sure that `$post->ID` is set before attempting to use it inside calls to [`COTMigrationUtil::get_post_or_object_meta()`](https://github.com/woocommerce/woocommerce/blob/77c87bc51611e3ed6e4062187e43d1b9124278ff/plugins/woocommerce/src/Internal/Utilities/COTMigrationUtil.php#L92).

This function mostly exists for HPOS/posts compat reasons and serves functions `woocommerce_wp_select()`, `woocommerce_wp_text_input()`, `woocommerce_wp_hidden_input()`, etc. in [`wc-meta-box-functions.php`](https://github.com/woocommerce/woocommerce/blob/b4fcbd80a411d0e428df2dacc46b6187f3b6fe72/plugins/woocommerce/includes/admin/wc-meta-box-functions.php).

Closes #35543.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [X] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

Per #35543, you should "write a snippet to call `woocommerce_wp_select` in a WooCommerce > Settings hook […]".

The issue can also be replicated by just calling those functions in almost any context where the `$post` global is not set, but to replicate the exact conditions of #35543, the following can be used:

1. Create a test plugin/snippet with the following code (or add it to the theme's `functions.php`)
   ```php
   add_action(
	   'woocommerce_settings_general',
	   function() {
		   woocommerce_wp_select(
			   array(
				   'id'          => 'my-favorite-topping',
				   'value'       => 'pepperoni',
				   'label'       => 'Pizza Topping',
				   'options'     => [
					   'pineapple' => 'Pineapple',
					   'salami'    => 'Salami',
					   'pepperoni' => 'Pepperoni',
					   'onion'     => 'Onion',
				   ],
				   'desc_tip'    => true,
				   'description' => 'Toppings are a serious matter. Choose wisely.',
			   )
		   );
	   },
	   999
   );
   ```
2. Go to WC > Settings and scroll to the bottom of the page.
3. You should see a dropdown named "Pizza Topping" (no need to make a selection, though the best choice has been pre-selected for you).
4. Now, to the "errors" part:
   - On `trunk`, you should see a warning in the log such as `PHP Notice:  Trying to get property 'ID' of non-object in […]`.
   - On this branch, no warning should be logged.


<!-- End testing instructions —>

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [X] Have you included testing instructions?

<!-- Mark completed items with an [x] —>

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
