### PR TITLE
Fix/37276 remove information schema queries

### DIFF
--- a/plugins/woocommerce/changelog/fix-37276-remove-information-schema-queries
+++ b/plugins/woocommerce/changelog/fix-37276-remove-information-schema-queries
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Replace information_schema queries in favor of create table parsing to remove foreign key constraints during updates

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -1846,7 +1846,7 @@ function wc_update_343_cleanup_foreign_keys() {
 	$create_table_sql = $wpdb->get_var( "SHOW CREATE TABLE {$wpdb->prefix}wc_download_log", 1 );
 
 	if ( ! empty( $create_table_sql ) ) {
-		// Extract and remove the foreign key constraints matching %wc_download_log_ib%
+		// Extract and remove the foreign key constraints matching %wc_download_log_ib%.
 		if ( preg_match_all( '/CONSTRAINT `([^`]*wc_download_log_ib[^`]*)` FOREIGN KEY/', $create_table_sql, $matches ) && ! empty( $matches[1] ) ) {
 			foreach ( $matches[1] as $foreign_key_name ) {
 				$wpdb->query( "ALTER TABLE {$wpdb->prefix}wc_download_log DROP FOREIGN KEY `{$foreign_key_name}`" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
@@ -2445,7 +2445,6 @@ function wc_update_700_remove_download_log_fk() {
 	$create_table_sql = $wpdb->get_var( "SHOW CREATE TABLE {$wpdb->prefix}wc_download_log", 1 );
 
 	if ( ! empty( $create_table_sql ) ) {
-		// Extract the foreign key constraints
 		if ( preg_match_all( '/CONSTRAINT `([^`]*)` FOREIGN KEY/', $create_table_sql, $matches ) && ! empty( $matches[1] ) ) {
 			foreach ( $matches[1] as $foreign_key_name ) {
 				$wpdb->query( "ALTER TABLE {$wpdb->prefix}wc_download_log DROP FOREIGN KEY `{$foreign_key_name}`" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -1843,18 +1843,14 @@ function wc_update_340_db_version() {
 function wc_update_343_cleanup_foreign_keys() {
 	global $wpdb;
 
-	$results = $wpdb->get_results(
-		"SELECT CONSTRAINT_NAME
-		FROM information_schema.TABLE_CONSTRAINTS
-		WHERE CONSTRAINT_SCHEMA = '{$wpdb->dbname}'
-		AND CONSTRAINT_NAME LIKE '%wc_download_log_ib%'
-		AND CONSTRAINT_TYPE = 'FOREIGN KEY'
-		AND TABLE_NAME = '{$wpdb->prefix}wc_download_log'"
-	);
+	$create_table_sql = $wpdb->get_var( "SHOW CREATE TABLE {$wpdb->prefix}wc_download_log", 1 );
 
-	if ( $results ) {
-		foreach ( $results as $fk ) {
-			$wpdb->query( "ALTER TABLE {$wpdb->prefix}wc_download_log DROP FOREIGN KEY {$fk->CONSTRAINT_NAME}" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	if ( ! empty( $create_table_sql ) ) {
+		// Extract and remove the foreign key constraints matching %wc_download_log_ib%
+		if ( preg_match_all( '/CONSTRAINT `([^`]*wc_download_log_ib[^`]*)` FOREIGN KEY/', $create_table_sql, $matches ) && ! empty( $matches[1] ) ) {
+			foreach ( $matches[1] as $foreign_key_name ) {
+				$wpdb->query( "ALTER TABLE {$wpdb->prefix}wc_download_log DROP FOREIGN KEY `{$foreign_key_name}`" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			}
 		}
 	}
 }
@@ -1912,18 +1908,13 @@ function wc_update_350_db_version() {
  */
 function wc_update_352_drop_download_log_fk() {
 	global $wpdb;
-	$results = $wpdb->get_results(
-		"SELECT CONSTRAINT_NAME
-		FROM information_schema.TABLE_CONSTRAINTS
-		WHERE CONSTRAINT_SCHEMA = '{$wpdb->dbname}'
-		AND CONSTRAINT_NAME = 'fk_wc_download_log_permission_id'
-		AND CONSTRAINT_TYPE = 'FOREIGN KEY'
-		AND TABLE_NAME = '{$wpdb->prefix}wc_download_log'"
-	);
 
-	// We only need to drop the old key as WC_Install::create_tables() takes care of creating the new FK.
-	if ( $results ) {
-		$wpdb->query( "ALTER TABLE {$wpdb->prefix}wc_download_log DROP FOREIGN KEY fk_wc_download_log_permission_id" ); // phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
+	$create_table_sql = $wpdb->get_var( "SHOW CREATE TABLE {$wpdb->prefix}wc_download_log", 1 );
+
+	if ( ! empty( $create_table_sql ) ) {
+		if ( strpos( $create_table_sql, 'CONSTRAINT `fk_wc_download_log_permission_id` FOREIGN KEY' ) !== false ) {
+			$wpdb->query( "ALTER TABLE {$wpdb->prefix}wc_download_log DROP FOREIGN KEY fk_wc_download_log_permission_id" ); // phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
+		}
 	}
 }
 
@@ -2451,17 +2442,14 @@ function wc_update_670_purge_comments_count_cache() {
 function wc_update_700_remove_download_log_fk() {
 	global $wpdb;
 
-	$results = $wpdb->get_results(
-		"SELECT CONSTRAINT_NAME
-		FROM information_schema.TABLE_CONSTRAINTS
-		WHERE CONSTRAINT_SCHEMA = '{$wpdb->dbname}'
-		AND CONSTRAINT_TYPE = 'FOREIGN KEY'
-		AND TABLE_NAME = '{$wpdb->prefix}wc_download_log'"
-	);
+	$create_table_sql = $wpdb->get_var( "SHOW CREATE TABLE {$wpdb->prefix}wc_download_log", 1 );
 
-	if ( $results ) {
-		foreach ( $results as $fk ) {
-			$wpdb->query( "ALTER TABLE {$wpdb->prefix}wc_download_log DROP FOREIGN KEY {$fk->CONSTRAINT_NAME}" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	if ( ! empty( $create_table_sql ) ) {
+		// Extract the foreign key constraints
+		if ( preg_match_all( '/CONSTRAINT `([^`]*)` FOREIGN KEY/', $create_table_sql, $matches ) && ! empty( $matches[1] ) ) {
+			foreach ( $matches[1] as $foreign_key_name ) {
+				$wpdb->query( "ALTER TABLE {$wpdb->prefix}wc_download_log DROP FOREIGN KEY `{$foreign_key_name}`" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			}
 		}
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/wc-update-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-update-functions-test.php
@@ -24,8 +24,8 @@ class WC_Update_Functions_Test extends \WC_Unit_Test_Case {
 					REFERENCES `{$wpdb->prefix}woocommerce_downloadable_product_permissions` (`permission_id`) ON DELETE CASCADE"
 		);
 		$table_definition = $wpdb->get_var( "SHOW CREATE TABLE {$wpdb->prefix}wc_download_log", 1 );
-		$this->assertNotFalse( strpos( $table_definition, "wc_download_log_ib" ) );
-		$this->assertNotFalse( strpos( $table_definition, "wc_download_log_ib_2" ) );
+		$this->assertNotFalse( strpos( $table_definition, 'wc_download_log_ib' ) );
+		$this->assertNotFalse( strpos( $table_definition, 'wc_download_log_ib_2' ) );
 
 		include_once WC_ABSPATH . 'includes/wc-update-functions.php';
 
@@ -33,7 +33,7 @@ class WC_Update_Functions_Test extends \WC_Unit_Test_Case {
 
 		// Verify that the keys were properly removed
 		$table_definition = $wpdb->get_var( "SHOW CREATE TABLE {$wpdb->prefix}wc_download_log", 1 );
-		$this->assertFalse( strpos( $table_definition, "wc_download_log_ib" ) );
+		$this->assertFalse( strpos( $table_definition, 'wc_download_log_ib' ) );
 	}
 
 	public function test_verify_wc_update_352_drop_download_log_fk_removes_foreign_keys() {
@@ -47,7 +47,7 @@ class WC_Update_Functions_Test extends \WC_Unit_Test_Case {
 					REFERENCES `{$wpdb->prefix}woocommerce_downloadable_product_permissions` (`permission_id`) ON DELETE CASCADE"
 		);
 		$table_definition = $wpdb->get_var( "SHOW CREATE TABLE {$wpdb->prefix}wc_download_log", 1 );
-		$this->assertNotFalse( strpos( $table_definition, "fk_wc_download_log_permission_id" ) );
+		$this->assertNotFalse( strpos( $table_definition, 'fk_wc_download_log_permission_id' ) );
 
 		include_once WC_ABSPATH . 'includes/wc-update-functions.php';
 
@@ -55,7 +55,7 @@ class WC_Update_Functions_Test extends \WC_Unit_Test_Case {
 
 		// Verify that the key was properly removed
 		$table_definition = $wpdb->get_var( "SHOW CREATE TABLE {$wpdb->prefix}wc_download_log", 1 );
-		$this->assertFalse( strpos( $table_definition, "fk_wc_download_log_permission_id" ) );
+		$this->assertFalse( strpos( $table_definition, 'fk_wc_download_log_permission_id' ) );
 	}
 
 	public function test_verify_wc_update_700_remove_download_log_fk_removes_foreign_keys() {

--- a/plugins/woocommerce/tests/php/includes/wc-update-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-update-functions-test.php
@@ -10,6 +10,9 @@
  */
 class WC_Update_Functions_Test extends \WC_Unit_Test_Case {
 
+	/**
+	 * Test wc_update_343_cleanup_foreign_keys() function.
+	 */
 	public function test_verify_wc_update_343_cleanup_foreign_keys_removes_foreign_keys() {
 		global $wpdb;
 
@@ -31,11 +34,14 @@ class WC_Update_Functions_Test extends \WC_Unit_Test_Case {
 
 		wc_update_343_cleanup_foreign_keys();
 
-		// Verify that the keys were properly removed
+		// Verify that the keys were properly removed.
 		$table_definition = $wpdb->get_var( "SHOW CREATE TABLE {$wpdb->prefix}wc_download_log", 1 );
 		$this->assertFalse( strpos( $table_definition, 'wc_download_log_ib' ) );
 	}
 
+	/**
+	 * Test wc_update_352_drop_download_log_fk() function.
+	 */
 	public function test_verify_wc_update_352_drop_download_log_fk_removes_foreign_keys() {
 		global $wpdb;
 
@@ -53,11 +59,14 @@ class WC_Update_Functions_Test extends \WC_Unit_Test_Case {
 
 		wc_update_352_drop_download_log_fk();
 
-		// Verify that the key was properly removed
+		// Verify that the key was properly removed.
 		$table_definition = $wpdb->get_var( "SHOW CREATE TABLE {$wpdb->prefix}wc_download_log", 1 );
 		$this->assertFalse( strpos( $table_definition, 'fk_wc_download_log_permission_id' ) );
 	}
 
+	/**
+	 * Test wc_update_700_remove_download_log_fk() function.
+	 */
 	public function test_verify_wc_update_700_remove_download_log_fk_removes_foreign_keys() {
 		global $wpdb;
 

--- a/plugins/woocommerce/tests/php/includes/wc-update-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-update-functions-test.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Update functions tests
+ *
+ * @package WooCommerce\Tests\Functions.
+ */
+
+/**
+ * Class WC_Core_Functions_Test
+ */
+class WC_Update_Functions_Test extends \WC_Unit_Test_Case {
+
+	public function test_verify_wc_update_343_cleanup_foreign_keys_removes_foreign_keys() {
+		global $wpdb;
+
+		// Add matching foreign keys between wc_download_log and wc_download_log_permission_id as it previously existed.
+		$wpdb->query(
+			"ALTER TABLE `{$wpdb->prefix}wc_download_log`
+					ADD CONSTRAINT `wc_download_log_ib`
+					FOREIGN KEY (`permission_id`)
+					REFERENCES `{$wpdb->prefix}woocommerce_downloadable_product_permissions` (`permission_id`) ON DELETE CASCADE,
+					ADD CONSTRAINT `wc_download_log_ib_2`
+					FOREIGN KEY (`permission_id`)
+					REFERENCES `{$wpdb->prefix}woocommerce_downloadable_product_permissions` (`permission_id`) ON DELETE CASCADE"
+		);
+		$table_definition = $wpdb->get_var( "SHOW CREATE TABLE {$wpdb->prefix}wc_download_log", 1 );
+		$this->assertNotFalse( strpos( $table_definition, "wc_download_log_ib" ) );
+		$this->assertNotFalse( strpos( $table_definition, "wc_download_log_ib_2" ) );
+
+		include_once WC_ABSPATH . 'includes/wc-update-functions.php';
+
+		wc_update_343_cleanup_foreign_keys();
+
+		// Verify that the keys were properly removed
+		$table_definition = $wpdb->get_var( "SHOW CREATE TABLE {$wpdb->prefix}wc_download_log", 1 );
+		$this->assertFalse( strpos( $table_definition, "wc_download_log_ib" ) );
+	}
+
+	public function test_verify_wc_update_352_drop_download_log_fk_removes_foreign_keys() {
+		global $wpdb;
+
+		// Add the foreign key between wc_download_log and wc_download_log_permission_id as it previously existed.
+		$wpdb->query(
+			"ALTER TABLE `{$wpdb->prefix}wc_download_log`
+					ADD CONSTRAINT `fk_wc_download_log_permission_id`
+					FOREIGN KEY (`permission_id`)
+					REFERENCES `{$wpdb->prefix}woocommerce_downloadable_product_permissions` (`permission_id`) ON DELETE CASCADE"
+		);
+		$table_definition = $wpdb->get_var( "SHOW CREATE TABLE {$wpdb->prefix}wc_download_log", 1 );
+		$this->assertNotFalse( strpos( $table_definition, "fk_wc_download_log_permission_id" ) );
+
+		include_once WC_ABSPATH . 'includes/wc-update-functions.php';
+
+		wc_update_352_drop_download_log_fk();
+
+		// Verify that the key was properly removed
+		$table_definition = $wpdb->get_var( "SHOW CREATE TABLE {$wpdb->prefix}wc_download_log", 1 );
+		$this->assertFalse( strpos( $table_definition, "fk_wc_download_log_permission_id" ) );
+	}
+
+	public function test_verify_wc_update_700_remove_download_log_fk_removes_foreign_keys() {
+		global $wpdb;
+
+		// Add the foreign key between wc_download_log and wc_download_log_permission_id as it previously existed.
+		$wpdb->query(
+			"ALTER TABLE `{$wpdb->prefix}wc_download_log`
+					ADD CONSTRAINT `fk_{$wpdb->prefix}wc_download_log_permission_id`
+					FOREIGN KEY (`permission_id`)
+					REFERENCES `{$wpdb->prefix}woocommerce_downloadable_product_permissions` (`permission_id`) ON DELETE CASCADE"
+		);
+		$table_definition = $wpdb->get_var( "SHOW CREATE TABLE {$wpdb->prefix}wc_download_log", 1 );
+		$this->assertNotFalse( strpos( $table_definition, "fk_{$wpdb->prefix}wc_download_log_permission_id" ) );
+
+		include_once WC_ABSPATH . 'includes/wc-update-functions.php';
+
+		wc_update_700_remove_download_log_fk();
+
+		// Verify that the key was properly removed.
+		$table_definition = $wpdb->get_var( "SHOW CREATE TABLE {$wpdb->prefix}wc_download_log", 1 );
+		$this->assertFalse( strpos( $table_definition, "fk_{$wpdb->prefix}wc_download_log_permission_id" ) );
+	}
+
+
+}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Partially fixes #37276.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Install WooCommerce version < 7.0.
2. Through MySQL run a `SHOW CREATE TABLE `{db_prefix} wc_download_log` to verify foreign keys exist on the `wc_download_log` table.
3. Update to the latest version of WooCommerce with this diff applied.
4. Check the `SHOW CREATE TABLE` for `wc_download_log` again to verify the foreign keys were properly removed.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
