### PR TITLE
Add edit product link modal under name field 

### DIFF
--- a/packages/js/product-editor/changelog/add-product-link-edit-37610
+++ b/packages/js/product-editor/changelog/add-product-link-edit-37610
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Refactoring product link modal and adding link to product block editor.

--- a/packages/js/product-editor/src/components/details-name-block/edit.tsx
+++ b/packages/js/product-editor/src/components/details-name-block/edit.tsx
@@ -109,7 +109,7 @@ export function Edit() {
 				</BaseControl>
 				{ productId &&
 					nameIsValid &&
-					product.status === 'publish' &&
+					[ 'publish', 'draft' ].includes( product.status ) &&
 					permalinkPrefix && (
 						<span className="woocommerce-product-form__secondary-text product-details-section__product-link">
 							{ __( 'Product link', 'woocommerce' ) }

--- a/packages/js/product-editor/src/components/details-name-block/edit.tsx
+++ b/packages/js/product-editor/src/components/details-name-block/edit.tsx
@@ -12,7 +12,6 @@ import {
 import { useBlockProps } from '@wordpress/block-editor';
 import { cleanForSlug } from '@wordpress/url';
 import { useSelect, useDispatch } from '@wordpress/data';
-import uniqueId from 'lodash/uniqueId';
 import {
 	PRODUCTS_STORE_NAME,
 	WCDataSelector,
@@ -86,7 +85,7 @@ export function Edit() {
 		<>
 			<div { ...blockProps }>
 				<BaseControl
-					id={ uniqueId() }
+					id={ 'product_name' }
 					label={ createInterpolateElement(
 						__( 'Name <required />', 'woocommerce' ),
 						{

--- a/packages/js/product-editor/src/components/details-name-block/edit.tsx
+++ b/packages/js/product-editor/src/components/details-name-block/edit.tsx
@@ -8,11 +8,7 @@ import {
 	createInterpolateElement,
 	useState,
 } from '@wordpress/element';
-import {
-	Button,
-	BaseControl,
-	__experimentalInputControl as InputControl,
-} from '@wordpress/components';
+
 import { useBlockProps } from '@wordpress/block-editor';
 import { cleanForSlug } from '@wordpress/url';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -22,6 +18,12 @@ import {
 	WCDataSelector,
 	Product,
 } from '@woocommerce/data';
+import {
+	Button,
+	BaseControl,
+	// @ts-expect-error `__experimentalInputControl` does exist.
+	__experimentalInputControl as InputControl,
+} from '@wordpress/components';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore No types for this exist yet.
 // eslint-disable-next-line @woocommerce/dependency-group

--- a/packages/js/product-editor/src/components/details-name-block/edit.tsx
+++ b/packages/js/product-editor/src/components/details-name-block/edit.tsx
@@ -34,17 +34,15 @@ import { useEntityProp, useEntityId } from '@wordpress/core-data';
 import { AUTO_DRAFT_NAME } from '../../utils';
 import { EditProductLinkModal } from '../edit-product-link-modal';
 import { useValidation } from '../../hooks/use-validation';
-import { useProductHelper } from '../../hooks/use-product-helper';
 
 export function Edit() {
 	const blockProps = useBlockProps();
 
-	const { updateProductWithStatus } = useProductHelper();
+	const { editEntityRecord, saveEntityRecord } = useDispatch( 'core' );
 
 	const [ showProductLinkEditModal, setShowProductLinkEditModal ] =
 		useState( false );
 
-	const { editEntityRecord } = useDispatch( 'core' );
 	const productId = useEntityId( 'postType', 'product' );
 	const product: Product = useSelect( ( select ) =>
 		select( 'core' ).getEditedEntityRecord(
@@ -141,15 +139,11 @@ export function Edit() {
 						onCancel={ () => setShowProductLinkEditModal( false ) }
 						onSaved={ () => setShowProductLinkEditModal( false ) }
 						saveHandler={ async ( updatedSlug ) => {
-							const { slug, permalink } =
-								await updateProductWithStatus(
-									product.id,
-									{
-										slug: updatedSlug,
-									},
-									product.status,
-									true
-								);
+							const { slug, permalink }: Product =
+								await saveEntityRecord( 'postType', 'product', {
+									id: product.id,
+									slug: updatedSlug,
+								} );
 
 							if ( slug && permalink ) {
 								editEntityRecord(

--- a/packages/js/product-editor/src/components/details-name-block/edit.tsx
+++ b/packages/js/product-editor/src/components/details-name-block/edit.tsx
@@ -8,12 +8,15 @@ import {
 	createInterpolateElement,
 	useState,
 } from '@wordpress/element';
-import { TextControl } from '@woocommerce/components';
-import { Button } from '@wordpress/components';
+import {
+	Button,
+	BaseControl,
+	__experimentalInputControl as InputControl,
+} from '@wordpress/components';
 import { useBlockProps } from '@wordpress/block-editor';
 import { cleanForSlug } from '@wordpress/url';
 import { useSelect, useDispatch } from '@wordpress/data';
-
+import uniqueId from 'lodash/uniqueId';
 import {
 	PRODUCTS_STORE_NAME,
 	WCDataSelector,
@@ -80,22 +83,29 @@ export function Edit() {
 	return (
 		<>
 			<div { ...blockProps }>
-				<TextControl
+				<BaseControl
+					id={ uniqueId() }
 					label={ createInterpolateElement(
 						__( 'Name <required />', 'woocommerce' ),
 						{
 							required: (
-								<span className="woocommerce-product-form__optional-input">
-									{ __( '(required)', 'woocommerce' ) }
+								<span className="woocommerce-product-form__required-input">
+									{ __( '*', 'woocommerce' ) }
 								</span>
 							),
 						}
 					) }
-					name={ 'woocommerce-product-name' }
-					placeholder={ __( 'e.g. 12 oz Coffee Mug', 'woocommerce' ) }
-					onChange={ setName }
-					value={ name || '' }
-				/>
+				>
+					<InputControl
+						name={ 'woocommerce-product-name' }
+						placeholder={ __(
+							'e.g. 12 oz Coffee Mug',
+							'woocommerce'
+						) }
+						onChange={ setName }
+						value={ name || '' }
+					/>
+				</BaseControl>
 				{ productId &&
 					nameIsValid &&
 					product.status === 'publish' &&

--- a/packages/js/product-editor/src/components/details-name-block/edit.tsx
+++ b/packages/js/product-editor/src/components/details-name-block/edit.tsx
@@ -2,36 +2,164 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { createElement, createInterpolateElement } from '@wordpress/element';
+import {
+	createElement,
+	Fragment,
+	createInterpolateElement,
+	useState,
+} from '@wordpress/element';
 import { TextControl } from '@woocommerce/components';
+import { Button } from '@wordpress/components';
 import { useBlockProps } from '@wordpress/block-editor';
+import { cleanForSlug } from '@wordpress/url';
+import { useSelect, useDispatch } from '@wordpress/data';
+
+import {
+	PRODUCTS_STORE_NAME,
+	WCDataSelector,
+	Product,
+} from '@woocommerce/data';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore No types for this exist yet.
 // eslint-disable-next-line @woocommerce/dependency-group
-import { useEntityProp } from '@wordpress/core-data';
+import { useEntityProp, useEntityId } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { AUTO_DRAFT_NAME } from '../../utils';
+import { EditProductLinkModal } from '../edit-product-link-modal';
+import { useValidation } from '../../hooks/use-validation';
+import { useProductHelper } from '../../hooks/use-product-helper';
 
 export function Edit() {
 	const blockProps = useBlockProps();
-	const [ name, setName ] = useEntityProp( 'postType', 'product', 'name' );
+
+	const { updateProductWithStatus } = useProductHelper();
+
+	const [ showProductLinkEditModal, setShowProductLinkEditModal ] =
+		useState( false );
+
+	const { editEntityRecord } = useDispatch( 'core' );
+	const productId = useEntityId( 'postType', 'product' );
+	const product: Product = useSelect( ( select ) =>
+		select( 'core' ).getEditedEntityRecord(
+			'postType',
+			'product',
+			productId
+		)
+	);
+
+	const [ name, setName ] = useEntityProp< string >(
+		'postType',
+		'product',
+		'name'
+	);
+
+	const { permalinkPrefix, permalinkSuffix } = useSelect(
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		( select: WCDataSelector ) => {
+			const { getPermalinkParts } = select( PRODUCTS_STORE_NAME );
+			if ( productId ) {
+				const parts = getPermalinkParts( productId );
+				return {
+					permalinkPrefix: parts?.prefix,
+					permalinkSuffix: parts?.suffix,
+				};
+			}
+			return {};
+		}
+	);
+
+	const nameIsValid = useValidation(
+		'product/name',
+		() => Boolean( name ) && name !== AUTO_DRAFT_NAME
+	);
 
 	return (
-		<div { ...blockProps }>
-			<TextControl
-				label={ createInterpolateElement(
-					__( 'Name <required />', 'woocommerce' ),
-					{
-						required: (
-							<span className="woocommerce-product-form__optional-input">
-								{ __( '(required)', 'woocommerce' ) }
-							</span>
-						),
-					}
+		<>
+			<div { ...blockProps }>
+				<TextControl
+					label={ createInterpolateElement(
+						__( 'Name <required />', 'woocommerce' ),
+						{
+							required: (
+								<span className="woocommerce-product-form__optional-input">
+									{ __( '(required)', 'woocommerce' ) }
+								</span>
+							),
+						}
+					) }
+					name={ 'woocommerce-product-name' }
+					placeholder={ __( 'e.g. 12 oz Coffee Mug', 'woocommerce' ) }
+					onChange={ setName }
+					value={ name || '' }
+				/>
+				{ productId &&
+					nameIsValid &&
+					product.status === 'publish' &&
+					permalinkPrefix && (
+						<span className="woocommerce-product-form__secondary-text product-details-section__product-link">
+							{ __( 'Product link', 'woocommerce' ) }
+							:&nbsp;
+							<a
+								href={ product.permalink }
+								target="_blank"
+								rel="noreferrer"
+							>
+								{ permalinkPrefix }
+								{ product.slug || cleanForSlug( name ) }
+								{ permalinkSuffix }
+							</a>
+							<Button
+								variant="link"
+								onClick={ () =>
+									setShowProductLinkEditModal( true )
+								}
+							>
+								{ __( 'Edit', 'woocommerce' ) }
+							</Button>
+						</span>
+					) }
+				{ showProductLinkEditModal && (
+					<EditProductLinkModal
+						permalinkPrefix={ permalinkPrefix || '' }
+						permalinkSuffix={ permalinkSuffix || '' }
+						product={ product }
+						onCancel={ () => setShowProductLinkEditModal( false ) }
+						onSaved={ () => setShowProductLinkEditModal( false ) }
+						saveHandler={ async ( updatedSlug ) => {
+							const { slug, permalink } =
+								await updateProductWithStatus(
+									product.id,
+									{
+										slug: updatedSlug,
+									},
+									product.status,
+									true
+								);
+
+							if ( slug && permalink ) {
+								editEntityRecord(
+									'postType',
+									'product',
+									product.id,
+									{
+										slug,
+										permalink,
+									}
+								);
+
+								return {
+									slug,
+									permalink,
+								};
+							}
+						} }
+					/>
 				) }
-				name={ 'woocommerce-product-name' }
-				placeholder={ __( 'e.g. 12 oz Coffee Mug', 'woocommerce' ) }
-				onChange={ setName }
-				value={ name || '' }
-			/>
-		</div>
+			</div>
+		</>
 	);
 }

--- a/packages/js/product-editor/src/components/details-name-block/style.scss
+++ b/packages/js/product-editor/src/components/details-name-block/style.scss
@@ -19,3 +19,7 @@
 		}
 	}
 }
+
+.woocommerce-product-form__required-input {
+	color: #CC1818;
+}

--- a/packages/js/product-editor/src/components/details-name-block/style.scss
+++ b/packages/js/product-editor/src/components/details-name-block/style.scss
@@ -1,0 +1,21 @@
+.product-details-section {
+
+	&__product-link {
+		color: #757575;
+		font-size: 12px;
+		display: block;
+		margin-top: $gap-smaller;
+
+		> a {
+			color: inherit;
+			text-decoration: none;
+			font-weight: 600;
+		}
+
+		.components-button.is-link {
+			font-size: 12px;
+			text-decoration: none;
+			margin-left: $gap-smaller;
+		}
+	}
+}

--- a/packages/js/product-editor/src/components/details-name-field/details-name-field.tsx
+++ b/packages/js/product-editor/src/components/details-name-field/details-name-field.tsx
@@ -22,11 +22,14 @@ import {
  */
 import { PRODUCT_DETAILS_SLUG } from '../../constants';
 import { EditProductLinkModal } from '../edit-product-link-modal';
+import { useProductHelper } from '../../hooks/use-product-helper';
 
 export const DetailsNameField = ( {} ) => {
+	const { updateProductWithStatus, isUpdatingDraft, isUpdatingPublished } =
+		useProductHelper();
 	const [ showProductLinkEditModal, setShowProductLinkEditModal ] =
 		useState( false );
-	const { getInputProps, values, touched, errors, setValue } =
+	const { getInputProps, values, touched, errors, setValue, resetForm } =
 		useFormContext< Product >();
 
 	const { permalinkPrefix, permalinkSuffix } = useSelect(
@@ -102,6 +105,35 @@ export const DetailsNameField = ( {} ) => {
 					product={ values }
 					onCancel={ () => setShowProductLinkEditModal( false ) }
 					onSaved={ () => setShowProductLinkEditModal( false ) }
+					isBusy={ isUpdatingDraft || isUpdatingPublished }
+					disabled={ isUpdatingDraft || isUpdatingPublished }
+					saveHandler={ async ( slug ) => {
+						const updatedProduct = await updateProductWithStatus(
+							values.id,
+							{
+								slug,
+							},
+							values.status,
+							true
+						);
+						if ( updatedProduct && updatedProduct.id ) {
+							// only reset the updated slug and permalink fields.
+							resetForm(
+								{
+									...values,
+									slug: updatedProduct.slug,
+									permalink: updatedProduct.permalink,
+								},
+								touched,
+								errors
+							);
+
+							return {
+								slug: updatedProduct.slug,
+								permalink: updatedProduct.permalink,
+							};
+						}
+					} }
 				/>
 			) }
 		</div>

--- a/packages/js/product-editor/src/components/details-name-field/details-name-field.tsx
+++ b/packages/js/product-editor/src/components/details-name-field/details-name-field.tsx
@@ -25,8 +25,7 @@ import { EditProductLinkModal } from '../edit-product-link-modal';
 import { useProductHelper } from '../../hooks/use-product-helper';
 
 export const DetailsNameField = ( {} ) => {
-	const { updateProductWithStatus, isUpdatingDraft, isUpdatingPublished } =
-		useProductHelper();
+	const { updateProductWithStatus } = useProductHelper();
 	const [ showProductLinkEditModal, setShowProductLinkEditModal ] =
 		useState( false );
 	const { getInputProps, values, touched, errors, setValue, resetForm } =
@@ -105,8 +104,6 @@ export const DetailsNameField = ( {} ) => {
 					product={ values }
 					onCancel={ () => setShowProductLinkEditModal( false ) }
 					onSaved={ () => setShowProductLinkEditModal( false ) }
-					isBusy={ isUpdatingDraft || isUpdatingPublished }
-					disabled={ isUpdatingDraft || isUpdatingPublished }
 					saveHandler={ async ( slug ) => {
 						const updatedProduct = await updateProductWithStatus(
 							values.id,

--- a/packages/js/product-editor/src/components/edit-product-link-modal/edit-product-link-modal.tsx
+++ b/packages/js/product-editor/src/components/edit-product-link-modal/edit-product-link-modal.tsx
@@ -22,8 +22,6 @@ type EditProductLinkModalProps = {
 	saveHandler: (
 		slug: string
 	) => Promise< { slug: string; permalink: string } | undefined >;
-	isBusy?: boolean;
-	disabled?: boolean;
 };
 
 export const EditProductLinkModal: React.FC< EditProductLinkModalProps > = ( {
@@ -33,11 +31,9 @@ export const EditProductLinkModal: React.FC< EditProductLinkModalProps > = ( {
 	onCancel,
 	onSaved,
 	saveHandler,
-	isBusy,
-	disabled,
 } ) => {
 	const { createNotice } = useDispatch( 'core/notices' );
-
+	const [ isSaving, setIsSaving ] = useState< boolean >( false );
 	const [ slug, setSlug ] = useState(
 		product.slug || cleanForSlug( product.name )
 	);
@@ -107,10 +103,12 @@ export const EditProductLinkModal: React.FC< EditProductLinkModalProps > = ( {
 					</Button>
 					<Button
 						isPrimary
-						isBusy={ isBusy }
-						disabled={ disabled || slug === product.slug }
-						onClick={ () => {
-							onSave();
+						isBusy={ isSaving }
+						disabled={ isSaving || slug === product.slug }
+						onClick={ async () => {
+							setIsSaving( true );
+							await onSave();
+							setIsSaving( false );
 						} }
 					>
 						{ __( 'Save', 'woocommerce' ) }

--- a/packages/js/product-editor/src/components/edit-product-link-modal/edit-product-link-modal.tsx
+++ b/packages/js/product-editor/src/components/edit-product-link-modal/edit-product-link-modal.tsx
@@ -13,10 +13,6 @@ import { cleanForSlug } from '@wordpress/url';
 import { Product } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 
-/**
- * Internal dependencies
- */
-
 type EditProductLinkModalProps = {
 	product: Product;
 	permalinkPrefix: string;
@@ -53,17 +49,19 @@ export const EditProductLinkModal: React.FC< EditProductLinkModalProps > = ( {
 			product_type: product.type,
 		} );
 
-		const updateValues = await saveHandler( slug );
+		const updatedValues = await saveHandler( slug );
 
-		if ( updateValues ) {
+		if ( updatedValues ) {
 			createNotice(
-				updateValues.slug === cleanForSlug( slug ) ? 'success' : 'info',
-				updateValues.slug === cleanForSlug( slug )
+				updatedValues.slug === cleanForSlug( slug )
+					? 'success'
+					: 'info',
+				updatedValues.slug === cleanForSlug( slug )
 					? __( 'Product link successfully updated.', 'woocommerce' )
 					: __(
 							'Product link already existed, updated to ',
 							'woocommerce'
-					  ) + updateValues.permalink
+					  ) + updatedValues.permalink
 			);
 		} else {
 			createNotice(

--- a/packages/js/product-editor/src/components/edit-product-link-modal/edit-product-link-modal.tsx
+++ b/packages/js/product-editor/src/components/edit-product-link-modal/edit-product-link-modal.tsx
@@ -45,19 +45,18 @@ export const EditProductLinkModal: React.FC< EditProductLinkModalProps > = ( {
 			product_type: product.type,
 		} );
 
-		const updatedValues = await saveHandler( slug );
+		const { slug: updatedSlug, permalink: updatedPermalink } =
+			( await saveHandler( slug ) ) ?? {};
 
-		if ( updatedValues ) {
+		if ( updatedSlug ) {
 			createNotice(
-				updatedValues.slug === cleanForSlug( slug )
-					? 'success'
-					: 'info',
-				updatedValues.slug === cleanForSlug( slug )
+				updatedSlug === cleanForSlug( slug ) ? 'success' : 'info',
+				updatedSlug === cleanForSlug( slug )
 					? __( 'Product link successfully updated.', 'woocommerce' )
 					: __(
 							'Product link already existed, updated to ',
 							'woocommerce'
-					  ) + updatedValues.permalink
+					  ) + updatedPermalink
 			);
 		} else {
 			createNotice(

--- a/packages/js/product-editor/src/components/edit-product-link-modal/test/edit-product-link-modal.test.tsx
+++ b/packages/js/product-editor/src/components/edit-product-link-modal/test/edit-product-link-modal.test.tsx
@@ -37,6 +37,12 @@ describe( 'EditProductLinkModal', () => {
 				}
 				onCancel={ () => {} }
 				onSaved={ () => {} }
+				saveHandler={ () =>
+					new Promise( () => ( {
+						slug: 'test-slug',
+						permalink: 'http://test-link',
+					} ) )
+				}
 			/>
 		);
 		expect(
@@ -57,6 +63,12 @@ describe( 'EditProductLinkModal', () => {
 				}
 				onCancel={ () => {} }
 				onSaved={ () => {} }
+				saveHandler={ () =>
+					new Promise( () => ( {
+						slug: 'test-slug',
+						permalink: 'http://test-link',
+					} ) )
+				}
 			/>
 		);
 		userEvent.type(
@@ -82,6 +94,12 @@ describe( 'EditProductLinkModal', () => {
 				}
 				onCancel={ () => {} }
 				onSaved={ () => {} }
+				saveHandler={ () =>
+					new Promise( () => ( {
+						slug: 'test-slug',
+						permalink: 'http://test-link',
+					} ) )
+				}
 			/>
 		);
 		userEvent.type(

--- a/packages/js/product-editor/src/style.scss
+++ b/packages/js/product-editor/src/style.scss
@@ -15,3 +15,4 @@
 @import 'components/details-summary-block/style.scss';
 @import 'components/product-mvp-ces-footer/style.scss';
 @import 'components/product-mvp-feedback-modal/style.scss';
+@import 'components/details-name-block/style.scss';


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adding the product link text and associated modal under the name field on the block editor. This required a refactor of the edit modal component to move data logic into props.

Closes #37610 .

<!-- Begin testing instructions -->


### Screenshots

![image](https://user-images.githubusercontent.com/444632/230487026-8c024dd6-a87d-4cb5-a405-1aa26edd7513.png)


![image](https://user-images.githubusercontent.com/444632/230487108-1f4155a8-c630-4781-9973-7a7882907c75.png)


### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable product block editor with `block-editor-feature-enabled` feature flag.
2. Navigate to Products -> Add new
3. Add a name such as "test product" to the name field, and hit publish. 
4. The product link text (screenshot above) should appear under the name field after publishing.
5. Click on the "Edit" button and it should display the edit link modal (also screenshot above)
6. The Save button should be disabled until you alter the link.
7. Alter the link, and then hit save.
8. You should see a busy state while it saves, and then the updated link in the text below the field.
9. Refresh the page to ensure the change has persisted.
10. Click on the link itself under the name field which should open the product in a new tab.

<!-- End testing instructions -->