### PR TITLE
Change the codecov to green light current coverage numbers but block drops in coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -21,7 +21,7 @@ ignore:
 coverage:
     precision: 1
     round: nearest
-    range: '50...80'
+    range: '45...100'
 
     status:
         project:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -27,9 +27,6 @@ coverage:
         project:
             default:
                 target: auto
-        patch:
-            default:
-                target: auto
 parsers:
     gcov:
         branch_detection:


### PR DESCRIPTION
### Changes proposed in this Pull Request:

As we prepare for the idea of making coverage checks required, we need to find a code coverage config that passes.

Our current coverage sits at ~46%. I've set the goal at 45% to give us 1% wiggle room. It could also be set at 46 with `threshold: 1%`, but this seems fine imo.

So when a user submits a PR that adds 0% improvement to the code coverage it will pass. 

When a user submits one that drops coverage it will fail.

The thinking behind this is:

1. We still want to block PRs if coverage goes down
2. If we don't set it this way, codecov will fail unless every PR increases coverage. and we don't expect everyone submitting a PR to arbitrarily be trying to raise code coverage
3. However I think this will block people dropping coverage which will still encourage the writing of more tests, and over time my thinking is we may even be able to raise the bar above the current %
<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

All PRs with 0% coverage change have been failing codecov, so if this PR succeeds we have set a benchmark that passes regardless of 0.0% change.

<!-- End testing instructions -->



<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
