### PR TITLE
Add the new feature to enable the new product editor blocks experience

### DIFF
--- a/plugins/woocommerce-admin/client/layout/controller.js
+++ b/plugins/woocommerce-admin/client/layout/controller.js
@@ -174,7 +174,7 @@ export const getPages = () => {
 		} );
 	}
 
-	if ( window.wcAdminFeatures[ 'new-product-management-experience' ] ) {
+	if ( window.wcAdminFeatures[ 'block-editor-feature-enabled' ] ) {
 		pages.push( {
 			container: ProductPage,
 			path: '/add-product',
@@ -184,20 +184,6 @@ export const getPages = () => {
 			],
 			navArgs: {
 				id: 'woocommerce-add-product',
-			},
-			wpOpenMenu: 'menu-posts-product',
-			capability: 'manage_woocommerce',
-		} );
-
-		pages.push( {
-			container: AddProductPage,
-			path: '/add-product-old',
-			breadcrumbs: [
-				[ '/add-product-old', __( 'Product', 'woocommerce' ) ],
-				__( 'Add New Product', 'woocommerce' ),
-			],
-			navArgs: {
-				id: 'woocommerce-add-product-old',
 			},
 			wpOpenMenu: 'menu-posts-product',
 			capability: 'manage_woocommerce',
@@ -216,16 +202,32 @@ export const getPages = () => {
 			wpOpenMenu: 'menu-posts-product',
 			capability: 'manage_woocommerce',
 		} );
+	} else if (
+		window.wcAdminFeatures[ 'new-product-management-experience' ]
+	) {
+		pages.push( {
+			container: AddProductPage,
+			path: '/add-product',
+			breadcrumbs: [
+				[ '/add-product', __( 'Product', 'woocommerce' ) ],
+				__( 'Add New Product', 'woocommerce' ),
+			],
+			navArgs: {
+				id: 'woocommerce-add-product',
+			},
+			wpOpenMenu: 'menu-posts-product',
+			capability: 'manage_woocommerce',
+		} );
 
 		pages.push( {
 			container: EditProductPage,
-			path: '/product-old/:productId',
+			path: '/product/:productId',
 			breadcrumbs: [
-				[ '/edit-product-old', __( 'Product', 'woocommerce' ) ],
-				__( 'Edit Product (Old)', 'woocommerce' ),
+				[ '/edit-product', __( 'Product', 'woocommerce' ) ],
+				__( 'Edit Product', 'woocommerce' ),
 			],
 			navArgs: {
-				id: 'woocommerce-edit-product-old',
+				id: 'woocommerce-edit-product',
 			},
 			wpOpenMenu: 'menu-posts-product',
 			capability: 'manage_woocommerce',

--- a/plugins/woocommerce-admin/client/typings/global.d.ts
+++ b/plugins/woocommerce-admin/client/typings/global.d.ts
@@ -9,6 +9,7 @@ declare global {
 		wcAdminFeatures: {
 			'activity-panels': boolean;
 			analytics: boolean;
+			'block-editor-feature-enabled': boolean;
 			coupons: boolean;
 			'customer-effort-score-tracks': boolean;
 			homescreen: boolean;

--- a/plugins/woocommerce/changelog/add-37128
+++ b/plugins/woocommerce/changelog/add-37128
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add new feature flag for the product edit blocks experience

--- a/plugins/woocommerce/client/admin/config/core.json
+++ b/plugins/woocommerce/client/admin/config/core.json
@@ -2,6 +2,7 @@
 	"features": {
 		"activity-panels": true,
 		"analytics": true,
+		"block-editor-feature-enabled": false,
 		"coupons": true,
 		"customer-effort-score-tracks": true,
 		"import-products-task": true,

--- a/plugins/woocommerce/client/admin/config/development.json
+++ b/plugins/woocommerce/client/admin/config/development.json
@@ -2,6 +2,7 @@
 	"features": {
 		"activity-panels": true,
 		"analytics": true,
+		"block-editor-feature-enabled": true,
 		"coupons": true,
 		"customer-effort-score-tracks": true,
 		"import-products-task": true,

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -215,7 +215,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 						'gateway_toggle' => wp_create_nonce( 'woocommerce-toggle-payment-gateway-enabled' ),
 					),
 					'urls'                              => array(
-						'add_product'     => Features::is_enabled( 'new-product-management-experience' ) ? esc_url_raw( admin_url( 'admin.php?page=wc-admin&path=/add-product' ) ) : null,
+						'add_product'     => Features::is_enabled( 'new-product-management-experience' ) || Features::is_enabled( 'block-editor-feature-enabled' ) ? esc_url_raw( admin_url( 'admin.php?page=wc-admin&path=/add-product' ) ) : null,
 						'import_products' => current_user_can( 'import' ) ? esc_url_raw( admin_url( 'edit.php?post_type=product&page=product_importer' ) ) : null,
 						'export_products' => current_user_can( 'export' ) ? esc_url_raw( admin_url( 'edit.php?post_type=product&page=product_exporter' ) ) : null,
 					),

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -424,7 +424,7 @@ class WC_Admin_Menus {
 	 * Maybe add new management product experience.
 	 */
 	public function maybe_add_new_product_management_experience() {
-		if ( Features::is_enabled( 'new-product-management-experience' ) ) {
+		if ( Features::is_enabled( 'new-product-management-experience' ) || Features::is_enabled( 'block-editor-feature-enabled' ) ) {
 			global $submenu;
 			if ( isset( $submenu['edit.php?post_type=product'][10] ) ) {
 				// Disable phpcs since we need to override submenu classes.

--- a/plugins/woocommerce/src/Admin/Features/BlockEditorFeatureEnabled.php
+++ b/plugins/woocommerce/src/Admin/Features/BlockEditorFeatureEnabled.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * WooCommerce Block Editor Feature Endabled
+ */
+
+namespace Automattic\WooCommerce\Admin\Features;
+
+use Automattic\WooCommerce\Admin\Features\TransientNotices;
+use Automattic\WooCommerce\Admin\PageController;
+use Automattic\WooCommerce\Internal\Admin\Loader;
+
+/**
+ * Loads assets related to the new product management experience page.
+ */
+class BlockEditorFeatureEnabled {
+
+	const FEATURE_ID = 'block-editor-feature-enabled';
+
+	/**
+	 * Option name used to toggle this feature.
+	 */
+	const TOGGLE_OPTION_NAME = 'woocommerce_' . self::FEATURE_ID . '_enabled';
+
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		if ( ! Features::is_enabled( 'new-product-management-experience' ) && Features::is_enabled( self::FEATURE_ID ) ) {
+			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_styles' ) );
+			add_action( 'get_edit_post_link', array( $this, 'update_edit_product_link' ), 10, 2 );
+		}
+	}
+
+	/**
+	 * Enqueue styles needed for the rich text editor.
+	 */
+	public function enqueue_styles() {
+		if ( ! PageController::is_admin_or_embed_page() ) {
+			return;
+		}
+		wp_enqueue_style( 'wp-edit-blocks' );
+		wp_enqueue_style( 'wp-format-library' );
+		wp_enqueue_editor();
+		/**
+		 * Enqueue any block editor related assets.
+		 *
+		 * @since 7.1.0
+		*/
+		do_action( 'enqueue_block_editor_assets' );
+	}
+
+	/**
+	 * Update the edit product links when the new experience is enabled.
+	 *
+	 * @param string $link    The edit link.
+	 * @param int    $post_id Post ID.
+	 * @return string
+	 */
+	public function update_edit_product_link( $link, $post_id ) {
+		$product = wc_get_product( $post_id );
+
+		if ( ! $product ) {
+			return $link;
+		}
+
+		if ( $product->get_type() === 'simple' ) {
+			return admin_url( 'admin.php?page=wc-admin&path=/product/' . $product->get_id() );
+		}
+
+		return $link;
+	}
+
+}

--- a/plugins/woocommerce/src/Admin/Features/Features.php
+++ b/plugins/woocommerce/src/Admin/Features/Features.php
@@ -42,6 +42,7 @@ class Features {
 		'multichannel-marketing',
 		'navigation',
 		'new-product-management-experience',
+		'block-editor-feature-enabled',
 		'settings',
 	);
 


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/37128

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Make sure you have `WooCommerce Admin Test Helper` plugin installed.
2. Visit `/wp-admin/tools.php?page=woocommerce-admin-test-helper`.
3. Under `Features` tab if you enable the feature `block-editor-feature-enabled` and then visit the page `Products -> Add New` you should see the new product editor blocks experience.
4. If you enable both features `new-product-management-experience` and `block-editor-feature-enabled` you should see the same thing as in point 3.
5. If you disable `block-editor-feature-enabled` while keep `new-product-management-experience` you should see the Product Form (non legacy) experience.
6. If you disable both you should see the legacy experience.

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [ ] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
