### PR TITLE
Restore reviews (comments) to the product editor

### DIFF
--- a/plugins/woocommerce/changelog/fix-34594-product-editor-reviews
+++ b/plugins/woocommerce/changelog/fix-34594-product-editor-reviews
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Restores comments (reviews) to the product editor.

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/Reviews.php
@@ -169,7 +169,7 @@ class Reviews {
 	 */
 	private function handle_edit_review(): void {
 		// Don't interfere with comment functionality relating to the reviews meta box within the product editor.
-		if ( sanitize_text_field( wp_unslash( $_POST['mode'] ) ) === 'single' ) {
+		if ( sanitize_text_field( wp_unslash( $_POST['mode'] ?? '' ) ) === 'single' ) {
 			return;
 		}
 
@@ -241,7 +241,7 @@ class Reviews {
 	 */
 	private function handle_reply_to_review() : void {
 		// Don't interfere with comment functionality relating to the reviews meta box within the product editor.
-		if ( sanitize_text_field( wp_unslash( $_POST['mode'] ) ) === 'single' ) {
+		if ( sanitize_text_field( wp_unslash( $_POST['mode'] ?? '' ) ) === 'single' ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/Reviews.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/Reviews.php
@@ -168,6 +168,11 @@ class Reviews {
 	 * @return void
 	 */
 	private function handle_edit_review(): void {
+		// Don't interfere with comment functionality relating to the reviews meta box within the product editor.
+		if ( sanitize_text_field( wp_unslash( $_POST['mode'] ) ) === 'single' ) {
+			return;
+		}
+
 		check_ajax_referer( 'replyto-comment', '_ajax_nonce-replyto-comment' );
 
 		$comment_id = isset( $_POST['comment_ID'] ) ? (int) sanitize_text_field( wp_unslash( $_POST['comment_ID'] ) ) : 0;
@@ -235,6 +240,11 @@ class Reviews {
 	 * @return void
 	 */
 	private function handle_reply_to_review() : void {
+		// Don't interfere with comment functionality relating to the reviews meta box within the product editor.
+		if ( sanitize_text_field( wp_unslash( $_POST['mode'] ) ) === 'single' ) {
+			return;
+		}
+
 		check_ajax_referer( 'replyto-comment', '_ajax_nonce-replyto-comment' );
 
 		$comment_post_ID = isset( $_POST['comment_post_ID'] ) ? (int) sanitize_text_field( wp_unslash( $_POST['comment_post_ID'] ) ) : 0; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase

--- a/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsCommentsOverrides.php
+++ b/plugins/woocommerce/src/Internal/Admin/ProductReviews/ReviewsCommentsOverrides.php
@@ -4,6 +4,7 @@ namespace Automattic\WooCommerce\Internal\Admin\ProductReviews;
 
 use Automattic\WooCommerce\Internal\Traits\AccessiblePrivateMethods;
 use WP_Comment_Query;
+use WP_Screen;
 
 /**
  * Tweaks the WordPress comments page to exclude reviews.
@@ -116,6 +117,12 @@ class ReviewsCommentsOverrides {
 	 * @return array
 	 */
 	protected function exclude_reviews_from_comments( $args ) : array {
+		$screen = get_current_screen();
+
+		// We only wish to intervene if the edit comments screen has been requested.
+		if ( ! $screen instanceof WP_Screen || 'edit-comments' !== $screen->id ) {
+			return $args;
+		}
 
 		if ( ! empty( $args['post_type'] ) && $args['post_type'] !== 'any' ) {
 			$post_types = (array) $args['post_type'];

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsCommentsOverridesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsCommentsOverridesTest.php
@@ -256,27 +256,30 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 			'post_type' => [ 'product' ],
 		];
 
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$current_screen = WP_Screen::get( 'edit-comments' );
 		$filtered_args  = $method->invoke( $overrides, $original_args );
 
 		$this->assertFalse(
-			in_array( 'product', $filtered_args['post_type'] ),
+			in_array( 'product', $filtered_args['post_type'], true ),
 			'In the context of the edit-comments screen, the product post type will be removed from the comments query.'
 		);
 
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$current_screen = WP_Screen::get( 'arbitrary-admin-page' );
 		$filtered_args  = $method->invoke( $overrides, $original_args );
 
 		$this->assertTrue(
-			in_array( 'product', $filtered_args['post_type'] ),
+			in_array( 'product', $filtered_args['post_type'], true ),
 			'In the context of all other admin screens, the product post type will not be removed from the comments query.'
 		);
 
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$current_screen = null;
 		$filtered_args  = $method->invoke( $overrides, $original_args );
 
 		$this->assertTrue(
-			in_array( 'product', $filtered_args['post_type'] ),
+			in_array( 'product', $filtered_args['post_type'], true ),
 			'If the $current_screen global is not set, the product post type will not be removed from the comments query.'
 		);
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsCommentsOverridesTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/ProductReviews/ReviewsCommentsOverridesTest.php
@@ -283,7 +283,7 @@ class ReviewsCommentsOverridesTest extends WC_Unit_Test_Case {
 			'If the $current_screen global is not set, the product post type will not be removed from the comments query.'
 		);
 
-		// Clean-up.
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$current_screen = $original_screen_value;
 	}
 


### PR DESCRIPTION
Product reviews (and replies to reviews) are expected to render in two places:

- The product editor.
- The dedicated Product Reviews admin screen. 

However, following the introduction of the [Product Reviews admin screen](https://github.com/woocommerce/woocommerce/pull/32763/) (which was introduced via our 6.7.0 release), the reviews meta box within the product editor stopped working. Here is an example of what we would expect to see:

![product-editor-reviews](https://user-images.githubusercontent.com/3594411/228030382-ee8c32ed-60f8-408c-84e9-c75b0e19484d.png)

Instead, it will not currently show any reviews or replies. This seems to be an oversight, accidentally caused by code which was introduced to [remove product comments](https://github.com/woocommerce/woocommerce/pull/32763/files#diff-8de64f3eb7a11e83d379de3ceb54c451a1c1a7bde7237bfb9a3346df151fca20R38) from the main edit comments screen.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34594 #35550.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

To test this change, you will need:

1. At least one product.
    - This does not need to be anything special. Creating a simple product with a title and a price is sufficient. 
    - Reviews should be enabled globally via the **WooCommerce ‣ Settings ‣ Products** screen.
    - In relation to your test product, reviews should also be enabled from within the **Advanced** tab of the product editor's **Product Data** meta box.
3. The product should have at least one review. You can create this yourself by visiting the product page as either an admin user or a customer.
4. There should also be at least one unrelated comment: the default comment that exists for the *Hello World!* blog post, if present in your test site, is fine for this purpose.

With those things in place:

1. Visit the **Comments** screen:
    - As is normal, you should continue to regular comments (such as blog post comments) here.
    - You should **not** see any product reviews or replies to product reviews.
2. Visit the **Products ‣ Reviews** screen:
    - You should see your product reviews here.
    - You should also see any replies to product reviews.
3. Visit the **Product Editor** for your test product:
    - After a (very brief) delay, you should see that the Reviews meta box is populated with any reviews left for this product, as demonstrated in the screenshot at the top of the PR description.
    - This will only be the case when testing this branch. When testing with WooCommerce 6.7.0 upto the current stable tag, reviews will not successfully render within this meta box.

Additionally, please try all of the following (since the relevant code was touched by this change):

1. Within the product editor review meta box:
    - Replying to reviews (via the *'Add Comment'* button).
    - Quick-editing reviews and replies.
2. Within the **Products ‣ Reviews** screen:
    - Replying to reviews.
    - Quick-editing reviews and replies.

The UI should behave as expected. You should *not* see anything looking like this (notice how the second row is 'corrupted'):

![image](https://user-images.githubusercontent.com/3594411/228057046-24fbe89e-3a62-47b9-b906-77f3e59317b7.png)

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
