### PR TITLE
Correct `UPDATE_WC` value in the "Smoke test daily" workflow

### DIFF
--- a/.github/workflows/smoke-test-daily.yml
+++ b/.github/workflows/smoke-test-daily.yml
@@ -155,7 +155,7 @@ jobs:
                   ADMIN_PASSWORD: ${{ secrets.SMOKE_TEST_PERF_ADMIN_PASSWORD }}
                   CUSTOMER_USER: ${{ secrets.SMOKE_TEST_PERF_ADMIN_USER }}
                   CUSTOMER_PASSWORD: ${{ secrets.SMOKE_TEST_PERF_ADMIN_PASSWORD }}
-                  UPDATE_WC: true
+                  UPDATE_WC: nightly
                   DEFAULT_TIMEOUT_OVERRIDE: 120000
               run: |
                   pnpm exec playwright test --config=tests/e2e-pw/playwright.config.js update-woocommerce.spec.js

--- a/plugins/woocommerce/changelog/e2e-fix-daily-k6-workflow-env-var
+++ b/plugins/woocommerce/changelog/e2e-fix-daily-k6-workflow-env-var
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix the value of `UPDATE_WC` environment variable in the daily k6 performance tests.


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
- [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/37048.

This PR fixes the value of the environment variable `UPDATE_WC` in the k6 performance tests job in the `Smoke test daily` workflow.

### How to test the changes in this Pull Request:

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Go to the [Smoke test daily](https://github.com/woocommerce/woocommerce/actions/workflows/smoke-test-daily.yml) page.
2. In the _"Use workflow from"_ dropdown, select this branch (`e2e/fix-k6-daily-env-var`).
3. Click _"Run workflow"_ to start it.
4. Wait for it to finish.
5. In the workflow run summary, you shouldn't see an error in the `k6 tests on nightly build` job.
6. Click on the `k6 tests on nightly build` job. Expand the `Update performance test site with E2E test` step.
   - Verify that you don't see the `can update WooCommerce to "true"` test failing.
   - Verify that you don't see any other failures in this step
   <img width="600" alt="thn0Q48do6" src="https://user-images.githubusercontent.com/4509348/222619677-8a2206c1-9eff-4594-ab78-b44c15d03208.png">


### Other information:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
- [x] Have you included testing instructions?

### FOR PR REVIEWER ONLY:

- [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
