### PR TITLE
Don't pass body param to window.fetch when performing GET request

### DIFF
--- a/plugins/woocommerce/changelog/dev-dont-pass-body-get
+++ b/plugins/woocommerce/changelog/dev-dont-pass-body-get
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix a bug where we try to perform GET requests with body param.

--- a/plugins/woocommerce/client/legacy/js/frontend/cart.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/cart.js
@@ -14,10 +14,13 @@ jQuery( function( $ ) {
 	 * @param {Object} options
 	 */
 	const ajax = options => {
+		const type = options.type || 'GET';
+		
 		window.fetch( options.url, {
-			method: options.type || 'GET',
+			method: type,
 			headers: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8' },
-			body: options.data
+			// Don't try to pass a body for GET requests, this will result in a TypeError.
+			body: type !== 'GET' ? options.data : undefined,
 		} )
 			.then( response => {
 				if ( !response.ok ) {


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

I'm not convinced this will fix https://github.com/woocommerce/woocommerce/issues/37371 but it does address an issue that was raised by that PR. As mentioned by @apenchev in [this comment](https://github.com/woocommerce/woocommerce/issues/37371#issuecomment-1484077230) we should guard against passing a body when request type is `GET`.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:


To confirm that this PR doesn't **introduce any new bugs to the cart workflow mentioned in https://github.com/woocommerce/woocommerce/issues/37371** you can test:

1. Have a basic store setup in development.
2. Add the "Best Selling" block to a store page (I used my home page)
3. Add the "Cart" block to the same page
4. Have a single product setup (i just used the one that the setup wizard gets you to create)
5. View the homepage as a user, add some of the product to cart, the cart should update with the new item (the page refreshes). There should be no errors in console.

Another thing you can test because we don't have unit tests setup for the legacy JS:

1. Make sure you have your page you setup in previous steps
2. Add some extra code to the `cart.js` that calls the `ajax` method.
3. Replace [this code](https://github.com/woocommerce/woocommerce/blob/8c41078bd27d2e255bbe7c70bf08fd76337d4dc9/plugins/woocommerce/client/legacy/js/frontend/cart.js#L378-L391) with the code below:

```
ajax( {
				type:     'GET',
				url:      $form.attr( 'action' ),
				data:     new URLSearchParams( new FormData( $form[0] ) ).toString(),
				dataType: 'html',
				success:  function( response ) {
					update_wc_div( response, preserve_notices );
				},
				complete: function() {
					unblock( $form );
					unblock( $( 'div.cart_totals' ) );
					$.scroll_to_notices( $( '[role="alert"]' ) );
				}
			} );
```
4. Now try add a product to cart as in previous steps. Note that it will **not work** because we're performing a GET request
5. We are just interested to see if there is a `TypeError` thrown. There should not be, since we don't include a body if the request is of `GET` type.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
