### PR TITLE
Add the summary field to the product form

### DIFF
--- a/packages/js/product-editor/changelog/add-37103
+++ b/packages/js/product-editor/changelog/add-37103
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add summary block

--- a/packages/js/product-editor/src/components/collapsible-block/index.ts
+++ b/packages/js/product-editor/src/components/collapsible-block/index.ts
@@ -14,4 +14,5 @@ export const settings = {
 	edit: Edit,
 };
 
-export const init = () => initBlock( { name, metadata, settings } );
+export const init = () =>
+	initBlock( { name, metadata: metadata as never, settings } );

--- a/packages/js/product-editor/src/components/details-name-block/index.ts
+++ b/packages/js/product-editor/src/components/details-name-block/index.ts
@@ -14,4 +14,9 @@ export const settings = {
 	edit: Edit,
 };
 
-export const init = () => initBlock( { name, metadata, settings } );
+export const init = () =>
+	initBlock( {
+		name,
+		metadata: metadata as never,
+		settings,
+	} );

--- a/packages/js/product-editor/src/components/details-summary-block/block.json
+++ b/packages/js/product-editor/src/components/details-summary-block/block.json
@@ -8,6 +8,9 @@
 	"keywords": [ "products", "summary", "excerpt" ],
 	"textdomain": "default",
 	"attributes": {
+		"align": {
+			"type": "string"
+		},
 		"label": {
 			"type": "string"
 		}

--- a/packages/js/product-editor/src/components/details-summary-block/block.json
+++ b/packages/js/product-editor/src/components/details-summary-block/block.json
@@ -1,0 +1,23 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "woocommerce/product-summary",
+	"title": "Product summary",
+	"category": "widgets",
+	"description": "The product summary.",
+	"keywords": [ "products", "summary", "excerpt" ],
+	"textdomain": "default",
+	"attributes": {
+		"label": {
+			"type": "string"
+		}
+	},
+	"supports": {
+		"align": false,
+		"html": false,
+		"multiple": false,
+		"reusable": false,
+		"inserter": false,
+		"lock": false
+	}
+}

--- a/packages/js/product-editor/src/components/details-summary-block/block.json
+++ b/packages/js/product-editor/src/components/details-summary-block/block.json
@@ -11,6 +11,10 @@
 		"align": {
 			"type": "string"
 		},
+		"direction": {
+			"type": "string",
+			"enum": [ "ltr", "rtl" ]
+		},
 		"label": {
 			"type": "string"
 		}

--- a/packages/js/product-editor/src/components/details-summary-block/constants.ts
+++ b/packages/js/product-editor/src/components/details-summary-block/constants.ts
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	alignCenter,
+	alignJustify,
+	alignLeft,
+	alignRight,
+} from '@wordpress/icons';
+
+export const ALIGNMENT_CONTROLS = [
+	{
+		icon: alignLeft,
+		title: __( 'Align text left', 'woocommerce' ),
+		align: 'left',
+	},
+	{
+		icon: alignCenter,
+		title: __( 'Align text center', 'woocommerce' ),
+		align: 'center',
+	},
+	{
+		icon: alignRight,
+		title: __( 'Align text right', 'woocommerce' ),
+		align: 'right',
+	},
+	{
+		icon: alignJustify,
+		title: __( 'Align text justify', 'woocommerce' ),
+		align: 'justify',
+	},
+];

--- a/packages/js/product-editor/src/components/details-summary-block/edit.tsx
+++ b/packages/js/product-editor/src/components/details-summary-block/edit.tsx
@@ -3,14 +3,28 @@
  */
 import { __ } from '@wordpress/i18n';
 import { createElement } from '@wordpress/element';
-import { RichText, useBlockProps } from '@wordpress/block-editor';
+import {
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore No types for this exist yet.
+	AlignmentControl,
+	BlockControls,
+	RichText,
+	useBlockProps,
+} from '@wordpress/block-editor';
 import { useEntityProp } from '@wordpress/core-data';
 import { BaseControl } from '@wordpress/components';
 import uniqueId from 'lodash/uniqueId';
 import { BlockAttributes } from '@wordpress/blocks';
+import classNames from 'classnames';
 
