### PR TITLE
Synchronized SSR from template to REST API

### DIFF
--- a/plugins/woocommerce/changelog/fix-sync-ssr-REST-and-UI
+++ b/plugins/woocommerce/changelog/fix-sync-ssr-REST-and-UI
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Synchronized SSR from template to REST API.

--- a/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
@@ -6,8 +6,6 @@
  */
 
 use Automattic\Jetpack\Constants;
-use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Register as Download_Directories;
-use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer as Order_DataSynchronizer;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -761,20 +759,30 @@ if ( 0 < count( $dropins_mu_plugins['mu_plugins'] ) ) :
 		<tr>
 			<td data-export-label="Enforce Approved Product Download Directories"><?php esc_html_e( 'Enforce Approved Product Download Directories', 'woocommerce' ); ?>:</td>
 			<td class="help"><?php echo wc_help_tip( esc_html__( 'Is your site enforcing the use of Approved Product Download Directories?', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
-			<td><?php echo wc_get_container()->get( Download_Directories::class )->get_mode() === Download_Directories::MODE_ENABLED ? '<mark class="yes"><span class="dashicons dashicons-yes"></span></mark>' : '<mark class="no">&ndash;</mark>'; ?></td>
+			<td><?php echo $settings['enforce_approved_download_dirs'] ? '<mark class="yes"><span class="dashicons dashicons-yes"></span></mark>' : '<mark class="no">&ndash;</mark>'; ?></td>
+		</tr>
+
+		<tr>
+			<td data-export-label="HPOS feature screen enabled"><?php esc_html_e( 'HPOS feature screen enabled:', 'woocommerce' ); ?></td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'Is HPOS feature screen enabled?', 'woocommerce' ) ); ?></td>
+			<td><?php echo $settings['HPOS_feature_screen_enabled'] ? '<mark class="yes"><span class="dashicons dashicons-yes"></span></mark>' : '<mark class="no">&ndash;</mark>'; ?></td>
+		</tr>
+		<tr>
+			<td data-export-label="HPOS feature enabled"><?php esc_html_e( 'HPOS enabled:', 'woocommerce' ); ?></td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'Is HPOS enabled?', 'woocommerce' ) ); ?></td>
+			<td><?php echo $settings['HPOS_enabled'] ? '<mark class="yes"><span class="dashicons dashicons-yes"></span></mark>' : '<mark class="no">&ndash;</mark>'; ?></td>
 		</tr>
 		<tr>
 			<td data-export-label="Order datastore"><?php esc_html_e( 'Order datastore:', 'woocommerce' ); ?></td>
 			<td class="help"><?php echo wc_help_tip( esc_html__( 'Datastore currently in use for orders.', 'woocommerce' ) ); ?></td>
-			<td><?php echo esc_html( WC_Data_Store::load( 'order' )->get_current_class_name() ); ?></td>
+			<td><?php echo esc_html( $settings['order_datastore'] ); ?></td>
 		</tr>
-		<?php if ( wc_get_container()->get( Automattic\WooCommerce\Internal\Features\FeaturesController::class )->feature_is_enabled( 'custom_order_tables' ) ) : ?>
 		<tr>
 			<td data-export-label="HPOS data sync enabled"><?php esc_html_e( 'HPOS data sync enabled:', 'woocommerce' ); ?></td>
 			<td class="help"><?php echo wc_help_tip( esc_html__( 'Is data sync enabled for HPOS?', 'woocommerce' ) ); ?></td>
-			<td><?php echo wc_get_container()->get( Order_DataSynchronizer::class )->data_sync_is_enabled() ? '<mark class="yes"><span class="dashicons dashicons-yes"></span></mark>' : '<mark class="no">&ndash;</mark>'; ?></td>
+			<td><?php echo $settings['HPOS_sync_enabled'] ? '<mark class="yes"><span class="dashicons dashicons-yes"></span></mark>' : '<mark class="no">&ndash;</mark>'; ?></td>
 		</tr>
-		<?php endif; ?>
+
 	</tbody>
 </table>
 <table class="wc_status_table widefat" cellspacing="0">

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
@@ -477,7 +477,7 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 					'type'        => 'object',
 					'context'     => array( 'view' ),
 					'readonly'    => true,
