### PR TITLE
[WIP - DO NOT MERGE] Analytics: Support filtering Orders report by non-variation attributes

### DIFF
--- a/plugins/woocommerce/changelog/fix-orders-report-filtering-by-attribute
+++ b/plugins/woocommerce/changelog/fix-orders-report-filtering-by-attribute
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Support filtering Analytics Orders report by non-variation attributes.

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -1490,12 +1490,26 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 				)
 			);
 
+			if ( $product->is_type( 'variation' ) ) {
+				// get the non-variation attributes.
+				$parent_product = new WC_Product_Variable( $product->get_parent_id() );
+				$attributes     = array_filter(
+					$parent_product->get_attributes(),
+					function( $attribute ) {
+						return false === $attribute->get_variation();
+					}
+				);
+			} else {
+				$attributes = $product->get_attributes();
+			}
+
 			$default_args = array(
 				'name'         => $product->get_name(),
 				'tax_class'    => $product->get_tax_class(),
 				'product_id'   => $product->is_type( 'variation' ) ? $product->get_parent_id() : $product->get_id(),
 				'variation_id' => $product->is_type( 'variation' ) ? $product->get_id() : 0,
 				'variation'    => $product->is_type( 'variation' ) ? $product->get_attributes() : array(),
+				'attributes'   => $attributes,
 				'subtotal'     => $total,
 				'total'        => $total,
 				'quantity'     => $qty,

--- a/plugins/woocommerce/includes/class-wc-order-item-product.php
+++ b/plugins/woocommerce/includes/class-wc-order-item-product.php
@@ -184,6 +184,19 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	}
 
 	/**
+	 * Set attributes data (stored as meta data - write only).
+	 *
+	 * @param array $data Key/Value pairs.
+	 */
+	public function set_attributes( $data = array() ) {
+		if ( is_array( $data ) ) {
+			foreach ( $data as $key => $value ) {
+				$this->add_meta_data( str_replace( 'attribute_', '', $key ), implode( ' ', $value->get_slugs() ), true );
+			}
+		}
+	}
+
+	/**
 	 * Set properties based on passed in product object.
 	 *
 	 * @param WC_Product $product Product instance.

--- a/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
@@ -1318,7 +1318,7 @@ class DataStore extends SqlQuery {
 		);
 		$match_operator        = $this->get_match_operator( $query_args );
 		$post_meta_comparators = array(
-			'RLIKE'  => 'attribute_is',
+			'RLIKE'     => 'attribute_is',
 			'NOT RLIKE' => 'attribute_is_not',
 		);
 

--- a/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
@@ -1318,8 +1318,8 @@ class DataStore extends SqlQuery {
 		);
 		$match_operator        = $this->get_match_operator( $query_args );
 		$post_meta_comparators = array(
-			'='  => 'attribute_is',
-			'!=' => 'attribute_is_not',
+			'RLIKE'  => 'attribute_is',
+			'NOT RLIKE' => 'attribute_is_not',
 		);
 
 		foreach ( $post_meta_comparators as $comparator => $arg ) {
@@ -1379,7 +1379,7 @@ class DataStore extends SqlQuery {
 				}
 
 				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-				$sql_clauses['where'][] = $wpdb->prepare( "( {$join_alias}.meta_key = %s AND {$join_alias}.meta_value {$comparator} %s )", $meta_key, $meta_value );
+				$sql_clauses['where'][] = $wpdb->prepare( "( {$join_alias}.meta_key = %s AND {$join_alias}.meta_value {$comparator} %s )", $meta_key, '[[:<:]]' . $meta_value . '[[:>:]]' );
 			}
 		}
 


### PR DESCRIPTION
**DO NOT MERGE - THIS IS A PROOF OF CONCEPT FIX**

### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Currently, the Analytics Orders report allow advanced filtering by attributes. However, it currently only works when filtering by attributes "used for variations". Filtering by attributes on Simple products, or non-"used for variations" attributes on Variation products does not work.

This PR fixes this for *new orders*. Additional changes would need to be made to backfill existing orders.

The implementation in this PR should be considered a proof-of-concept to demonstrate the problem areas in the code among with working fixes for his problems. However, more investigation would need to be done to determine if these fixes are the ideal ones from a performance standpoint. **This PR should not be merged until these aspects are fully considered.**

#### Saving non-variation attributes to `wp_woocommerce_order_itemmeta`

The Analytics Orders report works by pulling data from `wp_woocommerce_order_itemmeta`.

This PR modifies the code that is executed when a product is added to an order to save the non-variation attributes for products. Since products can have multiple values for a given non-variation attribute, they are stored as a single space-separated entry in the `wp_woocommerce_order_itemmeta` table (see query change discussion below).

#### Supporting filtering by non-variation attributes

The Analytics Orders report currently queries attribute values by the `=` operator.

This PR modifies the query to use the `RLIKE` operator, since that way we can match single values in the space-separated entry in the `wp_woocommerce_order_itemmeta` table.

This implementation is simple and avoids the need for any additional tables or joins, but I am not sure what performance implications there are for using `RLIKE` vs. `=` when dealing with a database with a large number of orders. This will need to be considered more fully before we decide to go this route.

#### Not implemented yet - backfilling `wp_woocommerce_order_itemmeta`

This PR only fixes things for new orders created with these changes.

Existing orders' meta data will need to be backfilled to save the non-variation attributes. I am not sure what the best approach will be to do this on an upgrade in order to avoid performance issues.

Partially addresses #32237.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Create some global attributes.
        - Material: Cotton, Polyester, Nylon
        - Size: Small, Medium, Large
3. Crate new products, both Simple and Variable, using these global attributes.
    - Use Material as a non-variation attribute
    - Use Size as a variation attribute
4. Create completed orders using these products.
5. Filter the Analytics Orders report by these attributes and verify things work as expected.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
