### PR TITLE
Adding charge sales tax field to product block editor template

### DIFF
--- a/plugins/woocommerce/changelog/add-charge-sales-tax-37396
+++ b/plugins/woocommerce/changelog/add-charge-sales-tax-37396
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Adding charge sales tax field to product block editor template.

--- a/plugins/woocommerce/includes/class-wc-post-types.php
+++ b/plugins/woocommerce/includes/class-wc-post-types.php
@@ -514,6 +514,27 @@ class WC_Post_Types {
 											),
 										),
 										array(
+											'woocommerce/product-radio',
+											array(
+												'title'    => __( 'Charge sales tax on', 'woocommerce' ),
+												'property' => 'tax_status',
+												'options'  => array(
+													array(
+														'label' => __( 'Product and shipping', 'woocommerce' ),
+														'value' => 'taxable',
+													),
+													array(
+														'label' => __( 'Only shipping', 'woocommerce' ),
+														'value' => 'shipping',
+													),
+													array(
+														'label' => __( "Don't charge tax", 'woocommerce' ),
+														'value' => 'none',
+													),
+												),
+											),
+										),
+										array(
 											'woocommerce/collapsible',
 											array(
 												'toggleText'       => __( 'Advanced', 'woocommerce' ),


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #37396  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable `product-block-editor` feature flag.
2. Navigate to Product -> Add New
3. Select "Pricing" tab.
4. Ensure "charge sales tax on..." field shows up as per the figma design.
![image](https://user-images.githubusercontent.com/444632/230181966-bf305658-a650-4d81-8ac9-7300da7c1b77.png)

5. Select an option, save the product, and refresh to ensure that the state is persisted.
6. For extra credit you can check the DB entry under `posts_meta` for the new product to confirm that the `_tax_status` field was updated.
![image](https://user-images.githubusercontent.com/444632/230182246-82ff7258-1264-4317-ae5b-829af6a92cd5.png)


<!-- End testing instructions -->