### PR TITLE
Live branches: tweak workflow naming for clarity

### DIFF
--- a/.github/workflows/pr-build-live-branch-skip.yml
+++ b/.github/workflows/pr-build-live-branch-skip.yml
@@ -1,5 +1,5 @@
 # Duplicate workflow that returns success for this check when there is no relevant file change. See https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
-name: Build Live Branch
+name: "Build Live Branch: Skip Changelogs"
 on:
     pull_request:
         paths:


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

While looking through our various workflows I noticed a duplicate entry. As this was the workflow I was looking for I then needed to understand why both versions existed by reading and understanding their instructions. This PR adds a simple distinction in the name to ensure it's easier to distinguish both workflows in the future. 

### How to test the changes in this Pull Request:

This does not change how the workflow works. Please check that I spelled and formatted things correctly, and ensure that the actual name of the workflow isn't used as a hard-coded magic string anywhere (I wasn't able to find anything). 

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
