### PR TITLE
Add Tracks events for product inventory tab

### DIFF
--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
@@ -280,6 +280,14 @@ const initInventoryTabTracks = () => {
 				'product_manage_stock_disabled_store_settings_link_click'
 			);
 		} );
+
+	document
+		.querySelector( '#inventory_product_data .notice a' )
+		?.addEventListener( 'click', () => {
+			recordEvent(
+				'product_inventory_variations_notice_learn_more_click'
+			);
+		} );
 };
 
 /**

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
@@ -266,6 +266,14 @@ const initProductTabsTracks = () => {
  */
 const initInventoryTabTracks = () => {
 	document
+		.querySelector( '#_manage_stock' )
+		?.addEventListener( 'click', ( event ) => {
+			recordEvent( 'product_manage_stock_click', {
+				is_enabled: ( event.target as HTMLInputElement )?.checked,
+			} );
+		} );
+
+	document
 		.querySelector( '#_manage_stock_disabled' )
 		?.addEventListener( 'click', () => {
 			recordEvent(

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
@@ -262,6 +262,19 @@ const initProductTabsTracks = () => {
 };
 
 /**
+ * Initializes the inventory tab Tracks events.
+ */
+const initInventoryTabTracks = () => {
+	document
+		.querySelector( '#_manage_stock_disabled' )
+		?.addEventListener( 'click', () => {
+			recordEvent(
+				'product_manage_stock_disabled_store_settings_link_click'
+			);
+		} );
+};
+
+/**
  * Initialize all product screen tracks.
  */
 
@@ -529,6 +542,7 @@ export const initProductScreenTracks = () => {
 	} );
 
 	initProductTabsTracks();
+	initInventoryTabTracks();
 };
 
 export function addExitPageListener( pageId: string ) {

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
@@ -236,7 +236,7 @@ const getDataForProductTabClickEvent = ( tabName: string ) => {
 	data.product_type = getProductType();
 
 	if ( tabName === 'inventory' ) {
-		data.is_stock_management_enabled =
+		data.is_store_stock_management_enabled =
 			document.querySelector( '#_manage_stock' ) !== null;
 	}
 

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
@@ -236,8 +236,8 @@ const getDataForProductTabClickEvent = ( tabName: string ) => {
 	data.product_type = getProductType();
 
 	if ( tabName === 'inventory' ) {
-		data.is_stock_management_disabled =
-			document.querySelector( '#_manage_stock_disabled' ) !== null;
+		data.is_stock_management_enabled =
+			document.querySelector( '#_manage_stock' ) !== null;
 	}
 
 	return data;

--- a/plugins/woocommerce/changelog/add-product-inventory-tracks
+++ b/plugins/woocommerce/changelog/add-product-inventory-tracks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Add Tracks events for product inventory tab interactions.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds the following Tracks events related to the product inventory tab.

* `wcadmin_product_tab_click`: Logged when any of the product (data) tabs are clicked
    * `product_tab`: `inventory`, `general`, etc.
    * `product_type`: `simple`, `variation`, etc.
    * `is_store_stock_management_enabled`: `true` if store stock management is enabled (only sent when `inventory` tab is clicked
* `wcadmin_product_manage_stock_click`: Logged when the "Track stock quantity for this product" is toggled
* `wcadmin_product_manage_stock_disabled_store_settings_link_click`: Logged when the "store settings" link in the "Disabled in store settings" message is clicked
* `wcadmin_product_inventory_variations_notice_learn_more_click`: Logged when the "learn more" link in the notice shown on the inventory tab for a variable product is clicked

Closes #37136.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Enable the logging of Tracks event to the browser dev console: `localStorage.setItem( 'debug', 'wc-admin:*' )`
    * Also, verify Tracks events actually get logged by using the Tracks Live View (make sure tracking is enabled for your site)
3. Go to the product screen
4. Click tabs and **verify that the `wcadmin_product_tab_click` event is logged**
5. On inventory tab: toggle "Track stock quantity for this product" and **verify that `wcadmin_product_manage_stock_click` event is logged**
6. Change product to a variable product.
7. Go to inventory tab: click "learn more" in the "Settings below apply to all variations without manual stock management enabled" notice and **verify that `wcadmin_product_inventory_variations_notice_learn_more_click` is logged**.
8. Disable store stock management ( WooCommerce > Settings > Products > Inventory).
9. Go to the product screen, inventory tab.
10. Click "store settings" in the "Disables in store settings" and **verify that the `wcadmin_product_manage_stock_disabled_store_settings_link_click` event is logged**.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
