### PR TITLE
Fix/37083 page displays 0 for empty recommended channels

### DIFF
--- a/plugins/woocommerce-admin/client/marketing/overview-multichannel/MarketingOverviewMultichannel.tsx
+++ b/plugins/woocommerce-admin/client/marketing/overview-multichannel/MarketingOverviewMultichannel.tsx
@@ -44,10 +44,10 @@ export const MarketingOverviewMultichannel: React.FC = () => {
 
 	return (
 		<div className="woocommerce-marketing-overview-multichannel">
-			{ dataRegistered?.length && <Campaigns /> }
+			{ !! dataRegistered?.length && <Campaigns /> }
 			{ dataRegistered &&
 				dataRecommended &&
-				( dataRegistered.length || dataRecommended.length ) && (
+				!! ( dataRegistered.length || dataRecommended.length ) && (
 					<Channels
 						registeredChannels={ dataRegistered }
 						recommendedChannels={ dataRecommended }

--- a/plugins/woocommerce/changelog/fix-37083-page_displays_0_for_empty_recommended_channels
+++ b/plugins/woocommerce/changelog/fix-37083-page_displays_0_for_empty_recommended_channels
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix 0 rendered on short-circuit evaluation.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?


### Changes proposed in this Pull Request:

The issue happens because, in the following code, we use short-circuit evaluation on arrays. When the array lengths are 0, they will be rendered as literal `0` on the page.

https://github.com/woocommerce/woocommerce/blob/deb1d131add8d90fa4fda42ceaf573a38887d02a/plugins/woocommerce-admin/client/marketing/overview-multichannel/MarketingOverviewMultichannel.tsx#L47-L56

This PR casts the array.length into a bool, stopping `0` from rendering.

Closes #37083.


### How to test the changes in this Pull Request:

1. Follow the step to reproduce explained in #37083.
2. Build the JS (pnpm run build ) and confirm no `0` is rendered on the multichannel marketing page.


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable? **(N/A)**
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
