### PR TITLE
[WIP] ajaxComplete support via XMLHttpRequest

### DIFF
--- a/plugins/woocommerce/client/legacy/js/frontend/cart.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/cart.js
@@ -14,19 +14,28 @@ jQuery( function( $ ) {
 	 * @param {Object} options
 	 */
 	const ajax = options => {
-		window.fetch( options.url, {
-			method: options.type || 'GET',
-			headers: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8' },
-			body: options.data
-		} )
-			.then( response => {
-				if ( !response.ok ) {
-					throw new Error( response.statusText );
-				}
-				return response.text();
-			} )
-			.then( options.success )
-			.finally( () => options.complete() );
+		const xhr = new XMLHttpRequest();
+		xhr.open( options.type || 'GET', options.url );
+
+		if ( !options.type || options.type.toUpperCase() === 'GET' || options.type.toUpperCase() === 'HEAD' ) {
+			xhr.send();
+		} else {
+			xhr.setRequestHeader( 'Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8' );
+			xhr.send( options.data );
+		}
+
+		xhr.onload = function() {
+			if ( xhr.status >= 200 && xhr.status < 300 || xhr.status === 304 ) {
+				options.success( xhr.response );
+			}
+			options.complete();
+			$( document ).trigger( 'ajaxComplete', [ xhr, options ] );
+		};
+
+		xhr.onabort = xhr.onerror = xhr.ontimeout = function() {
+			options.complete();
+			$( document ).trigger( 'ajaxComplete', [ xhr, options ] );
+		};
 	};
 
 	/**

--- a/plugins/woocommerce/client/legacy/js/frontend/geolocation.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/geolocation.js
@@ -127,17 +127,23 @@ jQuery( function( $ ) {
 	// Get the current geo hash. If it doesn't exist, or if it doesn't match the current
 	// page URL, perform a geolocation request.
 	if ( ! get_geo_hash() || needs_refresh() ) {
-		window.fetch( $geolocate_customer.url, {
-			method: $geolocate_customer.type,
-			headers: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8' }
-		} )
-		.then( response => {
-			if ( !response.ok ) {
-				throw new Error( response.statusText );
+		const options = $geolocate_customer;
+		const xhr = new XMLHttpRequest();
+
+		xhr.open( options.type, options.url );
+		xhr.responseType = 'json';
+		xhr.send();
+
+		xhr.onload = function() {
+			if ( xhr.status >= 200 && xhr.status < 300 || xhr.status === 304 ) {
+				options.success( xhr.response );
 			}
-			return response.json();
-		} )
-		.then( $geolocate_customer.success );
+			$( document ).trigger( 'ajaxComplete', [ xhr, options ] );
+		};
+
+		xhr.onabort = xhr.onerror = xhr.ontimeout = function() {
+			$( document ).trigger( 'ajaxComplete', [ xhr, options ] );
+		};
 	}
 
 	// Page updates.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

As mentioned in https://github.com/woocommerce/woocommerce/pull/36275#issuecomment-1482099830, the `ajaxComplete` jQuery functionality was broken when migrating from `$.ajax()` to `window.fetch()`.

This PR adds support for `ajaxComplete` by switching to `XMLHttpRequest` from `window.fetch()`, as it allows for much better compatibility with the `ajaxComplete` API.

I've tested this PR by adding and removing products from the cart and checkout on our website and it is working as inteded.

I haven't yet tested the `ajaxComplete` functionality with the blocks.

Could also fix #37371, as the PR contains a 'GET' and 'HEAD' methods check in **cart.js**.

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
