### PR TITLE
Update tested and required WordPress versions according to L-2 policy

### DIFF
--- a/plugins/woocommerce/changelog/dev-update-required-wordpress-version
+++ b/plugins/woocommerce/changelog/dev-update-required-wordpress-version
@@ -1,0 +1,4 @@
+Significance: major
+Type: dev
+
+Update tested and required WordPress versions according to L-2 policy.

--- a/plugins/woocommerce/readme.txt
+++ b/plugins/woocommerce/readme.txt
@@ -1,8 +1,8 @@
 === WooCommerce ===
 Contributors: automattic, mikejolley, jameskoster, claudiosanches, rodrigosprimo, peterfabian1000, vedjain, jamosova, obliviousharmony, konamiman, sadowski, wpmuguru, royho, barryhughes-1
 Tags: online store, ecommerce, shop, shopping cart, sell online, storefront, checkout, payments, woo, woo commerce, e-commerce, store
-Requires at least: 5.9
-Tested up to: 6.1
+Requires at least: 6.0
+Tested up to: 6.2
 Requires PHP: 7.2
 Stable tag: 7.5.1
 License: GPLv3

--- a/plugins/woocommerce/woocommerce.php
+++ b/plugins/woocommerce/woocommerce.php
@@ -8,7 +8,7 @@
  * Author URI: https://woocommerce.com
  * Text Domain: woocommerce
  * Domain Path: /i18n/languages/
- * Requires at least: 5.9
+ * Requires at least: 6.0
  * Requires PHP: 7.3
  *
  * @package WooCommerce


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

WooCommerce follows [an L-2 WordPress Core support policy](https://developer.woocommerce.com/2020/05/08/wordpress-core-support-policy/) (until WooCommerce 7.8 where [we switch to L-1](https://developer.woocommerce.com/2023/02/23/revisiting-wordpress-core-support-policy-for-woocommerce/)). This change updates the "tested" and "required" versions of WordPress to reflect the policy. 

This update is necessary now and also needs to be merged in the 7.6.0 release branch, as 7.6.0 will come out on April 11 -- just after WordPress 6.2 ([March 28](https://make.wordpress.org/core/6-2/)). 

### How to test the changes in this Pull Request:

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

This isn't changing any actual code so cannot really be tested well. 

1. Ensure that CI passes. 
2. Ensure that WooCommerce can be installed on a site running 6.2. 
3. Ensure the change makes sense. 

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
