### PR TITLE
Register product editor blocks server-side

### DIFF
--- a/plugins/woocommerce-admin/client/layout/controller.js
+++ b/plugins/woocommerce-admin/client/layout/controller.js
@@ -167,7 +167,7 @@ export const getPages = () => {
 		} );
 	}
 
-	if ( window.wcAdminFeatures[ 'block-editor-feature-enabled' ] ) {
+	if ( window.wcAdminFeatures[ 'product-block-editor' ] ) {
 		pages.push( {
 			container: ProductPage,
 			path: '/add-product',

--- a/plugins/woocommerce-admin/client/typings/global.d.ts
+++ b/plugins/woocommerce-admin/client/typings/global.d.ts
@@ -9,7 +9,7 @@ declare global {
 		wcAdminFeatures: {
 			'activity-panels': boolean;
 			analytics: boolean;
-			'block-editor-feature-enabled': boolean;
+			'product-block-editor': boolean;
 			coupons: boolean;
 			'customer-effort-score-tracks': boolean;
 			homescreen: boolean;

--- a/plugins/woocommerce/changelog/update-37241-block-registration
+++ b/plugins/woocommerce/changelog/update-37241-block-registration
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Register product editor blocks server-side

--- a/plugins/woocommerce/client/admin/config/core.json
+++ b/plugins/woocommerce/client/admin/config/core.json
@@ -2,7 +2,7 @@
 	"features": {
 		"activity-panels": true,
 		"analytics": true,
-		"block-editor-feature-enabled": false,
+		"product-block-editor": false,
 		"coupons": true,
 		"customer-effort-score-tracks": true,
 		"import-products-task": true,

--- a/plugins/woocommerce/client/admin/config/development.json
+++ b/plugins/woocommerce/client/admin/config/development.json
@@ -2,7 +2,7 @@
 	"features": {
 		"activity-panels": true,
 		"analytics": true,
-		"block-editor-feature-enabled": true,
+		"product-block-editor": true,
 		"coupons": true,
 		"customer-effort-score-tracks": true,
 		"import-products-task": true,

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -225,7 +225,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 						'gateway_toggle' => wp_create_nonce( 'woocommerce-toggle-payment-gateway-enabled' ),
 					),
 					'urls'                              => array(
-						'add_product'     => Features::is_enabled( 'new-product-management-experience' ) || Features::is_enabled( 'block-editor-feature-enabled' ) ? esc_url_raw( admin_url( 'admin.php?page=wc-admin&path=/add-product' ) ) : null,
+						'add_product'     => Features::is_enabled( 'new-product-management-experience' ) || Features::is_enabled( 'product-block-editor' ) ? esc_url_raw( admin_url( 'admin.php?page=wc-admin&path=/add-product' ) ) : null,
 						'import_products' => current_user_can( 'import' ) ? esc_url_raw( admin_url( 'edit.php?post_type=product&page=product_importer' ) ) : null,
 						'export_products' => current_user_can( 'export' ) ? esc_url_raw( admin_url( 'edit.php?post_type=product&page=product_exporter' ) ) : null,
 					),

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -427,7 +427,7 @@ class WC_Admin_Menus {
 	 * Maybe add new management product experience.
 	 */
 	public function maybe_add_new_product_management_experience() {
-		if ( Features::is_enabled( 'new-product-management-experience' ) || Features::is_enabled( 'block-editor-feature-enabled' ) ) {
+		if ( Features::is_enabled( 'new-product-management-experience' ) || Features::is_enabled( 'product-block-editor' ) ) {
 			global $submenu;
 			if ( isset( $submenu['edit.php?post_type=product'][10] ) ) {
 				// Disable phpcs since we need to override submenu classes.

--- a/plugins/woocommerce/src/Admin/Features/Features.php
+++ b/plugins/woocommerce/src/Admin/Features/Features.php
@@ -40,7 +40,7 @@ class Features {
 	protected static $beta_features = array(
 		'navigation',
 		'new-product-management-experience',
-		'block-editor-feature-enabled',
+		'product-block-editor',
 		'settings',
 	);
 

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
@@ -74,6 +74,7 @@ class BlockRegistry {
 			return false;
 		}
 
+		// phpcs:disable WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		$metadata = json_decode( file_get_contents( $block_json_file ), true );
 		if ( ! is_array( $metadata ) || ! $metadata['name'] ) {
 			return false;

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * WooCommerce Product Editor Block Registration
+ */
+
+namespace Automattic\WooCommerce\Admin\Features\ProductBlockEditor;
+
+use Automattic\WooCommerce\Internal\Admin\WCAdminAssets;
+
+/**
+ * Product block registration and style registration functionality.
+ */
+class BlockRegistry {
+	/**
+	 * The directory where blocks are stored after build.
+	 */
+	const BLOCKS_DIR = 'product-editor/blocks';
+
+	/**
+	 * Array of all available product blocks.
+	 */
+	const PRODUCT_BLOCKS = [
+		'woocommerce/product-name',
+		'woocommerce/product-pricing',
+		'woocommerce/product-section',
+		'woocommerce/product-tab',
+	];
+
+	/**
+	 * Get a file path for a given block file.
+	 *
+	 * @param string $path File path.
+	 */
+	public function get_file_path( $path ) {
+		return WC_ABSPATH . WCAdminAssets::get_path( 'js' ) . trailingslashit( self::BLOCKS_DIR ) . $path;
+	}
+
+	/**
+	 * Register all the product blocks.
+	 */
+	public function register_product_blocks() {
+		foreach ( self::PRODUCT_BLOCKS as $block_name ) {
+			$this->register_block( $block_name );
+		}
+	}
+
+	/**
+	 * Get the block name without the "woocommerce/" prefix.
+	 *
+	 * @param string $block_name Block name.
+	 *
+	 * @return string
+	 */
+	public function remove_block_prefix( $block_name ) {
+		if ( 0 === strpos( $block_name, 'woocommerce/' ) ) {
+			return substr_replace( $block_name, '', 0, strlen( 'woocommerce/' ) );
+		}
+
+		return $block_name;
+	}
+
+	/**
+	 * Register a single block.
+	 *
+	 * @param string $block_name Block name.
+	 *
+	 * @return WP_Block_Type|false The registered block type on success, or false on failure.
+	 */
+	public function register_block( $block_name ) {
+		$block_name      = $this->remove_block_prefix( $block_name );
+		$block_json_file = $this->get_file_path( $block_name . '/block.json' );
+
+		if ( ! file_exists( $block_json_file ) ) {
+			return false;
+		}
+
+		$metadata = json_decode( file_get_contents( $block_json_file ), true );
+		if ( ! is_array( $metadata ) || ! $metadata['name'] ) {
+			return false;
+		}
+
+		$registry = \WP_Block_Type_Registry::get_instance();
+
+		if ( $registry->is_registered( $metadata['name'] ) ) {
+			$registry->unregister( $metadata['name'] );
+		}
+
+		return register_block_type_from_metadata( $block_json_file );
+	}
+
+}

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -34,6 +34,8 @@ class Init {
 		if ( Features::is_enabled( self::FEATURE_ID ) ) {
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 			add_filter( 'woocommerce_register_post_type_product', array( $this, 'add_rest_base_config' ) );
+			$block_registry = new BlockRegistry();
+			$block_registry->register_product_blocks();
 		}
 	}
 

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -1,21 +1,22 @@
 <?php
 /**
- * WooCommerce Block Editor Feature Endabled
+ * WooCommerce Product Block Editor
  */
 
-namespace Automattic\WooCommerce\Admin\Features;
+namespace Automattic\WooCommerce\Admin\Features\ProductBlockEditor;
 
+use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Admin\Features\TransientNotices;
 use Automattic\WooCommerce\Admin\PageController;
 use Automattic\WooCommerce\Internal\Admin\Loader;
 use WP_Block_Editor_Context;
 
 /**
- * Loads assets related to the new product management experience page.
+ * Loads assets related to the product block editor.
  */
-class BlockEditorFeatureEnabled {
+class Init {
 
-	const FEATURE_ID = 'block-editor-feature-enabled';
+	const FEATURE_ID = 'product-block-editor';
 
 	/**
 	 * Option name used to toggle this feature.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

* Updates the feature ID to `product-block-editor`
* Registers blocks and block assets server-side

Note that there is more work that could be done here to allow blocks to be used in other context outside the product editor, but that goes beyond the scope of this PR.  If we want to do that, we'll need separate entry points for the edit and save files for each block.

This registration adds some key benefits around blocks, such as retrieving block meta data server-side, being able to filter blocks on the server, registering block assets via handles, and translation added to block.json files.

Closes #37241 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Add a test plugin with this snippet:
```
function log_blocks_and_styles() {
    global $wp_styles;
    error_log(print_r($wp_styles,true));
    $block_types = WP_Block_Type_Registry::get_instance()->get_all_registered();
    error_log(print_r($block_types,true));
}
add_action( 'init', 'log_blocks_and_styles', 20 );
```
2. Check your debug log to confirm that the product blocks (name, section, tab, and pricing) are registered.
3. Check that styles for blocks with editor.css files have been registered (e.g., `woocommerce-product-name-editor-style`)

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
