### PR TITLE
Prevent duplicate alias in orders query SQL

### DIFF
--- a/plugins/woocommerce/changelog/fix-37173
+++ b/plugins/woocommerce/changelog/fix-37173
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix table alias issue in order field queries.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableFieldQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableFieldQuery.php
@@ -246,7 +246,7 @@ class OrdersTableFieldQuery {
 		$this->table_aliases[] = $alias;
 
 		if ( $join ) {
-			$this->join[] = $join;
+			$this->join[ $alias ] = $join;
 		}
 
 		return $alias;

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -755,9 +755,9 @@ class OrdersTableQuery {
 
 		if ( empty( $on ) ) {
 			if ( $this->tables['orders'] === $table ) {
-				$on = "{$this->tables['orders']}.id = {$alias}.id";
+				$on = "`{$this->tables['orders']}`.id = `{$alias}`.id";
 			} else {
-				$on = "{$this->tables['orders']}.id = {$alias}.order_id";
+				$on = "`{$this->tables['orders']}`.id = `{$alias}`.order_id";
 			}
 		}
 
@@ -775,8 +775,8 @@ class OrdersTableQuery {
 		}
 
 		$sql_join  = '';
-		$sql_join .= "{$join_type} JOIN {$table} ";
-		$sql_join .= ( $alias !== $table ) ? "AS {$alias} " : '';
+		$sql_join .= "{$join_type} JOIN `{$table}` ";
+		$sql_join .= ( $alias !== $table ) ? "AS `{$alias}` " : '';
 		$sql_join .= "ON ( {$on} )";
 
 		$this->join[ $alias ] = $sql_join;


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
When performing a `wc_get_orders()` query with a `field_query` that involves the operational table, alongside usage of any other order field from that same table, an invalid query (with a duplicate JOIN) is created.

This PR makes sure the duplication doesn't occur by re-using the first found alias for that table, and also normalizes JOIN syntax everywhere so that duplication is also prevented that way.

Closes #37173.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure HPOS is enabled and in use: go to WooCommerce > Settings > Advanced and...
   i. make sure that "Enable the high performance order storage feature" is checked off on the "Features" tab.
   ii. make sure that "Use the WooCommerce orders tables" is selected on the "Custom data stores" tab.
2. Create a test PHP file with the following content, which creates an order with a distinguishable field in the operational table and then performs a query involving said field (directly) and another `field_query` also on fields from the operational table. The created order should be part of the results, which is what the code attempts to confirm.
   ```php
   <?php
   global $wpdb;
   
   $order = new \WC_Order();
   $order->set_created_via( 'magic' );
   $order->save();
   
   $q_args   = [
	   'created_via' => 'magic',
	   'field_query' => [
		   [
			   'field'   => 'version',
			   'compare' => 'EXISTS',
		   ]
	   ],
	   'return'      => 'ids',
	   'limit'       => -1,
   ];
   
   var_dump(
	   in_array(
		   $order->get_id(),
		   wc_get_orders( $q_args ),
		   true
	   ),
	   $wpdb->last_error
   );
   ```
3. Run the above file using WP CLI on your test instance:
   ```shell
   wp eval-file /path/to/the/file.php
   ```
4. Confirm that:
   i. On `trunk`, you see the following output:
      > bool(false)
      > string(54) "Not unique table/alias: 'wp_wc_order_operational_data'"

   ii. On this branch, you get this output instead, proving that the query was successful and the order was found in the results:
      > bool(true)
      > string(0) ""

<!-- End testing instructions -->