### PR TITLE
Update PR labeler to work with updated focus labels

### DIFF
--- a/.github/project-pr-labeler.yml
+++ b/.github/project-pr-labeler.yml
@@ -61,7 +61,7 @@
 'plugin: woocommerce':
 - plugins/woocommerce/**/*
 
-'focus: react admin':
+'focus: react admin [team:Ghidorah]':
 - plugins/woocommerce/src/Admin/**/*
 - plugins/woocommerce/src/Internal/Admin/**/*
 - plugins/woocommerce-admin/**/*


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

We recently added team names to the `focus: ...` labels:

https://github.com/woocommerce/woocommerce/labels?q=focus

The PR labeler relies on exact label names, however. This PR updates the PR labeler to conform to the new string.

### How to test the changes in this Pull Request:

1. ensure the changed label name is correct

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
