### PR TITLE
Ensure install procedure only runs once

### DIFF
--- a/plugins/woocommerce/changelog/try-install-optim-add-proper-lock
+++ b/plugins/woocommerce/changelog/try-install-optim-add-proper-lock
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Improve installation routine by fixing a race condition.

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -381,7 +381,7 @@ class WC_Install {
 		}
 
 		// Check if we are not already running this routine.
-		if ( !LockUtil::test_and_set_expiring( 'wc_installing', 10 * MINUTE_IN_SECONDS ) ) {
+		if ( ! LockUtil::test_and_set_expiring( 'wc_installing', 10 * MINUTE_IN_SECONDS ) ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/Utilities/LockUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/LockUtil.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Automattic\WooCommerce\Internal\Utilities;
+
+/**
+ * Helper functions for working with locks.
+ *
+ * The locks are stored in the options table as a datetime value of the time the lock expires.
+ * Thus, to check whether a lock is set, we need to check whether the current time is before the expiration time.
+ *
+ * To unlock a lock, we set the expiration time to 0.
+ */
+class LockUtil {
+
+	/**
+	 * Test and set a lock.
+	 *
+	 * @param string $lock_name The name of the lock.
+	 * @param int    $expiration The expiration time in minutes.
+	 *
+	 * @return bool True if the lock was set, false otherwise.
+	 */
+	public static function test_and_set_expiring( $lock_name, $expiration = 10 ) {
+		global $wpdb;
+
+		$expiration = (int) $expiration;
+
+		$result = $wpdb->query(
+			$wpdb->prepare(
+				"UPDATE {$wpdb->options}
+					SET option_value = IF(NOW() > CAST(option_value AS DATETIME), DATE_ADD(NOW(), INTERVAL %d MINUTE), option_value)
+					WHERE option_name = %s;",
+				$expiration,
+				$lock_name
+			)
+		);
+		return 1 === $result;
+	}
+
+	/**
+	 * Unlock a lock.
+	 *
+	 * @param string $lock_name The name of the lock.
+	 */
+	public static function unlock( $lock_name ) {
+		global $wpdb;
+
+		$wpdb->query(
+			$wpdb->prepare(
+				"UPDATE {$wpdb->options}
+					SET option_value = 0
+					WHERE option_name = %s;",
+				$lock_name
+			)
+		);
+
+	}
+}
+
+

--- a/plugins/woocommerce/src/Internal/Utilities/LockUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/LockUtil.php
@@ -16,29 +16,37 @@ class LockUtil {
 	 * Test and set a lock.
 	 *
 	 * @param string $lock_name The name of the lock.
-	 * @param int    $expiration The expiration time in minutes.
+	 * @param int    $expiration The expiration time in seconds.
 	 *
 	 * @return bool True if the lock was set, false otherwise.
 	 */
-	public static function test_and_set_expiring( $lock_name, $expiration = 10 ) {
+	public static function test_and_set_expiring( $lock_name, $expiration = 10 * MINUTE_IN_SECONDS ) {
 		global $wpdb;
 
 		$expiration = (int) $expiration;
 
 		$result = $wpdb->query(
 			$wpdb->prepare(
-				"UPDATE {$wpdb->options}
-					SET option_value = IF(NOW() > CAST(option_value AS DATETIME), DATE_ADD(NOW(), INTERVAL %d MINUTE), option_value)
-					WHERE option_name = %s;",
+				"INSERT INTO {$wpdb->options} (option_name, option_value, autoload) VALUES (%s, DATE_ADD(NOW(), INTERVAL %d SECOND), 'no')
+					ON DUPLICATE KEY UPDATE
+						option_value = IF(NOW() > CAST(option_value AS DATETIME), DATE_ADD(NOW(), INTERVAL %d SECOND), option_value);",
+				$lock_name,
 				$expiration,
-				$lock_name
+				$expiration
 			)
 		);
-		return 1 === $result;
+		/**  With ON DUPLICATE KEY UPDATE, the affected-rows value per row is 
+		 * 1 if the row is inserted as a new row,
+		 * 2 if an existing row is updated, and 
+		 * 0 if an existing row is set to its current values.
+		 */
+		return $result > 0;
 	}
 
 	/**
 	 * Unlock a lock.
+	 * 
+	 * Sets the expiration time to 1 second ago.
 	 *
 	 * @param string $lock_name The name of the lock.
 	 */
@@ -48,7 +56,7 @@ class LockUtil {
 		$wpdb->query(
 			$wpdb->prepare(
 				"UPDATE {$wpdb->options}
-					SET option_value = 0
+					SET option_value = DATE_SUB(NOW(), INTERVAL 1 SECOND)
 					WHERE option_name = %s;",
 				$lock_name
 			)

--- a/plugins/woocommerce/src/Internal/Utilities/LockUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/LockUtil.php
@@ -35,9 +35,9 @@ class LockUtil {
 				$expiration
 			)
 		);
-		/**  With ON DUPLICATE KEY UPDATE, the affected-rows value per row is 
+		/**  With ON DUPLICATE KEY UPDATE, the affected-rows value per row is
 		 * 1 if the row is inserted as a new row,
-		 * 2 if an existing row is updated, and 
+		 * 2 if an existing row is updated, and
 		 * 0 if an existing row is set to its current values.
 		 */
 		return $result > 0;
@@ -45,7 +45,7 @@ class LockUtil {
 
 	/**
 	 * Unlock a lock.
-	 * 
+	 *
 	 * Sets the expiration time to 1 second ago.
 	 *
 	 * @param string $lock_name The name of the lock.

--- a/plugins/woocommerce/tests/php/src/Internal/Utilities/LockUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Utilities/LockUtilTest.php
@@ -9,14 +9,7 @@ use Automattic\WooCommerce\Internal\Utilities\LockUtil;
  * Tests relating to LockUtil.
  */
 class LockUtilTest extends WC_Unit_Test_Case {
-
-	/**
-	 * Set-up subject under test.
-	 */
-	public function set_up() {
-		parent::set_up();
-	}
-
+	
 	/**
 	 * @testdox Test a lock can't be locked twice.
 	 */

--- a/plugins/woocommerce/tests/php/src/Internal/Utilities/LockUtilTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Utilities/LockUtilTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Tests for the Lock utility.
+ */
+
+use Automattic\WooCommerce\Internal\Utilities\LockUtil;
+
+/**
+ * Tests relating to LockUtil.
+ */
+class LockUtilTest extends WC_Unit_Test_Case {
+
+	/**
+	 * Set-up subject under test.
+	 */
+	public function set_up() {
+		parent::set_up();
+	}
+
+	/**
+	 * @testdox Test a lock can't be locked twice.
+	 */
+	public function test_cant_lock_twice() {
+		$this->assertTrue( LockUtil::test_and_set_expiring( 'test_lock_1', 30 ) );
+		$this->assertFalse( LockUtil::test_and_set_expiring( 'test_lock_1', 30 ) );
+	}
+
+	/**
+	 * @testdox Test 2 different locks can be locked independently.
+	 */
+	public function test_different_locks() {
+		$this->assertTrue( LockUtil::test_and_set_expiring( 'test_lock_2', 30 ) );
+		$this->assertTrue( LockUtil::test_and_set_expiring( 'test_lock_3', 30 ) );
+	}
+
+	/**
+	 * @testdox Test a lock can be unlocked.
+	 */
+	public function test_unlock() {
+		global $wpdb;
+		$this->assertTrue( LockUtil::test_and_set_expiring( 'test_lock_4', 30 ) );
+		LockUtil::unlock( 'test_lock_4' );
+		$this->assertTrue( LockUtil::test_and_set_expiring( 'test_lock_4', 30 ) );
+	}
+
+	/**
+	 * @testdox Test a lock expires.
+	 */
+	public function test_expires() {
+		$this->assertTrue( LockUtil::test_and_set_expiring( 'test_lock_5', 1 ) );
+		sleep( 2 );
+		$this->assertTrue( LockUtil::test_and_set_expiring( 'test_lock_5', 30 ) );
+	}
+}


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This is an experimental implementation of a proper locking mechanism using `INSERT INTO ... ON DUPLICATE KEY UPDATE`. There is some discussion to be had about the effects of locking the whole `wp_options` table in the case of MyISAM engine or how the gap locks would work in the case of InnoDB engine. 

The motivation was to avoid race conditions by using non-atomic test and set for `wc_installing` transient. Plus, a transient can be removed at any point prior its expiry, so there are really no guarantees about the existing locking solution.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1.
2.
3.

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [ ] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
