### PR TITLE
Change default order to ‘date DESC’ in orders list table

### DIFF
--- a/plugins/woocommerce/changelog/fix-36498
+++ b/plugins/woocommerce/changelog/fix-36498
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Default to sorting orders by date (desc) when HPOS is active.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -365,7 +365,7 @@ class ListTable extends WP_List_Table {
 		$direction = strtoupper( sanitize_text_field( wp_unslash( $_GET['order'] ?? '' ) ) );
 
 		if ( ! in_array( $field, $sortable, true ) ) {
-			$this->order_query_args['orderby'] = 'id';
+			$this->order_query_args['orderby'] = 'date';
 			$this->order_query_args['order']   = 'DESC';
 			return;
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
In the HPOS list table, we were sorting orders by `id` (desc) by default, which is not consistent with the default ordering when posts is the authoritative table.

Closes #36498.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable HPOS. To do this, go to WooCommerce > Settings > Advanced > Features and make sure "Enable the high performance order storage feature" is checked off.
2. Set "posts" as authoritative table by going to WooCommerce > Settings > Advanced > Custom data stores and making sure "Use the WordPress posts table" is selected. Make sure "Keep the posts table and the orders tables synchronized" is enabled.
3. Go to WooCommerce > Orders and create 2 test orders with any desired parameters, except for "Date created" which should be as follows: 2023-04-04 for the first order, 2023-04-03 for the second order. Take note of their IDs.
4. Confirm that WooCommerce > Orders displays the orders according to their date (desc). That is, the first order you created is shown first.
5. Go back to WooCommerce > Settings > Advanced > Custom data stores and switch the datastore in use to "WooCommerce orders table".
   If this is not possible because syncing hasn't completed, go to Tools > Scheduled Actions > Pending and manually run any `wc_schedule_pending_batch_processes` and `wc_run_batch_process` actions.
6. Go to WooCommerce > Orders:
   i. On `trunk`, you'll see that orders are sorted by id (desc) and so the first order you created is shown last.
   ii. On this branch, sorting matches the one from step 4. That is, the first order is shown first.

<!-- End testing instructions -->