### PR TITLE
 Disable React Fast Refresh completely in webpack when running `start` command

### DIFF
--- a/plugins/woocommerce-admin/package.json
+++ b/plugins/woocommerce-admin/package.json
@@ -38,7 +38,7 @@
 		"run:packages": "pnpm run --parallel --filter='../../packages/js/**'",
 		"prestart": "pnpm packages:build && cross-env WC_ADMIN_PHASE=development pnpm run build:feature-config",
 		"start": "concurrently \"cross-env WC_ADMIN_PHASE=development webpack --watch\" \"cross-env WC_ADMIN_PHASE=development pnpm packages:watch\"",
-		"start:hot": "pnpm prestart && concurrently \"cross-env WC_ADMIN_PHASE=development webpack serve\" \"cross-env WC_ADMIN_PHASE=development pnpm packages:watch\"",
+		"start:hot": "pnpm prestart && concurrently \"cross-env HOT=true WC_ADMIN_PHASE=development webpack serve\" \"cross-env WC_ADMIN_PHASE=development pnpm packages:watch\"",
 		"test-staged": "pnpm run test:client --bail --findRelatedTests",
 		"test:client": "jest --config client/jest.config.js",
 		"test:debug": "node --inspect-brk ./node_modules/.bin/jest --config client/jest.config.js --watch --runInBand --no-cache",

--- a/plugins/woocommerce-admin/webpack.config.js
+++ b/plugins/woocommerce-admin/webpack.config.js
@@ -22,6 +22,7 @@ const WooCommerceDependencyExtractionWebpackPlugin = require( '../../packages/js
 
 const NODE_ENV = process.env.NODE_ENV || 'development';
 const WC_ADMIN_PHASE = process.env.WC_ADMIN_PHASE || 'development';
+const isHot = Boolean( process.env.HOT );
 const isProduction = NODE_ENV === 'production';
 
 const wcAdminPackages = [
@@ -134,6 +135,7 @@ const webpackConfig = {
 						plugins: [
 							'@babel/plugin-proposal-class-properties',
 							! isProduction &&
+								isHot &&
 								require.resolve( 'react-refresh/babel' ),
 						].filter( Boolean ),
 					},
@@ -190,7 +192,7 @@ const webpackConfig = {
 			} ) ),
 		} ),
 		// React Fast Refresh.
-		! isProduction && new ReactRefreshWebpackPlugin(),
+		! isProduction && isHot && new ReactRefreshWebpackPlugin(),
 
 		// We reuse this Webpack setup for Storybook, where we need to disable dependency extraction.
 		! process.env.STORYBOOK &&
@@ -228,23 +230,26 @@ const webpackConfig = {
 if ( ! isProduction || WC_ADMIN_PHASE === 'development' ) {
 	// Set default sourcemap mode if it wasn't set by WP_DEVTOOL.
 	webpackConfig.devtool = webpackConfig.devtool || 'source-map';
-	// Add dev server config
-	// Copied from https://github.com/WordPress/gutenberg/blob/05bea6dd5c6198b0287c41a401d36a06b48831eb/packages/scripts/config/webpack.config.js#L312-L326
-	webpackConfig.devServer = {
-		devMiddleware: {
-			writeToDisk: true,
-		},
-		allowedHosts: 'auto',
-		host: 'localhost',
-		port: 8887,
-		proxy: {
-			'/build': {
-				pathRewrite: {
-					'^/build': '',
+
+	if ( isHot ) {
+		// Add dev server config
+		// Copied from https://github.com/WordPress/gutenberg/blob/05bea6dd5c6198b0287c41a401d36a06b48831eb/packages/scripts/config/webpack.config.js#L312-L326
+		webpackConfig.devServer = {
+			devMiddleware: {
+				writeToDisk: true,
+			},
+			allowedHosts: 'auto',
+			host: 'localhost',
+			port: 8887,
+			proxy: {
+				'/build': {
+					pathRewrite: {
+						'^/build': '',
+					},
 				},
 			},
-		},
-	};
+		};
+	}
 }
 
 module.exports = webpackConfig;

--- a/plugins/woocommerce/changelog/dev-update-webpack-config
+++ b/plugins/woocommerce/changelog/dev-update-webpack-config
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Update WCA webpack config and package.json to use start command when script debug is false
+
+

--- a/plugins/woocommerce/changelog/dev-update-webpack-config
+++ b/plugins/woocommerce/changelog/dev-update-webpack-config
@@ -1,5 +1,5 @@
 Significance: patch
 Type: dev
-Comment: Update WCA webpack config and package.json to use start command when script debug is false
+Comment: Use React Fast Refresh for WooCommerce Admin "start:hot" command only; fix empty page issue with "start" command when SCRIPT_DEBUG is set to false.
 
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

p1678994501619099-slack-C03CPM3UXDJ

The web UI shows an empty page when running `start` command with `SCRIPT_DEBUG = false` because react refresh runtime lib is only loaded when SCRIPT_DEBUG = true.

This PR updates the webpack config to skip React Fast Refresh when running the start command.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Set `define( 'SCRIPT_DEBUG', false )` in your wp-config.php
2. Run `cd plugins/woocommerce-admin`
3. Run `pnpm start`
4. Go to WooCommerce > Home
5. Confirm the page is loaded properly.
6. Set `define( 'SCRIPT_DEBUG', true )`
7. Run `pnpm start:hot`
8. Go to WooCommerce > Home
9. Confirm the page is loaded properly.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.