### PR TITLE
Fix incorrect workflow input for uploading Allure reports on PR merge tests

### DIFF
--- a/.github/workflows/smoke-test-pr-merge.yml
+++ b/.github/workflows/smoke-test-pr-merge.yml
@@ -48,7 +48,7 @@ jobs:
                   aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
                   aws-region: ${{ secrets.REPORTS_AWS_REGION }}
                   aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
-                  destination-dir: ${{ env.ARTIFACT_NAME }}
+                  artifact-name: ${{ env.ARTIFACT_NAME }}
                   s3-bucket: ${{ secrets.REPORTS_BUCKET }}
 
             - name: Publish Allure report
@@ -112,7 +112,7 @@ jobs:
                   aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
                   aws-region: ${{ secrets.REPORTS_AWS_REGION }}
                   aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
-                  destination-dir: ${{ env.ARTIFACT_NAME }}
+                  artifact-name: ${{ env.ARTIFACT_NAME }}
                   s3-bucket: ${{ secrets.REPORTS_BUCKET }}
                   include-allure-results: false
 

--- a/changelog/e2e-fix-allure-upload-input
+++ b/changelog/e2e-fix-allure-upload-input
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix the incorrect workflow input for uploading Allure reports.


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
- [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/37409.

The [Run tests against trunk after PR merge](https://github.com/woocommerce/woocommerce/actions/workflows/smoke-test-pr-merge.yml) workflow uses an incorrect workflow input to upload Allure reports. The input should be corrected from destination-dir to artifact-name.

### How to test the changes in this Pull Request:

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

The only way to test this is to merge this PR, as the `Run tests against trunk after PR merge` doesn't have a `workflow_dispatch` event.

To the PR merger, please do the following after merging this PR:
1. Go to [Run tests against trunk after PR merge](https://github.com/woocommerce/woocommerce/actions/workflows/smoke-test-pr-merge.yml).
2. You should see the title of this PR appear on the list. Click on it.
3. Wait for the tests to finish.
4. Verify that all the tests pass.
5. Verify that you don't see these warnings anymore:
    
    <img width="920" alt="yHx0Q4Cmxr" src="https://user-images.githubusercontent.com/4509348/227241378-9bb300aa-c9d1-40fa-8ee2-ccfdd6ec7bcc.png">


### Other information:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you included testing instructions?

### FOR PR REVIEWER ONLY:

- [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
