### PR TITLE
Load `taxonomy-pa_<slug>` template before `taxonomy-product_attribute`

### DIFF
--- a/changelog/fix-attribute-taxonomy-templates
+++ b/changelog/fix-attribute-taxonomy-templates
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix attribute taxonomy templates when a templates for specific product attribute exists.

--- a/changelog/fix-attribute-taxonomy-templates
+++ b/changelog/fix-attribute-taxonomy-templates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix attribute taxonomy templates when a templates for specific product attribute exists.

--- a/plugins/woocommerce/changelog/fix-issue-36560
+++ b/plugins/woocommerce/changelog/fix-issue-36560
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Taxonomy specific templates take precedence over 'taxonomy-product_attribute.php' template.

--- a/plugins/woocommerce/changelog/fix-issue-36560
+++ b/plugins/woocommerce/changelog/fix-issue-36560
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: fix
 
-Taxonomy specific templates take precedence over 'taxonomy-product_attribute.php' template.
+Fix attribute taxonomy templates when a templates for specific product attribute exists.

--- a/plugins/woocommerce/includes/class-wc-template-loader.php
+++ b/plugins/woocommerce/includes/class-wc-template-loader.php
@@ -250,25 +250,25 @@ class WC_Template_Loader {
 		if ( is_product_taxonomy() ) {
 			$object = get_queried_object();
 
+			$templates[] = 'taxonomy-' . $object->taxonomy . '-' . $object->slug . '.php';
+			$templates[] = WC()->template_path() . 'taxonomy-' . $object->taxonomy . '-' . $object->slug . '.php';
+			$templates[] = 'taxonomy-' . $object->taxonomy . '.php';
+			$templates[] = WC()->template_path() . 'taxonomy-' . $object->taxonomy . '.php';
+
 			if ( taxonomy_is_product_attribute( $object->taxonomy ) ) {
 				$templates[] = 'taxonomy-product_attribute.php';
 				$templates[] = WC()->template_path() . 'taxonomy-product_attribute.php';
 				$templates[] = $default_file;
-			} else {
-				$templates[] = 'taxonomy-' . $object->taxonomy . '-' . $object->slug . '.php';
-				$templates[] = WC()->template_path() . 'taxonomy-' . $object->taxonomy . '-' . $object->slug . '.php';
-				$templates[] = 'taxonomy-' . $object->taxonomy . '.php';
-				$templates[] = WC()->template_path() . 'taxonomy-' . $object->taxonomy . '.php';
+			}
 
-				if ( is_tax( 'product_cat' ) || is_tax( 'product_tag' ) ) {
-					$cs_taxonomy = str_replace( '_', '-', $object->taxonomy );
-					$cs_default  = str_replace( '_', '-', $default_file );
-					$templates[] = 'taxonomy-' . $object->taxonomy . '-' . $object->slug . '.php';
-					$templates[] = WC()->template_path() . 'taxonomy-' . $cs_taxonomy . '-' . $object->slug . '.php';
-					$templates[] = 'taxonomy-' . $object->taxonomy . '.php';
-					$templates[] = WC()->template_path() . 'taxonomy-' . $cs_taxonomy . '.php';
-					$templates[] = $cs_default;
-				}
+			if ( is_tax( 'product_cat' ) || is_tax( 'product_tag' ) ) {
+				$cs_taxonomy = str_replace( '_', '-', $object->taxonomy );
+				$cs_default  = str_replace( '_', '-', $default_file );
+				$templates[] = 'taxonomy-' . $object->taxonomy . '-' . $object->slug . '.php';
+				$templates[] = WC()->template_path() . 'taxonomy-' . $cs_taxonomy . '-' . $object->slug . '.php';
+				$templates[] = 'taxonomy-' . $object->taxonomy . '.php';
+				$templates[] = WC()->template_path() . 'taxonomy-' . $cs_taxonomy . '.php';
+				$templates[] = $cs_default;
 			}
 		}
 


### PR DESCRIPTION
This is a fix for Issue 36560.

The taxonomy for product attributes takes precedence over any specific taxonomy slugs or templates. This add the "if" statement for the generic taxonomy statement after the more specific taxonomy template checks. This ensures taxonomy-pa_<attribute name> will load before taxonomy-product_attribute.

### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Added the taxonomy check after the check for specific taxonomy terms or slugs. The generic product attribute check occurs after the specific taxonomy checks. This ensures the use of templates with slugs or specific to a taxonomy term are used before the fallback generic template.

This is to fix issue 36560 (https://github.com/woocommerce/woocommerce/issues/36560)

Closes #36560.

### How to test the changes in this Pull Request:

1. Set up 2 product attributes that have archive pages, example `Color` and `Size`.
2. Create two templates, `taxonomy-pa_color.php` and `taxonomy-product_attribute.php`
3. When viewing the archive page for Color, you should see the `taxonomy-pa_color.php`. When viewing the archive page for Size, you should see the `taxonomy-product_attributes.php` template.

### Other information:

-   [x ] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [ ] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

based on the prior PR and this one, there aren't any new tests, as this uses the existing tests, and just changes the order the templates for taxonomy are loaded.

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
