### PR TITLE
Fix imported ContainerInterface

### DIFF
--- a/plugins/woocommerce/changelog/pr-37055
+++ b/plugins/woocommerce/changelog/pr-37055
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Corrects imported ContainerInterface. It was not replaced because of the leading backslash.

--- a/plugins/woocommerce/src/Proxies/LegacyProxy.php
+++ b/plugins/woocommerce/src/Proxies/LegacyProxy.php
@@ -6,7 +6,7 @@
 namespace Automattic\WooCommerce\Proxies;
 
 use Automattic\WooCommerce\Internal\DependencyManagement\Definition;
-use \Psr\Container\ContainerInterface;
+use Automattic\WooCommerce\Vendor\Psr\Container\ContainerInterface;
 
 /**
  * Proxy class to access legacy WooCommerce functionality.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

I think it was not replaced because of leading backslash.
From https://github.com/woocommerce/woocommerce/pull/37015#issuecomment-1453436541
