### PR TITLE
Update WooCommerce Blocks package to 9.8.3

### DIFF
--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-9.8.3
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-9.8.3
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update WooCommerce Blocks to 9.8.3

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -21,7 +21,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.5.4",
-		"woocommerce/woocommerce-blocks": "9.8.2"
+		"woocommerce/woocommerce-blocks": "9.8.3"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.3.0",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "48377a0bfe2b30537b522f197ba28984",
+    "content-hash": "d92c2e109d56bc31d8d8f4e1ec0bbaf1",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -628,16 +628,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "9.8.2",
+            "version": "9.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "61488a0f1d1afc8fd7484e1b277d40afd782e005"
+                "reference": "9431e10310a9dc89d844bb9d480adab64297b130"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/61488a0f1d1afc8fd7484e1b277d40afd782e005",
-                "reference": "61488a0f1d1afc8fd7484e1b277d40afd782e005",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/9431e10310a9dc89d844bb9d480adab64297b130",
+                "reference": "9431e10310a9dc89d844bb9d480adab64297b130",
                 "shasum": ""
             },
             "require": {
@@ -683,9 +683,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v9.8.2"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v9.8.3"
             },
-            "time": "2023-03-22T14:39:35+00:00"
+            "time": "2023-03-28T14:44:30+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 9.8.3. It is intended to target WooCommerce 7.6 for release.

Details from all the different releases included in this pull:

##  WC Blocks 9.8.3

* [Release PR](https://github.com/woocommerce/woocommerce-blocks/pull/8884)
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/983.md)

### Changelog entry

**The following changelog entries are only those that impact existing blocks and functionality surfaced to users:**

#### Bug Fixes

- Fixed an issue where extensions were unable to programatically set the shipping address during payment processing. ([8878](https://github.com/woocommerce/woocommerce-blocks/pull/8878))
- Fix border styles not visible in the editor in Featured Product and Featured Category blocks. ([8838](https://github.com/woocommerce/woocommerce-blocks/pull/8838))
- Fix "Save changes" default behavior bug in the Firefox browser. ([8754](https://github.com/woocommerce/woocommerce-blocks/pull/8754))