### PR TITLE
Add tracks for plugin installation and activation

### DIFF
--- a/packages/js/data/changelog/add-track-event-for-plugins-actions
+++ b/packages/js/data/changelog/add-track-event-for-plugins-actions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add tracks for plugin actions and handle plugin error properly

--- a/packages/js/data/package.json
+++ b/packages/js/data/package.json
@@ -28,6 +28,7 @@
 	"dependencies": {
 		"@woocommerce/date": "workspace:*",
 		"@woocommerce/navigation": "workspace:*",
+		"@woocommerce/tracks": "workspace:*",
 		"@wordpress/api-fetch": "wp-6.0",
 		"@wordpress/compose": "wp-6.0",
 		"@wordpress/core-data": "wp-6.0",

--- a/packages/js/data/src/plugins/actions.ts
+++ b/packages/js/data/src/plugins/actions.ts
@@ -193,6 +193,7 @@ function* handlePluginAPIError(
 				: JSON.stringify( error );
 	}
 
+	// Track the error.
 	switch ( actionType ) {
 		case 'install':
 			recordEvent( 'install_plugins_error', {

--- a/packages/js/data/src/plugins/actions.ts
+++ b/packages/js/data/src/plugins/actions.ts
@@ -183,8 +183,8 @@ function* handlePluginAPIError(
 	let rawErrorMessage;
 
 	if ( isPluginResponseError( plugins, error ) ) {
-		rawErrorMessage = Object.values( error ).join( ', \n' );
 		// Backend error messages are in the form of { plugin-slug: [ error messages ] }.
+		rawErrorMessage = Object.values( error ).join( ', \n' );
 	} else {
 		// Other error such as API connection errors.
 		rawErrorMessage =

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -608,6 +608,7 @@ importers:
       '@woocommerce/date': workspace:*
       '@woocommerce/eslint-plugin': workspace:*
       '@woocommerce/navigation': workspace:*
+      '@woocommerce/tracks': workspace:*
       '@wordpress/api-fetch': wp-6.0
       '@wordpress/compose': wp-6.0
       '@wordpress/core-data': wp-6.0
@@ -635,6 +636,7 @@ importers:
     dependencies:
       '@woocommerce/date': link:../date
       '@woocommerce/navigation': link:../navigation
+      '@woocommerce/tracks': link:../tracks
       '@wordpress/api-fetch': 6.3.1
       '@wordpress/compose': 5.4.1_react@17.0.2
       '@wordpress/core-data': 4.4.5_react@17.0.2


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/team-ghidorah/issues/175.

Add `wcadmin_install_plugins_error` and `wcadmin_activate_plugins_error` tracks


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Install `Code Snippets`
2. Go to `Snippet`
3. Create a new Snippet using the following PHP code

```php
function plugins_api_result( $res, $action, $args  ) {
	return new \WP_Error( -1, 'ERROR' );
}

add_filter( 'plugins_api_result', 'plugins_api_result', 999, 3 );
```

4. Open the dev console and enable track logging: `localStorage.setItem( 'debug', 'wc-admin:*' );`
5. Go to OBW
6. Go to `Business Details > Free features` step
7. Select a few plugins
8. Click on "Continue"
9. Observe that an error notice is displayed. The error message should be similar to below depending on plugins you selected:

```
Could not install the following plugins: google-listings-and-ads, woocommerce-services with these Errors: The requested plugin `google-listings-and-ads` could not be installed. Plugin API call failed., 
The requested plugin `woocommerce-services` could not be installed. Plugin API call failed.
```

10. Confirm `wcadmin_install_plugins_error` track is recorded with `plugins` and `message` props

![Screenshot 2023-03-16 at 18 59 51](https://user-images.githubusercontent.com/4344253/225604127-944041ca-9546-4da7-9353-1e41b7f8a52a.png)

11. Go to browser console > network tab
12. Search `plugins%2Finstall` endpoint
13. Right-click on it and select `Block request URL`

<img src="https://user-images.githubusercontent.com/4344253/225604893-438a2d52-7bfd-4c0c-b357-0a26e3b98696.png" width="400px" />


14. Repeat steps 7-9
15. Observe that an error notice is displayed. The error message should be similar to below depending on plugins you selected:

```
Could not install the following plugins: google-listings-and-ads, woocommerce-services with these Errors: You are probably offline.
```

16. Go to the dev console tab
17. Confirm `wcadmin_install_plugins_error` track is recorded with `plugins` and `message` props

![Screenshot 2023-03-16 at 19 00 51](https://user-images.githubusercontent.com/4344253/225604509-4ff21a30-6842-4418-9cc4-835e8bf06b6e.png)


18.  Go to `Snippet` and replace the snippet with the following code:

```php
function plugins_pre_activate( $plugins  ) {
	// append an invalid plugin
	$plugins[] = 'invalid-plugin';
	return $plugins;
}
add_filter( 'woocommerce_admin_plugins_pre_activate', 'plugins_pre_activate', 999 );
```

19. Repeat steps 7-9
20.  Observe that an error notice is displayed. The error message should be similar to below, depending on plugins you selected:

```
Could not activate jetpack plugin, {"invalid-plugin":["The requested plugin `invalid-plugin`. is not yet installed."]}
```

22. Confirm `wcadmin_activate_plugins_error` track is recorded with `plugins` and `message` props

![Screenshot 2023-03-16 at 19 10 17](https://user-images.githubusercontent.com/4344253/225604560-78ba43eb-6216-4b97-8c81-82c78d4dbc79.png)


23. Search `plugins%2Factivate` endpoint
24. Right click on it and select `Block request URL`
25. Repeat steps 7-9
26.  Observe that an error notice is displayed. The error message should be similar to below depending on plugins you selected:

```
Could not activate jetpack plugin, You are probably offline.
```

27. Confirm `wcadmin_activate_plugins_error` track is recorded with `plugins` and `message` props

![Screenshot 2023-03-16 at 19 11 06](https://user-images.githubusercontent.com/4344253/225605335-4f02bdd5-7785-4a86-8f9b-c519185e1693.png)


<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
