### PR TITLE
Remove the MCM feature flag on update to WooCommerce 7.7

### DIFF
--- a/plugins/woocommerce/changelog/feature-remove-mcm-flag-option
+++ b/plugins/woocommerce/changelog/feature-remove-mcm-flag-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Remove the multichannel marketing feature flag from database since it's the default option now.

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -229,6 +229,9 @@ class WC_Install {
 			'wc_update_750_add_columns_to_order_stats_table',
 			'wc_update_750_disable_new_product_management_experience',
 		),
+		'7.7.0' => array(
+			'wc_update_770_remove_multichannel_marketing_feature_flag',
+		),
 	);
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -230,7 +230,7 @@ class WC_Install {
 			'wc_update_750_disable_new_product_management_experience',
 		),
 		'7.7.0' => array(
-			'wc_update_770_remove_multichannel_marketing_feature_flag',
+			'wc_update_770_remove_multichannel_marketing_feature_options',
 		),
 	);
 

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -2596,8 +2596,9 @@ function wc_update_750_disable_new_product_management_experience() {
 }
 
 /**
- * Remove the multichannel marketing feature flag. This feature is now enabled by default.
+ * Remove the multichannel marketing feature flag and options. This feature is now enabled by default.
  */
-function wc_update_770_remove_multichannel_marketing_feature_flag() {
+function wc_update_770_remove_multichannel_marketing_feature_options() {
 	delete_option( 'woocommerce_multichannel_marketing_enabled' );
+	delete_option( 'woocommerce_marketing_overview_welcome_hidden' );
 }

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -2594,3 +2594,10 @@ function wc_update_750_disable_new_product_management_experience() {
 		update_option( 'woocommerce_new_product_management_enabled', 'no' );
 	}
 }
+
+/**
+ * Remove the multichannel marketing feature flag. This feature is now enabled by default.
+ */
+function wc_update_770_remove_multichannel_marketing_feature_flag() {
+	delete_option( 'woocommerce_multichannel_marketing_enabled' );
+}


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This feature flag is no longer needed because the new marketing page will be the default on version 7.7 (pe2C5g-Ft-p2#comment-582). This PR will delete the option when WooCommerce is updated to version 7.7.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Go to the WooCommerce Settings > Advanced > Features and enable the new marketing page feature
<img width="905" alt="image" src="https://user-images.githubusercontent.com/73110514/228004319-0060339a-482d-4ecd-bd9d-f642206dfe4a.png">

2. Checkout this branch and reload WP admin
3. Update the database by clicking on the notice
<img width="448" alt="image" src="https://user-images.githubusercontent.com/73110514/228003875-e4a4b6e9-00a2-4cd1-bb52-efbae24360bf.png">

4. Confirm that the `woocommerce_multichannel_marketing_enabled` option is no longer present in the options table

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] ~Have you written new tests for your changes, as applicable?~
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
