### PR TITLE
fix: payments recommendations pane wrong image size

### DIFF
--- a/plugins/woocommerce-admin/client/payments/payment-recommendations.tsx
+++ b/plugins/woocommerce-admin/client/payments/payment-recommendations.tsx
@@ -193,7 +193,14 @@ const PaymentRecommendations: React.FC = () => {
 					</Button>
 				),
 				before: (
-					<img src={ plugin.square_image || plugin.image } alt="" />
+					<img
+						src={
+							plugin.square_image ||
+							plugin.image_72x72 ||
+							plugin.image
+						}
+						alt=""
+					/>
 				),
 			};
 		} );

--- a/plugins/woocommerce/changelog/fix-payment-recommendations-wrong-image
+++ b/plugins/woocommerce/changelog/fix-payment-recommendations-wrong-image
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fixed payments recommendations pane in WooCommerce Payment Settings using the wrong image prop


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Context: p1678780297582389-slack-C01SFMVEYAK

![image](https://user-images.githubusercontent.com/27843274/225553629-5a0e8203-5267-42a8-9b1c-6629b5318537.png)

The payments recommendations pane in WooCommerce Settings, payments tab was using the `.image` prop if the `square_image` prop doesn't exist on the payment method object.

The correct fallback should be `.image_72x72` as that seems to be the more appropriate aspect ratio, and is also the one used in https://github.com/woocommerce/woocommerce/blob/bd97319162c2b1c97a13db0813bbf7f6f4ac82c7/plugins/woocommerce-admin/client/tasks/fills/PaymentGatewaySuggestions/components/List/Item.js#L65

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Setup the WooCommerce store using Sweden as the store, and with suggestions enabled.
2. Visit WooCommerce settings > Payments
3. Should see the correct Klarna logo being used

![image](https://user-images.githubusercontent.com/27843274/225554521-011e4ec7-44a6-45ed-b8da-b240f12a1bdc.png)


<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.