### PR TITLE
Content lock all blocks in the product editor

### DIFF
--- a/packages/js/product-editor/changelog/fix-37209
+++ b/packages/js/product-editor/changelog/fix-37209
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Content lock all blocks in the product editor

--- a/packages/js/product-editor/src/components/details-name-block/block.json
+++ b/packages/js/product-editor/src/components/details-name-block/block.json
@@ -9,7 +9,8 @@
 	"textdomain": "default",
 	"attributes": {
 		"name": {
-			"type": "string"
+			"type": "string",
+			"__experimentalRole": "content"
 		}
 	},
 	"supports": {

--- a/packages/js/product-editor/src/components/details-summary-block/block.json
+++ b/packages/js/product-editor/src/components/details-summary-block/block.json
@@ -17,6 +17,10 @@
 		},
 		"label": {
 			"type": "string"
+		},
+		"content": {
+			"type": "string",
+			"__experimentalRole": "content"
 		}
 	},
 	"supports": {

--- a/packages/js/product-editor/src/components/pricing-block/block.json
+++ b/packages/js/product-editor/src/components/pricing-block/block.json
@@ -9,7 +9,8 @@
 	"textdomain": "default",
 	"attributes": {
 		"name": {
-			"type": "string"
+			"type": "string",
+			"__experimentalRole": "content"
 		},
 		"label": {
 			"type": "string"

--- a/packages/js/product-editor/src/components/tab/block.json
+++ b/packages/js/product-editor/src/components/tab/block.json
@@ -21,7 +21,10 @@
 		"multiple": true,
 		"reusable": false,
 		"inserter": false,
-		"lock": false
+		"lock": false,
+		"__experimentalToolbar": false
 	},
-	"usesContext": [ "selectedTab" ]
+	"usesContext": [ "selectedTab" ],
+	"editorStyle": "file:./editor.css",
+	"templateLock": "contentOnly"
 }

--- a/packages/js/product-editor/src/components/tab/edit.tsx
+++ b/packages/js/product-editor/src/components/tab/edit.tsx
@@ -1,11 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	BlockControls,
-	InnerBlocks,
-	useBlockProps,
-} from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 import classnames from 'classnames';
 import { createElement } from '@wordpress/element';
 import type { BlockAttributes } from '@wordpress/blocks';

--- a/packages/js/product-editor/src/components/tab/edit.tsx
+++ b/packages/js/product-editor/src/components/tab/edit.tsx
@@ -1,9 +1,13 @@
 /**
  * External dependencies
  */
+import {
+	BlockControls,
+	InnerBlocks,
+	useBlockProps,
+} from '@wordpress/block-editor';
 import classnames from 'classnames';
 import { createElement } from '@wordpress/element';
-import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 import type { BlockAttributes } from '@wordpress/blocks';
 
 /**
@@ -39,7 +43,9 @@ export function Edit( {
 				role="tabpanel"
 				className={ classes }
 			>
-				<InnerBlocks templateLock="all" />
+				{ /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */ }
+				{ /* @ts-ignore Content only template locking does exist for this property. */ }
+				<InnerBlocks templateLock="contentOnly" />
 			</div>
 		</div>
 	);

--- a/packages/js/product-editor/src/components/tab/style.scss
+++ b/packages/js/product-editor/src/components/tab/style.scss
@@ -3,3 +3,8 @@
         display: none;
     }
 }
+
+// Remove the Gutenberg selected outline.
+.wp-block-woocommerce-product-tab:after {
+    display: none;
+}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

* Sets all content within tabs to "contentOnly"
* Adds content role attributes to fields to allow them to be edited
* Hides the outline on tab blocks

<img width="824" alt="Screen Shot 2023-03-22 at 9 43 06 AM" src="https://user-images.githubusercontent.com/10561050/226977768-74056373-d3b3-4fde-9ab9-cd2b600b909c.png">


Closes #37209  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Navigate to the product block editor
2. Check that entire blocks are not highlighted, only inputs when focused
3. Check that toolbars don't show (other than the formatting toolbar for textarea fields)
4. Make sure you can still make edits in existing fields

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
