### PR TITLE
Add JSX config for TypeScript in woocommerce/product-editor package.

### DIFF
--- a/packages/js/product-editor/src/components/details-name-block/edit.tsx
+++ b/packages/js/product-editor/src/components/details-name-block/edit.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { createElement } from '@wordpress/element';
 import interpolateComponents from '@automattic/interpolate-components';
 import { TextControl } from '@woocommerce/components';
 import { useBlockProps } from '@wordpress/block-editor';

--- a/packages/js/product-editor/tsconfig-cjs.json
+++ b/packages/js/product-editor/tsconfig-cjs.json
@@ -7,6 +7,7 @@
 	"compilerOptions": {
 		"outDir": "build",
 		"resolveJsonModule": true,
+		"jsx": "preserve",
 		"typeRoots": [
 			"./typings",
 			"./node_modules/@types"

--- a/packages/js/product-editor/tsconfig.json
+++ b/packages/js/product-editor/tsconfig.json
@@ -6,6 +6,7 @@
 		"declaration": true,
 		"declarationMap": true,
 		"declarationDir": "./build-types",
+		"jsx": "preserve",
 		"resolveJsonModule": true,
 		"typeRoots": [
 			"./typings",


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Typscript has a [JSX configuration property](https://www.typescriptlang.org/docs/handbook/jsx.html) that removes the need to include an explicit import for `createElement` in files using JSX. This PR adds that property.

I only removed the explicit import from one file as a demonstration, I'll leave it up to the team whether they'll do that for all the files in one go, or just as you work on them.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

This is a developer-only change. The immediate user-facing impact would be broken builds that can be verified by testing the expected output for a file with the `createElement` import removed. Since the product editor still works for the file I touched on in this PR, that is significant for indicating no impact.

### FOR PR REVIEWER ONLY:

-   [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
