### PR TITLE
Enable linting with phpcs-changed locally

### DIFF
--- a/plugins/woocommerce/bin/composer/phpcs/composer.json
+++ b/plugins/woocommerce/bin/composer/phpcs/composer.json
@@ -1,7 +1,7 @@
 {
 	"require-dev": {
 		"woocommerce/woocommerce-sniffs": "^0.1.3",
-		"sirbrillig/phpcs-changed": "^2.10"
+		"sirbrillig/phpcs-changed": "^2.10.2"
 	},
 	"config": {
 		"platform": {

--- a/plugins/woocommerce/bin/composer/phpcs/composer.lock
+++ b/plugins/woocommerce/bin/composer/phpcs/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4df582a159fa9e6987962ca1917bb00c",
+    "content-hash": "29a05e32698301ded5eeb893b4c22b90",
     "packages": [],
     "packages-dev": [
         {
@@ -258,16 +258,16 @@
         },
         {
             "name": "sirbrillig/phpcs-changed",
-            "version": "v2.10.1",
+            "version": "v2.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sirbrillig/phpcs-changed.git",
-                "reference": "a5c3be6ec84395b168e7deadf8b167e50449e7a3"
+                "reference": "ba0432bc86ffdc31a6946117be6c2419b7e3e16d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sirbrillig/phpcs-changed/zipball/a5c3be6ec84395b168e7deadf8b167e50449e7a3",
-                "reference": "a5c3be6ec84395b168e7deadf8b167e50449e7a3",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-changed/zipball/ba0432bc86ffdc31a6946117be6c2419b7e3e16d",
+                "reference": "ba0432bc86ffdc31a6946117be6c2419b7e3e16d",
                 "shasum": ""
             },
             "require": {
@@ -308,9 +308,9 @@
             "description": "Run phpcs on files, but only report warnings/errors from lines which were changed.",
             "support": {
                 "issues": "https://github.com/sirbrillig/phpcs-changed/issues",
-                "source": "https://github.com/sirbrillig/phpcs-changed/tree/v2.10.1"
+                "source": "https://github.com/sirbrillig/phpcs-changed/tree/v2.10.2"
             },
-            "time": "2023-01-25T17:08:01+00:00"
+            "time": "2023-03-25T15:10:31+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",

--- a/plugins/woocommerce/changelog/update-phpcs-changed
+++ b/plugins/woocommerce/changelog/update-phpcs-changed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add composer scripts for linting with phpcs-changed

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -88,8 +88,11 @@
 		"phpcs": [
 			"phpcs -s -p"
 		],
-		"phpcs-pre-commit": [
-			"phpcs-changed --git -s"
+		"lint": [
+			"chg=$(git diff --relative --name-only -- '*.php'); [ -z $chg ] || phpcs-changed -s --git --git-unstaged $chg"
+		],
+		"lint-staged": [
+			"chg=$(git diff HEAD --relative --name-only -- '*.php'); [ -z $chg ] || phpcs-changed -s --git $chg"
 		],
 		"phpcbf": [
 			"phpcbf -p"

--- a/plugins/woocommerce/package.json
+++ b/plugins/woocommerce/package.json
@@ -98,7 +98,7 @@
 	"lint-staged": {
 		"*.php": [
 			"php -d display_errors=1 -l",
-			"composer run-script phpcs-pre-commit"
+			"composer run-script lint-staged"
 		],
 		"!(*min).js": [
 			"eslint --fix"


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

After [a tweak was made](https://github.com/woocommerce/woocommerce/issues/36850#issuecomment-1483841136) to the `phpcs-changed` command, it can now be run via composer on local files and get accurate results. However, it still requires a rather long command, so this PR does two things:

* Updates the composer.json and composer.lock files to point to the version of phpcs-changed that has the fix in it.
* Adds two scripts to the composer.json file: one for linting unstaged changes and one for staged changes.

Refs #36850

This could be taken further by, for example, reintroducing the [pre-commit hook](https://github.com/woocommerce/woocommerce/pull/34916), but this seems like a good first step.

### How to test the changes in this Pull Request:

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Check out this branch.
2. In your terminal, change to the `plugins/woocommerce` directory, so you can run composer commands.
3. Without making any changes, try running `composer run lint`. It should come back with no linting errors or exit codes.
4. Now go and make a change to a line that has an existing linting error in a file with lots of existing linting errors. [Here's a good candidate.](https://github.com/woocommerce/woocommerce/blob/c4fc54680b79f306234ba43c0c82f186f643cf1b/plugins/woocommerce/templates/cart/cart.php#L80)
5. Run `composer run lint` again. This time the linter should identify errors with the line you changed, _but not other lines in the file_.
6. Try running `composer run lint-staged`. Since nothing is staged, it should come back with no linting errors or exit codes.
7. Stage the change you made, `git add .`, and run `composer run lint-staged` again. Now you should see the same linting errors as before.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
