### PR TITLE
Overwrite clone method to prevent duplicate data when saving a clone.

### DIFF
--- a/plugins/woocommerce/changelog/fix-order-cache-duplicate
+++ b/plugins/woocommerce/changelog/fix-order-cache-duplicate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Overwrite clone method to prevent duplicate datq when saving a clone.

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -132,6 +132,17 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	}
 
 	/**
+	 * This method overwrites the base class's clone method to make it a no-op. In base class WC_Data, we are unsetting the meta_id to clone.
+	 * It seems like this was done to avoid conflicting the metadata when duplicating products. However, doing that does not seems necessary for orders.
+	 * In-fact, when we do that for orders, we lose the capability to clone orders with custom meta data by caching plugins. This is because, when we clone an order object for caching, it will clone the metadata without the ID. Unfortunately, when this cached object with nulled meta ID is retreived, WC_Data will consider it as a new meta and will insert it as a new meta-data causing duplicates.
+	 *
+	 * Eventually, we should move away from overwriting the __clone method in base class itself, since it's easily possible to still duplicate the product without having to hook into the __clone method.
+	 *
+	 * @since 7.6.0
+	 */
+	public function __clone() {}
+
+	/**
 	 * Get internal type.
 	 *
 	 * @return string

--- a/plugins/woocommerce/src/Caches/OrderCache.php
+++ b/plugins/woocommerce/src/Caches/OrderCache.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\WooCommerce\Caches;
 
+use Automattic\WooCommerce\Caching\CacheException;
 use Automattic\WooCommerce\Caching\ObjectCache;
 
 /**

--- a/plugins/woocommerce/tests/php/src/Caching/OrderCacheTest.php
+++ b/plugins/woocommerce/tests/php/src/Caching/OrderCacheTest.php
@@ -44,7 +44,7 @@ class OrderCacheTest extends \WC_Unit_Test_Case {
 		$order2->save_meta_data();
 
 		$orders_meta_table = OrdersTableDataStore::get_meta_table_name();
-		$query             = $wpdb->prepare( "SELECT id FROM $orders_meta_table WHERE order_id = %d AND meta_key = %s", $order->get_id(), 'test' );
+		$query             = $wpdb->prepare( "SELECT id FROM $orders_meta_table WHERE order_id = %d AND meta_key = %s", $order->get_id(), 'test' ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$this->assertEquals( 1, count( $wpdb->get_col( $query ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Already prepared query.
 	}
 

--- a/plugins/woocommerce/tests/php/src/Caching/OrderCacheTest.php
+++ b/plugins/woocommerce/tests/php/src/Caching/OrderCacheTest.php
@@ -44,8 +44,8 @@ class OrderCacheTest extends \WC_Unit_Test_Case {
 		$order2->save_meta_data();
 
 		$orders_meta_table = OrdersTableDataStore::get_meta_table_name();
-		$query = $wpdb->prepare( "SELECT id FROM $orders_meta_table WHERE order_id = %d AND meta_key = %s", $order->get_id(), 'test' );
-		$this->assertEquals( 1, count( $wpdb->get_col( $query ) ) );
+		$query             = $wpdb->prepare( "SELECT id FROM $orders_meta_table WHERE order_id = %d AND meta_key = %s", $order->get_id(), 'test' );
+		$this->assertEquals( 1, count( $wpdb->get_col( $query ) ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Already prepared query.
 	}
 
 }

--- a/plugins/woocommerce/tests/php/src/Caching/OrderCacheTest.php
+++ b/plugins/woocommerce/tests/php/src/Caching/OrderCacheTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use Automattic\WooCommerce\Caches\OrderCache;
+use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
+use Automattic\WooCommerce\Utilities\OrderUtil;
+
+/**
+ * Class OrderCacheTest.
+ */
+class OrderCacheTest extends \WC_Unit_Test_Case {
+
+	/**
+	 * System under test.
+	 *
+	 * @var OrderCache
+	 */
+	private $sut;
+
+	/**
+	 * Setup test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = new OrderCache();
+	}
+
+	/**
+	 * Test that the order cache does not cause duplicate data storage.
+	 */
+	public function test_meta_is_not_duplicated_when_cached() {
+		global $wpdb;
+		if ( ! OrderUtil::orders_cache_usage_is_enabled() ) {
+			// tip: add HPOS=1 env variable to run this test.
+			$this->markTestSkipped( 'HPOS based caching is not enabled.' );
+		}
+		$order = WC_Helper_Order::create_order();
+		$order->add_meta_data( 'test', 'test' );
+		$order->save_meta_data();
+
+		$order = wc_get_order( $order->get_id() );
+		$this->assertTrue( $this->sut->is_cached( $order->get_id() ), 'Order was not cached, but it was expected to be cached. Are you sure that HPOS based caching is enabled.' );
+
+		$order2 = wc_get_order( $order->get_id() );
+		$order2->save_meta_data();
+
+		$orders_meta_table = OrdersTableDataStore::get_meta_table_name();
+		$query = $wpdb->prepare( "SELECT id FROM $orders_meta_table WHERE order_id = %d", $order->get_id() );
+		$this->assertEquals( 1, count( $wpdb->get_col( $query ) ) );
+	}
+
+}

--- a/plugins/woocommerce/tests/php/src/Caching/OrderCacheTest.php
+++ b/plugins/woocommerce/tests/php/src/Caching/OrderCacheTest.php
@@ -44,7 +44,7 @@ class OrderCacheTest extends \WC_Unit_Test_Case {
 		$order2->save_meta_data();
 
 		$orders_meta_table = OrdersTableDataStore::get_meta_table_name();
-		$query = $wpdb->prepare( "SELECT id FROM $orders_meta_table WHERE order_id = %d", $order->get_id() );
+		$query = $wpdb->prepare( "SELECT id FROM $orders_meta_table WHERE order_id = %d AND meta_key = %s", $order->get_id(), 'test' );
 		$this->assertEquals( 1, count( $wpdb->get_col( $query ) ) );
 	}
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This method overwrites the base class's clone method to make it a no-op. In the base class `WC_Data`, we are unsetting the meta_id to clone. It seems like this was done to avoid conflicting the metadata when duplicating products (see #14118). However, doing that does not seem necessary for orders. 

In fact, when we do that for orders, we lose the capability to clone orders with custom metadata by caching plugins. This is because, when we clone an order object for caching, it will clone the metadata without the ID. Unfortunately, when this cached object with nulled meta ID is retrieved, WC_Data will consider it as a new meta and will insert it as a new meta-data causing duplicates if the object is saved.

Eventually, we should move away from overwriting the `__clone` method in the base class itself, since it's easily possible to still duplicate the product without having to hook into the `__clone` method.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

Unfortunately, this is not easy to test from UI since this needs cache setting unsettling. On a WP shell, run these commands:

For an order with ID XX, with HPOS enabled:
```php
\Automattic\WooCommerce\Utilities\OrderUtil::orders_cache_usage_is_enabled(); // confirm order cache is enabled, should be true.

$order = wc_get_order( xx ); // retrieve any existing order, this will also cache it.
$order->add_meta_data( 'test', 'test' ); 
$order->save(); // this makes sure that there is at least one custom meta for order. This will also invalidates the cache.
wc_get_order( $order->get_id() ); // sets the cache again.

$refreshed_order  = wc_get_order( $order->get_id() );
$refreshed_order->save_meta_data(); // try to save the order, this will insert duplicated metadata again on trunk, but will be fixed on this branch.
```
<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
