### PR TITLE
Add Tracks events to variations tab

### DIFF
--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
@@ -247,7 +247,7 @@ const getDataForProductTabClickEvent = ( tabName: string ) => {
 };
 
 /**
- * Adds the product tabs Tracks events.
+ * Attaches the product tabs Tracks events.
  */
 const addProductTabsTracks = () => {
 	const tabs = document.querySelectorAll( '.product_data_tabs > li' );
@@ -265,7 +265,7 @@ const addProductTabsTracks = () => {
 };
 
 /**
- * Adds the inventory tab Tracks events.
+ * Attaches the inventory tab Tracks events.
  */
 const addProductInventoryTabTracks = () => {
 	document
@@ -294,7 +294,7 @@ const addProductInventoryTabTracks = () => {
 };
 
 /**
- * Adds product tags tracks.
+ * Attaches product tags tracks.
  */
 const addProductTagsTracks = () => {
 	function deleteTagEventListener(/* event: Event */) {
@@ -373,7 +373,7 @@ const addProductTagsTracks = () => {
 };
 
 /**
- * Adds attributes tracks.
+ * Attaches attributes tracks.
  */
 const addAttributesTracks = () => {
 	function addNewTermEventHandler() {
@@ -403,7 +403,7 @@ const addAttributesTracks = () => {
 };
 
 /**
- * Adds product attributes tracks.
+ * Attaches product attributes tracks.
  */
 const addProductAttributesTracks = () => {
 	const attributesCount = document.querySelectorAll(
@@ -455,7 +455,7 @@ const addProductAttributesTracks = () => {
 };
 
 /**
- * Adds product variations tracks.
+ * Attaches product variations tracks.
  */
 const addProductVariationsTracks = () => {
 	document
@@ -519,7 +519,7 @@ const addProductVariationsTracks = () => {
 };
 
 /**
- * Adds general product screen tracks.
+ * Attaches general product screen tracks.
  */
 const addProductScreenTracks = () => {
 	const initialPublishingData = getPublishingWidgetData();

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
@@ -267,7 +267,7 @@ const addProductTabsTracks = () => {
 /**
  * Adds the inventory tab Tracks events.
  */
-const addInventoryTabTracks = () => {
+const addProductInventoryTabTracks = () => {
 	document
 		.querySelector( '#_manage_stock' )
 		?.addEventListener( 'click', ( event ) => {
@@ -373,9 +373,9 @@ const addProductTagsTracks = () => {
 };
 
 /**
- * Adds product attributes tracks.
+ * Adds attributes tracks.
  */
-const addProductAttributesTracks = () => {
+const addAttributesTracks = () => {
 	function addNewTermEventHandler() {
 		recordEvent( 'product_attributes_add_term', {
 			page: 'product',
@@ -400,7 +400,12 @@ const addProductAttributesTracks = () => {
 				addNewAttributeTermTracks();
 			}, 1000 );
 		} );
+};
 
+/**
+ * Adds product attributes tracks.
+ */
+const addProductAttributesTracks = () => {
 	const attributesCount = document.querySelectorAll(
 		'.woocommerce_attribute'
 	).length;
@@ -447,25 +452,6 @@ const addProductAttributesTracks = () => {
 				} );
 			}
 		} );
-
-	document
-		.querySelector(
-			'#woocommerce-product-updated-message-view-product__link'
-		)
-		?.addEventListener( 'click', () => {
-			recordEvent( 'product_view_product_click', getProductData() );
-		} );
-
-	const dismissProductUpdatedButtonSelector =
-		'.notice-success.is-dismissible > button';
-
-	waitUntilElementIsPresent( dismissProductUpdatedButtonSelector, () => {
-		document
-			.querySelector( dismissProductUpdatedButtonSelector )
-			?.addEventListener( 'click', () => {
-				recordEvent( 'product_view_product_dismiss', getProductData() );
-			} );
-	} );
 };
 
 /**
@@ -635,18 +621,38 @@ const addProductScreenTracks = () => {
 				checkbox: ( event.target as HTMLInputElement ).checked,
 			} );
 		} );
+
+	document
+		.querySelector(
+			'#woocommerce-product-updated-message-view-product__link'
+		)
+		?.addEventListener( 'click', () => {
+			recordEvent( 'product_view_product_click', getProductData() );
+		} );
+
+	const dismissProductUpdatedButtonSelector =
+		'.notice-success.is-dismissible > button';
+
+	waitUntilElementIsPresent( dismissProductUpdatedButtonSelector, () => {
+		document
+			.querySelector( dismissProductUpdatedButtonSelector )
+			?.addEventListener( 'click', () => {
+				recordEvent( 'product_view_product_dismiss', getProductData() );
+			} );
+	} );
 };
 
 /**
  * Initialize all product screen tracks.
  */
 export const initProductScreenTracks = () => {
+	addAttributesTracks();
 	addProductScreenTracks();
 	addProductTagsTracks();
 	addProductAttributesTracks();
 	addProductVariationsTracks();
 	addProductTabsTracks();
-	addInventoryTabTracks();
+	addProductInventoryTabTracks();
 };
 
 export function addExitPageListener( pageId: string ) {

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
@@ -249,7 +249,7 @@ const getDataForProductTabClickEvent = ( tabName: string ) => {
 /**
  * Attaches the product tabs Tracks events.
  */
-const addProductTabsTracks = () => {
+const attachProductTabsTracks = () => {
 	const tabs = document.querySelectorAll( '.product_data_tabs > li' );
 
 	tabs.forEach( ( tab ) => {
@@ -267,7 +267,7 @@ const addProductTabsTracks = () => {
 /**
  * Attaches the inventory tab Tracks events.
  */
-const addProductInventoryTabTracks = () => {
+const attachProductInventoryTabTracks = () => {
 	document
 		.querySelector( '#_manage_stock' )
 		?.addEventListener( 'click', ( event ) => {
@@ -296,7 +296,7 @@ const addProductInventoryTabTracks = () => {
 /**
  * Attaches product tags tracks.
  */
-const addProductTagsTracks = () => {
+const attachProductTagsTracks = () => {
 	function deleteTagEventListener(/* event: Event */) {
 		recordEvent( 'product_tags_delete', {
 			page: 'product',
@@ -375,7 +375,7 @@ const addProductTagsTracks = () => {
 /**
  * Attaches attributes tracks.
  */
-const addAttributesTracks = () => {
+const attachAttributesTracks = () => {
 	function addNewTermEventHandler() {
 		recordEvent( 'product_attributes_add_term', {
 			page: 'product',
@@ -405,7 +405,7 @@ const addAttributesTracks = () => {
 /**
  * Attaches product attributes tracks.
  */
-const addProductAttributesTracks = () => {
+const attachProductAttributesTracks = () => {
 	const attributesCount = document.querySelectorAll(
 		'.woocommerce_attribute'
 	).length;
@@ -457,7 +457,7 @@ const addProductAttributesTracks = () => {
 /**
  * Attaches product variations tracks.
  */
-const addProductVariationsTracks = () => {
+const attachProductVariationsTracks = () => {
 	document
 		.querySelector(
 			'#variable_product_options_inner .variations-add-attributes-link'
@@ -482,15 +482,6 @@ const addProductVariationsTracks = () => {
 
 	// We attach the events in this way because the buttons are added dynamically.
 	attachEventListenerToParentForChildren( variationsSection, [
-		{
-			eventName: 'click',
-			childQuery: '.generate_variations',
-			callback: () => {
-				recordEvent( 'product_variations_buttons', {
-					action: 'generate_variations',
-				} );
-			},
-		},
 		{
 			eventName: 'click',
 			childQuery: '.add_variation_manually',
@@ -521,7 +512,7 @@ const addProductVariationsTracks = () => {
 /**
  * Attaches general product screen tracks.
  */
-const addProductScreenTracks = () => {
+const attachProductScreenTracks = () => {
 	const initialPublishingData = getPublishingWidgetData();
 
 	document
@@ -646,13 +637,13 @@ const addProductScreenTracks = () => {
  * Initialize all product screen tracks.
  */
 export const initProductScreenTracks = () => {
-	addAttributesTracks();
-	addProductScreenTracks();
-	addProductTagsTracks();
-	addProductAttributesTracks();
-	addProductVariationsTracks();
-	addProductTabsTracks();
-	addProductInventoryTabTracks();
+	attachAttributesTracks();
+	attachProductScreenTracks();
+	attachProductTagsTracks();
+	attachProductAttributesTracks();
+	attachProductVariationsTracks();
+	attachProductTabsTracks();
+	attachProductInventoryTabTracks();
 };
 
 export function addExitPageListener( pageId: string ) {

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
@@ -7,7 +7,10 @@ import { recordEvent } from '@woocommerce/tracks';
 /**
  * Internal dependencies
  */
-import { waitUntilElementIsPresent } from './utils';
+import {
+	attachEventListenerToParentForChildren,
+	waitUntilElementIsPresent,
+} from './utils';
 
 /**
  * Get the product data.
@@ -274,7 +277,7 @@ const addInventoryTabTracks = () => {
 		} );
 
 	document
-		.querySelector( '#_manage_stock_disabled' )
+		.querySelector( '#_manage_stock_disabled > a' )
 		?.addEventListener( 'click', () => {
 			recordEvent(
 				'product_manage_stock_disabled_store_settings_link_click'
@@ -370,9 +373,9 @@ const addProductTagsTracks = () => {
 };
 
 /**
- * Adds product attribute tracks.
+ * Adds product attributes tracks.
  */
-const addProductAttributeTracks = () => {
+const addProductAttributesTracks = () => {
 	function addNewTermEventHandler() {
 		recordEvent( 'product_attributes_add_term', {
 			page: 'product',
@@ -463,6 +466,70 @@ const addProductAttributeTracks = () => {
 				recordEvent( 'product_view_product_dismiss', getProductData() );
 			} );
 	} );
+};
+
+/**
+ * Adds product variations tracks.
+ */
+const addProductVariationsTracks = () => {
+	document
+		.querySelector(
+			'#variable_product_options_inner .variations-add-attributes-link'
+		)
+		?.addEventListener( 'click', () => {
+			recordEvent( 'product_variations_empty_state', {
+				action: 'add_attribute_link',
+			} );
+		} );
+
+	document
+		.querySelector(
+			'#variable_product_options_inner .variations-learn-more-link'
+		)
+		?.addEventListener( 'click', () => {
+			recordEvent( 'product_variations_empty_state', {
+				action: 'learn_more_link',
+			} );
+		} );
+
+	const variationsSection = '#variable_product_options';
+
+	// We attach the events in this way because the buttons are added dynamically.
+	attachEventListenerToParentForChildren( variationsSection, [
+		{
+			eventName: 'click',
+			query: '.generate_variations',
+			callback: () => {
+				recordEvent( 'product_variations_buttons', {
+					action: 'generate_variations',
+				} );
+			},
+		},
+		{
+			eventName: 'click',
+			query: '.add_variation_manually',
+			callback: () => {
+				recordEvent( 'product_variations_buttons', {
+					action: 'add_variation_manually',
+				} );
+			},
+		},
+		{
+			eventName: 'change',
+			query: '#field_to_edit',
+			callback: () => {
+				const selectElement = document.querySelector(
+					'#field_to_edit'
+				) as HTMLSelectElement;
+				// Get the index of the selected option
+				const selectedIndex = selectElement.selectedIndex;
+				recordEvent( 'product_variations_buttons', {
+					action: 'bulk_actions',
+					selected: selectElement.options[ selectedIndex ]?.value,
+				} );
+			},
+		},
+	] );
 };
 
 /**
@@ -576,7 +643,8 @@ const addProductScreenTracks = () => {
 export const initProductScreenTracks = () => {
 	addProductScreenTracks();
 	addProductTagsTracks();
-	addProductAttributeTracks();
+	addProductAttributesTracks();
+	addProductVariationsTracks();
 	addProductTabsTracks();
 	addInventoryTabTracks();
 };

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
@@ -484,7 +484,7 @@ const addProductVariationsTracks = () => {
 	attachEventListenerToParentForChildren( variationsSection, [
 		{
 			eventName: 'click',
-			query: '.generate_variations',
+			childQuery: '.generate_variations',
 			callback: () => {
 				recordEvent( 'product_variations_buttons', {
 					action: 'generate_variations',
@@ -493,7 +493,7 @@ const addProductVariationsTracks = () => {
 		},
 		{
 			eventName: 'click',
-			query: '.add_variation_manually',
+			childQuery: '.add_variation_manually',
 			callback: () => {
 				recordEvent( 'product_variations_buttons', {
 					action: 'add_variation_manually',
@@ -502,7 +502,7 @@ const addProductVariationsTracks = () => {
 		},
 		{
 			eventName: 'change',
-			query: '#field_to_edit',
+			childQuery: '#field_to_edit',
 			callback: () => {
 				const selectElement = document.querySelector(
 					'#field_to_edit'

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/utils.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/utils.ts
@@ -1,4 +1,40 @@
 /**
+ * Attaches a click event listener to a parent element and calls a callback when one of the child elements,
+ * specified by the list of queries, is clicked. This allows handling events for child elements that may not
+ * exist in the DOM when the event listener is added.
+ *
+ * @param {string}        parentQuery query of the parent element.
+ * @param {Array<Object>} children    array of child query and callback pairs.
+ */
+export function attachEventListenerToParentForChildren(
+	parentQuery: string,
+	children: Array< {
+		eventName: 'click' | 'change';
+		query: string;
+		callback: () => void;
+	} >
+) {
+	const parent = document.querySelector( parentQuery );
+
+	if ( ! parent ) return;
+
+	const eventListener = ( event: Event ) => {
+		children.forEach( ( { eventName, query, callback } ) => {
+			if (
+				event.type === eventName &&
+				( event.target as Element ).matches( query )
+			) {
+				callback();
+			}
+		} );
+	};
+
+	children.forEach( ( { eventName } ) => {
+		parent.addEventListener( eventName, eventListener );
+	} );
+}
+
+/**
  * Recursive function that waits up to 3 seconds until an element is found, then calls the callback.
  *
  * @param {string}   query query of the element.

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/utils.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/utils.ts
@@ -4,13 +4,13 @@
  * exist in the DOM when the event listener is added.
  *
  * @param {string}        parentQuery query of the parent element.
- * @param {Array<Object>} children    array of child query and callback pairs.
+ * @param {Array<Object>} children    array of event, child query and callback pairs.
  */
 export function attachEventListenerToParentForChildren(
 	parentQuery: string,
 	children: Array< {
 		eventName: 'click' | 'change';
-		query: string;
+		childQuery: string;
 		callback: () => void;
 	} >
 ) {
@@ -19,10 +19,10 @@ export function attachEventListenerToParentForChildren(
 	if ( ! parent ) return;
 
 	const eventListener = ( event: Event ) => {
-		children.forEach( ( { eventName, query, callback } ) => {
+		children.forEach( ( { eventName, childQuery, callback } ) => {
 			if (
 				event.type === eventName &&
-				( event.target as Element ).matches( query )
+				( event.target as Element ).matches( childQuery )
 			) {
 				callback();
 			}

--- a/plugins/woocommerce/changelog/add-37150_tracks_events_to_variations_tab
+++ b/plugins/woocommerce/changelog/add-37150_tracks_events_to_variations_tab
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add tracks events to variations tab

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
@@ -1083,6 +1083,10 @@ jQuery( function ( $ ) {
 				} else {
 					wc_meta_boxes_product_variations_ajax.unblock();
 				}
+
+				window.wcTracks.recordEvent( 'product_variations_buttons', {
+					action: 'remove_variation',
+				} );
 			}
 
 			return false;

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
@@ -1154,6 +1154,10 @@ jQuery( function ( $ ) {
 						}
 					}
 				);
+
+				window.wcTracks.recordEvent( 'product_variations_buttons', {
+					action: 'generate_variations',
+				} );
 			}
 
 			return false;

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
@@ -26,7 +26,7 @@ $arrow_img_url          = WC_ADMIN_IMAGES_FOLDER_URL . '/product_data/no-variati
 						echo wp_kses_post(
 							sprintf(
 								/* translators: %1$s: url for attributes tab, %2$s: url for variable product documentation */
-								__( 'Add some attributes in the <a href="%1$s">Attributes</a> tab to generate variations. Make sure to check the <b>Used for variations</b> box. <a href="%2$s" target="_blank" rel="noreferrer">Learn more</a>', 'woocommerce' ),
+								__( 'Add some attributes in the <a class="variations-add-attributes-link" href="%1$s">Attributes</a> tab to generate variations. Make sure to check the <b>Used for variations</b> box. <a class="variations-learn-more-link" href="%2$s" target="_blank" rel="noreferrer">Learn more</a>', 'woocommerce' ),
 								esc_url( '#product_attributes' ),
 								esc_url( 'https://woocommerce.com/document/variable-product/' )
 							)


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds Tracks events to the variations tab:

- The "Attributes" link in the [new empty state](https://github.com/woocommerce/woocommerce/issues/37139) (when no attributes are added).
- The "Learn more" link in the [new empty state](https://github.com/woocommerce/woocommerce/issues/37139) (when no attributes are added).
- The "Generate variations" button in the [second new empty state](https://github.com/woocommerce/woocommerce/issues/37147) (when attributes are added, but the variations have not been generated yet).
- The "Add manually" button in the [second new empty state](https://github.com/woocommerce/woocommerce/issues/37147) (when attributes are added, but the variations have not been generated yet).
- The "Bulk actions" [dropdown](https://github.com/woocommerce/woocommerce/issues/37148).
- Each action selected in the "Bulk actions" [dropdown](https://github.com/woocommerce/woocommerce/issues/37148).

A few things have been refactored too.

Closes #37150.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the logging of Tracks event to the browser dev console: `localStorage.setItem( 'debug', 'wc-admin:*' )`
    * Also, verify Tracks events actually get logged by using the Tracks Live View (make sure tracking is enabled for your site)
2. Go to the product screen and select a `Variable product`.
3. Before adding an attribute, go to `Variations`.
4. Verify that after clicking the `Attributes` and `Learn more` links, the event `wcadmin_product_variations_empty_state` is sent with the actions`add_attribute_link` and `learn_more_link` are being tracked correctly.
5. Add an attribute and go back to the `Variations` tab.
6. Verify that the Tracks event `wcadmin_product_variations_buttons` is being sent when the `Generate variations` and `Add manually` buttons are pressed. The event will have the prop action, with the values: `generate_variations` and `add_variation_manually`.
7. After adding a variation, verify that the action `bulk_actions` is sent after changing the `Bulk action` dropdown with the selected option.

## UPDATE
- After pressing `Generate variations` a confirmation dialog will be shown, and the Tracks event will be recorded after confirming the action. 
- The remove variation action is now being recorded as well.
- Both are being recorded from the non-compiled JS side, so the easiest way to see it is by using the Network tab, in the browser's dev tools 

<!-- End testing instructions -->