### PR TITLE
Bypass scheduled actions for customer updates

### DIFF
--- a/plugins/woocommerce/changelog/update-bypass-actions-for-customer-updates
+++ b/plugins/woocommerce/changelog/update-bypass-actions-for-customer-updates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Bypass Action Scheduler for customer updates.

--- a/plugins/woocommerce/src/Admin/API/Reports/Customers/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Customers/DataStore.php
@@ -90,6 +90,9 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		add_action( 'added_user_meta', array( __CLASS__, 'update_registered_customer_via_last_active' ), 10, 3 );
 		add_action( 'updated_user_meta', array( __CLASS__, 'update_registered_customer_via_last_active' ), 10, 3 );
 
+		add_action( 'delete_user', array( __CLASS__, 'delete_customer_by_user_id' ) );
+		add_action( 'remove_user_from_blog', array( __CLASS__, 'delete_customer_by_user_id' ) );
+
 		add_action( 'woocommerce_analytics_delete_order_stats', array( __CLASS__, 'sync_on_order_delete' ), 15, 2 );
 	}
 
@@ -853,6 +856,11 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 */
 	public static function delete_customer_by_user_id( $user_id ) {
 		global $wpdb;
+
+		if ( (int) $user_id < 1 || doing_action( 'wp_uninitialize_site' ) ) {
+			// Skip the deletion.
+			return;
+		}
 
 		$user_id     = (int) $user_id;
 		$num_deleted = $wpdb->delete( self::get_db_table_name(), array( 'user_id' => $user_id ) );

--- a/plugins/woocommerce/src/Admin/API/Reports/Customers/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Customers/DataStore.php
@@ -85,8 +85,11 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 */
 	public static function init() {
 		add_action( 'woocommerce_update_customer', array( __CLASS__, 'update_registered_customer' ) );
-
 		add_action( 'profile_update', array( __CLASS__, 'update_registered_customer' ) );
+
+		add_action( 'added_user_meta', array( __CLASS__, 'update_registered_customer_via_last_active' ), 10, 3 );
+		add_action( 'updated_user_meta', array( __CLASS__, 'update_registered_customer_via_last_active' ), 10, 3 );
+
 		add_action( 'woocommerce_analytics_delete_order_stats', array( __CLASS__, 'sync_on_order_delete' ), 15, 2 );
 	}
 
@@ -775,6 +778,20 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		ReportsCache::invalidate();
 
 		return $results;
+	}
+
+	/**
+	 * Update the database if the "last active" meta value was changed.
+	 * Function expects to be hooked into the `added_user_meta` and `updated_user_meta` actions.
+	 *
+	 * @param int    $meta_id ID of updated metadata entry.
+	 * @param int    $user_id ID of the user being updated.
+	 * @param string $meta_key Meta key being updated.
+	 */
+	public static function update_registered_customer_via_last_active( $meta_id, $user_id, $meta_key ) {
+		if ( 'wc_last_active' === $meta_key ) {
+			self::update_registered_customer( $user_id );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/API/Reports/Customers/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Customers/DataStore.php
@@ -84,6 +84,8 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 * Set up all the hooks for maintaining and populating table data.
 	 */
 	public static function init() {
+		add_action( 'woocommerce_update_customer', array( __CLASS__, 'update_registered_customer' ) );
+
 		add_action( 'profile_update', array( __CLASS__, 'update_registered_customer' ) );
 		add_action( 'woocommerce_analytics_delete_order_stats', array( __CLASS__, 'sync_on_order_delete' ), 15, 2 );
 	}

--- a/plugins/woocommerce/src/Admin/API/Reports/Customers/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Customers/DataStore.php
@@ -84,6 +84,8 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 * Set up all the hooks for maintaining and populating table data.
 	 */
 	public static function init() {
+		add_action( 'woocommerce_new_customer', array( __CLASS__, 'update_registered_customer' ) );
+
 		add_action( 'woocommerce_update_customer', array( __CLASS__, 'update_registered_customer' ) );
 		add_action( 'profile_update', array( __CLASS__, 'update_registered_customer' ) );
 

--- a/plugins/woocommerce/src/Internal/Admin/Schedulers/CustomersScheduler.php
+++ b/plugins/woocommerce/src/Internal/Admin/Schedulers/CustomersScheduler.php
@@ -27,8 +27,6 @@ class CustomersScheduler extends ImportScheduler {
 	 * @internal
 	 */
 	public static function init() {
-		add_action( 'woocommerce_new_customer', array( __CLASS__, 'schedule_import' ) );
-
 		CustomersDataStore::init();
 		parent::init();
 	}
@@ -111,17 +109,6 @@ class CustomersScheduler extends ImportScheduler {
 	public static function get_total_imported() {
 		global $wpdb;
 		return $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}wc_customer_lookup" );
-	}
-
-	/**
-	 * Schedule import.
-	 *
-	 * @internal
-	 * @param int $user_id User ID.
-	 * @return void
-	 */
-	public static function schedule_import( $user_id ) {
-		self::schedule_action( 'import', array( $user_id ) );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Schedulers/CustomersScheduler.php
+++ b/plugins/woocommerce/src/Internal/Admin/Schedulers/CustomersScheduler.php
@@ -39,7 +39,7 @@ class CustomersScheduler extends ImportScheduler {
 	 */
 	public static function get_dependencies() {
 		return array(
-			'delete_batch_init' => OrdersScheduler::get_action( 'delete_batch_init' )
+			'delete_batch_init' => OrdersScheduler::get_action( 'delete_batch_init' ),
 		);
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/Schedulers/CustomersScheduler.php
+++ b/plugins/woocommerce/src/Internal/Admin/Schedulers/CustomersScheduler.php
@@ -28,7 +28,6 @@ class CustomersScheduler extends ImportScheduler {
 	 */
 	public static function init() {
 		add_action( 'woocommerce_new_customer', array( __CLASS__, 'schedule_import' ) );
-		add_action( 'woocommerce_privacy_remove_order_personal_data', array( __CLASS__, 'schedule_anonymize' ) );
 
 		CustomersDataStore::init();
 		parent::init();
@@ -42,8 +41,7 @@ class CustomersScheduler extends ImportScheduler {
 	 */
 	public static function get_dependencies() {
 		return array(
-			'delete_batch_init' => OrdersScheduler::get_action( 'delete_batch_init' ),
-			'anonymize'         => self::get_action( 'import' ),
+			'delete_batch_init' => OrdersScheduler::get_action( 'delete_batch_init' )
 		);
 	}
 
@@ -116,19 +114,6 @@ class CustomersScheduler extends ImportScheduler {
 	}
 
 	/**
-	 * Get all available scheduling actions.
-	 * Used to determine action hook names and clear events.
-	 *
-	 * @internal
-	 * @return array
-	 */
-	public static function get_scheduler_actions() {
-		$actions                = parent::get_scheduler_actions();
-		$actions['anonymize']   = 'wc-admin_anonymize_' . static::$name;
-		return $actions;
-	}
-
-	/**
 	 * Schedule import.
 	 *
 	 * @internal
@@ -137,20 +122,6 @@ class CustomersScheduler extends ImportScheduler {
 	 */
 	public static function schedule_import( $user_id ) {
 		self::schedule_action( 'import', array( $user_id ) );
-	}
-
-	/**
-	 * Schedule an action to anonymize a single Order.
-	 *
-	 * @internal
-	 * @param WC_Order $order Order object.
-	 * @return void
-	 */
-	public static function schedule_anonymize( $order ) {
-		if ( is_a( $order, 'WC_Order' ) ) {
-			// Postpone until any pending updates are completed.
-			self::schedule_action( 'anonymize', array( $order->get_id() ) );
-		}
 	}
 
 	/**
@@ -183,59 +154,6 @@ class CustomersScheduler extends ImportScheduler {
 
 		foreach ( $customer_ids as $customer_id ) {
 			CustomersDataStore::delete_customer( $customer_id );
-		}
-	}
-
-	/**
-	 * Anonymize the customer data for a single order.
-	 *
-	 * @internal
-	 * @param int $order_id Order id.
-	 * @return void
-	 */
-	public static function anonymize( $order_id ) {
-		global $wpdb;
-
-		$customer_id = $wpdb->get_var(
-			$wpdb->prepare( "SELECT customer_id FROM {$wpdb->prefix}wc_order_stats WHERE order_id = %d", $order_id )
-		);
-
-		if ( ! $customer_id ) {
-			return;
-		}
-
-		// Long form query because $wpdb->update rejects [deleted].
-		$deleted_text = __( '[deleted]', 'woocommerce' );
-		$updated      = $wpdb->query(
-			$wpdb->prepare(
-				"UPDATE {$wpdb->prefix}wc_customer_lookup
-					SET
-						user_id = NULL,
-						username = %s,
-						first_name = %s,
-						last_name = %s,
-						email = %s,
-						country = '',
-						postcode = %s,
-						city = %s,
-						state = %s
-					WHERE
-						customer_id = %d",
-				array(
-					$deleted_text,
-					$deleted_text,
-					$deleted_text,
-					'deleted@site.invalid',
-					$deleted_text,
-					$deleted_text,
-					$deleted_text,
-					$customer_id,
-				)
-			)
-		);
-		// If the customer row was anonymized, flush the cache.
-		if ( $updated ) {
-			ReportsCache::invalidate();
 		}
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Schedulers/CustomersScheduler.php
+++ b/plugins/woocommerce/src/Internal/Admin/Schedulers/CustomersScheduler.php
@@ -28,8 +28,6 @@ class CustomersScheduler extends ImportScheduler {
 	 */
 	public static function init() {
 		add_action( 'woocommerce_new_customer', array( __CLASS__, 'schedule_import' ) );
-		add_action( 'added_user_meta', array( __CLASS__, 'schedule_import_via_last_active' ), 10, 3 );
-		add_action( 'updated_user_meta', array( __CLASS__, 'schedule_import_via_last_active' ), 10, 3 );
 		add_action( 'woocommerce_privacy_remove_order_personal_data', array( __CLASS__, 'schedule_anonymize' ) );
 		add_action( 'delete_user', array( __CLASS__, 'schedule_user_delete' ) );
 		add_action( 'remove_user_from_blog', array( __CLASS__, 'schedule_user_delete' ) );
@@ -143,21 +141,6 @@ class CustomersScheduler extends ImportScheduler {
 	 */
 	public static function schedule_import( $user_id ) {
 		self::schedule_action( 'import', array( $user_id ) );
-	}
-
-	/**
-	 * Schedule an import if the "last active" meta value was changed.
-	 * Function expects to be hooked into the `updated_user_meta` action.
-	 *
-	 * @internal
-	 * @param int    $meta_id ID of updated metadata entry.
-	 * @param int    $user_id ID of the user being updated.
-	 * @param string $meta_key Meta key being updated.
-	 */
-	public static function schedule_import_via_last_active( $meta_id, $user_id, $meta_key ) {
-		if ( 'wc_last_active' === $meta_key ) {
-			self::schedule_import( $user_id );
-		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Schedulers/CustomersScheduler.php
+++ b/plugins/woocommerce/src/Internal/Admin/Schedulers/CustomersScheduler.php
@@ -28,6 +28,7 @@ class CustomersScheduler extends ImportScheduler {
 	 */
 	public static function init() {
 		add_action( 'woocommerce_new_customer', array( __CLASS__, 'schedule_import' ) );
+		add_action( 'added_user_meta', array( __CLASS__, 'schedule_import_via_last_active' ), 10, 3 );
 		add_action( 'updated_user_meta', array( __CLASS__, 'schedule_import_via_last_active' ), 10, 3 );
 		add_action( 'woocommerce_privacy_remove_order_personal_data', array( __CLASS__, 'schedule_anonymize' ) );
 		add_action( 'delete_user', array( __CLASS__, 'schedule_user_delete' ) );

--- a/plugins/woocommerce/src/Internal/Admin/Schedulers/CustomersScheduler.php
+++ b/plugins/woocommerce/src/Internal/Admin/Schedulers/CustomersScheduler.php
@@ -28,7 +28,6 @@ class CustomersScheduler extends ImportScheduler {
 	 */
 	public static function init() {
 		add_action( 'woocommerce_new_customer', array( __CLASS__, 'schedule_import' ) );
-		add_action( 'woocommerce_update_customer', array( __CLASS__, 'schedule_import' ) );
 		add_action( 'updated_user_meta', array( __CLASS__, 'schedule_import_via_last_active' ), 10, 3 );
 		add_action( 'woocommerce_privacy_remove_order_personal_data', array( __CLASS__, 'schedule_anonymize' ) );
 		add_action( 'delete_user', array( __CLASS__, 'schedule_user_delete' ) );

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api-init.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api-init.php
@@ -104,26 +104,4 @@ class WC_Admin_Tests_API_Init extends WC_REST_Unit_Test_Case {
 
 		$this->assertEmpty( $this->queue->actions );
 	}
-
-	/**
-	 * Test that updating  wc_last_active triggers a customer sync.
-	 *
-	 * @return void
-	 */
-	public function test_other_last_active_update_customer_sync() {
-		// First call creates the meta key.
-		// These don't use wc_update_user_last_active() because the timestamps will be the same.
-		update_user_meta( 1, 'wc_last_active', time() - 10 );
-		// Second call updates it which triggers the sync.
-		update_user_meta( 1, 'wc_last_active', time() );
-
-		$this->assertCount( 1, $this->queue->actions );
-		$this->assertArraySubset(
-			array(
-				'hook' => CustomersScheduler::get_action( 'import' ),
-				'args' => array( 1 ),
-			),
-			$this->queue->actions[0]
-		);
-	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-import.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-import.php
@@ -207,7 +207,6 @@ class WC_Admin_Tests_API_Reports_Import extends WC_REST_Unit_Test_Case {
 			$pending_actions
 		);
 		$this->assertContains( 'wc-admin_import_orders', $pending_hooks );
-		$this->assertContains( 'wc-admin_import_customers', $pending_hooks );
 
 		// Cancel outstanding actions.
 		$request  = new WP_REST_Request( 'POST', $this->endpoint . '/cancel' );
@@ -226,7 +225,6 @@ class WC_Admin_Tests_API_Reports_Import extends WC_REST_Unit_Test_Case {
 			$pending_actions
 		);
 		$this->assertNotContains( 'wc-admin_import_orders', $pending_hooks );
-		$this->assertNotContains( 'wc-admin_import_customers', $pending_hooks );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR changes the handling of various types of customer updates to update the Analytics lookup tables immediately instead of using Action Scheduler, to decrease the load on Action Scheduler and improve overall site performance.

- New customer is created (actions: `woocommerce_new_customer`)
- Customer updated (actions: `woocommerce_update_customer`, `updated_user_meta`)
- Customer deleted (actions `delete_user`, `remove_user_from_blog`)
- Personal data removed (action: `woocommerce_privacy_remove_order_personal_data`)

Closes #36330.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

- The Customers report can be found at WooCommerce > Customers (`/wp-admin/admin.php?page=wc-admin&path=%2Fcustomers`)

#### General store settings to configure prior to testing

- WooCommerce > Settings
    - Accounts & Privacy
        - Enable: Allow customers to create an account during checkout
        - Enable: Allow customers to create an account on the "My account" page
        - Enable: When creating an account, automatically generate an account username for the customer based on their name, surname, or email
        - Disable: When creating an account, send the new user a link to set their password
    - Account erasure requests
        - Enable: Remove personal data from orders on request

#### New customer is created (actions: `woocommerce_new_customer`)

1. Either create a new customer via code (you can put this in a mu-plugin to get a customer created automatically when any store page loads)...

```php
function test_create_customer() {
	try {
		$customer = new WC_Customer();
		$customer->set_username( 'customer' );
		$customer->set_password( 'abc123' );
		$customer->set_email( 'customer@example.com' );
		$customer->save();
	} catch ( Exception ) {}
}

add_action( 'admin_init', 'test_create_customer' );
```

or use the REST API ([doc](https://woocommerce.github.io/woocommerce-rest-api-docs/#create-a-customer)) to create a new customer...

```
POST /wp-json/wc/w3/customers
```

2. Verify the new customer appears instantly on the Customers report.
3. Verify no `wc-admin_import_customers` appears in Tools > Scheduled Actions.

#### Customer updated (actions: `woocommerce_update_customer`, `updated_user_meta`, `added_user_meta`)

1. Create a new customer account on the shop store front by going to My account  and registering a new account.
2. Update last name of your new account.
3. Verify the updated customer appears instantly on the Customers report.
4. Verify no `wc-admin_import_customers` appears in Tools > Scheduled Actions.
5. Manually remove the `wc_last_active` entry from `wp_usermeta` for the customer's record.
7. Refresh the logged in My account page.
8. Verify the customer's last active appears correctly on the Customers report.
9. Verify no `wc-admin_import_customers` appears in Tools > Scheduled Actions.

#### Customer deleted (actions `delete_user`, `remove_user_from_blog`)

1. Delete customer's user account from Users > All Users.
2. Verify no `wc-admin_delete_user_customers` appears in Tools > Scheduled Actions.

#### Personal data removed (action: `woocommerce_privacy_remove_order_personal_data`)

1. Go to Tools > Erase Personal Data.
2. Enter the email address of the customer account.
3. Uncheck "Send personal data erasure confirmation email".
4. Click "Send Request".
5. Click "Erase personal data" on the row in the table.
6. After it completes, verify customer data has been removed from Customers report.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
