### PR TITLE
Fix variable name in Reports\Stock\Stats

### DIFF
--- a/plugins/woocommerce/changelog/pr-37057
+++ b/plugins/woocommerce/changelog/pr-37057
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Corrects a variable name in Reports\Stock\Stats. It was missed during the last name change.

--- a/plugins/woocommerce/src/Admin/API/Reports/Stock/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Stock/Stats/Controller.php
@@ -68,6 +68,8 @@ class Controller extends \WC_REST_Reports_Controller {
 		 *
 		 * Allows modification of the report data right before it is returned.
 		 *
+		 * @since 6.5.0
+		 *
 		 * @param WP_REST_Response $response The response object.
 		 * @param WC_Product       $report   The original object.
 		 * @param WP_REST_Request  $request  Request used to generate the response.

--- a/plugins/woocommerce/src/Admin/API/Reports/Stock/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Stock/Stats/Controller.php
@@ -69,10 +69,10 @@ class Controller extends \WC_REST_Reports_Controller {
 		 * Allows modification of the report data right before it is returned.
 		 *
 		 * @param WP_REST_Response $response The response object.
-		 * @param WC_Product       $product   The original bject.
+		 * @param WC_Product       $report   The original object.
 		 * @param WP_REST_Request  $request  Request used to generate the response.
 		 */
-		return apply_filters( 'woocommerce_rest_prepare_report_stock_stats', $response, $product, $request );
+		return apply_filters( 'woocommerce_rest_prepare_report_stock_stats', $response, $report, $request );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

It must be an old variable name.
From https://github.com/woocommerce/woocommerce/pull/37015#issuecomment-1453436541
