### PR TITLE
Fix `possibly_refresh_data_source_pollers` function

### DIFF
--- a/plugins/woocommerce/changelog/fix-37389-error-option-not-set
+++ b/plugins/woocommerce/changelog/fix-37389-error-option-not-set
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add default value when calling get_option for woocommerce_task_list_tracked_completed_tasks.

--- a/plugins/woocommerce/src/Internal/Admin/Events.php
+++ b/plugins/woocommerce/src/Internal/Admin/Events.php
@@ -260,7 +260,7 @@ class Events {
 	 *   - RemoteFreeExtensionsDataSourcePoller
 	 */
 	protected function possibly_refresh_data_source_pollers() {
-		$completed_tasks = get_option( 'woocommerce_task_list_tracked_completed_tasks' );
+		$completed_tasks = get_option( 'woocommerce_task_list_tracked_completed_tasks', array() );
 
 		if ( ! in_array( 'payments', $completed_tasks, true ) && ! in_array( 'woocommerce-payments', $completed_tasks, true ) ) {
 			PaymentGatewaySuggestionsDataSourcePoller::get_instance()->read_specs_from_data_sources();


### PR DESCRIPTION
### All Submissions:

### Changes proposed in this Pull Request:

Closes #37389. Fixes error when `woocommerce_task_list_tracked_completed_tasks` option is not set.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Delete the option `woocommerce_task_list_tracked_completed_tasks`
2. Run `wc_admin_daily` job
3. Observe no error
4. Open `debug.log` and observe no error from the cronjob run

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [ ] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
