### PR TITLE
Set quantity value when stock tracking is enabled

### DIFF
--- a/plugins/woocommerce/changelog/dev-37117_set_default_quantity_value
+++ b/plugins/woocommerce/changelog/dev-37117_set_default_quantity_value
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Set quantity value when stock tracking is enabled

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
@@ -51,7 +51,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				array(
 					'id'                => '_stock',
 					'value'             => wc_stock_amount( $product_object->get_stock_quantity( 'edit' ) ?? 1 ),
-					'label'             => __( 'Stock quantity', 'woocommerce' ),
+					'label'             => __( 'Quantity', 'woocommerce' ),
 					'desc_tip'          => true,
 					'description'       => __( 'Stock quantity. If this is a variable product this value will be used to control stock for all variations, unless you define stock at variation level.', 'woocommerce' ),
 					'type'              => 'number',

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
@@ -62,7 +62,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				)
 			);
 
-			echo '<input type="hidden" name="_original_stock" value="' . esc_attr( wc_stock_amount( $product_object->get_stock_quantity( 'edit' ) ?? 1 ) ) . '" />';
+			echo '<input type="hidden" name="_original_stock" value="' . esc_attr( wc_stock_amount( $product_object->get_stock_quantity( 'edit' ) ) ) . '" />';
 
 			woocommerce_wp_select(
 				array(

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
@@ -50,7 +50,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			woocommerce_wp_text_input(
 				array(
 					'id'                => '_stock',
-					'value'             => wc_stock_amount( $product_object->get_stock_quantity( 'edit' ) ),
+					'value'             => wc_stock_amount( $product_object->get_stock_quantity( 'edit' ) ?? 1 ),
 					'label'             => __( 'Stock quantity', 'woocommerce' ),
 					'desc_tip'          => true,
 					'description'       => __( 'Stock quantity. If this is a variable product this value will be used to control stock for all variations, unless you define stock at variation level.', 'woocommerce' ),
@@ -62,7 +62,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				)
 			);
 
-			echo '<input type="hidden" name="_original_stock" value="' . esc_attr( wc_stock_amount( $product_object->get_stock_quantity( 'edit' ) ) ) . '" />';
+			echo '<input type="hidden" name="_original_stock" value="' . esc_attr( wc_stock_amount( $product_object->get_stock_quantity( 'edit' ) ?? 1 ) ) . '" />';
 
 			woocommerce_wp_select(
 				array(


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
When stock tracking is enabled for the first time, we default to quantity=1 (now we default to 0, which creates lots of issues).

![screenshot-user-images githubusercontent com-2023 03 07-22_00_02 (2)](https://user-images.githubusercontent.com/1314156/223597881-d7f92068-e136-40d2-aaa8-12ed3b2a2637.png)

Closes #37117.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?


#### Default value

1. Go to `Products` > `Add New` > `Product data` > `Inventory`.
2. Check the `Stock management` checkbox.
3. Verify that the `Stock quantity` label now says `Quantity` and its value is `1`.
4. Publish the product.
5. Verify that the quantity is `1`.

#### Changing to a different value

1. Go to `Products` > `Add New` > `Product data` > `Inventory`.
2. Check the `Stock management` checkbox.
3. Verify that the `Stock quantity` label now says `Quantity` and its value is `1`.
4. Change the quantity to `3`.
5. Publish the product.
6. Verify that the quantity is `3`.
7. Change the quantity to `7`.
8. Save the updated product.
9. Verify that the quantity is `7`.


<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
