### PR TITLE
Show link to store settings when stock management is disabled

### DIFF
--- a/plugins/woocommerce/changelog/update-manage-stock-disabled
+++ b/plugins/woocommerce/changelog/update-manage-stock-disabled
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Show link to store settings when stock management is disabled.

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
@@ -35,7 +35,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					'value'         => $product_object->get_manage_stock( 'edit' ) ? 'yes' : 'no',
 					'wrapper_class' => 'show_if_simple show_if_variable',
 					'label'         => __( 'Stock management', 'woocommerce' ),
-					'description'   => __( 'Manage stock level (quantity)', 'woocommerce' ),
+					'description'   => __( 'Track stock quantity for this product', 'woocommerce' ),
 				)
 			);
 

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
@@ -95,14 +95,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 			echo '</div>';
 		} else {
 
-			echo '<p class="form-field show_if_simple show_if_variable">';
-			echo '<label for="_manage_stock_disabled" aria-label="' . esc_attr__( 'Stock management disabled in store settings', 'woocommerce' ) . '">' . esc_attr__( 'Stock management', 'woocommerce' ) . '</label>';
-			echo '<output name="_manage_stock_disabled" id="_manage_stock_disabled" aria-live="off">' . sprintf(
-				/* translators: %s: url for store settings */
-				wp_kses( __( 'Disabled in <a href="%s" aria-label="stock management store settings">store settings</a>.', 'woocommerce' ), 'post' ),
-				esc_url( 'admin.php?page=wc-settings&tab=products&section=inventory' )
-			) . '</output>';
-			echo '</p>';
+			woocommerce_wp_note(
+				array(
+					'id'               => '_manage_stock_disabled',
+					'label'            => __( 'Stock management', 'woocommerce' ),
+					'label-aria-label' => __( 'Stock management disabled in store settings', 'woocommerce' ),
+					'message'          => sprintf(
+						/* translators: %s: url for store settings */
+						__( 'Disabled in <a href="%s" aria-label="stock management store settings">store settings</a>.', 'woocommerce' ),
+						esc_url( 'admin.php?page=wc-settings&tab=products&section=inventory' )
+					),
+					'wrapper_class'    => 'show_if_simple show_if_variable',
+				)
+			);
 
 		}
 

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
@@ -96,7 +96,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		} else {
 
 			echo '<p class="form-field show_if_simple show_if_variable">';
-			echo '<label for="_manage_stock_disabled" aria-label="' . esc_attr__( 'Stock management disabled in store settings', 'woocommerce' )  .'">' . esc_attr__( 'Stock management', 'woocommerce' ) . '</label>';
+			echo '<label for="_manage_stock_disabled" aria-label="' . esc_attr__( 'Stock management disabled in store settings', 'woocommerce' ) . '">' . esc_attr__( 'Stock management', 'woocommerce' ) . '</label>';
 			echo '<output name="_manage_stock_disabled" id="_manage_stock_disabled" aria-live="off">' . sprintf(
 				/* translators: %s: url for store settings */
 				wp_kses( __( 'Disabled in <a href="%s" aria-label="stock management store settings">store settings</a>.', 'woocommerce' ), 'post' ),

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
@@ -93,6 +93,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 			do_action( 'woocommerce_product_options_stock_fields' );
 
 			echo '</div>';
+		} else {
+
+			echo '<p class="form-field show_if_simple show_if_variable">';
+			echo '<label for="_manage_stock_disabled" aria-label="' . esc_attr__( 'Stock management disabled in store settings', 'woocommerce' )  .'">' . esc_attr__( 'Stock management', 'woocommerce' ) . '</label>';
+			echo '<output name="_manage_stock_disabled" id="_manage_stock_disabled" aria-live="off">' . sprintf(
+				/* translators: %s: url for store settings */
+				wp_kses( __( 'Disabled in <a href="%s" aria-label="stock management store settings">store settings</a>.', 'woocommerce' ), 'post' ),
+				esc_url( 'admin.php?page=wc-settings&tab=products&section=inventory' )
+			) . '</output>';
+			echo '</p>';
+
 		}
 
 		woocommerce_wp_select(

--- a/plugins/woocommerce/includes/admin/wc-meta-box-functions.php
+++ b/plugins/woocommerce/includes/admin/wc-meta-box-functions.php
@@ -285,3 +285,23 @@ function woocommerce_wp_radio( $field, WC_Data $data = null ) {
 
 	echo '</fieldset>';
 }
+
+/**
+ * Output a note.
+ *
+ * @param array $field Field data.
+ */
+function woocommerce_wp_note( $field ) {
+	$field['wrapper_class'] = isset( $field['wrapper_class'] ) ? $field['wrapper_class'] : '';
+
+	echo '<p class="form-field ' . esc_attr( $field['wrapper_class'] ) . '">';
+	echo '<label for="' . esc_attr( $field['id'] ) . '" ';
+
+	if ( ! empty( $field['label-aria-label'] ) ) {
+		echo 'aria-label="' . esc_attr( $field['label-aria-label'] ) . '"';
+	}
+
+	echo '>' . esc_attr( $field['label'] ) . '</label>';
+	echo '<output name="' . esc_attr( $field['id'] ) . '" id="' . esc_attr( $field['id'] ) . '" aria-live="off">' . wp_kses_post( $field['message'] ) . '</output>';
+	echo '</p>';
+}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #37115.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Disable stock management in store settings (`admin.php?page=wc-settings&tab=products&section=inventory`)
2. Add new product
3. Go to Inventory tab
4. Verify message "Disabled in store settings" is shown and "store settings" links to the store settings page.

<img width="814" alt="Screenshot 2023-03-08 at 20 17 59" src="https://user-images.githubusercontent.com/2098816/223890183-5bb2742f-5479-4bd6-ace4-b032813345c8.png">

5. Verify accessibility of message and link with screen reader.
6. Verify message only shows for Simple and Variable products. It should not be shown for other product types.
7. Enable stock management in store settings.
8. Add new product
9. Go to Inventory tab
10. Verify checkbox is shown with label "Track stock quantity for this product" (note: "Manage stock?" label in this case in addressed in #37135)

<img width="814" alt="Screenshot 2023-03-08 at 20 18 51" src="https://user-images.githubusercontent.com/2098816/223890303-6ba9ddc1-3cc3-4b30-8ff9-a14b4330fbe0.png">

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
