### PR TITLE
Fix `FormContext` type error in client/tasks/fills/steps/location.tsx

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/fills/steps/location.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/steps/location.tsx
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { COUNTRIES_STORE_NAME } from '@woocommerce/data';
 import { Fragment } from '@wordpress/element';
-import { Form, FormContext, Spinner } from '@woocommerce/components';
+import { Form, FormContextType, Spinner } from '@woocommerce/components';
 import { useSelect } from '@wordpress/data';
 import { Status, Options } from 'wordpress__notices';
 /**
@@ -126,7 +126,7 @@ const StoreLocation = ( {
 				getInputProps,
 				handleSubmit,
 				setValue,
-			}: FormContext< FormValues > ) => (
+			}: FormContextType< FormValues > ) => (
 				<Fragment>
 					<StoreAddress
 						// @ts-expect-error return type doesn't match, but they do work. We should revisit and refactor them in a follow up issue.

--- a/plugins/woocommerce/changelog/fix-location-type-error
+++ b/plugins/woocommerce/changelog/fix-location-type-error
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Fix FormContext type error caused by #37257
+
+


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes the type error caused by #37257. 

`FormContext` type was renamed to `FormContextType` in https://github.com/woocommerce/woocommerce/pull/37351/files#diff-3f1bb6b35bb1dc2ee3d0910ae803d0d3b2240cff3ce0b8894a211c66784c15e1R21. 

To avoid the same error, we should rebase trunk before merging TS-related PRs next time. 

```
woocommerce/client/admin:turbo:build: ERROR in client/tasks/fills/steps/location.tsx:129:7
woocommerce/client/admin:turbo:build: TS2749: 'FormContext' refers to a value, but is being used as a type here. Did you mean 'typeof FormContext'?
woocommerce/client/admin:turbo:build:     127 | 				handleSubmit,
woocommerce/client/admin:turbo:build:     128 | 				setValue,
woocommerce/client/admin:turbo:build:   > 129 | 			}: FormContext< FormValues > ) => (
woocommerce/client/admin:turbo:build:         | 			   ^^^^^^^^^^^
woocommerce/client/admin:turbo:build:     130 | 				<Fragment>
woocommerce/client/admin:turbo:build:     131 | 					<StoreAddress
woocommerce/client/admin:turbo:build:     132 | 						// @ts-expect-error return type doesn't match, but they do work. We should revisit and refactor them in a follow up issue.
woocommerce/client/admin:turbo:build: 
woocommerce/client/admin:turbo:build: ERROR in client/tasks/fills/steps/location.tsx:132:7
woocommerce/client/admin:turbo:build: TS2578: Unused '@ts-expect-error' directive.
woocommerce/client/admin:turbo:build:     130 | 				<Fragment>
woocommerce/client/admin:turbo:build:     131 | 					<StoreAddress
woocommerce/client/admin:turbo:build:   > 132 | 						// @ts-expect-error return type doesn't match, but they do work. We should revisit and refactor them in a follow up issue.
woocommerce/client/admin:turbo:build:         | 						^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
woocommerce/client/admin:turbo:build:     133 | 						getInputProps={ getInputProps }
woocommerce/client/admin:turbo:build:     134 | 						setValue={ setValue }
woocommerce/client/admin:turbo:build:     135 | 					/>
woocommerce/client/admin:turbo:build: 
woocommerce/client/admin:turbo:build: webpack 5.70.0 compiled with 2 errors and 3 warnings in 73611 ms
```

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [ ] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. CI should pass
2. Run `pnpm --filter="woocommerce/client/admin" build`

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
