### PR TITLE
Refresh data source poller transients on wc_admin_daily

### DIFF
--- a/plugins/woocommerce/changelog/update-37025-refresh-datasources-on-wc_admin_daily
+++ b/plugins/woocommerce/changelog/update-37025-refresh-datasources-on-wc_admin_daily
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Refresh data source poller transients on wc_admin_daily

--- a/plugins/woocommerce/src/Internal/Admin/Events.php
+++ b/plugins/woocommerce/src/Internal/Admin/Events.php
@@ -266,7 +266,7 @@ class Events {
 			PaymentGatewaySuggestionsDataSourcePoller::get_instance()->read_specs_from_data_sources();
 		}
 
-		if ( ! in_array( 'store_details', $completed_tasks, true ) ) {
+		if ( ! in_array( 'store_details', $completed_tasks, true ) && ! in_array( 'marketing', $completed_tasks, true ) ) {
 			RemoteFreeExtensionsDataSourcePoller::get_instance()->read_specs_from_data_sources();
 		}
 	}

--- a/plugins/woocommerce/src/Internal/Admin/Events.php
+++ b/plugins/woocommerce/src/Internal/Admin/Events.php
@@ -44,6 +44,9 @@ use Automattic\WooCommerce\Internal\Admin\Notes\WooCommerceSubscriptions;
 use Automattic\WooCommerce\Internal\Admin\Notes\WooSubscriptionsNotes;
 use Automattic\WooCommerce\Internal\Admin\Schedulers\MailchimpScheduler;
 use Automattic\WooCommerce\Admin\Notes\Note;
+use Automattic\WooCommerce\Admin\Features\PaymentGatewaySuggestions\PaymentGatewaySuggestionsDataSourcePoller;
+use Automattic\WooCommerce\Internal\Admin\RemoteFreeExtensions\RemoteFreeExtensionsDataSourcePoller;
+use Automattic\WooCommerce\Internal\Admin\WCPayPromotion\WCPayPromotionDataSourcePoller;
 
 /**
  * Events Class.
@@ -143,6 +146,7 @@ class Events {
 		$this->possibly_add_notes();
 		$this->possibly_delete_notes();
 		$this->possibly_update_notes();
+		$this->refresh_data_source_poller_transients();
 
 		if ( $this->is_remote_inbox_notifications_enabled() ) {
 			DataSourcePoller::get_instance()->read_specs_from_data_sources();
@@ -249,5 +253,11 @@ class Events {
 
 		// All checks have passed.
 		return true;
+	}
+
+	protected function refresh_data_source_poller_transients(){
+		PaymentGatewaySuggestionsDataSourcePoller::get_instance()->read_specs_from_data_sources();
+		WCPayPromotionDataSourcePoller::get_instance()->read_specs_from_data_sources();
+		RemoteFreeExtensionsDataSourcePoller::get_instance()->read_specs_from_data_sources();
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Events.php
+++ b/plugins/woocommerce/src/Internal/Admin/Events.php
@@ -254,14 +254,19 @@ class Events {
 		return true;
 	}
 
-	protected function possibly_refresh_data_source_pollers(){
+	/**
+	 *   Refresh transient for the following DataSourcePollers on wc_admin_daily cron job.
+	 *   - PaymentGatewaySuggestionsDataSourcePoller
+	 *   - RemoteFreeExtensionsDataSourcePoller
+	 */
+	protected function possibly_refresh_data_source_pollers() {
 		$completed_tasks = get_option( 'woocommerce_task_list_tracked_completed_tasks' );
 
-		if ( ! in_array( 'payments', $completed_tasks ) ) {
+		if ( ! in_array( 'payments', $completed_tasks, true ) ) {
 			PaymentGatewaySuggestionsDataSourcePoller::get_instance()->read_specs_from_data_sources();
 		}
 
-		if ( ! in_array( 'store_details', $completed_tasks ) ) {
+		if ( ! in_array( 'store_details', $completed_tasks, true ) ) {
 			RemoteFreeExtensionsDataSourcePoller::get_instance()->read_specs_from_data_sources();
 		}
 	}

--- a/plugins/woocommerce/src/Internal/Admin/Events.php
+++ b/plugins/woocommerce/src/Internal/Admin/Events.php
@@ -262,7 +262,7 @@ class Events {
 	protected function possibly_refresh_data_source_pollers() {
 		$completed_tasks = get_option( 'woocommerce_task_list_tracked_completed_tasks' );
 
-		if ( ! in_array( 'payments', $completed_tasks, true ) ) {
+		if ( ! in_array( 'payments', $completed_tasks, true ) && ! in_array( 'woocommerce-payments', $completed_tasks, true ) ) {
 			PaymentGatewaySuggestionsDataSourcePoller::get_instance()->read_specs_from_data_sources();
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/Events.php
+++ b/plugins/woocommerce/src/Internal/Admin/Events.php
@@ -46,7 +46,6 @@ use Automattic\WooCommerce\Internal\Admin\Schedulers\MailchimpScheduler;
 use Automattic\WooCommerce\Admin\Notes\Note;
 use Automattic\WooCommerce\Admin\Features\PaymentGatewaySuggestions\PaymentGatewaySuggestionsDataSourcePoller;
 use Automattic\WooCommerce\Internal\Admin\RemoteFreeExtensions\RemoteFreeExtensionsDataSourcePoller;
-use Automattic\WooCommerce\Internal\Admin\WCPayPromotion\WCPayPromotionDataSourcePoller;
 
 /**
  * Events Class.
@@ -146,7 +145,7 @@ class Events {
 		$this->possibly_add_notes();
 		$this->possibly_delete_notes();
 		$this->possibly_update_notes();
-		$this->refresh_data_source_poller_transients();
+		$this->possibly_refresh_data_source_pollers();
 
 		if ( $this->is_remote_inbox_notifications_enabled() ) {
 			DataSourcePoller::get_instance()->read_specs_from_data_sources();
@@ -255,9 +254,15 @@ class Events {
 		return true;
 	}
 
-	protected function refresh_data_source_poller_transients(){
-		PaymentGatewaySuggestionsDataSourcePoller::get_instance()->read_specs_from_data_sources();
-		WCPayPromotionDataSourcePoller::get_instance()->read_specs_from_data_sources();
-		RemoteFreeExtensionsDataSourcePoller::get_instance()->read_specs_from_data_sources();
+	protected function possibly_refresh_data_source_pollers(){
+		$completed_tasks = get_option( 'woocommerce_task_list_tracked_completed_tasks' );
+
+		if ( ! in_array( 'payments', $completed_tasks ) ) {
+			PaymentGatewaySuggestionsDataSourcePoller::get_instance()->read_specs_from_data_sources();
+		}
+
+		if ( ! in_array( 'store_details', $completed_tasks ) ) {
+			RemoteFreeExtensionsDataSourcePoller::get_instance()->read_specs_from_data_sources();
+		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #37025 .

This PR refreshes transients created by data source pollers on wc_admin_daily event, which runs daily in the background.

### How to test the changes in this Pull Request:

1. Checkout this branch.
2. Run `delete from wp_options where option_name like '%_specs';` to delete the existing transients.
3. Run `wc_admin_daily` cron job.
4. Run `select * from wp_options where option_name like '%_specs'` to confirm the transients are regenerated. 

<!-- End testing instructions -->

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [ ] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
