### PR TITLE
Remove accordion from "Other payment providers" in WC Pay Task

### DIFF
--- a/packages/js/admin-e2e-tests/changelog/remove-wcpay-accordion
+++ b/packages/js/admin-e2e-tests/changelog/remove-wcpay-accordion
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update showOtherPaymentMethods() to test latest payment task properly

--- a/packages/js/admin-e2e-tests/src/pages/PaymentsSetup.ts
+++ b/packages/js/admin-e2e-tests/src/pages/PaymentsSetup.ts
@@ -31,12 +31,6 @@ export class PaymentsSetup extends BasePage {
 	}
 
 	async showOtherPaymentMethods(): Promise< void > {
-		const selector = '.woocommerce-task-payments button.toggle-button';
-		await this.page.waitForSelector( selector );
-		const toggleButton = await this.page.$(
-			`${ selector }[aria-expanded=false]`
-		);
-		await toggleButton?.click();
 		await waitForElementByText( 'h2', 'Offline payment methods' );
 	}
 

--- a/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/components/WCPay/suggestion.scss
+++ b/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/components/WCPay/suggestion.scss
@@ -30,4 +30,8 @@
 			}
 		}
 	}
+
+	.woocommerce-wcpay-benefits {
+		margin-bottom: 24px;
+	}
 }

--- a/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/index.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/index.js
@@ -22,7 +22,6 @@ import ExternalIcon from 'gridicons/dist/external';
  */
 import { List, Placeholder as ListPlaceholder } from './components/List';
 import { Setup, Placeholder as SetupPlaceholder } from './components/Setup';
-import { Toggle } from './components/Toggle/Toggle';
 import { WCPaySuggestion } from './components/WCPay';
 import { getCountryCode } from '~/dashboard/utils';
 import {
@@ -182,14 +181,6 @@ export const PaymentGatewaySuggestions = ( { onComplete, query } ) => {
 		recordEvent( 'tasklist_payment_see_more', {} );
 	};
 
-	const trackToggle = ( isShow ) => {
-		recordEvent( 'tasklist_payment_show_toggle', {
-			toggle: isShow ? 'hide' : 'show',
-			payment_method_count:
-				offlineGateways.length + additionalGateways.length,
-		} );
-	};
-
 	if ( query.id && ! currentGateway ) {
 		return <SetupPlaceholder />;
 	}
@@ -270,16 +261,8 @@ export const PaymentGatewaySuggestions = ( { onComplete, query } ) => {
 			{ wcPayGateway.length ? (
 				<>
 					<WCPaySuggestion paymentGateway={ wcPayGateway[ 0 ] } />
-					<Toggle
-						heading={ __(
-							'Other payment providers',
-							'woocommerce'
-						) }
-						onToggle={ trackToggle }
-					>
-						{ additionalSection }
-						{ offlineSection }
-					</Toggle>
+					{ additionalSection }
+					{ offlineSection }
 				</>
 			) : (
 				<>

--- a/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/test/index.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/test/index.js
@@ -90,7 +90,7 @@ const paymentGatewaySuggestionsWithoutWCPay = paymentGatewaySuggestions.filter(
 );
 
 describe( 'PaymentGatewaySuggestions', () => {
-	test( 'should render only WCPay if its suggested', () => {
+	test( 'should render all payment gateways, including WCPay', () => {
 		const onComplete = jest.fn();
 		const query = {};
 		useSelect.mockImplementation( () => ( {
@@ -129,7 +129,7 @@ describe( 'PaymentGatewaySuggestions', () => {
 		).toBe( true );
 	} );
 
-	test( 'should render all payment gateways if no WCPay', () => {
+	test( 'should render all payment gateways except WCPay', () => {
 		const onComplete = jest.fn();
 		const query = {};
 		useSelect.mockImplementation( () => ( {

--- a/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/test/index.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/test/index.js
@@ -115,7 +115,10 @@ describe( 'PaymentGatewaySuggestions', () => {
 			( e ) => e.textContent
 		);
 
-		expect( paymentTitles ).toEqual( [] );
+		expect( paymentTitles ).toEqual( [
+			'Cash on delivery',
+			'Direct bank transfer',
+		] );
 
 		expect(
 			container
@@ -297,39 +300,6 @@ describe( 'PaymentGatewaySuggestions', () => {
 		expect( recordEvent ).toHaveBeenCalledWith( 'tasklist_payment_setup', {
 			selected: 'ppcp_gateway',
 		} );
-	} );
-
-	test( 'should record event correctly when Other payment providers is clicked', () => {
-		const onComplete = jest.fn();
-		const query = {};
-		useSelect.mockImplementation( () => ( {
-			isResolving: false,
-			getPaymentGateway: jest.fn(),
-			paymentGatewaySuggestions,
-			installedPaymentGateways: [],
-			countryCode: 'US',
-		} ) );
-
-		render(
-			<PaymentGatewaySuggestions
-				onComplete={ onComplete }
-				query={ query }
-			/>
-		);
-
-		fireEvent.click( screen.getByText( 'Other payment providers' ) );
-
-		// By default it's hidden, so when toggle it shows.
-		// Second call after "tasklist_payments_options".
-		expect(
-			recordEvent.mock.calls[ recordEvent.mock.calls.length - 1 ]
-		).toEqual( [
-			'tasklist_payment_show_toggle',
-			{
-				toggle: 'show',
-				payment_method_count: paymentGatewaySuggestions.length - 1, // Minus one for WCPay since it's not counted in "Other payment providers".
-			},
-		] );
 	} );
 
 	test( 'should record event correctly when see more is clicked', () => {

--- a/plugins/woocommerce/changelog/remove-wcpay-accordion
+++ b/plugins/woocommerce/changelog/remove-wcpay-accordion
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Remove accordion from "Other payment providers" in payment task

--- a/plugins/woocommerce/tests/e2e-pw/tests/admin-tasks/payment.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/admin-tasks/payment.spec.js
@@ -113,9 +113,6 @@ test.describe( 'Payment setup task', () => {
 			.catch( () => {} );
 		await page.waitForLoadState( 'networkidle' );
 
-		// purposely no await again
-		page.click( 'button.toggle-button' );
-
 		// enable COD payment option
 		await page.click(
 			'div.woocommerce-task-payment-cod > div.woocommerce-task-payment__footer > button'


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #37203.

Remove the accordion from "Other payment providers" in WC Pay Task and add proper space between sections.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Skip OBW
2. Go to `/wp-admin/admin.php?page=wc-settings`
3. Choose a WCPay country, such as the US 
4. Go to WooCommerce > Home > Payment task
5. Observe that "Other payments providers" section is visible


![Screenshot 2023-03-14 at 15 24 27](https://user-images.githubusercontent.com/4344253/224926975-3dfb7bf7-e853-4272-be78-746cc33ab90c.png)

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [ ] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
