### PR TITLE
Add listener to parent to avoid event being overwritten when DOM is replaced

### DIFF
--- a/plugins/woocommerce/changelog/fix-disable-save-btn
+++ b/plugins/woocommerce/changelog/fix-disable-save-btn
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Attach event to parent node to avoid it being overwritten when DOM changes
+
+

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes.js
@@ -30,13 +30,16 @@ jQuery( function ( $ ) {
 	 * Function to maybe disable the save button.
 	 */
 	jQuery.maybe_disable_save_button = function () {
-		var $tab = $( '.product_attributes' );
-		var $save_button = $( 'button.save_attributes' );
+		var $tab;
+		var $save_button;
 		if (
 			$( '.woocommerce_variation_new_attribute_data' ).is( ':visible' )
 		) {
 			$tab = $( '.woocommerce_variation_new_attribute_data' );
 			$save_button = $( 'button.create-variations' );
+		} else {
+			var $tab = $( '.product_attributes' );
+			var $save_button = $( 'button.save_attributes' );
 		}
 
 		var attributes_and_variations_data = $tab.find(
@@ -153,15 +156,14 @@ jQuery( function ( $ ) {
 		$( this ).find( '.wc-metabox-content' ).hide();
 	} );
 
-	$( '.product_attributes, .woocommerce_variation_new_attribute_data' ).on(
-		'keyup',
-		'input, textarea',
-		jQuery.maybe_disable_save_button
-	);
-
 	$( '#product_attributes' ).on(
 		'change',
 		'select.attribute_values',
+		jQuery.maybe_disable_save_button
+	);
+	$( '#product_attributes, #variable_product_options' ).on(
+		'keyup',
+		'input, textarea',
 		jQuery.maybe_disable_save_button
 	);
 } );


### PR DESCRIPTION

### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Add listener to parent to avoid event being overwritten when DOM is replaced
<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

With no global attributes created:

1. Access the legacy product manager.
2. Select Variable product type
3. Go to variations tab.
4. Fill a name and value to create attributes and variations
5. Check that the Create variations button is enabled
6. Click it
7. Check that variations were created
8. Go to Attributes tab.
9. Change something in the name or values of the attribute(s)
10. Check that the Save attributes button still reacts accordingly.

PS: if you have global attributes created, there's another bug, I plan on creating another issue for it:
![image](https://user-images.githubusercontent.com/13437655/227597851-2782ef38-cbf6-479f-90c0-568cce81012e.png)


<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [ ] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
