### PR TITLE
Hydrate product editor settings

### DIFF
--- a/packages/js/product-editor/changelog/add-37120_hydrate_product_editor_settings
+++ b/packages/js/product-editor/changelog/add-37120_hydrate_product_editor_settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Export the ProductEditorSettings type.

--- a/packages/js/product-editor/src/components/editor/editor.tsx
+++ b/packages/js/product-editor/src/components/editor/editor.tsx
@@ -26,10 +26,12 @@ import { BlockEditor } from '../block-editor';
 import { initBlocks } from './init-blocks';
 
 initBlocks();
-
+export type ProductEditorSettings = Partial<
+	EditorSettings & EditorBlockListSettings
+>;
 type EditorProps = {
 	product: Product;
-	settings: Partial< EditorSettings & EditorBlockListSettings > | undefined;
+	settings: ProductEditorSettings | undefined;
 };
 
 export function Editor( { product, settings }: EditorProps ) {

--- a/packages/js/product-editor/src/components/index.ts
+++ b/packages/js/product-editor/src/components/index.ts
@@ -10,4 +10,7 @@ export { DetailsFeatureField as __experimentalDetailsFeatureField } from './deta
 export { DetailsCategoriesField as __experimentalDetailsCategoriesField } from './details-categories-field';
 export { DetailsSummaryField as __experimentalDetailsSummaryField } from './details-summary-field';
 export { DetailsDescriptionField as __experimentalDetailsDescriptionField } from './details-description-field';
-export { Editor as __experimentalEditor } from './editor';
+export {
+	Editor as __experimentalEditor,
+	ProductEditorSettings,
+} from './editor';

--- a/plugins/woocommerce-admin/client/products/product-page.tsx
+++ b/plugins/woocommerce-admin/client/products/product-page.tsx
@@ -4,6 +4,7 @@
 import {
 	__experimentalEditor as Editor,
 	AUTO_DRAFT_NAME,
+	ProductEditorSettings,
 } from '@woocommerce/product-editor';
 import { Product } from '@woocommerce/data';
 import { useDispatch, useSelect, select as WPSelect } from '@wordpress/data';
@@ -16,6 +17,8 @@ import { useParams } from 'react-router-dom';
  */
 import './product-page.scss';
 
+declare const productBlockEditorSettings: ProductEditorSettings;
+
 const ProductEditor: React.FC< { product: Product | undefined } > = ( {
 	product,
 } ) => {
@@ -23,7 +26,12 @@ const ProductEditor: React.FC< { product: Product | undefined } > = ( {
 		return <Spinner />;
 	}
 
-	return <Editor product={ product } settings={ {} } />;
+	return (
+		<Editor
+			product={ product }
+			settings={ productBlockEditorSettings || {} }
+		/>
+	);
 };
 
 const EditProductEditor: React.FC< { productId: string } > = ( {

--- a/plugins/woocommerce/changelog/add-37120_hydrate_product_editor_settings
+++ b/plugins/woocommerce/changelog/add-37120_hydrate_product_editor_settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add productBlockEditorSettings script to be used for the Product Block Editor.

--- a/plugins/woocommerce/includes/class-wc-post-types.php
+++ b/plugins/woocommerce/includes/class-wc-post-types.php
@@ -366,6 +366,11 @@ class WC_Post_Types {
 					'show_in_nav_menus'   => true,
 					'show_in_rest'        => true,
 					'rest_namespace'      => 'wp/v3',
+					'template' => array(
+						array( 'core/paragraph', array(
+							'placeholder' => 'Product description',
+						) ),
+					),
 				)
 			)
 		);

--- a/plugins/woocommerce/includes/class-wc-post-types.php
+++ b/plugins/woocommerce/includes/class-wc-post-types.php
@@ -366,10 +366,13 @@ class WC_Post_Types {
 					'show_in_nav_menus'   => true,
 					'show_in_rest'        => true,
 					'rest_namespace'      => 'wp/v3',
-					'template' => array(
-						array( 'core/paragraph', array(
-							'placeholder' => 'Product description',
-						) ),
+					'template'            => array(
+						array(
+							'core/paragraph',
+							array(
+								'placeholder' => 'Product description',
+							),
+						),
 					),
 				)
 			)

--- a/plugins/woocommerce/src/Admin/Features/BlockEditorFeatureEnabled.php
+++ b/plugins/woocommerce/src/Admin/Features/BlockEditorFeatureEnabled.php
@@ -27,9 +27,11 @@ class BlockEditorFeatureEnabled {
 	 */
 	public function __construct() {
 		if ( ! Features::is_enabled( 'new-product-management-experience' ) && Features::is_enabled( self::FEATURE_ID ) ) {
-			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_styles' ) );
 			add_action( 'get_edit_post_link', array( $this, 'update_edit_product_link' ), 10, 2 );
+		}
+		if ( Features::is_enabled( self::FEATURE_ID ) ) {
+			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 		}
 	}
 

--- a/plugins/woocommerce/src/Admin/Features/BlockEditorFeatureEnabled.php
+++ b/plugins/woocommerce/src/Admin/Features/BlockEditorFeatureEnabled.php
@@ -8,6 +8,7 @@ namespace Automattic\WooCommerce\Admin\Features;
 use Automattic\WooCommerce\Admin\Features\TransientNotices;
 use Automattic\WooCommerce\Admin\PageController;
 use Automattic\WooCommerce\Internal\Admin\Loader;
+use WP_Block_Editor_Context;
 
 /**
  * Loads assets related to the new product management experience page.
@@ -26,9 +27,38 @@ class BlockEditorFeatureEnabled {
 	 */
 	public function __construct() {
 		if ( ! Features::is_enabled( 'new-product-management-experience' ) && Features::is_enabled( self::FEATURE_ID ) ) {
+			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_styles' ) );
 			add_action( 'get_edit_post_link', array( $this, 'update_edit_product_link' ), 10, 2 );
 		}
+	}
+
+	/**
+	 * Enqueue scripts needed for the product form block editor.
+	 */
+	public function enqueue_scripts() {
+		if ( ! PageController::is_admin_or_embed_page() ) {
+			return;
+		}
+		$post_type_object     = get_post_type_object( 'product' );
+		$block_editor_context = new WP_Block_Editor_Context( array( 'name' => 'core/edit-post' ) );
+
+		$editor_settings = array();
+		if ( ! empty( $post_type_object->template ) ) {
+			$editor_settings['template']     = $post_type_object->template;
+			$editor_settings['templateLock'] = ! empty( $post_type_object->template_lock ) ? $post_type_object->template_lock : false;
+		}
+
+		$editor_settings = get_block_editor_settings( $editor_settings, $block_editor_context );
+
+		$script_handle = 'wc-admin-edit-product';
+		wp_register_script( $script_handle, '', array(), '0.1.0', true );
+		wp_enqueue_script( $script_handle );
+		wp_add_inline_script(
+			$script_handle,
+			'var productBlockEditorSettings = productBlockEditorSettings || ' . wp_json_encode( $editor_settings ) . ';',
+			'before'
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/NewProductManagementExperience.php
+++ b/plugins/woocommerce/src/Admin/Features/NewProductManagementExperience.php
@@ -72,9 +72,6 @@ class NewProductManagementExperience {
 			$editor_settings['templateLock'] = ! empty( $post_type_object->template_lock ) ? $post_type_object->template_lock : false;
 		}
 
-		if ( wp_is_block_theme() && $editor_settings['supportsTemplateMode'] ) {
-			$editor_settings['defaultTemplatePartAreas'] = get_allowed_block_template_part_areas();
-		}
 		$editor_settings = get_block_editor_settings( $editor_settings, $block_editor_context );
 
 		$script_handle = 'wc-admin-edit-product';

--- a/plugins/woocommerce/src/Admin/Features/NewProductManagementExperience.php
+++ b/plugins/woocommerce/src/Admin/Features/NewProductManagementExperience.php
@@ -78,11 +78,11 @@ class NewProductManagementExperience {
 		$editor_settings = get_block_editor_settings( $editor_settings, $block_editor_context );
 
 		$script_handle = 'wc-admin-edit-product';
-		wp_register_script( $script_handle, '' );
+		wp_register_script( $script_handle, '', array(), '0.1.0' );
 		wp_enqueue_script( $script_handle );
 		wp_add_inline_script(
 			$script_handle,
-			"var productBlockEditorSettings = productBlockEditorSettings || " . wp_json_encode( $editor_settings ) . ";",
+			'var productBlockEditorSettings = productBlockEditorSettings || ' . wp_json_encode( $editor_settings ) . ';',
 			'before'
 		);
 	}

--- a/plugins/woocommerce/src/Admin/Features/NewProductManagementExperience.php
+++ b/plugins/woocommerce/src/Admin/Features/NewProductManagementExperience.php
@@ -78,7 +78,7 @@ class NewProductManagementExperience {
 		$editor_settings = get_block_editor_settings( $editor_settings, $block_editor_context );
 
 		$script_handle = 'wc-admin-edit-product';
-		wp_register_script( $script_handle, '', array(), '0.1.0' );
+		wp_register_script( $script_handle, '', array(), '0.1.0', true );
 		wp_enqueue_script( $script_handle );
 		wp_add_inline_script(
 			$script_handle,

--- a/plugins/woocommerce/src/Admin/Features/NewProductManagementExperience.php
+++ b/plugins/woocommerce/src/Admin/Features/NewProductManagementExperience.php
@@ -29,7 +29,6 @@ class NewProductManagementExperience {
 			return;
 		}
 
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_styles' ) );
 		add_action( 'get_edit_post_link', array( $this, 'update_edit_product_link' ), 10, 2 );
 	}
@@ -54,34 +53,6 @@ class NewProductManagementExperience {
 			wp_safe_redirect( $url );
 			exit;
 		}
-	}
-
-	/**
-	 * Enqueue scripts needed for the product form block editor.
-	 */
-	public function enqueue_scripts() {
-		if ( ! PageController::is_admin_or_embed_page() ) {
-			return;
-		}
-		$post_type_object     = get_post_type_object( 'product' );
-		$block_editor_context = new WP_Block_Editor_Context( array( 'name' => 'core/edit-post' ) );
-
-		$editor_settings = array();
-		if ( ! empty( $post_type_object->template ) ) {
-			$editor_settings['template']     = $post_type_object->template;
-			$editor_settings['templateLock'] = ! empty( $post_type_object->template_lock ) ? $post_type_object->template_lock : false;
-		}
-
-		$editor_settings = get_block_editor_settings( $editor_settings, $block_editor_context );
-
-		$script_handle = 'wc-admin-edit-product';
-		wp_register_script( $script_handle, '', array(), '0.1.0', true );
-		wp_enqueue_script( $script_handle );
-		wp_add_inline_script(
-			$script_handle,
-			'var productBlockEditorSettings = productBlockEditorSettings || ' . wp_json_encode( $editor_settings ) . ';',
-			'before'
-		);
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #37120  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Load this branch and make sure the `new-product-management-experience` feature is enabled
2. Go to **Products > Add New** and make sure the initial block editor still loads correctly.
3. Open your console and type in `productBlockEditorSettings` and make sure it is an object contain a bunch of the editor settings.

*Note: I did already add an initial template, but this won't take effect until we integrate the entity store which may be done as part of this PR: https://github.com/woocommerce/woocommerce/issues/37003

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
