### PR TITLE
Fix duplicated global attribute

### DIFF
--- a/plugins/woocommerce/changelog/fix-37020_duplicated_global_attribute
+++ b/plugins/woocommerce/changelog/fix-37020_duplicated_global_attribute
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix duplicated global attribute

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -652,9 +652,15 @@ jQuery( function ( $ ) {
 				attribute_row_indexes();
 			}
 
+			$parent.remove();
+
 			if (
 				! $( '.woocommerce_attribute_data' ).is( ':visible' ) &&
-				! $( 'div.add-global-attribute-container' ).hasClass( 'hidden' )
+				! $( 'div.add-global-attribute-container' ).hasClass(
+					'hidden'
+				) &&
+				$( '.product_attributes' ).find( 'input, select, textarea' )
+					.length === 0
 			) {
 				toggle_add_global_attribute_layout();
 			}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR fixes the duplicated global attribute under `Product > Add New > Product data > Attributes`.

Closes #37020.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Go to `Products > Attributes` and create a couple of global attributes.
2. Then go to Product > Add New > Product data > Attributes` and add a global attribute and **add some terms** and click **Save attributes**.
3. Remove the attribute that you just saved.
4. Add the same global attribute back in and **add terms**
5. Click **Save attributes** and confirm that only one attribute is being shown.
6. Click **Remove** and verify that the placeholder is back and there aren't any global attributes at the bottom.

**Before**

![Screenshot 2023-03-01 at 16 38 41](https://user-images.githubusercontent.com/1314156/222246424-5dc6b7f3-1ff4-4904-9d85-8c0c43460f9c.png)
<img width="863" alt="Screenshot 2023-03-01 at 9 42 16 AM" src="https://user-images.githubusercontent.com/2240960/222088189-0893624c-2767-4441-8510-c36e4bba31d7.png">

**Now**

![Screen Capture on 2023-03-07 at 15-16-26](https://user-images.githubusercontent.com/1314156/223513866-63ef53c9-bcfe-4707-b309-15495f33403c.gif)


<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
