### PR TITLE
Update product rest config and template block usage

### DIFF
--- a/packages/js/product-editor/changelog/update-product_rest_config
+++ b/packages/js/product-editor/changelog/update-product_rest_config
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update use of blocks within block editor to always make use of template.

--- a/packages/js/product-editor/src/components/block-editor/block-editor.tsx
+++ b/packages/js/product-editor/src/components/block-editor/block-editor.tsx
@@ -1,11 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	BlockInstance,
-	synchronizeBlocksWithTemplate,
-	Template,
-} from '@wordpress/blocks';
+import { synchronizeBlocksWithTemplate, Template } from '@wordpress/blocks';
 import {
 	createElement,
 	useMemo,
@@ -13,7 +9,7 @@ import {
 	useState,
 } from '@wordpress/element';
 import { Product } from '@woocommerce/data';
-import { useSelect, select as WPSelect, useDispatch } from '@wordpress/data';
+import { useSelect, select as WPSelect } from '@wordpress/data';
 import { uploadMedia } from '@wordpress/media-utils';
 import {
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -61,13 +57,7 @@ export function BlockEditor( {
 	settings: _settings,
 	product,
 }: BlockEditorProps ) {
-	const [ blocks, updateBlocks ] = useState< BlockInstance[] >();
 	const [ selectedTab, setSelectedTab ] = useState< string | null >( null );
-
-	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-	// @ts-ignore __experimentalTearDownEditor is not yet included in types package.
-	const { setupEditorState, __experimentalTearDownEditor } =
-		useDispatch( 'core/editor' );
 
 	const canUserCreateMedia = useSelect( ( select: typeof WPSelect ) => {
 		const { canUser } = select( 'core' );
@@ -98,22 +88,18 @@ export function BlockEditor( {
 		};
 	}, [ canUserCreateMedia, _settings ] );
 
-	useLayoutEffect( () => {
-		setupEditorState( product );
-		updateBlocks(
-			synchronizeBlocksWithTemplate( [], _settings?.template )
-		);
-
-		return () => {
-			__experimentalTearDownEditor();
-		};
-	}, [] );
-
-	const [ , onInput, onChange ] = useEntityBlockEditor(
+	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
 		'postType',
 		'product',
 		{ id: product.id }
 	);
+
+	useLayoutEffect( () => {
+		onChange(
+			synchronizeBlocksWithTemplate( [], _settings?.template ),
+			{}
+		);
+	}, [] );
 
 	if ( ! blocks ) {
 		return null;

--- a/packages/js/product-editor/src/components/block-editor/block-editor.tsx
+++ b/packages/js/product-editor/src/components/block-editor/block-editor.tsx
@@ -1,7 +1,11 @@
 /**
  * External dependencies
  */
-import { Template } from '@wordpress/blocks';
+import {
+	BlockInstance,
+	synchronizeBlocksWithTemplate,
+	Template,
+} from '@wordpress/blocks';
 import {
 	createElement,
 	useMemo,
@@ -57,6 +61,7 @@ export function BlockEditor( {
 	settings: _settings,
 	product,
 }: BlockEditorProps ) {
+	const [ blocks, updateBlocks ] = useState< BlockInstance[] >();
 	const [ selectedTab, setSelectedTab ] = useState< string | null >( null );
 
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -95,13 +100,16 @@ export function BlockEditor( {
 
 	useLayoutEffect( () => {
 		setupEditor( product, {}, _settings?.template );
+		updateBlocks(
+			synchronizeBlocksWithTemplate( [], _settings?.template )
+		);
 
 		return () => {
 			__experimentalTearDownEditor();
 		};
 	}, [] );
 
-	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
+	const [ , onInput, onChange ] = useEntityBlockEditor(
 		'postType',
 		'product',
 		{ id: product.id }

--- a/packages/js/product-editor/src/components/block-editor/block-editor.tsx
+++ b/packages/js/product-editor/src/components/block-editor/block-editor.tsx
@@ -66,7 +66,7 @@ export function BlockEditor( {
 
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore __experimentalTearDownEditor is not yet included in types package.
-	const { setupEditor, __experimentalTearDownEditor } =
+	const { setupEditorState, __experimentalTearDownEditor } =
 		useDispatch( 'core/editor' );
 
 	const canUserCreateMedia = useSelect( ( select: typeof WPSelect ) => {
@@ -99,7 +99,7 @@ export function BlockEditor( {
 	}, [ canUserCreateMedia, _settings ] );
 
 	useLayoutEffect( () => {
-		setupEditor( product, {}, _settings?.template );
+		setupEditorState( product );
 		updateBlocks(
 			synchronizeBlocksWithTemplate( [], _settings?.template )
 		);

--- a/plugins/woocommerce-admin/client/products/product-page.tsx
+++ b/plugins/woocommerce-admin/client/products/product-page.tsx
@@ -22,7 +22,7 @@ declare const productBlockEditorSettings: ProductEditorSettings;
 const ProductEditor: React.FC< { product: Product | undefined } > = ( {
 	product,
 } ) => {
-	if ( ! product ) {
+	if ( ! product || ! product.id ) {
 		return <Spinner />;
 	}
 

--- a/plugins/woocommerce-admin/client/products/product-page.tsx
+++ b/plugins/woocommerce-admin/client/products/product-page.tsx
@@ -22,7 +22,7 @@ declare const productBlockEditorSettings: ProductEditorSettings;
 const ProductEditor: React.FC< { product: Product | undefined } > = ( {
 	product,
 } ) => {
-	if ( ! product || ! product.id ) {
+	if ( ! product?.id ) {
 		return <Spinner />;
 	}
 

--- a/plugins/woocommerce/changelog/update-product_rest_config
+++ b/plugins/woocommerce/changelog/update-product_rest_config
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Update product post rest config when block editor feature is enabled.

--- a/plugins/woocommerce/src/Admin/Features/BlockEditorFeatureEnabled.php
+++ b/plugins/woocommerce/src/Admin/Features/BlockEditorFeatureEnabled.php
@@ -32,7 +32,7 @@ class BlockEditorFeatureEnabled {
 		}
 		if ( Features::is_enabled( self::FEATURE_ID ) ) {
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
-			add_filter( 'woocommerce_register_post_type_product', array ( $this, 'add_rest_base_config' ) );
+			add_filter( 'woocommerce_register_post_type_product', array( $this, 'add_rest_base_config' ) );
 		}
 	}
 

--- a/plugins/woocommerce/src/Admin/Features/BlockEditorFeatureEnabled.php
+++ b/plugins/woocommerce/src/Admin/Features/BlockEditorFeatureEnabled.php
@@ -32,6 +32,7 @@ class BlockEditorFeatureEnabled {
 		}
 		if ( Features::is_enabled( self::FEATURE_ID ) ) {
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+			add_filter( 'woocommerce_register_post_type_product', array ( $this, 'add_rest_base_config' ) );
 		}
 	}
 
@@ -102,4 +103,15 @@ class BlockEditorFeatureEnabled {
 		return $link;
 	}
 
+	/**
+	 * Updates the product endpoint to use WooCommerce REST API.
+	 *
+	 * @param array $post_args Args for the product post type.
+	 * @return array
+	 */
+	public function add_rest_base_config( $post_args ) {
+		$post_args['rest_base']      = 'products';
+		$post_args['rest_namespace'] = 'wc/v3';
+		return $post_args;
+	}
 }


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR updates the `rest_base` and `rest_namespace` of the product post type to use the WC REST api.
To keep the template working, the block editor required a couple small changes as well.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Make sure you have the `block-editor-feature-enabled` feature enabled and go to **WooCommerce > Products > Add new**
2. Make sure things load correctly
3. Now go to **WooCommerce > Products > All products** and click edit on a product, the block editor should load with the name correctly filled in.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
