### PR TITLE
Introduce a beta post command to the release post tool

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15897,7 +15897,6 @@ packages:
       react: 17.0.2
       react-resize-aware: 3.1.1_react@17.0.2
       use-memo-one: 1.1.2_react@17.0.2
-    dev: false
 
   /@wordpress/compose/6.5.0_react@17.0.2:
     resolution: {integrity: sha512-gtZwEeFFHGltsr0vqwyrxPbAcA6lVfE36s59mZBh9KHeC/s590q2FPQz+9jSE5Y+uQmnXZCtahCrjvnpnaBIUg==}
@@ -16069,9 +16068,9 @@ packages:
       react: ^17.0.0
     dependencies:
       '@babel/runtime': 7.19.0
-      '@wordpress/compose': 5.17.0_react@17.0.2
-      '@wordpress/deprecated': 3.28.0
-      '@wordpress/element': 4.20.0
+      '@wordpress/compose': 5.4.1_react@17.0.2
+      '@wordpress/deprecated': 3.6.1
+      '@wordpress/element': 4.4.1
       '@wordpress/is-shallow-equal': 4.28.0
       '@wordpress/priority-queue': 2.28.0
       '@wordpress/redux-routine': 4.28.0_redux@4.2.0
@@ -16186,7 +16185,6 @@ packages:
     dependencies:
       '@babel/runtime': 7.19.0
       '@wordpress/hooks': 3.6.1
-    dev: false
 
   /@wordpress/dom-ready/3.28.0:
     resolution: {integrity: sha512-PFFAnuPUouV0uSDZN6G/B8yksybtxzS/6H53OZJEA3h3EsNCicKRMGSowkumvLwXA23HV0K2Kht6JuS+bDECzA==}
@@ -16220,7 +16218,6 @@ packages:
     dependencies:
       '@babel/runtime': 7.19.0
       lodash: 4.17.21
-    dev: false
 
   /@wordpress/e2e-test-utils/3.0.0_ddjhsfu4aotkh3cuzmpsln6ywq:
     resolution: {integrity: sha512-XMdR8DeKyDQRF5jKeUlOzP4pTRtoJuOLsNZRLUFUvnrs9y/7/hH17VmPbWp3TJGvV/eGKzO4+D+wJTsP9nJmIw==}
@@ -16897,7 +16894,6 @@ packages:
       '@babel/runtime': 7.19.0
       '@wordpress/i18n': 4.6.1
       lodash: 4.17.21
-    dev: false
 
   /@wordpress/media-utils/3.4.1:
     resolution: {integrity: sha512-WNAaMqqw6Eqy61KTWBy1NlgXSZH82Cm2SPVbz0v6yhJ4ktJmSRFm7Fd4mTMFS/L7NKTxwo+DFqEHlTGKj3lyzQ==}
@@ -38327,7 +38323,7 @@ packages:
       serialize-javascript: 6.0.0
       source-map: 0.6.1
       terser: 5.10.0_acorn@8.8.1
-      webpack: 5.70.0
+      webpack: 5.70.0_webpack-cli@3.3.12
     transitivePeerDependencies:
       - acorn
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2136,6 +2136,7 @@ importers:
       commander: 9.4.0
       dotenv: ^10.0.0
       ejs: ^3.1.8
+      enquirer: ^2.3.6
       express: ^4.18.1
       form-data: ^4.0.0
       lodash.shuffle: ^4.2.0
@@ -2152,6 +2153,7 @@ importers:
       commander: 9.4.0
       dotenv: 10.0.0
       ejs: 3.1.8
+      enquirer: 2.3.6
       express: 4.18.1
       form-data: 4.0.0
       lodash.shuffle: 4.2.0
@@ -15895,6 +15897,7 @@ packages:
       react: 17.0.2
       react-resize-aware: 3.1.1_react@17.0.2
       use-memo-one: 1.1.2_react@17.0.2
+    dev: false
 
   /@wordpress/compose/6.5.0_react@17.0.2:
     resolution: {integrity: sha512-gtZwEeFFHGltsr0vqwyrxPbAcA6lVfE36s59mZBh9KHeC/s590q2FPQz+9jSE5Y+uQmnXZCtahCrjvnpnaBIUg==}
