### PR TITLE
Make sure expression before `&&` is always boolean in React rendering in marketing page

### DIFF
--- a/plugins/woocommerce-admin/client/marketing/components/CollapsibleCard/CollapsibleCard.tsx
+++ b/plugins/woocommerce-admin/client/marketing/components/CollapsibleCard/CollapsibleCard.tsx
@@ -64,7 +64,7 @@ const CollapsibleCard: React.FC< CollapsibleCardProps > = ( {
 			{ ! collapsed && (
 				<>
 					{ children }
-					{ footer && <CardFooter>{ footer }</CardFooter> }
+					{ !! footer && <CardFooter>{ footer }</CardFooter> }
 				</>
 			) }
 		</Card>

--- a/plugins/woocommerce-admin/client/marketing/components/knowledge-base/index.js
+++ b/plugins/woocommerce-admin/client/marketing/components/knowledge-base/index.js
@@ -79,7 +79,7 @@ const KnowledgeBase = ( {
 					target="_blank"
 					rel="noopener noreferrer"
 				>
-					{ post.image && (
+					{ !! post.image && (
 						<div className="woocommerce-marketing-knowledgebase-card__post-img">
 							<img src={ post.image } alt="" />
 						</div>
@@ -89,7 +89,7 @@ const KnowledgeBase = ( {
 						<p className="woocommerce-marketing-knowledgebase-card__post-meta">
 							{ __( 'By', 'woocommerce' ) + ' ' }
 							{ post.author_name }
-							{ post.author_avatar && (
+							{ !! post.author_avatar && (
 								<img
 									src={ post.author_avatar.replace(
 										's=96',

--- a/plugins/woocommerce-admin/client/marketing/coupons/index.js
+++ b/plugins/woocommerce-admin/client/marketing/coupons/index.js
@@ -22,7 +22,7 @@ const CouponsOverview = () => {
 
 	return (
 		<div className="woocommerce-marketing-coupons">
-			{ shouldShowExtensions && (
+			{ !! shouldShowExtensions && (
 				<RecommendedExtensions
 					title={ __(
 						'Recommended coupon extensions',

--- a/plugins/woocommerce-admin/client/marketing/overview-multichannel/Campaigns/Campaigns.tsx
+++ b/plugins/woocommerce-admin/client/marketing/overview-multichannel/Campaigns/Campaigns.tsx
@@ -139,7 +139,7 @@ export const Campaigns = () => {
 													{ el.title }
 												</Link>
 											</FlexItem>
-											{ el.description && (
+											{ !! el.description && (
 												<FlexItem className="woocommerce-marketing-campaigns-card__campaign-description">
 													{ el.description }
 												</FlexItem>
@@ -168,14 +168,14 @@ export const Campaigns = () => {
 				>
 					{ __( 'Create new campaign', 'woocommerce' ) }
 				</Button>
-				{ isModalOpen && (
+				{ !! isModalOpen && (
 					<CreateNewCampaignModal
 						onRequestClose={ () => setModalOpen( false ) }
 					/>
 				) }
 			</CardHeader>
 			{ getContent() }
-			{ total && total > perPage && (
+			{ !! ( total && total > perPage ) && (
 				<CardFooter className="woocommerce-marketing-campaigns-card__footer">
 					<Pagination
 						showPerPagePicker={ false }

--- a/plugins/woocommerce-admin/client/marketing/overview-multichannel/Campaigns/CreateNewCampaignModal/CreateNewCampaignModal.tsx
+++ b/plugins/woocommerce-admin/client/marketing/overview-multichannel/Campaigns/CreateNewCampaignModal/CreateNewCampaignModal.tsx
@@ -105,7 +105,7 @@ export const CreateNewCampaignModal = ( props: CreateCampaignModalProps ) => {
 									<FlexItem>
 										{ __( 'Create', 'woocommerce' ) }
 									</FlexItem>
-									{ isExternalURL( el.createUrl ) && (
+									{ !! isExternalURL( el.createUrl ) && (
 										<FlexItem>
 											<Icon
 												icon={ external }

--- a/plugins/woocommerce-admin/client/marketing/overview-multichannel/Channels/Channels.tsx
+++ b/plugins/woocommerce-admin/client/marketing/overview-multichannel/Channels/Channels.tsx
@@ -76,7 +76,7 @@ export const Channels: React.FC< ChannelsProps > = ( {
 			{ /* Recommended channels section. */ }
 			{ recommendedChannels.length >= 1 && (
 				<div>
-					{ hasRegisteredChannels && (
+					{ !! hasRegisteredChannels && (
 						<>
 							<CardDivider />
 							<CardBody>
@@ -95,7 +95,7 @@ export const Channels: React.FC< ChannelsProps > = ( {
 							</CardBody>
 						</>
 					) }
-					{ expanded &&
+					{ !! expanded &&
 						recommendedChannels.map( ( el, idx ) => {
 							return (
 								<Fragment key={ el.plugin }>

--- a/plugins/woocommerce-admin/client/marketing/overview-multichannel/Channels/RegisteredChannelCardBody.tsx
+++ b/plugins/woocommerce-admin/client/marketing/overview-multichannel/Channels/RegisteredChannelCardBody.tsx
@@ -31,7 +31,7 @@ export const RegisteredChannelCardBody: React.FC<
 		registeredChannel.description
 	) : (
 		<div className="woocommerce-marketing-registered-channel-description">
-			{ registeredChannel.syncStatus && (
+			{ !! registeredChannel.syncStatus && (
 				<>
 					<SyncStatus status={ registeredChannel.syncStatus } />
 					<div className="woocommerce-marketing-registered-channel-description__separator" />

--- a/plugins/woocommerce-admin/client/marketing/overview-multichannel/LearnMarketing/PostTile.tsx
+++ b/plugins/woocommerce-admin/client/marketing/overview-multichannel/LearnMarketing/PostTile.tsx
@@ -27,7 +27,7 @@ export const PostTile: React.FC< PostTileProps > = ( { post } ) => {
 			} }
 		>
 			<div className="woocommerce-marketing-learn-marketing-card__post-img">
-				{ post.image && <img src={ post.image } alt="" /> }
+				{ !! post.image && <img src={ post.image } alt="" /> }
 			</div>
 			<div className="woocommerce-marketing-learn-marketing-card__post-title">
 				{ post.title }
@@ -37,7 +37,7 @@ export const PostTile: React.FC< PostTileProps > = ( { post } ) => {
 					// translators: %s: author's name.
 					sprintf( __( 'By %s', 'woocommerce' ), post.author_name )
 				}
-				{ post.author_avatar && (
+				{ !! post.author_avatar && (
 					<img
 						src={ post.author_avatar.replace( 's=96', 's=32' ) }
 						alt=""

--- a/plugins/woocommerce-admin/client/marketing/overview-multichannel/MarketingOverviewMultichannel.tsx
+++ b/plugins/woocommerce-admin/client/marketing/overview-multichannel/MarketingOverviewMultichannel.tsx
@@ -57,8 +57,7 @@ export const MarketingOverviewMultichannel: React.FC = () => {
 	return (
 		<div className="woocommerce-marketing-overview-multichannel">
 			{ !! dataRegistered?.length && <Campaigns /> }
-			{ dataRegistered &&
-				dataRecommended &&
+			{ !! ( dataRegistered && dataRecommended ) &&
 				!! ( dataRegistered.length || dataRecommended.length ) && (
 					<Channels
 						registeredChannels={ dataRegistered }
@@ -67,7 +66,7 @@ export const MarketingOverviewMultichannel: React.FC = () => {
 					/>
 				) }
 			<InstalledExtensions />
-			{ shouldShowExtensions && <DiscoverTools /> }
+			{ !! shouldShowExtensions && <DiscoverTools /> }
 			<LearnMarketing />
 		</div>
 	);

--- a/plugins/woocommerce-admin/client/marketing/overview/index.js
+++ b/plugins/woocommerce-admin/client/marketing/overview/index.js
@@ -27,7 +27,7 @@ const MarketingOverview = () => {
 			<WelcomeCard />
 			<InstalledExtensions />
 			<MarketingOverviewSectionSlot />
-			{ shouldShowExtensions && (
+			{ !! shouldShowExtensions && (
 				<RecommendedExtensions category="marketing" />
 			) }
 			<KnowledgeBase category="marketing" />

--- a/plugins/woocommerce/changelog/feature-37175-react-render-boolean-expression
+++ b/plugins/woocommerce/changelog/feature-37175-react-render-boolean-expression
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix React rendering falsy value in marketing page.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/37175.

In this PR, we make sure that the expression before `&&` is always boolean by using double negation `!!`.

In some cases where we are using a variable like `shouldShowExtensions` and `isModalOpen` which _should_ already be boolean, we use `!!` in front of them anyway, so that we don't need to second guess it when we look at it, and we are future proofing it (e.g. when the variable type is changed from boolean to another type in the future).

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

Functionality test:

1. Make sure this fixes issue https://github.com/woocommerce/woocommerce/issues/37175.
2. Test the marketing page (classic) and it works as expected.
3. Test the marketing page (beta multichannel) and it works as expected.

Code check:

1. Look into the marketing page code base and make sure all the expression before `&&` in React rendering is always boolean. 
    - The expression should contain `!`, `!!`, or a comparison operator like `===` or `>=`.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
