### PR TITLE
Hydrating product entity when creating or editing product with block editor

### DIFF
--- a/packages/js/product-editor/changelog/add-initial-product-draft-37003
+++ b/packages/js/product-editor/changelog/add-initial-product-draft-37003
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Adding support for the entity data store, and the details name block.

--- a/packages/js/product-editor/changelog/add-initial-product-draft-37003
+++ b/packages/js/product-editor/changelog/add-initial-product-draft-37003
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Adding support for the entity data store, and the details name block.

--- a/plugins/woocommerce-admin/client/products/product-page.tsx
+++ b/plugins/woocommerce-admin/client/products/product-page.tsx
@@ -51,6 +51,7 @@ const AddProductEditor = () => {
 	useEffect( () => {
 		saveEntityRecord( 'postType', 'product', {
 			title: AUTO_DRAFT_NAME,
+			status: 'auto-draft',
 			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 			// @ts-ignore Incorrect types.
 		} ).then( ( autoDraftProduct: Product ) => {

--- a/plugins/woocommerce-admin/client/products/product-page.tsx
+++ b/plugins/woocommerce-admin/client/products/product-page.tsx
@@ -1,19 +1,37 @@
 /**
  * External dependencies
  */
-import { __experimentalEditor as Editor } from '@woocommerce/product-editor';
+import {
+	__experimentalEditor as Editor,
+	AUTO_DRAFT_NAME,
+} from '@woocommerce/product-editor';
 import { Product } from '@woocommerce/data';
+import { useDispatch } from '@wordpress/data';
+import { useEffect, useState } from '@wordpress/element';
+import { Spinner } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import './product-page.scss';
 
-const dummyProduct = {
-	name: 'Example product',
-	short_description: 'Short product description content',
-} as Product;
-
 export default function ProductPage() {
-	return <Editor product={ dummyProduct } settings={ {} } />;
+	const { saveEntityRecord } = useDispatch( 'core' );
+	const [ product, setProduct ] = useState< Product | undefined >(
+		undefined
+	);
+
+	useEffect( () => {
+		saveEntityRecord( 'postType', 'product', {
+			title: AUTO_DRAFT_NAME,
+		} ).then( ( autoDraftProduct: Product ) => {
+			setProduct( autoDraftProduct );
+		} );
+	}, [] );
+
+	if ( ! product ) {
+		return <Spinner />;
+	}
+
+	return <Editor product={ product } settings={ {} } />;
 }

--- a/plugins/woocommerce/changelog/add-initial-product-draft-37003
+++ b/plugins/woocommerce/changelog/add-initial-product-draft-37003
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Creating product entity in auto-draft status, and adding support for retrieving preexisting products.

--- a/plugins/woocommerce/includes/class-wc-post-types.php
+++ b/plugins/woocommerce/includes/class-wc-post-types.php
@@ -625,6 +625,15 @@ class WC_Post_Types {
 					/* translators: %s: number of orders */
 					'label_count'               => _n_noop( 'Failed <span class="count">(%s)</span>', 'Failed <span class="count">(%s)</span>', 'woocommerce' ),
 				),
+				'auto-draft'    => array(
+					'label'                     => _x( 'Auto Draft', 'Order status', 'woocommerce' ),
+					'public'                    => false,
+					'exclude_from_search'       => false,
+					'show_in_admin_all_list'    => true,
+					'show_in_admin_status_list' => true,
+					/* translators: %s: number of orders */
+					'label_count'               => _n_noop( 'Auto draft <span class="count">(%s)</span>', 'Auto draft <span class="count">(%s)</span>', 'woocommerce' ),
+				),
 			)
 		);
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Hydrating the product entity and providing that to the product editor instead of a dummy product. 

If you're editing a product, it will provide the preexisting entity object.

If you're adding one, it will create a temporary `auto-draft` product. This will ensure it doesn't show up in listings, and will be cleaned up after 7 days be preexisting logic.

Closes #37003 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Checkout branch.
2. Enable `new-product-management-experience` feature flag.
3. Navigate to Products -> Add new.
4. You should see the block editor.
5. Open phpMyAdmin and view the `posts` table.
6. You should see that a post was created with type `product` and a status of `auto-draft`.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
