### PR TITLE
Show create button at fixed position at the bottom of the dropdown list

### DIFF
--- a/packages/js/components/changelog/update-fixed-create-btn
+++ b/packages/js/components/changelog/update-fixed-create-btn
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Show create new category button in fixed position

--- a/packages/js/components/changelog/update-fixed-create-btn
+++ b/packages/js/components/changelog/update-fixed-create-btn
@@ -1,4 +1,4 @@
 Significance: minor
 Type: update
 
-Show create new category button in fixed position
+Add fixedPositionElement to Menu

--- a/packages/js/components/src/experimental-select-control/menu.tsx
+++ b/packages/js/components/src/experimental-select-control/menu.tsx
@@ -22,7 +22,6 @@ type MenuProps = {
 	getMenuProps: getMenuPropsType;
 	isOpen: boolean;
 	className?: string;
-	fixedPositionElement?: JSX.Element | null;
 };
 
 export const Menu = ( {
@@ -30,7 +29,6 @@ export const Menu = ( {
 	getMenuProps,
 	isOpen,
 	className,
-	fixedPositionElement,
 }: MenuProps ) => {
 	const [ boundingRect, setBoundingRect ] = useState< DOMRect >();
 	const selectControlMenuRef = useRef< HTMLDivElement >( null );
@@ -81,7 +79,6 @@ export const Menu = ( {
 					>
 						{ isOpen && children }
 					</ul>
-					{ fixedPositionElement ?? null }
 				</Popover>
 			</div>
 		</div>

--- a/packages/js/components/src/experimental-select-control/menu.tsx
+++ b/packages/js/components/src/experimental-select-control/menu.tsx
@@ -22,6 +22,7 @@ type MenuProps = {
 	getMenuProps: getMenuPropsType;
 	isOpen: boolean;
 	className?: string;
+	fixedPositionElement?: JSX.Element | null;
 };
 
 export const Menu = ( {
@@ -29,6 +30,7 @@ export const Menu = ( {
 	getMenuProps,
 	isOpen,
 	className,
+	fixedPositionElement,
 }: MenuProps ) => {
 	const [ boundingRect, setBoundingRect ] = useState< DOMRect >();
 	const selectControlMenuRef = useRef< HTMLDivElement >( null );
@@ -79,6 +81,7 @@ export const Menu = ( {
 					>
 						{ isOpen && children }
 					</ul>
+					{ fixedPositionElement ?? null }
 				</Popover>
 			</div>
 		</div>

--- a/packages/js/internal-style-build/abstracts/_colors.scss
+++ b/packages/js/internal-style-build/abstracts/_colors.scss
@@ -17,6 +17,7 @@ $input-active-border: #00a0d2;
 $input-active-inner: $button-focus-inner;
 $input-active-outer: $button-focus-outer;
 $table-border: #e2e4e7;
+$gutenberg-blue: #007cba;
 
 // Bright colors
 $valid-green: #4ab866;

--- a/packages/js/product-editor/changelog/update-fixed-create-btn
+++ b/packages/js/product-editor/changelog/update-fixed-create-btn
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Show create new category button in fixed position

--- a/packages/js/product-editor/src/components/details-categories-field/category-field-add-new-item.tsx
+++ b/packages/js/product-editor/src/components/details-categories-field/category-field-add-new-item.tsx
@@ -20,14 +20,11 @@ type CategoryFieldAddNewItemProps = {
 
 export const CategoryFieldAddNewItem: React.FC<
 	CategoryFieldAddNewItemProps
-> = ( { item, highlightedIndex, getItemProps, items } ) => {
+> = ( { item, highlightedIndex, items, getItemProps } ) => {
 	const index = items.findIndex( ( i ) => i.id === item.id );
 	return (
-		<li
-			{ ...getItemProps( {
-				item,
-				index,
-			} ) }
+		<span
+			{ ...getItemProps( { item, index } ) }
 			className={ classNames(
 				'woocommerce-category-field-dropdown__item is-new',
 				{
@@ -41,8 +38,10 @@ export const CategoryFieldAddNewItem: React.FC<
 					icon={ plus }
 					size={ 20 }
 				/>
-				{ sprintf( __( 'Create "%s"', 'woocommerce' ), item.name ) }
+				{ item.name
+					? sprintf( __( 'Create "%s"', 'woocommerce' ), item.name )
+					: __( 'Create new', 'woocommerce' ) }
 			</div>
-		</li>
+		</span>
 	);
 };

--- a/packages/js/product-editor/src/components/details-categories-field/category-field.tsx
+++ b/packages/js/product-editor/src/components/details-categories-field/category-field.tsx
@@ -197,10 +197,24 @@ export const CategoryField: React.FC< CategoryFieldProps > = ( {
 											?.parentID === 0 || item.id === -99
 							  )
 							: [];
+					const notCreatedItem = items.find(
+						( item ) => item.id === -99
+					);
 					return (
 						<Menu
 							isOpen={ isOpen }
 							getMenuProps={ getMenuProps }
+							fixedPositionElement={
+								notCreatedItem ? (
+									<CategoryFieldAddNewItem
+										key={ `${ notCreatedItem.id }` }
+										item={ notCreatedItem }
+										highlightedIndex={ highlightedIndex }
+										items={ items }
+										getItemProps={ getItemProps }
+									/>
+								) : null
+							}
 							className="woocommerce-category-field-dropdown__menu"
 						>
 							<>
@@ -212,17 +226,7 @@ export const CategoryField: React.FC< CategoryFieldProps > = ( {
 									</li>
 								) : (
 									rootItems.map( ( item ) => {
-										return item.id === -99 ? (
-											<CategoryFieldAddNewItem
-												key={ `${ item.id }` }
-												item={ item }
-												highlightedIndex={
-													highlightedIndex
-												}
-												items={ items }
-												getItemProps={ getItemProps }
-											/>
-										) : (
+										return item.id === -99 ? null : (
 											<CategoryFieldItem
 												key={ `${ item.id }` }
 												item={

--- a/packages/js/product-editor/src/components/details-categories-field/category-field.tsx
+++ b/packages/js/product-editor/src/components/details-categories-field/category-field.tsx
@@ -197,24 +197,10 @@ export const CategoryField: React.FC< CategoryFieldProps > = ( {
 											?.parentID === 0 || item.id === -99
 							  )
 							: [];
-					const notCreatedItem = items.find(
-						( item ) => item.id === -99
-					);
 					return (
 						<Menu
 							isOpen={ isOpen }
 							getMenuProps={ getMenuProps }
-							fixedPositionElement={
-								notCreatedItem ? (
-									<CategoryFieldAddNewItem
-										key={ `${ notCreatedItem.id }` }
-										item={ notCreatedItem }
-										highlightedIndex={ highlightedIndex }
-										items={ items }
-										getItemProps={ getItemProps }
-									/>
-								) : null
-							}
 							className="woocommerce-category-field-dropdown__menu"
 						>
 							<>
@@ -226,7 +212,17 @@ export const CategoryField: React.FC< CategoryFieldProps > = ( {
 									</li>
 								) : (
 									rootItems.map( ( item ) => {
-										return item.id === -99 ? null : (
+										return item.id === -99 ? (
+											<CategoryFieldAddNewItem
+												key={ `${ item.id }` }
+												item={ item }
+												highlightedIndex={
+													highlightedIndex
+												}
+												items={ items }
+												getItemProps={ getItemProps }
+											/>
+										) : (
 											<CategoryFieldItem
 												key={ `${ item.id }` }
 												item={

--- a/packages/js/product-editor/src/components/details-categories-field/category-field.tsx
+++ b/packages/js/product-editor/src/components/details-categories-field/category-field.tsx
@@ -117,7 +117,6 @@ export const CategoryField: React.FC< CategoryFieldProps > = ( {
 			selectedItems
 		);
 		if (
-			inputValue.length > 0 &&
 			! isSearching &&
 			! filteredItems.find(
 				( item ) => item.name.toLowerCase() === inputValue.toLowerCase()
@@ -205,15 +204,14 @@ export const CategoryField: React.FC< CategoryFieldProps > = ( {
 							isOpen={ isOpen }
 							getMenuProps={ getMenuProps }
 							fixedPositionElement={
-								notCreatedItem ? (
+								notCreatedItem && (
 									<CategoryFieldAddNewItem
-										key={ `${ notCreatedItem.id }` }
 										item={ notCreatedItem }
 										highlightedIndex={ highlightedIndex }
 										items={ items }
 										getItemProps={ getItemProps }
 									/>
-								) : null
+								)
 							}
 							className="woocommerce-category-field-dropdown__menu"
 						>

--- a/packages/js/product-editor/src/components/details-categories-field/category-field.tsx
+++ b/packages/js/product-editor/src/components/details-categories-field/category-field.tsx
@@ -224,7 +224,7 @@ export const CategoryField: React.FC< CategoryFieldProps > = ( {
 									</li>
 								) : (
 									rootItems.map( ( item ) => {
-										return item.id === -99 ? null : (
+										return item.id !== -99 ? (
 											<CategoryFieldItem
 												key={ `${ item.id }` }
 												item={
@@ -239,7 +239,7 @@ export const CategoryField: React.FC< CategoryFieldProps > = ( {
 												items={ items }
 												getItemProps={ getItemProps }
 											/>
-										);
+										) : null;
 									} )
 								) }
 							</>

--- a/packages/js/product-editor/src/components/details-categories-field/style.scss
+++ b/packages/js/product-editor/src/components/details-categories-field/style.scss
@@ -25,8 +25,11 @@
 			}
 		}
 		&.is-new {
+			color: $gutenberg-blue;
 			.category-field-dropdown__toggle {
+				margin-left: $gap-smaller;
 				margin-right: $gap-smaller;
+				fill: $gutenberg-blue;
 			}
 		}
 	}


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


Shows the Create button from the categories field at a fixed position at the bottom, so that the users can always see them.

Check additional acceptance criteria at issue #35969.


There is one acceptance criterion that I was unable to achieve and I think we should consider removing it in case we want to maintain the same behavior at the component, which is having the focus on the input field at all times:
> Users can quickly navigate to it using the Tab key.
It would involve at least preventing the default tab action. I'm not sure about doing this. The users can achieve similar behavior by pressing the End key on the keyboard.

Closes #35969 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Open the new product manager
2. Focus on the Category field
3. Check that "Create new" appears at the bottom of the list
4. Type some non-existing value
5. Check that the label changes to "Create 'value'"
6. Check that the up, down, home, and end buttons work as expected
7. Check that the "Create new" button is clickable


<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [ ] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
