### PR TITLE
e2e: Remove explicit timeouts for variable products and analytics tests

### DIFF
--- a/plugins/woocommerce/changelog/try-remove-e2e-waits
+++ b/plugins/woocommerce/changelog/try-remove-e2e-waits
@@ -1,4 +1,4 @@
 Significance: patch
 Type: tweak
 
-Improve e2e test reliability for variable products tests.
+Remove timeouts in e2e tests for variable products and analytics.

--- a/plugins/woocommerce/changelog/try-remove-e2e-waits
+++ b/plugins/woocommerce/changelog/try-remove-e2e-waits
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Improve e2e test reliability for variable products tests.

--- a/plugins/woocommerce/tests/e2e-pw/tests/admin-analytics/analytics-overview.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/admin-analytics/analytics-overview.spec.js
@@ -36,7 +36,13 @@ test.describe( 'Analytics pages', () => {
 				'//button[@title="Choose which analytics to display and the section name"]'
 			);
 			await page.click( 'text=Move up' );
-			await page.waitForTimeout( 1000 );
+
+			// wait for the changes to be saved
+			await page.waitForResponse(
+				( response ) =>
+					response.url().includes( '/users/' ) &&
+					response.status() === 200
+			);
 		}
 	} );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
@@ -70,7 +70,12 @@ test.describe.serial( 'Add New Variable Product Page', () => {
 		await page.keyboard.press( 'ArrowUp' );
 		await page.click( 'text=Save attributes' );
 
-		await page.waitForTimeout( 1000 ); // Wait for 1 second
+		// wait for the attributes to be saved
+		await page.waitForResponse(
+			( response ) =>
+				response.url().includes( '/post.php?post=' ) &&
+				response.status() === 200
+		);
 
 		// Save before going to the Variations tab to prevent variations from all attributes to be automatically created
 		await page.locator( '#save-post' ).click();
@@ -223,14 +228,15 @@ test.describe.serial( 'Add New Variable Product Page', () => {
 				.fill( 'val1 | val2' );
 			await page.keyboard.press( 'ArrowUp' );
 			await page.click( 'text=Save attributes' );
-			await expect(
-				page
-					.locator( '.woocommerce_attribute.closed' )
-					.filter( { hasText: `attr #${ i + 1 }` } )
-			).toBeVisible();
 		}
 
-		await page.waitForTimeout( 1000 ); // Wait for 1 second
+		// wait for the attributes to be saved
+		await page.waitForResponse(
+			( response ) =>
+				response.url().includes( '/post.php?post=' ) &&
+				response.status() === 200
+		);
+
 		// Save before going to the Variations tab to prevent variations from all attributes to be automatically created
 		await page.locator( '#save-post' ).click();
 		await expect(

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
@@ -55,19 +55,23 @@ test.describe.serial( 'Add New Variable Product Page', () => {
 			if ( i > 0 ) {
 				await page.click( 'button.add_attribute' );
 			}
-			const input = `input[name="attribute_names[${ i }]"]`;
 
-			await page.waitForSelector( input, { timeout: 1000 } ); // Wait for up to 1 second
-			await page.fill( input, `attr #${ i + 1 }` );
-			await page.fill(
-				`textarea[name="attribute_values[${ i }]"]`,
-				'val1 | val2'
-			);
+			await page
+				.locator(
+					`.woocommerce_attribute_data input[name="attribute_names[${ i }]"]`
+				)
+				.fill( `attr #${ i + 1 }` );
+			await page
+				.locator(
+					`.woocommerce_attribute_data textarea[name="attribute_values[${ i }]"]`
+				)
+				.fill( 'val1 | val2' );
 		}
 		await page.keyboard.press( 'ArrowUp' );
 		await page.click( 'text=Save attributes' );
 
 		await page.waitForTimeout( 1000 ); // Wait for 1 second
+
 		// Save before going to the Variations tab to prevent variations from all attributes to be automatically created
 		await page.locator( '#save-post' ).click();
 		await expect(
@@ -206,14 +210,17 @@ test.describe.serial( 'Add New Variable Product Page', () => {
 			if ( i > 0 ) {
 				await page.click( 'button.add_attribute' );
 			}
-			const input = `input[name="attribute_names[${ i }]"]`;
 
-			await page.waitForSelector( input, { timeout: 1000 } ); // Wait for up to 1 seconds
-			await page.fill( input, `attr #${ i + 1 }` );
-			await page.fill(
-				`textarea[name="attribute_values[${ i }]"]`,
-				'val1 | val2'
-			);
+			await page
+				.locator(
+					`.woocommerce_attribute_data input[name="attribute_names[${ i }]"]`
+				)
+				.fill( `attr #${ i + 1 }` );
+			await page
+				.locator(
+					`.woocommerce_attribute_data textarea[name="attribute_values[${ i }]"]`
+				)
+				.fill( 'val1 | val2' );
 			await page.keyboard.press( 'ArrowUp' );
 			await page.click( 'text=Save attributes' );
 			await expect(


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR improves the readability and maintainability of the variable products and analytics e2e tests by removing explicit timeouts.

#### Waiting for data to be saved

Instead of waiting a set amount of time to accommodate the saving of data:

```js
await page.waitForTimeout( 1000 );
```

We wait for the actual network response:

```js
await page.waitForResponse(
  ( response ) =>
	  response.url().includes( '/users/' ) &&
	  response.status() === 200
);
```

#### Avoiding `page.waitForSelector()` and `page.fill()`

By default, `page.fill()` does not require the selector to resolve to a single element. If multiple elements match the selector, the first one is used. This can result in confusing and unexpected behavior. It is recommended that `page.locator().fill()` be used instead. ([Playwright doc](https://playwright.dev/docs/api/class-page#page-fill))

If `page.locator()` is used, then `page.waitForSelector()` does not need to be used. Also, by default, `page.waitForSelector()` does not require the selector to resolve to a single element.  It is recommended that `Locator` objects be used instead. ([Playwright doc](https://playwright.dev/docs/api/class-page#page-wait-for-selector))

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Run e2e tests and verify they reliably pass (if the e2e test check on this PR passes, they did).

Note: To run just the tests modified in this PR locally, you can do the following after setting up your e2e env:

```
pnpm playwright test --config=tests/e2e-pw/playwright.config.js ./tests/e2e-pw/tests/admin-analytics/analytics-overview.spec.js
pnpm playwright test --config=tests/e2e-pw/playwright.config.js ./tests/e2e-pw/tests/merchant/create-variable-product.spec.js
```

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
