### PR TITLE
Item controls for attribute creation are always visible

### DIFF
--- a/plugins/woocommerce/changelog/dev-37159_item_controls_for_attribute_always_visible
+++ b/plugins/woocommerce/changelog/dev-37159_item_controls_for_attribute_always_visible
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Item controls for attribute creation are always visible

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1130,6 +1130,7 @@ $default-line-height: 18px;
 	}
 	.toolbar-top {
 		.button,
+		.select,
 		.select2-container {
 			margin: 1px;
 		}

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1130,7 +1130,7 @@ $default-line-height: 18px;
 	}
 	.toolbar-top {
 		.button,
-		.select,
+		.attribute_taxonomy,
 		.select2-container {
 			margin: 1px;
 		}

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -5621,6 +5621,7 @@ img.help_tip {
 			a.delete,
 			a.edit {
 				float: right;
+				margin-right: 12px;
 			}
 
 			a.delete {
@@ -5656,7 +5657,7 @@ img.help_tip {
 
 			.handlediv {
 				background-position: 6px 5px !important;
-				visibility: hidden;
+				margin: 4px 0 -1px !important;
 				height: 26px;
 			}
 
@@ -5672,7 +5673,6 @@ img.help_tip {
 
 			a.delete,
 			a.edit,
-			.handlediv,
 			.sort {
 				margin-top: 0.25em;
 			}
@@ -5682,14 +5682,6 @@ img.help_tip {
 			a.edit,
 			.sort {
 				margin-top: 0.45em;
-			}
-		}
-
-		h3:hover,
-		&.ui-sortable-helper {
-			a.delete,
-			.handlediv {
-				visibility: visible;
 			}
 		}
 

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute.php
@@ -5,9 +5,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <div data-taxonomy="<?php echo esc_attr( $attribute->get_taxonomy() ); ?>" class="woocommerce_attribute wc-metabox postbox closed <?php echo esc_attr( implode( ' ', $metabox_class ) ); ?>" rel="<?php echo esc_attr( $attribute->get_position() ); ?>">
 	<h3>
-		<a href="#" class="remove_row delete"><?php esc_html_e( 'Remove', 'woocommerce' ); ?></a>
 		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle', 'woocommerce' ); ?>"></div>
 		<div class="tips sort" data-tip="<?php esc_attr_e( 'Drag and drop to set admin attribute order', 'woocommerce' ); ?>"></div>
+		<a href="#" class="remove_row delete"><?php esc_html_e( 'Remove', 'woocommerce' ); ?></a>
 		<strong class="attribute_name<?php echo esc_attr( $attribute->get_name() === '' ? ' placeholder' : '' ); ?>"><?php echo esc_html( $attribute->get_name() !== '' ? wc_attribute_label( $attribute->get_name() ) : __( 'Custom attribute', 'woocommerce' ) ); ?></strong>
 	</h3>
 	<div class="woocommerce_attribute_data wc-metabox-content hidden">

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
@@ -67,7 +67,7 @@ $icon_url                        = WC_ADMIN_IMAGES_FOLDER_URL . '/icons/global-a
 			 */
 			if ( count( $attribute_taxonomies ) <= apply_filters( 'woocommerce_attribute_taxonomy_filter_threshold', 20 ) ) :
 				?>
-			<select name="attribute_taxonomy" class="select attribute_taxonomy">
+			<select name="attribute_taxonomy" class="attribute_taxonomy">
 				<option value=""><?php esc_html_e( 'Custom product attribute', 'woocommerce' ); ?></option>
 				<?php
 				if ( ! $has_local_attributes ) {

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
@@ -67,7 +67,7 @@ $icon_url                        = WC_ADMIN_IMAGES_FOLDER_URL . '/icons/global-a
 			 */
 			if ( count( $attribute_taxonomies ) <= apply_filters( 'woocommerce_attribute_taxonomy_filter_threshold', 20 ) ) :
 				?>
-			<select name="attribute_taxonomy" class="attribute_taxonomy">
+			<select name="attribute_taxonomy" class="select attribute_taxonomy">
 				<option value=""><?php esc_html_e( 'Custom product attribute', 'woocommerce' ); ?></option>
 				<?php
 				if ( ! $has_local_attributes ) {


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR introduces changes to make the item controls always visible. They are reordered as well, so that the expand/collapse arrow is positioned at the right edge.

![Screenshot 2023-04-07 at 14 27 38](https://user-images.githubusercontent.com/1314156/230651393-d964e43c-eb08-4cd3-a42d-bf89517a0b02.png)

Closes #37159.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to Products > Add New > Product data > Attributes
2. Create an attribute.
3. Verify that the item controls (Remove, Reorder, Expand/Collapse) are always visible and in the mentioned order.

<!-- End testing instructions -->