### PR TITLE
Add validation to enable Save attributes and Save variations buttons

### DIFF
--- a/plugins/woocommerce/changelog/fix-37021_add_validation_when_saving_attributes
+++ b/plugins/woocommerce/changelog/fix-37021_add_validation_when_saving_attributes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add validation when saving attributes and variations

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
@@ -34,7 +34,11 @@ jQuery( function ( $ ) {
 					this.open_modal_to_set_variations_price
 				)
 				.on( 'reload', this.reload )
-				.on( 'click', 'button.create-variations', this.create_variations);
+				.on(
+					'click',
+					'button.create-variations',
+					this.create_variations
+				);
 
 			$(
 				'input.variable_is_downloadable, input.variable_is_virtual, input.variable_manage_stock'
@@ -52,18 +56,10 @@ jQuery( function ( $ ) {
 				);
 		},
 
-		create_variations: function() {
+		create_variations: function () {
 			var new_attribute_data = $(
 				'.woocommerce_variation_new_attribute_data'
 			);
-			var attribute_name = new_attribute_data.find( 'input[name^="attribute_names"]' ).val();
-			var attribute_value = new_attribute_data
-				.find( 'textarea[name^="attribute_values"]' )
-				.val();
-
-			if ( ! attribute_name || ! attribute_value ) {
-				return;
-			}
 
 			$( '#variable_product_options' ).block( {
 				message: null,
@@ -110,9 +106,7 @@ jQuery( function ( $ ) {
 								'#variable_product_options_inner'
 							)
 						);
-						$( '#variable_product_options' ).trigger(
-							'reload'
-						);
+						$( '#variable_product_options' ).trigger( 'reload' );
 						$(
 							'#product_attributes > .product_attributes'
 						).replaceWith(

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -747,8 +747,32 @@ jQuery( function ( $ ) {
 		}
 	);
 
+	function is_attributes_and_variations_data_valid(
+		attributes_and_variations_data
+	) {
+		var valid = true;
+		attributes_and_variations_data.each( function () {
+			if ( ! $( this ).val() ) {
+				valid = false;
+			}
+		} );
+		return valid;
+	}
+
 	// Save attributes and update variations.
 	$( '.save_attributes' ).on( 'click', function () {
+		var attributes_and_variations_data = $( '.product_attributes' ).find(
+			'input, select, textarea'
+		);
+
+		if (
+			! is_attributes_and_variations_data_valid(
+				attributes_and_variations_data
+			)
+		) {
+			return;
+		}
+
 		$( '.product_attributes' ).block( {
 			message: null,
 			overlayCSS: {
@@ -756,13 +780,11 @@ jQuery( function ( $ ) {
 				opacity: 0.6,
 			},
 		} );
-		var original_data = $( '.product_attributes' ).find(
-			'input, select, textarea'
-		);
+
 		var data = {
 			post_id: woocommerce_admin_meta_boxes.post_id,
 			product_type: $( '#product-type' ).val(),
-			data: original_data.serialize(),
+			data: attributes_and_variations_data.serialize(),
 			action: 'woocommerce_save_attributes',
 			security: woocommerce_admin_meta_boxes.save_attributes_nonce,
 		};

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -482,6 +482,7 @@ jQuery( function ( $ ) {
 			$wrapper.unblock();
 
 			$( document.body ).trigger( 'woocommerce_added_attribute' );
+			jQuery.maybe_disable_save_button();
 		} );
 
 		if ( attribute ) {
@@ -664,6 +665,7 @@ jQuery( function ( $ ) {
 			) {
 				toggle_add_global_attribute_layout();
 			}
+			jQuery.maybe_disable_save_button();
 		}
 		return false;
 	} );

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -747,32 +747,8 @@ jQuery( function ( $ ) {
 		}
 	);
 
-	function is_attributes_and_variations_data_valid(
-		attributes_and_variations_data
-	) {
-		var valid = true;
-		attributes_and_variations_data.each( function () {
-			if ( ! $( this ).val() ) {
-				valid = false;
-			}
-		} );
-		return valid;
-	}
-
 	// Save attributes and update variations.
 	$( '.save_attributes' ).on( 'click', function () {
-		var attributes_and_variations_data = $( '.product_attributes' ).find(
-			'input, select, textarea'
-		);
-
-		if (
-			! is_attributes_and_variations_data_valid(
-				attributes_and_variations_data
-			)
-		) {
-			return;
-		}
-
 		$( '.product_attributes' ).block( {
 			message: null,
 			overlayCSS: {
@@ -781,10 +757,13 @@ jQuery( function ( $ ) {
 			},
 		} );
 
+		var original_data = $( '.product_attributes' ).find(
+			'input, select, textarea'
+		);
 		var data = {
 			post_id: woocommerce_admin_meta_boxes.post_id,
 			product_type: $( '#product-type' ).val(),
-			data: attributes_and_variations_data.serialize(),
+			data: original_data.serialize(),
 			action: 'woocommerce_save_attributes',
 			security: woocommerce_admin_meta_boxes.save_attributes_nonce,
 		};
@@ -851,7 +830,6 @@ jQuery( function ( $ ) {
 				);
 
 				$( document.body ).trigger( 'woocommerce_attributes_saved' );
-
 			}
 		} );
 	} );

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes.js
@@ -7,17 +7,18 @@ jQuery( function ( $ ) {
 	) {
 		var has_empty_fields = false;
 		attributes_and_variations_data.each( function () {
+			var $this = $( this );
 			// Check if the field is checkbox or a search field.
 			if (
-				$( this ).hasClass( 'checkbox' ) ||
-				-1 < this.className.indexOf( 'search__field' )
+				$this.hasClass( 'checkbox' ) ||
+				$this.filter( '[class*=search__field]' ).length
 			) {
 				return;
 			}
 
-			var is_empty = $( this ).is( 'select' )
-				? $( this ).find( ':selected' ).length === 0
-				: ! $( this ).val();
+			var is_empty = $this.is( 'select' )
+				? $this.find( ':selected' ).length === 0
+				: ! $this.val();
 			if ( is_empty ) {
 				has_empty_fields = true;
 			}

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes.js
@@ -111,7 +111,7 @@ jQuery( function ( $ ) {
 				'input, select, textarea'
 			);
 			if (
-				! is_attributes_and_variations_data_valid(
+				is_attribute_or_variation_empty(
 					attributes_and_variations_data
 				)
 			) {
@@ -123,13 +123,11 @@ jQuery( function ( $ ) {
 			$save_button.removeAttr( 'disabled' );
 		}
 	);
-	function is_attributes_and_variations_data_valid(
-		attributes_and_variations_data
-	) {
-		var valid = true;
+	function is_attribute_or_variation_empty( attributes_and_variations_data ) {
+		var valid = false;
 		attributes_and_variations_data.each( function () {
 			if ( ! $( this ).val() ) {
-				valid = false;
+				valid = true;
 			}
 		} );
 		return valid;

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes.js
@@ -5,13 +5,24 @@ jQuery( function ( $ ) {
 	jQuery.is_attribute_or_variation_empty = function (
 		attributes_and_variations_data
 	) {
-		var valid = false;
+		var has_empty_fields = false;
 		attributes_and_variations_data.each( function () {
-			if ( ! $( this ).val() ) {
-				valid = true;
+			// Check if the field is checkbox or a search field.
+			if (
+				$( this ).hasClass( 'checkbox' ) ||
+				-1 < this.className.indexOf( 'search__field' )
+			) {
+				return;
+			}
+
+			var is_empty = $( this ).is( 'select' )
+				? $( this ).find( ':selected' ).length === 0
+				: ! $( this ).val();
+			if ( is_empty ) {
+				has_empty_fields = true;
 			}
 		} );
-		return valid;
+		return has_empty_fields;
 	};
 
 	/**
@@ -144,6 +155,12 @@ jQuery( function ( $ ) {
 	$( '.product_attributes, .woocommerce_variation_new_attribute_data' ).on(
 		'keyup',
 		'input, textarea',
+		jQuery.maybe_disable_save_button
+	);
+
+	$( '#product_attributes' ).on(
+		'change',
+		'select.attribute_values',
 		jQuery.maybe_disable_save_button
 	);
 } );

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes.js
@@ -117,10 +117,15 @@ jQuery( function ( $ ) {
 			) {
 				if ( ! $save_button.is( ':disabled' ) ) {
 					$save_button.attr( 'disabled', 'disabled' );
+					$save_button.attr(
+						'title',
+						woocommerce_admin_meta_boxes.i18n_save_attribute_variation_tip
+					);
 				}
 				return;
 			}
 			$save_button.removeAttr( 'disabled' );
+			$save_button.removeAttr( 'title' );
 		}
 	);
 	function is_attribute_or_variation_empty( attributes_and_variations_data ) {

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes.js
@@ -1,4 +1,53 @@
 jQuery( function ( $ ) {
+	/**
+	 * Function to check if the attribute and variation fields are empty.
+	 */
+	jQuery.is_attribute_or_variation_empty = function (
+		attributes_and_variations_data
+	) {
+		var valid = false;
+		attributes_and_variations_data.each( function () {
+			if ( ! $( this ).val() ) {
+				valid = true;
+			}
+		} );
+		return valid;
+	};
+
+	/**
+	 * Function to maybe disable the save button.
+	 */
+	jQuery.maybe_disable_save_button = function () {
+		var $tab = $( '.product_attributes' );
+		var $save_button = $( 'button.save_attributes' );
+		if (
+			$( '.woocommerce_variation_new_attribute_data' ).is( ':visible' )
+		) {
+			$tab = $( '.woocommerce_variation_new_attribute_data' );
+			$save_button = $( 'button.create-variations' );
+		}
+
+		var attributes_and_variations_data = $tab.find(
+			'input, select, textarea'
+		);
+		if (
+			jQuery.is_attribute_or_variation_empty(
+				attributes_and_variations_data
+			)
+		) {
+			if ( ! $save_button.is( ':disabled' ) ) {
+				$save_button.attr( 'disabled', 'disabled' );
+				$save_button.attr(
+					'title',
+					woocommerce_admin_meta_boxes.i18n_save_attribute_variation_tip
+				);
+			}
+			return;
+		}
+		$save_button.removeAttr( 'disabled' );
+		$save_button.removeAttr( 'title' );
+	};
+
 	// Run tipTip
 	function runTipTip() {
 		// Remove any lingering tooltips
@@ -95,46 +144,6 @@ jQuery( function ( $ ) {
 	$( '.product_attributes, .woocommerce_variation_new_attribute_data' ).on(
 		'keyup',
 		'input, textarea',
-		function () {
-			var $tab = $( '.product_attributes' );
-			var $save_button = $( 'button.save_attributes' );
-			if (
-				$( '.woocommerce_variation_new_attribute_data' ).is(
-					':visible'
-				)
-			) {
-				$tab = $( '.woocommerce_variation_new_attribute_data' );
-				$save_button = $( 'button.create-variations' );
-			}
-
-			var attributes_and_variations_data = $tab.find(
-				'input, select, textarea'
-			);
-			if (
-				is_attribute_or_variation_empty(
-					attributes_and_variations_data
-				)
-			) {
-				if ( ! $save_button.is( ':disabled' ) ) {
-					$save_button.attr( 'disabled', 'disabled' );
-					$save_button.attr(
-						'title',
-						woocommerce_admin_meta_boxes.i18n_save_attribute_variation_tip
-					);
-				}
-				return;
-			}
-			$save_button.removeAttr( 'disabled' );
-			$save_button.removeAttr( 'title' );
-		}
+		jQuery.maybe_disable_save_button
 	);
-	function is_attribute_or_variation_empty( attributes_and_variations_data ) {
-		var valid = false;
-		attributes_and_variations_data.each( function () {
-			if ( ! $( this ).val() ) {
-				valid = true;
-			}
-		} );
-		return valid;
-	}
 } );

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes.js
@@ -1,22 +1,21 @@
 jQuery( function ( $ ) {
-
 	// Run tipTip
 	function runTipTip() {
 		// Remove any lingering tooltips
 		$( '#tiptip_holder' ).removeAttr( 'style' );
 		$( '#tiptip_arrow' ).removeAttr( 'style' );
-		$( '.tips' ).tipTip({
-			'attribute': 'data-tip',
-			'fadeIn': 50,
-			'fadeOut': 50,
-			'delay': 200,
-			'keepAlive': true
-		});
+		$( '.tips' ).tipTip( {
+			attribute: 'data-tip',
+			fadeIn: 50,
+			fadeOut: 50,
+			delay: 200,
+			keepAlive: true,
+		} );
 	}
 
 	runTipTip();
 
-	$( '.wc-metaboxes-wrapper' ).on( 'click', '.wc-metabox > h3', function() {
+	$( '.wc-metaboxes-wrapper' ).on( 'click', '.wc-metabox > h3', function () {
 		var metabox = $( this ).parent( '.wc-metabox' );
 
 		if ( metabox.hasClass( 'closed' ) ) {
@@ -30,51 +29,114 @@ jQuery( function ( $ ) {
 		} else {
 			metabox.addClass( 'open' );
 		}
-	});
+	} );
 
 	// Tabbed Panels
-	$( document.body ).on( 'wc-init-tabbed-panels', function() {
-		$( 'ul.wc-tabs' ).show();
-		$( 'ul.wc-tabs a' ).on( 'click', function( e ) {
-			e.preventDefault();
-			var panel_wrap = $( this ).closest( 'div.panel-wrap' );
-			$( 'ul.wc-tabs li', panel_wrap ).removeClass( 'active' );
-			$( this ).parent().addClass( 'active' );
-			$( 'div.panel', panel_wrap ).hide();
-			$( $( this ).attr( 'href' ) ).show();
-		});
-		$( 'div.panel-wrap' ).each( function() {
-			$( this ).find( 'ul.wc-tabs li' ).eq( 0 ).find( 'a' ).trigger( 'click' );
-		});
-	}).trigger( 'wc-init-tabbed-panels' );
+	$( document.body )
+		.on( 'wc-init-tabbed-panels', function () {
+			$( 'ul.wc-tabs' ).show();
+			$( 'ul.wc-tabs a' ).on( 'click', function ( e ) {
+				e.preventDefault();
+				var panel_wrap = $( this ).closest( 'div.panel-wrap' );
+				$( 'ul.wc-tabs li', panel_wrap ).removeClass( 'active' );
+				$( this ).parent().addClass( 'active' );
+				$( 'div.panel', panel_wrap ).hide();
+				$( $( this ).attr( 'href' ) ).show();
+			} );
+			$( 'div.panel-wrap' ).each( function () {
+				$( this )
+					.find( 'ul.wc-tabs li' )
+					.eq( 0 )
+					.find( 'a' )
+					.trigger( 'click' );
+			} );
+		} )
+		.trigger( 'wc-init-tabbed-panels' );
 
 	// Date Picker
-	$( document.body ).on( 'wc-init-datepickers', function() {
-		$( '.date-picker-field, .date-picker' ).datepicker({
-			dateFormat: 'yy-mm-dd',
-			numberOfMonths: 1,
-			showButtonPanel: true
-		});
-	}).trigger( 'wc-init-datepickers' );
+	$( document.body )
+		.on( 'wc-init-datepickers', function () {
+			$( '.date-picker-field, .date-picker' ).datepicker( {
+				dateFormat: 'yy-mm-dd',
+				numberOfMonths: 1,
+				showButtonPanel: true,
+			} );
+		} )
+		.trigger( 'wc-init-datepickers' );
 
 	// Meta-Boxes - Open/close
-	$( '.wc-metaboxes-wrapper' ).on( 'click', '.wc-metabox h3', function( event ) {
-		// If the user clicks on some form input inside the h3, like a select list (for variations), the box should not be toggled
-		if ( $( event.target ).filter( ':input, option, .sort' ).length ) {
-			return;
-		}
+	$( '.wc-metaboxes-wrapper' )
+		.on( 'click', '.wc-metabox h3', function ( event ) {
+			// If the user clicks on some form input inside the h3, like a select list (for variations), the box should not be toggled
+			if ( $( event.target ).filter( ':input, option, .sort' ).length ) {
+				return;
+			}
 
-		$( this ).next( '.wc-metabox-content' ).stop().slideToggle();
-	})
-	.on( 'click', '.expand_all', function() {
-		$( this ).closest( '.wc-metaboxes-wrapper' ).find( '.wc-metabox > .wc-metabox-content' ).show();
-		return false;
-	})
-	.on( 'click', '.close_all', function() {
-		$( this ).closest( '.wc-metaboxes-wrapper' ).find( '.wc-metabox > .wc-metabox-content' ).hide();
-		return false;
-	});
-	$( '.wc-metabox.closed' ).each( function() {
+			$( this ).next( '.wc-metabox-content' ).stop().slideToggle();
+		} )
+		.on( 'click', '.expand_all', function () {
+			$( this )
+				.closest( '.wc-metaboxes-wrapper' )
+				.find( '.wc-metabox > .wc-metabox-content' )
+				.show();
+			return false;
+		} )
+		.on( 'click', '.close_all', function () {
+			$( this )
+				.closest( '.wc-metaboxes-wrapper' )
+				.find( '.wc-metabox > .wc-metabox-content' )
+				.hide();
+			return false;
+		} );
+	$( '.wc-metabox.closed' ).each( function () {
 		$( this ).find( '.wc-metabox-content' ).hide();
-	});
-});
+	} );
+
+	$( '.product_attributes, .woocommerce_variation_new_attribute_data' ).on(
+		'keyup',
+		'input, textarea',
+		function () {
+			if ( $( '.product_attributes' ).is( ':visible' ) ) {
+				$tab = $( '.product_attributes' );
+				$save_button = $( 'button.save_attributes' );
+			}
+			if (
+				$( '.woocommerce_variation_new_attribute_data' ).is(
+					':visible'
+				)
+			) {
+				$tab = $( '.woocommerce_variation_new_attribute_data' );
+				$save_button = $( 'button.create-variations' );
+			}
+			if ( ! $tab ) {
+				return;
+			}
+
+			var attributes_and_variations_data = $tab.find(
+				'input, select, textarea'
+			);
+			if (
+				! is_attributes_and_variations_data_valid(
+					attributes_and_variations_data
+				)
+			) {
+				if ( ! $save_button.is( ':disabled' ) ) {
+					$save_button.attr( 'disabled', 'disabled' );
+				}
+				return;
+			}
+			$save_button.removeAttr( 'disabled' );
+		}
+	);
+	function is_attributes_and_variations_data_valid(
+		attributes_and_variations_data
+	) {
+		var valid = true;
+		attributes_and_variations_data.each( function () {
+			if ( ! $( this ).val() ) {
+				valid = false;
+			}
+		} );
+		return valid;
+	}
+} );

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes.js
@@ -96,10 +96,8 @@ jQuery( function ( $ ) {
 		'keyup',
 		'input, textarea',
 		function () {
-			if ( $( '.product_attributes' ).is( ':visible' ) ) {
-				$tab = $( '.product_attributes' );
-				$save_button = $( 'button.save_attributes' );
-			}
+			var $tab = $( '.product_attributes' );
+			var $save_button = $( 'button.save_attributes' );
 			if (
 				$( '.woocommerce_variation_new_attribute_data' ).is(
 					':visible'
@@ -107,9 +105,6 @@ jQuery( function ( $ ) {
 			) {
 				$tab = $( '.woocommerce_variation_new_attribute_data' );
 				$save_button = $( 'button.create-variations' );
-			}
-			if ( ! $tab ) {
-				return;
 			}
 
 			var attributes_and_variations_data = $tab.find(

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -419,6 +419,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					'i18n_product_other_tip'             => __( 'Product types define available product details and attributes, such as downloadable files and variations. They’re also used for analytics and inventory management.', 'woocommerce' ),
 					'i18n_product_description_tip'       => __( 'Describe this product. What makes it unique? What are its most important features?', 'woocommerce' ),
 					'i18n_product_short_description_tip' => __( 'Summarize this product in 1-2 short sentences. We’ll show it at the top of the page.', 'woocommerce' ),
+					'i18n_save_attribute_variation_tip'  => __( 'Make sure you enter the name and values for each attribute.', 'woocommerce' ),
 					/* translators: %1$s: maximum file size */
 					'i18n_product_image_tip'             => sprintf( __( 'For best results, upload JPEG or PNG files that are 1000 by 1000 pixels or larger. Maximum upload file size: %1$s.', 'woocommerce' ) , size_format( wp_max_upload_size() ) ),
 				);

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
@@ -106,7 +106,7 @@ $icon_url                        = WC_ADMIN_IMAGES_FOLDER_URL . '/icons/global-a
 		<span class="expand-close">
 			<a href="#" class="expand_all"><?php esc_html_e( 'Expand', 'woocommerce' ); ?></a> / <a href="#" class="close_all"><?php esc_html_e( 'Close', 'woocommerce' ); ?></a>
 		</span>
-		<button type="button" class="button save_attributes button-primary" disabled="disabled" title="<?php echo esc_html_e( 'Make sure you enter the name and values for each attribute.', 'woocommerce' ); ?>">><?php esc_html_e( 'Save attributes', 'woocommerce' ); ?></button>
+		<button type="button" class="button save_attributes button-primary" disabled="disabled" title="<?php echo esc_html_e( 'Make sure you enter the name and values for each attribute.', 'woocommerce' ); ?>"><?php esc_html_e( 'Save attributes', 'woocommerce' ); ?></button>
 	</div>
 	<?php do_action( 'woocommerce_product_options_attributes' ); ?>
 </div>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
@@ -106,7 +106,7 @@ $icon_url                        = WC_ADMIN_IMAGES_FOLDER_URL . '/icons/global-a
 		<span class="expand-close">
 			<a href="#" class="expand_all"><?php esc_html_e( 'Expand', 'woocommerce' ); ?></a> / <a href="#" class="close_all"><?php esc_html_e( 'Close', 'woocommerce' ); ?></a>
 		</span>
-		<button type="button" class="button save_attributes button-primary"><?php esc_html_e( 'Save attributes', 'woocommerce' ); ?></button>
+		<button type="button" class="button save_attributes button-primary" disabled="disabled"><?php esc_html_e( 'Save attributes', 'woocommerce' ); ?></button>
 	</div>
 	<?php do_action( 'woocommerce_product_options_attributes' ); ?>
 </div>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
@@ -106,7 +106,7 @@ $icon_url                        = WC_ADMIN_IMAGES_FOLDER_URL . '/icons/global-a
 		<span class="expand-close">
 			<a href="#" class="expand_all"><?php esc_html_e( 'Expand', 'woocommerce' ); ?></a> / <a href="#" class="close_all"><?php esc_html_e( 'Close', 'woocommerce' ); ?></a>
 		</span>
-		<button type="button" class="button save_attributes button-primary" disabled="disabled"><?php esc_html_e( 'Save attributes', 'woocommerce' ); ?></button>
+		<button type="button" class="button save_attributes button-primary" disabled="disabled" title="<?php echo esc_html_e( 'Make sure you enter the name and values for each attribute.', 'woocommerce' ); ?>">><?php esc_html_e( 'Save attributes', 'woocommerce' ); ?></button>
 	</div>
 	<?php do_action( 'woocommerce_product_options_attributes' ); ?>
 </div>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
@@ -29,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				require __DIR__ . '/html-product-attribute-inner.php';
 			?>
 				<div class="toolbar">
-					<button type="button" class="button button-primary create-variations" disabled="disabled"><?php esc_html_e( 'Create variations', 'woocommerce' ); ?></button>
+					<button type="button" class="button button-primary create-variations" disabled="disabled" title="<?php echo esc_html_e( 'Make sure you enter the name and values for each attribute.', 'woocommerce' ); ?>"><?php esc_html_e( 'Create variations', 'woocommerce' ); ?></button>
 				</div>
 			</div>
 		</div>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
@@ -29,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				require __DIR__ . '/html-product-attribute-inner.php';
 			?>
 				<div class="toolbar">
-					<button type="button" class="button button-primary create-variations"><?php esc_html_e( 'Create variations', 'woocommerce' ); ?></button>
+					<button type="button" class="button button-primary create-variations" disabled="disabled"><?php esc_html_e( 'Create variations', 'woocommerce' ); ?></button>
 				</div>
 			</div>
 		</div>

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
@@ -64,6 +64,7 @@ test.describe.serial( 'Add New Variable Product Page', () => {
 				'val1 | val2'
 			);
 		}
+		await page.keyboard.press( 'ArrowUp' );
 		await page.click( 'text=Save attributes' );
 
 		// Save before going to the Variations tab to prevent variations from all attributes to be automatically created
@@ -138,6 +139,7 @@ test.describe.serial( 'Add New Variable Product Page', () => {
 		await page.fill( 'input[name="variable_length[2]"]', productLength );
 		await page.fill( 'input[name="variable_width[2]"]', productWidth );
 		await page.fill( 'input[name="variable_height[2]"]', productHeight );
+		await page.keyboard.press( 'ArrowUp' );
 		await page.click( 'button.save-variation-changes' );
 
 		// bulk-edit variations
@@ -211,6 +213,7 @@ test.describe.serial( 'Add New Variable Product Page', () => {
 				`textarea[name="attribute_values[${ i }]"]`,
 				'val1 | val2'
 			);
+			await page.keyboard.press( 'ArrowUp' );
 			await page.click( 'text=Save attributes' );
 			await expect(
 				page


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR disables the `Save attributes` and `Save variations` buttons until a value is added in the `Name` and `Value` fields.
We want to prevent triggering the action with empty values.

![Screen Capture on 2023-03-03 at 11-12-25](https://user-images.githubusercontent.com/1314156/222742606-6b0a3717-5158-4130-bfde-fa0fed93c3c7.gif)


Closes #37021.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Go to Products > Add New > Product data > Attributes
2. The button Save attributes will be disabled.
3. Add a name and one or more values.
4. The save button should be enabled after filling out the inputs.
5. Next to `Product data` change the product type to `Variable product`.
6. Go to Variations and repeat steps 3 and 4.
7. The save buttons should work correctly.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
