### PR TITLE
Adding collapsible content block with flexible rendering

### DIFF
--- a/packages/js/components/changelog/add-toggle-content-block-37253
+++ b/packages/js/components/changelog/add-toggle-content-block-37253
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Adding simple DisplayState wrapper and modifying Collapsible component to allow rendering hidden content.

--- a/packages/js/components/src/collapsible-content/collapsible-content.tsx
+++ b/packages/js/components/src/collapsible-content/collapsible-content.tsx
@@ -50,12 +50,14 @@ export const CollapsibleContent: React.FC< CollapsedProps > = ( {
 					/>
 				</div>
 			</button>
-			<div
-				{ ...props }
-				className="woocommerce-collapsible-content__content"
-			>
-				<DisplayState state={ getState() }>{ children }</DisplayState>
-			</div>
+			<DisplayState state={ getState() }>
+				<div
+					{ ...props }
+					className="woocommerce-collapsible-content__content"
+				>
+					{ children }
+				</div>
+			</DisplayState>
 		</div>
 	);
 };

--- a/packages/js/components/src/collapsible-content/collapsible-content.tsx
+++ b/packages/js/components/src/collapsible-content/collapsible-content.tsx
@@ -7,10 +7,12 @@ import { Icon, chevronDown, chevronUp } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
+import { DisplayState } from '../display-state';
 
 export type CollapsedProps = {
 	initialCollapsed?: boolean;
 	toggleText: string;
+	persistRender?: boolean;
 	children: React.ReactNode;
 } & React.HTMLAttributes< HTMLDivElement >;
 
