### PR TITLE
Select tree dropdown menu SlotFill support

### DIFF
--- a/packages/js/components/changelog/update-select_tree_dropdown
+++ b/packages/js/components/changelog/update-select_tree_dropdown
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update select tree control dropdown menu for custom slot fill support for display within Modals

--- a/packages/js/components/src/experimental-select-tree-control/index.ts
+++ b/packages/js/components/src/experimental-select-tree-control/index.ts
@@ -1,1 +1,2 @@
 export * from './select-tree';
+export * from './select-tree-menu';

--- a/packages/js/components/src/experimental-select-tree-control/select-tree-menu.tsx
+++ b/packages/js/components/src/experimental-select-tree-control/select-tree-menu.tsx
@@ -27,7 +27,6 @@ type MenuProps = {
 	position?: Popover.Position;
 	scrollIntoViewOnOpen?: boolean;
 	items: LinkedTree[];
-	comboBoxWidth?: number;
 	treeRef?: React.ForwardedRef< HTMLOListElement >;
 	onClose?: () => void;
 } & Omit< TreeControlProps, 'items' >;
@@ -39,7 +38,6 @@ export const SelectTreeMenu = ( {
 	position = 'bottom center',
 	scrollIntoViewOnOpen = false,
 	items,
-	comboBoxWidth,
 	treeRef: ref,
 	onClose = () => {},
 	shouldShowCreateButton,

--- a/packages/js/components/src/experimental-select-tree-control/select-tree.tsx
+++ b/packages/js/components/src/experimental-select-tree-control/select-tree.tsx
@@ -2,10 +2,15 @@
 /**
  * External dependencies
  */
-import { createElement, useRef, useState } from 'react';
+import {
+	createElement,
+	useRef,
+	useState,
+	createPortal,
+} from '@wordpress/element';
 import classNames from 'classnames';
 import { search } from '@wordpress/icons';
-import { Dropdown, Spinner } from '@wordpress/components';
+import { Dropdown, Spinner, Popover } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -73,6 +78,10 @@ export const SelectTree = function SelectTree( {
 			className="woocommerce-experimental-select-tree-control__dropdown"
 			contentClassName="woocommerce-experimental-select-tree-control__dropdown-content"
 			focusOnMount={ false }
+			// @ts-expect-error this prop does exist, see: https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/popover/index.tsx#L180.
+			popoverProps={ {
+				__unstableSlotName: 'woocommerce-select-tree-control-menu',
+			} }
 			renderContent={ ( { onClose } ) =>
 				isLoading ? (
 					<div
@@ -147,7 +156,7 @@ export const SelectTree = function SelectTree( {
 										)
 										?.contains( event.relatedTarget )
 								) {
-									onClose();
+									// onClose();
 								}
 								setIsFocused( false );
 							},
@@ -197,3 +206,12 @@ export const SelectTree = function SelectTree( {
 		/>
 	);
 };
+
+export const SelectTreeMenuSlot: React.FC = () =>
+	createPortal(
+		<div aria-live="off">
+			{ /* @ts-expect-error name does exist on PopoverSlot see: https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/popover/index.tsx#L555 */ }
+			<Popover.Slot name="woocommerce-select-tree-control-menu" />
+		</div>,
+		document.body
+	);

--- a/packages/js/components/src/experimental-select-tree-control/select-tree.tsx
+++ b/packages/js/components/src/experimental-select-tree-control/select-tree.tsx
@@ -10,13 +10,13 @@ import {
 } from '@wordpress/element';
 import classNames from 'classnames';
 import { search } from '@wordpress/icons';
-import { Dropdown, Spinner, Popover } from '@wordpress/components';
+import { Popover } from '@wordpress/components';
+import { useInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
 import { useLinkedTree } from '../experimental-tree-control/hooks/use-linked-tree';
-import { Tree } from '../experimental-tree-control/tree';
 import {
 	Item,
 	LinkedTree,
@@ -25,6 +25,7 @@ import {
 import { SelectedItems } from '../experimental-select-control/selected-items';
 import { ComboBox } from '../experimental-select-control/combo-box';
 import { SuffixIcon } from '../experimental-select-control/suffix-icon';
+import { SelectTreeMenu } from './select-tree-menu';
 
 interface SelectTreeProps extends TreeControlProps {
 	id: string;
@@ -49,8 +50,13 @@ export const SelectTree = function SelectTree( {
 	...props
 }: SelectTreeProps ) {
 	const linkedTree = useLinkedTree( items );
+	const menuInstanceId = useInstanceId(
+		SelectTree,
+		'woocommerce-select-tree-control__menu'
+	);
 
 	const [ isFocused, setIsFocused ] = useState( false );
+	const [ isOpen, setIsOpen ] = useState( false );
 
 	const comboBoxRef = useRef< HTMLDivElement >( null );
 
@@ -74,144 +80,108 @@ export const SelectTree = function SelectTree( {
 	};
 
 	return (
-		<Dropdown
+		<div
 			className="woocommerce-experimental-select-tree-control__dropdown"
-			contentClassName="woocommerce-experimental-select-tree-control__dropdown-content"
-			focusOnMount={ false }
-			// @ts-expect-error this prop does exist, see: https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/popover/index.tsx#L180.
-			popoverProps={ {
-				__unstableSlotName: 'woocommerce-select-tree-control-menu',
-			} }
-			renderContent={ ( { onClose } ) =>
-				isLoading ? (
-					<div
-						style={ {
-							width: comboBoxWidth,
-						} }
-					>
-						<Spinner />
-					</div>
-				) : (
-					<Tree
-						{ ...props }
-						id={ `${ props.id }-menu` }
-						ref={ ref }
-						items={ linkedTree }
-						onTreeBlur={ onClose }
-						shouldItemBeExpanded={ shouldItemBeExpanded }
-						shouldShowCreateButton={ shouldShowCreateButton }
-						style={ {
-							width: comboBoxWidth,
-						} }
-					/>
-				)
-			}
-			renderToggle={ ( { isOpen, onToggle, onClose } ) => (
-				<div
-					className={ classNames(
-						'woocommerce-experimental-select-control',
-						{
-							'is-focused': isFocused,
-						}
-					) }
+			tabIndex={ -1 }
+		>
+			<div
+				className={ classNames(
+					'woocommerce-experimental-select-control',
+					{
+						'is-focused': isFocused,
+					}
+				) }
+			>
+				<label
+					htmlFor={ `${ props.id }-input` }
+					id={ `${ props.id }-label` }
+					className="woocommerce-experimental-select-control__label"
 				>
-					<label
-						htmlFor={ `${ props.id }-input` }
-						id={ `${ props.id }-label` }
-						className="woocommerce-experimental-select-control__label"
-					>
-						{ props.label }
-					</label>
-					<ComboBox
-						comboBoxProps={ {
-							className:
-								'woocommerce-experimental-select-control__combo-box-wrapper',
-							ref: comboBoxRef,
-							role: 'combobox',
-							'aria-expanded': isOpen,
-							'aria-haspopup': 'tree',
-							'aria-labelledby': `${ props.id }-label`,
-							'aria-owns': `${ props.id }-menu`,
+					{ props.label }
+				</label>
+				<ComboBox
+					comboBoxProps={ {
+						className:
+							'woocommerce-experimental-select-control__combo-box-wrapper',
+						ref: comboBoxRef,
+						role: 'combobox',
+						'aria-expanded': isOpen,
+						'aria-haspopup': 'tree',
+						'aria-labelledby': `${ props.id }-label`,
+						'aria-owns': `${ props.id }-menu`,
+					} }
+					inputProps={ {
+						className:
+							'woocommerce-experimental-select-control__input',
+						id: `${ props.id }-input`,
+						'aria-autocomplete': 'list',
+						'aria-controls': `${ props.id }-menu`,
+						autoComplete: 'off',
+						onFocus: () => {
+							if ( ! isOpen ) {
+								setIsOpen( true );
+							}
+							setIsFocused( true );
+						},
+						onBlur: ( event ) => {
+							// if blurring to an element inside the dropdown, don't close it
+							if (
+								isOpen &&
+								! document
+									.querySelector( '.' + menuInstanceId )
+									?.contains( event.relatedTarget )
+							) {
+								setIsOpen( false );
+							}
+							setIsFocused( false );
+						},
+						onKeyDown: ( event ) => {
+							setIsOpen( true );
+							if ( event.key === 'ArrowDown' ) {
+								event.preventDefault();
+								// focus on the first element from the Popover
+								(
+									document.querySelector(
+										`.${ menuInstanceId } input, .${ menuInstanceId } button`
+									) as HTMLInputElement | HTMLButtonElement
+								 )?.focus();
+							}
+							if ( event.key === 'Tab' ) {
+								setIsOpen( false );
+							}
+						},
+						onChange: ( event ) =>
+							onInputChange &&
+							onInputChange( event.target.value ),
+						placeholder,
+					} }
+					suffix={ suffix }
+				>
+					<SelectedItems
+						items={ ( props.selected as Item[] ) || [] }
+						getItemLabel={ ( item ) => item?.label || '' }
+						getItemValue={ ( item ) => item?.value || '' }
+						onRemove={ ( item ) => {
+							if ( ! Array.isArray( item ) && props.onRemove ) {
+								props.onRemove( item );
+								setIsOpen( false );
+							}
 						} }
-						inputProps={ {
-							className:
-								'woocommerce-experimental-select-control__input',
-							id: `${ props.id }-input`,
-							'aria-autocomplete': 'list',
-							'aria-controls': `${ props.id }-menu`,
-							autoComplete: 'off',
-							onFocus: () => {
-								if ( ! isOpen ) {
-									onToggle();
-								}
-								setIsFocused( true );
-							},
-							onBlur: ( event ) => {
-								// if blurring to an element inside the dropdown, don't close it
-								if (
-									isOpen &&
-									! document
-										.querySelector(
-											'.woocommerce-experimental-select-control ~ .components-popover'
-										)
-										?.contains( event.relatedTarget )
-								) {
-									// onClose();
-								}
-								setIsFocused( false );
-							},
-							onKeyDown: ( event ) => {
-								const baseQuery =
-									'.woocommerce-experimental-select-tree-control__dropdown > .components-popover';
-								if ( event.key === 'ArrowDown' ) {
-									event.preventDefault();
-									// focus on the first element from the Popover
-									(
-										document.querySelector(
-											`${ baseQuery } input, ${ baseQuery } button`
-										) as
-											| HTMLInputElement
-											| HTMLButtonElement
-									 )?.focus();
-								}
-								if ( event.key === 'Tab' ) {
-									onClose();
-								}
-							},
-							onChange: ( event ) =>
-								onInputChange &&
-								onInputChange( event.target.value ),
-							placeholder,
-						} }
-						suffix={ suffix }
-					>
-						<SelectedItems
-							items={ ( props.selected as Item[] ) || [] }
-							getItemLabel={ ( item ) => item?.label || '' }
-							getItemValue={ ( item ) => item?.value || '' }
-							onRemove={ ( item ) => {
-								if (
-									! Array.isArray( item ) &&
-									props.onRemove
-								) {
-									props.onRemove( item );
-									onClose();
-								}
-							} }
-							getSelectedItemProps={ () => ( {} ) }
-						/>
-					</ComboBox>
-				</div>
-			) }
-		/>
+						getSelectedItemProps={ () => ( {} ) }
+					/>
+				</ComboBox>
+			</div>
+			<SelectTreeMenu
+				{ ...props }
+				id={ `${ props.id }-menu` }
+				className={ menuInstanceId.toString() }
+				ref={ ref }
+				isOpen={ isOpen }
+				items={ linkedTree }
+				shouldShowCreateButton={ shouldShowCreateButton }
+				comboBoxWidth={ comboBoxWidth }
+				onClose={ () => setIsOpen( false ) }
+			/>
+		</div>
 	);
 };
-
-export const SelectTreeMenuSlot: React.FC = () =>
-	createPortal(
-		<div aria-live="off">
-			{ /* @ts-expect-error name does exist on PopoverSlot see: https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/popover/index.tsx#L555 */ }
-			<Popover.Slot name="woocommerce-select-tree-control-menu" />
-		</div>,
-		document.body
-	);

--- a/packages/js/components/src/experimental-select-tree-control/select-tree.tsx
+++ b/packages/js/components/src/experimental-select-tree-control/select-tree.tsx
@@ -2,15 +2,9 @@
 /**
  * External dependencies
  */
-import {
-	createElement,
-	useRef,
-	useState,
-	createPortal,
-} from '@wordpress/element';
+import { createElement, useState } from '@wordpress/element';
 import classNames from 'classnames';
 import { search } from '@wordpress/icons';
-import { Popover } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 
 /**
@@ -58,13 +52,6 @@ export const SelectTree = function SelectTree( {
 	const [ isFocused, setIsFocused ] = useState( false );
 	const [ isOpen, setIsOpen ] = useState( false );
 
-	const comboBoxRef = useRef< HTMLDivElement >( null );
-
-	// getting the parent's parent div width to set the width of the dropdown
-	const comboBoxWidth =
-		comboBoxRef.current?.parentElement?.parentElement?.getBoundingClientRect()
-			.width;
-
 	const shouldItemBeExpanded = ( item: LinkedTree ): boolean => {
 		if ( ! props.createValue || ! item.children?.length ) return false;
 		return item.children.some( ( child ) => {
@@ -103,7 +90,6 @@ export const SelectTree = function SelectTree( {
 					comboBoxProps={ {
 						className:
 							'woocommerce-experimental-select-control__combo-box-wrapper',
-						ref: comboBoxRef,
 						role: 'combobox',
 						'aria-expanded': isOpen,
 						'aria-haspopup': 'tree',
@@ -179,7 +165,6 @@ export const SelectTree = function SelectTree( {
 				isOpen={ isOpen }
 				items={ linkedTree }
 				shouldShowCreateButton={ shouldShowCreateButton }
-				comboBoxWidth={ comboBoxWidth }
 				onClose={ () => setIsOpen( false ) }
 			/>
 		</div>

--- a/packages/js/components/src/experimental-select-tree-control/select-tree.tsx
+++ b/packages/js/components/src/experimental-select-tree-control/select-tree.tsx
@@ -11,11 +11,7 @@ import { useInstanceId } from '@wordpress/compose';
  * Internal dependencies
  */
 import { useLinkedTree } from '../experimental-tree-control/hooks/use-linked-tree';
-import {
-	Item,
-	LinkedTree,
-	TreeControlProps,
-} from '../experimental-tree-control/types';
+import { Item, TreeControlProps } from '../experimental-tree-control/types';
 import { SelectedItems } from '../experimental-select-control/selected-items';
 import { ComboBox } from '../experimental-select-control/combo-box';
 import { SuffixIcon } from '../experimental-select-control/suffix-icon';
@@ -51,20 +47,6 @@ export const SelectTree = function SelectTree( {
 
 	const [ isFocused, setIsFocused ] = useState( false );
 	const [ isOpen, setIsOpen ] = useState( false );
-
-	const shouldItemBeExpanded = ( item: LinkedTree ): boolean => {
-		if ( ! props.createValue || ! item.children?.length ) return false;
-		return item.children.some( ( child ) => {
-			if (
-				new RegExp( props.createValue || '', 'ig' ).test(
-					child.data.label
-				)
-			) {
-				return true;
-			}
-			return shouldItemBeExpanded( child );
-		} );
-	};
 
 	return (
 		<div

--- a/packages/js/components/src/experimental-select-tree-control/stories/index.tsx
+++ b/packages/js/components/src/experimental-select-tree-control/stories/index.tsx
@@ -7,9 +7,10 @@ import React, { createElement, useState, useEffect } from 'react';
 /**
  * Internal dependencies
  */
-import { SelectTree, SelectTreeMenuSlot } from '../select-tree';
+import { SelectTree } from '../select-tree';
 import { Item } from '../../experimental-tree-control/types';
 import { Button, Modal, SlotFillProvider } from '@wordpress/components';
+import { SelectTreeMenuSlot } from '../select-tree-menu';
 
 const listItems: Item[] = [
 	{ value: '1', label: 'Technology' },

--- a/packages/js/components/src/experimental-select-tree-control/stories/index.tsx
+++ b/packages/js/components/src/experimental-select-tree-control/stories/index.tsx
@@ -1,15 +1,14 @@
 /**
  * External dependencies
  */
-
-import React, { createElement, useState, useEffect } from 'react';
+import React, { createElement, useState } from 'react';
+import { Button, Modal, SlotFillProvider } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import { SelectTree } from '../select-tree';
 import { Item } from '../../experimental-tree-control/types';
-import { Button, Modal, SlotFillProvider } from '@wordpress/components';
 import { SelectTreeMenuSlot } from '../select-tree-menu';
 
 const listItems: Item[] = [

--- a/packages/js/components/src/experimental-select-tree-control/stories/index.tsx
+++ b/packages/js/components/src/experimental-select-tree-control/stories/index.tsx
@@ -2,13 +2,14 @@
  * External dependencies
  */
 
-import React, { createElement } from 'react';
+import React, { createElement, useState, useEffect } from 'react';
 
 /**
  * Internal dependencies
  */
-import { SelectTree } from '../select-tree';
+import { SelectTree, SelectTreeMenuSlot } from '../select-tree';
 import { Item } from '../../experimental-tree-control/types';
+import { Button, Modal, SlotFillProvider } from '@wordpress/components';
 
 const listItems: Item[] = [
 	{ value: '1', label: 'Technology' },
@@ -92,6 +93,72 @@ export const MultipleSelectTree: React.FC = () => {
 				setSelected( newValues );
 			} }
 		/>
+	);
+};
+
+export const SingleWithinModalUsingBodyDropdownPlacement: React.FC = () => {
+	const [ isOpen, setOpen ] = useState( true );
+	const [ value, setValue ] = React.useState( '' );
+	const [ selected, setSelected ] = React.useState< Item[] >( [] );
+
+	const items = filterItems( listItems, value );
+
+	return (
+		<SlotFillProvider>
+			Selected: { JSON.stringify( selected ) }
+			<Button onClick={ () => setOpen( true ) }>
+				Show Dropdown in Modal
+			</Button>
+			{ isOpen && (
+				<Modal
+					title="Dropdown Modal"
+					onRequestClose={ () => setOpen( false ) }
+				>
+					<SelectTree
+						id="multiple-select-tree"
+						label="Multiple Select Tree"
+						multiple
+						items={ items }
+						selected={ selected }
+						shouldNotRecursivelySelect
+						shouldShowCreateButton={ ( typedValue ) =>
+							! value ||
+							listItems.findIndex(
+								( item ) => item.label === typedValue
+							) === -1
+						}
+						createValue={ value }
+						// eslint-disable-next-line no-alert
+						onCreateNew={ () => alert( 'create new called' ) }
+						onInputChange={ ( a ) => setValue( a || '' ) }
+						onSelect={ ( selectedItems ) => {
+							if ( Array.isArray( selectedItems ) ) {
+								setSelected( [
+									...selected,
+									...selectedItems,
+								] );
+							}
+						} }
+						onRemove={ ( removedItems ) => {
+							const newValues = Array.isArray( removedItems )
+								? selected.filter(
+										( item ) =>
+											! removedItems.some(
+												( { value: removedValue } ) =>
+													item.value === removedValue
+											)
+								  )
+								: selected.filter(
+										( item ) =>
+											item.value !== removedItems.value
+								  );
+							setSelected( newValues );
+						} }
+					/>
+				</Modal>
+			) }
+			<SelectTreeMenuSlot />
+		</SlotFillProvider>
 	);
 };
 

--- a/packages/js/components/src/experimental-select-tree-control/stories/index.tsx
+++ b/packages/js/components/src/experimental-select-tree-control/stories/index.tsx
@@ -98,8 +98,8 @@ export const MultipleSelectTree: React.FC = () => {
 
 export const SingleWithinModalUsingBodyDropdownPlacement: React.FC = () => {
 	const [ isOpen, setOpen ] = useState( true );
-	const [ value, setValue ] = React.useState( '' );
-	const [ selected, setSelected ] = React.useState< Item[] >( [] );
+	const [ value, setValue ] = useState( '' );
+	const [ selected, setSelected ] = useState< Item[] >( [] );
 
 	const items = filterItems( listItems, value );
 

--- a/packages/js/components/src/index.ts
+++ b/packages/js/components/src/index.ts
@@ -99,7 +99,10 @@ export {
 	TreeControl as __experimentalTreeControl,
 	Item as TreeItemType,
 } from './experimental-tree-control';
-export { SelectTree as __experimentalSelectTreeControl } from './experimental-select-tree-control';
+export {
+	SelectTree as __experimentalSelectTreeControl,
+	SelectTreeMenuSlot as __experimentalSelectTreeMenuSlot,
+} from './experimental-select-tree-control';
 export { default as TreeSelectControl } from './tree-select-control';
 
 // Exports below can be removed once the @woocommerce/product-editor package is released.

--- a/packages/js/product-editor/changelog/update-select_tree_dropdown
+++ b/packages/js/product-editor/changelog/update-select_tree_dropdown
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix issue with category parent select control clearing search value when typing.

--- a/packages/js/product-editor/src/components/details-categories-field/create-category-modal.tsx
+++ b/packages/js/product-editor/src/components/details-categories-field/create-category-modal.tsx
@@ -32,6 +32,15 @@ type CreateCategoryModalProps = {
 	onCreate: ( newCategory: ProductCategory ) => void;
 };
 
+function getCategoryItemLabel( item: ProductCategoryNode | null ): string {
+	return item?.name || '';
+}
+function getCategoryItemValue(
+	item: ProductCategoryNode | null
+): string | number {
+	return item?.id || '';
+}
+
 export const CreateCategoryModal: React.FC< CreateCategoryModalProps > = ( {
 	initialCategoryName,
 	onCancel,
@@ -109,8 +118,8 @@ export const CreateCategoryModal: React.FC< CreateCategoryModalProps > = ( {
 					onRemove={ () => setCategoryParent( null ) }
 					onInputChange={ debouncedSearch }
 					getFilteredItems={ getFilteredItems }
-					getItemLabel={ ( item ) => item?.name || '' }
-					getItemValue={ ( item ) => item?.id || '' }
+					getItemLabel={ getCategoryItemLabel }
+					getItemValue={ getCategoryItemValue }
 				>
 					{ ( {
 						items,


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR removes the use of the `Dropdown` component and makes use of the `Popover` instead.
This is needed for the category block field.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the `new-product-management-experience` feature flag and go to the edit product page.
2. Go to Category field.
3. Play around with the category field, including using the arrow keys to make sure the menu renders correctly.
4. Run storybook: `pnpm --filter=storybook storybook`
5. Go to the experimental SelectTreeControl story and open up the `Single within Modal` story, play around with the tree control within the modal, the menu should render correctly.

<!-- End testing instructions -->