### PR TITLE
Show spotlight when switching to variable product type

### DIFF
--- a/packages/js/data/changelog/add-variable-product-type-spotlight
+++ b/packages/js/data/changelog/add-variable-product-type-spotlight
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add variable_product_tour_shown to UserPreferences type.

--- a/packages/js/data/src/user/types.ts
+++ b/packages/js/data/src/user/types.ts
@@ -25,6 +25,7 @@ export type UserPreferences = {
 		[ key: string ]: number;
 	};
 	taxes_report_columns?: string;
+	variable_product_tour_shown?: string;
 	variations_report_columns?: string;
 };
 

--- a/plugins/woocommerce-admin/client/guided-tours/variable-product-tour/index.tsx
+++ b/plugins/woocommerce-admin/client/guided-tours/variable-product-tour/index.tsx
@@ -1,12 +1,33 @@
 /**
  * External dependencies
  */
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { TourKit } from '@woocommerce/components';
+import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+
+const VARIABLE_PRODUCT_TOUR_OPTION = 'woocommerce_variable_product_tour_shown';
+
+function useHasShownVariableProductTour(): undefined | boolean {
+	const { hasShownTour } = useSelect( ( select ) => {
+		const { getOption } = select( OPTIONS_STORE_NAME );
+
+		return {
+			hasShownTour: getOption( VARIABLE_PRODUCT_TOUR_OPTION ) as
+				| boolean
+				| undefined,
+		};
+	} );
+
+	return hasShownTour;
+}
 
 export const VariableProductTour = () => {
+	const hasShownTour = useHasShownVariableProductTour();
 	const [ isTourOpen, setIsTourOpen ] = useState( false );
+
+	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
 
 	const config = {
 		steps: [
@@ -32,7 +53,10 @@ export const VariableProductTour = () => {
 				},
 			},
 		],
-		closeHandler: () => setIsTourOpen( false ),
+		closeHandler: () => {
+			updateOptions( { [ VARIABLE_PRODUCT_TOUR_OPTION ]: true } );
+			setIsTourOpen( false );
+		},
 	};
 
 	// show the tour when the product type is changed to variable
@@ -41,7 +65,7 @@ export const VariableProductTour = () => {
 			'#product-type'
 		) as HTMLSelectElement;
 
