### PR TITLE
Emit error on webpack build when invalid export name used in import for JS

### DIFF
--- a/packages/js/admin-layout/changelog/update-webpack-invalid-export-error
+++ b/packages/js/admin-layout/changelog/update-webpack-invalid-export-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update webpack config to use @woocommerce/internal-style-build's parser config

--- a/packages/js/admin-layout/webpack.config.js
+++ b/packages/js/admin-layout/webpack.config.js
@@ -12,6 +12,7 @@ module.exports = {
 		path: __dirname,
 	},
 	module: {
+		parser: webpackConfig.parser,
 		rules: webpackConfig.rules,
 	},
 	plugins: webpackConfig.plugins,

--- a/packages/js/components/changelog/update-webpack-invalid-export-error
+++ b/packages/js/components/changelog/update-webpack-invalid-export-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update webpack config to use @woocommerce/internal-style-build's parser config

--- a/packages/js/components/webpack.config.js
+++ b/packages/js/components/webpack.config.js
@@ -12,6 +12,7 @@ module.exports = {
 		path: __dirname,
 	},
 	module: {
+		parser: webpackConfig.parser,
 		rules: webpackConfig.rules,
 	},
 	plugins: webpackConfig.plugins,

--- a/packages/js/customer-effort-score/changelog/update-webpack-invalid-export-error
+++ b/packages/js/customer-effort-score/changelog/update-webpack-invalid-export-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update webpack config to use @woocommerce/internal-style-build's parser config

--- a/packages/js/customer-effort-score/webpack.config.js
+++ b/packages/js/customer-effort-score/webpack.config.js
@@ -12,6 +12,7 @@ module.exports = {
 		path: __dirname,
 	},
 	module: {
+		parser: webpackConfig.parser,
 		rules: webpackConfig.rules,
 	},
 	plugins: webpackConfig.plugins,

--- a/packages/js/experimental/changelog/update-webpack-invalid-export-error
+++ b/packages/js/experimental/changelog/update-webpack-invalid-export-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update webpack config to use @woocommerce/internal-style-build's parser config

--- a/packages/js/experimental/webpack.config.js
+++ b/packages/js/experimental/webpack.config.js
@@ -12,6 +12,7 @@ module.exports = {
 		path: __dirname,
 	},
 	module: {
+		parser: webpackConfig.parser,
 		rules: webpackConfig.rules,
 	},
 	plugins: webpackConfig.plugins,

--- a/packages/js/internal-style-build/index.js
+++ b/packages/js/internal-style-build/index.js
@@ -11,6 +11,11 @@ const NODE_ENV = process.env.NODE_ENV || 'development';
 
 module.exports = {
 	webpackConfig: {
+		parser: {
+			javascript: {
+				exportsPresence: 'error',
+			},
+		},
 		rules: [
 			{
 				test: /\.s?css$/,

--- a/packages/js/onboarding/changelog/update-webpack-invalid-export-error
+++ b/packages/js/onboarding/changelog/update-webpack-invalid-export-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update webpack config to use @woocommerce/internal-style-build's parser config

--- a/packages/js/onboarding/webpack.config.js
+++ b/packages/js/onboarding/webpack.config.js
@@ -12,6 +12,7 @@ module.exports = {
 		path: __dirname,
 	},
 	module: {
+		parser: webpackConfig.parser,
 		rules: webpackConfig.rules,
 	},
 	plugins: webpackConfig.plugins,

--- a/packages/js/product-editor/changelog/update-webpack-invalid-export-error
+++ b/packages/js/product-editor/changelog/update-webpack-invalid-export-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update webpack config to use @woocommerce/internal-style-build's parser config

--- a/packages/js/product-editor/webpack.config.js
+++ b/packages/js/product-editor/webpack.config.js
@@ -12,6 +12,7 @@ module.exports = {
 		path: __dirname,
 	},
 	module: {
+		parser: webpackConfig.parser,
 		rules: webpackConfig.rules,
 	},
 	plugins: webpackConfig.plugins,

--- a/plugins/woocommerce-admin/webpack.config.js
+++ b/plugins/woocommerce-admin/webpack.config.js
@@ -101,6 +101,7 @@ const webpackConfig = {
 		uniqueName: '__wcAdmin_webpackJsonp',
 	},
 	module: {
+		parser: styleConfig.parser,
 		rules: [
 			{
 				test: /\.(t|j)sx?$/,

--- a/plugins/woocommerce/changelog/update-webpack-invalid-export-error
+++ b/plugins/woocommerce/changelog/update-webpack-invalid-export-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update webpack config to use @woocommerce/internal-style-build's parser config


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR set the webpack [`module.parser.javascript.exportsPresence`](https://webpack.js.org/configuration/module/#moduleparserjavascriptexportspresence) configuration option to `error` so that webpack's build will fail and emit an error whenever an invalid (missing) export name is used in an import statement in JS files.

**Note: For some reason (probably my lack of understanding of webpack and/or our build's particulars), this only seems to catch invalid export names when they are imported from a file in the same package as the source. Due to this, this change is less impactful than it could be. Still, I think it has some value in helping devs catch mistakes in JS files in some scenarios.**

Catches:

```
import { validExport, invalidExport } from `./constants`;
```

Doesn't catch:

```
import { validExport, invalidExport } from `@woocommerce/components`;
```

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Build branch.
2. Verify no webpack errors.
3. Make a change to an import in a JS file.

For example, I changed the import in `packages/js/components/src/abbreviated-card/index.js` from:

```
import Link from '../link';
```

to:

```
import Link, { foo } from '../link';
console.log( foo ); // you have to reference the invalid export name that was imported
```

4. Build branch.
5. Verify webpack emits errors.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
