### PR TITLE
Add placeholder support to code analyzer scan

### DIFF
--- a/.github/workflows/pr-highlight-changes.yml
+++ b/.github/workflows/pr-highlight-changes.yml
@@ -29,7 +29,7 @@ jobs:
               run: |
                   HEAD_REF=$(git rev-parse HEAD)
                   version=$(pnpm run analyzer major-minor "$HEAD_REF" "plugins/woocommerce/woocommerce.php" | tail -n 1)
-                  pnpm run analyzer "$HEAD_REF" $version -o "github"
+                  pnpm run analyzer scan templates "$HEAD_REF" --allowPlaceholder --since "$version" -o "github"
             - name: Check results
               uses: actions/github-script@v6
               with:

--- a/tools/code-analyzer/src/commands/analyzer/analyzer-scan.ts
+++ b/tools/code-analyzer/src/commands/analyzer/analyzer-scan.ts
@@ -58,8 +58,12 @@ const program = new Command()
 		'Output style for the results. Options: github, cli. Github output will set the results as an output variable for Github actions.',
 		'cli'
 	)
+	.option(
+		'-p, --allowPlaceholder',
+		'For template or hook changes, allow placeholder versions.'
+	)
 	.action( async ( scanType, compare, base, options ) => {
-		const { since: sinceVersion, source, outputStyle } = options;
+		const { since: sinceVersion, source, outputStyle, allowPlaceholder } = options;
 
 		if (
 			( scanType === 'hooks' ||
@@ -80,7 +84,9 @@ const program = new Command()
 						compare,
 						sinceVersion,
 						base,
-						source
+						source,
+						undefined,
+						!! allowPlaceholder
 					);
 
 					if ( hookChanges.length ) {
@@ -102,7 +108,9 @@ const program = new Command()
 						compare,
 						sinceVersion,
 						base,
-						source
+						source,
+						undefined,
+						!! allowPlaceholder
 					);
 					if ( templateChanges && templateChanges.length ) {
 						printTemplateResults(

--- a/tools/code-analyzer/src/lib/scan-changes.ts
+++ b/tools/code-analyzer/src/lib/scan-changes.ts
@@ -74,7 +74,8 @@ export const scanChangesForHooks = async (
 	sinceVersion: string,
 	base: string,
 	source: string,
-	clonedPath?: string
+	clonedPath?: string,
+	allowPlaceholder: boolean = false
 ) => {
 	const { diff, tmpRepoPath } = await generateVersionDiff(
 		compareVersion,
@@ -86,7 +87,8 @@ export const scanChangesForHooks = async (
 	const hookChanges = await scanForHookChanges(
 		diff,
 		sinceVersion,
-		tmpRepoPath
+		tmpRepoPath,
+		allowPlaceholder
 	);
 
 	return Array.from( hookChanges.values() );
@@ -97,7 +99,8 @@ export const scanChangesForTemplates = async (
 	sinceVersion: string,
 	base: string,
 	source: string,
-	clonedPath?: string
+	clonedPath?: string,
+	allowPlaceholder: boolean = false
 ) => {
 	const { diff, tmpRepoPath } = await generateVersionDiff(
 		compareVersion,
@@ -109,7 +112,8 @@ export const scanChangesForTemplates = async (
 	const templateChanges = await scanForTemplateChanges(
 		diff,
 		sinceVersion,
-		tmpRepoPath
+		tmpRepoPath,
+		allowPlaceholder
 	);
 
 	return Array.from( templateChanges.values() );

--- a/tools/code-analyzer/src/print.ts
+++ b/tools/code-analyzer/src/print.ts
@@ -69,12 +69,11 @@ export const printHookResults = (
 			description,
 			hookType,
 			changeType,
+			isPlaceholder,
 		} of data ) {
 			opt += `\\n* **File:** ${ filePath }`;
 
-			const cliMessage = `**${ name }** introduced in ${ version }`;
-			const ghMessage = `\\'${ name }\\' introduced in ${ version }`;
-			const message = output === 'github' ? ghMessage : cliMessage;
+			const message = `\\'${ name }\\' introduced in ${ version }${ isPlaceholder ? ' with version placeholder' : '' }`;
 			const title = `${ changeType } ${ hookType } found`;
 
 			opt += `\\n  * NOTICE - ${ message }: ${ description }`;
@@ -95,10 +94,9 @@ export const printHookResults = (
 			hookType,
 			changeType,
 			ghLink,
+			isPlaceholder,
 		} of data ) {
-			const cliMessage = `**${ name }** introduced in ${ version }`;
-			const ghMessage = `\\'${ name }\\' introduced in ${ version }`;
-			const message = output === 'github' ? ghMessage : cliMessage;
+			const message = `**${ name }** introduced in ${ version }${ isPlaceholder ? ' with version placeholder' : '' }`;
 			const title = `${ changeType } ${ hookType } found`;
 
 			log( 'FILE: ' + filePath );


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR updates the code analyzer scan command to also support placeholders. In addition, this PR fixes an issue I discovered while writing the testing instructions for this PR. Prior to this change, only the first `do_action` or `apply_filter` changed in a file would be detected. If there were multiple actions or filters added to a single file, the subsequent ones would be ignored.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Partially addresses #35754

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Fork this repository, checkout locally, and make sure to run `pnpm i`.
2. Merge these changes to your fork's `trunk`.
3. Create a new branch (for example `test/template-version`) in your fork.
4. Make changes to a file in `plugins/woocommerce/templates`, but do not update the `@version` tag in the file that you change.
5. Commit previous change to your test branch and push back to your fork.
6. Switch to the `tools/code-analyzer` directory.
7. Run the following command: `pnpm run analyzer scan templates "YOURBRANCH" "trunk" --since "8.0.0"`.
8. Verify that you see a warning that the template may require a version bump.
9. Update the file that you previous edited, and change the `@version` tag to `8.0.0`. Commit and push changes.
10. Again run `pnpm run analyzer scan templates "YOURBRANCH" "trunk" --since "8.0.0"`.
11. Verify that you do not see a warning. Instead you should see a notice that a version bump was found.
12. Update the file that you previously edited again, this time changing the `@version` tag to `x.x.x`. Commit and push changes.
13. Again run `pnpm run analyzer scan templates "YOURBRANCH" "trunk" --since "8.0.0"`.
14. You should again see a warning that a version bump may be required.
15. Run `pnpm run analyzer scan templates "YOURBRANCH" "trunk" --allowPlaceholder --since "8.0.0"`
16. Verify that you do not see a warning. Instead you should see a notice that a version bump placeholder was found.
17. Make sure actions are enabled in your fork.
18. Create a new PR to your fork (make sure the PR isn't to `woocommerce/woocommerce`) using your test branch. Verify that the `pr-highlight-changes.yml` workflow runs, and passes, and that there's a notice about a version bump placeholder being found.
19. Create a new branch (for example `test/hook-version`) in your fork.
20. Add a `do_action` or `apply_filter` call to a php file in the `woocommerce` plugin. Include the docblock and `@since 8.0.0`. For example:
```
/**
 * Does a thing.
 *
 * @since 8.0.0
 */
do_action( 'wc_some_thing' );
```
21. Commit and push the change.
22. Run `pnpm run analyzer scan hooks "YOURBRANCH" "trunk" --since "8.0.0"`.
23. Verify that the hook is detected with the version of 8.0.0.
24. Add a `do_action` or `apply_filter` call to a php file in the `woocommerce` plugin. Include the docblock and `@since x.x.x`. You may want to use the same file you used in the previous step to verify that this PR also addresses the issue where previously only a single hook was detected in each file. For example:
```
/**
 * Does a different thing.
 *
 * @since x.x.x
 */
do_action( 'wc_some_thing_else' );
```
25. Commit and push the change.
26. Run `pnpm run analyzer scan hooks "YOURBRANCH" "trunk" --since "8.0.0"`.
27. You shouldn't see the hook with `@since x.x.x` because the `--allowPlaceholder` flag was not included.
28. Repeat the previous command adding `--allowPlaceholder`. You should see the placeholder hook.


<!-- End testing instructions -->