### PR TITLE
Replace woocommerce-blocks textdomain in *.json files

### DIFF
--- a/plugins/woocommerce/bin/package-update.sh
+++ b/plugins/woocommerce/bin/package-update.sh
@@ -34,7 +34,7 @@ if [ -z "$SKIP_UPDATE_TEXTDOMAINS" ]; then
 	output 2 "Done!"
 
 	output 3 "Updating package JS textdomains..."
-	find ./packages/woocommerce-blocks \( -iname '*.js' -o -iname '*.ts' -o -iname '*.tsx' -o -iname '*.json' \) -exec sed -i.bak -e "s/'woo-gutenberg-products-block'/'woocommerce'/g" -e "s/\"woo-gutenberg-products-block\"/\"woocommerce\"/g" {} \;
+	find ./packages/woocommerce-blocks \( -iname '*.js' -o -iname '*.json' \) -exec sed -i.bak -e "s/'woo-gutenberg-products-block'/'woocommerce'/g" -e "s/\"woo-gutenberg-products-block\"/\"woocommerce\"/g" {} \;
 	find ./packages/woocommerce-blocks -iname '*.js' -exec sed -i.bak -e "s/'woocommerce-admin'/'woocommerce'/g" -e "s/\"woocommerce-admin\"/\"woocommerce\"/g" {} \;
 fi
 

--- a/plugins/woocommerce/bin/package-update.sh
+++ b/plugins/woocommerce/bin/package-update.sh
@@ -34,7 +34,7 @@ if [ -z "$SKIP_UPDATE_TEXTDOMAINS" ]; then
 	output 2 "Done!"
 
 	output 3 "Updating package JS textdomains..."
-	find ./packages/woocommerce-blocks -iname '*.js' -exec sed -i.bak -e "s/'woo-gutenberg-products-block'/'woocommerce'/g" -e "s/\"woo-gutenberg-products-block\"/\"woocommerce\"/g" {} \;
+	find ./packages/woocommerce-blocks \( -iname '*.js' -o -iname '*.ts' -o -iname '*.tsx' -o -iname '*.json' \) -exec sed -i.bak -e "s/'woo-gutenberg-products-block'/'woocommerce'/g" -e "s/\"woo-gutenberg-products-block\"/\"woocommerce\"/g" {} \;
 	find ./packages/woocommerce-blocks -iname '*.js' -exec sed -i.bak -e "s/'woocommerce-admin'/'woocommerce'/g" -e "s/\"woocommerce-admin\"/\"woocommerce\"/g" {} \;
 fi
 

--- a/plugins/woocommerce/changelog/enhance-textdomain-replacement
+++ b/plugins/woocommerce/changelog/enhance-textdomain-replacement
@@ -1,4 +1,4 @@
 Significance: minor
 Type: update
 
-Replace woocommerce-blocks textdomain in *.ts, *.tsx and *.json files
+Replace woocommerce-blocks textdomain *.json files

--- a/plugins/woocommerce/changelog/enhance-textdomain-replacement
+++ b/plugins/woocommerce/changelog/enhance-textdomain-replacement
@@ -1,4 +1,4 @@
 Significance: minor
 Type: update
 
-Replace woocommerce-blocks textdomain in *.json files
+Update textdomain in woocommerce-blocks *.json files to `woocommerce`

--- a/plugins/woocommerce/changelog/enhance-textdomain-replacement
+++ b/plugins/woocommerce/changelog/enhance-textdomain-replacement
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Replace woocommerce-blocks textdomain in *.ts, *.tsx and *.json files

--- a/plugins/woocommerce/changelog/enhance-textdomain-replacement
+++ b/plugins/woocommerce/changelog/enhance-textdomain-replacement
@@ -1,4 +1,4 @@
 Significance: minor
 Type: update
 
-Replace woocommerce-blocks textdomain *.json files
+Replace woocommerce-blocks textdomain in *.json files


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

In #23989, we introduced textdomain replacement for packages for *.php files, to replace `woo-gutenberg-products-block` with `woocommerce`. In #24696, we enhanced that part to not only replace textdomains in *.php, but also in *.js files. In #25569, we further improved the textdomain replacement, in a way that *.php files will be handled using `wp-textdomain`, while *.js files were still handeled using [`sed`](https://linux.die.net/man/1/sed). 

Since the last update, we're using various `block.json` files, which contain translatable strings. In https://github.com/woocommerce/woocommerce-blocks/issues/8639#issuecomment-1469443099, a user reported that the textdomains of JSON files are not replaced. This PR aims to update the textdomain replacement logic in a way that it not only replaces strings within *.js files, but also strings within *.json files.

### How to test the changes in this Pull Request:

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Check out this PR.
2. Open the following file
```
plugins/woocommerce/packages/woocommerce-blocks/build/active-filters/block.json
```
4. Verify that the file still contains the textdomain `woo-gutenberg-products-block`.
5. Go to `/wp-admin/options-general.php` and change the site language to Italian.
7. Go to `/wp-admin/update-core.php` and fetch the Italian translations.
8. Go to `/wp-admin/post-new.php` and open the block inserter.
9. Scroll down to the WooCommerce Blocks and verify that some blocks appear in English instead of in Italian.
10. Delete the folder `./plugins/woocommerce/packages/woocommerce-blocks/`.
11. Go to `./plugins/woocommerce`.
12. Run the following command:
```sh
composer i
```
13. Open the file  from step 2. and verify that it now contains the textdomain `woocommerce`.
14. Go back `/wp-admin/post-new.php` and open the block inserter again.
15. Verify that all blocks appear in Italian now.

### Screenshots:

<table>
<tr>
<td>Before:
<br><br>

<img width="355" alt="Screenshot 2023-03-15 at 16 33 29" src="https://user-images.githubusercontent.com/3323310/225268003-10244137-72e0-4135-a86a-27ef91137c68.png">

</td>
<td>After:
<br><br>

<img width="358" alt="Screenshot 2023-03-15 at 16 34 29" src="https://user-images.githubusercontent.com/3323310/225268365-1b97f1a1-0ca2-4b18-bb7b-2203ddc26a07.png">
</td>
</tr>
</table>

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
