### PR TITLE
Change variations dropdown visibility

### DIFF
--- a/plugins/woocommerce/changelog/add-37148_change_variations_dropdown_visibility
+++ b/plugins/woocommerce/changelog/add-37148_change_variations_dropdown_visibility
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Change variations dropdown menu visibility

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1018,8 +1018,13 @@ $default-line-height: 18px;
 		max-width: 100%;
 	}
 
+	.variation_actions {
+		max-width: 131px;
+	}
+
 	.toolbar-top {
-		.button {
+		.button,
+		.select {
 			margin: 1px;
 		}
 	}

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
@@ -655,8 +655,8 @@ jQuery( function ( $ ) {
 			} );
 
 			$( '.wc-metaboxes-wrapper' ).on(
-				'click',
-				'a.do_variation_action',
+				'change',
+				'#field_to_edit',
 				this.do_variation_action
 			);
 

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
@@ -1195,7 +1195,7 @@ jQuery( function ( $ ) {
 		 * Actions
 		 */
 		do_variation_action: function () {
-			var do_variation_action = $( 'select.variation_actions' ).val(),
+			var do_variation_action = $( this ).val(),
 				data = {},
 				changes = 0,
 				value;
@@ -1344,11 +1344,9 @@ jQuery( function ( $ ) {
 			if ( parseInt( wrapper.attr( 'data-total' ) ) > 0 ) {
 				$( '.add-variation-container' ).addClass( 'hidden' );
 				$( '#field_to_edit' ).removeClass( 'hidden' );
-				$( 'a.do_variation_action' ).removeClass( 'hidden' );
 			} else {
 				$( '.add-variation-container' ).removeClass( 'hidden' );
 				$( '#field_to_edit' ).addClass( 'hidden' );
-				$( 'a.do_variation_action' ).addClass( 'hidden' );
 			}
 		},
 

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
@@ -1451,7 +1451,7 @@ jQuery( function ( $ ) {
 
 				if ( page_nav.is( ':hidden' ) ) {
 					$( 'option, optgroup', '.variation_actions' ).show();
-					$( '.variation_actions' ).val( 'delete_all' );
+					$( '.variation_actions' ).val( 'bulk_actions' );
 					$( '#variable_product_options' ).find( '.toolbar' ).show();
 					page_nav.show();
 					$( '.pagination-links', page_nav ).hide();
@@ -1498,13 +1498,13 @@ jQuery( function ( $ ) {
 				toolbar.not( '.toolbar-top, .toolbar-buttons' ).hide();
 				page_nav.hide();
 				$( 'option, optgroup', variation_action ).hide();
-				$( '.variation_actions' ).val( 'delete_all' );
+				$( '.variation_actions' ).val( 'bulk_actions' );
 				$( 'option[data-global="true"]', variation_action ).show();
 			} else {
 				toolbar.show();
 				page_nav.show();
 				$( 'option, optgroup', variation_action ).show();
-				$( '.variation_actions' ).val( 'delete_all' );
+				$( '.variation_actions' ).val( 'bulk_actions' );
 
 				// Show/hide links
 				if ( 1 === total_pages ) {

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
@@ -98,6 +98,7 @@ $arrow_img_url          = WC_ADMIN_IMAGES_FOLDER_URL . '/product_data/no-variati
 				<button type="button" class="button generate_variations"><?php esc_html_e( 'Generate variations', 'woocommerce' ); ?></button>
 				<button type="button" class="button add_variation_manually"><?php esc_html_e( 'Add manually', 'woocommerce' ); ?></button>
 				<select id="field_to_edit" class="variation_actions hidden">
+					<option value="bulk_actions" disabled>Bulk actions</option>
 					<option value="delete_all"><?php esc_html_e( 'Delete all variations', 'woocommerce' ); ?></option>
 					<optgroup label="<?php esc_attr_e( 'Status', 'woocommerce' ); ?>">
 						<option value="toggle_enabled"><?php esc_html_e( 'Toggle &quot;Enabled&quot;', 'woocommerce' ); ?></option>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
@@ -97,7 +97,7 @@ $arrow_img_url          = WC_ADMIN_IMAGES_FOLDER_URL . '/product_data/no-variati
 			<div class="toolbar toolbar-top">
 				<button type="button" class="button generate_variations"><?php esc_html_e( 'Generate variations', 'woocommerce' ); ?></button>
 				<button type="button" class="button add_variation_manually"><?php esc_html_e( 'Add manually', 'woocommerce' ); ?></button>
-				<select id="field_to_edit" class="variation_actions hidden">
+				<select id="field_to_edit" class="select variation_actions hidden">
 					<option value="bulk_actions" disabled>Bulk actions</option>
 					<option value="delete_all"><?php esc_html_e( 'Delete all variations', 'woocommerce' ); ?></option>
 					<optgroup label="<?php esc_attr_e( 'Status', 'woocommerce' ); ?>">

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
@@ -136,7 +136,6 @@ $arrow_img_url          = WC_ADMIN_IMAGES_FOLDER_URL . '/product_data/no-variati
 					<?php do_action( 'woocommerce_variable_product_bulk_edit_actions' ); ?>
 					<?php /* phpcs:enable */ ?>
 				</select>
-				<a class="button bulk_edit do_variation_action hidden"><?php esc_html_e( 'Go', 'woocommerce' ); ?></a>
 
 				<div class="variations-pagenav">
 					<?php /* translators: variations count */ ?>

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
@@ -179,7 +179,6 @@ test.describe( 'Add New Variable Product Page', () => {
 		await page.selectOption( '#field_to_edit', 'toggle_downloadable', {
 			force: true,
 		} );
-		await page.click( 'a.do_variation_action' );
 		await page.click(
 			'#variable_product_options .toolbar-top a.expand_all'
 		);
@@ -196,7 +195,6 @@ test.describe( 'Add New Variable Product Page', () => {
 		await page.click( 'a[href="#variable_product_options"]' );
 		await page.waitForLoadState( 'networkidle' );
 		await page.selectOption( '#field_to_edit', 'delete_all' );
-		await page.click( 'a.do_variation_action' );
 		await page.waitForSelector( '.woocommerce_variation', {
 			state: 'detached',
 		} );


### PR DESCRIPTION
### All Submissions:

-   [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-   [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The dropdown is displayed in neither empty state. It is only shown when there is at least one variation created. The label now reads `Bulk actions`.

![Screen Capture on 2023-04-04 at 22-47-16](https://user-images.githubusercontent.com/1314156/229960147-042ff3c8-0a79-405d-aaed-6a87c134c373.gif)

Closes #37148.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Please include detailed instructions on how these changes can be tested, make sure to review and follow the guide for writing high-quality testing instructions below. -->

- [x] Have you followed the [Writing high-quality testing instructions guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions)?

1. Go to `Products` > `Add New`.
2. Select a `Variable product`.
3. Go to `Attributes` and create a new one.
4. Add a few values `Used for variations` and press `Save attributes`.
5. Go to `Variations` and add variations.
6. The dropdown menu Bulk actions should be visible next to the `Generate variations` and `Add manually` buttons.
7. Try the dropdown menu. It would work after selecting an option.

<!-- End testing instructions -->

### Other information:

-   [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-   [x] Have you written new tests for your changes, as applicable?
-   [x] Have you created a changelog file for each project being changed, ie `pnpm --filter=<project> changelog add`?
-   [x] Have you included testing instructions?

<!-- Mark completed items with an [x] -->

### FOR PR REVIEWER ONLY:

-   [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
