### PR TITLE
Update labels in pr labeller to include Solaris focus

### DIFF
--- a/.github/project-pr-labeler.yml
+++ b/.github/project-pr-labeler.yml
@@ -65,3 +65,12 @@
 - plugins/woocommerce/src/Admin/**/*
 - plugins/woocommerce/src/Internal/Admin/**/*
 - plugins/woocommerce-admin/**/*
+
+'focus: performance tests [team:Solaris]':
+- plugins/woocommerce/tests/performance/**/*
+
+'focus: api tests [team:Solaris]':
+- plugins/woocommerce/tests/api-core-tests/**/*
+
+'focus: e2e tests [team:Solaris]':
+- plugins/woocommerce/tests/e2e-pw/**/*

--- a/plugins/woocommerce/changelog/update-pr-labeler-solaris-focus
+++ b/plugins/woocommerce/changelog/update-pr-labeler-solaris-focus
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: workflow update not included in release zip
+
+


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/37059

We recently added team names to the `focus: ...` labels:

https://github.com/woocommerce/woocommerce/labels?q=focus

This PR adds labels for Solaris areas of focus to the labeller.

### How to test the changes in this Pull Request:

1. just as in https://github.com/woocommerce/woocommerce/pull/37061 ensure the changed label name is correct 

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
