### PR TITLE
Prevent duplicate registration of core blocks in client

### DIFF
--- a/packages/js/components/changelog/fix-37348
+++ b/packages/js/components/changelog/fix-37348
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Prevent duplicate registration of core blocks in client

--- a/packages/js/components/src/rich-text-editor/utils/register-blocks.ts
+++ b/packages/js/components/src/rich-text-editor/utils/register-blocks.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { BlockInstance } from '@wordpress/blocks';
+import { BlockInstance, getBlockType } from '@wordpress/blocks';
 import {
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore We need this to import the block modules for registration.
@@ -29,9 +29,10 @@ const ALLOWED_CORE_BLOCKS = [
 
 const registerCoreBlocks = () => {
 	const coreBlocks = __experimentalGetCoreBlocks();
-	const blocks = coreBlocks.filter( ( block: BlockInstance ) =>
-		ALLOWED_CORE_BLOCKS.includes( block.name )
-	);
+	const blocks = coreBlocks.filter( ( block: BlockInstance ) => {
+		const isRegistered = !! getBlockType( block.name );
+		return ! isRegistered && ALLOWED_CORE_BLOCKS.includes( block.name );
+	} );
 
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore An argument is allowed to specify which blocks to register.

--- a/packages/js/product-editor/changelog/fix-37348
+++ b/packages/js/product-editor/changelog/fix-37348
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Prevent duplicate registration of core blocks in client

--- a/packages/js/product-editor/src/components/editor/init-blocks.ts
+++ b/packages/js/product-editor/src/components/editor/init-blocks.ts
@@ -1,7 +1,13 @@
 /**
  * External dependencies
  */
-import { registerCoreBlocks } from '@wordpress/block-library';
+import { BlockInstance, getBlockType } from '@wordpress/blocks';
+import {
+	registerCoreBlocks,
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore We need this to import the block modules for registration.
+	__experimentalGetCoreBlocks,
+} from '@wordpress/block-library';
 
 /**
  * Internal dependencies
@@ -14,7 +20,14 @@ import { init as initPricing } from '../pricing-block';
 import { init as initCollapsible } from '../collapsible-block';
 
 export const initBlocks = () => {
-	registerCoreBlocks();
+	const coreBlocks = __experimentalGetCoreBlocks();
+	const blocks = coreBlocks.filter( ( block: BlockInstance ) => {
+		return ! getBlockType( block.name );
+	} );
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore An argument is allowed to specify which blocks to register.
+	registerCoreBlocks( blocks );
+
 	initName();
 	initSummary();
 	initSection();


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Checks core block registration before attempting to register a core block.

Closes #37348  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Navigate to the product block editor
2. Check your console to verify no duplicate block registration errors exist
3. Check that the editor continues to work as expected
4. Turn on the previous product editor experience
5. Check that the rich text areas continue to work as expected without error

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