@@ -16066,9 +16069,9 @@ packages:
       react: ^17.0.0
     dependencies:
       '@babel/runtime': 7.19.0
-      '@wordpress/compose': 5.4.1_react@17.0.2
-      '@wordpress/deprecated': 3.6.1
-      '@wordpress/element': 4.4.1
+      '@wordpress/compose': 5.17.0_react@17.0.2
+      '@wordpress/deprecated': 3.28.0
+      '@wordpress/element': 4.20.0
       '@wordpress/is-shallow-equal': 4.28.0
       '@wordpress/priority-queue': 2.28.0
       '@wordpress/redux-routine': 4.28.0_redux@4.2.0
@@ -16183,6 +16186,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.19.0
       '@wordpress/hooks': 3.6.1
+    dev: false
 
   /@wordpress/dom-ready/3.28.0:
     resolution: {integrity: sha512-PFFAnuPUouV0uSDZN6G/B8yksybtxzS/6H53OZJEA3h3EsNCicKRMGSowkumvLwXA23HV0K2Kht6JuS+bDECzA==}
@@ -16216,6 +16220,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.19.0
       lodash: 4.17.21
+    dev: false
 
   /@wordpress/e2e-test-utils/3.0.0_ddjhsfu4aotkh3cuzmpsln6ywq:
     resolution: {integrity: sha512-XMdR8DeKyDQRF5jKeUlOzP4pTRtoJuOLsNZRLUFUvnrs9y/7/hH17VmPbWp3TJGvV/eGKzO4+D+wJTsP9nJmIw==}
@@ -16892,6 +16897,7 @@ packages:
       '@babel/runtime': 7.19.0
       '@wordpress/i18n': 4.6.1
       lodash: 4.17.21
+    dev: false
 
   /@wordpress/media-utils/3.4.1:
     resolution: {integrity: sha512-WNAaMqqw6Eqy61KTWBy1NlgXSZH82Cm2SPVbz0v6yhJ4ktJmSRFm7Fd4mTMFS/L7NKTxwo+DFqEHlTGKj3lyzQ==}
@@ -17863,7 +17869,6 @@ packages:
   /ansi-colors/4.1.1:
     resolution: {integrity: sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==}
     engines: {node: '>=6'}
-    dev: true
 
   /ansi-escapes/3.2.0:
     resolution: {integrity: sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==}
@@ -22417,7 +22422,6 @@ packages:
     engines: {node: '>=8.6'}
     dependencies:
       ansi-colors: 4.1.1
-    dev: true
 
   /entities/1.1.2:
     resolution: {integrity: sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==}
@@ -29993,7 +29997,7 @@ packages:
       log-update: 4.0.0
       p-map: 4.0.0
       rfdc: 1.3.0
-      rxjs: 7.5.5
+      rxjs: 7.8.0
       through: 2.3.8
       wrap-ansi: 7.0.0
     dev: true
@@ -36333,6 +36337,12 @@ packages:
       tslib: 2.5.0
     dev: true
 
+  /rxjs/7.8.0:
+    resolution: {integrity: sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==}
+    dependencies:
+      tslib: 2.5.0
+    dev: true
+
   /safe-buffer/5.1.1:
     resolution: {integrity: sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==}
     dev: true
@@ -38317,7 +38327,7 @@ packages:
       serialize-javascript: 6.0.0
       source-map: 0.6.1
       terser: 5.10.0_acorn@8.8.1
-      webpack: 5.70.0_webpack-cli@3.3.12
+      webpack: 5.70.0
     transitivePeerDependencies:
       - acorn
 

--- a/tools/release-posts/commands/release-post/index.ts
+++ b/tools/release-posts/commands/release-post/index.ts
@@ -10,6 +10,7 @@ program
 	.name( 'release-post' )
 	.version( '0.0.1' )
 	.command( 'release', 'Generate release post', { isDefault: true } )
+	.command( 'beta', 'Generate draft beta release post' )
 	.command(
 		'contributors',
 		'Generate a list of contributors for a release post'

--- a/tools/release-posts/commands/release-post/release-post-beta.ts
+++ b/tools/release-posts/commands/release-post/release-post-beta.ts
@@ -139,12 +139,13 @@ const program = new Command()
 				`Finding recent release posts with title: ${ versionSearch }`
 			);
 
