### PR TITLE
Allow composing code analyzer change detections (hooks, templates, db, schema)

### DIFF
--- a/tools/code-analyzer/README.md
+++ b/tools/code-analyzer/README.md
@@ -34,6 +34,6 @@ version argument to `analyzer`.
 
 Here is an example of the `scan` command run to look for hook changes:
 
-`pnpm analyzer scan hooks "release/6.8" "6.8.0" -b release/6.7`
+`pnpm analyzer scan hooks "release/6.8" "release/6.7" --since "6.8.0"`
 \
 In this command we compare the `release/6.7` and `release/6.8` branches to find hook changes, and we're looking for changes introduced since `6.8.0` (using the `@since` tag).

--- a/tools/code-analyzer/README.md
+++ b/tools/code-analyzer/README.md
@@ -6,7 +6,7 @@
 
 ## Commands
 
-Currently there are just 2 commands:
+Currently there are 3 commands:
 
 1. `lint`. Analyzer is used as a linter for PRs to check if hook/template/db changes were introduced. It produces output either directly on CI or via setting output variables in GH actions.
 
@@ -29,3 +29,11 @@ writing the main file in this particular branch reports `6.8.1` so the output of
 
 This command is particularly useful combined with the analyzer, allowing you to determine the last major/minor.0 version of a branch or ref before passing that as the
 version argument to `analyzer`.
+
+3. `scan`. Scan is like `lint` but lets you scan for a specific change type. e.g. you can scan just for hook changes if you wish.
+
+Here is an example of the `scan` command run to look for hook changes:
+
+`pnpm analyzer scan hooks "release/6.8" "6.8.0" -b release/6.7`
+\
+In this command we compare the `release/6.7` and `release/6.8` branches to find hook changes, and we're looking for changes introduced since `6.8.0` (using the `@since` tag).

--- a/tools/code-analyzer/src/commands/analyzer/analyzer-scan.ts
+++ b/tools/code-analyzer/src/commands/analyzer/analyzer-scan.ts
@@ -40,16 +40,16 @@ const program = new Command()
 		'GitHub branch/tag/commit hash to compare against the base branch/tag/commit hash.'
 	)
 	.argument(
-		'[sinceVersion]',
-		'Specify the version used to determine which changes are included (version listed in @since code doc). Only needed for hook, template, schema changes.'
-	)
-	.option(
-		'-b, --base <base>',
-		'GitHub base branch/tag/commit hash.',
+		'[base]',
+		'Base branch to compare against. Defaults to trunk.',
 		'trunk'
 	)
 	.option(
-		'-s, --source <source>',
+		'-s, --since <sinceVersion>',
+		'Specify the version used to determine which changes are included (version listed in @since code doc). Only needed for hook, template, schema changes.'
+	)
+	.option(
+		'-src, --source <source>',
 		'Git repo url or local path to a git repo.',
 		join( process.cwd(), '../../' )
 	)
@@ -58,8 +58,8 @@ const program = new Command()
 		'Output style for the results. Options: github, cli. Github output will set the results as an output variable for Github actions.',
 		'cli'
 	)
