### PR TITLE
Use feature the new feature flags engine to guard the access to the new product blocks experience

### DIFF
--- a/plugins/woocommerce-admin/client/layout/controller.js
+++ b/plugins/woocommerce-admin/client/layout/controller.js
@@ -21,16 +21,17 @@ import { Spinner } from '@woocommerce/components';
  */
 import getReports from '../analytics/report/get-reports';
 import { getAdminSetting } from '~/utils/admin-settings';
+import { isFeatureEnabled } from '~/utils/features';
 import { NoMatch } from './NoMatch';
 
+const AddProductPage = lazy( () =>
+	import(
+		/* webpackChunkName: "edit-product-page" */ '../products/add-product-page'
+	)
+);
 const EditProductPage = lazy( () =>
 	import(
 		/* webpackChunkName: "edit-product-page" */ '../products/edit-product-page'
-	)
-);
-const AddProductPage = lazy( () =>
-	import(
-		/* webpackChunkName: "add-product-page" */ '../products/add-product-page'
 	)
 );
 const ProductPage = lazy( () =>
@@ -171,9 +172,18 @@ export const getPages = () => {
 		} );
 	}
 
-	if ( window.wcAdminFeatures[ 'product-block-editor' ] ) {
-		pages.push( {
+	if ( isFeatureEnabled( 'product_block_editor' ) ) {
+		const productPage = {
 			container: ProductPage,
+			layout: {
+				header: false,
+			},
+			wpOpenMenu: 'menu-posts-product',
+			capability: 'manage_woocommerce',
+		};
+
+		pages.push( {
+			...productPage,
 			path: '/add-product',
 			breadcrumbs: [
 				[ '/add-product', __( 'Product', 'woocommerce' ) ],
@@ -182,15 +192,10 @@ export const getPages = () => {
 			navArgs: {
 				id: 'woocommerce-add-product',
 			},
-			layout: {
-				header: false,
-			},
-			wpOpenMenu: 'menu-posts-product',
-			capability: 'manage_woocommerce',
 		} );
 
 		pages.push( {
-			container: ProductPage,
+			...productPage,
 			path: '/product/:productId',
 			breadcrumbs: [
 				[ '/edit-product', __( 'Product', 'woocommerce' ) ],
@@ -199,11 +204,6 @@ export const getPages = () => {
 			navArgs: {
 				id: 'woocommerce-edit-product',
 			},
-			layout: {
-				header: false,
-			},
-			wpOpenMenu: 'menu-posts-product',
-			capability: 'manage_woocommerce',
 		} );
 	} else if (
 		window.wcAdminFeatures[ 'new-product-management-experience' ]
@@ -460,9 +460,10 @@ export function updateLinkHref( item, nextQuery, excludedScreens ) {
 window.wpNavMenuUrlUpdate = function ( query ) {
 	const nextQuery = getPersistedQuery( query );
 	const excludedScreens = getQueryExcludedScreens();
+	const anchors = document.querySelectorAll( '#adminmenu a' );
 
-	Array.from( document.querySelectorAll( '#adminmenu a' ) ).forEach(
-		( item ) => updateLinkHref( item, nextQuery, excludedScreens )
+	Array.from( anchors ).forEach( ( item ) =>
+		updateLinkHref( item, nextQuery, excludedScreens )
 	);
 };
 

--- a/plugins/woocommerce-admin/client/typings/global.d.ts
+++ b/plugins/woocommerce-admin/client/typings/global.d.ts
@@ -9,7 +9,6 @@ declare global {
 		wcAdminFeatures: {
 			'activity-panels': boolean;
 			analytics: boolean;
-			'product-block-editor': boolean;
 			coupons: boolean;
 			'customer-effort-score-tracks': boolean;
 			homescreen: boolean;

--- a/plugins/woocommerce-admin/client/utils/features/features.ts
+++ b/plugins/woocommerce-admin/client/utils/features/features.ts
@@ -1,0 +1,40 @@
+/**
+ * Internal dependencies
+ */
+import { getAdminSetting } from '../admin-settings';
+import { Feature } from './types';
+
+const ADMIN_SETTINGS_FEATURES_NAME = 'features';
+
+/**
+ * Get the feature flag from admin settings.
+ *
+ * @param  featureId The feature id
+ * @return The feature flag
+ */
+export function getFeature( featureId: string ): Feature | undefined {
+	const features = getAdminSetting( ADMIN_SETTINGS_FEATURES_NAME );
+	return features && features[ featureId ];
+}
+
+/**
+ * Returns if the feature is enabled.
+ *
+ * @param  featureId The feature id
+ * @return `true` or `false` if the given feature is enabled
+ */
+export function isFeatureEnabled( featureId: string ): boolean {
+	const feature = getFeature( featureId );
+	return Boolean( feature?.is_enabled );
+}
+
+/**
+ * Returns if the feature is experimental.
+ *
+ * @param  featureId The feature id
+ * @return `true` or `false` if the given feature is experimental
+ */
+export function isFeatureExperimental( featureId: string ): boolean {
+	const feature = getFeature( featureId );
+	return Boolean( feature?.is_experimental );
+}

--- a/plugins/woocommerce-admin/client/utils/features/index.ts
+++ b/plugins/woocommerce-admin/client/utils/features/index.ts
@@ -1,0 +1,2 @@
+export * from './features';
+export * from './types';

--- a/plugins/woocommerce-admin/client/utils/features/types.ts
+++ b/plugins/woocommerce-admin/client/utils/features/types.ts
@@ -1,0 +1,7 @@
+/**
+ * Describe a Feature Flag
+ */
+export interface Feature {
+	is_enabled: boolean;
+	is_experimental: boolean;
+}

--- a/plugins/woocommerce/changelog/add-36989
+++ b/plugins/woocommerce/changelog/add-36989
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Get feature flags from client side

--- a/plugins/woocommerce/client/admin/config/core.json
+++ b/plugins/woocommerce/client/admin/config/core.json
@@ -2,7 +2,7 @@
 	"features": {
 		"activity-panels": true,
 		"analytics": true,
-		"product-block-editor": false,
+		"product-block-editor": true,
 		"coupons": true,
 		"core-profiler": false,
 		"customer-effort-score-tracks": true,

--- a/plugins/woocommerce/client/admin/config/development.json
+++ b/plugins/woocommerce/client/admin/config/development.json
@@ -15,7 +15,7 @@
 		"minified-js": true,
 		"mobile-app-banner": true,
 		"navigation": true,
-		"new-product-management-experience": true,
+		"new-product-management-experience": false,
 		"onboarding": true,
 		"onboarding-tasks": true,
 		"payment-gateway-suggestions": true,

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -227,7 +227,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 						'gateway_toggle' => wp_create_nonce( 'woocommerce-toggle-payment-gateway-enabled' ),
 					),
 					'urls'                              => array(
-						'add_product'     => Features::is_enabled( 'new-product-management-experience' ) || Features::is_enabled( 'product-block-editor' ) ? esc_url_raw( admin_url( 'admin.php?page=wc-admin&path=/add-product' ) ) : null,
+						'add_product'     => Features::is_enabled( 'new-product-management-experience' ) || \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_block_editor' ) ? esc_url_raw( admin_url( 'admin.php?page=wc-admin&path=/add-product' ) ) : null,
 						'import_products' => current_user_can( 'import' ) ? esc_url_raw( admin_url( 'edit.php?post_type=product&page=product_importer' ) ) : null,
 						'export_products' => current_user_can( 'export' ) ? esc_url_raw( admin_url( 'edit.php?post_type=product&page=product_exporter' ) ) : null,
 					),

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -427,7 +427,7 @@ class WC_Admin_Menus {
 	 * Maybe add new management product experience.
 	 */
 	public function maybe_add_new_product_management_experience() {
-		if ( Features::is_enabled( 'new-product-management-experience' ) || Features::is_enabled( 'product-block-editor' ) ) {
+		if ( Features::is_enabled( 'new-product-management-experience' ) || \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_block_editor' ) ) {
 			global $submenu;
 			if ( isset( $submenu['edit.php?post_type=product'][10] ) ) {
 				// Disable phpcs since we need to override submenu classes.

--- a/plugins/woocommerce/src/Admin/Features/Features.php
+++ b/plugins/woocommerce/src/Admin/Features/Features.php
@@ -40,7 +40,6 @@ class Features {
 	protected static $beta_features = array(
 		'navigation',
 		'new-product-management-experience',
-		'product-block-editor',
 		'settings',
 	);
 

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -15,14 +15,6 @@ use WP_Block_Editor_Context;
  * Loads assets related to the product block editor.
  */
 class Init {
-
-	const FEATURE_ID = 'product-block-editor';
-
-	/**
-	 * Option name used to toggle this feature.
-	 */
-	const TOGGLE_OPTION_NAME = 'woocommerce_' . self::FEATURE_ID . '_enabled';
-
 	/**
 	 * The context name used to identify the editor.
 	 */
@@ -32,11 +24,11 @@ class Init {
 	 * Constructor
 	 */
 	public function __construct() {
-		if ( ! Features::is_enabled( 'new-product-management-experience' ) && Features::is_enabled( self::FEATURE_ID ) ) {
-			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_styles' ) );
-			add_action( 'get_edit_post_link', array( $this, 'update_edit_product_link' ), 10, 2 );
-		}
-		if ( Features::is_enabled( self::FEATURE_ID ) ) {
+		if ( \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_block_editor' ) ) {
+			if ( ! Features::is_enabled( 'new-product-management-experience' ) ) {
+				add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_styles' ) );
+				add_action( 'get_edit_post_link', array( $this, 'update_edit_product_link' ), 10, 2 );
+			}
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 			add_filter( 'woocommerce_register_post_type_product', array( $this, 'add_product_template' ) );
 			$block_registry = new BlockRegistry();

--- a/plugins/woocommerce/src/Internal/Admin/Settings.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\Admin\API\Plugins;
 use Automattic\WooCommerce\Admin\PageController;
 use Automattic\WooCommerce\Admin\API\Reports\Orders\DataStore as OrdersDataStore;
 use Automattic\WooCommerce\Admin\PluginsHelper;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use WC_Marketplace_Suggestions;
 
 /**
@@ -233,7 +234,28 @@ class Settings {
 		$settings['connectNonce']                     = wp_create_nonce( 'connect' );
 		$settings['wcpay_welcome_page_connect_nonce'] = wp_create_nonce( 'wcpay-connect' );
 
+		$settings['features'] = $this->get_features();
+
 		return $settings;
+	}
+
+	/**
+	 * Removes non necesary feature properties for the client side.
+	 *
+	 * @return array
+	 */
+	public function get_features() {
+		$features     = FeaturesUtil::get_features( true, true );
+		$new_features = array();
+
+		foreach ( array_keys( $features ) as $feature_id ) {
+			$new_features[ $feature_id ] = array(
+				'is_enabled'      => $features[ $feature_id ]['is_enabled'],
+				'is_experimental' => $features[ $feature_id ]['is_experimental'],
+			);
+		}
+
+		return $new_features;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -90,32 +90,32 @@ class FeaturesController {
 	 */
 	public function __construct() {
 		$features = array(
-			'analytics'              => array(
+			'analytics'            => array(
 				'name'               => __( 'Analytics', 'woocommerce' ),
 				'description'        => __( 'Enables WooCommerce Analytics', 'woocommerce' ),
 				'is_experimental'    => false,
 				'enabled_by_default' => true,
 				'disable_ui'         => false,
 			),
-			'new_navigation'         => array(
+			'new_navigation'       => array(
 				'name'            => __( 'Navigation', 'woocommerce' ),
 				'description'     => __( 'Adds the new WooCommerce navigation experience to the dashboard', 'woocommerce' ),
 				'is_experimental' => false,
 				'disable_ui'      => false,
 			),
-			'new_product_management' => array(
+			'product_block_editor' => array(
 				'name'            => __( 'New product editor', 'woocommerce' ),
 				'description'     => __( 'Try the new product editor (Beta)', 'woocommerce' ),
 				'is_experimental' => true,
 				'disable_ui'      => false,
 			),
-			'custom_order_tables'    => array(
+			'custom_order_tables'  => array(
 				'name'            => __( 'High-Performance order storage (COT)', 'woocommerce' ),
 				'description'     => __( 'Enable the high performance order storage feature.', 'woocommerce' ),
 				'is_experimental' => true,
 				'disable_ui'      => false,
 			),
-			'cart_checkout_blocks'   => array(
+			'cart_checkout_blocks' => array(
 				'name'            => __( 'Cart & Checkout Blocks', 'woocommerce' ),
 				'description'     => __( 'Optimize for faster checkout', 'woocommerce' ),
 				'is_experimental' => false,
@@ -123,7 +123,7 @@ class FeaturesController {
 			),
 		);
 
-		$this->legacy_feature_ids = array( 'analytics', 'new_navigation', 'new_product_management' );
+		$this->legacy_feature_ids = array( 'analytics', 'new_navigation' );
 
 		$this->init_features( $features );
 
@@ -409,8 +409,6 @@ class FeaturesController {
 			return Analytics::TOGGLE_OPTION_NAME;
 		} elseif ( 'new_navigation' === $feature_id ) {
 			return Init::TOGGLE_OPTION_NAME;
-		} elseif ( 'new_product_management' === $feature_id ) {
-			return NewProductManagementExperience::TOGGLE_OPTION_NAME;
 		}
 
 		return "woocommerce_feature_{$feature_id}_enabled";
@@ -480,8 +478,6 @@ class FeaturesController {
 			$feature_id = 'analytics';
 		} elseif ( Init::TOGGLE_OPTION_NAME === $option ) {
 			$feature_id = 'new_navigation';
-		} elseif ( NewProductManagementExperience::TOGGLE_OPTION_NAME === $option ) {
-			$feature_id = 'new_product_management';
 		} else {
 			$feature_id = $matches[1];
 		}
@@ -657,9 +653,11 @@ class FeaturesController {
 			}
 		}
 
-		if ( 'new_product_management' === $feature_id ) {
-			$disabled = true;
-			$desc_tip = __( '⚠ This feature will be available soon. Stay tuned!', 'woocommerce' );
+		if ( 'product_block_editor' === $feature_id ) {
+			$disabled = version_compare( get_bloginfo( 'version' ), '6.2', '<' );
+			if ( $disabled ) {
+				$desc_tip = __( '⚠ This feature is compatible with WordPress version 6.2 or higher.', 'woocommerce' );
+			}
 		}
 
 		if ( ! $this->is_legacy_feature( $feature_id ) && ! $disabled && $this->verify_did_woocommerce_init() ) {


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/36989

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Visiting `/wp-admin/admin.php?page=wc-admin&path=/add-product` or `/wp-admin/admin.php?page=wc-admin&path=/product/{productId}` you should see the previous product experience.
2. After enabled the setting `New product management experience` in `WooCommerce -> Settings -> Advanced -> Features` and visiting back the urls of point 1, you should see the new product editor blocks. And the previous product experience remains accessible using `/wp-admin/admin.php?page=wc-admin&path=/add-product-old` or `/wp-admin/admin.php?page=wc-admin&path=/product-old/{productId}` routes.
3. After disabled the setting you should see the same as in point 1.

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [ ] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
