### PR TITLE
Improve accessibility around product editor tabs

### DIFF
--- a/packages/js/product-editor/changelog/add-37096-accessibility
+++ b/packages/js/product-editor/changelog/add-37096-accessibility
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Improve accessibility around product editor tabs

--- a/packages/js/product-editor/src/components/tab/edit.tsx
+++ b/packages/js/product-editor/src/components/tab/edit.tsx
@@ -30,13 +30,15 @@ export function Edit( {
 
 	return (
 		<div { ...blockProps }>
-			<TabButton
-				id={ id }
-				className={ isSelected ? 'is-selected' : undefined }
-			>
+			<TabButton id={ id } selected={ isSelected }>
 				{ title }
 			</TabButton>
-			<div className={ classes }>
+			<div
+				id={ `woocommerce-product-tab__${ id }-content` }
+				aria-labelledby={ `woocommerce-product-tab__${ id }` }
+				role="tabpanel"
+				className={ classes }
+			>
 				<InnerBlocks templateLock="all" />
 			</div>
 		</div>

--- a/packages/js/product-editor/src/components/tab/tab-button.tsx
+++ b/packages/js/product-editor/src/components/tab/tab-button.tsx
@@ -15,14 +15,17 @@ export function TabButton( {
 	children,
 	className,
 	id,
+	selected = false,
 }: {
 	children: string | JSX.Element;
 	className?: string;
 	id: string;
+	selected?: boolean;
 } ) {
 	const classes = classnames(
 		'wp-block-woocommerce-product-tab__button',
-		className
+		className,
+		{ 'is-selected': selected }
 	);
 
 	return (
@@ -34,6 +37,9 @@ export function TabButton( {
 						key={ id }
 						className={ classes }
 						onClick={ () => onClick( id ) }
+						id={ `woocommerce-product-tab__${ id }` }
+						aria-controls={ `woocommerce-product-tab__${ id }-content` }
+						aria-selected={ selected }
 					>
 						{ children }
 					</Button>

--- a/packages/js/product-editor/src/components/tabs/tabs.tsx
+++ b/packages/js/product-editor/src/components/tabs/tabs.tsx
@@ -8,7 +8,7 @@ import {
 	useState,
 } from '@wordpress/element';
 import { ReactElement } from 'react';
-import { Slot } from '@wordpress/components';
+import { NavigableMenu, Slot } from '@wordpress/components';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore No types for this exist yet.
 // eslint-disable-next-line @woocommerce/dependency-group
@@ -20,7 +20,7 @@ import { navigateTo, getNewPath, getQuery } from '@woocommerce/navigation';
 import { TABS_SLOT_NAME } from './constants';
 
 type TabsProps = {
-	onChange: ( tabId: string | null ) => void;
+	onChange?: ( tabId: string | null ) => void;
 };
 
 export type TabsFillProps = {
@@ -64,8 +64,20 @@ export function Tabs( { onChange = () => {} }: TabsProps ) {
 		}
 	}
 
+	function selectTabOnNavigate(
+		_childIndex: number,
+		child: HTMLButtonElement
+	) {
+		child.click();
+	}
+
 	return (
-		<div className="woocommerce-product-tabs">
+		<NavigableMenu
+			role="tablist"
+			onNavigate={ selectTabOnNavigate }
+			className="woocommerce-product-tabs"
+			orientation="horizontal"
+		>
 			<Slot
 				fillProps={
 					{
@@ -79,6 +91,6 @@ export function Tabs( { onChange = () => {} }: TabsProps ) {
 					return <>{ fills }</>;
 				} }
 			</Slot>
-		</div>
+		</NavigableMenu>
 	);
 }


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds accessibility for keyboard only and non-sighted users to the product tabs.  Note that follow-ups will address:

* Placement of tabs in header (pending header PR)
* Tests around tabs
* Disabled tabs (pending decision on template layouts)

<img width="657" alt="Screen Shot 2023-03-14 at 8 57 22 AM" src="https://user-images.githubusercontent.com/10561050/225063849-1a16c0ed-d94a-4b89-b257-88232ce552e8.png">

Closes (part of) #37096 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Open your favorite screen reader
2. Enable the blocks product editor feature
3. Navigate through the tabs using the tab key and arrow keys
4. Make sure tab labels are announced and that you can navigate without issue

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
