### PR TITLE
Install/update: Make the DELETE in 2 queries instead of 60+

### DIFF
--- a/plugins/woocommerce/changelog/try-install-optim-2
+++ b/plugins/woocommerce/changelog/try-install-optim-2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Optimize installation routine by reducing the number of DELETE statments for admin notices.

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -882,10 +882,25 @@ class WC_Install {
 			);
 		}
 
-		foreach ( $obsolete_notes_names as $obsolete_notes_name ) {
-			$wpdb->delete( $wpdb->prefix . 'wc_admin_notes', array( 'name' => $obsolete_notes_name ) );
-			$wpdb->delete( $wpdb->prefix . 'wc_admin_note_actions', array( 'name' => $obsolete_notes_name ) );
-		}
+		$note_names_placeholder = substr( str_repeat( ',%s', count( $obsolete_notes_names ) ), 1 );
+
+		$wpdb->query(
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Ignored for allowing interpolation in the IN statement.
+			$wpdb->prepare(
+				"DELETE FROM {$wpdb->prefix}wc_admin_notes WHERE name IN ( $note_names_placeholder )",
+				$obsolete_notes_names
+			)
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared.
+		);
+
+		$wpdb->query(
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Ignored for allowing interpolation in the IN statement.
+			$wpdb->prepare(
+				"DELETE FROM {$wpdb->prefix}wc_admin_note_actions WHERE name IN ( $note_names_placeholder )",
+				$obsolete_notes_names
+			)
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared.
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -1527,8 +1527,9 @@ CREATE TABLE {$wpdb->prefix}wc_category_lookup (
 		$tables = self::get_tables();
 
 		foreach ( $tables as $table ) {
-			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$wpdb->query( "DROP TABLE IF EXISTS {$table}" );
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		}
 	}
 

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -898,7 +898,7 @@ class WC_Install {
 			return;
 		}
 
-		$note_ids = array_column( $note_ids, 0 );
+		$note_ids             = array_column( $note_ids, 0 );
 		$note_ids_placeholder = substr( str_repeat( ',%d', count( $note_ids ) ), 1 );
 
 		$wpdb->query(

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -884,6 +884,15 @@ class WC_Install {
 
 		$note_names_placeholder = substr( str_repeat( ',%s', count( $obsolete_notes_names ) ), 1 );
 
+		$note_ids = $wpdb->get_results(
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Ignored for allowing interpolation in the IN statement.
+			$wpdb->prepare(
+				"SELECT note_id FROM {$wpdb->prefix}wc_admin_notes WHERE name IN ( $note_names_placeholder )",
+				$obsolete_notes_names
+			)
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare.
+		);
+
 		$wpdb->query(
 			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Ignored for allowing interpolation in the IN statement.
 			$wpdb->prepare(
@@ -896,7 +905,7 @@ class WC_Install {
 		$wpdb->query(
 			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Ignored for allowing interpolation in the IN statement.
 			$wpdb->prepare(
-				"DELETE FROM {$wpdb->prefix}wc_admin_note_actions WHERE name IN ( $note_names_placeholder )",
+				"DELETE FROM {$wpdb->prefix}wc_admin_note_actions WHERE note_id IN ( $note_ids )",
 				$obsolete_notes_names
 			)
 			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare.

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -885,21 +885,21 @@ class WC_Install {
 		$note_names_placeholder = substr( str_repeat( ',%s', count( $obsolete_notes_names ) ), 1 );
 
 		$wpdb->query(
-			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Ignored for allowing interpolation in the IN statement.
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Ignored for allowing interpolation in the IN statement.
 			$wpdb->prepare(
 				"DELETE FROM {$wpdb->prefix}wc_admin_notes WHERE name IN ( $note_names_placeholder )",
 				$obsolete_notes_names
 			)
-			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared.
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare.
 		);
 
 		$wpdb->query(
-			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Ignored for allowing interpolation in the IN statement.
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Ignored for allowing interpolation in the IN statement.
 			$wpdb->prepare(
 				"DELETE FROM {$wpdb->prefix}wc_admin_note_actions WHERE name IN ( $note_names_placeholder )",
 				$obsolete_notes_names
 			)
-			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared.
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare.
 		);
 	}
 
@@ -1544,7 +1544,7 @@ CREATE TABLE {$wpdb->prefix}wc_category_lookup (
 		}
 
 		if ( ! isset( $wp_roles ) ) {
-			$wp_roles = new WP_Roles(); // @codingStandardsIgnoreLine
+			$wp_roles = new WP_Roles(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		}
 
 		// Dummy gettext calls to get strings in the catalog.
@@ -1674,7 +1674,7 @@ CREATE TABLE {$wpdb->prefix}wc_category_lookup (
 		}
 
 		if ( ! isset( $wp_roles ) ) {
-			$wp_roles = new WP_Roles(); // @codingStandardsIgnoreLine
+			$wp_roles = new WP_Roles(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		}
 
 		$capabilities = self::get_core_capabilities();

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -889,6 +889,23 @@ class WC_Install {
 			$wpdb->prepare(
 				"SELECT note_id FROM {$wpdb->prefix}wc_admin_notes WHERE name IN ( $note_names_placeholder )",
 				$obsolete_notes_names
+			),
+			ARRAY_N
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare.
+		);
+
+		if ( ! $note_ids ) {
+			return;
+		}
+
+		$note_ids = array_column( $note_ids, 0 );
+		$note_ids_placeholder = substr( str_repeat( ',%d', count( $note_ids ) ), 1 );
+
+		$wpdb->query(
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Ignored for allowing interpolation in the IN statement.
+			$wpdb->prepare(
+				"DELETE FROM {$wpdb->prefix}wc_admin_notes WHERE note_id IN ( $note_ids_placeholder )",
+				$note_ids
 			)
 			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare.
 		);
@@ -896,17 +913,8 @@ class WC_Install {
 		$wpdb->query(
 			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Ignored for allowing interpolation in the IN statement.
 			$wpdb->prepare(
-				"DELETE FROM {$wpdb->prefix}wc_admin_notes WHERE name IN ( $note_names_placeholder )",
-				$obsolete_notes_names
-			)
-			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare.
-		);
-
-		$wpdb->query(
-			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Ignored for allowing interpolation in the IN statement.
-			$wpdb->prepare(
-				"DELETE FROM {$wpdb->prefix}wc_admin_note_actions WHERE note_id IN ( $note_ids )",
-				$obsolete_notes_names
+				"DELETE FROM {$wpdb->prefix}wc_admin_note_actions WHERE note_id IN ( $note_ids_placeholder )",
+				$note_ids
 			)
 			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare.
 		);

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -1518,7 +1518,8 @@ CREATE TABLE {$wpdb->prefix}wc_category_lookup (
 		$tables = self::get_tables();
 
 		foreach ( $tables as $table ) {
-			$wpdb->query( "DROP TABLE IF EXISTS {$table}" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$wpdb->query( "DROP TABLE IF EXISTS {$table}" );
 		}
 	}
 

--- a/plugins/woocommerce/src/Admin/Notes/DataStore.php
+++ b/plugins/woocommerce/src/Admin/Notes/DataStore.php
@@ -391,7 +391,7 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 	 * @param string $type Comma separated list of note types.
 	 * @param string $status Comma separated list of statuses.
 	 * @param string $context Optional argument that the woocommerce_note_where_clauses filter can use to determine whether to apply extra conditions. Extensions should define their own contexts and use them to avoid adding to notes where clauses when not needed.
-	 * @return array An array of objects containing a note id.
+	 * @return string Count of objects with given type, status and context.
 	 */
 	public function get_notes_count( $type = array(), $status = array(), $context = self::WC_ADMIN_NOTE_OPER_GLOBAL ) {
 		global $wpdb;

--- a/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
@@ -122,7 +122,7 @@ class WC_Install_Test extends \WC_Unit_Test_Case {
 		$note->add_action( 'test-action-2', 'Action 2', 'https://example.com' );
 		$data_store->create( $note );
 
-		$this->assertEquals( 1, count ( $data_store->get_notes_with_name( $note_name ) ) );
+		$this->assertEquals( 1, count( $data_store->get_notes_with_name( $note_name ) ) );
 
 		WC_Install::delete_obsolete_notes();
 


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

During the installation and upgrade procedures, there are several functions that run in a fairly suboptimal fashion. One of them is `delete_obsolete_notes`: it runs 60+ `DELETE` queries where max 3 queries should suffice. 

This PR should improve how WC install/update behaves on hosts where many WC installations are updated simultaneously. It should decrease the load on the db by reducing the number of queries issued. 

The old queries used a full table scan for each DELETE (so 60 times full table scan). I think the second delete was a mistake as the names of actions related to notes don't correspond to the names of actions, so it was essentially a broken DELETE query. 

The new version does only 1 full table scan on the notes table and then uses found note_id indexed column to delete both the notes and the respective actions. The tables are quite small, so hoping it makes sense from the perspective of the load of the db server.

For further context, please see p6q8Tx-2Gk-p2

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

This change shouldn't actually change anything visibly (besides reducing the number of queries run during install/update), so the testing actually only checks that the obsolete admin notes are still cleared up correctly.

1. Install a new WC installation (7.5.1), any settings are fine.
2. Install a helper plugin to add an obsolete admin note: 
[wc-admin-note-test.zip](https://github.com/woocommerce/woocommerce/files/11100375/wc-admin-note-test.zip)


3. Activate the plugin `WooCommerce Admin Note Test`
4. Go to WC > Status > Tools and click on `Add admin note` button
<img width="1728" alt="Screenshot 2023-03-29 at 13 12 08" src="https://user-images.githubusercontent.com/2207451/228516974-d5cb4e9c-7c17-4673-bde7-d3fbff1bf2dc.png">

5. You should see a confirmation that the tool ran at the top with green accent:
<img width="1728" alt="Screenshot 2023-03-29 at 13 26 10" src="https://user-images.githubusercontent.com/2207451/228521423-3e11601d-a272-443e-98bf-d8415d6d4ed3.png">


5. Switch over to another screen, e.g. WC > Orders. Click on Activity, you should see 2 new testing admin notes:
<img width="1728" alt="Screenshot 2023-03-29 at 13 37 51" src="https://user-images.githubusercontent.com/2207451/228524640-9136a2c1-f7e8-443a-bd52-82ff9f3fdacb.png">

7. Update 'woocommerce_version' option in the db to '7.4.0':
8. You can do this by running `UPDATE wp_options SET option_value="7.4.0" WHERE option_name="woocommerce_version"` in your favourite SQL editor.
9. Alternatively, you can use WP CLI and run
```
wp shell
wp> update_option('woocommerce_version', '7.4.0');
```
10. Go back to your browser
11. Hit refresh
12. Check the Activity again, the testing admin notes should be gone.
13. Now activate this branch and start over from step 4. You should see exactly the same result. No other admin notes should go missing, only the 2 testing ones should be gone.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
