### PR TITLE
Fix WC_Coupon set_status function @since version

### DIFF
--- a/plugins/woocommerce/changelog/pr-37557
+++ b/plugins/woocommerce/changelog/pr-37557
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed the since tag.

--- a/plugins/woocommerce/changelog/pr-37557
+++ b/plugins/woocommerce/changelog/pr-37557
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fixed the since tag.
+Corrected the `@since` tag for WC_Coupon::set_status() from 3.0.0 to 6.2.0

--- a/plugins/woocommerce/includes/class-wc-coupon.php
+++ b/plugins/woocommerce/includes/class-wc-coupon.php
@@ -187,7 +187,8 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	}
 
 	/**
-	 * Get coupon status.
+	 * Get coupon 
+	 .
 	 *
 	 * @since  6.2.0
 	 * @param  string $context What the value is for. Valid values are 'view' and 'edit'.
@@ -507,7 +508,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	/**
 	 * Set coupon status.
 	 *
-	 * @since 3.0.0
+	 * @since 6.2.0
 	 * @param string $status Status.
 	 */
 	public function set_status( $status ) {

--- a/plugins/woocommerce/includes/class-wc-coupon.php
+++ b/plugins/woocommerce/includes/class-wc-coupon.php
@@ -187,8 +187,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	}
 
 	/**
-	 * Get coupon 
-	 .
+	 * Get coupon status.
 	 *
 	 * @since  6.2.0
 	 * @param  string $context What the value is for. Valid values are 'view' and 'edit'.

--- a/plugins/woocommerce/includes/class-wc-coupon.php
+++ b/plugins/woocommerce/includes/class-wc-coupon.php
@@ -231,8 +231,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	}
 
 	/**
-	 * Get coupon 
-	 .
+	 * Get coupon status.
 	 *
 	 * @since  6.2.0
 	 * @param  string $context What the value is for. Valid values are 'view' and 'edit'.

--- a/plugins/woocommerce/includes/class-wc-coupon.php
+++ b/plugins/woocommerce/includes/class-wc-coupon.php
@@ -231,7 +231,8 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	}
 
 	/**
-	 * Get coupon status.
+	 * Get coupon 
+	 .
 	 *
 	 * @since  6.2.0
 	 * @param  string $context What the value is for. Valid values are 'view' and 'edit'.
@@ -570,7 +571,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	/**
 	 * Set coupon status.
 	 *
-	 * @since 3.0.0
+	 * @since 6.2.0
 	 * @param string $status Status.
 	 * @return void
 	 */


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Class `WC_Coupon` function `set_status()` was created for 6.2.0 version.

This is a really small fix.