### PR TITLE
Fix missing result prop in `wcadmin_install_plugin_error` track

### DIFF
--- a/plugins/woocommerce/changelog/fix-install-plugin-error-track
+++ b/plugins/woocommerce/changelog/fix-install-plugin-error-track
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix missing result prop in wcadmin_install_plugin_error track

--- a/plugins/woocommerce/src/Admin/PluginsHelper.php
+++ b/plugins/woocommerce/src/Admin/PluginsHelper.php
@@ -234,7 +234,7 @@ class PluginsHelper {
 					'api_version'           => $api->version,
 					'api_download_link'     => $api->download_link,
 					'upgrader_skin_message' => implode( ',', $upgrader->skin->get_upgrade_messages() ),
-					'result'                => $result,
+					'result'                => is_wp_error( $result ) ? $result->get_error_message() : 'null',
 				);
 				wc_admin_record_tracks_event( 'install_plugin_error', $properties );
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #37267.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Install `Code Snippets` and `woocommerce-beta-tester`
2. Go to Snippets
3. Create a new snipeet and paste the following code (remember to activate the snipeet)

```php
function upgrader_post_install_callback( $response, $hook_extra, $result ) {
	error_log('hello world');
    return new WP_Error( 'Install Error', 'install error message...' );
}

add_filter( 'upgrader_post_install', 'upgrader_post_install_callback', 999, 3 );

```

4. Go to WooCommerce > Home > Marketing task
5. Click any "Get Started" button to install a marketing plugin.
6. Visit the `WooCommerce->Status->Logs` page
7. Select the latest `tracks-*` log from the dropdown
8. Search the wcadmin_install_plugin_error string
9. Observe that `result` prop is `install error message...`

![Screenshot 2023-03-28 at 15 17 22](https://user-images.githubusercontent.com/4344253/228159520-52f3c968-3c6b-4121-a0e0-c3110c3b187a.png)


<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
