### PR TITLE
Replacing multiple components on the product page with a single hook.

### DIFF
--- a/packages/js/product-editor/changelog/update-product-page-add-hook-37281
+++ b/packages/js/product-editor/changelog/update-product-page-add-hook-37281
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Fix issue were template was not re-synced when switching between products.

--- a/packages/js/product-editor/src/components/block-editor/block-editor.tsx
+++ b/packages/js/product-editor/src/components/block-editor/block-editor.tsx
@@ -94,7 +94,7 @@ export function BlockEditor( {
 			synchronizeBlocksWithTemplate( [], _settings?.template ),
 			{}
 		);
-	}, [] );
+	}, [ product.id ] );
 
 	if ( ! blocks ) {
 		return null;

--- a/plugins/woocommerce-admin/client/products/hooks/use-product-entity-record.ts
+++ b/plugins/woocommerce-admin/client/products/hooks/use-product-entity-record.ts
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import { AUTO_DRAFT_NAME } from '@woocommerce/product-editor';
+import { Product } from '@woocommerce/data';
+import { useDispatch, useSelect, select as WPSelect } from '@wordpress/data';
+
+import { useEffect, useState, useMemo } from '@wordpress/element';
+
+const useAutoDraft = () => {
+	const { saveEntityRecord } = useDispatch( 'core' );
+	const [ product, setProduct ] = useState< Product | undefined >(
+		undefined
+	);
+
+	useEffect( () => {
+		saveEntityRecord( 'postType', 'product', {
+			title: AUTO_DRAFT_NAME,
+			status: 'auto-draft',
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore Incorrect types.
+		} ).then( ( autoDraftProduct: Product ) => {
+			setProduct( autoDraftProduct );
+		} );
+	}, [] );
+
+	return product;
+};
+
+const useProductEntity = ( productId: number ) => {
+	const product = useSelect( ( select: typeof WPSelect ) => {
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore Missing types.
+		const { getEntityRecord } = select( 'core' );
+
+		return getEntityRecord( 'postType', 'product', productId ) as Product;
+	} );
+
+	return product;
+};
+
+export function useProductEntityRecord(
+	productId: string | undefined
+): Product | undefined {
+	const selectedHook = useMemo( () => {
+		return productId
+			? useProductEntity.bind( {}, Number.parseInt( productId, 10 ) )
+			: useAutoDraft;
+	}, [ productId ] );
+
+	return selectedHook();
+}

--- a/plugins/woocommerce-admin/client/products/hooks/use-product-entity-record.ts
+++ b/plugins/woocommerce-admin/client/products/hooks/use-product-entity-record.ts
@@ -5,48 +5,46 @@ import { AUTO_DRAFT_NAME } from '@woocommerce/product-editor';
 import { Product } from '@woocommerce/data';
 import { useDispatch, useSelect, select as WPSelect } from '@wordpress/data';
 
-import { useEffect, useState, useMemo } from '@wordpress/element';
-
-const useAutoDraft = () => {
-	const { saveEntityRecord } = useDispatch( 'core' );
-	const [ product, setProduct ] = useState< Product | undefined >(
-		undefined
-	);
-
-	useEffect( () => {
-		saveEntityRecord( 'postType', 'product', {
-			title: AUTO_DRAFT_NAME,
-			status: 'auto-draft',
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-			// @ts-ignore Incorrect types.
-		} ).then( ( autoDraftProduct: Product ) => {
-			setProduct( autoDraftProduct );
-		} );
-	}, [] );
-
-	return product;
-};
-
-const useProductEntity = ( productId: number ) => {
-	const product = useSelect( ( select: typeof WPSelect ) => {
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-ignore Missing types.
-		const { getEntityRecord } = select( 'core' );
-
-		return getEntityRecord( 'postType', 'product', productId ) as Product;
-	} );
-
-	return product;
-};
+import { useEffect, useState } from '@wordpress/element';
 
 export function useProductEntityRecord(
 	productId: string | undefined
 ): Product | undefined {
-	const selectedHook = useMemo( () => {
-		return productId
-			? useProductEntity.bind( {}, Number.parseInt( productId, 10 ) )
-			: useAutoDraft;
+	const { saveEntityRecord } = useDispatch( 'core' );
+	const [ newProduct, setNewProduct ] = useState< Product | undefined >(
+		undefined
+	);
+
+	useEffect( () => {
+		if ( ! productId ) {
+			saveEntityRecord( 'postType', 'product', {
+				title: AUTO_DRAFT_NAME,
+				status: 'auto-draft',
+				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+				// @ts-ignore Incorrect types.
+			} ).then( ( autoDraftProduct: Product ) => {
+				setNewProduct( autoDraftProduct );
+			} );
+		}
 	}, [ productId ] );
 
-	return selectedHook();
+	const product = useSelect(
+		( select: typeof WPSelect ) => {
+			if ( ! productId ) {
+				return undefined;
+			}
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore Missing types.
+			const { getEntityRecord } = select( 'core' );
+
+			return getEntityRecord(
+				'postType',
+				'product',
+				Number.parseInt( productId, 10 )
+			) as Product;
+		},
+		[ productId ]
+	);
+
+	return productId !== undefined ? product : newProduct;
 }

--- a/plugins/woocommerce-admin/client/products/hooks/use-product-entity-record.ts
+++ b/plugins/woocommerce-admin/client/products/hooks/use-product-entity-record.ts
@@ -3,7 +3,7 @@
  */
 import { AUTO_DRAFT_NAME } from '@woocommerce/product-editor';
 import { Product } from '@woocommerce/data';
-import { useDispatch, useSelect, select as WPSelect } from '@wordpress/data';
+import { useDispatch, resolveSelect } from '@wordpress/data';
 
 import { useEffect, useState } from '@wordpress/element';
 
@@ -11,40 +11,32 @@ export function useProductEntityRecord(
 	productId: string | undefined
 ): Product | undefined {
 	const { saveEntityRecord } = useDispatch( 'core' );
-	const [ newProduct, setNewProduct ] = useState< Product | undefined >(
+	const [ product, setProduct ] = useState< Product | undefined >(
 		undefined
 	);
 
 	useEffect( () => {
-		if ( ! productId ) {
-			saveEntityRecord( 'postType', 'product', {
-				title: AUTO_DRAFT_NAME,
-				status: 'auto-draft',
-				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-				// @ts-ignore Incorrect types.
-			} ).then( ( autoDraftProduct: Product ) => {
-				setNewProduct( autoDraftProduct );
+		const getRecordPromise: Promise< Product > = productId
+			? resolveSelect( 'core' ).getEntityRecord< Product >(
+					'postType',
+					'product',
+					Number.parseInt( productId, 10 )
+			  )
+			: // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			  // @ts-ignore Incorrect types.
+			  ( saveEntityRecord( 'postType', 'product', {
+					title: AUTO_DRAFT_NAME,
+					status: 'auto-draft',
+			  } ) as Promise< Product > );
+		getRecordPromise
+			.then( ( autoDraftProduct: Product ) => {
+				setProduct( autoDraftProduct );
+			} )
+			.catch( ( e ) => {
+				setProduct( undefined );
+				throw e;
 			} );
-		}
 	}, [ productId ] );
 
-	const product = useSelect(
-		( select: typeof WPSelect ) => {
-			if ( ! productId ) {
-				return undefined;
-			}
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-			// @ts-ignore Missing types.
-			const { getEntityRecord } = select( 'core' );
-
-			return getEntityRecord(
-				'postType',
-				'product',
-				Number.parseInt( productId, 10 )
-			) as Product;
-		},
-		[ productId ]
-	);
-
-	return productId !== undefined ? product : newProduct;
+	return product;
 }

--- a/plugins/woocommerce-admin/client/products/product-page.tsx
+++ b/plugins/woocommerce-admin/client/products/product-page.tsx
@@ -3,26 +3,27 @@
  */
 import {
 	__experimentalEditor as Editor,
-	AUTO_DRAFT_NAME,
 	ProductEditorSettings,
 } from '@woocommerce/product-editor';
-import { Product } from '@woocommerce/data';
-import { useDispatch, useSelect, select as WPSelect } from '@wordpress/data';
-import { useEffect, useState } from '@wordpress/element';
+
 import { Spinner } from '@wordpress/components';
 import { useParams } from 'react-router-dom';
 
 /**
  * Internal dependencies
  */
+import { useProductEntityRecord } from './hooks/use-product-entity-record';
+
 import './product-page.scss';
 import './product-block-page.scss';
 
 declare const productBlockEditorSettings: ProductEditorSettings;
 
-const ProductEditor: React.FC< { product: Product | undefined } > = ( {
-	product,
-} ) => {
+export default function ProductPage() {
+	const { productId } = useParams();
+
+	const product = useProductEntityRecord( productId );
+
 	if ( ! product?.id ) {
 		return <Spinner />;
 	}
@@ -33,57 +34,4 @@ const ProductEditor: React.FC< { product: Product | undefined } > = ( {
 			settings={ productBlockEditorSettings || {} }
 		/>
 	);
-};
-
-const EditProductEditor: React.FC< { productId: number } > = ( {
-	productId,
-} ) => {
-	const { product } = useSelect(
-		( select: typeof WPSelect ) => {
-			const { getEntityRecord } = select( 'core' );
-
-			return {
-				product: getEntityRecord(
-					'postType',
-					'product',
-					productId
-				) as Product,
-			};
-		},
-		[ productId ]
-	);
-
-	return <ProductEditor product={ product } />;
-};
-
-const AddProductEditor = () => {
-	const { saveEntityRecord } = useDispatch( 'core' );
-	const [ product, setProduct ] = useState< Product | undefined >(
-		undefined
-	);
-
-	useEffect( () => {
-		saveEntityRecord( 'postType', 'product', {
-			title: AUTO_DRAFT_NAME,
-			status: 'auto-draft',
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-			// @ts-ignore Incorrect types.
-		} ).then( ( autoDraftProduct: Product ) => {
-			setProduct( autoDraftProduct );
-		} );
-	}, [] );
-
-	return <ProductEditor product={ product } />;
-};
-
-export default function ProductPage() {
-	const { productId } = useParams();
-
-	if ( productId ) {
-		return (
-			<EditProductEditor productId={ Number.parseInt( productId, 10 ) } />
-		);
-	}
-
-	return <AddProductEditor />;
 }

--- a/plugins/woocommerce/changelog/update-product-page-add-hook-37281
+++ b/plugins/woocommerce/changelog/update-product-page-add-hook-37281
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Replacing multiple components on the block product page with a single hook.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Refactor `product-page.tsx` logic to utilize a single hook instead of three components, suggested as part of a [previous code review.](https://github.com/woocommerce/woocommerce/pull/37064#discussion_r1130713116) 

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #37281 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Create a dummy product if you don't have one.
2. Enable the `block-editor-feature-enabled` feature flag.
3. Go to Products -> Add new.
4. You should have the block editor successfully load with the text `AUTO_DRAFT` present in the name field.
5. Get the preexisting productId and go to `/wp-admin/admin.php?page=wc-admin&path=/product/[PRODUCT_ID]`
6. The editor should successfully load with the name of the product present in the field.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