-			const posts = await searchForPostsByCategory(
-				siteId,
-				versionSearch,
-				'WooCommerce Core',
-				authToken
-			);
+			const posts =
+				( await searchForPostsByCategory(
+					siteId,
+					versionSearch,
+					'WooCommerce Core',
+					authToken
+				) ) || [];
 
 			Logger.endTask();
 
@@ -156,7 +157,7 @@ const program = new Command()
 					: [ 'No posts found - generate default link' ],
 			} );
 
-			const lastReleasePostTitle = await prompt.run();
+			const lastReleasePostTitle: string = await prompt.run();
 			const lastReleasePost = posts.find(
 				( p ) => p.title === lastReleasePostTitle
 			);

--- a/tools/release-posts/commands/release-post/release-post-beta.ts
+++ b/tools/release-posts/commands/release-post/release-post-beta.ts
@@ -176,6 +176,7 @@ const program = new Command()
 					releaseDate,
 					betaNumber: prereleaseVersion,
 					version: semverVersion,
+					previousVersion: semverPreviousVersion,
 					prettyVersion: `${ semverVersion.major }.${ semverVersion.minor }.${ semverVersion.patch } Beta ${ prereleaseVersion }`,
 					prettyPreviousVersion: `${ semverPreviousVersion.major }.${
 						semverPreviousVersion.minor

--- a/tools/release-posts/commands/release-post/release-post-beta.ts
+++ b/tools/release-posts/commands/release-post/release-post-beta.ts
@@ -1,0 +1,223 @@
+/**
+ * External dependencies
+ */
+import semver from 'semver';
+import { writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { Logger } from 'cli-core/src/logger';
+import { Command } from '@commander-js/extra-typings';
+import dotenv from 'dotenv';
+// @ts-expect-error - The enquirer types are incorrect.
+// eslint-disable-next-line @woocommerce/dependency-group
+import { Select } from 'enquirer';
+
+/**
+ * Internal dependencies
+ */
+import { renderTemplate } from '../../lib/render-template';
+import { getWordpressComAuthToken } from '../../lib/oauth-helper';
+import { getEnvVar } from '../../lib/environment';
+import { getMostRecentFinal } from '../../lib/github-api';
+import {
+	getFirstTuesdayOfTheMonth,
+	getSecondTuesdayOfTheMonth,
+} from '../../lib/dates';
+import {
+	createWpComDraftPost,
+	searchForPostsByCategory,
+} from '../../lib/draft-post';
+
+const DEVELOPER_WOOCOMMERCE_SITE_ID = '96396764';
+
+dotenv.config();
+
+// Define the release post command
+const program = new Command()
+	.command( 'beta' )
+	.description( 'CLI to automate generation of a draft beta release post.' )
+	.argument(
+		'<releaseVersion>',
+		'The version for this post in x.y.z-beta.n format. Ex: 7.1.0-beta.1'
+	)
+	.option(
+		'--releaseDate <date>',
+		'The date for the final release as mm-dd-yyyy, year inferred as current year, defaults to second tuesday of next month.',
+		getSecondTuesdayOfTheMonth(
+			new Date().getMonth() + 1
+		).toLocaleDateString( 'en-US', {
+			month: '2-digit',
+			day: '2-digit',
+			year: 'numeric',
+		} )
+	)
+	.option( '--outputOnly', 'Only output the post, do not publish it' )
+	.option(
+		'--tags <tags>',
+		'Comma separated list of tags to add to the post.',
+		'Releases,WooCommerce Core'
+	)
+	.option(
+		'--siteId <siteId>',
+		'For posting to a non-default site (for testing)'
+	)
+	.action( async ( releaseVersion, options ) => {
+		const {
+			outputOnly,
+			siteId = DEVELOPER_WOOCOMMERCE_SITE_ID,
+			tags,
+			releaseDate,
+		} = options;
+
+		const postTags = ( tags &&
+			tags.split( ',' ).map( ( tag ) => tag.trim() ) ) || [
+			'WooCommerce Core',
+			'Releases',
+		];
+
+		const finalReleaseDate = new Date( releaseDate );
+		const isOutputOnly = !! outputOnly;
+		const semverVersion = semver.parse( releaseVersion );
+
+		// This is supposed to be a beta post so throw if the version provided is not a beta version.
+		// Things we don't accept:
+		//    * missing beta.x
+		//    * any other kind of prerelease, e.g. rc
+		//    * .x must be a number, so not: beta.1b or beta.1.1 but beta.1 is ok.
+		if (
+			! semverVersion ||
+			! semverVersion.prerelease.length ||
+			typeof semverVersion.prerelease[ 1 ] === 'string'
+		) {
+			throw new Error(
+				`Invalid current version: ${ releaseVersion }. Provide current version in x.y.z-beta.n format.`
+			);
+		} else {
+			const [ , prereleaseVersion ] = semverVersion.prerelease;
+
+			// Now infer the previous version, if the one you provide is beta.1 we'll need to find the last major release from
+			// Github releases. If what you provided is beta.2 we'll assume previous was beta.1
+			const previousVersion =
+				prereleaseVersion === 1
+					? ( await getMostRecentFinal() ).tag_name
+					: `${ semverVersion.major }.${ semverVersion.minor }.${
+							semverVersion.patch
+					  }-beta.${ prereleaseVersion - 1 }`;
+
+			const semverPreviousVersion = semver.parse( previousVersion );
+
+			if ( ! semverPreviousVersion ) {
+				throw new Error(
+					`Could not parse previous version from: ${ previousVersion }`
+				);
+			}
+
+			const clientId = getEnvVar( 'WPCOM_OAUTH_CLIENT_ID', true );
+			const clientSecret = getEnvVar( 'WPCOM_OAUTH_CLIENT_SECRET', true );
+			const redirectUri =
+				getEnvVar( 'WPCOM_OAUTH_REDIRECT_URI' ) ||
+				'http://localhost:3000/oauth';
+
+			Logger.startTask(
+				'Getting auth token for WordPress.com (needed to find last beta post).'
+			);
+			const authToken = await getWordpressComAuthToken(
+				clientId,
+				clientSecret,
+				siteId,
+				redirectUri,
+				'posts'
+			);
+			Logger.endTask();
+
+			const versionSearch =
+				prereleaseVersion === 1
+					? `WooCommerce ${ semverPreviousVersion.major }.${ semverPreviousVersion.minor }.${ semverPreviousVersion.patch }`
+					: `WooCommerce ${ semverPreviousVersion.major }.${ semverPreviousVersion.minor } Beta ${ semverPreviousVersion.prerelease[ 1 ] }`;
+
+			Logger.startTask(
+				`Finding recent release posts with title: ${ versionSearch }`
+			);
+
+			const posts = await searchForPostsByCategory(
+				siteId,
+				versionSearch,
+				'WooCommerce Core',
+				authToken
+			);
+
+			Logger.endTask();
+
+			const prompt = new Select( {
+				name: 'Previous post',
+				message: 'Choose the previous post to link to:',
+				choices: posts.length
+					? posts.map( ( p ) => p.title )
+					: [ 'No posts found - generate default link' ],
+			} );
+
+			const lastReleasePostTitle = await prompt.run();
+			const lastReleasePost = posts.find(
+				( p ) => p.title === lastReleasePostTitle
+			);
+
+			if ( ! lastReleasePost ) {
+				Logger.warn(
+					'Could not find previous release post, make sure to update the link in the post before publishing.'
+				);
+			}
+
+			if ( ! authToken && ! isOutputOnly ) {
+				throw new Error(
+					'Error getting auth token, check your env settings are correct.'
+				);
+			} else {
+				const html = await renderTemplate( 'beta-release.ejs', {
+					releaseDate,
+					betaNumber: prereleaseVersion,
+					version: semverVersion,
+					prettyVersion: `${ semverVersion.major }.${ semverVersion.minor }.${ semverVersion.patch } Beta ${ prereleaseVersion }`,
+					prettyPreviousVersion: `${ semverPreviousVersion.major }.${
+						semverPreviousVersion.minor
+					}.${ semverPreviousVersion.patch }${
+						semverPreviousVersion.prerelease.length
+							? ' ' +
+							  semverPreviousVersion.prerelease[ 0 ] +
+							  ' ' +
+							  semverPreviousVersion.prerelease[ 1 ]
+							: ''
+					}`,
+					rcReleaseDate: getFirstTuesdayOfTheMonth(
+						finalReleaseDate.getMonth()
+					),
+					finalReleaseDate,
+					lastReleasePostUrl:
+						lastReleasePost?.URL ||
+						'https://developer.woocommerce.com/category/woocommerce-core-release-notes/',
+				} );
+
+				if ( isOutputOnly ) {
+					const tmpFile = join(
+						tmpdir(),
+						`beta-release-${ releaseVersion }.html`
+					);
+
+					await writeFile( tmpFile, html );
+
+					Logger.notice( `Output written to ${ tmpFile }` );
+				} else {
+					Logger.startTask( 'Publishing draft release post' );
+					await createWpComDraftPost(
+						siteId,
+						`WooCommerce ${ semverVersion.major }.${ semverVersion.minor } Beta ${ prereleaseVersion } Released`,
+						html,
+						postTags,
+						authToken
+					);
+					Logger.endTask();
+				}
+			}
+		}
+	} );
+
+program.parse( process.argv );

--- a/tools/release-posts/commands/release-post/release-post-release.ts
+++ b/tools/release-posts/commands/release-post/release-post-release.ts
@@ -150,7 +150,7 @@ const program = new Command()
 
 		let postContent;
 
-		if ( 'undefined' !== typeof options.editPostId ) {
+		if ( typeof options.editPostId !== 'undefined' ) {
 			try {
 				const prevPost = await fetchWpComPost(
 					siteId,
@@ -197,7 +197,7 @@ const program = new Command()
 		};
 
 		const html =
-			'undefined' !== typeof options.editPostId
+			typeof options.editPostId !== 'undefined'
 				? editPostHTML( postContent, {
 						hooks: await renderTemplate(
 							'hooks.ejs',
@@ -234,7 +234,7 @@ const program = new Command()
 
 			try {
 				const { URL } =
-					'undefined' !== typeof options.editPostId
+					typeof options.editPostId !== 'undefined'
 						? await editWpComPostContent(
 								siteId,
 								options.editPostId,

--- a/tools/release-posts/lib/dates.ts
+++ b/tools/release-posts/lib/dates.ts
@@ -1,0 +1,22 @@
+export const getFirstTuesdayOfTheMonth = ( month: number ): Date => {
+	// create a new Date object for the first day of the month
+	const firstDayOfMonth = new Date( new Date().getFullYear(), month, 1 );
+
+	// create a new Date object for the first Tuesday of the month
+	const firstTuesday = new Date( firstDayOfMonth );
+
+	firstTuesday.setDate( 1 + ( ( 2 - firstDayOfMonth.getDay() + 7 ) % 7 ) );
+
+	return firstTuesday;
+};
+
+export const getSecondTuesdayOfTheMonth = ( month: number ): Date => {
+	// create a new Date object for the first Tuesday of the month
+	const firstTuesday = getFirstTuesdayOfTheMonth( month );
+
+	// create a new Date object for the second Tuesday of the current month
+	const secondTuesday = new Date( firstTuesday );
+	secondTuesday.setDate( secondTuesday.getDate() + 7 );
+
+	return secondTuesday;
+};

--- a/tools/release-posts/lib/draft-post.ts
+++ b/tools/release-posts/lib/draft-post.ts
@@ -4,6 +4,14 @@
 import fetch from 'node-fetch';
 import { Logger } from 'cli-core/src/logger';
 
+// Typing just the things we need from the WP.com Post object.
+// (which is not the same as WP Post object or API Post object).
+// See example response here: https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/posts/ to add more props.
+type WordpressComPost = {
+	title: string;
+	URL: string;
+};
+
 /**
  * Fetch a post from WordPress.com
  *
@@ -66,7 +74,7 @@ export const searchForPostsByCategory = async (
 			throw new Error( `Error creating draft post: ${ text }` );
 		}
 
-		return ( await post.json() ).posts;
+		return ( await post.json() ).posts as WordpressComPost[];
 	} catch ( e: unknown ) {
 		if ( e instanceof Error ) {
 			Logger.error( e.message );

--- a/tools/release-posts/lib/draft-post.ts
+++ b/tools/release-posts/lib/draft-post.ts
@@ -41,6 +41,39 @@ export const fetchWpComPost = async (
 	}
 };
 
+export const searchForPostsByCategory = async (
+	siteId: string,
+	search: string,
+	category: string,
+	authToken: string
+) => {
+	try {
+		const post = await fetch(
+			`https://public-api.wordpress.com/rest/v1.1/sites/${ siteId }/posts?${ new URLSearchParams(
+				{ search, category }
+			) }`,
+			{
+				headers: {
+					Authorization: `Bearer ${ authToken }`,
+					'Content-Type': 'application/json',
+				},
+				method: 'GET',
+			}
+		);
+
+		if ( post.status !== 200 ) {
+			const text = await post.text();
+			throw new Error( `Error creating draft post: ${ text }` );
+		}
+
+		return ( await post.json() ).posts;
+	} catch ( e: unknown ) {
+		if ( e instanceof Error ) {
+			Logger.error( e.message );
+		}
+	}
+};
+
 /**
  * Edit a post on wordpress.com
  *

--- a/tools/release-posts/lib/github-api.ts
+++ b/tools/release-posts/lib/github-api.ts
@@ -102,3 +102,16 @@ export const getContributorData = async (
 		headRef,
 	} as ContributorData;
 };
+
+export const getMostRecentFinal = async () => {
+	const octokit = new Octokit( {
+		auth: getEnvVar( 'GITHUB_ACCESS_TOKEN', true ),
+	} );
+
+	const release = await octokit.repos.getLatestRelease( {
+		owner: 'woocommerce',
+		repo: 'woocommerce',
+	} );
+
+	return release.data;
+};

--- a/tools/release-posts/package.json
+++ b/tools/release-posts/package.json
@@ -31,6 +31,7 @@
 		"commander": "9.4.0",
 		"dotenv": "^10.0.0",
 		"ejs": "^3.1.8",
+		"enquirer": "^2.3.6",
 		"express": "^4.18.1",
 		"form-data": "^4.0.0",
 		"lodash.shuffle": "^4.2.0",

--- a/tools/release-posts/templates/beta-release.ejs
+++ b/tools/release-posts/templates/beta-release.ejs
@@ -1,7 +1,9 @@
 <!-- wp:paragraph -->
 <p>
-	Beta <%= betaNumber %> for the March 2023 release of WooCommerce is now
-	available for testing! You can either
+	Beta <%= betaNumber %> for the <%=
+	finalReleaseDate.toLocaleDateString('en-US', {month: 'long', day:
+	'numeric'}) release of WooCommerce is now available for testing! You can
+	either
 	<a
 		href="https://downloads.wordpress.org/plugin/woocommerce.<%= version.version %>.zip"
 		target="_blank"
@@ -41,7 +43,7 @@
 <!-- wp:paragraph -->
 <p>
 	For the complete list, view the&nbsp;<a
-		href="https://github.com/woocommerce/woocommerce/blob/release/<%= previousVersion.major %>.<%= previousVersion.minor %>/plugins/woocommerce/readme.txt"
+		href="https://github.com/woocommerce/woocommerce/blob/release/<%= version.major %>.<%= version.minor %>/plugins/woocommerce/readme.txt"
 		>changelog</a
 	>&nbsp;in the readme for this release.
 </p>

--- a/tools/release-posts/templates/beta-release.ejs
+++ b/tools/release-posts/templates/beta-release.ejs
@@ -1,0 +1,162 @@
+<!-- wp:heading -->
+<h1>WooCommerce <%= prettyVersion %></h1>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>
+	Beta <%= betaNumber %> for the March 2023 release of WooCommerce is now
+	available for testing! You can either
+	<a
+		href="https://downloads.wordpress.org/plugin/woocommerce.<%= version.version %>.zip"
+		target="_blank"
+		rel="noreferrer noopener"
+		>download it directly from WordPress.org</a
+	>
+	or install our
+	<a
+		rel="noreferrer noopener"
+		href="https://woocommerce.wordpress.com/2018/07/30/woocommerce-beta-tester-2-0-0/"
+		target="_blank"
+		>WooCommerce Beta Tester Plugin</a
+	>.
+</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">Highlights</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>
+	Since the release of
+	<a href="<%= lastReleasePostUrl %>"><%= prettyPreviousVersion %></a>, the
+	following changes have been made:
+</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:list -->
+<ul>
+	<!-- wp:list-item -->
+	<li>List your changes here.</li>
+	<!-- /wp:list-item -->
+</ul>
+<!-- /wp:list -->
+
+<!-- wp:paragraph -->
+<p>
+	For the complete list, view the&nbsp;<a
+		href="https://github.com/woocommerce/woocommerce/blob/release/<%= version.major %>.<%= version.minor %>/plugins/woocommerce/readme.txt"
+		>changelog</a
+	>&nbsp;in the readme for this release.
+</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"anchor":"actions-and-filters"} -->
+<h2 class="wp-block-heading" id="actions-and-filters">Actions and Filters</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>No changes introduced.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"anchor":"database-changes"} -->
+<h2 class="wp-block-heading" id="database-changes">Database Changes</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>No changes introduced.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"anchor":"template-changes"} -->
+<h2 class="wp-block-heading" id="template-changes">Template Changes</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>No changes introduced.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"anchor":"release-schedule"} -->
+<h2 class="wp-block-heading" id="release-schedule">Release Schedule</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>We're still on track for our planned March 14 release.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:table -->
+<figure class="wp-block-table">
+	<table>
+		<tbody>
+			<tr>
+				<td><strong>Version</strong></td>
+				<td><strong>Release</strong></td>
+			</tr>
+			<tr>
+				<td>Release Candidate</td>
+				<td>
+					<%= rcReleaseDate.toLocaleDateString('en-US', { month:
+					'long', day: 'numeric', year: 'numeric' }) %>
+				</td>
+			</tr>
+			<tr>
+				<td>Final Release</td>
+				<td>
+					<%= finalReleaseDate.toLocaleDateString('en-US', { month:
+					'long', day: 'numeric', year: 'numeric' }) %>
+				</td>
+			</tr>
+		</tbody>
+	</table>
+</figure>
+<!-- /wp:table -->
+
+<!-- wp:heading {"anchor":"testing"} -->
+<h2 class="wp-block-heading" id="testing">Testing</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>
+	If you'd like to dive in and help test this new release, our handy&nbsp;<a
+		href="https://wordpress.org/plugins/woocommerce-beta-tester/"
+		target="_blank"
+		>WooCommerce Beta Tester plugin</a
+	>&nbsp;allows you to switch between beta versions and release candidates.
+	You can also&nbsp;<a
+		href="https://downloads.wordpress.org/plugin/woocommerce.<%= version.version %>.zip"
+		target="_blank"
+		rel="noreferrer noopener"
+		>download the release from WordPress.org</a
+	>.
+</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>
+	A set of testing instructions has been published on&nbsp;our&nbsp;<a
+		href="https://github.com/woocommerce/woocommerce/wiki/Release-Testing-Instructions-WooCommerce-<%= version.major %>.<%= version.minor %>"
+		target="_blank"
+		rel="noreferrer noopener"
+		>Wiki page in GitHub</a
+	>. We've also posted&nbsp;<a
+		href="https://woocommerce.wordpress.com/2015/07/25/how-to-beta-test-woocommerce/"
+		target="_blank"
+		>a helpful writeup on beta testing</a
+	>&nbsp;to help get you started.
+</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>
+	If you discover any bugs during the testing process, please let us know
+	by&nbsp;<a
+		href="https://github.com/woocommerce/woocommerce/issues/new?assignees=&amp;labels=&amp;template=1-bug-report.yml&amp;title=[<%= version.major %>.<%= version.minor %> beta]: Title of the issue"
+		target="_blank"
+		rel="noreferrer noopener"
+		>logging a report in GitHub</a
+	>.
+</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->

--- a/tools/release-posts/templates/beta-release.ejs
+++ b/tools/release-posts/templates/beta-release.ejs
@@ -2,7 +2,7 @@
 <p>
 	Beta <%= betaNumber %> for the <%=
 	finalReleaseDate.toLocaleDateString('en-US', {month: 'long', day:
-	'numeric'}) release of WooCommerce is now available for testing! You can
+	'numeric'}) %> release of WooCommerce is now available for testing! You can
 	either
 	<a
 		href="https://downloads.wordpress.org/plugin/woocommerce.<%= version.version %>.zip"

--- a/tools/release-posts/templates/beta-release.ejs
+++ b/tools/release-posts/templates/beta-release.ejs
@@ -1,7 +1,3 @@
-<!-- wp:heading -->
-<h1>WooCommerce <%= prettyVersion %></h1>
-<!-- /wp:heading -->
-
 <!-- wp:paragraph -->
 <p>
 	Beta <%= betaNumber %> for the March 2023 release of WooCommerce is now
@@ -80,7 +76,11 @@
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>We're still on track for our planned March 14 release.</p>
+<p>
+	We're still on track for our planned <%=
+	finalReleaseDate.toLocaleDateString('en-US', {month: 'long', day:
+	'numeric'}) %> release.
+</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:table -->

--- a/tools/release-posts/templates/beta-release.ejs
+++ b/tools/release-posts/templates/beta-release.ejs
@@ -45,7 +45,7 @@
 <!-- wp:paragraph -->
 <p>
 	For the complete list, view the&nbsp;<a
-		href="https://github.com/woocommerce/woocommerce/blob/release/<%= version.major %>.<%= version.minor %>/plugins/woocommerce/readme.txt"
+		href="https://github.com/woocommerce/woocommerce/blob/release/<%= previousVersion.major %>.<%= previousVersion.minor %>/plugins/woocommerce/readme.txt"
 		>changelog</a
 	>&nbsp;in the readme for this release.
 </p>

--- a/tools/release-posts/tsconfig.json
+++ b/tools/release-posts/tsconfig.json
@@ -1,7 +1,10 @@
 {
-  "extends": "@tsconfig/node16/tsconfig.json",
-  "ts-node": {
-    "transpileOnly": true,
-    "files": true,
-  }
+	"extends": "@tsconfig/node16/tsconfig.json",
+	"compilerOptions": {
+		"module": "Node16"
+	},
+	"ts-node": {
+		"transpileOnly": true,
+		"files": true
+	}
 }


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR introduces a new beta post generating command to simplify generating beta posts as part of release duties. I've tried to keep it very simple to use and infer as much information as possible.

Beta posts are a basic version of the release post and they consist of some basic info:

* Title
* Link to previous version post
* List of change highlights 
* Link to changelog of current version
* List of template/filter/hook changes 
* Dates of RC and Final
* Tags to ensure they're posted to the right place

The biggest pain I found was having to copy paste this stuff every time and remember to update all the links, so for the beta post I've opted to keep it simple for now and avoid trying to fill in everything. This new command fills in everything from the list above except for: **List of template/filter/hook changes** and **List of change highlights **.

It also make some assumptions to keep things simple:

* When you run it, it assumes you're doing a beta post for a release that will happen **next month**. 
* If you're running it to do a beta.2 or beta.3 (any beta above first), it will work out the previous version as being current beta -1
* If it's your first beta for a version (beta.1) it will work out the latest non-prerelease Github release and use that, It will also search developer.woocommerce.com posts to suggest the post to link to. It's a best effort based on search

**With these assumptions in place you get a quickly auto-generated and drafted post with a very simple command and it's up to you to go and adjust any details that weren't perfect. Instead of trying to make a complex command that does everything.
My reasoning is that if a command is hard to remember or takes too long, you're not going to run it. It needs to be convenient but also save you enough hassle. I hope this strikes the right balance.**

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:


1. You'll need a wp.com oauth app, hopefully you already have one setup, otherwise [create one here](https://developer.wordpress.com/apps/new/). And you're going to need all the env variables set. e.g:

```
GITHUB_ACCESS_TOKEN="<create a classic token in github dev settings>"
WPCOM_OAUTH_CLIENT_ID="<id for the app you created>"
WPCOM_OAUTH_CLIENT_SECRET="<secret for the app you created>"

# optional - override if you need the redirect handler to run on a different port or path
WPCOM_OAUTH_REDIRECT_URI="http://localhost:3000/oauth"
```
2. Try an output only command e.g. `pnpm release-post beta 7.5.0-beta.1 --outputOnly`
3. Try publish draft by omitting `--outputOnly`

Have a look at the output and see if you're happy with it. It's designed that it expects you to run it around the right time, so the month is only going to be correct if you're running this when you first start rotation. But you can also override that.

4. Test override by providing a `--releaseDate` in your command in format `mm-dd-yyyy`. This flag refers to the final release date and so RC date will work backwards from that.

Note that during testing it will search the developer WC.com posts for a reasonable post to be chosen as the one to link to from previous, its not perfect, Feedback welcome on improving this. We could show every post with the right tag ordered by most recent published date instead. 


<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
