### PR TITLE
Reduce flakiness on E2E setup

### DIFF
--- a/plugins/woocommerce/changelog/e2e-setup-flakiness
+++ b/plugins/woocommerce/changelog/e2e-setup-flakiness
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Reduce flakiness on E2E test setup.

--- a/plugins/woocommerce/tests/e2e-pw/global-setup.js
+++ b/plugins/woocommerce/tests/e2e-pw/global-setup.js
@@ -59,7 +59,7 @@ module.exports = async ( config ) => {
 			await adminPage.fill( 'input[name="log"]', admin.username );
 			await adminPage.fill( 'input[name="pwd"]', admin.password );
 			await adminPage.click( 'text=Log In' );
-			await adminPage.waitForLoadState( 'networkidle' );
+			await adminPage.waitForLoadState( 'domcontentloaded' );
 
 			await expect( adminPage.locator( 'div.wrap > h1' ) ).toHaveText(
 				'Dashboard'

--- a/plugins/woocommerce/tests/e2e-pw/global-setup.js
+++ b/plugins/woocommerce/tests/e2e-pw/global-setup.js
@@ -59,6 +59,8 @@ module.exports = async ( config ) => {
 			await adminPage.fill( 'input[name="log"]', admin.username );
 			await adminPage.fill( 'input[name="pwd"]', admin.password );
 			await adminPage.click( 'text=Log In' );
+			await adminPage.waitForLoadState( 'networkidle' );
+			await adminPage.goto( `/wp-admin` );
 			await adminPage.waitForLoadState( 'domcontentloaded' );
 
 			await expect( adminPage.locator( 'div.wrap > h1' ) ).toHaveText(


### PR DESCRIPTION
Reduce flakiness on E2E test setup.

When waiting for `networkidle`, it would try to find the text in the selector too fast, which would fail and cause the admin login to repeat. However, when repeating, it was already logged in, which would cause it to fail all retries, as it couldn't find the login form anymore.

This PR fixes this behavior by waiting for `domcontentload` instead, so that we check the text in the selector after the DOM is fully loaded, which seems to have fixed the flakiness we have observed in QIT E2E tests.