### PR TITLE
fix: added skydropx slug back to shipping partners list

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/fills/shipping/shipping-providers/shipping-providers.ts
+++ b/plugins/woocommerce-admin/client/tasks/fills/shipping/shipping-providers/shipping-providers.ts
@@ -83,6 +83,7 @@ const providers = {
 	},
 	Skydropx: {
 		name: 'Skydropx' as const,
+		slug: 'skydropx-cotizador-y-envios', // https://wordpress.org/plugins/skydropx-cotizador-y-envios/
 		url: 'https://wordpress.org/plugins/skydropx-cotizador-y-envios/',
 		'single-partner-layout': SkydropxSinglePartner,
 	},

--- a/plugins/woocommerce/changelog/fix-skydropx-auto-install
+++ b/plugins/woocommerce/changelog/fix-skydropx-auto-install
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Added skydropx slug back to shipping partners list so that it can be installed through the shipping task


### PR DESCRIPTION
- fix: added skydropx slug back to shipping partners list

### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Previously the skydropx plugin was excluded from the shipping partners list as it was doing a redirect on activation, which then causes an error in the REST API call.

This has been remedied by them in the next version, which should be 1.0.7

Not too sure when they will release it but it will be out before 7.6 is released to public, so it should be safe to make this change before skydropx publishes it. In the unlikely event they do not release it, we will have to make a code freeze violation request to revert this commit.



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Set up a new site, go through OBW without installing any plugins. Set your location to Mexico
2. If skydropx has published 1.0.7, ignore this step. Otherwise, **only install** this custom build of skydropx plugin **without activating it**.  [skydropx-cotizador-y-envios.zip](https://github.com/woocommerce/woocommerce/files/10999342/skydropx-cotizador-y-envios.zip)
3. Go to shipping task on the home screen and set up skydropx via the shipping task
4. Should succeed without any errors.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
