### PR TITLE
Add default priority for countries that don't exist in payment recommendation map

### DIFF
--- a/plugins/woocommerce/changelog/update-default-payment-gateway-priority
+++ b/plugins/woocommerce/changelog/update-default-payment-gateway-priority
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Add default priority for countries that are not in the payment recommendation map

--- a/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
+++ b/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
@@ -42,7 +42,7 @@ class DefaultPaymentGateways {
 		'zipmoney'                                        => 10,
 		'payoneer-checkout'                               => 11,
 	);
-	
+
 	/**
 	 * Get default specs.
 	 *
@@ -1176,7 +1176,7 @@ class DefaultPaymentGateways {
 	/**
 	 * Get the default recommendation priority for a payment gateway.
 	 * This is used when a country is not in the $recommendation_priority_map array.
-	 * 
+	 *
 	 * @param string $id Payment gateway id.
 	 * @return int Priority.
 	 */

--- a/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
+++ b/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
@@ -12,6 +12,37 @@ defined( 'ABSPATH' ) || exit;
  */
 class DefaultPaymentGateways {
 	/**
+	 * Priority is used to determine which payment gateway to recommend first.
+	 * The lower the number, the higher the priority.
+	 *
+	 * @var array
+	 */
+	private static $recommendation_priority = array(
+		'woocommerce_payments'                            => 1,
+		'woocommerce_payments:with-in-person-payments'    => 1,
+		'woocommerce_payments:without-in-person-payments' => 1,
+		'stripe'                                          => 2,
+		'woo-mercado-pago-custom'                         => 3,
+		// PayPal Payments.
+		'ppcp-gateway'                                    => 4,
+		'mollie_wc_gateway_banktransfer'                  => 5,
+		'razorpay'                                        => 5,
+		'payfast'                                         => 5,
+		'payubiz'                                         => 6,
+		'square_credit_card'                              => 6,
+		'klarna_payments'                                 => 6,
+		// Klarna Checkout.
+		'kco'                                             => 6,
+		'paystack'                                        => 6,
+		'eway'                                            => 7,
+		'amazon_payments_advanced'                        => 7,
+		'affirm'                                          => 8,
+		'afterpay'                                        => 9,
+		'zipmoney'                                        => 10,
+		'payoneer-checkout'                               => 11,
+	);
+	
+	/**
 	 * Get default specs.
 	 *
 	 * @return array Default specs.
@@ -1126,9 +1157,9 @@ class DefaultPaymentGateways {
 			'GH' => [ 'paystack', 'ppcp-gateway' ],
 		);
 
-		// If the country code is not in the list, return null.
+		// If the country code is not in the list, return default priority.
 		if ( ! isset( $recommendation_priority_map[ $country_code ] ) ) {
-			return null;
+			return self::get_default_recommendation_priority( $gateway_id );
 		}
 
 		$index = array_search( $gateway_id, $recommendation_priority_map[ $country_code ], true );
@@ -1139,5 +1170,19 @@ class DefaultPaymentGateways {
 		}
 
 		return $index;
+	}
+
+	/**
+	 * Get the default recommendation priority for a payment gateway.
+	 * This is used when a country is not in the $recommendation_priority_map array.
+	 * 
+	 * @param string $id Payment gateway id.
+	 * @return int Priority.
+	 */
+	private static function get_default_recommendation_priority( $id ) {
+		if ( ! $id || ! array_key_exists( $id, self::$recommendation_priority ) ) {
+			return null;
+		}
+		return self::$recommendation_priority[ $id ];
 	}
 }

--- a/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
+++ b/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
@@ -12,6 +12,7 @@ defined( 'ABSPATH' ) || exit;
  */
 class DefaultPaymentGateways {
 	/**
+	 * This is the default priority for countries that are not in the $recommendation_priority_map.
 	 * Priority is used to determine which payment gateway to recommend first.
 	 * The lower the number, the higher the priority.
 	 *


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds default priority for countries that don't exist in [`recommendation_priority_map`](https://github.com/woocommerce/woocommerce/blob/55b83a2e4e9739cb506eae10a9ec49e1ccc6b60a/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php#L948), as suggested and changed in WCCOM https://github.com/Automattic/woocommerce.com/pull/16485#pullrequestreview-1370204872


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com`
2. Uncheck `Display suggestions within WooCommerce` option
3. Go to `/wp-admin/admin.php?page=wc-settings`
4. Change store country to `Malaysia`
5. Open browser dev console > network tab
6. Go to WooCommerce > Home > Set up payments task
7. Search `payment-gateway-suggestions` on network tab and confirm that `recommendation_priority` value is an integer for PayPal.

<!-- End testing instructions -->