### PR TITLE
Don't run dbDelta twice unnecessarily.

### DIFF
--- a/plugins/woocommerce/changelog/try-install-optim-1
+++ b/plugins/woocommerce/changelog/try-install-optim-1
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Optimize the install routine so that it doesn't run dbDelta twice.

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -466,12 +466,12 @@ class WC_Install {
 	/**
 	 * Check if all the base tables are present without running dbDelta unnecessarily.
 	 *
-	 * @param bool $modify_notice Whether to modify notice based on if all tables are present.
+	 * @param bool  $modify_notice Whether to modify notice based on if all tables are present.
 	 * @param array $dbdelta_result Result of dbDelta.
 	 *
 	 * @return array List of queries.
 	 */
-	public static function verify_base_tables_light( $modify_notice = true, $dbdelta_result = [] ) {
+	public static function verify_base_tables_light( $modify_notice = true, $dbdelta_result = array() ) {
 		$missing_tables = wc_get_container()
 			->get( DatabaseUtil::class )
 			->parse_dbdelta_output( $dbdelta_result )['created_tables'];

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -467,11 +467,11 @@ class WC_Install {
 	 * Check if all the base tables are present without running dbDelta unnecessarily.
 	 *
 	 * @param bool $modify_notice Whether to modify notice based on if all tables are present.
-	 * @param bool $dbdelta_result Result of dbDelta.
+	 * @param array $dbdelta_result Result of dbDelta.
 	 *
 	 * @return array List of queries.
 	 */
-	public static function verify_base_tables_light( $modify_notice = true, $dbdelta_result = '' ) {
+	public static function verify_base_tables_light( $modify_notice = true, $dbdelta_result = [] ) {
 		$missing_tables = wc_get_container()
 			->get( DatabaseUtil::class )
 			->parse_dbdelta_output( $dbdelta_result )['created_tables'];


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

During each request (front end and backend), WC checks whether the version of code that is executed corresponds to the `woocommerce_version` that is stored in the database (function [WC_Install::check_version()](https://github.com/woocommerce/woocommerce/blob/7.5.0/plugins/woocommerce/includes/class-wc-install.php?rgh-link-date=2023-03-16T18%3A20%3A42Z#L257)). If the code's version is newer (higher version), install procedure is executed ([WC_Install::install()](https://github.com/woocommerce/woocommerce/blob/7.5.0/plugins/woocommerce/includes/class-wc-install.php?rgh-link-date=2023-03-16T18%3A20%3A42Z#L377)).

This executes a bunch of functions, and among them is WordPress default dbDelta to make sure the db structure is correct and no fatal errors are happening because of a mismatch between what the code expects and what's in the db.

This change should reduce the number of times dbDelta is executed during the installation of WC core. Currently, it's executed twice:
- from \WC_Install::create_tables
- from \WC_Install::verify_base_tables (via \Automattic\WooCommerce\Internal\Utilities\DatabaseUtil::get_missing_tables)

~This is unnecessary and can result in doubling the number of `DESCRIBE` statements.~

Actually, to have the correct admin notice added, we need to run dbDelta twice, so this change can't be done without compromising the admin notice about missing tables. If I understand correctly, this was put into place to identify the cases where we try to fix the DB tables using `dbDelta`, but fail to do so. We run `dbDelta` again to see if we failed for some reason, which is an indication of some problem. 

For further context, please see p6q8Tx-2Gk-p2

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1.
2.
3.

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [ ] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
