### PR TITLE
Add `--verbose` support to HPOS verify DB command

### DIFF
--- a/plugins/woocommerce/changelog/fix-order_count
+++ b/plugins/woocommerce/changelog/fix-order_count
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Minor fixup for getting order ids in verify db command.

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -370,6 +370,7 @@ class CLIRunner {
 			$total_time += $batch_total_time;
 
 			if ( $verbose && count( $failed_ids_in_current_batch ) > 0 ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r -- This is a CLI command and debugging code is intended.
 				$errors = print_r( $failed_ids_in_current_batch, true );
 				WP_CLI::warning(
 					sprintf(

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -325,7 +325,7 @@ class CLIRunner {
 		$order_id_start = (int) $assoc_args['start-from'];
 		$order_id_end   = (int) $assoc_args['end-at'];
 		$order_id_end   = -1 === $order_id_end ? PHP_INT_MAX : $order_id_end;
-		$order_count    = $this->get_verify_order_count( $order_id_start, $order_id_end );
+		$order_count    = $this->get_verify_order_count( $order_id_start, $order_id_end, false );
 		$batch_size     = ( (int) $assoc_args['batch-size'] ) === 0 ? 500 : (int) $assoc_args['batch-size'];
 
 		$progress = WP_CLI\Utils\make_progress_bar( 'Order Data Verification', $order_count / $batch_size );
@@ -372,8 +372,8 @@ class CLIRunner {
 				)
 			);
 
-			$order_id_start  = max( $order_ids );
-			$remaining_count = $this->get_verify_order_count( $order_id_start, false );
+			$order_id_start  = max( $order_ids ) + 1;
+			$remaining_count = $this->get_verify_order_count( $order_id_start, $order_id_end, false );
 			if ( $remaining_count === $order_count ) {
 				return WP_CLI::error( __( 'Infinite loop detected, aborting. No errors found.', 'woocommerce' ) );
 			}

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -363,7 +363,7 @@ class CLIRunner {
 			$batch_start_time            = microtime( true );
 			$failed_ids_in_current_batch = $this->post_to_cot_migrator->verify_migrated_orders( $order_ids );
 			$failed_ids_in_current_batch = $this->verify_meta_data( $order_ids, $failed_ids_in_current_batch );
-			$failed_ids                  = $failed_ids + $failed_ids_in_current_batch;
+			$failed_ids                  = $verbose ? array() : $failed_ids + $failed_ids_in_current_batch;
 			$processed                  += count( $order_ids );
 			$batch_total_time            = microtime( true ) - $batch_start_time;
 			$batch_count ++;
@@ -410,6 +410,10 @@ class CLIRunner {
 		$progress->finish();
 		WP_CLI::log( __( 'Verification completed.', 'woocommerce' ) );
 
+		if ( $verbose ) {
+			return;
+		}
+
 		if ( 0 === count( $failed_ids ) ) {
 			return WP_CLI::success(
 				sprintf(
@@ -425,9 +429,6 @@ class CLIRunner {
 				)
 			);
 		} else {
-			if ( $verbose ) {
-				return;
-			}
 			$errors = print_r( $failed_ids, true );
 
 			return WP_CLI::error(

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -76,7 +76,7 @@ class CLIRunner {
 					sprintf(
 						// translators: %s - link to testing instructions webpage.
 						__( 'Custom order table usage is not enabled. If you are testing, you can enable it by following the testing instructions in %s', 'woocommerce' ),
-						'https://developer.woocommerce.com/' // TODO: Change the link when testing instructin page is live.
+						'https://github.com/woocommerce/woocommerce/wiki/High-Performance-Order-Storage-Upgrade-Recipe-Book'
 					)
 				);
 			}
@@ -352,7 +352,7 @@ class CLIRunner {
 				)
 			);
 
-			$order_ids        = $wpdb->get_col(
+			$order_ids                   = $wpdb->get_col(
 				$wpdb->prepare(
 					"SELECT ID FROM $wpdb->posts WHERE post_type = 'shop_order' AND ID >= %d AND ID <= %d ORDER BY ID ASC LIMIT %d",
 					$order_id_start,
@@ -360,12 +360,12 @@ class CLIRunner {
 					$batch_size
 				)
 			);
-			$batch_start_time = microtime( true );
+			$batch_start_time            = microtime( true );
 			$failed_ids_in_current_batch = $this->post_to_cot_migrator->verify_migrated_orders( $order_ids );
 			$failed_ids_in_current_batch = $this->verify_meta_data( $order_ids, $failed_ids_in_current_batch );
 			$failed_ids                  = $failed_ids + $failed_ids_in_current_batch;
-			$processed += count( $order_ids );
-			$batch_total_time = microtime( true ) - $batch_start_time;
+			$processed                  += count( $order_ids );
+			$batch_total_time            = microtime( true ) - $batch_start_time;
 			$batch_count ++;
 			$total_time += $batch_total_time;
 

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -294,7 +294,7 @@ class CLIRunner {
 	 * default: -1
 	 * ---
 	 *
-	 * [--verbose=<verbose>]
+	 * [--verbose]
 	 * : Whether to output errors as they happen in batch, or output them all together at the end.
 	 * ---
 	 * default: false
@@ -425,6 +425,9 @@ class CLIRunner {
 				)
 			);
 		} else {
+			if ( $verbose ) {
+				return;
+			}
 			$errors = print_r( $failed_ids, true );
 
 			return WP_CLI::error(


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds more tooling - `verbose` to HPOS's verify DB command.  When `--verbose` is passed, any errors will be logged immediately to the output buffer instead of at the end which is the default behavior.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable HPOS and perform migration for all the orders.
2. Turn the sync off, and manually edit a few orders, some towards early ids and some toward later IDs.
3.  Run the CLI command: `wp wc cot verify_cot_data  --verbose`, it should display errors as they are encountered in the output.
4. Run it again without the `--verbose` param, this time all the errors will be displayed in the end.

<!-- End testing instructions -->