### PR TITLE
Update WooCommerce Blocks package to 9.8.1

### DIFF
--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-9.8.1
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-9.8.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update WooCommerce Blocks to 9.8.1

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -21,7 +21,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.5.4",
-		"woocommerce/woocommerce-blocks": "9.8.0"
+		"woocommerce/woocommerce-blocks": "9.8.1"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.3.0",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f08d44536a1162957e0edb212f042956",
+    "content-hash": "5c0ebd9977d69b819fa45b7b463fb356",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -628,16 +628,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "v9.8.0",
+            "version": "v9.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "e41d383535dc5daeea37e3bd700b950b33d6c1d0"
+                "reference": "2c336eb8304ca59ae9b9169cc8cc58b9ca529e5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/e41d383535dc5daeea37e3bd700b950b33d6c1d0",
-                "reference": "e41d383535dc5daeea37e3bd700b950b33d6c1d0",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/2c336eb8304ca59ae9b9169cc8cc58b9ca529e5b",
+                "reference": "2c336eb8304ca59ae9b9169cc8cc58b9ca529e5b",
                 "shasum": ""
             },
             "require": {
@@ -683,9 +683,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v9.8.0"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v9.8.1"
             },
-            "time": "2023-03-14T10:14:32+00:00"
+            "time": "2023-03-15T13:26:05+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 9.8.1. It includes changes from WooCommerce Blocks 9.7.0-9.8.0 and is intended to target WooCommerce 7.6 for release.

Details from all the different releases included in this pull:

##  WC Blocks 9.8.1

* [Release PR](https://github.com/woocommerce/woocommerce-blocks/pull/8760)
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/981.md)

### Changelog entry

### The following changelog entries are only those that impact existing blocks and functionality surfaced to users:

#### Bug Fixes

- Fix Single Product page not visible in block themes that provided a custom template. ([8758](https://github.com/woocommerce/woocommerce-blocks/pull/8758))
- Products by Attributes: Fix the block rendered empty in the Editor. ([8759](https://github.com/woocommerce/woocommerce-blocks/pull/8759))
- Fix the local pickup price in the shipping type selector and pickup options. ([8623](https://github.com/woocommerce/woocommerce-blocks/pull/8623))