### PR TITLE
Add different confirmation message when attribute is used in a variation

### DIFF
--- a/plugins/woocommerce/changelog/update-confirm-remove-attr
+++ b/plugins/woocommerce/changelog/update-confirm-remove-attr
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Show different error message when deleting an attribute used in variations

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -628,57 +628,56 @@ jQuery( function ( $ ) {
 		}
 	);
 
-	$( '#product_attributes' ).on( 'click', '.product_attributes .remove_row', function () {
-		var confirmMessage = woocommerce_admin_meta_boxes.remove_attribute;
-		var $parent = $( this ).parent().parent();
-		if ( !$parent.is( '.taxonomy' ) ) {
-			var variationsData = $(
-				'.woocommerce_variations :input'
-			).serializeJSON();
-			var val = $parent.find( 'input.attribute_name' ).val();
-			if ( variationsData[ `attribute_${ val }` ] ) {
-				confirmMessage = woocommerce_admin_meta_boxes.i18n_remove_used_attribute_confirmation_message;
+	$( '#product_attributes' ).on(
+		'click',
+		'.product_attributes .remove_row',
+		function () {
+			var $parent = $( this ).parent().parent();
+			var confirmMessage = $parent
+				.find( 'input[name^="attribute_variation"]' )
+				.is( ':checked' )
+				? woocommerce_admin_meta_boxes.i18n_remove_used_attribute_confirmation_message
+				: woocommerce_admin_meta_boxes.remove_attribute;
+
+			if ( window.confirm( confirmMessage ) ) {
+				if ( $parent.is( '.taxonomy' ) ) {
+					$parent.find( 'select, input[type=text]' ).val( '' );
+					$parent.hide();
+					$( 'select.attribute_taxonomy' )
+						.find(
+							'option[value="' + $parent.data( 'taxonomy' ) + '"]'
+						)
+						.prop( 'disabled', false );
+					selectedAttributes = selectedAttributes.filter(
+						( attr ) => attr !== $parent.data( 'taxonomy' )
+					);
+					$( 'select.wc-attribute-search' ).data(
+						'disabled-items',
+						selectedAttributes
+					);
+				} else {
+					$parent.find( 'select, input[type=text]' ).val( '' );
+					$parent.hide();
+					attribute_row_indexes();
+				}
+
+				$parent.remove();
+
+				if (
+					! $( '.woocommerce_attribute_data' ).is( ':visible' ) &&
+					! $( 'div.add-global-attribute-container' ).hasClass(
+						'hidden'
+					) &&
+					$( '.product_attributes' ).find( 'input, select, textarea' )
+						.length === 0
+				) {
+					toggle_add_global_attribute_layout();
+				}
+				jQuery.maybe_disable_save_button();
 			}
+			return false;
 		}
-		if ( window.confirm( confirmMessage ) ) {
-
-			if ( $parent.is( '.taxonomy' ) ) {
-				$parent.find( 'select, input[type=text]' ).val( '' );
-				$parent.hide();
-				$( 'select.attribute_taxonomy' )
-					.find(
-						'option[value="' + $parent.data( 'taxonomy' ) + '"]'
-					)
-					.prop( 'disabled', false );
-				selectedAttributes = selectedAttributes.filter(
-					( attr ) => attr !== $parent.data( 'taxonomy' )
-				);
-				$( 'select.wc-attribute-search' ).data(
-					'disabled-items',
-					selectedAttributes
-				);
-			} else {
-				$parent.find( 'select, input[type=text]' ).val( '' );
-				$parent.hide();
-				attribute_row_indexes();
-			}
-
-			$parent.remove();
-
-			if (
-				! $( '.woocommerce_attribute_data' ).is( ':visible' ) &&
-				! $( 'div.add-global-attribute-container' ).hasClass(
-					'hidden'
-				) &&
-				$( '.product_attributes' ).find( 'input, select, textarea' )
-					.length === 0
-			) {
-				toggle_add_global_attribute_layout();
-			}
-			jQuery.maybe_disable_save_button();
-		}
-		return false;
-	} );
+	);
 
 	// Attribute ordering.
 	$( '.product_attributes' ).sortable( {

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -628,9 +628,19 @@ jQuery( function ( $ ) {
 		}
 	);
 
-	$( '.product_attributes' ).on( 'click', '.remove_row', function () {
-		if ( window.confirm( woocommerce_admin_meta_boxes.remove_attribute ) ) {
-			var $parent = $( this ).parent().parent();
+	$( '#product_attributes' ).on( 'click', '.product_attributes .remove_row', function () {
+		var confirmMessage = woocommerce_admin_meta_boxes.remove_attribute;
+		var $parent = $( this ).parent().parent();
+		if ( !$parent.is( '.taxonomy' ) ) {
+			var variationsData = $(
+				'.woocommerce_variations :input'
+			).serializeJSON();
+			var val = $parent.find( 'input.attribute_name' ).val();
+			if ( variationsData[ `attribute_${ val }` ] ) {
+				confirmMessage = woocommerce_admin_meta_boxes.i18n_remove_used_attribute_confirmation_message;
+			}
+		}
+		if ( window.confirm( confirmMessage ) ) {
 
 			if ( $parent.is( '.taxonomy' ) ) {
 				$parent.find( 'select, input[type=text]' ).val( '' );

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -432,6 +432,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					'i18n_save_attribute_variation_tip'  => __( 'Make sure you enter the name and values for each attribute.', 'woocommerce' ),
 					/* translators: %1$s: maximum file size */
 					'i18n_product_image_tip'             => sprintf( __( 'For best results, upload JPEG or PNG files that are 1000 by 1000 pixels or larger. Maximum upload file size: %1$s.', 'woocommerce' ) , size_format( wp_max_upload_size() ) ),
+					'i18n_remove_used_attribute_confirmation_message' => __( 'If you remove this attribute, customers will no longer be able to purchase some variations of this product.', 'woocommerce' ),
 				);
 
 				wp_localize_script( 'wc-admin-meta-boxes', 'woocommerce_admin_meta_boxes', $params );


### PR DESCRIPTION
### All Submissions:

-   [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Add different confirmation message when deleting an attribute which is used in a variation

Closes #37162 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Create a new product in the legacy product manager
2. Select 'Variable' product type
3. Go to 'Attributes' tab and create an attribute with any name and values.
4. Go to 'Variations' tab and create a variation with the just created attribute.
5. Go back to 'Attributes' tab and remove the attribute.
6. Check that the confirmation message is 'If you remove this attribute, customers will no longer be able to purchase some variations of this product.'
7. Try to delete an attribute which doesn't have a variation
8. Check that the confirmation message is different.

<!-- End testing instructions -->

### Other information:

-   [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [ ] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [ ] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
