### PR TITLE
Updated task progress header title

### DIFF
--- a/plugins/woocommerce-admin/client/task-lists/progress-title/default-progress-title.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/progress-title/default-progress-title.tsx
@@ -7,6 +7,11 @@ import { useSelect } from '@wordpress/data';
 import { getVisibleTasks, ONBOARDING_STORE_NAME } from '@woocommerce/data';
 import { getSetting } from '@woocommerce/settings';
 
+/**
+ * Internal dependencies
+ */
+import sanitizeHTML from '../../lib/sanitize-html';
+
 export type DefaultProgressTitleProps = {
 	taskListId: string;
 };
@@ -64,6 +69,9 @@ export const DefaultProgressTitle: React.FC< DefaultProgressTitleProps > = ( {
 	}
 
 	return (
-		<h1 className="woocommerce-task-progress-header__title" dangerouslySetInnerHTML={ sanitizeHTML( title ) } />
+		<h1
+			className="woocommerce-task-progress-header__title"
+			dangerouslySetInnerHTML={ sanitizeHTML( title ) }
+		/>
 	);
 };

--- a/plugins/woocommerce-admin/client/task-lists/progress-title/default-progress-title.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/progress-title/default-progress-title.tsx
@@ -64,6 +64,6 @@ export const DefaultProgressTitle: React.FC< DefaultProgressTitleProps > = ( {
 	}
 
 	return (
-		<h1 className="woocommerce-task-progress-header__title">{ title }</h1>
+		<h1 className="woocommerce-task-progress-header__title" dangerouslySetInnerHTML={ sanitizeHTML( title ) } />
 	);
 };

--- a/plugins/woocommerce/changelog/patch-1
+++ b/plugins/woocommerce/changelog/patch-1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix special Characters not rendered in admin titles

--- a/plugins/woocommerce/changelog/patch-1
+++ b/plugins/woocommerce/changelog/patch-1
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix special Characters not rendered in admin titles
+Fix special characters not rendered in admin titles


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #36246.

This PR updated task progress header title to support special characters using the `dangerouslySetInnerHTML` function was a ready solution used throughout the application, so it makes sense to apply it here as well.

<img src="https://user-images.githubusercontent.com/1872327/210150925-4f1e52e5-28ec-4aec-832d-79a72af1eb6c.png" width="400px" />

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Install and activate WooCommerce in a brand new site
2. Skip Onboarding Wizard
3. Go to `Settings > General` (/wp-admin/options-general.php)
4. Change Site Title to `Joe&#039;s`
5. Go to `WooCommerce > Home`
6. Observe that the home screen title renders `Welcome to Joe's`

<img src="https://user-images.githubusercontent.com/4344253/231335474-7eda2db5-b08b-4cfa-aed1-2962f08087be.png" width="400px" />


<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
