### PR TITLE
Fix class namespaces in Onboarding

### DIFF
--- a/plugins/woocommerce/changelog/pr-37056
+++ b/plugins/woocommerce/changelog/pr-37056
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Corrects class namespaces in Onboarding. It was missed during last restructuring.

--- a/plugins/woocommerce/src/Admin/Features/Onboarding.php
+++ b/plugins/woocommerce/src/Admin/Features/Onboarding.php
@@ -41,7 +41,7 @@ class Onboarding extends DeprecatedClassFacade {
 	 */
 	public static function get_allowed_industries() {
 		wc_deprecated_function( 'get_allowed_industries', '6.3', '\Automattic\WooCommerce\Internal\Admin\OnboardingIndustries::get_allowed_industries()' );
-		return \Automattic\WooCommerce\Internal\Admin\OnboardingIndustries::get_allowed_industries();
+		return \Automattic\WooCommerce\Internal\Admin\Onboarding\OnboardingIndustries::get_allowed_industries();
 	}
 
 	/**
@@ -52,7 +52,7 @@ class Onboarding extends DeprecatedClassFacade {
 	 */
 	public static function get_allowed_product_types() {
 		wc_deprecated_function( 'get_allowed_product_types', '6.3', '\Automattic\WooCommerce\Internal\Admin\OnboardingProducts::get_allowed_product_types()' );
-		return \Automattic\WooCommerce\Internal\Admin\OnboardingProducts::get_allowed_product_types();
+		return \Automattic\WooCommerce\Internal\Admin\Onboarding\OnboardingProducts::get_allowed_product_types();
 	}
 
 	/**
@@ -63,7 +63,7 @@ class Onboarding extends DeprecatedClassFacade {
 	 */
 	public static function get_themes() {
 		wc_deprecated_function( 'get_themes', '6.3', '\Automattic\WooCommerce\Internal\Admin\OnboardingThemes::get_themes()' );
-		return \Automattic\WooCommerce\Internal\Admin\OnboardingThemes::get_themes();
+		return \Automattic\WooCommerce\Internal\Admin\Onboarding\OnboardingThemes::get_themes();
 	}
 
 	/**
@@ -75,7 +75,7 @@ class Onboarding extends DeprecatedClassFacade {
 	 */
 	public static function get_theme_data( $theme ) {
 		wc_deprecated_function( 'get_theme_data', '6.3', '\Automattic\WooCommerce\Internal\Admin\OnboardingThemes::get_theme_data()' );
-		return \Automattic\WooCommerce\Internal\Admin\OnboardingThemes::get_theme_data();
+		return \Automattic\WooCommerce\Internal\Admin\Onboarding\OnboardingThemes::get_theme_data();
 	}
 
 	/**
@@ -86,7 +86,7 @@ class Onboarding extends DeprecatedClassFacade {
 	 */
 	public static function get_allowed_themes() {
 		wc_deprecated_function( 'get_allowed_themes', '6.3', '\Automattic\WooCommerce\Internal\Admin\OnboardingThemes::get_allowed_themes()' );
-		return \Automattic\WooCommerce\Internal\Admin\OnboardingThemes::get_allowed_themes();
+		return \Automattic\WooCommerce\Internal\Admin\Onboarding\OnboardingThemes::get_allowed_themes();
 	}
 
 	/**
@@ -98,6 +98,6 @@ class Onboarding extends DeprecatedClassFacade {
 	 */
 	public static function get_product_data( $product_types ) {
 		wc_deprecated_function( 'get_product_data', '6.3', '\Automattic\WooCommerce\Internal\Admin\OnboardingProducts::get_product_data()' );
-		return \Automattic\WooCommerce\Internal\Admin\OnboardingProducts::get_product_data();
+		return \Automattic\WooCommerce\Internal\Admin\Onboarding\OnboardingProducts::get_product_data();
 	}
 }


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

`\Onboarding` was missing from those namespaces.
From https://github.com/woocommerce/woocommerce/pull/37015#issuecomment-1453436541