@@ -18,9 +20,19 @@ export const CollapsibleContent: React.FC< CollapsedProps > = ( {
 	initialCollapsed = true,
 	toggleText,
 	children,
+	persistRender = false,
 	...props
 }: CollapsedProps ) => {
 	const [ collapsed, setCollapsed ] = useState( initialCollapsed );
+
+	const getState = () => {
+		if ( ! collapsed ) {
+			return 'visible';
+		}
+
+		return persistRender ? 'visually-hidden' : 'hidden';
+	};
+
 	return (
 		<div
 			aria-expanded={ collapsed ? 'false' : 'true' }
@@ -38,14 +50,12 @@ export const CollapsibleContent: React.FC< CollapsedProps > = ( {
 					/>
 				</div>
 			</button>
-			{ ! collapsed && (
-				<div
-					{ ...props }
-					className="woocommerce-collapsible-content__content"
-				>
-					{ children }
-				</div>
-			) }
+			<div
+				{ ...props }
+				className="woocommerce-collapsible-content__content"
+			>
+				<DisplayState state={ getState() }>{ children }</DisplayState>
+			</div>
 		</div>
 	);
 };

--- a/packages/js/components/src/display-state/display-state.tsx
+++ b/packages/js/components/src/display-state/display-state.tsx
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { createElement, Fragment } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+
+export type DisplayStateProps = {
+	state?: 'visible' | 'visually-hidden' | 'hidden';
+	children: React.ReactNode;
+} & React.HTMLAttributes< HTMLDivElement >;
+
+export const DisplayState: React.FC< DisplayStateProps > = ( {
+	state = 'visible',
+	children,
+} ) => {
+	if ( state === 'visible' ) {
+		return <>{ children }</>;
+	}
+
+	if ( state === 'visually-hidden' ) {
+		return <div style={ { display: 'none' } }>{ children }</div>;
+	}
+
+	return null;
+};

--- a/packages/js/components/src/display-state/index.ts
+++ b/packages/js/components/src/display-state/index.ts
@@ -1,0 +1,1 @@
+export * from './display-state';

--- a/packages/js/components/src/index.ts
+++ b/packages/js/components/src/index.ts
@@ -103,3 +103,4 @@ export {
 	ProductSectionLayout as __experimentalProductSectionLayout,
 	ProductFieldSection as __experimentalProductFieldSection,
 } from './product-section-layout';
+export { DisplayState } from './display-state';

--- a/packages/js/product-editor/changelog/add-toggle-content-block-37253
+++ b/packages/js/product-editor/changelog/add-toggle-content-block-37253
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Adding Collapsible block with support for flexible rendering.

--- a/packages/js/product-editor/src/components/collapsible-block/block.json
+++ b/packages/js/product-editor/src/components/collapsible-block/block.json
@@ -1,0 +1,28 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "woocommerce/collapsible",
+	"title": "Collapsible",
+	"category": "widgets",
+	"description": "Container with collapsible inner blocks.",
+	"textdomain": "default",
+	"attributes": {
+		"toggleText": {
+			"type": "string"
+		},
+		"initialCollapsed": {
+			"type": "boolean"
+		},
+		"persistRender": {
+			"type": "boolean"
+		}
+	},
+	"supports": {
+		"align": false,
+		"html": false,
+		"multiple": true,
+		"reusable": false,
+		"inserter": false,
+		"lock": false
+	}
+}

--- a/packages/js/product-editor/src/components/collapsible-block/edit.tsx
+++ b/packages/js/product-editor/src/components/collapsible-block/edit.tsx
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import { CollapsibleContent } from '@woocommerce/components';
+import type { BlockAttributes } from '@wordpress/blocks';
+import { createElement } from '@wordpress/element';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+
+export function Edit( { attributes }: { attributes: BlockAttributes } ) {
+	const blockProps = useBlockProps();
+	const { toggleText, initialCollapsed, persistRender = true } = attributes;
+
+	return (
+		<div { ...blockProps }>
+			<CollapsibleContent
+				toggleText={ toggleText }
+				initialCollapsed={ initialCollapsed }
+				persistRender={ persistRender }
+			>
+				<InnerBlocks templateLock="all" />
+			</CollapsibleContent>
+		</div>
+	);
+}

--- a/packages/js/product-editor/src/components/collapsible-block/index.ts
+++ b/packages/js/product-editor/src/components/collapsible-block/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Internal dependencies
+ */
+import { initBlock } from '../../utils';
+import metadata from './block.json';
+import { Edit } from './edit';
+
+const { name } = metadata;
+
+export { metadata, name };
+
+export const settings = {
+	example: {},
+	edit: Edit,
+};
+
+export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/js/product-editor/src/components/editor/init-blocks.ts
+++ b/packages/js/product-editor/src/components/editor/init-blocks.ts
@@ -10,6 +10,7 @@ import { init as initName } from '../details-name-block';
 import { init as initSection } from '../section';
 import { init as initTab } from '../tab';
 import { init as initPricing } from '../pricing-block';
+import { init as initCollapsible } from '../collapsible-block';
 
 export const initBlocks = () => {
 	registerCoreBlocks();
@@ -17,4 +18,5 @@ export const initBlocks = () => {
 	initSection();
 	initTab();
 	initPricing();
+	initCollapsible();
 };


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adding the collapsible content block, which will allow for inner blocks that are visually toggled. For this I used the `CollapsibleContent` component, and modified it to support allowing hidden content to render.

Closes #37253 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Enable the block product editor feature flag: `block-editor-feature-enabled`
2. To add test blocks, you can enter `git fetch` and then `git cherry-pick 41f57c71c94bd3158de3d468d9b0f690e5eb15e9`
3. Alternatively you can add the new block to the template found in `class-wc-post-types.php`:
```php
array(
	'woocommerce/collapsible',
	array(
		'toggleText' => 'Show name field',
		'initialCollapsed' => true,
		'persistRender' => true,
	),
	array(
		array(
			'woocommerce/product-name',
			array(
				'name' => 'Product name',
			),
		),
	),
),
```
4. Go to Product -> Add new
5. You should see the following in the block editor, which displays the name field when clicked:
![image](https://user-images.githubusercontent.com/444632/226062186-40d20fd2-4920-4b06-8016-4d5ec73d2664.png)
6. If you change `persistRender` to `false`, it will not render the collapsed content at all. By default it will.


<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
