### PR TITLE
Move the Save draft and Preview buttons to the product editor header

### DIFF
--- a/packages/js/product-editor/changelog/add-37249
+++ b/packages/js/product-editor/changelog/add-37249
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add action buttons to the editor header

--- a/packages/js/product-editor/src/components/editor/editor.tsx
+++ b/packages/js/product-editor/src/components/editor/editor.tsx
@@ -52,6 +52,7 @@ export function Editor( { product, settings }: EditorProps ) {
 								<Header
 									productId={ product.id }
 									productName={ product.name }
+									productStatus={ product.status }
 								/>
 							}
 							content={

--- a/packages/js/product-editor/src/components/editor/editor.tsx
+++ b/packages/js/product-editor/src/components/editor/editor.tsx
@@ -48,13 +48,7 @@ export function Editor( { product, settings }: EditorProps ) {
 					<FullscreenMode isActive={ false } />
 					<SlotFillProvider>
 						<InterfaceSkeleton
-							header={
-								<Header
-									productId={ product.id }
-									productName={ product.name }
-									productStatus={ product.status }
-								/>
-							}
+							header={ <Header productName={ product.name } /> }
 							content={
 								<>
 									<BlockEditor

--- a/packages/js/product-editor/src/components/header/header.tsx
+++ b/packages/js/product-editor/src/components/header/header.tsx
@@ -113,12 +113,12 @@ export function Header( {
 				actions: [
 					{
 						label: __( 'View in store', 'woocommerce' ),
-						// Leave the url to support a11y
+						// Leave the url to support a11y.
 						url: savedProduct.permalink,
 						onClick( event: MouseEvent< HTMLAnchorElement > ) {
 							event.preventDefault();
-							// Notice actions does not support target anchor prop
-							// So this forces the page to be opened in a new tab
+							// Notice actions do not support target anchor prop,
+							// so this forces the page to be opened in a new tab.
 							window.open( savedProduct.permalink, '_blank' );
 						},
 					},

--- a/packages/js/product-editor/src/components/header/header.tsx
+++ b/packages/js/product-editor/src/components/header/header.tsx
@@ -8,6 +8,7 @@ import { createElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { navigateTo, getNewPath } from '@woocommerce/navigation';
 import { WooHeaderItem } from '@woocommerce/admin-layout';
+import { MouseEvent } from 'react';
 
 /**
  * Internal dependencies
@@ -17,7 +18,6 @@ import { MoreMenu } from './more-menu';
 import { usePreview } from './hooks/use-preview';
 import { usePublish } from './hooks/use-publish';
 import { useSaveDraft } from './hooks/use-save-draft';
-import { MouseEvent } from 'react';
 
 export type HeaderProps = {
 	productId: number;
@@ -115,7 +115,7 @@ export function Header( {
 						label: __( 'View in store', 'woocommerce' ),
 						// Leave the url to support a11y
 						url: savedProduct.permalink,
-						onClick( event: MouseEvent ) {
+						onClick( event: MouseEvent< HTMLAnchorElement > ) {
 							event.preventDefault();
 							// Notice actions does not support target anchor prop
 							// So this forces the page to be opened in a new tab

--- a/packages/js/product-editor/src/components/header/header.tsx
+++ b/packages/js/product-editor/src/components/header/header.tsx
@@ -17,6 +17,7 @@ import { MoreMenu } from './more-menu';
 import { usePreview } from './hooks/use-preview';
 import { usePublish } from './hooks/use-publish';
 import { useSaveDraft } from './hooks/use-save-draft';
+import { MouseEvent } from 'react';
 
 export type HeaderProps = {
 	productId: number;
@@ -108,15 +109,23 @@ export function Header( {
 				? __( 'Product successfully created.', 'woocommerce' )
 				: __( 'Product published.', 'woocommerce' );
 			const noticeOptions = {
+				icon: '🎉',
 				actions: [
 					{
 						label: __( 'View in store', 'woocommerce' ),
-						href: savedProduct.permalink,
+						// Leave the url to support a11y
+						url: savedProduct.permalink,
+						onClick( event: MouseEvent ) {
+							event.preventDefault();
+							// Notice actions does not support target anchor prop
+							// So this forces the page to be opened in a new tab
+							window.open( savedProduct.permalink, '_blank' );
+						},
 					},
 				],
 			};
 
-			createNotice( 'success', `🎉‎ ${ noticeContent }`, noticeOptions );
+			createNotice( 'success', noticeContent, noticeOptions );
 
 			tryRedirectToEditPage( savedProduct.id );
 		},

--- a/packages/js/product-editor/src/components/header/header.tsx
+++ b/packages/js/product-editor/src/components/header/header.tsx
@@ -73,7 +73,7 @@ export function Header( {
 	const previewButtonProps = usePreview( {
 		productId,
 		disabled: isDisabled,
-		'aria-label': __( 'Preview in new tab', 'woocommerce' ),
+		onSaveSuccess: handleSaveSuccess,
 	} );
 
 	const publishButtonProps = usePublish( {
@@ -97,9 +97,7 @@ export function Header( {
 			<div className="woocommerce-product-header__actions">
 				<Button { ...saveDraftButtonProps } />
 
-				<Button { ...previewButtonProps }>
-					{ __( 'Preview', 'woocommerce' ) }
-				</Button>
+				<Button { ...previewButtonProps } />
 
 				<Button { ...publishButtonProps }>
 					{ isCreating

--- a/packages/js/product-editor/src/components/header/header.tsx
+++ b/packages/js/product-editor/src/components/header/header.tsx
@@ -60,7 +60,7 @@ export function Header( {
 	const isDisabled = isSavingLocked || isSaving;
 	const isCreating = ( productStatus as string ) === 'auto-draft';
 
-	function tryRedirectToEditPage( id: number ) {
+	function maybeRedirectToEditPage( id: number ) {
 		if ( isCreating ) {
 			const url = getNewPath( {}, `/product/${ id }` );
 			navigateTo( { url } );
@@ -76,7 +76,7 @@ export function Header( {
 				__( 'Product saved as draft.', 'woocommerce' )
 			);
 
-			tryRedirectToEditPage( savedProduct.id );
+			maybeRedirectToEditPage( savedProduct.id );
 		},
 		onSaveError() {
 			createNotice(
@@ -90,7 +90,7 @@ export function Header( {
 		productId,
 		disabled: isDisabled,
 		onSaveSuccess( savedProduct: Product ) {
-			tryRedirectToEditPage( savedProduct.id );
+			maybeRedirectToEditPage( savedProduct.id );
 		},
 		onSaveError() {
 			createNotice(
@@ -127,7 +127,7 @@ export function Header( {
 
 			createNotice( 'success', noticeContent, noticeOptions );
 
-			tryRedirectToEditPage( savedProduct.id );
+			maybeRedirectToEditPage( savedProduct.id );
 		},
 		onPublishError() {
 			const noticeContent = isCreating

--- a/packages/js/product-editor/src/components/header/header.tsx
+++ b/packages/js/product-editor/src/components/header/header.tsx
@@ -16,8 +16,8 @@ import { MouseEvent } from 'react';
 import { getHeaderTitle } from '../../utils';
 import { MoreMenu } from './more-menu';
 import { usePublish } from './hooks/use-publish';
-import { useSaveDraft } from './hooks/use-save-draft';
 import { PreviewButton } from './preview-button';
+import { SaveDraftButton } from './save-draft-button';
 
 export type HeaderProps = {
 	productId: number;
@@ -66,25 +66,6 @@ export function Header( {
 			navigateTo( { url } );
 		}
 	}
-
-	const saveDraftButtonProps = useSaveDraft( {
-		productId,
-		disabled: isDisabled,
-		onSaveSuccess( savedProduct: Product ) {
-			createNotice(
-				'success',
-				__( 'Product saved as draft.', 'woocommerce' )
-			);
-
-			maybeRedirectToEditPage( savedProduct.id );
-		},
-		onSaveError() {
-			createNotice(
-				'error',
-				__( 'Failed to update product.', 'woocommerce' )
-			);
-		},
-	} );
 
 	const publishButtonProps = usePublish( {
 		productId,
@@ -136,7 +117,7 @@ export function Header( {
 			</h1>
 
 			<div className="woocommerce-product-header__actions">
-				<Button { ...saveDraftButtonProps } />
+				<SaveDraftButton />
 
 				<PreviewButton />
 

--- a/packages/js/product-editor/src/components/header/header.tsx
+++ b/packages/js/product-editor/src/components/header/header.tsx
@@ -13,11 +13,8 @@ import { WooHeaderItem } from '@woocommerce/admin-layout';
  * Internal dependencies
  */
 import { AUTO_DRAFT_NAME, getHeaderTitle } from '../../utils';
-
-/**
- * Internal dependencies
- */
 import { MoreMenu } from './more-menu';
+import { usePreview } from './hooks/use-preview';
 
 export type HeaderProps = {
 	productId: number;
@@ -69,6 +66,11 @@ export function Header( { productId, productName }: HeaderProps ) {
 		} );
 	}
 
+	const previewButtonProps = usePreview( {
+		productId,
+		disabled: isDisabled,
+	} );
+
 	return (
 		<div
 			className="woocommerce-product-header"
@@ -81,6 +83,8 @@ export function Header( { productId, productName }: HeaderProps ) {
 			</h1>
 
 			<div className="woocommerce-product-header__actions">
+				<Button { ...previewButtonProps } />
+
 				<Button
 					onClick={ handleSave }
 					variant="primary"

--- a/packages/js/product-editor/src/components/header/header.tsx
+++ b/packages/js/product-editor/src/components/header/header.tsx
@@ -1,109 +1,30 @@
 /**
  * External dependencies
  */
-import { Product, ProductStatus } from '@woocommerce/data';
-import { Button } from '@wordpress/components';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useEntityProp } from '@wordpress/core-data';
 import { createElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { navigateTo, getNewPath } from '@woocommerce/navigation';
 import { WooHeaderItem } from '@woocommerce/admin-layout';
-import { MouseEvent } from 'react';
 
 /**
  * Internal dependencies
  */
 import { getHeaderTitle } from '../../utils';
 import { MoreMenu } from './more-menu';
-import { usePublish } from './hooks/use-publish';
 import { PreviewButton } from './preview-button';
 import { SaveDraftButton } from './save-draft-button';
+import { PublishButton } from './publish-button';
 
 export type HeaderProps = {
-	productId: number;
 	productName: string;
-	productStatus: ProductStatus;
 };
 
-export function Header( {
-	productId,
-	productName,
-	productStatus,
-}: HeaderProps ) {
-	const { isSavingLocked, isSaving, editedProductName } = useSelect(
-		( select ) => {
-			const { isSavingEntityRecord, getEditedEntityRecord } =
-				select( 'core' );
-			const { isPostSavingLocked } = select( 'core/editor' );
-
-			const product: Product = getEditedEntityRecord(
-				'postType',
-				'product',
-				productId
-			);
-
-			return {
-				isSavingLocked: isPostSavingLocked(),
-				isSaving: isSavingEntityRecord(
-					'postType',
-					'product',
-					productId
-				),
-				editedProductName: product?.name,
-			};
-		},
-		[ productId ]
+export function Header( { productName }: HeaderProps ) {
+	const [ editedProductName ] = useEntityProp< string >(
+		'postType',
+		'product',
+		'name'
 	);
-
-	const { createNotice } = useDispatch( 'core/notices' );
-
-	const isDisabled = isSavingLocked || isSaving;
-	const isCreating = ( productStatus as string ) === 'auto-draft';
-
-	function maybeRedirectToEditPage( id: number ) {
-		if ( isCreating ) {
-			const url = getNewPath( {}, `/product/${ id }` );
-			navigateTo( { url } );
-		}
-	}
-
-	const publishButtonProps = usePublish( {
-		productId,
-		disabled: isDisabled,
-		isBusy: isSaving,
-		onPublishSuccess( savedProduct: Product ) {
-			const noticeContent = isCreating
-				? __( 'Product successfully created.', 'woocommerce' )
-				: __( 'Product published.', 'woocommerce' );
-			const noticeOptions = {
-				icon: '🎉',
-				actions: [
-					{
-						label: __( 'View in store', 'woocommerce' ),
-						// Leave the url to support a11y.
-						url: savedProduct.permalink,
-						onClick( event: MouseEvent< HTMLAnchorElement > ) {
-							event.preventDefault();
-							// Notice actions do not support target anchor prop,
-							// so this forces the page to be opened in a new tab.
-							window.open( savedProduct.permalink, '_blank' );
-						},
-					},
-				],
-			};
-
-			createNotice( 'success', noticeContent, noticeOptions );
-
-			maybeRedirectToEditPage( savedProduct.id );
-		},
-		onPublishError() {
-			const noticeContent = isCreating
-				? __( 'Failed to create product.', 'woocommerce' )
-				: __( 'Failed to publish product.', 'woocommerce' );
-
-			createNotice( 'error', noticeContent );
-		},
-	} );
 
 	return (
 		<div
@@ -121,11 +42,7 @@ export function Header( {
 
 				<PreviewButton />
 
-				<Button { ...publishButtonProps }>
-					{ isCreating
-						? __( 'Add', 'woocommerce' )
-						: __( 'Save', 'woocommerce' ) }
-				</Button>
+				<PublishButton />
 
 				<WooHeaderItem.Slot name="product" />
 				<MoreMenu />

--- a/packages/js/product-editor/src/components/header/header.tsx
+++ b/packages/js/product-editor/src/components/header/header.tsx
@@ -15,9 +15,9 @@ import { MouseEvent } from 'react';
  */
 import { getHeaderTitle } from '../../utils';
 import { MoreMenu } from './more-menu';
-import { usePreview } from './hooks/use-preview';
 import { usePublish } from './hooks/use-publish';
 import { useSaveDraft } from './hooks/use-save-draft';
+import { PreviewButton } from './preview-button';
 
 export type HeaderProps = {
 	productId: number;
@@ -86,20 +86,6 @@ export function Header( {
 		},
 	} );
 
-	const previewButtonProps = usePreview( {
-		productId,
-		disabled: isDisabled,
-		onSaveSuccess( savedProduct: Product ) {
-			maybeRedirectToEditPage( savedProduct.id );
-		},
-		onSaveError() {
-			createNotice(
-				'error',
-				__( 'Failed to preview product.', 'woocommerce' )
-			);
-		},
-	} );
-
 	const publishButtonProps = usePublish( {
 		productId,
 		disabled: isDisabled,
@@ -152,7 +138,7 @@ export function Header( {
 			<div className="woocommerce-product-header__actions">
 				<Button { ...saveDraftButtonProps } />
 
-				<Button { ...previewButtonProps } />
+				<PreviewButton />
 
 				<Button { ...publishButtonProps }>
 					{ isCreating

--- a/packages/js/product-editor/src/components/header/hooks/use-preview/index.ts
+++ b/packages/js/product-editor/src/components/header/hooks/use-preview/index.ts
@@ -1,0 +1,1 @@
+export * from './use-preview';

--- a/packages/js/product-editor/src/components/header/hooks/use-preview/use-preview.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-preview/use-preview.tsx
@@ -48,13 +48,10 @@ export function usePreview( {
 
 	const { editEntityRecord, saveEditedEntityRecord } = useDispatch( 'core' );
 
-	let previewLink: string | undefined;
+	let previewLink: URL | undefined;
 	if ( typeof permalink === 'string' ) {
-		if ( permalink.includes( '?' ) ) {
-			previewLink = `${ permalink }&preview=true`;
-		} else {
-			previewLink = `${ permalink }?preview=true`;
-		}
+		previewLink = new URL( permalink );
+		previewLink.searchParams.append( 'preview', 'true' );
 	}
 
 	/**
@@ -117,7 +114,7 @@ export function usePreview( {
 		'aria-disabled': disabled,
 		// Note that the href is always passed for a11y support. So
 		// the final rendered element is always an anchor.
-		href: previewLink,
+		href: previewLink?.toString(),
 		variant: 'tertiary',
 		onClick: handleClick,
 	};

--- a/packages/js/product-editor/src/components/header/hooks/use-preview/use-preview.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-preview/use-preview.tsx
@@ -67,10 +67,11 @@ export function usePreview( {
 	async function handleClick( event: MouseEvent< HTMLAnchorElement > ) {
 		if ( typeof onClick === 'function' ) onClick( event );
 
-		// Prevent an infinite recursion call due to `anchorRef.current?.click()`
+		// Prevent an infinite recursion call due to the
+		// `anchorRef.current?.click()` call.
 		if ( ! hasEdits ) return;
 
-		// Prevent the normal anchor behaviour
+		// Prevent the default anchor behaviour.
 		event.preventDefault();
 
 		try {
@@ -90,8 +91,8 @@ export function usePreview( {
 				productId
 			);
 
-			// Redirect using the default anchor behaviour. This way the usage
-			// of window.open is avoided which comes with a some edge cases.
+			// Redirect using the default anchor behaviour. This way, the usage
+			// of `window.open` is avoided which comes with some edge cases.
 			anchorRef.current?.click();
 
 			if ( typeof onSaveSuccess === 'function' ) {

--- a/packages/js/product-editor/src/components/header/hooks/use-preview/use-preview.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-preview/use-preview.tsx
@@ -4,7 +4,6 @@
 import { Product } from '@woocommerce/data';
 import { Button } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
 
 export function usePreview( {
 	productId,
@@ -40,8 +39,6 @@ export function usePreview( {
 	}
 
 	return {
-		'aria-label': __( 'Preview in new tab', 'woocommerce' ),
-		children: __( 'Preview', 'woocommerce' ),
 		target: '_blank',
 		...props,
 		'aria-disabled': disabled || isDisabled,

--- a/packages/js/product-editor/src/components/header/hooks/use-preview/use-preview.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-preview/use-preview.tsx
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import { Product } from '@woocommerce/data';
+import { Button } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+
+export function usePreview( {
+	productId,
+	disabled,
+	...props
+}: Omit< Button.AnchorProps, 'variant' | 'href' > & {
+	productId: number;
+} ): Button.AnchorProps {
+	const { permalink, isDisabled } = useSelect(
+		( select ) => {
+			const { getEditedEntityRecord } = select( 'core' );
+			const product = getEditedEntityRecord< Product | undefined >(
+				'postType',
+				'product',
+				productId
+			);
+
+			return {
+				permalink: product?.permalink,
+				isDisabled: ( product?.status as string ) === 'auto-draft',
+			};
+		},
+		[ productId ]
+	);
+
+	let previewLink: string | undefined;
+	if ( typeof permalink === 'string' ) {
+		if ( permalink.includes( '?' ) ) {
+			previewLink = `${ permalink }&preview=true`;
+		} else {
+			previewLink = `${ permalink }?preview=true`;
+		}
+	}
+
+	return {
+		'aria-label': __( 'Preview in new tab', 'woocommerce' ),
+		children: __( 'Preview', 'woocommerce' ),
+		target: '_blank',
+		...props,
+		'aria-disabled': disabled || isDisabled,
+		href: previewLink,
+		variant: 'tertiary',
+	};
+}

--- a/packages/js/product-editor/src/components/header/hooks/use-preview/use-preview.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-preview/use-preview.tsx
@@ -3,18 +3,30 @@
  */
 import { Product } from '@woocommerce/data';
 import { Button } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useRef } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { MouseEvent } from 'react';
 
 export function usePreview( {
 	productId,
 	disabled,
+	onClick,
+	onSaveSuccess,
+	onSaveError,
 	...props
-}: Omit< Button.AnchorProps, 'variant' | 'href' > & {
+}: Omit< Button.AnchorProps, 'aria-disabled' | 'variant' | 'href' > & {
 	productId: number;
+	onSaveSuccess?( product: Product ): void;
+	onSaveError?( error: Error ): void;
 } ): Button.AnchorProps {
-	const { permalink, isDisabled } = useSelect(
+	const anchorRef = useRef< HTMLAnchorElement >();
+
+	const { permalink, productStatus, hasEdits } = useSelect(
 		( select ) => {
-			const { getEditedEntityRecord } = select( 'core' );
+			const { getEditedEntityRecord, hasEditsForEntityRecord } =
+				select( 'core' );
+
 			const product = getEditedEntityRecord< Product | undefined >(
 				'postType',
 				'product',
@@ -23,11 +35,18 @@ export function usePreview( {
 
 			return {
 				permalink: product?.permalink,
-				isDisabled: ( product?.status as string ) === 'auto-draft',
+				productStatus: product?.status,
+				hasEdits: hasEditsForEntityRecord< boolean >(
+					'postType',
+					'product',
+					productId
+				),
 			};
 		},
 		[ productId ]
 	);
+
+	const { editEntityRecord, saveEditedEntityRecord } = useDispatch( 'core' );
 
 	let previewLink: string | undefined;
 	if ( typeof permalink === 'string' ) {
@@ -38,11 +57,67 @@ export function usePreview( {
 		}
 	}
 
+	/**
+	 * Overrides the default anchor behaviour when the product has unsaved changes.
+	 * Before redirecting to the preview page all changes are saved and then the
+	 * redirection is performed.
+	 *
+	 * @param event
+	 */
+	async function handleClick( event: MouseEvent< HTMLAnchorElement > ) {
+		if ( typeof onClick === 'function' ) onClick( event );
+
+		// Prevent an infinite recursion call due to `anchorRef.current?.click()`
+		if ( ! hasEdits ) return;
+
+		// Prevent the normal anchor behaviour
+		event.preventDefault();
+
+		try {
+			// If the product status is `auto-draft` it's not possible to
+			// reach the preview page, so the status is changed to `draft`
+			// before redirecting.
+			if ( ( productStatus as string ) === 'auto-draft' ) {
+				await editEntityRecord( 'postType', 'product', productId, {
+					status: 'draft',
+				} );
+			}
+
+			// Persist the product changes before redirecting
+			const publishedProduct = await saveEditedEntityRecord< Product >(
+				'postType',
+				'product',
+				productId
+			);
+
+			// Redirect using the default anchor behaviour. This way the usage
+			// of window.open is avoided which comes with a some edge cases.
+			anchorRef.current?.click();
+
+			if ( typeof onSaveSuccess === 'function' ) {
+				onSaveSuccess( publishedProduct );
+			}
+		} catch ( error ) {
+			if ( typeof onSaveError === 'function' ) {
+				onSaveError( error as Error );
+			}
+		}
+	}
+
 	return {
+		'aria-label': __( 'Preview in new tab', 'woocommerce' ),
+		children: __( 'Preview', 'woocommerce' ),
 		target: '_blank',
 		...props,
-		'aria-disabled': disabled || isDisabled,
+		ref( element: HTMLAnchorElement ) {
+			if ( typeof props.ref === 'function' ) props.ref( element );
+			anchorRef.current = element;
+		},
+		'aria-disabled': disabled,
+		// Note that the href is always passed for a11y support. So
+		// the final rendered element is always an anchor.
 		href: previewLink,
 		variant: 'tertiary',
+		onClick: handleClick,
 	};
 }

--- a/packages/js/product-editor/src/components/header/hooks/use-publish/index.ts
+++ b/packages/js/product-editor/src/components/header/hooks/use-publish/index.ts
@@ -1,0 +1,1 @@
+export * from './use-publish';

--- a/packages/js/product-editor/src/components/header/hooks/use-publish/use-publish.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-publish/use-publish.tsx
@@ -16,15 +16,25 @@ export function usePublish( {
 	onPublishSuccess?( product: Product ): void;
 	onPublishError?( error: Error ): void;
 } ): Button.ButtonProps {
-	const hasEdits = useSelect(
+	const { productStatus, hasEdits } = useSelect(
 		( select ) => {
-			const { hasEditsForEntityRecord } = select( 'core' );
+			const { getEditedEntityRecord, hasEditsForEntityRecord } =
+				select( 'core' );
 
-			return hasEditsForEntityRecord< boolean >(
+			const product = getEditedEntityRecord< Product >(
 				'postType',
 				'product',
 				productId
 			);
+
+			return {
+				productStatus: product?.status,
+				hasEdits: hasEditsForEntityRecord< boolean >(
+					'postType',
+					'product',
+					productId
+				),
+			};
 		},
 		[ productId ]
 	);
@@ -54,7 +64,8 @@ export function usePublish( {
 
 	return {
 		...props,
-		'aria-disabled': disabled || ! hasEdits,
+		'aria-disabled':
+			disabled || ( productStatus === 'publish' && ! hasEdits ),
 		variant: 'primary',
 		onClick: handleClick,
 	};

--- a/packages/js/product-editor/src/components/header/hooks/use-publish/use-publish.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-publish/use-publish.tsx
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import { Product } from '@woocommerce/data';
+import { Button } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+
+export function usePublish( {
+	productId,
+	disabled,
+	onPublishSuccess,
+	onPublishError,
+	...props
+}: Omit< Button.ButtonProps, 'variant' | 'onClick' > & {
+	productId: number;
+	onPublishSuccess( product: Product ): void;
+	onPublishError?( error: Error ): void;
+} ): Button.ButtonProps {
+	const { editEntityRecord, saveEditedEntityRecord } = useDispatch( 'core' );
+
+	async function handleClick() {
+		try {
+			await editEntityRecord( 'postType', 'product', productId, {
+				status: 'publish',
+			} );
+			const publishedProduct = await saveEditedEntityRecord< Product >(
+				'postType',
+				'product',
+				productId
+			);
+
+			if ( typeof onPublishSuccess === 'function' ) {
+				onPublishSuccess( publishedProduct );
+			}
+		} catch ( error ) {
+			if ( typeof onPublishError === 'function' ) {
+				onPublishError( error as Error );
+			}
+		}
+	}
+
+	return {
+		...props,
+		'aria-disabled': disabled,
+		variant: 'primary',
+		onClick: handleClick,
+	};
+}

--- a/packages/js/product-editor/src/components/header/hooks/use-publish/use-publish.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-publish/use-publish.tsx
@@ -3,7 +3,7 @@
  */
 import { Product } from '@woocommerce/data';
 import { Button } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 export function usePublish( {
 	productId,
@@ -13,9 +13,22 @@ export function usePublish( {
 	...props
 }: Omit< Button.ButtonProps, 'variant' | 'onClick' > & {
 	productId: number;
-	onPublishSuccess( product: Product ): void;
+	onPublishSuccess?( product: Product ): void;
 	onPublishError?( error: Error ): void;
 } ): Button.ButtonProps {
+	const hasEdits = useSelect(
+		( select ) => {
+			const { hasEditsForEntityRecord } = select( 'core' );
+
+			return hasEditsForEntityRecord< boolean >(
+				'postType',
+				'product',
+				productId
+			);
+		},
+		[ productId ]
+	);
+
 	const { editEntityRecord, saveEditedEntityRecord } = useDispatch( 'core' );
 
 	async function handleClick() {
@@ -41,7 +54,7 @@ export function usePublish( {
 
 	return {
 		...props,
-		'aria-disabled': disabled,
+		'aria-disabled': disabled || ! hasEdits,
 		variant: 'primary',
 		onClick: handleClick,
 	};

--- a/packages/js/product-editor/src/components/header/hooks/use-publish/use-publish.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-publish/use-publish.tsx
@@ -43,9 +43,15 @@ export function usePublish( {
 
 	async function handleClick() {
 		try {
-			await editEntityRecord( 'postType', 'product', productId, {
-				status: 'publish',
-			} );
+			// The publish button click not only change the status of the product
+			// but also save all the pending changes. So even if the status is
+			// publish it's possible to save the product too.
+			if ( productStatus !== 'publish' ) {
+				await editEntityRecord( 'postType', 'product', productId, {
+					status: 'publish',
+				} );
+			}
+
 			const publishedProduct = await saveEditedEntityRecord< Product >(
 				'postType',
 				'product',

--- a/packages/js/product-editor/src/components/header/hooks/use-save-draft/index.ts
+++ b/packages/js/product-editor/src/components/header/hooks/use-save-draft/index.ts
@@ -1,0 +1,1 @@
+export * from './use-save-draft';

--- a/packages/js/product-editor/src/components/header/hooks/use-save-draft/use-save-draft.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-save-draft/use-save-draft.tsx
@@ -1,0 +1,94 @@
+/**
+ * External dependencies
+ */
+import { Product } from '@woocommerce/data';
+import { Button, Icon } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { check } from '@wordpress/icons';
+import { createElement, Fragment } from '@wordpress/element';
+
+export function useSaveDraft( {
+	productId,
+	disabled,
+	onSaveSuccess,
+	onSaveError,
+	...props
+}: Omit< Button.ButtonProps, 'variant' | 'onClick' > & {
+	productId: number;
+	onSaveSuccess?( product: Product ): void;
+	onSaveError?( error: Error ): void;
+} ): Button.ButtonProps {
+	const { productStatus, hasEdits } = useSelect(
+		( select ) => {
+			const { getEditedEntityRecord, hasEditsForEntityRecord } =
+				select( 'core' );
+
+			const product = getEditedEntityRecord< Product | undefined >(
+				'postType',
+				'product',
+				productId
+			);
+
+			const hasEdits = hasEditsForEntityRecord< boolean >(
+				'postType',
+				'product',
+				productId
+			);
+
+			return {
+				productStatus: product?.status,
+				hasEdits,
+			};
+		},
+		[ productId ]
+	);
+
+	const { editEntityRecord, saveEditedEntityRecord } = useDispatch( 'core' );
+
+	async function handleClick() {
+		try {
+			await editEntityRecord( 'postType', 'product', productId, {
+				status: 'draft',
+			} );
+			const publishedProduct = await saveEditedEntityRecord< Product >(
+				'postType',
+				'product',
+				productId
+			);
+
+			if ( typeof onSaveSuccess === 'function' ) {
+				onSaveSuccess( publishedProduct );
+			}
+		} catch ( error ) {
+			if ( typeof onSaveError === 'function' ) {
+				onSaveError( error as Error );
+			}
+		}
+	}
+
+	let children;
+	if ( productStatus === 'publish' ) {
+		children = __( 'Switch to draft', 'woocommerce' );
+	} else {
+		if ( hasEdits ) {
+			children = __( 'Save draft', 'woocommerce' );
+		} else {
+			children = (
+				<>
+					<Icon icon={ check } />
+					{ __( 'Saved', 'woocommerce' ) }
+				</>
+			);
+		}
+	}
+
+	return {
+		children,
+		...props,
+		'aria-disabled':
+			disabled || ( productStatus !== 'publish' && ! hasEdits ),
+		variant: 'tertiary',
+		onClick: handleClick,
+	};
+}

--- a/packages/js/product-editor/src/components/header/hooks/use-save-draft/use-save-draft.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-save-draft/use-save-draft.tsx
@@ -30,15 +30,13 @@ export function useSaveDraft( {
 				productId
 			);
 
-			const hasEdits = hasEditsForEntityRecord< boolean >(
-				'postType',
-				'product',
-				productId
-			);
-
 			return {
 				productStatus: product?.status,
-				hasEdits,
+				hasEdits: hasEditsForEntityRecord< boolean >(
+					'postType',
+					'product',
+					productId
+				),
 			};
 		},
 		[ productId ]
@@ -70,17 +68,15 @@ export function useSaveDraft( {
 	let children;
 	if ( productStatus === 'publish' ) {
 		children = __( 'Switch to draft', 'woocommerce' );
+	} else if ( hasEdits ) {
+		children = __( 'Save draft', 'woocommerce' );
 	} else {
-		if ( hasEdits ) {
-			children = __( 'Save draft', 'woocommerce' );
-		} else {
-			children = (
-				<>
-					<Icon icon={ check } />
-					{ __( 'Saved', 'woocommerce' ) }
-				</>
-			);
-		}
+		children = (
+			<>
+				<Icon icon={ check } />
+				{ __( 'Saved', 'woocommerce' ) }
+			</>
+		);
 	}
 
 	return {

--- a/packages/js/product-editor/src/components/header/preview-button/index.ts
+++ b/packages/js/product-editor/src/components/header/preview-button/index.ts
@@ -1,0 +1,1 @@
+export * from './preview-button';

--- a/packages/js/product-editor/src/components/header/preview-button/preview-button.tsx
+++ b/packages/js/product-editor/src/components/header/preview-button/preview-button.tsx
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import { Product, ProductStatus } from '@woocommerce/data';
+import { getNewPath, navigateTo } from '@woocommerce/navigation';
+import { Button } from '@wordpress/components';
+import { useEntityProp } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
+import { createElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { usePreview } from '../hooks/use-preview';
+
+export function PreviewButton( {
+	...props
+}: Omit<
+	Button.AnchorProps,
+	'aria-disabled' | 'variant' | 'href' | 'children'
+> ) {
+	const [ productStatus ] = useEntityProp< ProductStatus | 'auto-draft' >(
+		'postType',
+		'product',
+		'status'
+	);
+
+	const { createErrorNotice } = useDispatch( 'core/notices' );
+
+	const previewButtonProps = usePreview( {
+		...props,
+		onSaveSuccess( savedProduct: Product ) {
+			if ( productStatus === 'auto-draft' ) {
+				const url = getNewPath( {}, `/product/${ savedProduct.id }` );
+				navigateTo( { url } );
+			}
+		},
+		onSaveError() {
+			createErrorNotice(
+				__( 'Failed to preview product.', 'woocommerce' )
+			);
+		},
+	} );
+
+	return <Button { ...previewButtonProps } />;
+}

--- a/packages/js/product-editor/src/components/header/publish-button/index.ts
+++ b/packages/js/product-editor/src/components/header/publish-button/index.ts
@@ -1,0 +1,1 @@
+export * from './publish-button';

--- a/packages/js/product-editor/src/components/header/publish-button/publish-button.tsx
+++ b/packages/js/product-editor/src/components/header/publish-button/publish-button.tsx
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import { Product, ProductStatus } from '@woocommerce/data';
+import { getNewPath, navigateTo } from '@woocommerce/navigation';
+import { Button } from '@wordpress/components';
+import { useEntityProp } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
+import { createElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { MouseEvent } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { usePublish } from '../hooks/use-publish';
+
+export function PublishButton(
+	props: Omit< Button.ButtonProps, 'aria-disabled' | 'variant' | 'children' >
+) {
+	const [ productStatus ] = useEntityProp< ProductStatus | 'auto-draft' >(
+		'postType',
+		'product',
+		'status'
+	);
+
+	const isCreating = productStatus === 'auto-draft';
+
+	const { createSuccessNotice, createErrorNotice } =
+		useDispatch( 'core/notices' );
+
+	const publishButtonProps = usePublish( {
+		...props,
+		onPublishSuccess( savedProduct: Product ) {
+			const noticeContent = isCreating
+				? __( 'Product successfully created.', 'woocommerce' )
+				: __( 'Product published.', 'woocommerce' );
+			const noticeOptions = {
+				icon: '🎉',
+				actions: [
+					{
+						label: __( 'View in store', 'woocommerce' ),
+						// Leave the url to support a11y.
+						url: savedProduct.permalink,
+						onClick( event: MouseEvent< HTMLAnchorElement > ) {
+							event.preventDefault();
+							// Notice actions do not support target anchor prop,
+							// so this forces the page to be opened in a new tab.
+							window.open( savedProduct.permalink, '_blank' );
+						},
+					},
+				],
+			};
+
+			createSuccessNotice( noticeContent, noticeOptions );
+
+			if ( productStatus === 'auto-draft' ) {
+				const url = getNewPath( {}, `/product/${ savedProduct.id }` );
+				navigateTo( { url } );
+			}
+		},
+		onPublishError() {
+			const noticeContent = isCreating
+				? __( 'Failed to create product.', 'woocommerce' )
+				: __( 'Failed to publish product.', 'woocommerce' );
+
+			createErrorNotice( noticeContent );
+		},
+	} );
+
+	return <Button { ...publishButtonProps } />;
+}

--- a/packages/js/product-editor/src/components/header/save-draft-button/index.ts
+++ b/packages/js/product-editor/src/components/header/save-draft-button/index.ts
@@ -1,0 +1,1 @@
+export * from './save-draft-button';

--- a/packages/js/product-editor/src/components/header/save-draft-button/save-draft-button.tsx
+++ b/packages/js/product-editor/src/components/header/save-draft-button/save-draft-button.tsx
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import { Product, ProductStatus } from '@woocommerce/data';
+import { getNewPath, navigateTo } from '@woocommerce/navigation';
+import { Button } from '@wordpress/components';
+import { useEntityProp } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
+import { createElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { useSaveDraft } from '../hooks/use-save-draft';
+
+export function SaveDraftButton(
+	props: Omit< Button.ButtonProps, 'aria-disabled' | 'variant' | 'children' >
+) {
+	const [ productStatus ] = useEntityProp< ProductStatus | 'auto-draft' >(
+		'postType',
+		'product',
+		'status'
+	);
+
+	const { createSuccessNotice, createErrorNotice } =
+		useDispatch( 'core/notices' );
+
+	const saveDraftButtonProps = useSaveDraft( {
+		...props,
+		onSaveSuccess( savedProduct: Product ) {
+			createSuccessNotice(
+				__( 'Product saved as draft.', 'woocommerce' )
+			);
+
+			if ( productStatus === 'auto-draft' ) {
+				const url = getNewPath( {}, `/product/${ savedProduct.id }` );
+				navigateTo( { url } );
+			}
+		},
+		onSaveError() {
+			createErrorNotice(
+				__( 'Failed to update product.', 'woocommerce' )
+			);
+		},
+	} );
+
+	return <Button { ...saveDraftButtonProps } />;
+}

--- a/plugins/woocommerce-admin/client/stylesheets/shared/_global.scss
+++ b/plugins/woocommerce-admin/client/stylesheets/shared/_global.scss
@@ -61,7 +61,7 @@
 
 body.woocommerce-page {
 	.components-button.is-primary {
-		&:not(:disabled) {
+		&:not(:disabled):not([aria-disabled='true']):hover {
 			color: $studio-white;
 		}
 	}

--- a/plugins/woocommerce/changelog/add-37249
+++ b/plugins/woocommerce/changelog/add-37249
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix global button aria-disabled style


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/37249

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Got to `/wp-admin/tools.php?page=woocommerce-admin-test-helper`
2. Under `Features` tab make sure to enable `block-editor-feature-enabled`
3. Then visit `/wp-admin/admin.php?page=wc-admin&path=/add-product`
4. The preview button should open a new tab with the frontend preview
5. The "Save" button should say "Save" for existing products and "Add" for new products (auto-drafts), but should publish the product
6. The "Save draft" should follow the Gutenberg post format, say Save draft if edited and draft status, show Switch to draft if published, show Saved if draft and saved (no edits).

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [ ] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
