### PR TITLE
Updating rest namespace for product post type to v3

### DIFF
--- a/plugins/woocommerce/changelog/update-entity-store-endpoint-36990
+++ b/plugins/woocommerce/changelog/update-entity-store-endpoint-36990
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Updating rest namespace for product posttype to version 3.

--- a/plugins/woocommerce/includes/class-wc-post-types.php
+++ b/plugins/woocommerce/includes/class-wc-post-types.php
@@ -308,7 +308,7 @@ class WC_Post_Types {
 		}
 
 		// If theme support changes, we may need to flush permalinks since some are changed based on this flag.
-		$theme_support =  wc_current_theme_supports_woocommerce_or_fse() ? 'yes' : 'no';
+		$theme_support = wc_current_theme_supports_woocommerce_or_fse() ? 'yes' : 'no';
 		if ( get_option( 'current_theme_supports_woocommerce' ) !== $theme_support && update_option( 'current_theme_supports_woocommerce', $theme_support ) ) {
 			update_option( 'woocommerce_queue_flush_rewrite_rules', 'yes' );
 		}
@@ -365,6 +365,7 @@ class WC_Post_Types {
 					'has_archive'         => $has_archive,
 					'show_in_nav_menus'   => true,
 					'show_in_rest'        => true,
+					'rest_namespace'      => 'wp/v3',
 				)
 			)
 		);


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #36990  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Checkout branch.
2. Open the network tab in your browser dev tools. 
3. Either get the productId of an existing product, or create a new one.
4. In the console, run `window.wp.data.select( 'core' ).getEditedEntityRecord( 'postType', 'product', PRODUCT_ID )` with that product ID in place of `PRODUCT_ID`.
5. Observe that the resulting API request uses the `v3` namespace:
![image](https://user-images.githubusercontent.com/444632/222299660-ad7e1f98-9940-48ec-95e5-ce0dd0588fb3.png)


<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
