### PR TITLE
Also delete when order type is placehoder, since it was created by HPOS.

### DIFF
--- a/plugins/woocommerce/changelog/fix-delete_placeholder
+++ b/plugins/woocommerce/changelog/fix-delete_placeholder
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Also delete when order type is placehoder, since it was created by HPOS.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1790,9 +1790,18 @@ FROM $order_meta_table
 
 			$order->set_id( 0 );
 
-			// Only delete post data if the posts table is authoritative and synchronization is enabled.
+			/** We can delete the post data if:
+			 * 1. If the HPOS table is authoritative and synchronization is enabled.
+			 * 2. If the post record is of type `shop_order_placehold`, since this is created by the HPOS in the first place.
+			 *
+			 * In other words, we do not delete the post record when HPOS table is authoritative and synchronization is disabled but post record is a full record and not just a placeholder, because it implies that the order was created before HPOS was enabled.
+			 */
 			$data_synchronizer = wc_get_container()->get( DataSynchronizer::class );
-			if ( $data_synchronizer->data_sync_is_enabled() && $order->get_data_store()->get_current_class_name() === self::class ) {
+			if (
+				( $data_synchronizer->data_sync_is_enabled() && $order->get_data_store()->get_current_class_name() === self::class ) ||
+				( get_post_type( $order_id ) === 'shop_order_placehold' )
+			) {
+
 				// Delete the associated post, which in turn deletes order items, etc. through {@see WC_Post_Data}.
 				// Once we stop creating posts for orders, we should do the cleanup here instead.
 				wp_delete_post( $order_id );

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1791,17 +1791,13 @@ FROM $order_meta_table
 			$order->set_id( 0 );
 
 			/** We can delete the post data if:
-			 * 1. If the HPOS table is authoritative and synchronization is enabled.
-			 * 2. If the post record is of type `shop_order_placehold`, since this is created by the HPOS in the first place.
+			 * 1. The HPOS table is authoritative and synchronization is enabled.
+			 * 2. The post record is of type `shop_order_placehold`, since this is created by the HPOS in the first place.
 			 *
 			 * In other words, we do not delete the post record when HPOS table is authoritative and synchronization is disabled but post record is a full record and not just a placeholder, because it implies that the order was created before HPOS was enabled.
 			 */
 			$data_synchronizer = wc_get_container()->get( DataSynchronizer::class );
-			if (
-				( $data_synchronizer->data_sync_is_enabled() && $order->get_data_store()->get_current_class_name() === self::class ) ||
-				( get_post_type( $order_id ) === 'shop_order_placehold' )
-			) {
-
+			if ( $data_synchronizer->data_sync_is_enabled() || get_post_type( $order_id ) === 'shop_order_placehold' ) {
 				// Delete the associated post, which in turn deletes order items, etc. through {@see WC_Post_Data}.
 				// Once we stop creating posts for orders, we should do the cleanup here instead.
 				wp_delete_post( $order_id );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Currently, we do not delete the order placeholder entry unless the sync is enabled. However, it should be fine (and expected) to delete this placeholder entry when HPOS data is deleted, because HPOS created this entry in the first place.

Basically, we can delete the post data for order if:
1. If the HPOS table is authoritative and synchronization is enabled.
2. If the post record is of type `shop_order_placehold`, since this is created by the HPOS in the first place.

In other words, we do not delete the post record when HPOS table is authoritative and synchronization is disabled but post record is a full record and not just a placeholder, because it implies that the order was created before HPOS was enabled.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

With HPOS enabled and sync off:

1. Create a new order, and note it's ID, let's say its xxxx.
2. Trash the order and then permanently delete from WooCommerce > Orders > Trash
3. Try to open the post edit page for this deleted order by going to `/wp-admin/post.php?post=4375&action=edit`. The error message should say that `You attempted to edit an item that does not exist. Perhaps it was deleted?` on this branch. On truck, if you repeat the same steps, the message would say `You attempted to edit an order that does not exist. Perhaps it was deleted?` which means that the post entry still exists.
4. You can also check the from console, by running code: `get_post(xxxx)` and make sure that it returns null.

Note that this is already covered by unit test, which can be verified by failing test in the target PR #36650 

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