-	.action( async ( scanType, compare, sinceVersion, options ) => {
-		const { source, base, outputStyle } = options;
+	.action( async ( scanType, compare, base, options ) => {
+		const { since: sinceVersion, source, outputStyle } = options;
 
 		if (
 			( scanType === 'hooks' ||

--- a/tools/code-analyzer/src/commands/analyzer/analyzer-scan.ts
+++ b/tools/code-analyzer/src/commands/analyzer/analyzer-scan.ts
@@ -68,7 +68,7 @@ const program = new Command()
 			! sinceVersion
 		) {
 			throw new Error(
-				`To scan for ${ scanType } changes you must provide the sinceVersion argument.`
+				`To scan for ${ scanType } changes you must provide the since argument.`
 			);
 		}
 

--- a/tools/code-analyzer/src/commands/analyzer/analyzer-scan.ts
+++ b/tools/code-analyzer/src/commands/analyzer/analyzer-scan.ts
@@ -1,0 +1,138 @@
+/**
+ * External dependencies
+ */
+import { Command } from '@commander-js/extra-typings';
+import { Logger } from 'cli-core/src/logger';
+import { join } from 'path';
+
+/**
+ * Internal dependencies
+ */
+import {
+	scanChangesForDB,
+	scanChangesForHooks,
+	scanChangesForSchema,
+	scanChangesForTemplates,
+	ScanType,
+} from '../../lib/scan-changes';
+import {
+	printDatabaseUpdates,
+	printHookResults,
+	printSchemaChange,
+	printTemplateResults,
+} from '../../print';
+
+const printEmptyNotice = ( scanType: ScanType ) => {
+	Logger.notice( `\n\n##  ${ scanType.toUpperCase() } CHANGES` );
+	Logger.notice( '---------------------------------------------------' );
+	Logger.notice( `No ${ scanType } changes found.` );
+	Logger.notice( '---------------------------------------------------' );
+};
+
+const program = new Command()
+	.command( 'scan' )
+	.argument(
+		'<type>',
+		'Type of change to scan for. Options: templates, hooks, database, schema.'
+	)
+	.argument(
+		'<compare>',
+		'GitHub branch/tag/commit hash to compare against the base branch/tag/commit hash.'
+	)
+	.argument(
+		'<sinceVersion>',
+		'Specify the version used to determine which changes are included (version listed in @since code doc).'
+	)
+	.option(
+		'-b, --base <base>',
+		'GitHub base branch/tag/commit hash.',
+		'trunk'
+	)
+	.option(
+		'-s, --source <source>',
+		'Git repo url or local path to a git repo.',
+		join( process.cwd(), '../../' )
+	)
+	.option(
+		'-o, --outputStyle <outputStyle>',
+		'Output style for the results. Options: github, cli. Github output will set the results as an output variable for Github actions.',
+		'cli'
+	)
+	.action( async ( scanType, compare, sinceVersion, options ) => {
+		const { source, base, outputStyle } = options;
+
+		switch ( scanType ) {
+			case 'hooks':
+				const hookChanges = await scanChangesForHooks(
+					compare,
+					sinceVersion,
+					base,
+					source
+				);
+
+				if ( hookChanges.length ) {
+					printHookResults(
+						hookChanges,
+						outputStyle,
+						'HOOKS',
+						Logger.notice
+					);
+				} else {
+					printEmptyNotice( 'hooks' );
+				}
+				break;
+			case 'templates':
+				const templateChanges = await scanChangesForTemplates(
+					compare,
+					sinceVersion,
+					base,
+					source
+				);
+				if ( templateChanges && templateChanges.length ) {
+					printTemplateResults(
+						templateChanges,
+						outputStyle,
+						'TEMPLATES',
+						Logger.notice
+					);
+				} else {
+					printEmptyNotice( 'templates' );
+				}
+				break;
+			case 'database':
+				const dbChanges = await scanChangesForDB(
+					compare,
+					base,
+					source
+				);
+				if ( dbChanges ) {
+					printDatabaseUpdates( dbChanges, 'cli', Logger.notice );
+				} else {
+					printEmptyNotice( 'database' );
+				}
+				break;
+			case 'schema':
+				const schemaChanges = await scanChangesForSchema(
+					compare,
+					base,
+					source
+				);
+				if ( schemaChanges && schemaChanges.length ) {
+					printSchemaChange(
+						schemaChanges,
+						sinceVersion,
+						'cli',
+						Logger.notice
+					);
+				} else {
+					printEmptyNotice( 'schema' );
+				}
+				break;
+			default:
+				throw new Error(
+					'Invalid scan type. Options: templates, hooks, database, schema.'
+				);
+		}
+	} );
+
+program.parse( process.argv );

--- a/tools/code-analyzer/src/commands/analyzer/index.ts
+++ b/tools/code-analyzer/src/commands/analyzer/index.ts
@@ -10,6 +10,7 @@ program
 	.name( 'analyzer' )
 	.version( '0.0.1' )
 	.command( 'lint', 'Lint changes', { isDefault: true } )
-	.command( 'major-minor', 'Determine major/minor version of a plugin' );
+	.command( 'major-minor', 'Determine major/minor version of a plugin' )
+	.command( 'scan', 'Detect changes between plugin versions' );
 
 program.parse( process.argv );

--- a/tools/code-analyzer/src/lib/scan-changes.ts
+++ b/tools/code-analyzer/src/lib/scan-changes.ts
@@ -15,6 +15,121 @@ import { scanForDBChanges } from './db-changes';
 import { scanForHookChanges } from './hook-changes';
 import { scanForTemplateChanges } from './template-changes';
 import { SchemaDiff, generateSchemaDiff } from '../git';
+import { scanForSchemaChanges } from './schema-changes';
+
+export type ScanType = 'schema' | 'db' | 'hooks' | 'templates' | string;
+
+const generateVersionDiff = async (
+	compareVersion: string,
+	base: string,
+	source: string,
+	clonedPath?: string
+) => {
+	Logger.startTask( `Making temporary clone of ${ source }...` );
+
+	const tmpRepoPath =
+		typeof clonedPath !== 'undefined'
+			? clonedPath
+			: await cloneRepo( source );
+
+	Logger.endTask();
+
+	Logger.notice(
+		`Temporary clone of ${ source } created at ${ tmpRepoPath }`
+	);
+
+	Logger.notice(
+		`Temporary clone of ${ source } created at ${ tmpRepoPath }`
+	);
+
+	const diff = await generateDiff(
+		tmpRepoPath,
+		base,
+		compareVersion,
+		Logger.error,
+		[ 'tools' ]
+	);
+
+	return { diff, tmpRepoPath };
+};
+
+export const scanChangesForDB = async (
+	compareVersion: string,
+	base: string,
+	source: string,
+	clonedPath?: string
+) => {
+	const { diff } = await generateVersionDiff(
+		compareVersion,
+		base,
+		source,
+		clonedPath
+	);
+
+	return scanForDBChanges( diff );
+};
+
+export const scanChangesForHooks = async (
+	compareVersion: string,
+	sinceVersion: string,
+	base: string,
+	source: string,
+	clonedPath?: string
+) => {
+	const { diff, tmpRepoPath } = await generateVersionDiff(
+		compareVersion,
+		base,
+		source,
+		clonedPath
+	);
+
+	const hookChanges = await scanForHookChanges(
+		diff,
+		sinceVersion,
+		tmpRepoPath
+	);
+
+	return Array.from( hookChanges.values() );
+};
+
+export const scanChangesForTemplates = async (
+	compareVersion: string,
+	sinceVersion: string,
+	base: string,
+	source: string,
+	clonedPath?: string
+) => {
+	const { diff, tmpRepoPath } = await generateVersionDiff(
+		compareVersion,
+		base,
+		source,
+		clonedPath
+	);
+
+	const templateChanges = await scanForTemplateChanges(
+		diff,
+		sinceVersion,
+		tmpRepoPath
+	);
+
+	return Array.from( templateChanges.values() );
+};
+
+export const scanChangesForSchema = async (
+	compareVersion: string,
+	base: string,
+	source: string,
+	clonedPath?: string
+) => {
+	const { tmpRepoPath } = await generateVersionDiff(
+		compareVersion,
+		base,
+		source,
+		clonedPath
+	);
+
+	return scanForSchemaChanges( compareVersion, base, tmpRepoPath );
+};
 
 export const scanForChanges = async (
 	compareVersion: string,

--- a/tools/code-analyzer/src/lib/schema-changes.ts
+++ b/tools/code-analyzer/src/lib/schema-changes.ts
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import { Logger } from 'cli-core/src/logger';
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+
+/**
+ * Internal dependencies
+ */
+import { generateSchemaDiff } from '../git';
+import { execAsync } from '../utils';
+
+export const scanForSchemaChanges = async (
+	compareVersion: string,
+	base: string,
+	tmpRepoPath: string
+) => {
+	const pluginPath = join( tmpRepoPath, 'plugins/woocommerce' );
+
+	const build = async () => {
+		const fileStr = await readFile(
+			join( pluginPath, 'package.json' ),
+			'utf-8'
+		);
+		const packageJSON = JSON.parse( fileStr );
+
+		// Temporarily save the current PNPM version.
+		await execAsync( `tmpgPNPM="$(pnpm --version)"` );
+
+		if ( packageJSON.engines && packageJSON.engines.pnpm ) {
+			await execAsync( `npm i -g pnpm@${ packageJSON.engines.pnpm }`, {
+				cwd: pluginPath,
+			} );
+		}
+
+		// Note doing the minimal work to get a DB scan to work, avoiding full build for speed.
+		await execAsync( 'composer install', { cwd: pluginPath } );
+		await execAsync( 'pnpm run --filter=woocommerce build:feature-config', {
+			cwd: pluginPath,
+		} );
+	};
+
+	Logger.startTask( 'Generating schema diff...' );
+
+	const schemaDiff = await generateSchemaDiff(
+		tmpRepoPath,
+		compareVersion,
+		base,
+		build,
+		Logger.error
+	);
+
+	// Restore the previously saved PNPM version
+	await execAsync( `npm i -g pnpm@"$tmpgPNPM"` );
+
+	Logger.endTask();
+
+	return schemaDiff;
+};


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This is intended to solve #36835 

There is a desire to be able to compose separate code analyzer checks so that you can run them individually or combine them. This achieves that in 2 ways:

1. It exposes a new CLI command that allows you to scan just one type of changes if you want.
2. It also exposes separate functions for scanning each change type that could be reused if you want to compose them in other monorepo tools.

I also felt there was a chance here to make the command much more memorable and intuitive so I shuffled the arguments around in a way that feels better compared to the `lint` command.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->
1. Checkout this branch, make sure `pnpm i` has been run
2. Go to the directory of the code analyzer tool. `tools/code-analyzer`
3. Run some test commands using the new `scan` command. For example `pnpm analyzer scan hooks "release/6.8" "release/6.7" --since "6.8.0"`
4. If you want to check that the changes listed match outputs of lint you can run that command. Its arguments are different so here is an example matching the example command in `3`: `pnpm run analyzer -- lint "release/6.8" "6.8.0" -b release/6.7` **but note the output doesn't have to be exactly the same, we're just looking to see that the same changes were found by the scan (because I adjusted some of the output for example the output when there are no changes is slightly different)**
<!-- End testing instructions -->


### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
