### PR TITLE
Update deprecated jQuery ready calls

### DIFF
--- a/plugins/woocommerce/changelog/fix-33322
+++ b/plugins/woocommerce/changelog/fix-33322
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Swap out deprecated jQuery ready handlers

--- a/plugins/woocommerce/client/legacy/js/admin/wc-status-widget.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-status-widget.js
@@ -1,6 +1,6 @@
 /*global jQuery */
 (function( $ ) {
-	$( document ).on( 'ready', function() {
+	$( function() {
 		window.wcTracks.recordEvent( 'wcadmin_status_widget_view' );
 	});
 

--- a/plugins/woocommerce/includes/admin/views/html-admin-dashboard-setup.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-dashboard-setup.php
@@ -35,7 +35,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		const currentStep = widget.data( 'current-step' );
 		const totalSteps = widget.data( 'total-steps' );
 
-		$( document ).on( 'ready', function() {
+		$( function() {
 			window.wcTracks.recordEvent( 'wcadmin_setup_widget_view', {
 				completed_tasks: currentStep,
 				total_tasks: totalSteps,


### PR DESCRIPTION
### All Submissions:

-   [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Removes deprecated jQuery `ready` handler signature

Closes #33322 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

- [X] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

- Spin up WooCommerce environment without this patch applied (I used wp-env - SCRIPT_DEBUG should be enabled, I think)
- Go through setup steps or disable the setup wizard
- View admin dashboard
- See WooCommerce status widget
- See deprecation logged in console (`JQMIGRATE: 'ready' event is deprecated [jquery-migrate.js:100:12](http://localhost:8888/wp-includes/js/jquery/jquery-migrate.js?ver=3.3.2)`)
- Apply patch
- See there is no longer a deprecation logged

<!-- End testing instructions -->

### Other information:

-   [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [X] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [X] Have you included testing instructions?

An e2e test could probably ensure that the WooCommerce events that are supposed to fire actually fire. Currently does not seem to be tested.

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
