### PR TITLE
Fix the ArrayUtil::get_value_or_default method

### DIFF
--- a/plugins/woocommerce/changelog/fix-arrayutil_get_value_or_default
+++ b/plugins/woocommerce/changelog/fix-arrayutil_get_value_or_default
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix ArrayUtil::get_value_or_default method not behaving as documented for null array values

--- a/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
@@ -7,7 +7,6 @@
  */
 
 use Automattic\Jetpack\Constants;
-use Automattic\WooCommerce\Utilities\ArrayUtil;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -431,7 +430,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 					// Radio inputs.
 					case 'radio':
 						$option_value = $value['value'];
-						$disabled_values = ArrayUtil::get_value_or_default($value, 'disabled', array());
+						$disabled_values = $value['disabled'] ?? array();
 
 						?>
 						<tr valign="top">
@@ -488,7 +487,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 							$visibility_class[] = 'show_options_if_checked';
 						}
 
-						$must_disable = ArrayUtil::get_value_or_default( $value, 'disabled', false );
+						$must_disable = $value['disabled'] ?? false;
 
 						if ( ! isset( $value['checkboxgroup'] ) || 'start' === $value['checkboxgroup'] ) {
 							$has_tooltip             = isset( $value['tooltip'] ) && '' !== $value['tooltip'];

--- a/plugins/woocommerce/includes/admin/class-wc-admin-status.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-status.php
@@ -7,7 +7,6 @@
  */
 
 use Automattic\Jetpack\Constants;
-use Automattic\WooCommerce\Utilities\ArrayUtil;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -49,13 +48,13 @@ class WC_Admin_Status {
 				$response = $tools_controller->execute_tool( $action );
 
 				$tool                  = $tools[ $action ];
-				$tool_requires_refresh = ArrayUtil::get_value_or_default( $tool, 'requires_refresh', false );
+				$tool_requires_refresh = $tool['requires_refresh'] ?? false;
 				$tool                  = array(
 					'id'          => $action,
 					'name'        => $tool['name'],
 					'action'      => $tool['button'],
 					'description' => $tool['desc'],
-					'disabled'    => ArrayUtil::get_value_or_default( $tool, 'disabled', false ),
+					'disabled'    => $tool['disabled'] ?? false,
 				);
 				$tool                  = array_merge( $tool, $response );
 

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -765,19 +765,19 @@ class FeaturesController {
 			return $list;
 		}
 
-		// phpcs:disable WordPress.Security.NonceVerification
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput
 		if ( ! function_exists( 'get_current_screen' ) || get_current_screen() && 'plugins' !== get_current_screen()->id || 'incompatible_with_feature' !== ArrayUtil::get_value_or_default( $_GET, 'plugin_status' ) ) {
 			return $list;
 		}
 
-		$feature_id = ArrayUtil::get_value_or_default( $_GET, 'feature_id', 'all' );
+		$feature_id = $_GET['feature_id'] ?? 'all';
 		if ( 'all' !== $feature_id && ! $this->feature_exists( $feature_id ) ) {
 			return $list;
 		}
 
 		$incompatibles = array();
 
-		// phpcs:enable WordPress.Security.NonceVerification
+		// phpcs:enable WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput
 		foreach ( array_keys( $list ) as $plugin_name ) {
 			if ( ! $this->plugin_util->is_woocommerce_aware_plugin( $plugin_name ) || ! $this->proxy->call_function( 'is_plugin_active', $plugin_name ) ) {
 				continue;
@@ -1054,16 +1054,16 @@ class FeaturesController {
 	 * @return string[] The actual views array to use.
 	 */
 	private function handle_plugins_page_views_list( $views ): array {
-		// phpcs:disable WordPress.Security.NonceVerification
+		// phpcs:disable WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput
 		if ( 'incompatible_with_feature' !== ArrayUtil::get_value_or_default( $_GET, 'plugin_status' ) ) {
 			return $views;
 		}
 
-		$feature_id = ArrayUtil::get_value_or_default( $_GET, 'feature_id', 'all' );
+		$feature_id = $_GET['feature_id'] ?? 'all';
 		if ( 'all' !== $feature_id && ! $this->feature_exists( $feature_id ) ) {
 			return $views;
 		}
-		// phpcs:enable WordPress.Security.NonceVerification
+		// phpcs:enable WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput
 
 		$all_items = get_plugins();
 

--- a/plugins/woocommerce/src/Utilities/ArrayUtil.php
+++ b/plugins/woocommerce/src/Utilities/ArrayUtil.php
@@ -80,13 +80,20 @@ class ArrayUtil {
 	/**
 	 * Gets the value for a given key from an array, or a default value if the key doesn't exist in the array.
 	 *
+	 * This is equivalent to "$array[$key] ?? $default" except in one case:
+	 * when they key exists, has a null value, and a non-null default is supplied:
+	 *
+	 * $array = ['key' => null]
+	 * $array['key'] ?? 'default' => 'default'
+	 * ArrayUtil::get_value_or_default($array, 'key', 'default') => null
+	 *
 	 * @param array  $array The array to get the value from.
 	 * @param string $key The key to use to retrieve the value.
 	 * @param null   $default The default value to return if the key doesn't exist in the array.
 	 * @return mixed|null The value for the key, or the default value passed.
 	 */
 	public static function get_value_or_default( array $array, string $key, $default = null ) {
-		return isset( $array[ $key ] ) ? $array[ $key ] : $default;
+		return array_key_exists( $key, $array ) ? $array[ $key ] : $default;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Utilities/PluginUtil.php
+++ b/plugins/woocommerce/src/Utilities/PluginUtil.php
@@ -97,7 +97,7 @@ class PluginUtil {
 	 */
 	public function get_plugin_name( string $plugin_id ): string {
 		$plugin_data = $this->proxy->call_function( 'get_plugin_data', WP_PLUGIN_DIR . DIRECTORY_SEPARATOR . $plugin_id );
-		return ArrayUtil::get_value_or_default( $plugin_data, 'Name', $plugin_id );
+		return $plugin_data['Name'] ?? $plugin_id;
 	}
 
 	/**
@@ -111,7 +111,7 @@ class PluginUtil {
 		if ( is_string( $plugin_file_or_data ) ) {
 			return in_array( $plugin_file_or_data, $this->get_woocommerce_aware_plugins(), true );
 		} elseif ( is_array( $plugin_file_or_data ) ) {
-			return '' !== ArrayUtil::get_value_or_default( $plugin_file_or_data, 'WC tested up to', '' );
+			return '' !== ( $plugin_file_or_data['WC tested up to'] ?? '' );
 		} else {
 			throw new \Exception( 'is_woocommerce_aware_plugin requires a plugin name or an array of plugin data as input' );
 		}

--- a/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/LookupDataStoreTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/ProductAttributesLookup/LookupDataStoreTest.php
@@ -8,7 +8,6 @@ namespace Automattic\WooCommerce\Tests\Internal\ProductAttributesLookup;
 use Automattic\WooCommerce\Internal\ProductAttributesLookup\DataRegenerator;
 use Automattic\WooCommerce\Internal\ProductAttributesLookup\LookupDataStore;
 use Automattic\WooCommerce\Testing\Tools\FakeQueue;
-use Automattic\WooCommerce\Utilities\ArrayUtil;
 
 /**
  * Tests for the LookupDataStore class.
@@ -1111,7 +1110,7 @@ class LookupDataStoreTest extends \WC_Unit_Test_Case {
 			$attribute->set_id( $attribute_data['id'] );
 			$attribute->set_name( $taxonomy );
 			$attribute->set_options( $attribute_data['options'] );
-			$attribute->set_variation( ArrayUtil::get_value_or_default( $attribute_data, 'variation', false ) );
+			$attribute->set_variation( $attribute_data['variation'] ?? false );
 			$attributes[] = $attribute;
 		}
 

--- a/plugins/woocommerce/tests/php/src/Utilities/ArrayUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Utilities/ArrayUtilTest.php
@@ -136,6 +136,15 @@ class ArrayUtilTest extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox `get_value_or_default` returns null if the key exists and has a null value.
+	 */
+	public function test_get_value_or_default_returns_null_if_key_exists_and_value_is_null() {
+		$array = array( 'foo' => null );
+
+		$this->assertNull( ArrayUtil::get_value_or_default( $array, 'foo', 'buzz' ) );
+	}
+
+	/**
 	 * Data provider for test_to_ranges_string
 	 *
 	 * @return array[]


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

The `ArrayUtil::get_value_or_default` method was supposed to return null if the key exists in the array and has a null value, but instead it was returning the supplied default value, as the `??` operator. This pull request modifies the method so that it behaves as originally intended (and documented), example:

```
$array = ['key' => null]
$array['key'] ?? 'default' => 'default'
ArrayUtil::get_value_or_default($array, 'key', 'default') => without fix: 'default'
ArrayUtil::get_value_or_default($array, 'key', 'default') => with fix: null
```

Also the few existing usages of the method that supplied a default value have been converted to instances of the `??` operator for compatibility.

### How to test the changes in this Pull Request:

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

Verify that the places where the method has been replaced with `??` still work as expected, these are:

* Settings pages where radio buttons and checkboxes are displayed.
* The features page (WooCommerce - Settings - Advanced - Features)
* The tools page (WooCommerce - Status - Tools)

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [ ] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
