### PR TITLE
Replacing rest_namespace modification with middleware due to blocks issues

### DIFF
--- a/packages/js/product-editor/changelog/fix-rest-namespace-blocks-37619
+++ b/packages/js/product-editor/changelog/fix-rest-namespace-blocks-37619
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Adding apifetch middleware to override product api endpoint only for the product editor.

--- a/packages/js/product-editor/package.json
+++ b/packages/js/product-editor/package.json
@@ -41,6 +41,7 @@
 		"@woocommerce/number": "workspace:*",
 		"@woocommerce/settings": "^1.0.0",
 		"@woocommerce/tracks": "workspace:^1.3.0",
+		"@wordpress/api-fetch": "wp-6.0",
 		"@wordpress/block-editor": "^9.8.0",
 		"@wordpress/blocks": "^12.3.0",
 		"@wordpress/components": "wp-6.0",

--- a/packages/js/product-editor/src/utils/index.ts
+++ b/packages/js/product-editor/src/utils/index.ts
@@ -22,6 +22,7 @@ import { preventLeavingProductForm } from './prevent-leaving-product-form';
 export * from './create-ordered-children';
 export * from './sort-fills-by-order';
 export * from './init-blocks';
+export * from './product-apifetch-middleware';
 
 export {
 	AUTO_DRAFT_NAME,

--- a/packages/js/product-editor/src/utils/product-apifetch-middleware.ts
+++ b/packages/js/product-editor/src/utils/product-apifetch-middleware.ts
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { getQuery } from '@woocommerce/navigation';
+
+const isProductEditor = () => {
+	const query: { page?: string; path?: string } = getQuery();
+	return (
+		query?.page === 'wc-admin' &&
+		[ '/add-product', '/product/' ].some( ( path ) =>
+			query?.path?.startsWith( path )
+		)
+	);
+};
+
+export const productApiFetchMiddleware = () => {
+	// This is needed to ensure that we use the correct namespace for the entity data store
+	// without disturbing the rest_namespace outside of the product block editor.
+	apiFetch.use( ( options, next ) => {
+		const versionTwoRegex = new RegExp( '^/wp/v2/product' );
+		if (
+			options.path &&
+			versionTwoRegex.test( options?.path ) &&
+			isProductEditor()
+		) {
+			options.path = options.path.replace(
+				versionTwoRegex,
+				'/wc/v3/products'
+			);
+		}
+		return next( options );
+	} );
+};

--- a/plugins/woocommerce-admin/client/products/hooks/use-product-entity-record.ts
+++ b/plugins/woocommerce-admin/client/products/hooks/use-product-entity-record.ts
@@ -6,19 +6,7 @@ import { Product } from '@woocommerce/data';
 import { useDispatch, resolveSelect } from '@wordpress/data';
 import { getQuery } from '@woocommerce/navigation';
 import { useEffect, useState } from '@wordpress/element';
-
-type ApiFetchOptions = Record< string, string >;
-
-type Middleware = (
-	options: ApiFetchOptions,
-	next: ( options: ApiFetchOptions ) => void
-) => void;
-
-type ApiFetch = {
-	use: ( middleware: Middleware ) => void;
-};
-
-declare const wp: { apiFetch: ApiFetch };
+import apiFetch from '@wordpress/api-fetch';
 
 const isProductEditor = () => {
 	const query: { page?: string; path?: string } = getQuery();
@@ -41,9 +29,13 @@ export function useProductEntityRecord(
 	useEffect( () => {
 		// This is needed to ensure that we use the correct namespace for the entity data store
 		// without disturbing the rest_namespace outside of the product block editor.
-		wp.apiFetch.use( ( options, next ) => {
+		apiFetch.use( ( options, next ) => {
 			const versionTwoRegex = new RegExp( '^/wp/v2/product' );
-			if ( versionTwoRegex.test( options?.path ) && isProductEditor() ) {
+			if (
+				options.path &&
+				versionTwoRegex.test( options?.path ) &&
+				isProductEditor()
+			) {
 				options.path = options.path.replace(
 					versionTwoRegex,
 					'/wc/v3/products'

--- a/plugins/woocommerce-admin/client/products/hooks/use-product-entity-record.ts
+++ b/plugins/woocommerce-admin/client/products/hooks/use-product-entity-record.ts
@@ -4,19 +4,7 @@
 import { AUTO_DRAFT_NAME } from '@woocommerce/product-editor';
 import { Product } from '@woocommerce/data';
 import { useDispatch, resolveSelect } from '@wordpress/data';
-import { getQuery } from '@woocommerce/navigation';
 import { useEffect, useState } from '@wordpress/element';
-import apiFetch from '@wordpress/api-fetch';
-
-const isProductEditor = () => {
-	const query: { page?: string; path?: string } = getQuery();
-	return (
-		query?.page === 'wc-admin' &&
-		[ '/add-product', '/product/' ].some( ( path ) =>
-			query?.path?.startsWith( path )
-		)
-	);
-};
 
 export function useProductEntityRecord(
 	productId: string | undefined
@@ -25,25 +13,6 @@ export function useProductEntityRecord(
 	const [ product, setProduct ] = useState< Product | undefined >(
 		undefined
 	);
-
-	useEffect( () => {
-		// This is needed to ensure that we use the correct namespace for the entity data store
-		// without disturbing the rest_namespace outside of the product block editor.
-		apiFetch.use( ( options, next ) => {
-			const versionTwoRegex = new RegExp( '^/wp/v2/product' );
-			if (
-				options.path &&
-				versionTwoRegex.test( options?.path ) &&
-				isProductEditor()
-			) {
-				options.path = options.path.replace(
-					versionTwoRegex,
-					'/wc/v3/products'
-				);
-			}
-			return next( options );
-		} );
-	}, [] );
 
 	useEffect( () => {
 		const getRecordPromise: Promise< Product > = productId

--- a/plugins/woocommerce-admin/client/products/product-page.tsx
+++ b/plugins/woocommerce-admin/client/products/product-page.tsx
@@ -4,6 +4,7 @@
 import {
 	__experimentalEditor as Editor,
 	ProductEditorSettings,
+	productApiFetchMiddleware,
 } from '@woocommerce/product-editor';
 
 import { Spinner } from '@wordpress/components';
@@ -19,6 +20,8 @@ import './product-block-page.scss';
 import './fills/product-block-editor-fills';
 
 declare const productBlockEditorSettings: ProductEditorSettings;
+
+productApiFetchMiddleware();
 
 export default function ProductPage() {
 	const { productId } = useParams();

--- a/plugins/woocommerce/changelog/fix-rest-namespace-blocks-37619
+++ b/plugins/woocommerce/changelog/fix-rest-namespace-blocks-37619
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Removing modification to rest_namespace on post type and replacing with middleware.

--- a/plugins/woocommerce/includes/class-wc-post-types.php
+++ b/plugins/woocommerce/includes/class-wc-post-types.php
@@ -365,7 +365,6 @@ class WC_Post_Types {
 					'has_archive'         => $has_archive,
 					'show_in_nav_menus'   => true,
 					'show_in_rest'        => true,
-					'rest_namespace'      => 'wp/v3',
 					'template'            => array(
 						array(
 							'woocommerce/product-tab',

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -33,7 +33,6 @@ class Init {
 		}
 		if ( Features::is_enabled( self::FEATURE_ID ) ) {
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
-			add_filter( 'woocommerce_register_post_type_product', array( $this, 'add_rest_base_config' ) );
 			$block_registry = new BlockRegistry();
 			$block_registry->register_product_blocks();
 		}
@@ -106,15 +105,4 @@ class Init {
 		return $link;
 	}
 
-	/**
-	 * Updates the product endpoint to use WooCommerce REST API.
-	 *
-	 * @param array $post_args Args for the product post type.
-	 * @return array
-	 */
-	public function add_rest_base_config( $post_args ) {
-		$post_args['rest_base']      = 'products';
-		$post_args['rest_namespace'] = 'wc/v3';
-		return $post_args;
-	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1440,6 +1440,7 @@ importers:
       '@woocommerce/number': workspace:*
       '@woocommerce/settings': ^1.0.0
       '@woocommerce/tracks': workspace:^1.3.0
+      '@wordpress/api-fetch': wp-6.0
       '@wordpress/block-editor': ^9.8.0
       '@wordpress/blocks': ^12.3.0
       '@wordpress/browserslist-config': wp-6.0
@@ -1493,6 +1494,7 @@ importers:
       '@woocommerce/number': link:../number
       '@woocommerce/settings': 1.0.0
       '@woocommerce/tracks': link:../tracks
+      '@wordpress/api-fetch': 6.3.1
       '@wordpress/block-editor': 9.8.0_mtk4wljkd5jimhszw4p7nnxuzm
       '@wordpress/blocks': 12.5.0_react@17.0.2
       '@wordpress/components': 19.8.5_eqi5qhcxfphl6j3pngzexvnehi
@@ -5102,7 +5104,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.8
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
   /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.21.3:
@@ -5111,7 +5113,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.19.0
 
   /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.12.9:
     resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
@@ -8076,7 +8078,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.8
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-proposal-unicode-property-regex': 7.18.6_@babel+core@7.17.8
       '@babel/plugin-transform-dotall-regex': 7.18.6_@babel+core@7.17.8
       '@babel/types': 7.21.3
@@ -8089,7 +8091,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-proposal-unicode-property-regex': 7.18.6_@babel+core@7.21.3
       '@babel/plugin-transform-dotall-regex': 7.18.6_@babel+core@7.21.3
       '@babel/types': 7.21.3
@@ -15987,7 +15989,7 @@ packages:
       '@wordpress/style-engine': 0.15.0
       '@wordpress/token-list': 2.19.0
       '@wordpress/url': 3.29.0
-      '@wordpress/warning': 2.28.0
+      '@wordpress/warning': 2.19.0
       '@wordpress/wordcount': 3.19.0
       change-case: 4.1.2
       classnames: 2.3.1
@@ -19396,8 +19398,8 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      browserslist: 4.21.4
-      caniuse-lite: 1.0.30001418
+      browserslist: 4.20.2
+      caniuse-lite: 1.0.30001352
       fraction.js: 4.2.0
       normalize-range: 0.1.2
       picocolors: 1.0.0
@@ -20902,7 +20904,6 @@ packages:
       escalade: 3.1.1
       node-releases: 2.0.6
       picocolors: 1.0.0
-    dev: true
 
   /browserslist/4.20.4:
     resolution: {integrity: sha512-ok1d+1WpnU24XYN7oC3QWgTyMhY/avPJ/r9T00xxvUOIparA/gc+UPUMaod3i+G6s+nI2nUb9xZ5k794uIwShw==}
@@ -24296,9 +24297,9 @@ packages:
       has: 1.0.3
       is-core-module: 2.8.0
       is-glob: 4.0.3
-      minimatch: 3.1.2
+      minimatch: 3.0.4
       object.values: 1.1.5
-      resolve: 1.22.1
+      resolve: 1.20.0
       tsconfig-paths: 3.14.0
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
@@ -24327,9 +24328,9 @@ packages:
       has: 1.0.3
       is-core-module: 2.8.0
       is-glob: 4.0.3
-      minimatch: 3.1.2
+      minimatch: 3.0.4
       object.values: 1.1.5
-      resolve: 1.22.1
+      resolve: 1.20.0
       tsconfig-paths: 3.14.0
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
@@ -32889,7 +32890,6 @@ packages:
     resolution: {integrity: sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==}
     dependencies:
       brace-expansion: 1.1.11
-    dev: true
 
   /minimatch/3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -36364,7 +36364,7 @@ packages:
       is-touch-device: 1.0.1
       lodash: 4.17.21
       moment: 2.29.4
-      object.assign: 4.1.2
+      object.assign: 4.1.4
       object.values: 1.1.5
       prop-types: 15.8.1
       raf: 3.4.1


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In development of the product block editor require the use of the `/wc/v3/products` version of the products API. Adding this to the postType has created [an issue](https://github.com/woocommerce/woocommerce/issues/37619) (and potentially others) in other areas of the application. In this PR I'm removing any modification on the post type definition directly and using `apiFetch` middle ware to conditionally modify the path only for the purpose of the product block editor. 

Closes #37619  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable this branch and install the WCA Test Helper plugin. 
2. Create a simple test product.
3. Enable the `product-block-editor` feature flag using the WCA Test Helper plugin.
4. Navigate to Products -> Add new, and you should see the product block editor.
5. Ensure that it renders properly with no error, in particular the images block should appear like so:
![image](https://user-images.githubusercontent.com/444632/230664080-0b3aa9f3-c3bb-4c94-8b6f-eed933d433d3.png)

6. Navigate to any page block editor through Pages -> (select page), and add the `Products (beta)` block:
![image](https://user-images.githubusercontent.com/444632/230664208-0f634691-4cf9-4f8f-92a0-718a7ed48761.png)

7. The block should appear correctly, including the product title/etc:
![image](https://user-images.githubusercontent.com/444632/230664266-a2f35ae9-c0ec-414d-841c-81d7b9860d1f.png)


<!-- End testing instructions -->