-		if ( ! productTypeSelect ) {
+		if ( hasShownTour || ! productTypeSelect ) {
 			return;
 		}
 

--- a/plugins/woocommerce-admin/client/guided-tours/variable-product-tour/index.tsx
+++ b/plugins/woocommerce-admin/client/guided-tours/variable-product-tour/index.tsx
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-import { useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { TourKit } from '@woocommerce/components';
 
 export const VariableProductTour = () => {
-	const [ isTourOpen, setIsTourOpen ] = useState( true );
+	const [ isTourOpen, setIsTourOpen ] = useState( false );
 
 	const config = {
 		steps: [
@@ -34,6 +34,32 @@ export const VariableProductTour = () => {
 		],
 		closeHandler: () => setIsTourOpen( false ),
 	};
+
+	// show the tour when the product type is changed to variable
+	useEffect( () => {
+		const productTypeSelect = document.querySelector(
+			'#product-type'
+		) as HTMLSelectElement;
+
+		if ( ! productTypeSelect ) {
+			return;
+		}
+
+		function handleProductTypeChange() {
+			if ( productTypeSelect.value === 'variable' ) {
+				setIsTourOpen( true );
+			}
+		}
+
+		productTypeSelect.addEventListener( 'change', handleProductTypeChange );
+
+		return () => {
+			productTypeSelect.removeEventListener(
+				'change',
+				handleProductTypeChange
+			);
+		};
+	} );
 
 	if ( ! isTourOpen ) {
 		return null;

--- a/plugins/woocommerce-admin/client/guided-tours/variable-product-tour/index.tsx
+++ b/plugins/woocommerce-admin/client/guided-tours/variable-product-tour/index.tsx
@@ -1,33 +1,16 @@
 /**
  * External dependencies
  */
-import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { TourKit } from '@woocommerce/components';
-import { OPTIONS_STORE_NAME } from '@woocommerce/data';
-
-const VARIABLE_PRODUCT_TOUR_OPTION = 'woocommerce_variable_product_tour_shown';
-
-function useHasShownVariableProductTour(): undefined | boolean {
-	const { hasShownTour } = useSelect( ( select ) => {
-		const { getOption } = select( OPTIONS_STORE_NAME );
-
-		return {
-			hasShownTour: getOption( VARIABLE_PRODUCT_TOUR_OPTION ) as
-				| boolean
-				| undefined,
-		};
-	} );
-
-	return hasShownTour;
-}
+import { useUserPreferences } from '@woocommerce/data';
 
 export const VariableProductTour = () => {
-	const hasShownTour = useHasShownVariableProductTour();
 	const [ isTourOpen, setIsTourOpen ] = useState( false );
 
-	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
+	const { updateUserPreferences, variable_product_tour_shown: hasShownTour } =
+		useUserPreferences();
 
 	const config = {
 		steps: [
@@ -54,7 +37,7 @@ export const VariableProductTour = () => {
 			},
 		],
 		closeHandler: () => {
-			updateOptions( { [ VARIABLE_PRODUCT_TOUR_OPTION ]: true } );
+			updateUserPreferences( { variable_product_tour_shown: 'yes' } );
 			setIsTourOpen( false );
 		},
 	};
@@ -65,7 +48,7 @@ export const VariableProductTour = () => {
 			'#product-type'
 		) as HTMLSelectElement;
 
-		if ( hasShownTour || ! productTypeSelect ) {
+		if ( hasShownTour === 'yes' || ! productTypeSelect ) {
 			return;
 		}
 

--- a/plugins/woocommerce-admin/client/guided-tours/variable-product-tour/index.tsx
+++ b/plugins/woocommerce-admin/client/guided-tours/variable-product-tour/index.tsx
@@ -45,13 +45,6 @@ export const VariableProductTour = () => {
 			},
 		],
 		options: {
-			callbacks: {
-				onNextStep: ( currentStepIndex ) => {
-					recordEvent( 'variable_product_tour_step_viewed', {
-						step: getStepName( config.steps, currentStepIndex + 1 ),
-					} );
-				},
-			},
 			// WooTourKit does not handle merging of default options properly,
 			// so we need to duplicate the effects options here.
 			effects: {
@@ -105,9 +98,6 @@ export const VariableProductTour = () => {
 			if ( productTypeSelect.value === 'variable' ) {
 				setIsTourOpen( true );
 				recordEvent( 'variable_product_tour_started', {
-					step: getStepName( config.steps, 0 ),
-				} );
-				recordEvent( 'variable_product_tour_step_viewed', {
 					step: getStepName( config.steps, 0 ),
 				} );
 			}

--- a/plugins/woocommerce-admin/client/guided-tours/variable-product-tour/index.tsx
+++ b/plugins/woocommerce-admin/client/guided-tours/variable-product-tour/index.tsx
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { TourKit } from '@woocommerce/components';
+
+export const VariableProductTour = () => {
+	const [ isTourOpen, setIsTourOpen ] = useState( true );
+
+	const config = {
+		steps: [
+			{
+				referenceElements: {
+					desktop: '.attribute_tab',
+				},
+				focusElement: {
+					desktop: '.attribute_tab',
+				},
+				meta: {
+					name: 'attributes',
+					heading: __( 'Start by adding attributes', 'woocommerce' ),
+					descriptions: {
+						desktop: __(
+							'Add attributes like size and color for customers to choose from on the product page. We will use them to generate product variations.',
+							'woocommerce'
+						),
+					},
+					primaryButton: {
+						text: __( 'Got it', 'woocommerce' ),
+					},
+				},
+			},
+		],
+		closeHandler: () => setIsTourOpen( false ),
+	};
+
+	if ( ! isTourOpen ) {
+		return null;
+	}
+
+	return <TourKit config={ config } />;
+};

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/variable-product-tour/index.tsx
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/variable-product-tour/index.tsx
@@ -1,0 +1,13 @@
+/**
+ * External dependencies
+ */
+import { render } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { VariableProductTour } from '../../guided-tours/variable-product-tour';
+
+const root = document.createElement( 'div' );
+root.setAttribute( 'id', 'variable-product-tour-root' );
+render( <VariableProductTour />, document.body.appendChild( root ) );

--- a/plugins/woocommerce-admin/webpack.config.js
+++ b/plugins/woocommerce-admin/webpack.config.js
@@ -65,6 +65,7 @@ const wpAdminScripts = [
 	'settings-tracking',
 	'order-tracking',
 	'product-import-tracking',
+	'variable-product-tour',
 ];
 const getEntryPoints = () => {
 	const entryPoints = {

--- a/plugins/woocommerce/changelog/add-variable-product-type-spotlight
+++ b/plugins/woocommerce/changelog/add-variable-product-type-spotlight
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Show tour when product type is changed to variable.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-pointers.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-pointers.php
@@ -38,6 +38,7 @@ class WC_Admin_Pointers {
 		switch ( $screen->id ) {
 			case 'product':
 				$this->create_product_tutorial();
+				$this->create_variable_product_tutorial();
 				break;
 			case 'woocommerce_page_wc-addons':
 				$this->create_wc_addons_tutorial();
@@ -62,6 +63,17 @@ class WC_Admin_Pointers {
 		$labels          = $wp_post_types['product']->labels;
 		$labels->add_new = __( 'Enable guided mode', 'woocommerce' );
 		WCAdminAssets::register_script( 'wp-admin-scripts', 'product-tour', true );
+	}
+
+	/**
+	 * Pointers for creating a variable product.
+	 */
+	public function create_variable_product_tutorial() {
+		if ( ! current_user_can( 'manage_options' ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return;
+		}
+
+		WCAdminAssets::register_script( 'wp-admin-scripts', 'variable-product-tour', true );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/WCAdminUser.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCAdminUser.php
@@ -103,6 +103,11 @@ class WCAdminUser {
 	 * @return array Fields to expose over the WP user endpoint.
 	 */
 	public function get_user_data_fields() {
+		/**
+		 * Filter user data fields exposed over the WordPress user endpoint.
+		 *
+		 * @param array $fields Array of fields to expose over the WP user endpoint.
+		 */
 		return apply_filters( 'woocommerce_admin_get_user_data_fields', array( 'variable_product_tour_shown' ) );
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/WCAdminUser.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCAdminUser.php
@@ -103,7 +103,7 @@ class WCAdminUser {
 	 * @return array Fields to expose over the WP user endpoint.
 	 */
 	public function get_user_data_fields() {
-		return apply_filters( 'woocommerce_admin_get_user_data_fields', array() );
+		return apply_filters( 'woocommerce_admin_get_user_data_fields', array( 'variable_product_tour_shown' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/WCAdminUser.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCAdminUser.php
@@ -106,6 +106,7 @@ class WCAdminUser {
 		/**
 		 * Filter user data fields exposed over the WordPress user endpoint.
 		 *
+		 * @since 4.0.0
 		 * @param array $fields Array of fields to expose over the WP user endpoint.
 		 */
 		return apply_filters( 'woocommerce_admin_get_user_data_fields', array( 'variable_product_tour_shown' ) );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
@@ -53,18 +53,10 @@ test.describe( 'Add New Variable Product Page', () => {
 			.getByRole( 'link', { name: 'Attributes' } )
 			.scrollIntoViewIfNeeded();
 
-		await expect(
-			page.getByRole( 'button', { name: 'Got it' } )
-		).toBeVisible();
-
 		// dismiss the variable product tour
 		await page
 			.getByRole( 'button', { name: 'Got it' } )
 			.click( { force: true } );
-
-		await expect(
-			page.getByRole( 'button', { name: 'Got it' } )
-		).not.toBeVisible();
 
 		// wait for the tour's dismissal to be saved
 		await page.waitForResponse(

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
@@ -44,10 +44,6 @@ test.describe( 'Add New Variable Product Page', () => {
 		await page.goto( 'wp-admin/post-new.php?post_type=product' );
 		await page.selectOption( '#product-type', 'variable', { force: true } );
 
-		await expect(
-			page.getByRole( 'button', { name: 'Got it' } )
-		).toBeVisible();
-
 		// because of the way that the tour is dynamically positioned,
 		// Playwright can't automatically scroll the button into view,
 		// so we will manually scroll the attributes tab into view,
@@ -56,6 +52,10 @@ test.describe( 'Add New Variable Product Page', () => {
 			.locator( '.attribute_tab' )
 			.getByRole( 'link', { name: 'Attributes' } )
 			.scrollIntoViewIfNeeded();
+
+		await expect(
+			page.getByRole( 'button', { name: 'Got it' } )
+		).toBeVisible();
 
 		// dismiss the variable product tour
 		await page

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
@@ -40,6 +40,40 @@ test.describe( 'Add New Variable Product Page', () => {
 		await api.post( 'products/batch', { delete: ids } );
 	} );
 
+	test( 'shows the variable product tour', async ( { page } ) => {
+		await page.goto( 'wp-admin/post-new.php?post_type=product' );
+		await page.selectOption( '#product-type', 'variable', { force: true } );
+
+		await expect(
+			page.getByRole( 'button', { name: 'Got it' } )
+		).toBeVisible();
+
+		// because of the way that the tour is dynamically positioned,
+		// Playwright can't automatically scroll the button into view,
+		// so we will manually scroll the attributes tab into view,
+		// which will cause the tour to be scrolled into view as well
+		await page
+			.locator( '.attribute_tab' )
+			.getByRole( 'link', { name: 'Attributes' } )
+			.scrollIntoViewIfNeeded();
+
+		// dismiss the variable product tour
+		await page
+			.getByRole( 'button', { name: 'Got it' } )
+			.click( { force: true } );
+
+		await expect(
+			page.getByRole( 'button', { name: 'Got it' } )
+		).not.toBeVisible();
+
+		// wait for the tour's dismissal to be saved
+		await page.waitForResponse(
+			( response ) =>
+				response.url().includes( '/users/' ) &&
+				response.status() === 200
+		);
+	} );
+
 	test( 'can create product, attributes and variations, edit variations and delete variations', async ( {
 		page,
 	} ) => {
@@ -54,10 +88,18 @@ test.describe( 'Add New Variable Product Page', () => {
 			if ( i > 0 ) {
 				await page.click( 'button.add_attribute' );
 			}
-			await page.waitForSelector( `input[name="attribute_names[${ i }]"]` );
+			await page.waitForSelector(
+				`input[name="attribute_names[${ i }]"]`
+			);
 
-			await page.locator( `input[name="attribute_names[${ i }]"]` ).first().type( `attr #${ i + 1 }` );
-			await page.locator( `textarea[name="attribute_values[${ i }]"]` ).first().type( 'val1 | val2' );
+			await page
+				.locator( `input[name="attribute_names[${ i }]"]` )
+				.first()
+				.type( `attr #${ i + 1 }` );
+			await page
+				.locator( `textarea[name="attribute_values[${ i }]"]` )
+				.first()
+				.type( 'val1 | val2' );
 		}
 		await page.click( 'text=Save attributes' );
 		// wait for the attributes to be saved
@@ -167,10 +209,11 @@ test.describe( 'Add New Variable Product Page', () => {
 		} );
 		const variationsCount = await page.$$( '.woocommerce_variation' );
 		await expect( variationsCount ).toHaveLength( 0 );
-
 	} );
 
-	test( 'can manually add a variation, manage stock levels, set variation defaults and remove a variation', async ( { page } ) => {
+	test( 'can manually add a variation, manage stock levels, set variation defaults and remove a variation', async ( {
+		page,
+	} ) => {
 		await page.goto( 'wp-admin/post-new.php?post_type=product' );
 		await page.fill( '#title', manualVariableProduct );
 		await page.selectOption( '#product-type', 'variable', { force: true } );
@@ -180,10 +223,18 @@ test.describe( 'Add New Variable Product Page', () => {
 			if ( i > 0 ) {
 				await page.click( 'button.add_attribute' );
 			}
-			await page.waitForSelector( `input[name="attribute_names[${ i }]"]` );
+			await page.waitForSelector(
+				`input[name="attribute_names[${ i }]"]`
+			);
 
-			await page.locator( `input[name="attribute_names[${ i }]"]` ).first().type( `attr #${ i + 1 }` );
-			await page.locator( `textarea[name="attribute_values[${ i }]"]` ).first().type( 'val1 | val2' );
+			await page
+				.locator( `input[name="attribute_names[${ i }]"]` )
+				.first()
+				.type( `attr #${ i + 1 }` );
+			await page
+				.locator( `textarea[name="attribute_values[${ i }]"]` )
+				.first()
+				.type( 'val1 | val2' );
 		}
 		await page.click( 'text=Save attributes' );
 		// wait for the attributes to be saved
@@ -289,6 +340,8 @@ test.describe( 'Add New Variable Product Page', () => {
 		page.on( 'dialog', ( dialog ) => dialog.accept() );
 		await page.hover( '.woocommerce_variation' );
 		await page.click( '.remove_variation.delete' );
-		await expect( page.locator( '.woocommerce_variation' ) ).toHaveCount( 0 );
+		await expect( page.locator( '.woocommerce_variation' ) ).toHaveCount(
+			0
+		);
 	} );
 } );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR introduces a single step tour (spotlight) when switching to the variable product type.

<img width="917" alt="Screenshot 2023-03-23 at 21 19 14" src="https://user-images.githubusercontent.com/2098816/227400060-b281e93e-1689-46e9-843a-9d37477ff423.png">

This only shows a single time for each user (unless the user never interacts with it, in which case it will be shown again). This is stored in the `woocommerce_admin_variable_product_tour_shown` user preference (`wp_usermeta` table).

Tracks events are recorded for the tour:
* `wcadmin_variable_product_tour_started`
* `wcadmin_variable_product_tour_step_viewed`
* `wcadmin_variable_product_tour_completed`

Each has a single `step` prop that is set to `attributes`. The Tracks events are recorded this way to allow for additional steps to be added in the future and be automatically recorded.

Closes #37149.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Create a new product.
2. Change the type to "Variable product".
3. Verify that the spotlight is shown.
4. Dismiss the spotlight, either by the X or the "Got it" button.
5. Refresh the page.
6. Change the type to "Variable product".
7. Verify that the spotlight is not shown.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
