### PR TITLE
fix: mobile app connection owner bug

### DIFF
--- a/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/components/useJetpackPluginState.tsx
+++ b/plugins/woocommerce-admin/client/homescreen/mobile-app-modal/components/useJetpackPluginState.tsx
@@ -89,8 +89,7 @@ export const useJetpackPluginState = () => {
 						);
 					} else if (
 						jetpackConnectionData &&
-						jetpackConnectionData?.currentUser?.username !==
-							jetpackConnectionData?.connectionOwner
+						! jetpackConnectionData?.currentUser?.isMaster
 					) {
 						setPluginState(
 							JetpackPluginStates.NOT_OWNER_OF_CONNECTION

--- a/plugins/woocommerce/changelog/fix-mobile-app-connection-owner-bug
+++ b/plugins/woocommerce/changelog/fix-mobile-app-connection-owner-bug
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+fixed bug where jetpack connection owner field was assumed to be username when its actually display name

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/GetMobileApp.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/GetMobileApp.php
@@ -90,7 +90,7 @@ class GetMobileApp extends Task {
 	private static function is_current_user_connected() {
 		if ( class_exists( '\Automattic\Jetpack\Connection\Manager' ) && method_exists( '\Automattic\Jetpack\Connection\Manager', 'is_user_connected' ) ) {
 			$connection = new Manager();
-			return $connection->is_user_connected();
+			return $connection->is_connection_owner();
 		}
 		return false;
 	}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

A bug was discovered where users who had changed their wpcom display names would be shown the "not owner of connection" modal for the mobile app feature modal.

The cause of this was the assumption that the `.connectionOwner` field represents the user's wpcom username, but it turns out that it actually holds the user's display name. This went unnoticed in testing as the default display name is the user's username.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Set up the WooCommerce site using Jurassic Ninja, live branch or some other setup where you can have a Jetpack connection running. To test this thoroughly, check that your wpcom account's display name != your username.
2. After going through the onboarding wizard and connecting your wordpress.com account, observe that you can see the mobile app task in the task list and in the help menu.
3. Create another user on the wordpress site and log in as that user. You should not be able to see the mobile app task or help menu entry.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
