### PR TITLE
Prevent click event when buttons are aria-disabled

### DIFF
--- a/packages/js/product-editor/changelog/fix-37249
+++ b/packages/js/product-editor/changelog/fix-37249
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent click event when the element is aria-disabled"

--- a/packages/js/product-editor/src/components/header/hooks/use-preview/use-preview.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-preview/use-preview.tsx
@@ -61,6 +61,8 @@ export function usePreview( {
 		[ productId ]
 	);
 
+	const ariaDisabled = disabled || isDisabled;
+
 	const { editEntityRecord, saveEditedEntityRecord } = useDispatch( 'core' );
 
 	let previewLink: URL | undefined;
@@ -77,6 +79,10 @@ export function usePreview( {
 	 * @param event
 	 */
 	async function handleClick( event: MouseEvent< HTMLAnchorElement > ) {
+		if ( ariaDisabled ) {
+			return event.preventDefault();
+		}
+
 		if ( onClick ) {
 			onClick( event );
 		}
@@ -130,7 +136,7 @@ export function usePreview( {
 			if ( typeof props.ref === 'function' ) props.ref( element );
 			anchorRef.current = element;
 		},
-		'aria-disabled': disabled || isDisabled,
+		'aria-disabled': ariaDisabled,
 		// Note that the href is always passed for a11y support. So
 		// the final rendered element is always an anchor.
 		href: previewLink?.toString(),

--- a/packages/js/product-editor/src/components/header/hooks/use-publish/use-publish.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-publish/use-publish.tsx
@@ -55,10 +55,16 @@ export function usePublish( {
 	);
 
 	const isCreating = productStatus === 'auto-draft';
+	const ariaDisabled =
+		disabled || isDisabled || ( productStatus === 'publish' && ! hasEdits );
 
 	const { editEntityRecord, saveEditedEntityRecord } = useDispatch( 'core' );
 
 	async function handleClick( event: MouseEvent< HTMLButtonElement > ) {
+		if ( ariaDisabled ) {
+			return event.preventDefault();
+		}
+
 		if ( onClick ) {
 			onClick( event );
 		}
@@ -94,10 +100,7 @@ export function usePublish( {
 			? __( 'Add', 'woocommerce' )
 			: __( 'Save', 'woocommerce' ),
 		...props,
-		'aria-disabled':
-			disabled ||
-			isDisabled ||
-			( productStatus === 'publish' && ! hasEdits ),
+		'aria-disabled': ariaDisabled,
 		isBusy,
 		variant: 'primary',
 		onClick: handleClick,

--- a/packages/js/product-editor/src/components/header/hooks/use-save-draft/use-save-draft.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-save-draft/use-save-draft.tsx
@@ -55,9 +55,16 @@ export function useSaveDraft( {
 		[ productId ]
 	);
 
+	const ariaDisabled =
+		disabled || isDisabled || ( productStatus !== 'publish' && ! hasEdits );
+
 	const { editEntityRecord, saveEditedEntityRecord } = useDispatch( 'core' );
 
 	async function handleClick( event: MouseEvent< HTMLButtonElement > ) {
+		if ( ariaDisabled ) {
+			return event.preventDefault();
+		}
+
 		if ( onClick ) {
 			onClick( event );
 		}
@@ -99,10 +106,7 @@ export function useSaveDraft( {
 	return {
 		children,
 		...props,
-		'aria-disabled':
-			disabled ||
-			isDisabled ||
-			( productStatus !== 'publish' && ! hasEdits ),
+		'aria-disabled': ariaDisabled,
 		variant: 'tertiary',
 		onClick: handleClick,
 	};


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/37249

When a button is `disabled` it does not receives focus which disabled screen readers from announcing it. In order to solve this, we need to use `aria-disabled` instead and prevent any clicking event on the component to simulate the real `disabled` state.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Got to `/wp-admin/tools.php?page=woocommerce-admin-test-helper`
2. Under Features tab make sure to enable `block-editor-feature-enabled`
3. Then visit `/wp-admin/admin.php?page=wc-admin&path=/add-product`
4. The header buttons should not been actionable during their `disabled` state

<!-- End testing instructions -->