### PR TITLE
Revert "Replace $.ajax() calls with browser-native window.fetch() calls."

### DIFF
--- a/plugins/woocommerce/changelog/revert-36275-trunk
+++ b/plugins/woocommerce/changelog/revert-36275-trunk
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Revert changes to use window.fetch in legacy cart JS

--- a/plugins/woocommerce/client/legacy/js/frontend/add-to-cart-variation.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/add-to-cart-variation.js
@@ -167,16 +167,16 @@
 
 		if ( attributes.count && attributes.count === attributes.chosenCount ) {
 			if ( form.useAjax ) {
-				if ( form.controller ) {
-					form.controller.abort();
+				if ( form.xhr ) {
+					form.xhr.abort();
 				}
 				form.$form.block( { message: null, overlayCSS: { background: '#fff', opacity: 0.6 } } );
 				currentAttributes.product_id  = parseInt( form.$form.data( 'product_id' ), 10 );
 				currentAttributes.custom_data = form.$form.data( 'custom_data' );
-				const options                 = {
+				form.xhr                      = $.ajax( {
 					url: wc_add_to_cart_variation_params.wc_ajax_url.toString().replace( '%%endpoint%%', 'get_variation' ),
 					type: 'POST',
-					data: $.param( currentAttributes ),
+					data: currentAttributes,
 					success: function( variation ) {
 						if ( variation ) {
 							form.$form.trigger( 'found_variation', [ variation ] );
@@ -199,25 +199,7 @@
 					complete: function() {
 						form.$form.unblock();
 					}
-				};
-
-				const controller = new AbortController();
-				form.controller = controller;
-
-				window.fetch( options.url, {
-					method: options.type,
-					headers: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8' },
-					body: options.data,
-					signal: controller.signal
-				} )
-					.then( response => {
-						if ( !response.ok ) {
-							throw new Error( response.statusText );
-						}
-						return response.json();
-					})
-					.then( options.success )
-					.finally( () => options.complete() );
+				} );
 			} else {
 				form.$form.trigger( 'update_variation_values' );
 

--- a/plugins/woocommerce/client/legacy/js/frontend/add-to-cart.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/add-to-cart.js
@@ -51,21 +51,7 @@ jQuery( function( $ ) {
 			}
 		};
 
-		const options = this.requests[0];
-		window.fetch( options.url, {
-			method: options.type,
-			headers: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8' },
-			body: options.data
-		} )
-			.then( response => {
-				if ( !response.ok ) {
-					throw new Error( response.statusText );
-				}
-				return response.json();
-			} )
-			.then( options.success )
-			.catch( error => options.error && options.error() )
-			.finally( () => options.complete && options.complete() );
+		$.ajax( this.requests[0] );
 	};
 
 	/**
@@ -109,7 +95,7 @@ jQuery( function( $ ) {
 			e.data.addToCartHandler.addRequest({
 				type: 'POST',
 				url: wc_add_to_cart_params.wc_ajax_url.toString().replace( '%%endpoint%%', 'add_to_cart' ),
-				data: $.param( data ),
+				data: data,
 				success: function( response ) {
 					if ( ! response ) {
 						return;
@@ -153,9 +139,9 @@ jQuery( function( $ ) {
 		e.data.addToCartHandler.addRequest({
 			type: 'POST',
 			url: wc_add_to_cart_params.wc_ajax_url.toString().replace( '%%endpoint%%', 'remove_from_cart' ),
-			data: new URLSearchParams( {
+			data: {
 				cart_item_key : $thisbutton.data( 'cart_item_key' )
-			} ).toString(),
+			},
 			success: function( response ) {
 				if ( ! response || ! response.fragments ) {
 					window.location = $thisbutton.attr( 'href' );

--- a/plugins/woocommerce/client/legacy/js/frontend/cart-fragments.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/cart-fragments.js
@@ -38,9 +38,9 @@ jQuery( function( $ ) {
 	var $fragment_refresh = {
 		url: wc_cart_fragments_params.wc_ajax_url.toString().replace( '%%endpoint%%', 'get_refreshed_fragments' ),
 		type: 'POST',
-		data: new URLSearchParams( {
+		data: {
 			time: new Date().getTime()
-		} ).toString(),
+		},
 		timeout: wc_cart_fragments_params.request_timeout,
 		success: function( data ) {
 			if ( data && data.fragments ) {
@@ -68,25 +68,7 @@ jQuery( function( $ ) {
 
 	/* Named callback for refreshing cart fragment */
 	function refresh_cart_fragment() {
-		const controller = new AbortController();
-		const timeoutId = setTimeout( () => controller.abort(), $fragment_refresh.timeout );
-
-		window.fetch( $fragment_refresh.url, {
-			method: $fragment_refresh.type,
-			headers: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8' },
-			body: $fragment_refresh.data,
-			signal: controller.signal
-		} )
-			.then( response => {
-				clearTimeout( timeoutId );
-
-				if ( !response.ok ) {
-					throw new Error( response.statusText );
-				}
-				return response.json();
-			} )
-			.then( $fragment_refresh.success )
-			.catch( error => $fragment_refresh.error() );
+		$.ajax( $fragment_refresh );
 	}
 
 	/* Cart Handling */

--- a/plugins/woocommerce/client/legacy/js/frontend/cart.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/cart.js
@@ -9,27 +9,6 @@ jQuery( function( $ ) {
 	// Utility functions for the file.
 
 	/**
-	 * Perform an AJAX request that expects an HTML response.
-	 *
-	 * @param {Object} options
-	 */
-	const ajax = options => {
-		window.fetch( options.url, {
-			method: options.type || 'GET',
-			headers: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8' },
-			body: options.data
-		} )
-			.then( response => {
-				if ( !response.ok ) {
-					throw new Error( response.statusText );
-				}
-				return response.text();
-			} )
-			.then( options.success )
-			.finally( () => options.complete() );
-	};
-
-	/**
 	 * Gets a url for a given AJAX endpoint.
 	 *
 	 * @param {String} endpoint The AJAX Endpoint
@@ -243,17 +222,13 @@ jQuery( function( $ ) {
 
 			var data = {
 				security: wc_cart_params.update_shipping_method_nonce,
+				shipping_method: shipping_methods
 			};
 
-			// Flatten shipping_methods for use in URLSearchParams()
-			for ( var k in shipping_methods ) {
-				data[ 'shipping_method[' + k + ']' ] = shipping_methods[ k ];
-			}
-
-			ajax( {
+			$.ajax( {
 				type:     'post',
 				url:      get_url( 'update_shipping_method' ),
-				data:     new URLSearchParams( data ).toString(),
+				data:     data,
 				dataType: 'html',
 				success:  function( response ) {
 					update_cart_totals_div( response );
@@ -285,10 +260,10 @@ jQuery( function( $ ) {
 							.appendTo( $form );
 
 			// Make call to actual form post URL.
-			ajax( {
+			$.ajax( {
 				type:     $form.attr( 'method' ),
 				url:      $form.attr( 'action' ),
-				data:     new URLSearchParams( new FormData( $form[0] ) ).toString(),
+				data:     $form.serialize(),
 				dataType: 'html',
 				success:  function( response ) {
 					update_wc_div( response );
@@ -372,10 +347,10 @@ jQuery( function( $ ) {
 			block( $( 'div.cart_totals' ) );
 
 			// Make call to actual form post URL.
-			ajax( {
+			$.ajax( {
 				type:     $form.attr( 'method' ),
 				url:      $form.attr( 'action' ),
-				data:     new URLSearchParams( new FormData( $form[0] ) ).toString(),
+				data:     $form.serialize(),
 				dataType: 'html',
 				success:  function( response ) {
 					update_wc_div( response, preserve_notices );
@@ -394,7 +369,7 @@ jQuery( function( $ ) {
 		update_cart_totals: function() {
 			block( $( 'div.cart_totals' ) );
 
-			ajax( {
+			$.ajax( {
 				url:      get_url( 'get_cart_totals' ),
 				dataType: 'html',
 				success:  function( response ) {
@@ -496,10 +471,10 @@ jQuery( function( $ ) {
 				coupon_code: coupon_code
 			};
 
-			ajax( {
+			$.ajax( {
 				type:     'POST',
 				url:      get_url( 'apply_coupon' ),
-				data:     new URLSearchParams( data ).toString(),
+				data:     data,
 				dataType: 'html',
 				success: function( response ) {
 					$( '.woocommerce-error, .woocommerce-message, .woocommerce-info' ).remove();
@@ -533,10 +508,10 @@ jQuery( function( $ ) {
 				coupon: coupon
 			};
 
-			ajax( {
+			$.ajax( {
 				type:    'POST',
 				url:      get_url( 'remove_coupon' ),
-				data:     new URLSearchParams( data ).toString(),
+				data:     data,
 				dataType: 'html',
 				success: function( response ) {
 					$( '.woocommerce-error, .woocommerce-message, .woocommerce-info' ).remove();
@@ -566,10 +541,10 @@ jQuery( function( $ ) {
 							.appendTo( $form );
 
 			// Make call to actual form post URL.
-			ajax( {
+			$.ajax( {
 				type:     $form.attr( 'method' ),
 				url:      $form.attr( 'action' ),
-				data:     new URLSearchParams( new FormData( $form[0] ) ).toString(),
+				data:     $form.serialize(),
 				dataType: 'html',
 				success:  function( response ) {
 					update_wc_div( response );
@@ -596,7 +571,7 @@ jQuery( function( $ ) {
 			block( $form );
 			block( $( 'div.cart_totals' ) );
 
-			ajax( {
+			$.ajax( {
 				type:     'GET',
 				url:      $a.attr( 'href' ),
 				dataType: 'html',
@@ -625,7 +600,7 @@ jQuery( function( $ ) {
 			block( $form );
 			block( $( 'div.cart_totals' ) );
 
-			ajax( {
+			$.ajax( {
 				type:     'GET',
 				url:      $a.attr( 'href' ),
 				dataType: 'html',

--- a/plugins/woocommerce/client/legacy/js/frontend/geolocation.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/geolocation.js
@@ -127,17 +127,7 @@ jQuery( function( $ ) {
 	// Get the current geo hash. If it doesn't exist, or if it doesn't match the current
 	// page URL, perform a geolocation request.
 	if ( ! get_geo_hash() || needs_refresh() ) {
-		window.fetch( $geolocate_customer.url, {
-			method: $geolocate_customer.type,
-			headers: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8' }
-		} )
-		.then( response => {
-			if ( !response.ok ) {
-				throw new Error( response.statusText );
-			}
-			return response.json();
-		} )
-		.then( $geolocate_customer.success );
+		$.ajax( $geolocate_customer );
 	}
 
 	// Page updates.


### PR DESCRIPTION
After some discussion, we've decided the best path forward for now is to revert this PR.

It's been brought to my attention that it's probably safer for us to leave the legacy JS for now, as those wanting a modern solution can employ blocks to do all the work done by the legacy JS. While I don't think that entirely solves the problem I do think we should be pragmatic and reduce risk.

I'll explore whether this warrants a fix release for 7.5.

Reverts woocommerce/woocommerce#36275

### Testing Instructions

Please follow the reproduction steps from https://github.com/woocommerce/woocommerce/issues/37371 which is the first place problems with this change were surfaced.