### PR TITLE
Do not attempt to cache orders during order creation

### DIFF
--- a/plugins/woocommerce/changelog/fix-order-cache-order-type
+++ b/plugins/woocommerce/changelog/fix-order-cache-order-type
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Do not attempt to cache order during order creation (HPOS).

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -199,6 +199,8 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			return $this->get_id();
 		}
 
+		$updating = $this->get_id() > 0;
+
 		try {
 			/**
 			 * Trigger action before saving to the DB. Allows you to adjust object props before save.
@@ -216,7 +218,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 
 			$this->save_items();
 
-			if ( OrderUtil::orders_cache_usage_is_enabled() ) {
+			if ( $updating && OrderUtil::orders_cache_usage_is_enabled() ) {
 				$order_cache = wc_get_container()->get( OrderCache::class );
 				$order_cache->update_if_cached( $this );
 			}

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -199,8 +199,6 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			return $this->get_id();
 		}
 
-		$updating = $this->get_id() > 0;
-
 		try {
 			/**
 			 * Trigger action before saving to the DB. Allows you to adjust object props before save.
@@ -218,9 +216,9 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 
 			$this->save_items();
 
-			if ( $updating && OrderUtil::orders_cache_usage_is_enabled() ) {
+			if ( OrderUtil::orders_cache_usage_is_enabled() ) {
 				$order_cache = wc_get_container()->get( OrderCache::class );
-				$order_cache->update_if_cached( $this );
+				$order_cache->remove( $this->get_id() );
 			}
 
 			/**

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
@@ -269,4 +269,23 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 		$this->assertEquals( $coupon->get_id(), $coupon_data['id'] );
 		$this->assertEquals( $coupon_code, $coupon_data['code'] );
 	}
+
+	/**
+	 * @testDox Cache does not interfere if wc_get_order returns a different class than WC_Order.
+	 */
+	public function test_cache_does_not_interferes_with_order_object() {
+		add_action(
+			'woocommerce_new_order',
+			function( $order_id ) {
+				// this makes the cache store a specific order class instance, but it's quickly replaced by a generic one
+				// as we're in the middle of a save and this gets executed before the logic in WC_Abstract_Order.
+				$order = wc_get_order( $order_id );
+			}
+		);
+		$order = new WC_Order();
+		$order->save();
+
+		$order = wc_get_order( $order->get_id() );
+		$this->assertInstanceOf( Automattic\WooCommerce\Admin\Overrides\Order::class, $order );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
As described in #37568, during an order's save various hooks are fired, and after most are executed, the orders cache attempts to cache the order.
Thing is, if during the execution of any of those hooks, `wc_get_order()` gets called on that same order ID, we end up in a situation where the cache first obtained and saved a specific order class (during the `wc_get_order()` call) and _then_ `WC_Abstract_Order::save()` [overrides that](https://github.com/woocommerce/woocommerce/blob/96a1e9cd7b08b78270f54f051a8786a702281b8e/plugins/woocommerce/includes/abstracts/abstract-wc-order.php#L219-L222) with the generic `WC_Order` instance that initiated the save.

This PR attempts to fix this by preventing the cache logic in `WC_Abstract_Order::save()` from intervening when we're creating an order. During edits/updates, things should be safer, as we should already be working on an object of the correct type.

Closes #37568.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a test file with the following contents.
   ```php
   <?php
   add_action(
	   'woocommerce_new_order',
	   function( $order_id ) {
		   // this makes the cache store a specific order class instance, but it's quickly replaced by a generic one
		   // as we're in the middle of a save and this gets executed before the logic in WC_Abstract_Order.
		   $order = wc_get_order( $order_id );
	   }
   );
   
   $order = new \WC_Order();
   $order->save();
   
   $order = wc_get_order( $order->get_id() );
   var_dump( get_class( $order ) );
   ```
3. Confirm that, on `trunk`, it prints `WC_Order`.
4. Confirm that, on this branch, it prints `Automattic\WooCommerce\Admin\Overrides\Order`, which is the correct order type.

<!-- End testing instructions -->