### PR TITLE
Update WooCommerce Blocks package to 9.8.2

### DIFF
--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-9.8.2
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-9.8.2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update WooCommerce Blocks to 9.8.2

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -21,7 +21,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.5.4",
-		"woocommerce/woocommerce-blocks": "9.8.1"
+		"woocommerce/woocommerce-blocks": "9.8.2"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.3.0",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5c0ebd9977d69b819fa45b7b463fb356",
+    "content-hash": "48377a0bfe2b30537b522f197ba28984",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -628,16 +628,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "v9.8.1",
+            "version": "9.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "2c336eb8304ca59ae9b9169cc8cc58b9ca529e5b"
+                "reference": "61488a0f1d1afc8fd7484e1b277d40afd782e005"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/2c336eb8304ca59ae9b9169cc8cc58b9ca529e5b",
-                "reference": "2c336eb8304ca59ae9b9169cc8cc58b9ca529e5b",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/61488a0f1d1afc8fd7484e1b277d40afd782e005",
+                "reference": "61488a0f1d1afc8fd7484e1b277d40afd782e005",
                 "shasum": ""
             },
             "require": {
@@ -683,9 +683,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v9.8.1"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v9.8.2"
             },
-            "time": "2023-03-15T13:26:05+00:00"
+            "time": "2023-03-22T14:39:35+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 9.8.2. It is intended to target WooCommerce 7.6 for release.

Details from all the different releases included in this pull:

##  WC Blocks 9.8.2

* [Release PR](https://github.com/woocommerce/woocommerce-blocks/pull/8816)
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/982.md)

### Changelog entry

**The following changelog entries are only those that impact existing blocks and functionality surfaced to users:**

#### Enhancements

- Display the link to add the shipping address when the shipping address is not available. ([8141](https://github.com/woocommerce/woocommerce-blocks/pull/8141))

#### Bug Fixes

- Fix Customer Account block doing a 404 request in the frontend. ([8798](https://github.com/woocommerce/woocommerce-blocks/pull/8798))
- Fix issue that prevented spaces being added to Mini Cart, Cart and Checkout buttons in Firefox. ([8777](https://github.com/woocommerce/woocommerce-blocks/pull/8777))