### PR TITLE
Update stable tag to 7.5.1

### DIFF
--- a/plugins/woocommerce/readme.txt
+++ b/plugins/woocommerce/readme.txt
@@ -4,7 +4,7 @@ Tags: online store, ecommerce, shop, shopping cart, sell online, storefront, che
 Requires at least: 5.9
 Tested up to: 6.1
 Requires PHP: 7.2
-Stable tag: 7.5.0
+Stable tag: 7.5.1
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 


### PR DESCRIPTION
Given the [release of 7.5.1](https://developer.woocommerce.com/2023/03/21/woocommerce-7-5-1-fix-release/), this PR updates the stable tag in the `release/7.6` branch.