### PR TITLE
Solves Cross-Sells display variable product

### DIFF
--- a/plugins/woocommerce/changelog/fix-37613-cross-sells-display-cart
+++ b/plugins/woocommerce/changelog/fix-37613-cross-sells-display-cart
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed Cross-Sells display variable product

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -822,6 +822,11 @@ class WC_Cart extends WC_Legacy_Cart {
 				if ( $values['quantity'] > 0 ) {
 					$cross_sells = array_merge( $values['data']->get_cross_sell_ids(), $cross_sells );
 					$in_cart[]   = $values['product_id'];
+
+					// Add variations to the in cart array.
+					if ( $values['data']->is_type( 'variation' ) ) {
+						$in_cart[] = $values['variation_id'];
+					}
 				}
 			}
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #37613.

After reviewing the code in plugins/woocommerce/includes/class-wc-cart.php, I saw that the variation id was not being added to the in_cart array. Instead, the parent id was added. 
I added a condition to check if the product is a variation product. Then added the variation id to the array. That solved the problem

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to the Product edit page of any product.
2. Scroll down to Product data → Linked Products
3. Add a variable product to Cross-sells.
4. Preview the changes and add the edited product to the cart.
5. Click "View cart" and you will see the linked cross-sells product being displayed under "You may be interested in…" on the cart page.
6. Add the Cross-sells product to the cart.
7.  You should see the product is not showing in cross-sells anymore.

<!-- End testing instructions -->