### PR TITLE
Orders: Update date modified on refund

### DIFF
--- a/plugins/woocommerce/changelog/fix-28969-modify-order-on-refund
+++ b/plugins/woocommerce/changelog/fix-28969-modify-order-on-refund
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update the date modified field for an order when a refund for it is successfully processed.

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -660,6 +660,9 @@ function wc_create_refund( $args = array() ) {
 			}
 		}
 
+		$order->set_date_modified( $refund->get_date_created() );
+		$order->save();
+
 		do_action( 'woocommerce_refund_created', $refund->get_id(), $args );
 		do_action( 'woocommerce_order_refunded', $order->get_id(), $refund->get_id() );
 

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -660,7 +660,7 @@ function wc_create_refund( $args = array() ) {
 			}
 		}
 
-		$order->set_date_modified( $refund->get_date_created() );
+		$order->set_date_modified( time() );
 		$order->save();
 
 		do_action( 'woocommerce_refund_created', $refund->get_id(), $args );

--- a/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-order-functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-order-functions.php
@@ -1410,6 +1410,36 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that order modified date is updated when a refund is created for it.
+	 *
+	 * @link https://github.com/woocommerce/woocommerce/issues/28969
+	 */
+	public function test_wc_create_refund_28969() {
+		$order = WC_Helper_Order::create_order(
+			1,
+			WC_Helper_Product::create_simple_product(),
+			array(
+				'status' => 'completed',
+			)
+		);
+		// Ensure the order is a complete object with an initial modified date.
+		$order = wc_get_order( $order->get_id() );
+
+		// Ensure the order's initial modified date is sufficiently in the past.
+		sleep( 1 );
+
+		$args = array(
+			'order_id' => $order->get_id(),
+			'amount'   => 1,
+		);
+
+		wc_create_refund( $args );
+		$updated_order = wc_get_order( $order->get_id() );
+
+		$this->assertNotEquals( $order->get_date_modified()->getTimestamp(), $updated_order->get_date_modified()->getTimestamp() );
+	}
+
+	/**
 	 * Test wc_sanitize_order_id().
 	 */
 	public function test_wc_sanitize_order_id() {


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Ensures that when a refund is processed successfully for an order, the date_modified field for the order is updated to match the creation date of the refund.

Refs #28969
(But doesn't close it, as there is a second issue which will be addressed with a separate PR)

### How to test the changes in this Pull Request:

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

As far as I can tell, WC Admin doesn't surface the `date_modified` field for orders anywhere. You can check the field directly in the database table if you want, or you can use this small mu-plugin to output the value to a WC log file.

```php
add_action(
	'woocommerce_order_refunded',
	function ( $order_id, $refund_id ) {
		$order  = wc_get_order( $order_id );
		$refund = wc_get_order( $refund_id );
		wc_get_logger()->debug( 'Refund created: ' . $refund->get_date_created()->format( 'Y-m-d H:i:s' ) );
		wc_get_logger()->debug( 'Order modified: ' . $order->get_date_modified()->format( 'Y-m-d H:i:s' ) );
	},
	10,
	2
);
```

These instructions are for testing with both wp_posts and HPOS scenarios. To start, make sure "High-Performance order storage (COT)" is enabled at WooCommerce > Settings > Advanced > Features. Then switch to the "Custom data stores" tab and check the box for "Keep the posts table and the orders tables synchronized". Finally, start with the "Use the WordPress posts table" option selected.

Start off going through the following steps before checking out this PR branch to observe the current behavior.

1. Create a product that costs at least $10.
2. From the WooCommerce > Orders screen, manually create a new order. Add the new product to it, and set the status to Completed. Save the order.
3. Now while still on the Edit screen for the new order, click the Refund button. Refund $1 from the order.
4. In a separate browser tab, navigate to WooCommerce > Status > Logs. You should see two entries:
    * `DEBUG Refund created` will show the timestamp for the refund you just processed.
    * `DEBUG Order modified` should still show the timestamp from when you originally created the order. It will be earlier than the refund date. This is the issue.
5. Back on WooCommerce > Settings > Advanced > Custom data stores, switch the option to "Use the WooCommerce orders tables", and then do another $1 refund. Observe that here also the order's modified date does not change.
6. Now check out this PR branch. Do another $1 refund. This time the logs should show that the order's modified date matches the creation date of the refund you just did (or should be within one second of each other).
7. Test this with both table options for the Custom data stores. The order modified date should update in both cases when a refund is processed.
8. Now test doing a refund via the REST API. You'll need to make sure your test site has permalinks set up and that you have an app password created for your admin user (WP Admin > Edit Profile). Try the following request, inputting the relevant values for the order ID and your app password:
    ```
    curl --request POST \
      --url http://localhost:8888/wp-json/wc/v3/orders/{order ID}/refunds \
      --header 'Authorization: Basic {your app password}' \
      --header 'Content-Type: multipart/form-data' \
      --form amount=1 \
      --form api_refund=false
    ```
    The logs should still show the order modified date matching, or being within one second of the refund creation date.

It might also be worth running the new unit test in your environment and make sure it works as expected. I had a hard time figuring out how best to create an order and modify it such that the `date_modified` field would be different after a refund, given that the whole test is executed in less than a second. I couldn't figure out a way to set an artificial timestamp on the order that would stick. So the way it's written now seems to work, but I'm concerned that it might be flaky.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