-					'properties' => array(
+					'properties'  => array(
 						'api_enabled'                    => array(
 							'description' => __( 'REST API enabled?', 'woocommerce' ),
 							'type'        => 'boolean',

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
@@ -1289,7 +1289,7 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 				get_option( 'woocommerce_default_customer_address' ),
 				array(
 					'geolocation_ajax',
-					'geolocation'
+					'geolocation',
 				),
 				true
 			),

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
@@ -11,6 +11,9 @@
 defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Internal\WCCom\ConnectionHelper;
+use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Register as Download_Directories;
+use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer as Order_DataSynchronizer;
+use Automattic\WooCommerce\Utilities\OrderUtil;
 /**
  * System status controller class.
  *
@@ -546,6 +549,42 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 							'items'       => array(
 								'type' => 'string',
 							),
+						),
+						'wccom_connected'          => array(
+							'description' => __( 'Is WooCommerce.com connected?', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view' ),
+							'readonly'    => true,
+						),
+						'enforce_approved_download_dirs' => array(
+							'description' => __( 'Enforce approved download directories?', 'woocommerce' ),
+							'type'        => 'boolean',
+							'context'     => array( 'view' ),
+							'readonly'    => true,
+						),
+						'HPOS_feature_screen_enabled' => array(
+							'description' => __( 'Is HPOS feature screen enabled?', 'woocommerce' ),
+							'type'        => 'boolean',
+							'context'     => array( 'view' ),
+							'readonly'    => true,
+						),
+						'HPOS_enabled' => array(
+							'description' => __( 'Is HPOS enabled?', 'woocommerce' ),
+							'type'        => 'boolean',
+							'context'     => array( 'view' ),
+							'readonly'    => true,
+						),
+						'order_datastore' => array(
+							'description' => __( 'Order datastore.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view' ),
+							'readonly'    => true,
+						),
+						'HPOS_sync_enabled' => array(
+							'description' => __( 'Is HPOS sync enabled?', 'woocommerce' ),
+							'type'        => 'boolean',
+							'context'     => array( 'view' ),
+							'readonly'    => true,
 						),
 					),
 				),
@@ -1238,18 +1277,26 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 
 		// Return array of useful settings for debugging.
 		return array(
-			'api_enabled'               => 'yes' === get_option( 'woocommerce_api_enabled' ),
-			'force_ssl'                 => 'yes' === get_option( 'woocommerce_force_ssl_checkout' ),
-			'currency'                  => get_woocommerce_currency(),
-			'currency_symbol'           => get_woocommerce_currency_symbol(),
-			'currency_position'         => get_option( 'woocommerce_currency_pos' ),
-			'thousand_separator'        => wc_get_price_thousand_separator(),
-			'decimal_separator'         => wc_get_price_decimal_separator(),
-			'number_of_decimals'        => wc_get_price_decimals(),
-			'geolocation_enabled'       => in_array( get_option( 'woocommerce_default_customer_address' ), array( 'geolocation_ajax', 'geolocation' ), true ),
-			'taxonomies'                => $term_response,
-			'product_visibility_terms'  => $product_visibility_terms,
-			'woocommerce_com_connected' => ConnectionHelper::is_connected() ? 'yes' : 'no',
+			'api_enabled'                    => 'yes' === get_option( 'woocommerce_api_enabled' ),
+			'force_ssl'                      => 'yes' === get_option( 'woocommerce_force_ssl_checkout' ),
+			'currency'                       => get_woocommerce_currency(),
+			'currency_symbol'                => get_woocommerce_currency_symbol(),
+			'currency_position'              => get_option( 'woocommerce_currency_pos' ),
+			'thousand_separator'             => wc_get_price_thousand_separator(),
+			'decimal_separator'              => wc_get_price_decimal_separator(),
+			'number_of_decimals'             => wc_get_price_decimals(),
+			'geolocation_enabled'            => in_array( get_option( 'woocommerce_default_customer_address' ), array(
+				'geolocation_ajax',
+				'geolocation'
+			), true ),
+			'taxonomies'                     => $term_response,
+			'product_visibility_terms'       => $product_visibility_terms,
+			'woocommerce_com_connected'      => ConnectionHelper::is_connected() ? 'yes' : 'no',
+			'enforce_approved_download_dirs' => wc_get_container()->get( Download_Directories::class )->get_mode() === Download_Directories::MODE_ENABLED,
+			'order_datastore'                => WC_Data_Store::load( 'order' )->get_current_class_name(),
+			'HPOS_feature_screen_enabled'    => wc_get_container()->get( Automattic\WooCommerce\Internal\Features\FeaturesController::class )->feature_is_enabled( 'custom_order_tables' ),
+			'HPOS_enabled'                   => OrderUtil::custom_orders_table_usage_is_enabled(),
+			'HPOS_sync_enabled'              => wc_get_container()->get( Order_DataSynchronizer::class )->data_sync_is_enabled(),
 		);
 	}
 

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
@@ -477,62 +477,62 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 					'type'        => 'object',
 					'context'     => array( 'view' ),
 					'readonly'    => true,
-					'properties'  => array(
-						'api_enabled'              => array(
+					'properties' => array(
+						'api_enabled'                    => array(
 							'description' => __( 'REST API enabled?', 'woocommerce' ),
 							'type'        => 'boolean',
 							'context'     => array( 'view' ),
 							'readonly'    => true,
 						),
-						'force_ssl'                => array(
+						'force_ssl'                      => array(
 							'description' => __( 'SSL forced?', 'woocommerce' ),
 							'type'        => 'boolean',
 							'context'     => array( 'view' ),
 							'readonly'    => true,
 						),
-						'currency'                 => array(
+						'currency'                       => array(
 							'description' => __( 'Currency.', 'woocommerce' ),
 							'type'        => 'string',
 							'context'     => array( 'view' ),
 							'readonly'    => true,
 						),
-						'currency_symbol'          => array(
+						'currency_symbol'                => array(
 							'description' => __( 'Currency symbol.', 'woocommerce' ),
 							'type'        => 'string',
 							'context'     => array( 'view' ),
 							'readonly'    => true,
 						),
-						'currency_position'        => array(
+						'currency_position'              => array(
 							'description' => __( 'Currency position.', 'woocommerce' ),
 							'type'        => 'string',
 							'context'     => array( 'view' ),
 							'readonly'    => true,
 						),
-						'thousand_separator'       => array(
+						'thousand_separator'             => array(
 							'description' => __( 'Thousand separator.', 'woocommerce' ),
 							'type'        => 'string',
 							'context'     => array( 'view' ),
 							'readonly'    => true,
 						),
-						'decimal_separator'        => array(
+						'decimal_separator'              => array(
 							'description' => __( 'Decimal separator.', 'woocommerce' ),
 							'type'        => 'string',
 							'context'     => array( 'view' ),
 							'readonly'    => true,
 						),
-						'number_of_decimals'       => array(
+						'number_of_decimals'             => array(
 							'description' => __( 'Number of decimals.', 'woocommerce' ),
 							'type'        => 'integer',
 							'context'     => array( 'view' ),
 							'readonly'    => true,
 						),
-						'geolocation_enabled'      => array(
+						'geolocation_enabled'            => array(
 							'description' => __( 'Geolocation enabled?', 'woocommerce' ),
 							'type'        => 'boolean',
 							'context'     => array( 'view' ),
 							'readonly'    => true,
 						),
-						'taxonomies'               => array(
+						'taxonomies'                     => array(
 							'description' => __( 'Taxonomy terms for product/order statuses.', 'woocommerce' ),
 							'type'        => 'array',
 							'context'     => array( 'view' ),
@@ -541,7 +541,7 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 								'type' => 'string',
 							),
 						),
-						'product_visibility_terms' => array(
+						'product_visibility_terms'       => array(
 							'description' => __( 'Terms in the product visibility taxonomy.', 'woocommerce' ),
 							'type'        => 'array',
 							'context'     => array( 'view' ),
@@ -550,8 +550,8 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 								'type' => 'string',
 							),
 						),
-						'wccom_connected'          => array(
-							'description' => __( 'Is WooCommerce.com connected?', 'woocommerce' ),
+						'wccom_connected'                => array(
+							'description' => __( 'Is store connected to WooCommerce.com?', 'woocommerce' ),
 							'type'        => 'string',
 							'context'     => array( 'view' ),
 							'readonly'    => true,
@@ -562,25 +562,25 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 							'context'     => array( 'view' ),
 							'readonly'    => true,
 						),
-						'HPOS_feature_screen_enabled' => array(
+						'HPOS_feature_screen_enabled'    => array(
 							'description' => __( 'Is HPOS feature screen enabled?', 'woocommerce' ),
 							'type'        => 'boolean',
 							'context'     => array( 'view' ),
 							'readonly'    => true,
 						),
-						'HPOS_enabled' => array(
+						'HPOS_enabled'                   => array(
 							'description' => __( 'Is HPOS enabled?', 'woocommerce' ),
 							'type'        => 'boolean',
 							'context'     => array( 'view' ),
 							'readonly'    => true,
 						),
-						'order_datastore' => array(
+						'order_datastore'                => array(
 							'description' => __( 'Order datastore.', 'woocommerce' ),
 							'type'        => 'string',
 							'context'     => array( 'view' ),
 							'readonly'    => true,
 						),
-						'HPOS_sync_enabled' => array(
+						'HPOS_sync_enabled'              => array(
 							'description' => __( 'Is HPOS sync enabled?', 'woocommerce' ),
 							'type'        => 'boolean',
 							'context'     => array( 'view' ),
@@ -1285,10 +1285,14 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 			'thousand_separator'             => wc_get_price_thousand_separator(),
 			'decimal_separator'              => wc_get_price_decimal_separator(),
 			'number_of_decimals'             => wc_get_price_decimals(),
-			'geolocation_enabled'            => in_array( get_option( 'woocommerce_default_customer_address' ), array(
-				'geolocation_ajax',
-				'geolocation'
-			), true ),
+			'geolocation_enabled'            => in_array(
+				get_option( 'woocommerce_default_customer_address' ),
+				array(
+					'geolocation_ajax',
+					'geolocation'
+				),
+				true
+			),
 			'taxonomies'                     => $term_response,
 			'product_visibility_terms'       => $product_visibility_terms,
 			'woocommerce_com_connected'      => ConnectionHelper::is_connected() ? 'yes' : 'no',

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/system-status.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/system-status.php
@@ -178,7 +178,7 @@ class WC_Tests_REST_System_Status_V2 extends WC_REST_Unit_Test_Case {
 		$data     = $response->get_data();
 		$settings = (array) $data['settings'];
 
-		$this->assertEquals( 12, count( $settings ) );
+		$this->assertEquals( 17, count( $settings ) );
 		$this->assertEquals( ( 'yes' === get_option( 'woocommerce_api_enabled' ) ), $settings['api_enabled'] );
 		$this->assertEquals( get_woocommerce_currency(), $settings['currency'] );
 		$this->assertEquals( $term_response, $settings['taxonomies'] );

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/system-status.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/system-status.php
@@ -201,7 +201,7 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 		$data     = $response->get_data();
 		$settings = (array) $data['settings'];
 
-		$this->assertEquals( 12, count( $settings ) );
+		$this->assertEquals( 17, count( $settings ) );
 		$this->assertEquals( ( 'yes' === get_option( 'woocommerce_api_enabled' ) ), $settings['api_enabled'] );
 		$this->assertEquals( get_woocommerce_currency(), $settings['currency'] );
 		$this->assertEquals( $term_response, $settings['taxonomies'] );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34864, follow up after https://github.com/woocommerce/woocommerce/pull/35487

Due to weirdness in WC architecture, our SSR values need to be added to REST API endpoint and should be just fetched in the admin UI template to ensure the consistency between those data sources. This PR should add the missing items in the REST API while only slightly altering the behaviour of how HPOS is displayed in the SSR in admin.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Install a new WC store with latest stable WC version (7.5.1 as of writing these instructions)
2. Go to WC > Settings > Advanced > Features
3. Enable HPOS by checking the checkbox next to `Enable the high performance order storage feature.`
4. Click Save Changes
5. Go to WC > Settings > Advanced > Custom data stores
6. Switch the `Data store for orders` to `Use the WooCommerce orders tables` and turn on sync.
7. Click Save changes
![Screenshot 2023-03-24 at 14 53 19](https://user-images.githubusercontent.com/2207451/227540215-f92d69f5-1251-444e-850f-1d1676514099.png)

9. Go to WC > Status and check that you can see the items related to HPOS under **Settings** (you need to scroll quite a bit)
![Screenshot 2023-03-24 at 14 55 32](https://user-images.githubusercontent.com/2207451/227540588-f58da69c-0595-4b9d-a027-54f64ada64eb.png)

10. Generate a new set of REST API keys for admin:
11. Navigate to WC > Settings > Advanced > REST API
12. Click on Add Key button at the top
13. GIve the keys a simple name like "SSR test", set the User to the admin of the site and Permission to `Read`:
![Screenshot 2023-03-24 at 14 57 33](https://user-images.githubusercontent.com/2207451/227541155-a0943f7a-62e0-498c-8b11-8e30cfe04c2a.png)
14. Copy the consumer key and secret to your favourite text editor, e.g. vim. 😈 
15. Head over to your favourite REST API client and ensure it's set up to use the consumer key and secret from step 14 to authenticate, e.g. this is what you'd use in Postman:
![Screenshot 2023-03-24 at 15 03 10](https://user-images.githubusercontent.com/2207451/227542550-0faa3d39-c06f-44f4-87ae-9ca6b9d37115.png)
18. In the REST API client, navigate to `http://yourdoma.in/wp-json/wc/v3/system_status`
19. Check that there's nothing about HPOS in the `settings` section. Also info about enforcement of the download directories is missing.
![Screenshot 2023-03-24 at 15 05 43](https://user-images.githubusercontent.com/2207451/227543127-3b88e63a-ec01-436e-9735-5ec4896a20ef.png)
20. Now replace the WC version with the one provided in this branch.
21. Go to WC > Status and check that you can see the (new) items related to HPOS under **Settings**
![Screenshot 2023-03-24 at 15 09 53](https://user-images.githubusercontent.com/2207451/227544488-b5ca8a6a-d7bd-49c3-8dbb-8c252fa225b7.png)
22. Go to your REST API client and refresh the result from the same endpoint (`http://yourdoma.in/wp-json/wc/v3/system_status`)
23. You should see the same items as in the admin UI now:
![Screenshot 2023-03-24 at 15 12 14](https://user-images.githubusercontent.com/2207451/227545624-eb599ed0-06db-4462-9ded-8e923d263d7f.png)





<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
