### PR TITLE
Dev/fix a type usage

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/fills/steps/location.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/steps/location.tsx
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { COUNTRIES_STORE_NAME } from '@woocommerce/data';
 import { Fragment } from '@wordpress/element';
-import { Form, FormContext, Spinner } from '@woocommerce/components';
+import { Form, FormContextType, Spinner } from '@woocommerce/components';
 import { useSelect } from '@wordpress/data';
 import { Status, Options } from 'wordpress__notices';
 /**
@@ -126,7 +126,7 @@ const StoreLocation = ( {
 				getInputProps,
 				handleSubmit,
 				setValue,
-			}: FormContext< FormValues > ) => (
+			}: FormContextType< FormValues > ) => (
 				<Fragment>
 					<StoreAddress
 						// @ts-expect-error return type doesn't match, but they do work. We should revisit and refactor them in a follow up issue.

--- a/plugins/woocommerce/changelog/dev-fix-a-type-usage
+++ b/plugins/woocommerce/changelog/dev-fix-a-type-usage
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Minor fix to a type name
+
+


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Recently some wholesale changes to type names were made [in a PR](https://github.com/woocommerce/woocommerce/pull/37351). 

Then [this change](https://github.com/woocommerce/woocommerce/pull/37257/files#diff-e336abd62cbd9e4d251f7c257a85e837100f0f0f9085de30ec1b9f5e1b4b4716R129) was introduced based on the old type names.

As a result `trunk` builds fail right now due to this type mismatch. This is the only occurring problem that was stopping the `pnpm build` from completing.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. If you like you can check out trunk and try building it: `pnpm build`. You should see it fail with a type error related to `FormContext`
2. Now check out this branch and run `pnpm build` it should pass
3. CI checks should pass.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
