### PR TITLE
Update Avalara CTA copy in tax task

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/fills/tax/avalara/card.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/tax/avalara/card.tsx
@@ -46,7 +46,7 @@ export const Card: React.FC< TaxChildProps > = ( { task } ) => {
 			actionText={
 				avalaraActivated
 					? __( 'Continue setup', 'woocommerce' )
-					: __( 'Enable & set up', 'woocommerce' )
+					: __( 'Download', 'woocommerce' )
 			}
 			onClick={ () => {
 				recordEvent( 'tasklist_tax_select_option', {

--- a/plugins/woocommerce/changelog/update-36746-update-avalara-cta-copy
+++ b/plugins/woocommerce/changelog/update-36746-update-avalara-cta-copy
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Change Avalara CTA copy in tax task to Download


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR updates Avalara CTA copy in tax task to `Download`


Closes #36746  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:


1. Checkout this branch and build the assets.
2. Start OBW and choose a country that doesn't support `WooCommerce Tax`, but supports `Avalara`, such as Denmark.
3. Go to `WooCommerce -> Home`
4. Click on `Add tax rates` task.
5. Confirm the CTA copy change.

<!-- End testing instructions -->

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [ ] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
