### PR TITLE
Dev - Allow to filter wc_help_tip output

### DIFF
--- a/plugins/woocommerce/changelog/fix-36543
+++ b/plugins/woocommerce/changelog/fix-36543
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Dev - Allow to filter wc_help_tip

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1593,20 +1593,24 @@ function wc_back_link( $label, $url ) {
  */
 function wc_help_tip( $tip, $allow_html = false ) {
 	if ( $allow_html ) {
-		$tip = wc_sanitize_tooltip( $tip );
+		$sanitized_tip = wc_sanitize_tooltip( $tip );
 	} else {
-		$tip = esc_attr( $tip );
+		$sanitized_tip = esc_attr( $tip );
 	}
 
 	/**
 	 * Filter the help tip.
 	 *
-	 * @param string $tip_html   Help tip HTML.
-	 * @param string $tip        Help tip text.
-	 * @param bool   $allow_html Allow sanitized HTML if true or escape.
+	 * @since 7.7.0
+	 *
+	 * @param string $tip_html       Help tip HTML.
+	 * @param string $sanitized_tip  Sanitized help tip text.
+	 * @param string $tip            Original help tip text.
+	 * @param bool   $allow_html     Allow sanitized HTML if true or escape.
+	 * 
 	 * @return string
 	 */
-	return apply_filters( 'wc_help_tip', '<span class="woocommerce-help-tip" data-tip="' . $tip . '"></span>', $tip, $allow_html );
+	return apply_filters( 'wc_help_tip', '<span class="woocommerce-help-tip" data-tip="' . $sanitized_tip . '"></span>', $sanitized_tip, $tip, $allow_html );
 }
 
 /**

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1598,7 +1598,15 @@ function wc_help_tip( $tip, $allow_html = false ) {
 		$tip = esc_attr( $tip );
 	}
 
-	return '<span class="woocommerce-help-tip" data-tip="' . $tip . '"></span>';
+	/**
+	 * Filter the help tip.
+	 *
+	 * @param string $tip_html   Help tip HTML.
+	 * @param string $tip        Help tip text.
+	 * @param bool   $allow_html Allow sanitized HTML if true or escape.
+	 * @return string
+	 */
+	return apply_filters( 'wc_help_tip', '<span class="woocommerce-help-tip" data-tip="' . $tip . '"></span>', $tip, $allow_html );
 }
 
 /**

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1607,7 +1607,7 @@ function wc_help_tip( $tip, $allow_html = false ) {
 	 * @param string $sanitized_tip  Sanitized help tip text.
 	 * @param string $tip            Original help tip text.
 	 * @param bool   $allow_html     Allow sanitized HTML if true or escape.
-	 * 
+	 *
 	 * @return string
 	 */
 	return apply_filters( 'wc_help_tip', '<span class="woocommerce-help-tip" data-tip="' . $sanitized_tip . '"></span>', $sanitized_tip, $tip, $allow_html );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

This filter hook allows developers to modify the HTML output of the help tip displayed on WooCommerce setting pages.

Closes #36543.

### How to test the changes in this Pull Request:

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. In theme's functions.php file, add a callback function to the wc_help_tip filter hook that modifies the help tip HTML. For example:

```php
add_filter( 'wc_help_tip', function($tip_html, $sanitized_tip, $tip, $allow_html) {
	return '<div class="woocommerce-help-tip" data-tip="' . strtoupper($sanitized_tip) . '"></div>';
}, 10, 4 )
```

2. Load a page on your site that displays a help tip. For example Products - Categories, there's a help tip to the left of the "Uncategorized" category.
3. Verify that the modifications to the help tip have been applied, inspectiing the HTML of the help tip element using your browser's inspector tool if necessary. For the above example the text of the help tip will appear in uppercase.

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
