### PR TITLE
Update WooCommerce blocks package to 9.6.6

### DIFF
--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-9.6.6
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-9.6.6
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Woo Blocks 9.6.6

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -21,7 +21,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.5.4",
-		"woocommerce/woocommerce-blocks": "9.6.5"
+		"woocommerce/woocommerce-blocks": "9.6.6"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.3.0",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f08d44536a1162957e0edb212f042956",
+    "content-hash": "ba320add8c7c0cfe6ba8935d78cfb7ec",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -628,16 +628,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "v9.6.5",
+            "version": "v9.6.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "0d316bd6a7edd18a4af6fa55406b1279b18b28a4"
+                "reference": "789d2508a9d9ecf9496d94b0d24eb22ed32cb4df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/0d316bd6a7edd18a4af6fa55406b1279b18b28a4",
-                "reference": "0d316bd6a7edd18a4af6fa55406b1279b18b28a4",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/789d2508a9d9ecf9496d94b0d24eb22ed32cb4df",
+                "reference": "789d2508a9d9ecf9496d94b0d24eb22ed32cb4df",
                 "shasum": ""
             },
             "require": {
@@ -683,9 +683,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v9.6.5"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v9.6.6"
             },
-            "time": "2023-03-06T15:42:05+00:00"
+            "time": "2023-03-17T15:51:39+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 9.6.6. 
## Blocks 9.6.6

* [Release PR](https://github.com/woocommerce/woocommerce-blocks/pull/8778)
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/966.md)



### Changelog entry

#### Bug Fixes

- Product Image Gallery: fix 404 error. ([8445](https://github.com/woocommerce/woocommerce-blocks/pull/8445))



