### PR TITLE
Fix reference to WC_API_Server

### DIFF
--- a/plugins/woocommerce/changelog/pr-37054
+++ b/plugins/woocommerce/changelog/pr-37054
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Corrects references for WC_API_Server. It was all uppercase.

--- a/plugins/woocommerce/includes/legacy/api/v1/class-wc-api-customers.php
+++ b/plugins/woocommerce/includes/legacy/api/v1/class-wc-api-customers.php
@@ -59,22 +59,22 @@ class WC_API_Customers extends WC_API_Resource {
 
 		# GET /customers
 		$routes[ $this->base ] = array(
-			array( array( $this, 'get_customers' ),     WC_API_SERVER::READABLE ),
+			array( array( $this, 'get_customers' ),     WC_API_Server::READABLE ),
 		);
 
 		# GET /customers/count
 		$routes[ $this->base . '/count' ] = array(
-			array( array( $this, 'get_customers_count' ), WC_API_SERVER::READABLE ),
+			array( array( $this, 'get_customers_count' ), WC_API_Server::READABLE ),
 		);
 
 		# GET /customers/<id>
 		$routes[ $this->base . '/(?P<id>\d+)' ] = array(
-			array( array( $this, 'get_customer' ),  WC_API_SERVER::READABLE ),
+			array( array( $this, 'get_customer' ),  WC_API_Server::READABLE ),
 		);
 
 		# GET /customers/<id>/orders
 		$routes[ $this->base . '/(?P<id>\d+)/orders' ] = array(
-			array( array( $this, 'get_customer_orders' ), WC_API_SERVER::READABLE ),
+			array( array( $this, 'get_customer_orders' ), WC_API_Server::READABLE ),
 		);
 
 		return $routes;

--- a/plugins/woocommerce/includes/legacy/api/v2/class-wc-api-coupons.php
+++ b/plugins/woocommerce/includes/legacy/api/v2/class-wc-api-coupons.php
@@ -46,8 +46,8 @@ class WC_API_Coupons extends WC_API_Resource {
 		# GET/PUT/DELETE /coupons/<id>
 		$routes[ $this->base . '/(?P<id>\d+)' ] = array(
 			array( array( $this, 'get_coupon' ),    WC_API_Server::READABLE ),
-			array( array( $this, 'edit_coupon' ),   WC_API_SERVER::EDITABLE | WC_API_SERVER::ACCEPT_DATA ),
-			array( array( $this, 'delete_coupon' ), WC_API_SERVER::DELETABLE ),
+			array( array( $this, 'edit_coupon' ),   WC_API_Server::EDITABLE | WC_API_Server::ACCEPT_DATA ),
+			array( array( $this, 'delete_coupon' ), WC_API_Server::DELETABLE ),
 		);
 
 		# GET /coupons/code/<code>, note that coupon codes can contain spaces, dashes and underscores

--- a/plugins/woocommerce/includes/legacy/api/v2/class-wc-api-customers.php
+++ b/plugins/woocommerce/includes/legacy/api/v2/class-wc-api-customers.php
@@ -58,35 +58,35 @@ class WC_API_Customers extends WC_API_Resource {
 
 		# GET/POST /customers
 		$routes[ $this->base ] = array(
-			array( array( $this, 'get_customers' ),   WC_API_SERVER::READABLE ),
-			array( array( $this, 'create_customer' ), WC_API_SERVER::CREATABLE | WC_API_Server::ACCEPT_DATA ),
+			array( array( $this, 'get_customers' ),   WC_API_Server::READABLE ),
+			array( array( $this, 'create_customer' ), WC_API_Server::CREATABLE | WC_API_Server::ACCEPT_DATA ),
 		);
 
 		# GET /customers/count
 		$routes[ $this->base . '/count' ] = array(
-			array( array( $this, 'get_customers_count' ), WC_API_SERVER::READABLE ),
+			array( array( $this, 'get_customers_count' ), WC_API_Server::READABLE ),
 		);
 
 		# GET/PUT/DELETE /customers/<id>
 		$routes[ $this->base . '/(?P<id>\d+)' ] = array(
-			array( array( $this, 'get_customer' ),    WC_API_SERVER::READABLE ),
-			array( array( $this, 'edit_customer' ),   WC_API_SERVER::EDITABLE | WC_API_SERVER::ACCEPT_DATA ),
-			array( array( $this, 'delete_customer' ), WC_API_SERVER::DELETABLE ),
+			array( array( $this, 'get_customer' ),    WC_API_Server::READABLE ),
+			array( array( $this, 'edit_customer' ),   WC_API_Server::EDITABLE | WC_API_Server::ACCEPT_DATA ),
+			array( array( $this, 'delete_customer' ), WC_API_Server::DELETABLE ),
 		);
 
 		# GET /customers/email/<email>
 		$routes[ $this->base . '/email/(?P<email>.+)' ] = array(
-			array( array( $this, 'get_customer_by_email' ), WC_API_SERVER::READABLE ),
+			array( array( $this, 'get_customer_by_email' ), WC_API_Server::READABLE ),
 		);
 
 		# GET /customers/<id>/orders
 		$routes[ $this->base . '/(?P<id>\d+)/orders' ] = array(
-			array( array( $this, 'get_customer_orders' ), WC_API_SERVER::READABLE ),
+			array( array( $this, 'get_customer_orders' ), WC_API_Server::READABLE ),
 		);
 
 		# GET /customers/<id>/downloads
 		$routes[ $this->base . '/(?P<id>\d+)/downloads' ] = array(
-			array( array( $this, 'get_customer_downloads' ), WC_API_SERVER::READABLE ),
+			array( array( $this, 'get_customer_downloads' ), WC_API_Server::READABLE ),
 		);
 
 		# POST|PUT /customers/bulk

--- a/plugins/woocommerce/includes/legacy/api/v2/class-wc-api-orders.php
+++ b/plugins/woocommerce/includes/legacy/api/v2/class-wc-api-orders.php
@@ -62,27 +62,27 @@ class WC_API_Orders extends WC_API_Resource {
 		# GET|POST /orders/<id>/notes
 		$routes[ $this->base . '/(?P<order_id>\d+)/notes' ] = array(
 			array( array( $this, 'get_order_notes' ), WC_API_Server::READABLE ),
-			array( array( $this, 'create_order_note' ), WC_API_SERVER::CREATABLE | WC_API_Server::ACCEPT_DATA ),
+			array( array( $this, 'create_order_note' ), WC_API_Server::CREATABLE | WC_API_Server::ACCEPT_DATA ),
 		);
 
 		# GET|PUT|DELETE /orders/<order_id>/notes/<id>
 		$routes[ $this->base . '/(?P<order_id>\d+)/notes/(?P<id>\d+)' ] = array(
 			array( array( $this, 'get_order_note' ), WC_API_Server::READABLE ),
-			array( array( $this, 'edit_order_note' ), WC_API_SERVER::EDITABLE | WC_API_Server::ACCEPT_DATA ),
-			array( array( $this, 'delete_order_note' ), WC_API_SERVER::DELETABLE ),
+			array( array( $this, 'edit_order_note' ), WC_API_Server::EDITABLE | WC_API_Server::ACCEPT_DATA ),
+			array( array( $this, 'delete_order_note' ), WC_API_Server::DELETABLE ),
 		);
 
 		# GET|POST /orders/<order_id>/refunds
 		$routes[ $this->base . '/(?P<order_id>\d+)/refunds' ] = array(
 			array( array( $this, 'get_order_refunds' ), WC_API_Server::READABLE ),
-			array( array( $this, 'create_order_refund' ), WC_API_SERVER::CREATABLE | WC_API_Server::ACCEPT_DATA ),
+			array( array( $this, 'create_order_refund' ), WC_API_Server::CREATABLE | WC_API_Server::ACCEPT_DATA ),
 		);
 
 		# GET|PUT|DELETE /orders/<order_id>/refunds/<id>
 		$routes[ $this->base . '/(?P<order_id>\d+)/refunds/(?P<id>\d+)' ] = array(
 			array( array( $this, 'get_order_refund' ), WC_API_Server::READABLE ),
-			array( array( $this, 'edit_order_refund' ), WC_API_SERVER::EDITABLE | WC_API_Server::ACCEPT_DATA ),
-			array( array( $this, 'delete_order_refund' ), WC_API_SERVER::DELETABLE ),
+			array( array( $this, 'edit_order_refund' ), WC_API_Server::EDITABLE | WC_API_Server::ACCEPT_DATA ),
+			array( array( $this, 'delete_order_refund' ), WC_API_Server::DELETABLE ),
 		);
 
 		# POST|PUT /orders/bulk

--- a/plugins/woocommerce/includes/legacy/api/v2/class-wc-api-products.php
+++ b/plugins/woocommerce/includes/legacy/api/v2/class-wc-api-products.php
@@ -37,7 +37,7 @@ class WC_API_Products extends WC_API_Resource {
 		# GET/POST /products
 		$routes[ $this->base ] = array(
 			array( array( $this, 'get_products' ), WC_API_Server::READABLE ),
-			array( array( $this, 'create_product' ), WC_API_SERVER::CREATABLE | WC_API_Server::ACCEPT_DATA ),
+			array( array( $this, 'create_product' ), WC_API_Server::CREATABLE | WC_API_Server::ACCEPT_DATA ),
 		);
 
 		# GET /products/count
@@ -75,7 +75,7 @@ class WC_API_Products extends WC_API_Resource {
 		# GET/POST /products/attributes
 		$routes[ $this->base . '/attributes' ] = array(
 			array( array( $this, 'get_product_attributes' ), WC_API_Server::READABLE ),
-			array( array( $this, 'create_product_attribute' ), WC_API_SERVER::CREATABLE | WC_API_Server::ACCEPT_DATA ),
+			array( array( $this, 'create_product_attribute' ), WC_API_Server::CREATABLE | WC_API_Server::ACCEPT_DATA ),
 		);
 
 		# GET/PUT/DELETE /attributes/<id>

--- a/plugins/woocommerce/includes/legacy/api/v3/class-wc-api-coupons.php
+++ b/plugins/woocommerce/includes/legacy/api/v3/class-wc-api-coupons.php
@@ -46,8 +46,8 @@ class WC_API_Coupons extends WC_API_Resource {
 		# GET/PUT/DELETE /coupons/<id>
 		$routes[ $this->base . '/(?P<id>\d+)' ] = array(
 			array( array( $this, 'get_coupon' ),    WC_API_Server::READABLE ),
-			array( array( $this, 'edit_coupon' ),   WC_API_SERVER::EDITABLE | WC_API_SERVER::ACCEPT_DATA ),
-			array( array( $this, 'delete_coupon' ), WC_API_SERVER::DELETABLE ),
+			array( array( $this, 'edit_coupon' ),   WC_API_Server::EDITABLE | WC_API_Server::ACCEPT_DATA ),
+			array( array( $this, 'delete_coupon' ), WC_API_Server::DELETABLE ),
 		);
 
 		# GET /coupons/code/<code>, note that coupon codes can contain spaces, dashes and underscores

--- a/plugins/woocommerce/includes/legacy/api/v3/class-wc-api-customers.php
+++ b/plugins/woocommerce/includes/legacy/api/v3/class-wc-api-customers.php
@@ -58,35 +58,35 @@ class WC_API_Customers extends WC_API_Resource {
 
 		# GET/POST /customers
 		$routes[ $this->base ] = array(
-			array( array( $this, 'get_customers' ),   WC_API_SERVER::READABLE ),
-			array( array( $this, 'create_customer' ), WC_API_SERVER::CREATABLE | WC_API_Server::ACCEPT_DATA ),
+			array( array( $this, 'get_customers' ),   WC_API_Server::READABLE ),
+			array( array( $this, 'create_customer' ), WC_API_Server::CREATABLE | WC_API_Server::ACCEPT_DATA ),
 		);
 
 		# GET /customers/count
 		$routes[ $this->base . '/count' ] = array(
-			array( array( $this, 'get_customers_count' ), WC_API_SERVER::READABLE ),
+			array( array( $this, 'get_customers_count' ), WC_API_Server::READABLE ),
 		);
 
 		# GET/PUT/DELETE /customers/<id>
 		$routes[ $this->base . '/(?P<id>\d+)' ] = array(
-			array( array( $this, 'get_customer' ),    WC_API_SERVER::READABLE ),
-			array( array( $this, 'edit_customer' ),   WC_API_SERVER::EDITABLE | WC_API_SERVER::ACCEPT_DATA ),
-			array( array( $this, 'delete_customer' ), WC_API_SERVER::DELETABLE ),
+			array( array( $this, 'get_customer' ),    WC_API_Server::READABLE ),
+			array( array( $this, 'edit_customer' ),   WC_API_Server::EDITABLE | WC_API_Server::ACCEPT_DATA ),
+			array( array( $this, 'delete_customer' ), WC_API_Server::DELETABLE ),
 		);
 
 		# GET /customers/email/<email>
 		$routes[ $this->base . '/email/(?P<email>.+)' ] = array(
-			array( array( $this, 'get_customer_by_email' ), WC_API_SERVER::READABLE ),
+			array( array( $this, 'get_customer_by_email' ), WC_API_Server::READABLE ),
 		);
 
 		# GET /customers/<id>/orders
 		$routes[ $this->base . '/(?P<id>\d+)/orders' ] = array(
-			array( array( $this, 'get_customer_orders' ), WC_API_SERVER::READABLE ),
+			array( array( $this, 'get_customer_orders' ), WC_API_Server::READABLE ),
 		);
 
 		# GET /customers/<id>/downloads
 		$routes[ $this->base . '/(?P<id>\d+)/downloads' ] = array(
-			array( array( $this, 'get_customer_downloads' ), WC_API_SERVER::READABLE ),
+			array( array( $this, 'get_customer_downloads' ), WC_API_Server::READABLE ),
 		);
 
 		# POST|PUT /customers/bulk

--- a/plugins/woocommerce/includes/legacy/api/v3/class-wc-api-orders.php
+++ b/plugins/woocommerce/includes/legacy/api/v3/class-wc-api-orders.php
@@ -62,27 +62,27 @@ class WC_API_Orders extends WC_API_Resource {
 		# GET|POST /orders/<id>/notes
 		$routes[ $this->base . '/(?P<order_id>\d+)/notes' ] = array(
 			array( array( $this, 'get_order_notes' ), WC_API_Server::READABLE ),
-			array( array( $this, 'create_order_note' ), WC_API_SERVER::CREATABLE | WC_API_Server::ACCEPT_DATA ),
+			array( array( $this, 'create_order_note' ), WC_API_Server::CREATABLE | WC_API_Server::ACCEPT_DATA ),
 		);
 
 		# GET|PUT|DELETE /orders/<order_id>/notes/<id>
 		$routes[ $this->base . '/(?P<order_id>\d+)/notes/(?P<id>\d+)' ] = array(
 			array( array( $this, 'get_order_note' ), WC_API_Server::READABLE ),
-			array( array( $this, 'edit_order_note' ), WC_API_SERVER::EDITABLE | WC_API_Server::ACCEPT_DATA ),
-			array( array( $this, 'delete_order_note' ), WC_API_SERVER::DELETABLE ),
+			array( array( $this, 'edit_order_note' ), WC_API_Server::EDITABLE | WC_API_Server::ACCEPT_DATA ),
+			array( array( $this, 'delete_order_note' ), WC_API_Server::DELETABLE ),
 		);
 
 		# GET|POST /orders/<order_id>/refunds
 		$routes[ $this->base . '/(?P<order_id>\d+)/refunds' ] = array(
 			array( array( $this, 'get_order_refunds' ), WC_API_Server::READABLE ),
-			array( array( $this, 'create_order_refund' ), WC_API_SERVER::CREATABLE | WC_API_Server::ACCEPT_DATA ),
+			array( array( $this, 'create_order_refund' ), WC_API_Server::CREATABLE | WC_API_Server::ACCEPT_DATA ),
 		);
 
 		# GET|PUT|DELETE /orders/<order_id>/refunds/<id>
 		$routes[ $this->base . '/(?P<order_id>\d+)/refunds/(?P<id>\d+)' ] = array(
 			array( array( $this, 'get_order_refund' ), WC_API_Server::READABLE ),
-			array( array( $this, 'edit_order_refund' ), WC_API_SERVER::EDITABLE | WC_API_Server::ACCEPT_DATA ),
-			array( array( $this, 'delete_order_refund' ), WC_API_SERVER::DELETABLE ),
+			array( array( $this, 'edit_order_refund' ), WC_API_Server::EDITABLE | WC_API_Server::ACCEPT_DATA ),
+			array( array( $this, 'delete_order_refund' ), WC_API_Server::DELETABLE ),
 		);
 
 		# POST|PUT /orders/bulk

--- a/plugins/woocommerce/includes/legacy/api/v3/class-wc-api-products.php
+++ b/plugins/woocommerce/includes/legacy/api/v3/class-wc-api-products.php
@@ -37,7 +37,7 @@ class WC_API_Products extends WC_API_Resource {
 		# GET/POST /products
 		$routes[ $this->base ] = array(
 			array( array( $this, 'get_products' ), WC_API_Server::READABLE ),
-			array( array( $this, 'create_product' ), WC_API_SERVER::CREATABLE | WC_API_Server::ACCEPT_DATA ),
+			array( array( $this, 'create_product' ), WC_API_Server::CREATABLE | WC_API_Server::ACCEPT_DATA ),
 		);
 
 		# GET /products/count
@@ -104,7 +104,7 @@ class WC_API_Products extends WC_API_Resource {
 		# GET/POST /products/attributes
 		$routes[ $this->base . '/attributes' ] = array(
 			array( array( $this, 'get_product_attributes' ), WC_API_Server::READABLE ),
-			array( array( $this, 'create_product_attribute' ), WC_API_SERVER::CREATABLE | WC_API_Server::ACCEPT_DATA ),
+			array( array( $this, 'create_product_attribute' ), WC_API_Server::CREATABLE | WC_API_Server::ACCEPT_DATA ),
 		);
 
 		# GET/PUT/DELETE /products/attributes/<id>
@@ -117,7 +117,7 @@ class WC_API_Products extends WC_API_Resource {
 		# GET/POST /products/attributes/<attribute_id>/terms
 		$routes[ $this->base . '/attributes/(?P<attribute_id>\d+)/terms' ] = array(
 			array( array( $this, 'get_product_attribute_terms' ), WC_API_Server::READABLE ),
-			array( array( $this, 'create_product_attribute_term' ), WC_API_SERVER::CREATABLE | WC_API_Server::ACCEPT_DATA ),
+			array( array( $this, 'create_product_attribute_term' ), WC_API_Server::CREATABLE | WC_API_Server::ACCEPT_DATA ),
 		);
 
 		# GET/PUT/DELETE /products/attributes/<attribute_id>/terms/<id>

--- a/plugins/woocommerce/includes/legacy/api/v3/class-wc-api-taxes.php
+++ b/plugins/woocommerce/includes/legacy/api/v3/class-wc-api-taxes.php
@@ -46,8 +46,8 @@ class WC_API_Taxes extends WC_API_Resource {
 		# GET/PUT/DELETE /taxes/<id>
 		$routes[ $this->base . '/(?P<id>\d+)' ] = array(
 			array( array( $this, 'get_tax' ), WC_API_Server::READABLE ),
-			array( array( $this, 'edit_tax' ), WC_API_SERVER::EDITABLE | WC_API_SERVER::ACCEPT_DATA ),
-			array( array( $this, 'delete_tax' ), WC_API_SERVER::DELETABLE ),
+			array( array( $this, 'edit_tax' ), WC_API_Server::EDITABLE | WC_API_Server::ACCEPT_DATA ),
+			array( array( $this, 'delete_tax' ), WC_API_Server::DELETABLE ),
 		);
 
 		# GET/POST /taxes/classes
@@ -63,7 +63,7 @@ class WC_API_Taxes extends WC_API_Resource {
 
 		# GET /taxes/classes/<slug>
 		$routes[ $this->base . '/classes/(?P<slug>\w[\w\s\-]*)' ] = array(
-			array( array( $this, 'delete_tax_class' ), WC_API_SERVER::DELETABLE ),
+			array( array( $this, 'delete_tax_class' ), WC_API_Server::DELETABLE ),
 		);
 
 		# POST|PUT /taxes/bulk


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?


### Changes proposed in this Pull Request:

Was spelled "WC_API_SERVER"
From https://github.com/woocommerce/woocommerce/pull/37015#issuecomment-1453436541

### Testing instructions

Please set up PHPStan. @phpstan discovered this problem.
Here is how https://github.com/woocommerce/woocommerce/pull/37015#issuecomment-1453584344
