### PR TITLE
Convert "Allow backorders?" into radio buttons

### DIFF
--- a/plugins/woocommerce/changelog/dev-37118_convert_allow_backorders_into_radio_buttons
+++ b/plugins/woocommerce/changelog/dev-37118_convert_allow_backorders_into_radio_buttons
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Convert "Allow backorders?" into radio buttons

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
@@ -78,7 +78,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			 *
 			 * @param bool If false, "Allow backorders?" will be shown as a select. Default: it will use radio buttons.
 			 */
-			if ( apply_filters( 'woocommerce_product_allow_backorder_use_radio', false ) ) {
+			if ( apply_filters( 'woocommerce_product_allow_backorder_use_radio', true ) ) {
 				woocommerce_wp_radio( $common_backorder_args );
 			} else {
 				$select_input_args = array(

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
@@ -65,10 +65,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 			echo '<input type="hidden" name="_original_stock" value="' . esc_attr( wc_stock_amount( $product_object->get_stock_quantity( 'edit' ) ) ) . '" />';
 
 			$common_backorder_args = array(
-				'id'          => '_backorders',
-				'value'       => $product_object->get_backorders( 'edit' ),
-				'label'       => __( 'Allow backorders?', 'woocommerce' ),
-				'options'     => wc_get_product_backorder_options(),
+				'id'      => '_backorders',
+				'value'   => $product_object->get_backorders( 'edit' ),
+				'label'   => __( 'Allow backorders?', 'woocommerce' ),
+				'options' => wc_get_product_backorder_options(),
 			);
 
 			/**

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
@@ -78,7 +78,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			 *
 			 * @param bool If false, "Allow backorders?" will be shown as a select. Default: it will use radio buttons.
 			 */
-			if ( apply_filters( 'woocommerce_allow_backorder_use_radio', false ) ) {
+			if ( apply_filters( 'woocommerce_product_allow_backorder_use_radio', false ) ) {
 				woocommerce_wp_radio( $common_backorder_args );
 			} else {
 				$select_input_args = array(

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
@@ -64,11 +64,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 			echo '<input type="hidden" name="_original_stock" value="' . esc_attr( wc_stock_amount( $product_object->get_stock_quantity( 'edit' ) ) ) . '" />';
 
-			$common_backorder_args = array(
-				'id'      => '_backorders',
-				'value'   => $product_object->get_backorders( 'edit' ),
-				'label'   => __( 'Allow backorders?', 'woocommerce' ),
-				'options' => wc_get_product_backorder_options(),
+			$backorder_args = array(
+				'id'          => '_backorders',
+				'value'       => $product_object->get_backorders( 'edit' ),
+				'label'       => __( 'Allow backorders?', 'woocommerce' ),
+				'options'     => wc_get_product_backorder_options(),
+				'desc_tip'    => true,
+				'description' => __( 'If managing stock, this controls whether or not backorders are allowed. If enabled, stock quantity can go below 0.', 'woocommerce' ),
 			);
 
 			/**
@@ -79,13 +81,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 			 * @param bool If false, "Allow backorders?" will be shown as a select. Default: it will use radio buttons.
 			 */
 			if ( apply_filters( 'woocommerce_product_allow_backorder_use_radio', true ) ) {
-				woocommerce_wp_radio( $common_backorder_args );
+				woocommerce_wp_radio( $backorder_args );
 			} else {
-				$select_input_args = array(
-					'desc_tip'    => true,
-					'description' => __( 'If managing stock, this controls whether or not backorders are allowed. If enabled, stock quantity can go below 0.', 'woocommerce' ),
-				);
-				woocommerce_wp_select( array_merge( $common_backorder_args, $select_input_args ) );
+				woocommerce_wp_select( $backorder_args );
 			}
 
 			woocommerce_wp_text_input(
@@ -128,14 +126,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 		}
 
-		$stock_status_options     = wc_get_product_stock_status_options();
-		$stock_status_count       = count( $stock_status_options );
-		$common_stock_status_args = array(
+		$stock_status_options = wc_get_product_stock_status_options();
+		$stock_status_count   = count( $stock_status_options );
+		$stock_status_args    = array(
 			'id'            => '_stock_status',
 			'value'         => $product_object->get_stock_status( 'edit' ),
 			'wrapper_class' => 'stock_status_field hide_if_variable hide_if_external hide_if_grouped',
 			'label'         => __( 'Stock status', 'woocommerce' ),
 			'options'       => $stock_status_options,
+			'desc_tip'      => true,
+			'description'   => __( 'Controls whether or not the product is listed as "in stock" or "out of stock" on the frontend.', 'woocommerce' ),
 		);
 
 		/**
@@ -146,13 +146,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 		 * @param bool If false, the "Stock status" will be shown as a select. Default: it will use radio buttons.
 		 */
 		if ( apply_filters( 'woocommerce_product_stock_status_use_radio', $stock_status_count <= 3 && $stock_status_count >= 1 ) ) {
-			woocommerce_wp_radio( $common_stock_status_args );
+			woocommerce_wp_radio( $stock_status_args );
 		} else {
-			$select_input_args = array(
-				'desc_tip'    => true,
-				'description' => __( 'Controls whether or not the product is listed as "in stock" or "out of stock" on the frontend.', 'woocommerce' ),
-			);
-			woocommerce_wp_select( array_merge( $common_stock_status_args, $select_input_args ) );
+			woocommerce_wp_select( $stock_status_args );
 		}
 
 		do_action( 'woocommerce_product_options_stock_status' );

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
@@ -64,16 +64,29 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 			echo '<input type="hidden" name="_original_stock" value="' . esc_attr( wc_stock_amount( $product_object->get_stock_quantity( 'edit' ) ) ) . '" />';
 
-			woocommerce_wp_select(
-				array(
-					'id'          => '_backorders',
-					'value'       => $product_object->get_backorders( 'edit' ),
-					'label'       => __( 'Allow backorders?', 'woocommerce' ),
-					'options'     => wc_get_product_backorder_options(),
+			$common_backorder_args = array(
+				'id'          => '_backorders',
+				'value'       => $product_object->get_backorders( 'edit' ),
+				'label'       => __( 'Allow backorders?', 'woocommerce' ),
+				'options'     => wc_get_product_backorder_options(),
+			);
+
+			/**
+			 * Allow 3rd parties to control whether "Allow backorder?" option will use radio buttons or a select.
+			 *
+			 * @since 7.6.0
+			 *
+			 * @param bool If false, "Allow backorders?" will be shown as a select. Default: it will use radio buttons.
+			 */
+			if ( apply_filters( 'woocommerce_allow_backorder_use_radio', false ) ) {
+				woocommerce_wp_radio( $common_backorder_args );
+			} else {
+				$select_input_args = array(
 					'desc_tip'    => true,
 					'description' => __( 'If managing stock, this controls whether or not backorders are allowed. If enabled, stock quantity can go below 0.', 'woocommerce' ),
-				)
-			);
+				);
+				woocommerce_wp_select( array_merge( $common_backorder_args, $select_input_args ) );
+			}
 
 			woocommerce_wp_text_input(
 				array(


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR adds the code to convert the "Allow backorders?" dropdown into radio buttons.

If the number of items inside exceeds three, it should be displayed as a dropdown again.

 ![screenshot-user-images githubusercontent com-2023 03 07-22_00_02 (3)](https://user-images.githubusercontent.com/1314156/223598221-8492ad0e-7653-4303-a6f5-2d2723807817.png)

Closes #37118.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Go to `Products` > `Add New` > `Product data` > `Inventory`.
2. Verify that the `Allow backorders?` uses a radio button to set that option.
3. Install and activate [this plugin](https://gist.github.com/octaedro/00d104aac22c32f1ffa5b9f6dbb49d18) to use a `select` instead of the `radio` buttons.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
