### PR TITLE
Code refactor: Simplify boolean expression before `&&` in Marketing page

### DIFF
--- a/plugins/woocommerce-admin/client/marketing/components/CreateNewCampaignModal/CreateNewCampaignModal.tsx
+++ b/plugins/woocommerce-admin/client/marketing/components/CreateNewCampaignModal/CreateNewCampaignModal.tsx
@@ -47,6 +47,9 @@ export const CreateNewCampaignModal = ( props: CreateCampaignModalProps ) => {
 	const { loadInstalledPluginsAfterActivation } =
 		useInstalledPluginsWithoutChannels();
 
+	const hasCampaignTypes = !! campaignTypes?.length;
+	const hasRecommendedChannels = !! recommendedChannels?.length;
+
 	const onInstalledAndActivated = ( pluginSlug: string ) => {
 		refetchCampaignTypes();
 		refetchRegisteredChannels();
@@ -64,7 +67,7 @@ export const CreateNewCampaignModal = ( props: CreateCampaignModalProps ) => {
 		>
 			<div className="woocommerce-marketing-new-campaigns">
 				<div className="woocommerce-marketing-new-campaigns__question-label">
-					{ !! campaignTypes?.length
+					{ hasCampaignTypes
 						? __(
 								'Where would you like to promote your products?',
 								'woocommerce'
@@ -109,7 +112,7 @@ export const CreateNewCampaignModal = ( props: CreateCampaignModalProps ) => {
 									<FlexItem>
 										{ __( 'Create', 'woocommerce' ) }
 									</FlexItem>
-									{ !! isExternalURL( el.createUrl ) && (
+									{ isExternalURL( el.createUrl ) && (
 										<FlexItem>
 											<Icon
 												icon={ external }
@@ -123,7 +126,7 @@ export const CreateNewCampaignModal = ( props: CreateCampaignModalProps ) => {
 					</Flex>
 				) ) }
 			</div>
-			{ !! recommendedChannels?.length && (
+			{ hasRecommendedChannels && (
 				<div className="woocommerce-marketing-add-channels">
 					<Flex direction="column">
 						<FlexItem>

--- a/plugins/woocommerce-admin/client/marketing/coupons/index.js
+++ b/plugins/woocommerce-admin/client/marketing/coupons/index.js
@@ -16,13 +16,14 @@ import '../data';
 const CouponsOverview = () => {
 	const { currentUserCan } = useUser();
 
-	const shouldShowExtensions =
+	const showExtensions = !! (
 		getAdminSetting( 'allowMarketplaceSuggestions', false ) &&
-		currentUserCan( 'install_plugins' );
+		currentUserCan( 'install_plugins' )
+	);
 
 	return (
 		<div className="woocommerce-marketing-coupons">
-			{ !! shouldShowExtensions && (
+			{ showExtensions && (
 				<RecommendedExtensions
 					title={ __(
 						'Recommended coupon extensions',

--- a/plugins/woocommerce-admin/client/marketing/overview-multichannel/Campaigns/Campaigns.tsx
+++ b/plugins/woocommerce-admin/client/marketing/overview-multichannel/Campaigns/Campaigns.tsx
@@ -158,6 +158,8 @@ export const Campaigns = () => {
 		);
 	};
 
+	const showFooter = !! ( total && total > perPage );
+
 	return (
 		<Card className="woocommerce-marketing-campaigns-card">
 			<CardHeader>
@@ -170,14 +172,14 @@ export const Campaigns = () => {
 				>
 					{ __( 'Create new campaign', 'woocommerce' ) }
 				</Button>
-				{ !! isModalOpen && (
+				{ isModalOpen && (
 					<CreateNewCampaignModal
 						onRequestClose={ () => setModalOpen( false ) }
 					/>
 				) }
 			</CardHeader>
 			{ getContent() }
-			{ !! ( total && total > perPage ) && (
+			{ showFooter && (
 				<CardFooter className="woocommerce-marketing-campaigns-card__footer">
 					<Pagination
 						showPerPagePicker={ false }

--- a/plugins/woocommerce-admin/client/marketing/overview-multichannel/Channels/Channels.tsx
+++ b/plugins/woocommerce-admin/client/marketing/overview-multichannel/Channels/Channels.tsx
@@ -103,7 +103,7 @@ export const Channels = forwardRef< ChannelsRef, ChannelsProps >(
 				{ /* Recommended channels section. */ }
 				{ recommendedChannels.length >= 1 && (
 					<div>
-						{ !! hasRegisteredChannels && (
+						{ hasRegisteredChannels && (
 							<>
 								<CardDivider />
 								<CardBody>
@@ -127,7 +127,7 @@ export const Channels = forwardRef< ChannelsRef, ChannelsProps >(
 								</CardBody>
 							</>
 						) }
-						{ !! expanded &&
+						{ expanded &&
 							recommendedChannels.map( ( el, idx ) => (
 								<Fragment key={ el.plugin }>
 									<SmartPluginCardBody

--- a/plugins/woocommerce-admin/client/marketing/overview-multichannel/IntroductionBanner/IntroductionBanner.tsx
+++ b/plugins/woocommerce-admin/client/marketing/overview-multichannel/IntroductionBanner/IntroductionBanner.tsx
@@ -47,8 +47,9 @@ export const IntroductionBanner = ( {
 	 * and clicking on the "Add channels" button in this introduction banner
 	 * will scroll to the button in Channels card.
 	 */
-	const showAddChannelsButton =
-		!! dataRegistered?.length && !! dataRecommended?.length;
+	const showAddChannelsButton = !! (
+		dataRegistered?.length && dataRecommended?.length
+	);
 
 	return (
 		<Card className="woocommerce-marketing-introduction-banner">

--- a/plugins/woocommerce-admin/client/marketing/overview-multichannel/MarketingOverviewMultichannel.tsx
+++ b/plugins/woocommerce-admin/client/marketing/overview-multichannel/MarketingOverviewMultichannel.tsx
@@ -61,14 +61,21 @@ export const MarketingOverviewMultichannel: React.FC = () => {
 		return <CenteredSpinner />;
 	}
 
-	const shouldShowCampaigns = !! (
+	const showCampaigns = !! (
 		dataRegistered?.length &&
 		( isIntroductionBannerDismissed || metaCampaigns?.total )
 	);
 
-	const shouldShowExtensions =
+	const showChannels = !! (
+		dataRegistered &&
+		dataRecommended &&
+		( dataRegistered.length || dataRecommended.length )
+	);
+
+	const showExtensions = !! (
 		getAdminSetting( 'allowMarketplaceSuggestions', false ) &&
-		currentUserCan( 'install_plugins' );
+		currentUserCan( 'install_plugins' )
+	);
 
 	const onInstalledAndActivated = ( pluginSlug: string ) => {
 		refetchCampaignTypes();
@@ -86,18 +93,17 @@ export const MarketingOverviewMultichannel: React.FC = () => {
 					} }
 				/>
 			) }
-			{ shouldShowCampaigns && <Campaigns /> }
-			{ !! ( dataRegistered && dataRecommended ) &&
-				!! ( dataRegistered.length || dataRecommended.length ) && (
-					<Channels
-						ref={ channelsRef }
-						registeredChannels={ dataRegistered }
-						recommendedChannels={ dataRecommended }
-						onInstalledAndActivated={ onInstalledAndActivated }
-					/>
-				) }
+			{ showCampaigns && <Campaigns /> }
+			{ showChannels && (
+				<Channels
+					ref={ channelsRef }
+					registeredChannels={ dataRegistered }
+					recommendedChannels={ dataRecommended }
+					onInstalledAndActivated={ onInstalledAndActivated }
+				/>
+			) }
 			<InstalledExtensions />
-			{ !! shouldShowExtensions && <DiscoverTools /> }
+			{ showExtensions && <DiscoverTools /> }
 			<LearnMarketing />
 		</div>
 	);

--- a/plugins/woocommerce/changelog/feature-marketing-boolean-expression
+++ b/plugins/woocommerce/changelog/feature-marketing-boolean-expression
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Simplify boolean expression before && in Marketing page.


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

This is a follow-up to https://github.com/woocommerce/woocommerce/pull/37227#issuecomment-1475792721.

In this PR, we simplify the boolean expression changes made in PR https://github.com/woocommerce/woocommerce/pull/37227. 

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Go to Marketing page: `/wp-admin/admin.php?page=wc-admin&path=%2Fmarketing`. It should work the same as before.
2. Go to Coupons page: `/wp-admin/edit.php?post_type=shop_coupon`. It should work the same as before.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
