### PR TITLE
Prevent dbDelta from running unnecessary ALTER table during upgrade

### DIFF
--- a/plugins/woocommerce/changelog/fix-stop-alters-from-dbdelta
+++ b/plugins/woocommerce/changelog/fix-stop-alters-from-dbdelta
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Update column definitions with synonymous types to prevent dbDelta from trying to ALTER them on each install.

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -1001,7 +1001,7 @@ class WC_Install {
 	 *      woocommerce_order_itemmeta - Order line item meta is stored in a table for storing extra data.
 	 *      woocommerce_tax_rates - Tax Rates are stored inside 2 tables making tax queries simple and efficient.
 	 *      woocommerce_tax_rate_locations - Each rate can be applied to more than one postcode/city hence the second table.
-	 * 
+	 *
 	 * @return array Strings containing the results of the various update queries as returned by dbDelta.
 	 */
 	public static function create_tables() {

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -1001,6 +1001,8 @@ class WC_Install {
 	 *      woocommerce_order_itemmeta - Order line item meta is stored in a table for storing extra data.
 	 *      woocommerce_tax_rates - Tax Rates are stored inside 2 tables making tax queries simple and efficient.
 	 *      woocommerce_tax_rate_locations - Each rate can be applied to more than one postcode/city hence the second table.
+	 * 
+	 * @return array Strings containing the results of the various update queries as returned by dbDelta.
 	 */
 	public static function create_tables() {
 		global $wpdb;

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -1428,9 +1428,6 @@ CREATE TABLE {$wpdb->prefix}wc_category_lookup (
 ) $collate;
 		";
 
-		$f = fopen('/tmp/tables.sql', 'w');
-		fwrite($f, $tables);
-		fclose($f);
 		return $tables;
 	}
 

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -1047,7 +1047,7 @@ class WC_Install {
 
 		// Clear table caches.
 		delete_transient( 'wc_attribute_taxonomies' );
-		
+
 		return $db_delta_result;
 	}
 

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -1035,7 +1035,7 @@ class WC_Install {
 			}
 		}
 
-		dbDelta( self::get_schema() );
+		$db_delta_result = dbDelta( self::get_schema() );
 
 		$index_exists = $wpdb->get_row( "SHOW INDEX FROM {$wpdb->comments} WHERE column_name = 'comment_type' and key_name = 'woo_idx_comment_type'" );
 
@@ -1047,6 +1047,8 @@ class WC_Install {
 
 		// Clear table caches.
 		delete_transient( 'wc_attribute_taxonomies' );
+		
+		return $db_delta_result;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -1015,7 +1015,7 @@ class WC_Install {
 		 */
 		if ( $wpdb->get_var( "SHOW TABLES LIKE '{$wpdb->prefix}woocommerce_downloadable_product_permissions';" ) ) {
 			if ( ! $wpdb->get_var( "SHOW COLUMNS FROM `{$wpdb->prefix}woocommerce_downloadable_product_permissions` LIKE 'permission_id';" ) ) {
-				$wpdb->query( "ALTER TABLE {$wpdb->prefix}woocommerce_downloadable_product_permissions DROP PRIMARY KEY, ADD `permission_id` BIGINT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT;" );
+				$wpdb->query( "ALTER TABLE {$wpdb->prefix}woocommerce_downloadable_product_permissions DROP PRIMARY KEY, ADD `permission_id` bigint(20) unsigned NOT NULL PRIMARY KEY AUTO_INCREMENT;" );
 			}
 		}
 
@@ -1085,16 +1085,16 @@ class WC_Install {
 
 		$tables = "
 CREATE TABLE {$wpdb->prefix}woocommerce_sessions (
-  session_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  session_id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
   session_key char(32) NOT NULL,
   session_value longtext NOT NULL,
-  session_expiry BIGINT UNSIGNED NOT NULL,
+  session_expiry bigint(20) unsigned NOT NULL,
   PRIMARY KEY  (session_id),
   UNIQUE KEY session_key (session_key)
 ) $collate;
 CREATE TABLE {$wpdb->prefix}woocommerce_api_keys (
-  key_id BIGINT UNSIGNED NOT NULL auto_increment,
-  user_id BIGINT UNSIGNED NOT NULL,
+  key_id bigint(20) unsigned NOT NULL auto_increment,
+  user_id bigint(20) unsigned NOT NULL,
   description varchar(200) NULL,
   permissions varchar(10) NOT NULL,
   consumer_key char(64) NOT NULL,
@@ -1107,7 +1107,7 @@ CREATE TABLE {$wpdb->prefix}woocommerce_api_keys (
   KEY consumer_secret (consumer_secret)
 ) $collate;
 CREATE TABLE {$wpdb->prefix}woocommerce_attribute_taxonomies (
-  attribute_id BIGINT UNSIGNED NOT NULL auto_increment,
+  attribute_id bigint(20) unsigned NOT NULL auto_increment,
   attribute_name varchar(200) NOT NULL,
   attribute_label varchar(200) NULL,
   attribute_type varchar(20) NOT NULL,
@@ -1117,17 +1117,17 @@ CREATE TABLE {$wpdb->prefix}woocommerce_attribute_taxonomies (
   KEY attribute_name (attribute_name(20))
 ) $collate;
 CREATE TABLE {$wpdb->prefix}woocommerce_downloadable_product_permissions (
-  permission_id BIGINT UNSIGNED NOT NULL auto_increment,
+  permission_id bigint(20) unsigned NOT NULL auto_increment,
   download_id varchar(36) NOT NULL,
-  product_id BIGINT UNSIGNED NOT NULL,
-  order_id BIGINT UNSIGNED NOT NULL DEFAULT 0,
+  product_id bigint(20) unsigned NOT NULL,
+  order_id bigint(20) unsigned NOT NULL DEFAULT 0,
   order_key varchar(200) NOT NULL,
   user_email varchar(200) NOT NULL,
-  user_id BIGINT UNSIGNED NULL,
+  user_id bigint(20) unsigned NULL,
   downloads_remaining varchar(9) NULL,
   access_granted datetime NOT NULL default '0000-00-00 00:00:00',
   access_expires datetime NULL default null,
-  download_count BIGINT UNSIGNED NOT NULL DEFAULT 0,
+  download_count bigint(20) unsigned NOT NULL DEFAULT 0,
   PRIMARY KEY  (permission_id),
   KEY download_order_key_product (product_id,order_id,order_key(16),download_id),
   KEY download_order_product (download_id,order_id,product_id),
@@ -1135,16 +1135,16 @@ CREATE TABLE {$wpdb->prefix}woocommerce_downloadable_product_permissions (
   KEY user_order_remaining_expires (user_id,order_id,downloads_remaining,access_expires)
 ) $collate;
 CREATE TABLE {$wpdb->prefix}woocommerce_order_items (
-  order_item_id BIGINT UNSIGNED NOT NULL auto_increment,
-  order_item_name TEXT NOT NULL,
+  order_item_id bigint(20) unsigned NOT NULL auto_increment,
+  order_item_name text NOT NULL,
   order_item_type varchar(200) NOT NULL DEFAULT '',
-  order_id BIGINT UNSIGNED NOT NULL,
+  order_id bigint(20) unsigned NOT NULL,
   PRIMARY KEY  (order_item_id),
   KEY order_id (order_id)
 ) $collate;
 CREATE TABLE {$wpdb->prefix}woocommerce_order_itemmeta (
-  meta_id BIGINT UNSIGNED NOT NULL auto_increment,
-  order_item_id BIGINT UNSIGNED NOT NULL,
+  meta_id bigint(20) unsigned NOT NULL auto_increment,
+  order_item_id bigint(20) unsigned NOT NULL,
   meta_key varchar(255) default NULL,
   meta_value longtext NULL,
   PRIMARY KEY  (meta_id),
@@ -1152,15 +1152,15 @@ CREATE TABLE {$wpdb->prefix}woocommerce_order_itemmeta (
   KEY meta_key (meta_key(32))
 ) $collate;
 CREATE TABLE {$wpdb->prefix}woocommerce_tax_rates (
-  tax_rate_id BIGINT UNSIGNED NOT NULL auto_increment,
+  tax_rate_id bigint(20) unsigned NOT NULL auto_increment,
   tax_rate_country varchar(2) NOT NULL DEFAULT '',
   tax_rate_state varchar(200) NOT NULL DEFAULT '',
   tax_rate varchar(8) NOT NULL DEFAULT '',
   tax_rate_name varchar(200) NOT NULL DEFAULT '',
-  tax_rate_priority BIGINT UNSIGNED NOT NULL,
+  tax_rate_priority bigint(20) unsigned NOT NULL,
   tax_rate_compound int(1) NOT NULL DEFAULT 0,
   tax_rate_shipping int(1) NOT NULL DEFAULT 1,
-  tax_rate_order BIGINT UNSIGNED NOT NULL,
+  tax_rate_order bigint(20) unsigned NOT NULL,
   tax_rate_class varchar(200) NOT NULL DEFAULT '',
   PRIMARY KEY  (tax_rate_id),
   KEY tax_rate_country (tax_rate_country),
@@ -1169,23 +1169,23 @@ CREATE TABLE {$wpdb->prefix}woocommerce_tax_rates (
   KEY tax_rate_priority (tax_rate_priority)
 ) $collate;
 CREATE TABLE {$wpdb->prefix}woocommerce_tax_rate_locations (
-  location_id BIGINT UNSIGNED NOT NULL auto_increment,
+  location_id bigint(20) unsigned NOT NULL auto_increment,
   location_code varchar(200) NOT NULL,
-  tax_rate_id BIGINT UNSIGNED NOT NULL,
+  tax_rate_id bigint(20) unsigned NOT NULL,
   location_type varchar(40) NOT NULL,
   PRIMARY KEY  (location_id),
   KEY tax_rate_id (tax_rate_id),
   KEY location_type_code (location_type(10),location_code(20))
 ) $collate;
 CREATE TABLE {$wpdb->prefix}woocommerce_shipping_zones (
-  zone_id BIGINT UNSIGNED NOT NULL auto_increment,
+  zone_id bigint(20) unsigned NOT NULL auto_increment,
   zone_name varchar(200) NOT NULL,
-  zone_order BIGINT UNSIGNED NOT NULL,
+  zone_order bigint(20) unsigned NOT NULL,
   PRIMARY KEY  (zone_id)
 ) $collate;
 CREATE TABLE {$wpdb->prefix}woocommerce_shipping_zone_locations (
-  location_id BIGINT UNSIGNED NOT NULL auto_increment,
-  zone_id BIGINT UNSIGNED NOT NULL,
+  location_id bigint(20) unsigned NOT NULL auto_increment,
+  zone_id bigint(20) unsigned NOT NULL,
   location_code varchar(200) NOT NULL,
   location_type varchar(40) NOT NULL,
   PRIMARY KEY  (location_id),
@@ -1193,26 +1193,26 @@ CREATE TABLE {$wpdb->prefix}woocommerce_shipping_zone_locations (
   KEY location_type_code (location_type(10),location_code(20))
 ) $collate;
 CREATE TABLE {$wpdb->prefix}woocommerce_shipping_zone_methods (
-  zone_id BIGINT UNSIGNED NOT NULL,
-  instance_id BIGINT UNSIGNED NOT NULL auto_increment,
+  zone_id bigint(20) unsigned NOT NULL,
+  instance_id bigint(20) unsigned NOT NULL auto_increment,
   method_id varchar(200) NOT NULL,
-  method_order BIGINT UNSIGNED NOT NULL,
+  method_order bigint(20) unsigned NOT NULL,
   is_enabled tinyint(1) NOT NULL DEFAULT '1',
   PRIMARY KEY  (instance_id)
 ) $collate;
 CREATE TABLE {$wpdb->prefix}woocommerce_payment_tokens (
-  token_id BIGINT UNSIGNED NOT NULL auto_increment,
+  token_id bigint(20) unsigned NOT NULL auto_increment,
   gateway_id varchar(200) NOT NULL,
   token text NOT NULL,
-  user_id BIGINT UNSIGNED NOT NULL DEFAULT '0',
+  user_id bigint(20) unsigned NOT NULL DEFAULT '0',
   type varchar(200) NOT NULL,
   is_default tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY  (token_id),
   KEY user_id (user_id)
 ) $collate;
 CREATE TABLE {$wpdb->prefix}woocommerce_payment_tokenmeta (
-  meta_id BIGINT UNSIGNED NOT NULL auto_increment,
-  payment_token_id BIGINT UNSIGNED NOT NULL,
+  meta_id bigint(20) unsigned NOT NULL auto_increment,
+  payment_token_id bigint(20) unsigned NOT NULL,
   meta_key varchar(255) NULL,
   meta_value longtext NULL,
   PRIMARY KEY  (meta_id),
@@ -1220,7 +1220,7 @@ CREATE TABLE {$wpdb->prefix}woocommerce_payment_tokenmeta (
   KEY meta_key (meta_key(32))
 ) $collate;
 CREATE TABLE {$wpdb->prefix}woocommerce_log (
-  log_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  log_id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
   timestamp datetime NOT NULL,
   level smallint(4) NOT NULL,
   source varchar(200) NOT NULL,
@@ -1230,10 +1230,10 @@ CREATE TABLE {$wpdb->prefix}woocommerce_log (
   KEY level (level)
 ) $collate;
 CREATE TABLE {$wpdb->prefix}wc_webhooks (
-  webhook_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  webhook_id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
   status varchar(200) NOT NULL,
   name text NOT NULL,
-  user_id BIGINT UNSIGNED NOT NULL,
+  user_id bigint(20) unsigned NOT NULL,
   delivery_url text NOT NULL,
   secret text NOT NULL,
   topic varchar(200) NOT NULL,
@@ -1248,11 +1248,11 @@ CREATE TABLE {$wpdb->prefix}wc_webhooks (
   KEY user_id (user_id)
 ) $collate;
 CREATE TABLE {$wpdb->prefix}wc_download_log (
-  download_log_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  download_log_id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
   timestamp datetime NOT NULL,
-  permission_id BIGINT UNSIGNED NOT NULL,
-  user_id BIGINT UNSIGNED NULL,
-  user_ip_address VARCHAR(100) NULL DEFAULT '',
+  permission_id bigint(20) unsigned NOT NULL,
+  user_id bigint(20) unsigned NULL,
+  user_ip_address varchar(100) NULL DEFAULT '',
   PRIMARY KEY  (download_log_id),
   KEY permission_id (permission_id),
   KEY timestamp (timestamp)
@@ -1281,7 +1281,7 @@ CREATE TABLE {$wpdb->prefix}wc_product_meta_lookup (
   KEY min_max_price (`min_price`, `max_price`)
 ) $collate;
 CREATE TABLE {$wpdb->prefix}wc_tax_rate_classes (
-  tax_rate_class_id BIGINT UNSIGNED NOT NULL auto_increment,
+  tax_rate_class_id bigint(20) unsigned NOT NULL auto_increment,
   name varchar(200) NOT NULL DEFAULT '',
   slug varchar(200) NOT NULL DEFAULT '',
   PRIMARY KEY  (tax_rate_class_id),
@@ -1296,18 +1296,18 @@ CREATE TABLE {$wpdb->prefix}wc_reserved_stock (
 	PRIMARY KEY  (`order_id`, `product_id`)
 ) $collate;
 CREATE TABLE {$wpdb->prefix}wc_rate_limits (
-  rate_limit_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  rate_limit_id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
   rate_limit_key varchar(200) NOT NULL,
-  rate_limit_expiry BIGINT UNSIGNED NOT NULL,
+  rate_limit_expiry bigint(20) unsigned NOT NULL,
   rate_limit_remaining smallint(10) NOT NULL DEFAULT '0',
   PRIMARY KEY  (rate_limit_id),
   UNIQUE KEY rate_limit_key (rate_limit_key($max_index_length))
 ) $collate;
 $product_attributes_lookup_table_creation_sql
 CREATE TABLE {$wpdb->prefix}wc_product_download_directories (
-	url_id BIGINT UNSIGNED NOT NULL auto_increment,
+	url_id bigint(20) unsigned NOT NULL auto_increment,
 	url varchar(256) NOT NULL,
-	enabled TINYINT(1) NOT NULL DEFAULT 0,
+	enabled tinyint(1) NOT NULL DEFAULT 0,
 	PRIMARY KEY (url_id),
 	KEY url (url($max_index_length))
 ) $collate;
@@ -1323,22 +1323,22 @@ CREATE TABLE {$wpdb->prefix}wc_order_stats (
 	tax_total double DEFAULT 0 NOT NULL,
 	shipping_total double DEFAULT 0 NOT NULL,
 	net_total double DEFAULT 0 NOT NULL,
-	returning_customer boolean DEFAULT NULL,
+	returning_customer tinyint(1) DEFAULT NULL,
 	status varchar(200) NOT NULL,
-	customer_id BIGINT UNSIGNED NOT NULL,
+	customer_id bigint(20) unsigned NOT NULL,
 	PRIMARY KEY (order_id),
 	KEY date_created (date_created),
 	KEY customer_id (customer_id),
 	KEY status (status({$max_index_length}))
 ) $collate;
 CREATE TABLE {$wpdb->prefix}wc_order_product_lookup (
-	order_item_id BIGINT UNSIGNED NOT NULL,
-	order_id BIGINT UNSIGNED NOT NULL,
-	product_id BIGINT UNSIGNED NOT NULL,
-	variation_id BIGINT UNSIGNED NOT NULL,
-	customer_id BIGINT UNSIGNED NULL,
+	order_item_id bigint(20) unsigned NOT NULL,
+	order_id bigint(20) unsigned NOT NULL,
+	product_id bigint(20) unsigned NOT NULL,
+	variation_id bigint(20) unsigned NOT NULL,
+	customer_id bigint(20) unsigned NULL,
 	date_created datetime DEFAULT '0000-00-00 00:00:00' NOT NULL,
-	product_qty INT NOT NULL,
+	product_qty int(11) NOT NULL,
 	product_net_revenue double DEFAULT 0 NOT NULL,
 	product_gross_revenue double DEFAULT 0 NOT NULL,
 	coupon_amount double DEFAULT 0 NOT NULL,
@@ -1352,8 +1352,8 @@ CREATE TABLE {$wpdb->prefix}wc_order_product_lookup (
 	KEY date_created (date_created)
 ) $collate;
 CREATE TABLE {$wpdb->prefix}wc_order_tax_lookup (
-	order_id BIGINT UNSIGNED NOT NULL,
-	tax_rate_id BIGINT UNSIGNED NOT NULL,
+	order_id bigint(20) unsigned NOT NULL,
+	tax_rate_id bigint(20) unsigned NOT NULL,
 	date_created datetime DEFAULT '0000-00-00 00:00:00' NOT NULL,
 	shipping_tax double DEFAULT 0 NOT NULL,
 	order_tax double DEFAULT 0 NOT NULL,
@@ -1363,8 +1363,8 @@ CREATE TABLE {$wpdb->prefix}wc_order_tax_lookup (
 	KEY date_created (date_created)
 ) $collate;
 CREATE TABLE {$wpdb->prefix}wc_order_coupon_lookup (
-	order_id BIGINT UNSIGNED NOT NULL,
-	coupon_id BIGINT NOT NULL,
+	order_id bigint(20) unsigned NOT NULL,
+	coupon_id bigint(20) NOT NULL,
 	date_created datetime DEFAULT '0000-00-00 00:00:00' NOT NULL,
 	discount_amount double DEFAULT 0 NOT NULL,
 	PRIMARY KEY (order_id, coupon_id),
@@ -1372,7 +1372,7 @@ CREATE TABLE {$wpdb->prefix}wc_order_coupon_lookup (
 	KEY date_created (date_created)
 ) $collate;
 CREATE TABLE {$wpdb->prefix}wc_admin_notes (
-	note_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+	note_id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
 	name varchar(255) NOT NULL,
 	type varchar(20) NOT NULL,
 	locale varchar(20) NOT NULL,
@@ -1383,17 +1383,17 @@ CREATE TABLE {$wpdb->prefix}wc_admin_notes (
 	source varchar(200) NOT NULL,
 	date_created datetime NOT NULL default '0000-00-00 00:00:00',
 	date_reminder datetime NULL default null,
-	is_snoozable boolean DEFAULT 0 NOT NULL,
+	is_snoozable tinyint(1) DEFAULT 0 NOT NULL,
 	layout varchar(20) DEFAULT '' NOT NULL,
 	image varchar(200) NULL DEFAULT NULL,
-	is_deleted boolean DEFAULT 0 NOT NULL,
-	is_read boolean DEFAULT 0 NOT NULL,
+	is_deleted tinyint(1) DEFAULT 0 NOT NULL,
+	is_read tinyint(1) DEFAULT 0 NOT NULL,
 	icon varchar(200) NOT NULL default 'info',
 	PRIMARY KEY (note_id)
 ) $collate;
 CREATE TABLE {$wpdb->prefix}wc_admin_note_actions (
-	action_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-	note_id BIGINT UNSIGNED NOT NULL,
+	action_id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+	note_id bigint(20) unsigned NOT NULL,
 	name varchar(255) NOT NULL,
 	label varchar(255) NOT NULL,
 	query longtext NOT NULL,
@@ -1405,8 +1405,8 @@ CREATE TABLE {$wpdb->prefix}wc_admin_note_actions (
 	KEY note_id (note_id)
 ) $collate;
 CREATE TABLE {$wpdb->prefix}wc_customer_lookup (
-	customer_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-	user_id BIGINT UNSIGNED DEFAULT NULL,
+	customer_id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+	user_id bigint(20) unsigned DEFAULT NULL,
 	username varchar(60) DEFAULT '' NOT NULL,
 	first_name varchar(255) NOT NULL,
 	last_name varchar(255) NOT NULL,
@@ -1422,12 +1422,15 @@ CREATE TABLE {$wpdb->prefix}wc_customer_lookup (
 	KEY email (email)
 ) $collate;
 CREATE TABLE {$wpdb->prefix}wc_category_lookup (
-	category_tree_id BIGINT UNSIGNED NOT NULL,
-	category_id BIGINT UNSIGNED NOT NULL,
+	category_tree_id bigint(20) unsigned NOT NULL,
+	category_id bigint(20) unsigned NOT NULL,
 	PRIMARY KEY (category_tree_id,category_id)
 ) $collate;
 		";
 
+		$f = fopen('/tmp/tables.sql', 'w');
+		fwrite($f, $tables);
+		fclose($f);
 		return $tables;
 	}
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/util/install.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/util/install.php
@@ -167,11 +167,4 @@ class WC_Tests_Install extends WC_Unit_Test_Case {
 		$this->assertContains( 'some_table_name', WC_Install::get_tables() );
 	}
 
-	/**
-	 * Test that dbDelta is a noop on an installed site.
-	 */
-	public function test_dbDelta_is_a_noop() {
-		$db_delta_result = WC_Install::create_tables();
-		$this->assertEmpty( $db_delta_result );
-	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/util/install.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/util/install.php
@@ -166,4 +166,12 @@ class WC_Tests_Install extends WC_Unit_Test_Case {
 
 		$this->assertContains( 'some_table_name', WC_Install::get_tables() );
 	}
+
+	/**
+	 * Test that dbDelta is a noop on an installed site.
+	 */
+	public function test_dbDelta_is_a_noop() {
+		$db_delta_result = WC_Install::create_tables();
+		$this->assertEmpty( $db_delta_result );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
@@ -97,4 +97,12 @@ class WC_Install_Test extends \WC_Unit_Test_Case {
 		$this->assertContains( 'premium_support', array_keys( $plugin_row_data ) );
 	}
 
+	/**
+	 * Test that dbDelta is a noop on an installed site.
+	 */
+	public function test_dbDelta_is_a_noop() {
+		$db_delta_result = WC_Install::create_tables();
+		$this->assertEmpty( $db_delta_result );
+	}
+
 }


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

During each request (front end and backend), WC checks whether the version of code that is executed corresponds to the`woocommerce_version` that is stored in the database (function [WC_Install::check_version()](https://github.com/woocommerce/woocommerce/blob/7.5.0/plugins/woocommerce/includes/class-wc-install.php#L257)). If the code's version is newer (higher version), install procedure is executed ([WC_Install::install()](https://github.com/woocommerce/woocommerce/blob/7.5.0/plugins/woocommerce/includes/class-wc-install.php#L377)).

This executes a bunch of functions, and among them is WordPress default `dbDelta` to make sure the db structure is correct and no fatal errors are happening because of a mismatch between what the code expects and what's in the db. 

The problem is that `dbDelta` can't handle all the column types very well. E.g., it fails to see that `BIGINT UNSIGNED` is the same as `bigint(20) unsigned`, but also that `BOOLEAN` is actually `tinyint(1)` in MySQL/MariaDB: 

> "Changed type of wp_woocommerce_sessions.session_id from bigint(20) unsigned to BIGINT UNSIGNED"
> ...

Because of that, `dbDelta` tries to run about 65 `ALTER` queries on each WC update. This creates a problem for infrastructure where WC is managed and/or symlinked, because all WC instances are updated at the same time and they start executing all those meaningless `ALTER` statements that are useless at the same time, bombarding the SQL servers needlessly.

The proposed fix here, until we fix `dbDelta`, is to simply rename the column types so they correspond to what is reported from `DESCRIBE` SQL query and thus `dbDelta` runs nothing, unless it's needed.

Translations carried out:
- `BIGINT UNSIGNED` to `bigint(20) unsigned`
- `TEXT` to `text`
- `VARCHAR(100)` to `varchar(100)`
- `TINYINT(1)` to `tinyint(1)`
- `boolean` to `tinyint(1)`
- `INT` to `int(11)`

I'd also like to note that `DEFAULT '0000-00-00 00:00:00'` is no longer valid `datetime` in newer MySQL versions, but that's tangential to the issue at hand.

<details><summary>Queries for WC 7.5.0</summary>

0: "ALTER TABLE wp_woocommerce_sessions CHANGE COLUMN `session_id` session_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT"
1: "ALTER TABLE wp_woocommerce_sessions CHANGE COLUMN `session_expiry` session_expiry BIGINT UNSIGNED NOT NULL"
2: "ALTER TABLE wp_woocommerce_api_keys CHANGE COLUMN `key_id` key_id BIGINT UNSIGNED NOT NULL auto_increment"
3: "ALTER TABLE wp_woocommerce_api_keys CHANGE COLUMN `user_id` user_id BIGINT UNSIGNED NOT NULL"
4: "ALTER TABLE wp_woocommerce_attribute_taxonomies CHANGE COLUMN `attribute_id` attribute_id BIGINT UNSIGNED NOT NULL auto_increment"
5: "ALTER TABLE wp_woocommerce_downloadable_product_permissions CHANGE COLUMN `permission_id` permission_id BIGINT UNSIGNED NOT NULL auto_increment"
6: "ALTER TABLE wp_woocommerce_downloadable_product_permissions CHANGE COLUMN `product_id` product_id BIGINT UNSIGNED NOT NULL"
7: "ALTER TABLE wp_woocommerce_downloadable_product_permissions CHANGE COLUMN `order_id` order_id BIGINT UNSIGNED NOT NULL DEFAULT 0"
8: "ALTER TABLE wp_woocommerce_downloadable_product_permissions CHANGE COLUMN `user_id` user_id BIGINT UNSIGNED NULL"
9: "ALTER TABLE wp_woocommerce_downloadable_product_permissions CHANGE COLUMN `download_count` download_count BIGINT UNSIGNED NOT NULL DEFAULT 0"
10: "ALTER TABLE wp_woocommerce_order_items CHANGE COLUMN `order_item_id` order_item_id BIGINT UNSIGNED NOT NULL auto_increment"
11: "ALTER TABLE wp_woocommerce_order_items CHANGE COLUMN `order_item_name` order_item_name TEXT NOT NULL"
12: "ALTER TABLE wp_woocommerce_order_items CHANGE COLUMN `order_id` order_id BIGINT UNSIGNED NOT NULL"
13: "ALTER TABLE wp_woocommerce_order_itemmeta CHANGE COLUMN `meta_id` meta_id BIGINT UNSIGNED NOT NULL auto_increment"
14: "ALTER TABLE wp_woocommerce_order_itemmeta CHANGE COLUMN `order_item_id` order_item_id BIGINT UNSIGNED NOT NULL"
15: "ALTER TABLE wp_woocommerce_tax_rates CHANGE COLUMN `tax_rate_id` tax_rate_id BIGINT UNSIGNED NOT NULL auto_increment"
16: "ALTER TABLE wp_woocommerce_tax_rates CHANGE COLUMN `tax_rate_priority` tax_rate_priority BIGINT UNSIGNED NOT NULL"
17: "ALTER TABLE wp_woocommerce_tax_rates CHANGE COLUMN `tax_rate_order` tax_rate_order BIGINT UNSIGNED NOT NULL"
18: "ALTER TABLE wp_woocommerce_tax_rate_locations CHANGE COLUMN `location_id` location_id BIGINT UNSIGNED NOT NULL auto_increment"
19: "ALTER TABLE wp_woocommerce_tax_rate_locations CHANGE COLUMN `tax_rate_id` tax_rate_id BIGINT UNSIGNED NOT NULL"
20: "ALTER TABLE wp_woocommerce_shipping_zones CHANGE COLUMN `zone_id` zone_id BIGINT UNSIGNED NOT NULL auto_increment"
21: "ALTER TABLE wp_woocommerce_shipping_zones CHANGE COLUMN `zone_order` zone_order BIGINT UNSIGNED NOT NULL"
22: "ALTER TABLE wp_woocommerce_shipping_zone_locations CHANGE COLUMN `location_id` location_id BIGINT UNSIGNED NOT NULL auto_increment"
23: "ALTER TABLE wp_woocommerce_shipping_zone_locations CHANGE COLUMN `zone_id` zone_id BIGINT UNSIGNED NOT NULL"
24: "ALTER TABLE wp_woocommerce_shipping_zone_methods CHANGE COLUMN `zone_id` zone_id BIGINT UNSIGNED NOT NULL"
25: "ALTER TABLE wp_woocommerce_shipping_zone_methods CHANGE COLUMN `instance_id` instance_id BIGINT UNSIGNED NOT NULL auto_increment"
26: "ALTER TABLE wp_woocommerce_shipping_zone_methods CHANGE COLUMN `method_order` method_order BIGINT UNSIGNED NOT NULL"
27: "ALTER TABLE wp_woocommerce_payment_tokens CHANGE COLUMN `token_id` token_id BIGINT UNSIGNED NOT NULL auto_increment"
28: "ALTER TABLE wp_woocommerce_payment_tokens CHANGE COLUMN `user_id` user_id BIGINT UNSIGNED NOT NULL DEFAULT '0'"
29: "ALTER TABLE wp_woocommerce_payment_tokenmeta CHANGE COLUMN `meta_id` meta_id BIGINT UNSIGNED NOT NULL auto_increment"
30: "ALTER TABLE wp_woocommerce_payment_tokenmeta CHANGE COLUMN `payment_token_id` payment_token_id BIGINT UNSIGNED NOT NULL"
31: "ALTER TABLE wp_woocommerce_log CHANGE COLUMN `log_id` log_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT"
32: "ALTER TABLE wp_wc_webhooks CHANGE COLUMN `webhook_id` webhook_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT"
33: "ALTER TABLE wp_wc_webhooks CHANGE COLUMN `user_id` user_id BIGINT UNSIGNED NOT NULL"
34: "ALTER TABLE wp_wc_download_log CHANGE COLUMN `download_log_id` download_log_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT"
35: "ALTER TABLE wp_wc_download_log CHANGE COLUMN `permission_id` permission_id BIGINT UNSIGNED NOT NULL"
36: "ALTER TABLE wp_wc_download_log CHANGE COLUMN `user_id` user_id BIGINT UNSIGNED NULL"
37: "ALTER TABLE wp_wc_download_log CHANGE COLUMN `user_ip_address` user_ip_address VARCHAR(100) NULL DEFAULT ''"
38: "ALTER TABLE wp_wc_tax_rate_classes CHANGE COLUMN `tax_rate_class_id` tax_rate_class_id BIGINT UNSIGNED NOT NULL auto_increment"
39: "ALTER TABLE wp_wc_rate_limits CHANGE COLUMN `rate_limit_id` rate_limit_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT"
40: "ALTER TABLE wp_wc_rate_limits CHANGE COLUMN `rate_limit_expiry` rate_limit_expiry BIGINT UNSIGNED NOT NULL"
41: "ALTER TABLE wp_wc_product_download_directories CHANGE COLUMN `url_id` url_id BIGINT UNSIGNED NOT NULL auto_increment"
42: "ALTER TABLE wp_wc_product_download_directories CHANGE COLUMN `enabled` enabled TINYINT(1) NOT NULL DEFAULT 0"
43: "ALTER TABLE wp_wc_order_stats CHANGE COLUMN `returning_customer` returning_customer boolean DEFAULT NULL"
44: "ALTER TABLE wp_wc_order_stats CHANGE COLUMN `customer_id` customer_id BIGINT UNSIGNED NOT NULL"
45: "ALTER TABLE wp_wc_order_product_lookup CHANGE COLUMN `order_item_id` order_item_id BIGINT UNSIGNED NOT NULL"
46: "ALTER TABLE wp_wc_order_product_lookup CHANGE COLUMN `order_id` order_id BIGINT UNSIGNED NOT NULL"
47: "ALTER TABLE wp_wc_order_product_lookup CHANGE COLUMN `product_id` product_id BIGINT UNSIGNED NOT NULL"
48: "ALTER TABLE wp_wc_order_product_lookup CHANGE COLUMN `variation_id` variation_id BIGINT UNSIGNED NOT NULL"
49: "ALTER TABLE wp_wc_order_product_lookup CHANGE COLUMN `customer_id` customer_id BIGINT UNSIGNED NULL"
50: "ALTER TABLE wp_wc_order_product_lookup CHANGE COLUMN `product_qty` product_qty INT NOT NULL"
51: "ALTER TABLE wp_wc_order_tax_lookup CHANGE COLUMN `order_id` order_id BIGINT UNSIGNED NOT NULL"
52: "ALTER TABLE wp_wc_order_tax_lookup CHANGE COLUMN `tax_rate_id` tax_rate_id BIGINT UNSIGNED NOT NULL"
53: "ALTER TABLE wp_wc_order_coupon_lookup CHANGE COLUMN `order_id` order_id BIGINT UNSIGNED NOT NULL"
54: "ALTER TABLE wp_wc_order_coupon_lookup CHANGE COLUMN `coupon_id` coupon_id BIGINT NOT NULL"
55: "ALTER TABLE wp_wc_admin_notes CHANGE COLUMN `note_id` note_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT"
56: "ALTER TABLE wp_wc_admin_notes CHANGE COLUMN `is_snoozable` is_snoozable boolean DEFAULT 0 NOT NULL"
57: "ALTER TABLE wp_wc_admin_notes CHANGE COLUMN `is_deleted` is_deleted boolean DEFAULT 0 NOT NULL"
58: "ALTER TABLE wp_wc_admin_notes CHANGE COLUMN `is_read` is_read boolean DEFAULT 0 NOT NULL"
59: "ALTER TABLE wp_wc_admin_note_actions CHANGE COLUMN `action_id` action_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT"
60: "ALTER TABLE wp_wc_admin_note_actions CHANGE COLUMN `note_id` note_id BIGINT UNSIGNED NOT NULL"
61: "ALTER TABLE wp_wc_customer_lookup CHANGE COLUMN `customer_id` customer_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT"
62: "ALTER TABLE wp_wc_customer_lookup CHANGE COLUMN `user_id` user_id BIGINT UNSIGNED DEFAULT NULL"
63: "ALTER TABLE wp_wc_category_lookup CHANGE COLUMN `category_tree_id` category_tree_id BIGINT UNSIGNED NOT NULL"
64: "ALTER TABLE wp_wc_category_lookup CHANGE COLUMN `category_id` category_id BIGINT UNSIGNED NOT NULL"


</details>

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

#### GUI testing

⚠️ Please note that this method is unreliable and only provided for convenience/experimentation. See below for proper testing. 

This change is a bit tricky to test, because the version check runs on **each request**. Thus, you might need to be a bit lucky to catch it in the GUI. This might work, though, and ideally would be repeated with MySQL 5.5, 5.6, 5.7, <8.0.17, >= 8.0.17 and MariaDB 10.4.26 (the version running on our infra). 


1. Install WP & WC, activate WC (any settings are fine)
2. Install QueryMonitor
3. Using your favourite SQL administration tool (PHP MyAdmin, Adminer, cli mysql) set the `woocommerce_version` to "7.4.0", e.g. by running `UPDATE wp_options SET option_value="7.4.0" WHERE option_name="woocommerce_version"`. Alternatively, you can use WP CLI and run 
```
wp shell
wp> update_option('woocommerce_version', '7.4.0');
```
(please note that `wp option update woocommerce_version '7.4.0'` didn't work for me for some reason, didn't bother checking why).
5. Switch over to your browser and quickly hit refresh
6. Examine the QueryMonitor output for Database Queries. You should see 60+ `ALTER` db queries, similar to the below (showing 1 for illustration purposes):
<img width="1723" alt="Screenshot 2023-03-16 at 22 21 47" src="https://user-images.githubusercontent.com/2207451/225757143-8844cace-9fce-4b5d-9782-d90cb6f2cc92.png">

This problem is currently most pronounced on db server versions except for MySQL >=8.0.17, where you should see around 65 `ALTER` queries, most of them related to conversion of columns to BIGINT UNSIGNED. On MySQL 8.0.17+, you should see around 6 queries, and none of them are related to integer data types.
<img width="1723" alt="Screenshot 2023-03-16 at 23 03 21" src="https://user-images.githubusercontent.com/2207451/225763159-d02b9d41-3536-472e-9682-e1c2231dd3be.png">




7. Apply this branch
8. Update `woocommerce_version` again as in step 3.
9. Switch over to your browser and quickly hit refresh
10. Examine the QueryMonitor output for Database Queries. There should be no `ALTER` queries.

#### Programmatic testing

The problem with the GUI approach based on Query Monitor is that some other request might get triggered in the background and we miss the request where the `dbDelta` gets called. Seeing no `ALTER` statements, we'd think all is great, but it's not. Au contraire, a classic instance where the absence of evidence isn't evidence of absence (of `ALTER` statements), so to actually get better, we can add simple logging code to `dbDelta` and examine the logs before the patch after the patch:

1. Install WP & WC, activate WC (any settings are fine)
2. Find the following line in your WordPress installation in file `upgrade.php`: `$allqueries = array_merge( $cqueries, $iqueries );`. In v 6.1.1. it's around line number 3115.
3. Add the following logging code after the line:
```
	$f = fopen('/tmp/queries.txt', 'a');
	$log_record = date("Y-m-d H:i:s") . " " . $_SERVER['REQUEST_URI'] . ": ";
	fwrite($f, $log_record . print_r($allqueries, true));
	fclose($f);
```
4.  Using your favourite SQL administration tool (PHP MyAdmin, Adminer, cli mysql) set the `woocommerce_version` to "7.4.0", e.g. by running `UPDATE wp_options SET option_value="7.4.0" WHERE option_name="woocommerce_version"`. 
5. Go back to the browser and reload the WC page (any page is fine).
6. Check the log file, you should see a bunch of queries from `dbDelta`, e.g. like this on MySQL 8.0.17+
```
2023-03-16 22:15:22 /wp-admin/edit.php?post_type=shop_order: Array
(
    [0] => ALTER TABLE wp_woocommerce_order_items CHANGE COLUMN `order_item_name` order_item_name TEXT NOT NULL
    [1] => ALTER TABLE wp_wc_download_log CHANGE COLUMN `user_ip_address` user_ip_address VARCHAR(100) NULL DEFAULT ''
    [2] => ALTER TABLE wp_wc_order_stats CHANGE COLUMN `returning_customer` returning_customer boolean DEFAULT NULL
    [3] => ALTER TABLE wp_wc_admin_notes CHANGE COLUMN `is_snoozable` is_snoozable boolean DEFAULT 0 NOT NULL
    [4] => ALTER TABLE wp_wc_admin_notes CHANGE COLUMN `is_deleted` is_deleted boolean DEFAULT 0 NOT NULL
    [5] => ALTER TABLE wp_wc_admin_notes CHANGE COLUMN `is_read` is_read boolean DEFAULT 0 NOT NULL
)
```
8. Apply this branch
9. Using your favourite SQL administration tool (PHP MyAdmin, Adminer, cli mysql) set the `woocommerce_version` to "7.4.0", e.g. by running `UPDATE wp_options SET option_value="7.4.0" WHERE option_name="woocommerce_version"`. 
10. Go back to the browser and reload the WC page (any page is fine).
11. Check the log file, you shouldn't see any new queries from `dbDelta`, e.g. like this on MySQL 8.0.17+, first the ALTER queries from previous update, then no queries:
```
2023-03-16 22:15:22 /wp-admin/edit.php?post_type=shop_order: Array
(
    [0] => ALTER TABLE wp_woocommerce_order_items CHANGE COLUMN `order_item_name` order_item_name TEXT NOT NULL
    [1] => ALTER TABLE wp_wc_download_log CHANGE COLUMN `user_ip_address` user_ip_address VARCHAR(100) NULL DEFAULT ''
    [2] => ALTER TABLE wp_wc_order_stats CHANGE COLUMN `returning_customer` returning_customer boolean DEFAULT NULL
    [3] => ALTER TABLE wp_wc_admin_notes CHANGE COLUMN `is_snoozable` is_snoozable boolean DEFAULT 0 NOT NULL
    [4] => ALTER TABLE wp_wc_admin_notes CHANGE COLUMN `is_deleted` is_deleted boolean DEFAULT 0 NOT NULL
    [5] => ALTER TABLE wp_wc_admin_notes CHANGE COLUMN `is_read` is_read boolean DEFAULT 0 NOT NULL
)
2023-03-16 22:16:05 /wp-admin/admin-ajax.php: Array
(
)
```

Ideally, we'd test this on our infrastructure (Atomic platform), but also other MySQL servers. Based on local testing and checking results [on db-fiddle](https://www.db-fiddle.com/f/3PMNx6vwxNerug3DDW6Fiy/1), it seems like MySQL versions should be handled correctly, and the MariaDBs I saw as well. 

#### Positive test case:

Edit later:
We should also test a positive test case, e.g. that adding a new column actually still works. 
1. Edit the WC_Install::get_schema and add one column, e.g. add `session_test_column bigint(20) unsigned NOT NULL,` to the very first table so it becomes:
```
CREATE TABLE {$wpdb->prefix}woocommerce_sessions (
  session_id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
  session_key char(32) NOT NULL,
  session_value longtext NOT NULL,
  session_expiry bigint(20) unsigned NOT NULL,
  session_test_column bigint(20) unsigned NOT NULL,
  PRIMARY KEY  (session_id),
  UNIQUE KEY session_key (session_key)
) $collate;
```
2. Using your favourite SQL administration tool (PHP MyAdmin, Adminer, cli mysql) set the `woocommerce_version` to "7.4.0", e.g. by running `UPDATE wp_options SET option_value="7.4.0" WHERE option_name="woocommerce_version"`. 
3. Go back to the browser and reload the WC page (any page is fine).
4. Check the log file, you should see a query to create this column:
```
2023-03-17 08:10:04 /wp-admin/admin-ajax.php: Array
(
    [0] => ALTER TABLE wp_woocommerce_sessions ADD COLUMN session_test_column bigint(20) unsigned NOT NULL
)
```

More context: p6q8Tx-2Gk-p2

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [ ] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
