### PR TITLE
Prevent possible PHP warnings produced by 'woocommerce_ajax_order_items_removed' hook

### DIFF
--- a/plugins/woocommerce/changelog/fix-32717
+++ b/plugins/woocommerce/changelog/fix-32717
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Prevent 'woocommerce_ajax_order_items_removed' from generating PHP warnings.

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -1305,7 +1305,7 @@ class WC_AJAX {
 				'city'     => isset( $_POST['city'] ) ? wc_strtoupper( wc_clean( wp_unslash( $_POST['city'] ) ) ) : '',
 			);
 
-			if ( ! is_array( $order_item_ids ) && is_numeric( $order_item_ids ) ) {
+			if ( is_numeric( $order_item_ids ) ) {
 				$order_item_ids = array( $order_item_ids );
 			}
 

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -1322,6 +1322,10 @@ class WC_AJAX {
 					$item_id = absint( $item_id );
 					$item    = $order->get_item( $item_id );
 
+					if ( ! $item ) {
+						continue;
+					}
+
 					// Before deleting the item, adjust any stock values already reduced.
 					if ( $item->is_type( 'line_item' ) ) {
 						$changed_stock = wc_maybe_adjust_line_item_product_stock( $item, 0 );
@@ -1353,7 +1357,7 @@ class WC_AJAX {
 			 * @param bool|array|WP_Error $changed_store Result of wc_maybe_adjust_line_item_product_stock().
 			 * @param bool|WC_Order|WC_Order_Refund $order As returned by wc_get_order().
 			 */
-			do_action( 'woocommerce_ajax_order_items_removed', $item_id, $item, $changed_stock, $order );
+			do_action( 'woocommerce_ajax_order_items_removed', $item_id ?? 0, $item ?? false, $changed_stock ?? false, $order );
 
 			// Get HTML to return.
 			ob_start();


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Under certain circumstances, when removing an order item via admin, some PHP warnings could be triggered due some possibly undefined variables [when firing hook `woocommerce_ajax_order_items_removed`](https://github.com/woocommerce/woocommerce/blob/5019a344a1bb762c5bccd54d989f17b25dfb8613/plugins/woocommerce/includes/class-wc-ajax.php#L1346-L1356).

The hook receives arguments that are only available inside a [`foreach` loop above](https://github.com/woocommerce/woocommerce/blob/5019a344a1bb762c5bccd54d989f17b25dfb8613/plugins/woocommerce/includes/class-wc-ajax.php#L1321-L1339) so that's where the `do_action()` call should probably live. Even when those vars are set, the hook would only fire with the last value of those vars, which seems incorrect.

This PR moves the hook to the correct location. Given that, under normal circumstances, only one order item is passed via the admin to this AJAX endpoint, the behavior of only firing once should be preserved.

Closes #32717.



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:
<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [X] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

While our current code is certainly prone to generating the PHP warnings mentioned, under normal usage, those shouldn't be triggered, so maybe users are encountering this through other plugins/etc. Because of this the testing instructions are a bit artificial.
In any case, plugging the hole in core is probably the way to go.

1. Go to WC > Orders.
2. Create a test order with a few products.
3. Open the browser's JS console and execute the following command:
   ```js
   jQuery.ajax({url: woocommerce_admin_meta_boxes.ajax_url, data: { order_id: woocommerce_admin_meta_boxes.post_id, order_item_ids: [1], action: 'woocommerce_remove_order_item', security: woocommerce_admin_meta_boxes.order_item_nonce }, type: 'POST' });  
   ```
4.
   - On `trunk`, you should see a few PHP warnings like these:
      > PHP Warning:  foreach() argument must be of type array|object, string given in [...]woocommerce/includes/class-wc-ajax.php on line 1321
      > PHP Warning:  Undefined variable $item_id in [...]woocommerce/includes/class-wc-ajax.php on line 1356
      > PHP Warning:  Undefined variable $item in [...]woocommerce/includes/class-wc-ajax.php on line 1356
      > PHP Warning:  Undefined variable $changed_stock in [...]woocommerce/includes/class-wc-ajax.php on line 1356      
   - On this branch, no warnings should be logged.
5. Confirm that you are able to add and remove products and order items from the order successfully.

<!-- End testing instructions —>

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [X] Have you written new tests for your changes, as applicable?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [X] Have you included testing instructions?

<!-- Mark completed items with an [x] —>

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
