### PR TITLE
Record values for toggled checkboxes/features in settings

### DIFF
--- a/plugins/woocommerce/changelog/fix-toggled_checkboxes_in_settings_tracks
+++ b/plugins/woocommerce/changelog/fix-toggled_checkboxes_in_settings_tracks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Record values for toggled checkboxes/features in settings

--- a/plugins/woocommerce/includes/tracks/events/class-wc-settings-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-settings-tracking.php
@@ -29,6 +29,16 @@ class WC_Settings_Tracking {
 	protected $updated_options = array();
 
 	/**
+	 * Toggled options.
+	 *
+	 * @var array
+	 */
+	protected $toggled_options = array(
+		'enabled' => array(),
+		'disabled' => array()
+	);
+
+	/**
 	 * Init tracking.
 	 */
 	public function init() {
@@ -81,6 +91,12 @@ class WC_Settings_Tracking {
 			return;
 		}
 
+		// Check and save toggled options.
+		if ( in_array( $new_value, ['yes', 'no'] ) && in_array( $old_value, ['yes', 'no'] ) ) {
+			$option_state = $new_value === 'yes' ? 'enabled' : 'disabled';
+			$this->toggled_options[ $option_state ][] = $option_name;
+		}
+
 		$this->updated_options[] = $option_name;
 	}
 
@@ -97,6 +113,12 @@ class WC_Settings_Tracking {
 		$properties = array(
 			'settings' => implode( ',', $this->updated_options ),
 		);
+
+		foreach ( $this->toggled_options as $state => $options ) {
+            if ( ! empty( $options ) ) {
+                $properties[ $state ] = implode( ',', $options );
+            }
+        }
 
 		if ( isset( $current_tab ) ) {
 			$properties['tab'] = $current_tab;

--- a/plugins/woocommerce/includes/tracks/events/class-wc-settings-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-settings-tracking.php
@@ -120,12 +120,8 @@ class WC_Settings_Tracking {
             }
         }
 
-		if ( isset( $current_tab ) ) {
-			$properties['tab'] = $current_tab;
-		}
-		if ( isset( $current_section ) ) {
-			$properties['section'] = $current_section;
-		}
+		$properties['tab'] = $current_tab ?? '';
+        $properties['section'] = $current_section ?? '';
 
 		WC_Tracks::record_event( 'settings_change', $properties );
 	}

--- a/plugins/woocommerce/includes/tracks/events/class-wc-settings-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-settings-tracking.php
@@ -35,7 +35,7 @@ class WC_Settings_Tracking {
 	 */
 	protected $toggled_options = array(
 		'enabled' => array(),
-		'disabled' => array()
+		'disabled' => array(),
 	);
 
 	/**
@@ -92,8 +92,8 @@ class WC_Settings_Tracking {
 		}
 
 		// Check and save toggled options.
-		if ( in_array( $new_value, ['yes', 'no'] ) && in_array( $old_value, ['yes', 'no'] ) ) {
-			$option_state = $new_value === 'yes' ? 'enabled' : 'disabled';
+		if ( in_array( $new_value, array( 'yes', 'no' ), true ) && in_array( $old_value, array( 'yes', 'no' ), true ) ) {
+			$option_state                             = 'yes' === $new_value ? 'enabled' : 'disabled';
 			$this->toggled_options[ $option_state ][] = $option_name;
 		}
 
@@ -115,13 +115,13 @@ class WC_Settings_Tracking {
 		);
 
 		foreach ( $this->toggled_options as $state => $options ) {
-            if ( ! empty( $options ) ) {
-                $properties[ $state ] = implode( ',', $options );
-            }
+			if ( ! empty( $options ) ) {
+				$properties[ $state ] = implode( ',', $options );
+			}
         }
 
 		$properties['tab'] = $current_tab ?? '';
-        $properties['section'] = $current_section ?? '';
+		$properties['section'] = $current_section ?? '';
 
 		WC_Tracks::record_event( 'settings_change', $properties );
 	}

--- a/plugins/woocommerce/includes/tracks/events/class-wc-settings-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-settings-tracking.php
@@ -34,7 +34,7 @@ class WC_Settings_Tracking {
 	 * @var array
 	 */
 	protected $toggled_options = array(
-		'enabled' => array(),
+		'enabled'  => array(),
 		'disabled' => array(),
 	);
 
@@ -118,9 +118,9 @@ class WC_Settings_Tracking {
 			if ( ! empty( $options ) ) {
 				$properties[ $state ] = implode( ',', $options );
 			}
-        }
+		}
 
-		$properties['tab'] = $current_tab ?? '';
+		$properties['tab']     = $current_tab ?? '';
 		$properties['section'] = $current_section ?? '';
 
 		WC_Tracks::record_event( 'settings_change', $properties );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR adds the code to record the toggled checkboxes/features in settings.

Closes [20](https://github.com/woocommerce/mothra-private/issues/20).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Go to `WooCommerce` > `Settings` > `General` and check `Calculate coupon discounts sequentially` and press `Save changes`. 
2. Go to Tracks `Live view` and look for the event `wcadmin_settings_change`.
3. Verify that the prop "enabled" is set as "woocommerce_calc_discounts_sequentially"

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
