### PR TITLE
Add Liberia as store location for e2e test

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-failing-malta-test
+++ b/plugins/woocommerce/changelog/e2e-fix-failing-malta-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update OBW end to end test as WC Pay supports Malta now

--- a/plugins/woocommerce/tests/e2e-pw/test-data/data.js
+++ b/plugins/woocommerce/tests/e2e-pw/test-data/data.js
@@ -95,6 +95,24 @@ const storeDetails = {
 			downloadable: 'Downloads',
 		},
 	},
+	liberia: {
+		store: {
+			address: 'addr1',
+			city: 'Kakata',
+			zip: 'Division 1',
+			email: admin.email,
+			country: 'Liberia — Margibi', // corresponding to the text value of the option,
+			countryCode: 'LR',
+		},
+		expectedIndustries: 8, // There are 8 checkboxes on the page (in Liberia), adjust this constant if we change that
+		industries: {
+			other: 'Other',
+		},
+		products: {
+			physical: 'Physical products',
+			downloadable: 'Downloads',
+		},
+	},
 };
 
 module.exports = {

--- a/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/complete-onboarding-wizard.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/complete-onboarding-wizard.spec.js
@@ -145,23 +145,23 @@ test.describe( 'Store owner can complete onboarding wizard', () => {
 	} );
 } );
 
-// !Changed from Japanese to Malta store, as Japanese Yen does not use decimals
+// !Changed from Japanese to Liberian store, as Japanese Yen does not use decimals
 test.describe(
-	'A Malta store can complete the selective bundle install but does not include WCPay.',
+	'A Liberian store can complete the selective bundle install but does not include WCPay.',
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 
 		test.beforeEach( async () => {
 			// Complete "Store Details" step through the API to prevent flakiness when run on external sites.
-			await api.update.storeDetails( storeDetails.malta.store );
+			await api.update.storeDetails( storeDetails.liberia.store );
 		} );
 
 		// eslint-disable-next-line jest/expect-expect
 		test( 'can choose the "Other" industry', async ( { page } ) => {
 			await onboarding.completeIndustrySection(
 				page,
-				storeDetails.malta.industries,
-				storeDetails.malta.expectedIndustries
+				storeDetails.liberia.industries,
+				storeDetails.liberia.expectedIndustries
 			);
 			await page.click( 'button >> text=Continue' );
 		} );
@@ -174,14 +174,14 @@ test.describe(
 
 			await onboarding.completeIndustrySection(
 				page,
-				storeDetails.malta.industries,
-				storeDetails.malta.expectedIndustries
+				storeDetails.liberia.industries,
+				storeDetails.liberia.expectedIndustries
 			);
 			await page.click( 'button >> text=Continue' );
 
 			await onboarding.completeProductTypesSection(
 				page,
-				storeDetails.malta.products
+				storeDetails.liberia.products
 			);
 			// Make sure WC Payments is NOT present
 			await expect(


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

WC Pay has support for stores in Malta now.  We have an end to end test which goes through the onboarding wizard, setting the country to Malta and asserting that WC Pay is not shown as an option.

This test changes the country from Malta to Liberia (which is not yet supported by WC Pay).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Ensure that tests pass on CI
2. Pull this branch
3. `pnpm run env:start` (or restart)
4. `pnpm run test:e2e-pw`
5. All tests should pass except the product variations test which is waiting for a fix [over here](https://github.com/woocommerce/woocommerce/pull/37246) 

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
