### PR TITLE
Add a category for product editor blocks

### DIFF
--- a/plugins/woocommerce/changelog/fix-37200
+++ b/plugins/woocommerce/changelog/fix-37200
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a category for product editor blocks

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
@@ -54,9 +54,12 @@ class BlockRegistry {
 
 	/**
 	 * Register product related block categories.
+	 *
+	 * @param array[]                 $block_categories Array of categories for block types.
+	 * @param WP_Block_Editor_Context $editor_context   The current block editor context.
 	 */
 	public function register_categories( $block_categories, $editor_context ) {
-		if ( $editor_context->name === INIT::EDITOR_CONTEXT_NAME ) {
+		if ( INIT::EDITOR_CONTEXT_NAME === $editor_context->name ) {
 			$block_categories[] = array(
 				'slug'  => 'woocommerce',
 				'title' => __( 'WooCommerce', 'woocommerce' ),

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
@@ -31,17 +31,40 @@ class BlockRegistry {
 	 *
 	 * @param string $path File path.
 	 */
-	public function get_file_path( $path ) {
+	private function get_file_path( $path ) {
 		return WC_ABSPATH . WCAdminAssets::get_path( 'js' ) . trailingslashit( self::BLOCKS_DIR ) . $path;
+	}
+
+	/**
+	 * Initialize all blocks.
+	 */
+	public function init() {
+		add_filter( 'block_categories_all', array( $this, 'register_categories' ), 10, 2 );
+		$this->register_product_blocks();
 	}
 
 	/**
 	 * Register all the product blocks.
 	 */
-	public function register_product_blocks() {
+	private function register_product_blocks() {
 		foreach ( self::PRODUCT_BLOCKS as $block_name ) {
 			$this->register_block( $block_name );
 		}
+	}
+
+	/**
+	 * Register product related block categories.
+	 */
+	public function register_categories( $block_categories, $editor_context ) {
+		if ( $editor_context->name === INIT::EDITOR_CONTEXT_NAME ) {
+			$block_categories[] = array(
+				'slug'  => 'woocommerce',
+				'title' => __( 'WooCommerce', 'woocommerce' ),
+				'icon'  => null,
+			);
+		}
+
+		return $block_categories;
 	}
 
 	/**
@@ -51,7 +74,7 @@ class BlockRegistry {
 	 *
 	 * @return string
 	 */
-	public function remove_block_prefix( $block_name ) {
+	private function remove_block_prefix( $block_name ) {
 		if ( 0 === strpos( $block_name, 'woocommerce/' ) ) {
 			return substr_replace( $block_name, '', 0, strlen( 'woocommerce/' ) );
 		}
@@ -66,7 +89,7 @@ class BlockRegistry {
 	 *
 	 * @return WP_Block_Type|false The registered block type on success, or false on failure.
 	 */
-	public function register_block( $block_name ) {
+	private function register_block( $block_name ) {
 		$block_name      = $this->remove_block_prefix( $block_name );
 		$block_json_file = $this->get_file_path( $block_name . '/block.json' );
 

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -24,6 +24,11 @@ class Init {
 	const TOGGLE_OPTION_NAME = 'woocommerce_' . self::FEATURE_ID . '_enabled';
 
 	/**
+	 * The context name used to identify the editor.
+	 */
+	const EDITOR_CONTEXT_NAME = 'woocommerce/edit-product';
+
+	/**
 	 * Constructor
 	 */
 	public function __construct() {
@@ -35,7 +40,7 @@ class Init {
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 			add_filter( 'woocommerce_register_post_type_product', array( $this, 'add_rest_base_config' ) );
 			$block_registry = new BlockRegistry();
-			$block_registry->register_product_blocks();
+			$block_registry->init();
 		}
 	}
 
@@ -47,7 +52,7 @@ class Init {
 			return;
 		}
 		$post_type_object     = get_post_type_object( 'product' );
-		$block_editor_context = new WP_Block_Editor_Context( array( 'name' => 'core/edit-post' ) );
+		$block_editor_context = new WP_Block_Editor_Context( array( 'name' => self::EDITOR_CONTEXT_NAME ) );
 
 		$editor_settings = array();
 		if ( ! empty( $post_type_object->template ) ) {
@@ -63,6 +68,11 @@ class Init {
 		wp_add_inline_script(
 			$script_handle,
 			'var productBlockEditorSettings = productBlockEditorSettings || ' . wp_json_encode( $editor_settings ) . ';',
+			'before'
+		);
+		wp_add_inline_script(
+			$script_handle,
+			sprintf( 'wp.blocks.setCategories( %s );', wp_json_encode( $editor_settings['blockCategories'] ) ),
 			'before'
 		);
 	}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

* Adds specific editor context name
* Registers categories prior to the product editor loading blocks

Closes #37200  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Navigate to the product blocks editor
2. Open your console
3. Make sure no warnings are shown regarding missing block categories

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
