### PR TITLE
Fix rest api filter to allow any strings in replacement

### DIFF
--- a/plugins/woocommerce-beta-tester/api/rest-api-filters/rest-api-filters.php
+++ b/plugins/woocommerce-beta-tester/api/rest-api-filters/rest-api-filters.php
@@ -61,6 +61,12 @@ class WCA_Test_Helper_Rest_Api_Filters {
         $dot_notation = $request->get_param('dot_notation');
         $replacement = $request->get_param('replacement');
 
+        if ($replacement === 'false' ) {
+            $replacement = false;
+        } else if ($replacement === 'true' ) {
+            $replacement = true;
+        }
+
         self::update(
             function ( $filters ) use (
                 $endpoint,
@@ -70,7 +76,7 @@ class WCA_Test_Helper_Rest_Api_Filters {
                 $filters[] = array(
                 'endpoint' => $endpoint,
                 'dot_notation' => $dot_notation,
-                'replacement' => filter_var( $replacement, FILTER_VALIDATE_BOOLEAN ),
+                'replacement' => $replacement,
                 'enabled' => true,
                 );
                 return $filters;

--- a/plugins/woocommerce-beta-tester/api/rest-api-filters/rest-api-filters.php
+++ b/plugins/woocommerce-beta-tester/api/rest-api-filters/rest-api-filters.php
@@ -1,115 +1,115 @@
 <?php
 
 register_woocommerce_admin_test_helper_rest_route(
-    '/rest-api-filters',
-    [ WCA_Test_Helper_Rest_Api_Filters::class, 'create' ],
-    array(
-        'methods' => 'POST',
-        'args'                => array(
-            'endpoint'     => array(
-                'description'       => 'Rest API endpoint.',
-                'type'              => 'string',
-                'required'            => true,
-                'sanitize_callback' => 'sanitize_text_field',
-            ),
-            'dot_notation' => array(
-                'description'       => 'Dot notation of the target field.',
-                'type'              => 'string',
-                'required'            => true,
-                'sanitize_callback' => 'sanitize_text_field',
-            ),
-            'replacement'   => array(
-                'description'       => 'Replacement value for the target field.',
-                'type'              => 'string',
-                'required'            => true,
-                'sanitize_callback' => 'sanitize_text_field',
-            ),
-        ),
-    )
+	'/rest-api-filters',
+	array( WCA_Test_Helper_Rest_Api_Filters::class, 'create' ),
+	array(
+		'methods' => 'POST',
+		'args'    => array(
+			'endpoint'     => array(
+				'description'       => 'Rest API endpoint.',
+				'type'              => 'string',
+				'required'          => true,
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+			'dot_notation' => array(
+				'description'       => 'Dot notation of the target field.',
+				'type'              => 'string',
+				'required'          => true,
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+			'replacement'  => array(
+				'description'       => 'Replacement value for the target field.',
+				'type'              => 'string',
+				'required'          => true,
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+		),
+	)
 );
 
 register_woocommerce_admin_test_helper_rest_route(
-    '/rest-api-filters',
-    [ WCA_Test_Helper_Rest_Api_Filters::class, 'delete' ],
-    array(
-        'methods' => 'DELETE',
-        'args'                => array(
-            'index'     => array(
-                'description'       => 'Rest API endpoint.',
-                'type'              => 'integer',
-                'required' => true,
-            ),
-        ),
-    )
+	'/rest-api-filters',
+	array( WCA_Test_Helper_Rest_Api_Filters::class, 'delete' ),
+	array(
+		'methods' => 'DELETE',
+		'args'    => array(
+			'index' => array(
+				'description' => 'Rest API endpoint.',
+				'type'        => 'integer',
+				'required'    => true,
+			),
+		),
+	)
 );
 
 
 register_woocommerce_admin_test_helper_rest_route(
-    '/rest-api-filters/(?P<index>\d+)/toggle',
-    [ WCA_Test_Helper_Rest_Api_Filters::class, 'toggle' ],
-    array(
-        'methods' => 'POST',
-    )
+	'/rest-api-filters/(?P<index>\d+)/toggle',
+	array( WCA_Test_Helper_Rest_Api_Filters::class, 'toggle' ),
+	array(
+		'methods' => 'POST',
+	)
 );
 
 
 class WCA_Test_Helper_Rest_Api_Filters {
-    const WC_ADMIN_TEST_HELPER_REST_API_FILTER_OPTION = 'wc-admin-test-helper-rest-api-filters';
+	const WC_ADMIN_TEST_HELPER_REST_API_FILTER_OPTION = 'wc-admin-test-helper-rest-api-filters';
 
-    public static function create( $request ) {
-        $endpoint = $request->get_param('endpoint');
-        $dot_notation = $request->get_param('dot_notation');
-        $replacement = $request->get_param('replacement');
+	public static function create( $request ) {
+		$endpoint     = $request->get_param( 'endpoint' );
+		$dot_notation = $request->get_param( 'dot_notation' );
+		$replacement  = $request->get_param( 'replacement' );
 
-        if ($replacement === 'false' ) {
-            $replacement = false;
-        } else if ($replacement === 'true' ) {
-            $replacement = true;
-        }
+		if ( 'false' === $replacement ) {
+			$replacement = false;
+		} elseif ( 'true' === $replacement ) {
+			$replacement = true;
+		}
 
-        self::update(
-            function ( $filters ) use (
-                $endpoint,
-                $dot_notation,
-                $replacement
-            ) {
-                $filters[] = array(
-                'endpoint' => $endpoint,
-                'dot_notation' => $dot_notation,
-                'replacement' => $replacement,
-                'enabled' => true,
-                );
-                return $filters;
-            }
-        );
-        return new WP_REST_RESPONSE(null, 204);
-    }
+		self::update(
+			function ( $filters ) use (
+				$endpoint,
+				$dot_notation,
+				$replacement
+			) {
+				$filters[] = array(
+					'endpoint'     => $endpoint,
+					'dot_notation' => $dot_notation,
+					'replacement'  => $replacement,
+					'enabled'      => true,
+				);
+				return $filters;
+			}
+		);
+		return new WP_REST_RESPONSE( null, 204 );
+	}
 
-    public static function update( callable $callback ) {
-        $filters = get_option(self::WC_ADMIN_TEST_HELPER_REST_API_FILTER_OPTION, array());
-        $filters = $callback( $filters );
-        return update_option(self::WC_ADMIN_TEST_HELPER_REST_API_FILTER_OPTION, $filters);
-    }
+	public static function update( callable $callback ) {
+		$filters = get_option( self::WC_ADMIN_TEST_HELPER_REST_API_FILTER_OPTION, array() );
+		$filters = $callback( $filters );
+		return update_option( self::WC_ADMIN_TEST_HELPER_REST_API_FILTER_OPTION, $filters );
+	}
 
-    public static function delete( $request ) {
-        self::update(
-            function ( $filters ) use ( $request ) {
-                array_splice($filters, $request->get_param('index'), 1);
-                return $filters;
-            }
-        );
+	public static function delete( $request ) {
+		self::update(
+			function ( $filters ) use ( $request ) {
+				array_splice( $filters, $request->get_param( 'index' ), 1 );
+				return $filters;
+			}
+		);
 
-        return new WP_REST_RESPONSE(null, 204);
-    }
+		return new WP_REST_RESPONSE( null, 204 );
+	}
 
-    public static function toggle( $request ) {
-        self::update(
-            function ( $filters ) use ( $request ) {
-                $index = $request->get_param('index');
-                $filters[$index]['enabled'] = !$filters[$index]['enabled'];
-                return $filters;
-            }
-        );
-        return new WP_REST_RESPONSE(null, 204);
-    }
+	public static function toggle( $request ) {
+		self::update(
+			function ( $filters ) use ( $request ) {
+				$index                        = $request->get_param( 'index' );
+				$filters[ $index ]['enabled'] = ! $filters[ $index ]['enabled'];
+				return $filters;
+			}
+		);
+		return new WP_REST_RESPONSE( null, 204 );
+	}
 }

--- a/plugins/woocommerce-beta-tester/api/rest-api-filters/rest-api-filters.php
+++ b/plugins/woocommerce-beta-tester/api/rest-api-filters/rest-api-filters.php
@@ -56,6 +56,12 @@ register_woocommerce_admin_test_helper_rest_route(
 class WCA_Test_Helper_Rest_Api_Filters {
 	const WC_ADMIN_TEST_HELPER_REST_API_FILTER_OPTION = 'wc-admin-test-helper-rest-api-filters';
 
+	/**
+	 * Create a filter.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response
+	 */
 	public static function create( $request ) {
 		$endpoint     = $request->get_param( 'endpoint' );
 		$dot_notation = $request->get_param( 'dot_notation' );
@@ -85,12 +91,24 @@ class WCA_Test_Helper_Rest_Api_Filters {
 		return new WP_REST_RESPONSE( null, 204 );
 	}
 
+	/**
+	 * Update the filters.
+	 *
+	 * @param callable $callback Callback to update the filters.
+	 * @return bool
+	 */
 	public static function update( callable $callback ) {
 		$filters = get_option( self::WC_ADMIN_TEST_HELPER_REST_API_FILTER_OPTION, array() );
 		$filters = $callback( $filters );
 		return update_option( self::WC_ADMIN_TEST_HELPER_REST_API_FILTER_OPTION, $filters );
 	}
 
+	/**
+	 * Delete a filter.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response
+	 */
 	public static function delete( $request ) {
 		self::update(
 			function ( $filters ) use ( $request ) {
@@ -102,6 +120,12 @@ class WCA_Test_Helper_Rest_Api_Filters {
 		return new WP_REST_RESPONSE( null, 204 );
 	}
 
+	/**
+	 * Toggle a filter on or off.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response
+	 */
 	public static function toggle( $request ) {
 		self::update(
 			function ( $filters ) use ( $request ) {

--- a/plugins/woocommerce-beta-tester/changelog/fix-rest-api-filter
+++ b/plugins/woocommerce-beta-tester/changelog/fix-rest-api-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix rest api filter to allow any strings in replacement


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Previously, I suggested using `filter_var( $replacement, FILTER_VALIDATE_BOOLEAN );` to convert the boolean value in https://github.com/woocommerce/woocommerce-admin-test-helper/pull/37#discussion_r851026561. However, it also converts all other strings to a boolean value.

This PR reverts [the change](https://github.com/woocommerce/woocommerce-admin-test-helper/commit/f0e8ad9c86a4ee5c40e081f9e27c86c05bf50f38) 417e2efaa29b8ada869bbc551f17d581f6d6bb5d so we can replace the value with any strings.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Go to `/wp-admin/tools.php?page=woocommerce-admin-test-helper`
2. Go to `REST API FIlters` tab
3. Click New Filter and enter the following values. Click Create New Filter button.

- Endpoint: /wc/v3/payment_gateways
- Dot Notation: 0.id
- Replacement: 'test'

4. Open developer console window > network tab
5. Go to woocmmerce > home > payment task
6. Search `payment_gateways`
7. Confirm the id value of the first item in response is test

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