-export function Edit( { attributes }: { attributes: BlockAttributes } ) {
-	const { label } = attributes;
+export function Edit( {
+	attributes,
+	setAttributes,
+}: {
+	attributes: BlockAttributes;
+	setAttributes( attributes: BlockAttributes ): void;
+} ) {
+	const { align, label } = attributes;
 	const blockProps = useBlockProps();
 	const id = uniqueId();
 	const [ summary, setSummary ] = useEntityProp< string >(
@@ -19,8 +33,23 @@ export function Edit( { attributes }: { attributes: BlockAttributes } ) {
 		'short_description'
 	);
 
+	function handleAlignmentChange( value: string ) {
+		setAttributes( {
+			align: value,
+		} );
+	}
+
 	return (
 		<div { ...blockProps }>
+			{ /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */ }
+			{ /* @ts-ignore No types for this exist yet. */ }
+			<BlockControls group="block">
+				<AlignmentControl
+					value={ align }
+					onChange={ handleAlignmentChange }
+				/>
+			</BlockControls>
+
 			<BaseControl
 				id={ id }
 				label={ label || __( 'Summary', 'woocommerce' ) }
@@ -36,7 +65,9 @@ export function Edit( { attributes }: { attributes: BlockAttributes } ) {
 						'woocommerce'
 					) }
 					data-empty={ Boolean( summary ) }
-					className="components-summary-control"
+					className={ classNames( 'components-summary-control', {
+						[ `has-text-align-${ align }` ]: align,
+					} ) }
 				/>
 			</BaseControl>
 		</div>

--- a/packages/js/product-editor/src/components/details-summary-block/edit.tsx
+++ b/packages/js/product-editor/src/components/details-summary-block/edit.tsx
@@ -3,6 +3,11 @@
  */
 import { __ } from '@wordpress/i18n';
 import { createElement } from '@wordpress/element';
+import { useEntityProp } from '@wordpress/core-data';
+import { BaseControl } from '@wordpress/components';
+import uniqueId from 'lodash/uniqueId';
+import { BlockEditProps } from '@wordpress/blocks';
+import classNames from 'classnames';
 import {
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore No types for this exist yet.
@@ -11,21 +16,21 @@ import {
 	RichText,
 	useBlockProps,
 } from '@wordpress/block-editor';
-import { useEntityProp } from '@wordpress/core-data';
-import { BaseControl } from '@wordpress/components';
-import uniqueId from 'lodash/uniqueId';
-import { BlockAttributes } from '@wordpress/blocks';
-import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import { ParagraphRTLControl } from './paragraph-rtl-control';
+import { SummaryAttributes } from './types';
 
 export function Edit( {
 	attributes,
 	setAttributes,
-}: {
-	attributes: BlockAttributes;
-	setAttributes( attributes: BlockAttributes ): void;
-} ) {
-	const { align, label } = attributes;
-	const blockProps = useBlockProps();
+}: BlockEditProps< SummaryAttributes > ) {
+	const { align, direction, label } = attributes;
+	const blockProps = useBlockProps( {
+		style: { direction },
+	} );
 	const id = uniqueId();
 	const [ summary, setSummary ] = useEntityProp< string >(
 		'postType',
@@ -33,10 +38,12 @@ export function Edit( {
 		'short_description'
 	);
 
-	function handleAlignmentChange( value: string ) {
-		setAttributes( {
-			align: value,
-		} );
+	function handleAlignmentChange( value: SummaryAttributes[ 'align' ] ) {
+		setAttributes( { align: value } );
+	}
+
+	function handleDirectionChange( value: SummaryAttributes[ 'direction' ] ) {
+		setAttributes( { direction: value } );
 	}
 
 	return (
@@ -47,6 +54,11 @@ export function Edit( {
 				<AlignmentControl
 					value={ align }
 					onChange={ handleAlignmentChange }
+				/>
+
+				<ParagraphRTLControl
+					direction={ direction }
+					onChange={ handleDirectionChange }
 				/>
 			</BlockControls>
 
@@ -68,6 +80,7 @@ export function Edit( {
 					className={ classNames( 'components-summary-control', {
 						[ `has-text-align-${ align }` ]: align,
 					} ) }
+					dir={ direction }
 				/>
 			</BaseControl>
 		</div>

--- a/packages/js/product-editor/src/components/details-summary-block/edit.tsx
+++ b/packages/js/product-editor/src/components/details-summary-block/edit.tsx
@@ -3,10 +3,10 @@
  */
 import { __ } from '@wordpress/i18n';
 import { createElement } from '@wordpress/element';
-import { useEntityProp } from '@wordpress/core-data';
-import { BaseControl } from '@wordpress/components';
-import uniqueId from 'lodash/uniqueId';
 import { BlockEditProps } from '@wordpress/blocks';
+import { BaseControl } from '@wordpress/components';
+import { useEntityProp } from '@wordpress/core-data';
+import uniqueId from 'lodash/uniqueId';
 import classNames from 'classnames';
 import {
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -22,6 +22,7 @@ import {
  */
 import { ParagraphRTLControl } from './paragraph-rtl-control';
 import { SummaryAttributes } from './types';
+import { ALIGNMENT_CONTROLS } from './constants';
 
 export function Edit( {
 	attributes,
@@ -52,6 +53,7 @@ export function Edit( {
 			{ /* @ts-ignore No types for this exist yet. */ }
 			<BlockControls group="block">
 				<AlignmentControl
+					alignmentControls={ ALIGNMENT_CONTROLS }
 					value={ align }
 					onChange={ handleAlignmentChange }
 				/>

--- a/packages/js/product-editor/src/components/details-summary-block/edit.tsx
+++ b/packages/js/product-editor/src/components/details-summary-block/edit.tsx
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { createElement } from '@wordpress/element';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
+import { useEntityProp } from '@wordpress/core-data';
+import { BaseControl } from '@wordpress/components';
+import uniqueId from 'lodash/uniqueId';
+import { BlockAttributes } from '@wordpress/blocks';
+
+export function Edit( { attributes }: { attributes: BlockAttributes } ) {
+	const { label } = attributes;
+	const blockProps = useBlockProps();
+	const id = uniqueId();
+	const [ summary, setSummary ] = useEntityProp< string >(
+		'postType',
+		'product',
+		'short_description'
+	);
+
+	return (
+		<div { ...blockProps }>
+			<BaseControl
+				id={ id }
+				label={ label || __( 'Summary', 'woocommerce' ) }
+			>
+				<RichText
+					id={ id }
+					identifier="content"
+					tagName="p"
+					value={ summary }
+					onChange={ setSummary }
+					placeholder={ __(
+						"Summarize this product in 1-2 short sentences. We'll show it at the top of the page.",
+						'woocommerce'
+					) }
+					data-empty={ Boolean( summary ) }
+					className="components-summary-control"
+				/>
+			</BaseControl>
+		</div>
+	);
+}

--- a/packages/js/product-editor/src/components/details-summary-block/index.ts
+++ b/packages/js/product-editor/src/components/details-summary-block/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Internal dependencies
+ */
+import { initBlock } from '../../utils';
+import metadata from './block.json';
+import { Edit } from './edit';
+
+const { name } = metadata;
+
+export { metadata, name };
+
+export const settings = {
+	example: {},
+	edit: Edit,
+};
+
+export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/js/product-editor/src/components/details-summary-block/index.ts
+++ b/packages/js/product-editor/src/components/details-summary-block/index.ts
@@ -1,17 +1,30 @@
 /**
+ * External dependencies
+ */
+import { BlockConfiguration } from '@wordpress/blocks';
+
+/**
  * Internal dependencies
  */
 import { initBlock } from '../../utils';
-import metadata from './block.json';
+import blockConfiguration from './block.json';
 import { Edit } from './edit';
+import { SummaryAttributes } from './types';
 
-const { name } = metadata;
+const { name, ...metadata } =
+	blockConfiguration as BlockConfiguration< SummaryAttributes >;
 
-export { metadata, name };
+export { name, metadata };
 
 export const settings = {
 	example: {},
 	edit: Edit,
 };
 
-export const init = () => initBlock( { name, metadata, settings } );
+export function init() {
+	return initBlock< SummaryAttributes >( {
+		name,
+		metadata,
+		settings,
+	} );
+}

--- a/packages/js/product-editor/src/components/details-summary-block/paragraph-rtl-control/index.ts
+++ b/packages/js/product-editor/src/components/details-summary-block/paragraph-rtl-control/index.ts
@@ -1,0 +1,2 @@
+export * from './paragraph-rtl-control';
+export * from './types';

--- a/packages/js/product-editor/src/components/details-summary-block/paragraph-rtl-control/paragraph-rtl-control.tsx
+++ b/packages/js/product-editor/src/components/details-summary-block/paragraph-rtl-control/paragraph-rtl-control.tsx
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import { createElement, Fragment } from '@wordpress/element';
+import { ToolbarButton } from '@wordpress/components';
+import { _x, isRTL } from '@wordpress/i18n';
+import { formatLtr } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { ParagraphRTLControlProps } from './types';
+
+export function ParagraphRTLControl( {
+	direction,
+	onChange,
+}: ParagraphRTLControlProps ) {
+	function handleClick() {
+		if ( typeof onChange === 'function' ) {
+			onChange( direction === 'ltr' ? undefined : 'ltr' );
+		}
+	}
+
+	return (
+		<>
+			{ isRTL() && (
+				<ToolbarButton
+					icon={ formatLtr }
+					title={ _x(
+						'Left to right',
+						'editor button',
+						'woocommerce'
+					) }
+					isActive={ direction === 'ltr' }
+					onClick={ handleClick }
+				/>
+			) }
+		</>
+	);
+}

--- a/packages/js/product-editor/src/components/details-summary-block/paragraph-rtl-control/types.ts
+++ b/packages/js/product-editor/src/components/details-summary-block/paragraph-rtl-control/types.ts
@@ -1,0 +1,11 @@
+/**
+ * Internal dependencies
+ */
+import { SummaryAttributes } from '../types';
+
+export type ParagraphRTLControlProps = Pick<
+	SummaryAttributes,
+	'direction'
+> & {
+	onChange( direction?: SummaryAttributes[ 'direction' ] ): void;
+};

--- a/packages/js/product-editor/src/components/details-summary-block/style.scss
+++ b/packages/js/product-editor/src/components/details-summary-block/style.scss
@@ -1,0 +1,6 @@
+// This alignment class does not exists in
+// https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/common.scss
+.has-text-align-justify {
+	/*rtl:ignore*/
+	text-align: justify;
+}

--- a/packages/js/product-editor/src/components/details-summary-block/types.ts
+++ b/packages/js/product-editor/src/components/details-summary-block/types.ts
@@ -1,0 +1,10 @@
+/**
+ * External dependencies
+ */
+import { BlockAlignment } from '@wordpress/blocks';
+
+export type SummaryAttributes = {
+	align: BlockAlignment;
+	direction: 'ltr' | 'rtl';
+	label: string;
+};

--- a/packages/js/product-editor/src/components/details-summary-block/types.ts
+++ b/packages/js/product-editor/src/components/details-summary-block/types.ts
@@ -1,10 +1,5 @@
-/**
- * External dependencies
- */
-import { BlockAlignment } from '@wordpress/blocks';
-
 export type SummaryAttributes = {
-	align: BlockAlignment;
+	align: 'left' | 'center' | 'right' | 'justify';
 	direction: 'ltr' | 'rtl';
 	label: string;
 };

--- a/packages/js/product-editor/src/components/editor/editor.tsx
+++ b/packages/js/product-editor/src/components/editor/editor.tsx
@@ -6,7 +6,7 @@ import {
 	EditorSettings,
 	EditorBlockListSettings,
 } from '@wordpress/block-editor';
-import { SlotFillProvider } from '@wordpress/components';
+import { Popover, SlotFillProvider } from '@wordpress/components';
 import { Product } from '@woocommerce/data';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore No types for this exist yet.
@@ -60,6 +60,8 @@ export function Editor( { product, settings }: EditorProps ) {
 								/>
 							}
 						/>
+
+						<Popover.Slot />
 					</SlotFillProvider>
 				</ShortcutProvider>
 			</EntityProvider>

--- a/packages/js/product-editor/src/components/editor/init-blocks.ts
+++ b/packages/js/product-editor/src/components/editor/init-blocks.ts
@@ -7,6 +7,7 @@ import { registerCoreBlocks } from '@wordpress/block-library';
  * Internal dependencies
  */
 import { init as initName } from '../details-name-block';
+import { init as initSummary } from '../details-summary-block';
 import { init as initSection } from '../section';
 import { init as initTab } from '../tab';
 import { init as initPricing } from '../pricing-block';
@@ -15,6 +16,7 @@ import { init as initCollapsible } from '../collapsible-block';
 export const initBlocks = () => {
 	registerCoreBlocks();
 	initName();
+	initSummary();
 	initSection();
 	initTab();
 	initPricing();

--- a/packages/js/product-editor/src/components/pricing-block/index.ts
+++ b/packages/js/product-editor/src/components/pricing-block/index.ts
@@ -14,4 +14,9 @@ export const settings = {
 	edit: Edit,
 };
 
-export const init = () => initBlock( { name, metadata, settings } );
+export const init = () =>
+	initBlock( {
+		name,
+		metadata: metadata as never,
+		settings,
+	} );

--- a/packages/js/product-editor/src/style.scss
+++ b/packages/js/product-editor/src/style.scss
@@ -8,3 +8,4 @@
 @import 'components/section/style.scss';
 @import 'components/tab/style.scss';
 @import 'components/tabs/style.scss';
+@import 'components/details-summary-block/style.scss';

--- a/packages/js/product-editor/src/utils/init-blocks.ts
+++ b/packages/js/product-editor/src/utils/init-blocks.ts
@@ -1,26 +1,31 @@
 /**
  * External dependencies
  */
-import { BlockConfiguration, registerBlockType } from '@wordpress/blocks';
+import {
+	Block,
+	BlockConfiguration,
+	registerBlockType,
+} from '@wordpress/blocks';
 
-interface BlockRepresentation {
-	name: string;
-	metadata: BlockConfiguration;
-	settings: Partial< BlockConfiguration >;
+interface BlockRepresentation< T extends Record< string, object > > {
+	name?: string;
+	metadata: BlockConfiguration< T >;
+	settings: Partial< BlockConfiguration< T > >;
 }
 
 /**
  * Function to register an individual block.
  *
- * @param {Object} block The block to be registered.
- *
- * @return {?WPBlockType} The block, if it has been successfully registered;
- *                        otherwise `undefined`.
+ * @param  block The block to be registered.
+ * @return The block, if it has been successfully registered; otherwise `undefined`.
  */
-export const initBlock = ( block: BlockRepresentation ) => {
+export function initBlock<
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	T extends Record< string, any > = Record< string, any >
+>( block: BlockRepresentation< T > ): Block< T > | undefined {
 	if ( ! block ) {
 		return;
 	}
 	const { metadata, settings, name } = block;
-	return registerBlockType( { name, ...metadata }, settings );
-};
+	return registerBlockType< T >( { name, ...metadata }, settings );
+}

--- a/plugins/woocommerce-admin/client/products/product-block-page.scss
+++ b/plugins/woocommerce-admin/client/products/product-block-page.scss
@@ -19,6 +19,25 @@
 		}
 	}
 
+	.components-summary-control {
+		width: 100%;
+		min-height: calc($gap-larger * 3);
+		background-color: $white;
+		box-sizing: border-box;
+		border: 1px solid #757575;
+		border-radius: 2px;
+		padding: $gap-smaller;
+		margin: 0;
+		appearance: textarea;
+		resize: vertical;
+		overflow: hidden;
+
+		&:focus {
+			box-shadow: inset 0 0 0 1px var(--wp-admin-theme-color-darker-10, --wp-admin-theme-color);
+			border-color: var(--wp-admin-theme-color-darker-10, --wp-admin-theme-color);
+		}
+	}
+
 	.woocommerce-product-form {
 		&__custom-label-input {
 			display: flex;

--- a/plugins/woocommerce/changelog/add-37103
+++ b/plugins/woocommerce/changelog/add-37103
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add summary block

--- a/plugins/woocommerce/includes/class-wc-post-types.php
+++ b/plugins/woocommerce/includes/class-wc-post-types.php
@@ -388,6 +388,9 @@ class WC_Post_Types {
 											),
 										),
 										array(
+											'woocommerce/product-summary',
+										),
+										array(
 											'core/columns',
 											array(),
 											array(


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/37103

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Visit `/wp-admin/admin.php?page=wc-admin&path=/add-product`.
2. A new summary field should be shown.

<img width="1147" alt="image" src="https://user-images.githubusercontent.com/13334210/226005742-526c546e-2833-433a-bbc3-2b2b2c8abaf5.png">

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [ ] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
