### PR TITLE
Add woocommerce pay order before payment action in pay-for-order page

### DIFF
--- a/plugins/woocommerce/changelog/add-woocommerce-pay-order-before-payment-action
+++ b/plugins/woocommerce/changelog/add-woocommerce-pay-order-before-payment-action
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add woocommerce pay order before payment action

--- a/plugins/woocommerce/changelog/add-woocommerce-pay-order-before-payment-action
+++ b/plugins/woocommerce/changelog/add-woocommerce-pay-order-before-payment-action
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-Add woocommerce pay order before payment action
+Adds new action hook `woocommerce_pay_order_before_payment` to the `checkout/form-pay.php` template.

--- a/plugins/woocommerce/templates/checkout/form-pay.php
+++ b/plugins/woocommerce/templates/checkout/form-pay.php
@@ -67,6 +67,8 @@ $totals = $order->get_order_item_totals(); // phpcs:ignore WordPress.WP.GlobalVa
 		</tfoot>
 	</table>
 
+	<?php do_action( 'woocommerce_pay_order_before_payment' ); ?>
+
 	<div id="payment">
 		<?php if ( $order->needs_payment() ) : ?>
 			<ul class="wc_payment_methods payment_methods methods">

--- a/plugins/woocommerce/templates/checkout/form-pay.php
+++ b/plugins/woocommerce/templates/checkout/form-pay.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.8.0
+ * @version 8.2.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/checkout/form-pay.php
+++ b/plugins/woocommerce/templates/checkout/form-pay.php
@@ -67,7 +67,14 @@ $totals = $order->get_order_item_totals(); // phpcs:ignore WordPress.WP.GlobalVa
 		</tfoot>
 	</table>
 
-	<?php do_action( 'woocommerce_pay_order_before_payment' ); ?>
+	<?php
+	/**
+	 * Triggered from within the checkout/form-pay.php template, immediately before the payment section.
+	 *
+	 * @since 8.2.0
+	 */
+	do_action( 'woocommerce_pay_order_before_payment' ); 
+	?>
 
 	<div id="payment">
 		<?php if ( $order->needs_payment() ) : ?>


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Add `woocommerce_pay_order_before_payment` action in the pay-for-order page.  [This will be used by WCPay.](https://github.com/Automattic/woocommerce-payments/pull/5903)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1.  Add this PHP snippet
```
add_action( 'woocommerce_pay_order_before_payment', function(){
  echo 'This should show before the payment methods';
} );
```
2. Create a pay-for-order order using a plugin that creates them (like WooCommerce Bookings)
3. On the pay-for-order page, look for the above text

<!-- End testing instructions -->