### PR TITLE
Show `Stock status` options as radio buttons

### DIFF
--- a/plugins/woocommerce/changelog/dev-37116_show_stock_status_as_radio_buttons
+++ b/plugins/woocommerce/changelog/dev-37116_show_stock_status_as_radio_buttons
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Show "Stock status" as a collection of radio buttons

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
@@ -125,7 +125,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		);
 
 		/**
-		 * Allow 3rd parties to control whether the the option will use radio buttons or a select.
+		 * Allow 3rd parties to control whether the "Stock status" option will use radio buttons or a select.
 		 *
 		 * @since 7.6.0
 		 *

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
@@ -131,7 +131,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		 *
 		 * @param bool If false, the "Stock status" will be shown as a select. Default: it will use radio buttons.
 		 */
-		if ( apply_filters( 'woocommerce_stock_status_use_radio', count( $stock_status_options ) === 3 ) ) {
+		if ( apply_filters( 'woocommerce_product_stock_status_use_radio', count( $stock_status_options ) === 3 ) ) {
 			woocommerce_wp_radio( $common_stock_status_args );
 		} else {
 			$select_input_args = array(

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
@@ -115,17 +115,24 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 		}
 
-		woocommerce_wp_select(
-			array(
-				'id'            => '_stock_status',
-				'value'         => $product_object->get_stock_status( 'edit' ),
-				'wrapper_class' => 'stock_status_field hide_if_variable hide_if_external hide_if_grouped',
-				'label'         => __( 'Stock status', 'woocommerce' ),
-				'options'       => wc_get_product_stock_status_options(),
-				'desc_tip'      => true,
-				'description'   => __( 'Controls whether or not the product is listed as "in stock" or "out of stock" on the frontend.', 'woocommerce' ),
-			)
+		$stock_status_options = wc_get_product_stock_status_options();
+		$common_stock_status_args = array(
+			'id'            => '_stock_status',
+			'value'         => $product_object->get_stock_status('edit'),
+			'wrapper_class' => 'stock_status_field hide_if_variable hide_if_external hide_if_grouped',
+			'label'         => __('Stock status', 'woocommerce'),
+			'options'       => $stock_status_options,
 		);
+
+		if ( apply_filters( 'woocommerce_stock_status_use_radio', count( $stock_status_options ) === 3 ) ) {
+			woocommerce_wp_radio( $common_stock_status_args );
+		} else {
+			$select_input_args = array(
+				'desc_tip'    => true,
+				'description' => __('Controls whether or not the product is listed as "in stock" or "out of stock" on the frontend.', 'woocommerce'),
+			);
+			woocommerce_wp_select( array_merge( $common_stock_status_args, $select_input_args ) );
+		}
 
 		do_action( 'woocommerce_product_options_stock_status' );
 		?>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
@@ -116,6 +116,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		}
 
 		$stock_status_options     = wc_get_product_stock_status_options();
+		$stock_status_count       = count( $stock_status_options );
 		$common_stock_status_args = array(
 			'id'            => '_stock_status',
 			'value'         => $product_object->get_stock_status( 'edit' ),
@@ -131,7 +132,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		 *
 		 * @param bool If false, the "Stock status" will be shown as a select. Default: it will use radio buttons.
 		 */
-		if ( apply_filters( 'woocommerce_product_stock_status_use_radio', count( $stock_status_options ) === 3 ) ) {
+		if ( apply_filters( 'woocommerce_product_stock_status_use_radio', $stock_status_count <= 3 && $stock_status_count >= 1 ) ) {
 			woocommerce_wp_radio( $common_stock_status_args );
 		} else {
 			$select_input_args = array(

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
@@ -115,21 +115,28 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 		}
 
-		$stock_status_options = wc_get_product_stock_status_options();
+		$stock_status_options     = wc_get_product_stock_status_options();
 		$common_stock_status_args = array(
 			'id'            => '_stock_status',
-			'value'         => $product_object->get_stock_status('edit'),
+			'value'         => $product_object->get_stock_status( 'edit' ),
 			'wrapper_class' => 'stock_status_field hide_if_variable hide_if_external hide_if_grouped',
-			'label'         => __('Stock status', 'woocommerce'),
+			'label'         => __( 'Stock status', 'woocommerce' ),
 			'options'       => $stock_status_options,
 		);
 
+		/**
+		 * Allow 3rd parties to control whether the the option will use radio buttons or a select.
+		 *
+		 * @since 7.6.0
+		 *
+		 * @param bool If false, the "Stock status" will be shown as a select. Default: it will use radio buttons.
+		 */
 		if ( apply_filters( 'woocommerce_stock_status_use_radio', count( $stock_status_options ) === 3 ) ) {
 			woocommerce_wp_radio( $common_stock_status_args );
 		} else {
 			$select_input_args = array(
 				'desc_tip'    => true,
-				'description' => __('Controls whether or not the product is listed as "in stock" or "out of stock" on the frontend.', 'woocommerce'),
+				'description' => __( 'Controls whether or not the product is listed as "in stock" or "out of stock" on the frontend.', 'woocommerce' ),
 			);
 			woocommerce_wp_select( array_merge( $common_stock_status_args, $select_input_args ) );
 		}

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
@@ -55,10 +55,10 @@ test.describe.serial( 'Add New Variable Product Page', () => {
 			if ( i > 0 ) {
 				await page.click( 'button.add_attribute' );
 			}
-			await page.fill(
-				`input[name="attribute_names[${ i }]"]`,
-				`attr #${ i + 1 }`
-			);
+			const input = `input[name="attribute_names[${ i }]"]`;
+
+			await page.waitForSelector( input, { timeout: 1000 } ); // Wait for up to 1 second
+			await page.fill( input, `attr #${ i + 1 }` );
 			await page.fill(
 				`textarea[name="attribute_values[${ i }]"]`,
 				'val1 | val2'
@@ -67,6 +67,7 @@ test.describe.serial( 'Add New Variable Product Page', () => {
 		await page.keyboard.press( 'ArrowUp' );
 		await page.click( 'text=Save attributes' );
 
+		await page.waitForTimeout( 1000 ); // Wait for 1 second
 		// Save before going to the Variations tab to prevent variations from all attributes to be automatically created
 		await page.locator( '#save-post' ).click();
 		await expect(
@@ -205,10 +206,10 @@ test.describe.serial( 'Add New Variable Product Page', () => {
 			if ( i > 0 ) {
 				await page.click( 'button.add_attribute' );
 			}
-			await page.fill(
-				`input[name="attribute_names[${ i }]"]`,
-				`attr #${ i + 1 }`
-			);
+			const input = `input[name="attribute_names[${ i }]"]`;
+
+			await page.waitForSelector( input, { timeout: 1000 } ); // Wait for up to 1 seconds
+			await page.fill( input, `attr #${ i + 1 }` );
 			await page.fill(
 				`textarea[name="attribute_values[${ i }]"]`,
 				'val1 | val2'
@@ -222,6 +223,7 @@ test.describe.serial( 'Add New Variable Product Page', () => {
 			).toBeVisible();
 		}
 
+		await page.waitForTimeout( 1000 ); // Wait for 1 second
 		// Save before going to the Variations tab to prevent variations from all attributes to be automatically created
 		await page.locator( '#save-post' ).click();
 		await expect(


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR adds the code to display the Stock status options as a collection of radio buttons instead of a dropdown.

If the number of items inside exceeds three, it should be displayed as a dropdown again.

<img width="547" alt="Screenshot 2023-03-08 at 17 02 53" src="https://user-images.githubusercontent.com/1314156/223835059-d4048b0f-f1e1-46af-be2d-d20b11be307d.png">

Closes #37116.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Go to `Products` > `Add New` > `Product data` > `Inventory`.
2. Verify that the `Stock status` uses a radio button to set that option.
3. Install and activate [this plugin](https://gist.github.com/octaedro/add7edd40d8240e292bf6872bac1649e) to use a `select` instead of the `radio` buttons.
4. Delete that plugin and install [this plugin](https://gist.github.com/octaedro/36022cb2965c1032b03ea78a95fc08fd) that adds another `Stock status` option.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
