### PR TITLE
 Remove unique constraint from order_key to prevent empty key conflict.

### DIFF
--- a/plugins/woocommerce/changelog/fix-order_key_migration
+++ b/plugins/woocommerce/changelog/fix-order_key_migration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove unique constraint from order_key, since orders can be created with emtpy order key, which conflicts with the constraint.

--- a/plugins/woocommerce/changelog/fix-order_key_migration
+++ b/plugins/woocommerce/changelog/fix-order_key_migration
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Remove unique constraint from order_key, since orders can be created with emtpy order key, which conflicts with the constraint.
+Remove unique constraint from order_key, since orders can be created with empty order keys, which then conflict with the constraint.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -847,7 +847,7 @@ WHERE
 			$wpdb->prepare(
 				"SELECT {$orders_table}.id FROM {$orders_table}
 				INNER JOIN {$op_table} ON {$op_table}.order_id = {$orders_table}.id
-				WHERE {$op_table}.order_key = %s",
+				WHERE {$op_table}.order_key = %s AND {$op_table}.order_key != ''",
 				$order_key
 			)
 		);

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2412,7 +2412,7 @@ CREATE TABLE $operational_data_table_name (
 	discount_total_amount decimal(26, 8) NULL,
 	recorded_sales tinyint(1) NULL,
 	UNIQUE KEY order_id (order_id),
-	UNIQUE KEY order_key (order_key)
+	KEY order_key (order_key)
 ) $collate;
 CREATE TABLE $meta_table (
 	id bigint(20) unsigned auto_increment primary key,

--- a/plugins/woocommerce/tests/php/src/Database/Migrations/CustomOrderTable/PostsToOrdersMigrationControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Database/Migrations/CustomOrderTable/PostsToOrdersMigrationControllerTest.php
@@ -746,4 +746,21 @@ WHERE order_id = {$order_id} AND meta_key = 'non_unique_key_1' AND meta_value in
 
 		$this->assertEmpty( $errors );
 	}
+
+	/**
+	 * @testDox Test migration for multiple null order_key meta value.
+	 */
+	public function test_order_key_null_multiple() {
+		$order1 = OrderHelper::create_order();
+		$order2 = OrderHelper::create_order();
+		delete_post_meta( $order1->get_id(), '_order_key' );
+		delete_post_meta( $order2->get_id(), '_order_key' );
+
+		$this->sut->migrate_order( $order1->get_id() );
+		$this->sut->migrate_order( $order2->get_id() );
+
+		$errors = $this->sut->verify_migrated_orders( array( $order1->get_id(), $order2->get_id() ) );
+
+		$this->assertEmpty( $errors );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

While order_key is generally expected to be unique per order, it looks like it's not necessarily true, and orders can have no keys at all. In this case, wpdb->prepare converts a null value to an empty string, which conflicts with existing orders that also don't have any order key.

This PR removes the unique constraint and makes it consistent with the post store. Note that migration for existing orders will be tackled in a different PR.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Delete the orders table by going to WooCommerce > Status > Tools. Create the tables again, verify that unique constraint is removed.

<!-- End testing instructions -->