### PR TITLE
Escape backquotes in syncpack pre-push message

### DIFF
--- a/bin/pre-push.sh
+++ b/bin/pre-push.sh
@@ -27,7 +27,7 @@ pnpm exec syncpack -- list-mismatches
 
 if [ $? -ne 0 ]; then
 	echo "You must sync the dependencies listed above before you can push this branch."
-	echo "This can usually be accomplished automatically by updating the pinned version in `.syncpackrc` and then running \`pnpm run sync-dependencies\`."
+	echo "This can usually be accomplished automatically by updating the pinned version in \`.syncpackrc\` and then running \`pnpm run sync-dependencies\`."
 	exit 1
 fi
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR escapes the backquotes in the syncpack pre-push error message.

Before (missing `.syncpack.rc`):

```
This can usually be accomplished automatically by updating the pinned version in  and then running `pnpm run sync-dependencies`.
```

After (shows `syncpack.rc`):

```
This can usually be accomplished automatically by updating the pinned version in `.syncpackrc` and then running `pnpm run sync-dependencies`.
```

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Make a change to a synced dependency in a `package.json` file (I changed `"@wordpress/data": "^1"` in `@woocommerce/product-editor`'s)
2. Try to push branch
3. Verify error message is:

```
This can usually be accomplished automatically by updating the pinned version in `.syncpackrc` and then running `pnpm run sync-dependencies`.
```


<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
