### PR TITLE
Render 'safe_text' settings as 'text' inputs

### DIFF
--- a/plugins/woocommerce/changelog/fix-34391
+++ b/plugins/woocommerce/changelog/fix-34391
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Make sure 'safe_text' settings are rendered as 'text' inputs for compatibility.

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-settings-api.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-settings-api.php
@@ -459,6 +459,20 @@ abstract class WC_Settings_API {
 	}
 
 	/**
+	 * Generates HTML for the 'safe_text' input type (mostly used for gateway-related settings).
+	 *
+	 * @param string $key Field key.
+	 * @param array  $data Field data.
+	 * @return string
+	 *
+	 * @since 7.6.0
+	 */
+	public function generate_safe_text_html( $key, $data ) {
+		$data['type'] = 'text';
+		return $this->generate_text_html( $key, $data );
+	}
+
+	/**
 	 * Generate Price Input HTML.
 	 *
 	 * @param string $key Field key.


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

A while ago we introduced the `safe_text` setting type to be used for a payment method's "title", with some added sanitization (i.e. some additional tags stripped vs regular text fields).

This, however, means that these fields are inputs of type `safe_text` which is not necessarily invalid HTML but does mean that those inputs are not properly styled (see screenshot below) and there could be other compatibility issues.

<img width="675" alt="Screenshot 2023-03-09 at 16 50 39" src="https://user-images.githubusercontent.com/184724/224139211-4b210992-e8e0-42ca-9f6a-a5372badb91e.png">


This PR makes sure that `safe_text` settings are rendered as regular `input="text"` fields but are still passed through their special sanitization routine.

Closes #34391.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [X] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Go to WooCommerce > Settings > Payments. 
2. Click on the "Cash On Delivery" gateway link.
3. Confirm that:
   - On `trunk`, the "Title" setting is rendered with `input type="safe_text"` (and possibly not properly styled).
      <img width="653" alt="Screenshot 2023-03-09 at 16 50 50" src="https://user-images.githubusercontent.com/184724/224139744-0df1d94e-5917-4056-9879-2360137a6c4a.png">
   - On this branch, the "Title" setting is rendered with `input type="text"`.
4. Test various values for this field, including some with HTML (specifically, test `<a>` tags). On any branch, only a few tags should be allowed (`<br>`, `<p>`, `<span>`, not `<a>`).

<!-- End testing instructions —>

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [X] Have you written new tests for your changes, as applicable?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [X] Have you included testing instructions?

<!-- Mark completed items with an [x] —>

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
