### PR TITLE
Added SSR to WCCOM endpoints

### DIFF
--- a/plugins/woocommerce/changelog/add-ssr-report-endpoint
+++ b/plugins/woocommerce/changelog/add-ssr-report-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Added SSR to WCCOM endpoints.

--- a/plugins/woocommerce/includes/wccom-site/class-wc-wccom-site.php
+++ b/plugins/woocommerce/includes/wccom-site/class-wc-wccom-site.php
@@ -241,9 +241,11 @@ class WC_WCCOM_Site {
 	public static function register_rest_namespace( $namespaces ) {
 		require_once WC_ABSPATH . 'includes/wccom-site/rest-api/class-wc-rest-wccom-site-installer-errors.php';
 		require_once WC_ABSPATH . 'includes/wccom-site/rest-api/endpoints/class-wc-rest-wccom-site-installer-controller.php';
+		require_once WC_ABSPATH . 'includes/wccom-site/rest-api/endpoints/class-wc-rest-wccom-site-ssr-controller.php';
 
 		$namespaces['wccom-site/v1'] = array(
 			'installer' => 'WC_REST_WCCOM_Site_Installer_Controller',
+			'ssr'       => 'WC_REST_WCCOM_Site_SSR_Controller',
 		);
 
 		return $namespaces;

--- a/plugins/woocommerce/includes/wccom-site/rest-api/endpoints/class-wc-rest-wccom-site-installer-controller.php
+++ b/plugins/woocommerce/includes/wccom-site/rest-api/endpoints/class-wc-rest-wccom-site-installer-controller.php
@@ -77,6 +77,12 @@ class WC_REST_WCCOM_Site_Installer_Controller extends WC_REST_Controller {
 		$current_user = wp_get_current_user();
 
 		if ( empty( $current_user ) || ( $current_user instanceof WP_User && ! $current_user->exists() ) ) {
+			/**
+			 * Filter the error returned when the user is not authenticated.
+			 *
+			 * @since 3.7.0
+			 * @param WP_Error $error Error object.
+			 */
 			return apply_filters(
 				WC_WCCOM_Site::AUTH_ERROR_FILTER_NAME,
 				new WP_Error(

--- a/plugins/woocommerce/includes/wccom-site/rest-api/endpoints/class-wc-rest-wccom-site-installer-controller.php
+++ b/plugins/woocommerce/includes/wccom-site/rest-api/endpoints/class-wc-rest-wccom-site-installer-controller.php
@@ -32,7 +32,7 @@ class WC_REST_WCCOM_Site_Installer_Controller extends WC_REST_Controller {
 	protected $rest_base = 'installer';
 
 	/**
-	 * Register the routes for product reviews.
+	 * Register the routes for WCCCOM Installer Controller.
 	 *
 	 * @since 3.7.0
 	 */

--- a/plugins/woocommerce/includes/wccom-site/rest-api/endpoints/class-wc-rest-wccom-site-ssr-controller.php
+++ b/plugins/woocommerce/includes/wccom-site/rest-api/endpoints/class-wc-rest-wccom-site-ssr-controller.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * WCCOM Site System Status Report REST API Controller
+ *
+ * Handles requests to /ssr.
+ *
+ * @package WooCommerce\WCCom\API
+ * @since   7.7.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST API WCCOM System Status Report Controller Class.
+ *
+ * @extends WC_REST_Controller
+ */
+class WC_REST_WCCOM_Site_SSR_Controller extends WC_REST_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wccom-site/v1';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'ssr';
+
+	/**
+	 * Register the routes for WCCCOM Installer Controller.
+	 *
+	 * @since 3.7.0
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_ssr' ),
+					'permission_callback' => array( $this, 'check_permission' ),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Check permissions.
+	 *
+	 * Please note that access to this endpoint is also governed by the WC_WCCOM_Site::authenticate_wccom() method.
+	 *
+	 * @since 7.7.0
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return bool|WP_Error
+	 */
+	public function check_permission( $request ) {
+		$current_user = wp_get_current_user();
+
+		if ( empty( $current_user ) || ( $current_user instanceof WP_User && ! $current_user->exists() ) ) {
+			return apply_filters(
+				WC_WCCOM_Site::AUTH_ERROR_FILTER_NAME,
+				new WP_Error(
+					WC_REST_WCCOM_Site_Installer_Errors::NOT_AUTHENTICATED_CODE,
+					WC_REST_WCCOM_Site_Installer_Errors::NOT_AUTHENTICATED_MESSAGE,
+					array( 'status' => WC_REST_WCCOM_Site_Installer_Errors::NOT_AUTHENTICATED_HTTP_CODE )
+				)
+			);
+		}
+
+		if ( ! user_can( $current_user, 'install_plugins' ) || ! user_can( $current_user, 'install_themes' ) ) {
+			return new WP_Error(
+				WC_REST_WCCOM_Site_Installer_Errors::NO_PERMISSION_CODE,
+				WC_REST_WCCOM_Site_Installer_Errors::NO_PERMISSION_MESSAGE,
+				array( 'status' => WC_REST_WCCOM_Site_Installer_Errors::NO_PERMISSION_HTTP_CODE )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get SSR data.
+	 *
+	 * @since 7.7.0
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_ssr( $request ) {
+		$ssr_controller = new WC_REST_System_Status_Controller();
+		return $ssr_controller->get_items( $request );
+	}
+}

--- a/plugins/woocommerce/includes/wccom-site/rest-api/endpoints/class-wc-rest-wccom-site-ssr-controller.php
+++ b/plugins/woocommerce/includes/wccom-site/rest-api/endpoints/class-wc-rest-wccom-site-ssr-controller.php
@@ -63,6 +63,12 @@ class WC_REST_WCCOM_Site_SSR_Controller extends WC_REST_Controller {
 		$current_user = wp_get_current_user();
 
 		if ( empty( $current_user ) || ( $current_user instanceof WP_User && ! $current_user->exists() ) ) {
+			/**
+			 * Filter the error returned when the user is not authenticated.
+			 *
+			 * @since 7.7.0
+			 * @param WP_Error $error Error object.
+			 */
 			return apply_filters(
 				WC_WCCOM_Site::AUTH_ERROR_FILTER_NAME,
 				new WP_Error(


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This work just extends the existing infrastructure used for communication from connected Woo stores with WCCOM. It adds an endpoint to fetch the SSR to make it easier for support folks to understand what's going on on sites connected to WCCOM.

Based on the discussion on p6JqRr-8v3-p2.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

Since this is an addition of new functionality, there's not really any before/after. 

1. Install WC from this branch.
2. In your favourite REST client, navigate to `/wp-json/wccom-site/v1` endpoint.
3. You should see 3 routes in the response, the last one being `/wccom-site/v1/ssr`. It should only allow `GET` method.
4. Navigate to `/wp-json/wccom-site/v1/ssr`.
5. You should see JSON response:
```
{
    "code": "no_access_token",
    "message": "No access token provided",
    "data": {
        "status": 400
    }
}
```
6. Install and activate this small plugin: [fake-wccom-auth.zip](https://github.com/woocommerce/woocommerce/files/11062297/fake-wccom-auth.zip)
7. Now navigate to `/wp-json/wccom-site/v1/ssr?userid=1`
8. You should see SSR details:
```
{
    "environment": {
        "home_url": "http://wctest.local",
        "site_url": "http://wctest.local",
        "version": "7.7.0",
        "log_directory": "/Users/peter/Local Sites/wctest/app/public/wp-content/uploads/wc-logs/",
        "log_directory_writable": true,
        "wp_version": "6.1.1",
...
```
9. Deactivate the plugin from 6 just in case.

It might be even better to test this all the way through to WCCOM, but I don't have sufficient knowledge of setting this up end to end. cc @denho who does.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
