### PR TITLE
Remove multichannel marketing option from WC Tracker

### DIFF
--- a/plugins/woocommerce/changelog/update-remove-multichannel-tracker
+++ b/plugins/woocommerce/changelog/update-remove-multichannel-tracker
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Remove multichannel marketing info from WC Tracker

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -696,7 +696,6 @@ class WC_Tracker {
 			'hpos_transactions_enabled'             => get_option( 'woocommerce_use_db_transactions_for_custom_orders_table_data_sync' ),
 			'hpos_transactions_level'               => get_option( 'woocommerce_db_transactions_isolation_level_for_custom_orders_table_data_sync' ),
 			'show_marketplace_suggestions'          => get_option( 'woocommerce_show_marketplace_suggestions' ),
-			'multichannel_marketing_enabled'        => get_option( 'woocommerce_multichannel_marketing_enabled' ),
 		);
 	}
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Reverts one of the changes from #37017 which included the value of the _"Enables the new WooCommerce Multichannel Marketing experience in the Marketing page"_ in the WC Tracker data, as this toggle is slated to be removed completely in WooCommerce 7.7 (pe2C5g-Ft-p2#comment-582). 

### How to test the changes in this Pull Request:

Using WP CLI, try running:

`wp eval "print_r( WC_Tracker::get_tracking_data()['settings'] );"`

At the end of the output, you should no longer see the new MCM-related options. Originally  looked like:

```
    [show_marketplace_suggestions] => yes
    [multichannel_marketing_enabled] => no
```

Should now end with just

```
    [show_marketplace_suggestions] => yes
```


### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.