### PR TITLE
update select all to checkbox in menu editor

### DIFF
--- a/plugins/woocommerce/changelog/fix-37090-menu-select-all
+++ b/plugins/woocommerce/changelog/fix-37090-menu-select-all
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+update select all to checkbox in menu editor

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -375,9 +375,12 @@ class WC_Admin_Menus {
 					?>
 				</ul>
 			</div>
-			<p class="button-controls">
+			<p class="button-controls" data-items-type="posttype-woocommerce-endpoints">
 				<span class="list-controls">
-					<a href="<?php echo esc_url( admin_url( 'nav-menus.php?page-tab=all&selectall=1#posttype-woocommerce-endpoints' ) ); ?>" class="select-all"><?php esc_html_e( 'Select all', 'woocommerce' ); ?></a>
+					<label>
+						<input type="checkbox" class="select-all" />
+						<?php esc_html_e( 'Select all', 'woocommerce' ); ?>
+					</label>
 				</span>
 				<span class="add-to-menu">
 					<button type="submit" class="button-secondary submit-add-to-menu right" value="<?php esc_attr_e( 'Add to menu', 'woocommerce' ); ?>" name="add-post-type-menu-item" id="submit-posttype-woocommerce-endpoints"><?php esc_html_e( 'Add to menu', 'woocommerce' ); ?></button>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the `Select All` link in the menu editor to a checkbox for consistency with WP core select all functionality. The [core script](https://github.com/WordPress/WordPress/blame/master/wp-admin/js/nav-menu.js#L1303) was changed 4 years ago so this change should be compatible with our L-2 policy.

Closes #37090 .

### How to test the changes in this Pull Request:

1. Go to WooCommerce -> Settings -> Advanced
2. Create/Select a `My Account` page
3. Go to Themes -> Menus
4. Create a menu if none exists
5. Expand the `WooCommerce endpoints` meta box
6. Click the `Select All` checkbox
7. All the WooCommerce pages should be checked
8. Click `Add to menu`
9. All the endpoints should be added to the menu
