### PR TITLE
Revert "Add missing woocommerce_run_on_woocommerce_admin_updated hook for RemoteInboxNotificationsEngine scheduled action"

### DIFF
--- a/plugins/woocommerce/changelog/revert-36768-fix-36767-woocommerce_run_on_woocommerce_admin_updated-does-not-run
+++ b/plugins/woocommerce/changelog/revert-36768-fix-36767-woocommerce_run_on_woocommerce_admin_updated-does-not-run
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Revert #36768
+
+

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
@@ -48,7 +48,7 @@ class RemoteInboxNotificationsEngine {
 					array( __CLASS__, 'run_on_woocommerce_admin_updated' ),
 					'woocommerce-remote-inbox-engine'
 				);
-				if ( $next_hook === null ) {
+				if ( null === $next_hook ) {
 					WC()->queue()->schedule_single(
 						time(),
 						'woocommerce_run_on_woocommerce_admin_updated',

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
@@ -40,11 +40,23 @@ class RemoteInboxNotificationsEngine {
 
 		// Hook into WCA updated. This is hooked up here rather than in
 		// on_admin_init because that runs too late to hook into the action.
-		WC()->queue()->schedule_single(
-			time(),
+		add_action(
 			'woocommerce_updated',
-			array( __CLASS__, 'run_on_woocommerce_admin_updated' ),
-			'woocommerce-remote-inbox-engine'
+			function() {
+				$next_hook = WC()->queue()->get_next(
+					'woocommerce_run_on_woocommerce_admin_updated',
+					array( __CLASS__, 'run_on_woocommerce_admin_updated' ),
+					'woocommerce-remote-inbox-engine'
+				);
+				if ( $next_hook === null ) {
+					WC()->queue()->schedule_single(
+						time(),
+						'woocommerce_run_on_woocommerce_admin_updated',
+						array( __CLASS__, 'run_on_woocommerce_admin_updated' ),
+						'woocommerce-remote-inbox-engine'
+					);
+				}
+			}
 		);
 
 		add_filter( 'woocommerce_get_note_from_db', array( __CLASS__, 'get_note_from_db' ), 10, 1 );


### PR DESCRIPTION
Reverts woocommerce/woocommerce#36768

woocommerce/woocommerce#36768 causes a problem that the profiler and task list are automatically marked as completed.

p1679418450835579-slack-C025EHY377G

## Test instructions

1. Use a fresh site or JN live branch
2. Go to WooCommerce > Home
3. Confirm that OBW appears.