### PR TITLE
fix incorrect variable in api core tests - 37387

### DIFF
--- a/plugins/woocommerce/changelog/fix-incorrect-variable-in-api-core-tests-37387
+++ b/plugins/woocommerce/changelog/fix-incorrect-variable-in-api-core-tests-37387
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix incorrect variable name in api-core-tests

--- a/plugins/woocommerce/tests/api-core-tests/tests/products/products-crud.test.js
+++ b/plugins/woocommerce/tests/api-core-tests/tests/products/products-crud.test.js
@@ -929,7 +929,7 @@ test.describe('Products API tests: CRUD', () => {
 			productTagId = responseJSON.id;
 
 			expect(response.status()).toEqual(201);
-			expect(typeof productId).toEqual('number');
+			expect(typeof productTagId).toEqual('number');
 			expect(responseJSON.name).toEqual('Leather Shoes');
 			expect(responseJSON.slug).toEqual('leather-shoes');
 		});


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
fix incorrect variable in api core tests. productId was being used incorrectly - productTagId should be used in this test
this corrects a false positive in one of the tests

Closes https://github.com/woocommerce/woocommerce/issues/37387.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. pull down this branch
2. set up the test environment with `pnpm env:test`
3. execute the tests with `pnpm run test:api-pw`
4. tests should pass 

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
