### PR TITLE
Dev - Add customer object parameter to taxable address filter

### DIFF
--- a/plugins/woocommerce/changelog/add-customer-object-taxable-address-filter
+++ b/plugins/woocommerce/changelog/add-customer-object-taxable-address-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Dev - Add customer object parameter to taxable address filter

--- a/plugins/woocommerce/includes/class-wc-customer.php
+++ b/plugins/woocommerce/includes/class-wc-customer.php
@@ -210,6 +210,8 @@ class WC_Customer extends WC_Legacy_Customer {
 		/**
 		 * Filters the taxable address for a given customer.
 		 *
+		 * @since 3.0.0
+		 *
 		 * @param array  $taxable_address An array of country, state, postcode, and city for the customer's taxable address.
 		 * @param object $customer        The customer object for which the taxable address is being requested.
 		 *

--- a/plugins/woocommerce/includes/class-wc-customer.php
+++ b/plugins/woocommerce/includes/class-wc-customer.php
@@ -207,7 +207,15 @@ class WC_Customer extends WC_Legacy_Customer {
 			$city     = $this->get_shipping_city();
 		}
 
-		return apply_filters( 'woocommerce_customer_taxable_address', array( $country, $state, $postcode, $city ) );
+		/**
+		 * Filters the taxable address for a given customer.
+		 *
+		 * @param array  $taxable_address An array of country, state, postcode, and city for the customer's taxable address.
+		 * @param object $customer        The customer object for which the taxable address is being requested.
+		 *
+		 * @return array The filtered taxable address for the customer.
+		 */
+		return apply_filters( 'woocommerce_customer_taxable_address', array( $country, $state, $postcode, $city ), $this );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Add $customer object parameter to WC_Customer::get_taxable_address() filter. This modification provides more context to code hooking the filter, allowing developers to determine which customer's taxable address is being examined.

Closes #36352 .

1. Hook into the woocommerce_customer_taxable_address filter using the add_filter() function, ensuring that the filter callback function accepts two parameters.
2. Inside the callback function, access the $customer object parameter and verify that it corresponds to the customer whose taxable address is being requested.
3. Test the filter with multiple customers to verify that the correct customer object is being passed as a parameter.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
