### PR TITLE
Use SelectTree component in Category field

### DIFF
--- a/packages/js/components/changelog/update-migrate-category-field
+++ b/packages/js/components/changelog/update-migrate-category-field
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Add unit tests
+
+

--- a/packages/js/components/src/experimental-select-tree-control/test/select-tree.test.tsx
+++ b/packages/js/components/src/experimental-select-tree-control/test/select-tree.test.tsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react';
+import React, { createElement } from 'react';
 import { SelectTree } from '../select-tree';
-import { createElement } from 'react';
 import { Item } from '../../experimental-tree-control';
 
 const mockItems: Item[] = [

--- a/packages/js/components/src/experimental-select-tree-control/test/select-tree.test.tsx
+++ b/packages/js/components/src/experimental-select-tree-control/test/select-tree.test.tsx
@@ -1,0 +1,107 @@
+import { render } from '@testing-library/react';
+import { SelectTree } from '../select-tree';
+import { createElement } from 'react';
+import { Item } from '../../experimental-tree-control';
+
+const mockItems: Item[] = [
+	{
+		label: 'Item 1',
+		value: 'item-1',
+	},
+	{
+		label: 'Item 2',
+		value: 'item-2',
+		parent: 'item-1',
+	},
+	{
+		label: 'Item 3',
+		value: 'item-3',
+	},
+];
+
+const DEFAULT_PROPS = {
+	id: 'select-tree',
+	items: mockItems,
+	label: 'Select Tree',
+	placeholder: 'Type here',
+};
+
+describe( 'SelectTree', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should show the popover only when focused', () => {
+		const { queryByPlaceholderText, queryByText } = render(
+			<SelectTree { ...DEFAULT_PROPS } />
+		);
+		expect( queryByText( 'Item 1' ) ).not.toBeInTheDocument();
+		queryByPlaceholderText( 'Type here' )?.focus();
+		expect( queryByText( 'Item 1' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should show create button when callback is true ', () => {
+		const { queryByText, queryByPlaceholderText } = render(
+			<SelectTree
+				{ ...DEFAULT_PROPS }
+				shouldShowCreateButton={ () => true }
+			/>
+		);
+		queryByPlaceholderText( 'Type here' )?.focus();
+		expect( queryByText( 'Create new' ) ).toBeInTheDocument();
+	} );
+	it( 'should not show create button when callback is false or no callback', () => {
+		const { queryByText, queryByPlaceholderText } = render(
+			<SelectTree { ...DEFAULT_PROPS } />
+		);
+		queryByPlaceholderText( 'Type here' )?.focus();
+		expect( queryByText( 'Create new' ) ).not.toBeInTheDocument();
+	} );
+	it( 'should show a root item when focused and child when expand button is clicked', () => {
+		const { queryByText, queryByLabelText, queryByPlaceholderText } =
+			render( <SelectTree { ...DEFAULT_PROPS } /> );
+		queryByPlaceholderText( 'Type here' )?.focus();
+		expect( queryByText( 'Item 1' ) ).toBeInTheDocument();
+
+		expect( queryByText( 'Item 2' ) ).not.toBeInTheDocument();
+		queryByLabelText( 'Expand' )?.click();
+		expect( queryByText( 'Item 2' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should show selected items', () => {
+		const { queryAllByRole, queryByPlaceholderText } = render(
+			<SelectTree { ...DEFAULT_PROPS } selected={ [ mockItems[ 0 ] ] } />
+		);
+		queryByPlaceholderText( 'Type here' )?.focus();
+		expect( queryAllByRole( 'treeitem' )[ 0 ] ).toHaveAttribute(
+			'aria-selected',
+			'true'
+		);
+	} );
+
+	it( 'should show Create "<createValue>" button', () => {
+		const { queryByPlaceholderText, queryByText } = render(
+			<SelectTree
+				{ ...DEFAULT_PROPS }
+				createValue="new item"
+				shouldShowCreateButton={ () => true }
+			/>
+		);
+		queryByPlaceholderText( 'Type here' )?.focus();
+		expect( queryByText( 'Create "new item"' ) ).toBeInTheDocument();
+	} );
+	it( 'should call onCreateNew when Create "<createValue>" button is clicked', () => {
+		const mockFn = jest.fn();
+		const { queryByPlaceholderText, queryByText } = render(
+			<SelectTree
+				{ ...DEFAULT_PROPS }
+				createValue="new item"
+				shouldShowCreateButton={ () => true }
+				onCreateNew={ mockFn }
+			/>
+		);
+		queryByPlaceholderText( 'Type here' )?.focus();
+		queryByText( 'Create "new item"' )?.click();
+		expect( mockFn ).toBeCalledTimes( 1 );
+	} );
+} );

--- a/packages/js/components/src/experimental-select-tree-control/test/select-tree.test.tsx
+++ b/packages/js/components/src/experimental-select-tree-control/test/select-tree.test.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import React, { createElement } from 'react';
+import React, { createElement } from '@wordpress/element';
 import { SelectTree } from '../select-tree';
 import { Item } from '../../experimental-tree-control';
 

--- a/packages/js/product-editor/changelog/update-migrate-category-field
+++ b/packages/js/product-editor/changelog/update-migrate-category-field
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Use SelectTree component in product editor's category field

--- a/packages/js/product-editor/src/components/details-categories-field/category-field-item.tsx
+++ b/packages/js/product-editor/src/components/details-categories-field/category-field-item.tsx
@@ -9,6 +9,11 @@ import { ProductCategory } from '@woocommerce/data';
 import { __experimentalSelectControlMenuItemProps as MenuItemProps } from '@woocommerce/components';
 import classNames from 'classnames';
 
+/**
+ * Internal dependencies
+ */
+import { ProductCategoryLinkedList } from './use-category-search';
+
 export type CategoryTreeItem = {
 	data: ProductCategory;
 	children: CategoryTreeItem[];
@@ -19,13 +24,10 @@ export type CategoryTreeItem = {
 type CategoryFieldItemProps = {
 	item: CategoryTreeItem;
 	selectedIds: number[];
-	items: Pick< ProductCategory, 'id' | 'name' >[];
+	items: ProductCategoryLinkedList[];
 	highlightedIndex: number;
 	openParent?: () => void;
-} & Pick<
-	MenuItemProps< Pick< ProductCategory, 'id' | 'name' > >,
-	'getItemProps'
->;
+} & Pick< MenuItemProps< ProductCategoryLinkedList >, 'getItemProps' >;
 
 export const CategoryFieldItem: React.FC< CategoryFieldItemProps > = ( {
 	item,

--- a/packages/js/product-editor/src/components/details-categories-field/category-field-item.tsx
+++ b/packages/js/product-editor/src/components/details-categories-field/category-field-item.tsx
@@ -12,7 +12,7 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import { ProductCategoryLinkedList } from './use-category-search';
+import { ProductCategoryNode } from './use-category-search';
 
 export type CategoryTreeItem = {
 	data: ProductCategory;
@@ -24,10 +24,10 @@ export type CategoryTreeItem = {
 type CategoryFieldItemProps = {
 	item: CategoryTreeItem;
 	selectedIds: number[];
-	items: ProductCategoryLinkedList[];
+	items: ProductCategoryNode[];
 	highlightedIndex: number;
 	openParent?: () => void;
-} & Pick< MenuItemProps< ProductCategoryLinkedList >, 'getItemProps' >;
+} & Pick< MenuItemProps< ProductCategoryNode >, 'getItemProps' >;
 
 export const CategoryFieldItem: React.FC< CategoryFieldItemProps > = ( {
 	item,

--- a/packages/js/product-editor/src/components/details-categories-field/category-field.tsx
+++ b/packages/js/product-editor/src/components/details-categories-field/category-field.tsx
@@ -13,17 +13,14 @@ import { debounce } from 'lodash';
  * Internal dependencies
  */
 import { CategoryTreeItem } from './category-field-item';
-import {
-	useCategorySearch,
-	ProductCategoryLinkedList,
-} from './use-category-search';
+import { useCategorySearch, ProductCategoryNode } from './use-category-search';
 import { CreateCategoryModal } from './create-category-modal';
 
 type CategoryFieldProps = {
 	label: string;
 	placeholder: string;
-	value?: ProductCategoryLinkedList[];
-	onChange: ( value: ProductCategoryLinkedList[] ) => void;
+	value?: ProductCategoryNode[];
+	onChange: ( value: ProductCategoryNode[] ) => void;
 };
 
 /**
@@ -31,10 +28,10 @@ type CategoryFieldProps = {
  * if not included already.
  */
 function getSelectedWithParents(
-	selected: ProductCategoryLinkedList[] = [],
+	selected: ProductCategoryNode[] = [],
 	item: ProductCategory,
 	treeKeyValues: Record< number, CategoryTreeItem >
-): ProductCategoryLinkedList[] {
+): ProductCategoryNode[] {
 	selected.push( { id: item.id, name: item.name, parent: item.parent } );
 
 	const parentId =
@@ -59,7 +56,7 @@ function getSelectedWithParents(
 }
 
 function mapFromCategoryType(
-	categories: ProductCategoryLinkedList[]
+	categories: ProductCategoryNode[]
 ): TreeItemType[] {
 	return categories.map( ( val ) =>
 		val.parent
@@ -77,7 +74,7 @@ function mapFromCategoryType(
 
 function mapToCategoryType(
 	categories: TreeItemType[]
-): ProductCategoryLinkedList[] {
+): ProductCategoryNode[] {
 	return categories.map( ( cat ) => ( {
 		id: +cat.value,
 		name: cat.label,
@@ -139,7 +136,7 @@ export const CategoryField: React.FC< CategoryFieldProps > = ( {
 				selected={ mapFromCategoryType( value ) }
 				onSelect={ ( selectedItems ) => {
 					if ( Array.isArray( selectedItems ) ) {
-						const newItems: ProductCategoryLinkedList[] =
+						const newItems: ProductCategoryNode[] =
 							mapToCategoryType(
 								selectedItems.filter(
 									( { value: selectedItemValue } ) =>

--- a/packages/js/product-editor/src/components/details-categories-field/category-field.tsx
+++ b/packages/js/product-editor/src/components/details-categories-field/category-field.tsx
@@ -64,13 +64,13 @@ function mapFromCategoryType(
 	return categories.map( ( val ) =>
 		val.parent
 			? {
-					id: String( val.id ),
-					name: val.name,
+					value: String( val.id ),
+					label: val.name,
 					parent: String( val.parent ),
 			  }
 			: {
-					id: String( val.id ),
-					name: val.name,
+					value: String( val.id ),
+					label: val.name,
 			  }
 	);
 }
@@ -79,8 +79,8 @@ function mapToCategoryType(
 	categories: TreeItemType[]
 ): ProductCategoryLinkedList[] {
 	return categories.map( ( cat ) => ( {
-		id: +cat.id,
-		name: cat.name,
+		id: +cat.value,
+		name: cat.label,
 		parent: cat.parent ? +cat.parent : 0,
 	} ) );
 }
@@ -117,30 +117,32 @@ export const CategoryField: React.FC< CategoryFieldProps > = ( {
 				id="category-field"
 				multiple
 				shouldNotRecursivelySelect
-				allowCreate
 				createValue={ searchValue }
 				label={ label }
 				isLoading={ isSearching }
 				onInputChange={ searchDelayed }
-				getFilteredItems={ ( allItems, inputValue, selectedItems ) => {
-					return getFilteredItemsForSelectTree(
-						allItems,
-						inputValue,
-						selectedItems
-					);
-				} }
 				placeholder={ value.length === 0 ? placeholder : '' }
 				onCreateNew={ () => {
 					setShowCreateNewModal( true );
 				} }
-				items={ mapFromCategoryType( categoriesSelectList ) }
+				shouldShowCreateButton={ ( typedValue ) =>
+					! typedValue ||
+					categoriesSelectList.findIndex(
+						( item ) => item.name === typedValue
+					) === -1
+				}
+				items={ getFilteredItemsForSelectTree(
+					mapFromCategoryType( categoriesSelectList ),
+					searchValue,
+					mapFromCategoryType( value )
+				) }
 				selected={ mapFromCategoryType( value ) }
 				onSelect={ ( selectedItems ) => {
 					if ( Array.isArray( selectedItems ) ) {
 						const newItems: ProductCategoryLinkedList[] =
 							mapToCategoryType(
 								selectedItems.filter(
-									( { id: selectedItemValue } ) =>
+									( { value: selectedItemValue } ) =>
 										! value.some(
 											( item ) =>
 												item.id === +selectedItemValue
@@ -155,12 +157,12 @@ export const CategoryField: React.FC< CategoryFieldProps > = ( {
 						? value.filter(
 								( item ) =>
 									! removedItems.some(
-										( { id: removedValue } ) =>
+										( { value: removedValue } ) =>
 											item.id === +removedValue
 									)
 						  )
 						: value.filter(
-								( item ) => item.id !== +removedItems.id
+								( item ) => item.id !== +removedItems.value
 						  );
 					onChange( newValues );
 				} }

--- a/packages/js/product-editor/src/components/details-categories-field/create-category-modal.tsx
+++ b/packages/js/product-editor/src/components/details-categories-field/create-category-modal.tsx
@@ -24,7 +24,7 @@ import {
  * Internal dependencies
  */
 import {
-	ProductCategoryLinkedList,
+	ProductCategoryNode,
 	useCategorySearch,
 } from './use-category-search';
 import { CategoryFieldItem } from './category-field-item';
@@ -55,7 +55,7 @@ export const CreateCategoryModal: React.FC< CreateCategoryModalProps > = ( {
 		initialCategoryName || ''
 	);
 	const [ categoryParent, setCategoryParent ] =
-		useState< ProductCategoryLinkedList | null >( null );
+		useState< ProductCategoryNode | null >( null );
 
 	const onSave = async () => {
 		recordEvent( 'product_category_add', {
@@ -95,7 +95,7 @@ export const CreateCategoryModal: React.FC< CreateCategoryModalProps > = ( {
 					value={ categoryName }
 					onChange={ setCategoryName }
 				/>
-				<SelectControl< ProductCategoryLinkedList >
+				<SelectControl< ProductCategoryNode >
 					items={ categoriesSelectList }
 					label={ createInterpolateElement(
 						__( 'Parent category <optional/>', 'woocommerce' ),

--- a/packages/js/product-editor/src/components/details-categories-field/create-category-modal.tsx
+++ b/packages/js/product-editor/src/components/details-categories-field/create-category-modal.tsx
@@ -23,7 +23,10 @@ import {
 /**
  * Internal dependencies
  */
-import { useCategorySearch } from './use-category-search';
+import {
+	ProductCategoryLinkedList,
+	useCategorySearch,
+} from './use-category-search';
 import { CategoryFieldItem } from './category-field-item';
 
 type CreateCategoryModalProps = {
@@ -51,10 +54,8 @@ export const CreateCategoryModal: React.FC< CreateCategoryModalProps > = ( {
 	const [ categoryName, setCategoryName ] = useState(
 		initialCategoryName || ''
 	);
-	const [ categoryParent, setCategoryParent ] = useState< Pick<
-		ProductCategory,
-		'id' | 'name'
-	> | null >( null );
+	const [ categoryParent, setCategoryParent ] =
+		useState< ProductCategoryLinkedList | null >( null );
 
 	const onSave = async () => {
 		recordEvent( 'product_category_add', {
@@ -94,7 +95,7 @@ export const CreateCategoryModal: React.FC< CreateCategoryModalProps > = ( {
 					value={ categoryName }
 					onChange={ setCategoryName }
 				/>
-				<SelectControl< Pick< ProductCategory, 'id' | 'name' > >
+				<SelectControl< ProductCategoryLinkedList >
 					items={ categoriesSelectList }
 					label={ createInterpolateElement(
 						__( 'Parent category <optional/>', 'woocommerce' ),

--- a/packages/js/product-editor/src/components/details-categories-field/create-category-modal.tsx
+++ b/packages/js/product-editor/src/components/details-categories-field/create-category-modal.tsx
@@ -23,10 +23,7 @@ import {
 /**
  * Internal dependencies
  */
-import {
-	ProductCategoryNode,
-	useCategorySearch,
-} from './use-category-search';
+import { ProductCategoryNode, useCategorySearch } from './use-category-search';
 import { CategoryFieldItem } from './category-field-item';
 
 type CreateCategoryModalProps = {

--- a/packages/js/product-editor/src/components/details-categories-field/details-categories-field.tsx
+++ b/packages/js/product-editor/src/components/details-categories-field/details-categories-field.tsx
@@ -3,13 +3,14 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useFormContext } from '@woocommerce/components';
-import { Product, ProductCategory } from '@woocommerce/data';
+import { Product } from '@woocommerce/data';
 import { createElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { CategoryField } from './category-field';
+import { ProductCategoryLinkedList } from './use-category-search';
 
 export const DetailsCategoriesField = () => {
 	const { getInputProps } = useFormContext< Product >();
@@ -18,9 +19,7 @@ export const DetailsCategoriesField = () => {
 		<CategoryField
 			label={ __( 'Categories', 'woocommerce' ) }
 			placeholder={ __( 'Search or create category…', 'woocommerce' ) }
-			{ ...getInputProps< Pick< ProductCategory, 'id' | 'name' >[] >(
-				'categories'
-			) }
+			{ ...getInputProps< ProductCategoryLinkedList[] >( 'categories' ) }
 		/>
 	);
 };

--- a/packages/js/product-editor/src/components/details-categories-field/details-categories-field.tsx
+++ b/packages/js/product-editor/src/components/details-categories-field/details-categories-field.tsx
@@ -10,7 +10,7 @@ import { createElement } from '@wordpress/element';
  * Internal dependencies
  */
 import { CategoryField } from './category-field';
-import { ProductCategoryLinkedList } from './use-category-search';
+import { ProductCategoryNode } from './use-category-search';
 
 export const DetailsCategoriesField = () => {
 	const { getInputProps } = useFormContext< Product >();
@@ -19,7 +19,7 @@ export const DetailsCategoriesField = () => {
 		<CategoryField
 			label={ __( 'Categories', 'woocommerce' ) }
 			placeholder={ __( 'Search or create category…', 'woocommerce' ) }
-			{ ...getInputProps< ProductCategoryLinkedList[] >( 'categories' ) }
+			{ ...getInputProps< ProductCategoryNode[] >( 'categories' ) }
 		/>
 	);
 };

--- a/packages/js/product-editor/src/components/details-categories-field/test/category-field.test.tsx
+++ b/packages/js/product-editor/src/components/details-categories-field/test/category-field.test.tsx
@@ -21,7 +21,7 @@ jest.mock( '../use-category-search', () => {
 			originalModule.getCategoriesTreeWithMissingParents,
 		useCategorySearch: jest.fn().mockReturnValue( {
 			searchCategories: jest.fn(),
-			getFilteredItemsForSelectTree: jest.fn(),
+			getFilteredItemsForSelectTree: jest.fn().mockReturnValue( [] ),
 			isSearching: false,
 			categoriesSelectList: [],
 			categoryTreeKeyValues: {},

--- a/packages/js/product-editor/src/components/details-categories-field/test/category-field.test.tsx
+++ b/packages/js/product-editor/src/components/details-categories-field/test/category-field.test.tsx
@@ -13,6 +13,7 @@ import { createElement } from '@wordpress/element';
 import { CategoryField } from '../category-field';
 import {
 	getCategoriesTreeWithMissingParents,
+	ProductCategoryNode,
 	useCategorySearch,
 } from '../use-category-search';
 
@@ -118,9 +119,9 @@ describe( 'CategoryField', () => {
 					<CategoryField
 						label="Categories"
 						placeholder="Search or create category…"
-						{ ...getInputProps<
-							Pick< ProductCategory, 'id' | 'name' >[]
-						>( 'categories' ) }
+						{ ...getInputProps< ProductCategoryNode[] >(
+							'categories'
+						) }
 					/>
 				) }
 			</Form>
@@ -214,9 +215,9 @@ describe( 'CategoryField', () => {
 						<CategoryField
 							label="Categories"
 							placeholder="Search or create category…"
-							{ ...getInputProps<
-								Pick< ProductCategory, 'id' | 'name' >[]
-							>( 'categories' ) }
+							{ ...getInputProps< ProductCategoryNode[] >(
+								'categories'
+							) }
 						/>
 					) }
 				</Form>
@@ -242,9 +243,9 @@ describe( 'CategoryField', () => {
 						<CategoryField
 							label="Categories"
 							placeholder="Search or create category…"
-							{ ...getInputProps<
-								Pick< ProductCategory, 'id' | 'name' >[]
-							>( 'categories' ) }
+							{ ...getInputProps< ProductCategoryNode[] >(
+								'categories'
+							) }
 						/>
 					) }
 				</Form>
@@ -270,9 +271,9 @@ describe( 'CategoryField', () => {
 						<CategoryField
 							label="Categories"
 							placeholder="Search or create category…"
-							{ ...getInputProps<
-								Pick< ProductCategory, 'id' | 'name' >[]
-							>( 'categories' ) }
+							{ ...getInputProps< ProductCategoryNode[] >(
+								'categories'
+							) }
 						/>
 					) }
 				</Form>
@@ -299,9 +300,9 @@ describe( 'CategoryField', () => {
 						<CategoryField
 							label="Categories"
 							placeholder="Search or create category…"
-							{ ...getInputProps<
-								Pick< ProductCategory, 'id' | 'name' >[]
-							>( 'categories' ) }
+							{ ...getInputProps< ProductCategoryNode[] >(
+								'categories'
+							) }
 						/>
 					) }
 				</Form>

--- a/packages/js/product-editor/src/components/details-categories-field/use-category-search.ts
+++ b/packages/js/product-editor/src/components/details-categories-field/use-category-search.ts
@@ -293,9 +293,9 @@ export const useCategorySearch = () => {
 			return allItems.filter(
 				( item ) =>
 					selectedItems.indexOf( item ) < 0 &&
-					( searchRegex.test( item.name ) ||
-						( categoryTreeKeyValues[ +item.id ] &&
-							categoryTreeKeyValues[ +item.id ].isOpen ) )
+					( searchRegex.test( item.label ) ||
+						( categoryTreeKeyValues[ +item.value ] &&
+							categoryTreeKeyValues[ +item.value ].isOpen ) )
 			);
 		},
 		[ categoriesAndNewItem ]

--- a/packages/js/product-editor/src/components/details-categories-field/use-category-search.ts
+++ b/packages/js/product-editor/src/components/details-categories-field/use-category-search.ts
@@ -9,6 +9,7 @@ import {
 	ProductCategory,
 } from '@woocommerce/data';
 import { escapeRegExp } from 'lodash';
+import { TreeItemType } from '@woocommerce/components';
 
 /**
  * Internal dependencies
@@ -32,6 +33,11 @@ function openParents(
 		}
 	}
 }
+
+export type ProductCategoryLinkedList = Pick<
+	ProductCategory,
+	'id' | 'name' | 'parent'
+>;
 
 /**
  * Sort function for category tree items, sorts by popularity and then alphabetically.
@@ -256,9 +262,9 @@ export const useCategorySearch = () => {
 	 */
 	const getFilteredItems = useCallback(
 		(
-			allItems: Pick< ProductCategory, 'id' | 'name' >[],
+			allItems: ProductCategoryLinkedList[],
 			inputValue: string,
-			selectedItems: Pick< ProductCategory, 'id' | 'name' >[]
+			selectedItems: ProductCategoryLinkedList[]
 		) => {
 			const searchRegex = new RegExp( escapeRegExp( inputValue ), 'i' );
 			return allItems.filter(
@@ -272,9 +278,33 @@ export const useCategorySearch = () => {
 		[ categoriesAndNewItem ]
 	);
 
+	/**
+	 * this is the same as getFilteredItems but for the SelectTree component, where item id is a string.
+	 * After all the occurrences of getFilteredItems are migrated to use SelectTree,
+	 * this can become the standard version
+	 */
+	const getFilteredItemsForSelectTree = useCallback(
+		(
+			allItems: TreeItemType[],
+			inputValue: string,
+			selectedItems: TreeItemType[]
+		) => {
+			const searchRegex = new RegExp( escapeRegExp( inputValue ), 'i' );
+			return allItems.filter(
+				( item ) =>
+					selectedItems.indexOf( item ) < 0 &&
+					( searchRegex.test( item.name ) ||
+						( categoryTreeKeyValues[ +item.id ] &&
+							categoryTreeKeyValues[ +item.id ].isOpen ) )
+			);
+		},
+		[ categoriesAndNewItem ]
+	);
+
 	return {
 		searchCategories,
 		getFilteredItems,
+		getFilteredItemsForSelectTree,
 		categoriesSelectList: categoriesAndNewItem[ 0 ],
 		categories: categoriesAndNewItem[ 1 ],
 		isSearching,

--- a/packages/js/product-editor/src/components/details-categories-field/use-category-search.ts
+++ b/packages/js/product-editor/src/components/details-categories-field/use-category-search.ts
@@ -34,7 +34,7 @@ function openParents(
 	}
 }
 
-export type ProductCategoryLinkedList = Pick<
+export type ProductCategoryNode = Pick<
 	ProductCategory,
 	'id' | 'name' | 'parent'
 >;
@@ -262,9 +262,9 @@ export const useCategorySearch = () => {
 	 */
 	const getFilteredItems = useCallback(
 		(
-			allItems: ProductCategoryLinkedList[],
+			allItems: ProductCategoryNode[],
 			inputValue: string,
-			selectedItems: ProductCategoryLinkedList[]
+			selectedItems: ProductCategoryNode[]
 		) => {
 			const searchRegex = new RegExp( escapeRegExp( inputValue ), 'i' );
 			return allItems.filter(

--- a/packages/js/tsconfig.json
+++ b/packages/js/tsconfig.json
@@ -18,7 +18,6 @@
 		"**/build",
 		"**/build-module",
 		"**/build-types",
-		"**/test/*",
 		"**/jest.config.js",
 		"**/jest-preset.js",
 		"**/webpack.*.js",

--- a/packages/js/tsconfig.json
+++ b/packages/js/tsconfig.json
@@ -18,6 +18,7 @@
 		"**/build",
 		"**/build-module",
 		"**/build-types",
+		"**/test/*",
 		"**/jest.config.js",
 		"**/jest-preset.js",
 		"**/webpack.*.js",


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Use SelectTree component in Category field

Closes #37043 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Open the new product manager.
2. Go to Category field.
3. Test, using only keyboard (related keys: up, down, left, right, tab, home, end, tab), selecting categories and creating a new category
4. Test the same usage with mouse
5. Compare the behavior with the previous implementation and see if any regressions are found

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [ ] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
