### PR TITLE
Specify args for wp.data resolution in marketing page to support WP 5.9

### DIFF
--- a/plugins/woocommerce-admin/client/marketing/hooks/useRecommendedChannels.ts
+++ b/plugins/woocommerce-admin/client/marketing/hooks/useRecommendedChannels.ts
@@ -40,7 +40,7 @@ export const useRecommendedChannels = (): UseRecommendedChannels => {
 			} );
 
 		return {
-			loading: ! hasFinishedResolution( 'getRecommendedChannels' ),
+			loading: ! hasFinishedResolution( 'getRecommendedChannels', [] ),
 			data: nonActiveRecommendedChannels,
 			error,
 		};

--- a/plugins/woocommerce-admin/client/marketing/hooks/useRegisteredChannels.ts
+++ b/plugins/woocommerce-admin/client/marketing/hooks/useRegisteredChannels.ts
@@ -63,7 +63,7 @@ export const useRegisteredChannels = (): UseRegisteredChannels => {
 	const { invalidateResolution } = useDispatch( STORE_KEY );
 
 	const refetch = useCallback( () => {
-		invalidateResolution( 'getRegisteredChannels' );
+		invalidateResolution( 'getRegisteredChannels', [] );
 	}, [ invalidateResolution ] );
 
 	return useSelect( ( select ) => {
@@ -72,7 +72,7 @@ export const useRegisteredChannels = (): UseRegisteredChannels => {
 		const state = getRegisteredChannels< RegisteredChannelsState >();
 
 		return {
-			loading: ! hasFinishedResolution( 'getRegisteredChannels' ),
+			loading: ! hasFinishedResolution( 'getRegisteredChannels', [] ),
 			data: state.data?.map( convert ),
 			error: state.error,
 			refetch,

--- a/plugins/woocommerce/changelog/feature-37176-specify-wp-data-resolution-args
+++ b/plugins/woocommerce/changelog/feature-37176-specify-wp-data-resolution-args
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix WP data resolution (`invalidateResolution`) not working with WP 5.9 in marketing page.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/37176.

<!-- Begin testing instructions -->

In this PR, we specify empty array `[]` as the second argument for calls to `invalidateResolution` in marketing page to make it work with WordPress 5.9.

To make things consistent, we also specify empty array `[]` as the second argument for calls to `hasFinishedResolution`.

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

#### Functionality test:

Pre-conditions: 

- Use WordPress 5.9.
- Enable WooCommerce Multichannel Marketing experience in WooCommerce Settings > Advanced > Features page: `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
 
1. Go to WooCommerce Marketing page: `/wp-admin/admin.php?page=wc-admin&path=%2Fmarketing`
2. Install and activate a channel that registers itself as a marketing channel, e.g. Google Listings and Ads. 
3. You should see the channel appears as a registered channel in the Channels card (i.e. it should not disappear and be gone).

#### Code check

1. Search for `invalidateResolution` under the `plugins/woocommerce-admin/client/marketing` folder. Make sure all the calls to the function has the second argument specified.
2. Search for `hasFinishedResolution` under the `plugins/woocommerce-admin/client/marketing` folder. Make sure all the calls to the function has the second argument specified.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
