### PR TITLE
Fix class name in ProductDownloadsServiceProvider

### DIFF
--- a/changelog/pr-37052
+++ b/changelog/pr-37052
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Corrects a class reference in the ProductDownloadsServiceProvider.

--- a/changelog/pr-37052
+++ b/changelog/pr-37052
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Corrects a class reference in the ProductDownloadsServiceProvider.

--- a/plugins/woocommerce/changelog/pr-37052
+++ b/plugins/woocommerce/changelog/pr-37052
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Corrects a class reference in the ProductDownloadsServiceProvider.

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/ProductDownloadsServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/ProductDownloadsServiceProvider.php
@@ -19,7 +19,7 @@ class ProductDownloadsServiceProvider extends AbstractServiceProvider {
 	 */
 	protected $provides = array(
 		Register::class,
-		Sync::class,
+		Synchronize::class,
 		SyncUI::class,
 		UI::class,
 	);


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fix class name

From https://github.com/woocommerce/woocommerce/pull/37015#issuecomment-1453436541
