### PR TITLE
Thank you page (/checkout/order-received): payment gateway title formatting

### DIFF
--- a/plugins/woocommerce/changelog/fix-27518-payment-gateway-title
+++ b/plugins/woocommerce/changelog/fix-27518-payment-gateway-title
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Avoid over-aggressive escaping of the payment gateway title in the context of the checkout thank you page.

--- a/plugins/woocommerce/templates/order/order-details.php
+++ b/plugins/woocommerce/templates/order/order-details.php
@@ -15,8 +15,6 @@
  * @version 7.7.0
  */
 
-use Automattic\WooCommerce\Internal\Utilities\HtmlSanitizer;
-
 defined( 'ABSPATH' ) || exit;
 
 $order = wc_get_order( $order_id ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
@@ -85,7 +83,7 @@ if ( $show_downloads ) {
 				?>
 					<tr>
 						<th scope="row"><?php echo esc_html( $total['label'] ); ?></th>
-						<td><?php echo ( 'payment_method' === $key ) ? wc_get_container()->get( HtmlSanitizer::class )->sanitize( $total['value'] ) : wp_kses_post( $total['value'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></td>
+						<td><?php echo wp_kses_post( $total['value'] ); ?></td>
 					</tr>
 					<?php
 			}

--- a/plugins/woocommerce/templates/order/order-details.php
+++ b/plugins/woocommerce/templates/order/order-details.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 4.6.0
+ * @version 7.7.0
  */
 
 use Automattic\WooCommerce\Internal\Utilities\HtmlSanitizer;

--- a/plugins/woocommerce/templates/order/order-details.php
+++ b/plugins/woocommerce/templates/order/order-details.php
@@ -15,6 +15,8 @@
  * @version 4.6.0
  */
 
+use Automattic\WooCommerce\Internal\Utilities\HtmlSanitizer;
+
 defined( 'ABSPATH' ) || exit;
 
 $order = wc_get_order( $order_id ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
@@ -83,7 +85,7 @@ if ( $show_downloads ) {
 				?>
 					<tr>
 						<th scope="row"><?php echo esc_html( $total['label'] ); ?></th>
-						<td><?php echo ( 'payment_method' === $key ) ? esc_html( $total['value'] ) : wp_kses_post( $total['value'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></td>
+						<td><?php echo ( 'payment_method' === $key ) ? wc_get_container()->get( HtmlSanitizer::class )->sanitize( $total['value'] ) : wp_kses_post( $total['value'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></td>
 					</tr>
 					<?php
 			}


### PR DESCRIPTION
We allow a safe subset of HTML to be used in payment gateway titles but, within the thank-you page, there is a spot where we 'over-escape' things, leading to a broken appearance in some cases.

| Before (Broken) | After (Fixed) |
| --- | --- |
| ![Screenshot_20230328_124951](https://user-images.githubusercontent.com/3594411/228352323-0bbdc33e-6cb8-4db4-ab91-f0473a07d440.png) | ![Screenshot_20230328_125011](https://user-images.githubusercontent.com/3594411/228352329-9c70fdb6-da43-469e-98d3-ba5d3628e61c.png) |

In the above screenshots, we can see how the payment gateway title is displayed twice: once toward the top of the page, and again further down, beside the order items. However, currently, the second of those is fully escaped and so the payment icon does not appear—instead we see the raw HTML for the image tag. 

The screenshot on the right shows how things look with this change. This time, the image is actually rendered.

Closes #27518.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Visit **WooCommerce ‣ Settings ‣ Payments** and enable the Direct Bank Transfer gateway. Edit the title so it includes an image tag. Example: `Direct bank transfer <img src="https://tinyurl.com/ytwpth6y" />` (and remember to save).
2. As a customer, purchase an item and use the Direct Bank Transfer gateway when doing so.
3. Once you arrive at the thank-you page (the URL will look something like `/checkout/order-received/1234/?key=wc_order_ABC123DEF456`) you should see that your custom payment gateway title, including the image, are successfully rendered in both places, as demonstrated in the second of the screenshots found above.

Please note this change just allows for a safe subset of HTML (including image tags) to be used, it doesn't mean that any old HTML is allowed. Refer to [`HtmlSanitizer::LOW_HTML_BALANCED_TAGS_NO_LINKS`](https://github.com/woocommerce/woocommerce/blob/7.5.1/plugins/woocommerce/src/Internal/Utilities/HtmlSanitizer.php#L13-L32) to see what we allow by default.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
