### PR TITLE
Restore the sort order when orders are cached.

### DIFF
--- a/plugins/woocommerce/changelog/fix-order-caching
+++ b/plugins/woocommerce/changelog/fix-order-caching
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Restore the sort order when orders are cached.

--- a/plugins/woocommerce/includes/class-wc-order-factory.php
+++ b/plugins/woocommerce/includes/class-wc-order-factory.php
@@ -135,7 +135,7 @@ class WC_Order_Factory {
 
 		if ( $use_orders_cache ) {
 			foreach ( $result as $order_id => $order ) {
-				$order_cache->set( $order, $order->get_id( $order_id ) );
+				$order_cache->set( $order, $order->get_id() );
 			}
 			$result = array_replace( $result, $already_cached_orders );
 		}

--- a/plugins/woocommerce/tests/php/includes/class-wc-order-factory-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-order-factory-test.php
@@ -1,5 +1,6 @@
 <?php
 
+use Automattic\WooCommerce\Caches\OrderCache;
 use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
 
 /**
@@ -74,6 +75,25 @@ class WC_Order_Factory_Test extends WC_Unit_Test_Case {
 		$this->assertInstanceOf( WC_Order::class, $orders_with_diff_types[1] );
 		$this->assertInstanceOf( WC_Order_Refund::class, $orders_with_diff_types[2] );
 		$this->assertInstanceOf( WC_Order_Refund::class, $orders_with_diff_types[3] );
+	}
+
+	/**
+	 * @testDox Test that cache does not interfere with order sorting.
+	 */
+	public function test_cache_dont_interfere_with_orders() {
+		OrderHelper::toggle_cot( $this->cot_state );
+		$order1 = OrderHelper::create_order();
+		$order2 = OrderHelper::create_order();
+
+		wp_cache_flush();
+		$cache = wc_get_container()->get( OrderCache::class );
+		$cache->set( $order2, $order2->get_id() );
+
+		$orders = WC_Order_Factory::get_orders( array( $order1->get_id(), $order2->get_id() ) );
+		$this->assertEquals( 2, count( $orders ) );
+		$this->assertEquals( $order1->get_id(), $orders[0]->get_id() );
+		$this->assertEquals( $order2->get_id(), $orders[1]->get_id() );
+		OrderHelper::toggle_cot( false );
 	}
 
 }


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

With HPOS, we also enable order caching. Unfortunately, there is a bug in the order cache setting code in `WC_Order_Factory`, which causes the cached orders to be always sorted first inside the get_orders method. This PR fixes that to preserve the original sort order that it was provided.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:


<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

Since this includes a lot of caching and uncaching orders, there is no easy way to test it from the interface. But since this is a well-covered flow, unit and e2e passing is enough. I also added a unit test to test explicitly for this behavior.

For smoke testing:

1. With HPOS enabled, open the order list view and verify that orders are listed in the order as expected.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
