### PR TITLE
Update the CI workflow to include WP 6.0 and 5.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,9 @@ jobs:
         include:
           - wp: nightly
             php: '7.4'
-          - wp: '5.9'
+          - wp: '6.0'
             php: 7.4
-          - wp: '5.8'
+          - wp: '5.9'
             php: 7.4
     services:
       database:

--- a/plugins/woocommerce/changelog/update-ci-workflow-remove-wp-5-8
+++ b/plugins/woocommerce/changelog/update-ci-workflow-remove-wp-5-8
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: workflow update. not part of release zip
+
+


### PR DESCRIPTION

### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR updates the CI workflow to include PHP versions matching our L-2 support policy for WordPress releases now that latest is 6.1



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Similar to https://github.com/woocommerce/woocommerce/pull/33193

Spot-check the changes, and once merged, verify that the workflows for 5.9 and 6.0 run, and that the workflow for 5.8 no longer runs.

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
