### PR TITLE
Add tracks events to attributes tab

### DIFF
--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
@@ -437,9 +437,10 @@ const attachProductAttributesTracks = () => {
 		{
 			eventName: 'click',
 			childQuery: '.woocommerce_attribute_visible_on_product_page',
-			callback: () => {
+			callback: ( clickedElement ) => {
+				const elementName = clickedElement.getAttribute( 'name' );
 				const visibleOnProductPage = document.querySelector(
-					'.woocommerce_attribute_visible_on_product_page'
+					`[name="${ elementName }"]`
 				) as HTMLInputElement;
 
 				recordEvent( 'product_attributes_buttons', {
@@ -451,9 +452,10 @@ const attachProductAttributesTracks = () => {
 		{
 			eventName: 'click',
 			childQuery: '.woocommerce_attribute_used_for_variations',
-			callback: () => {
+			callback: ( clickedElement ) => {
+				const elementName = clickedElement.getAttribute( 'name' );
 				const usedForVariations = document.querySelector(
-					'.woocommerce_attribute_used_for_variations'
+					`[name="${ elementName }"]`
 				) as HTMLInputElement;
 
 				recordEvent( 'product_attributes_buttons', {

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
@@ -457,6 +457,34 @@ const attachProductAttributesTracks = () => {
 				} );
 			},
 		},
+		{
+			eventName: 'click',
+			query: '.woocommerce_attribute_visible_on_product_page',
+			callback: () => {
+				const visibleOnProductPage = document.querySelector(
+					'.woocommerce_attribute_visible_on_product_page'
+				) as HTMLInputElement;
+
+				recordEvent( 'product_attributes_buttons', {
+					action: 'used_for_variations',
+					checked: visibleOnProductPage?.checked,
+				} );
+			},
+		},
+		{
+			eventName: 'click',
+			query: '.woocommerce_attribute_used_for_variations',
+			callback: () => {
+				const usedForVariations = document.querySelector(
+					'.woocommerce_attribute_used_for_variations'
+				) as HTMLInputElement;
+
+				recordEvent( 'product_attributes_buttons', {
+					action: 'used_for_variations',
+					checked: usedForVariations?.checked,
+				} );
+			},
+		},
 	] );
 
 	const attributesCount = document.querySelectorAll(

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
@@ -436,19 +436,6 @@ const attachProductAttributesTracks = () => {
 	attachEventListenerToParentForChildren( attributesSection, [
 		{
 			eventName: 'click',
-			childQuery:
-				'.select2-selection__placeholder, .select2-selection__rendered',
-			callback: () => {
-				recordEvent( 'product_attributes_buttons', {
-					action: 'add_existing',
-					empty_state:
-						document.querySelectorAll( '.woocommerce_attribute' )
-							.length === 0,
-				} );
-			},
-		},
-		{
-			eventName: 'click',
 			childQuery: '.woocommerce_attribute_visible_on_product_page',
 			callback: () => {
 				const visibleOnProductPage = document.querySelector(

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
@@ -443,7 +443,7 @@ const attachProductAttributesTracks = () => {
 				) as HTMLInputElement;
 
 				recordEvent( 'product_attributes_buttons', {
-					action: 'used_for_variations',
+					action: 'visible_on_product_page',
 					checked: visibleOnProductPage?.checked,
 				} );
 			},

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
@@ -406,6 +406,59 @@ const attachAttributesTracks = () => {
  * Attaches product attributes tracks.
  */
 const attachProductAttributesTracks = () => {
+	document
+		.querySelector( '#product_attributes .add_custom_attribute' )
+		?.addEventListener( 'click', () => {
+			recordEvent( 'product_attributes_buttons', {
+				action: 'add_first_attribute',
+			} );
+		} );
+	document
+		.querySelector( '#product_attributes .add_attribute' )
+		?.addEventListener( 'click', () => {
+			// We verify that we are not adding an existing attribute to not
+			// duplicate the recorded event.
+			const selectElement = document.querySelector(
+				'.attribute_taxonomy'
+			) as HTMLSelectElement;
+			// Get the index of the selected option
+			const selectedIndex = selectElement.selectedIndex;
+			if ( selectElement.options[ selectedIndex ]?.value === '' ) {
+				recordEvent( 'product_attributes_buttons', {
+					action: 'add_new',
+				} );
+			}
+		} );
+
+	document
+		.querySelector( '#product_attributes .attribute_taxonomy' )
+		?.addEventListener( 'click', () => {
+			recordEvent( 'product_attributes_buttons', {
+				action: 'add_existing',
+				empty_state:
+					document.querySelectorAll( '.woocommerce_attribute' )
+						.length === 0,
+			} );
+		} );
+
+	const attributesSection = '#product_attributes';
+
+	// We attach the events in this way because the buttons are added dynamically.
+	attachEventListenerToParentForChildren( attributesSection, [
+		{
+			eventName: 'click',
+			query: '.select2-selection__placeholder, .select2-selection__rendered',
+			callback: () => {
+				recordEvent( 'product_attributes_buttons', {
+					action: 'add_existing',
+					empty_state:
+						document.querySelectorAll( '.woocommerce_attribute' )
+							.length === 0,
+				} );
+			},
+		},
+	] );
+
 	const attributesCount = document.querySelectorAll(
 		'.woocommerce_attribute'
 	).length;

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
@@ -447,7 +447,8 @@ const attachProductAttributesTracks = () => {
 	attachEventListenerToParentForChildren( attributesSection, [
 		{
 			eventName: 'click',
-			query: '.select2-selection__placeholder, .select2-selection__rendered',
+			childQuery:
+				'.select2-selection__placeholder, .select2-selection__rendered',
 			callback: () => {
 				recordEvent( 'product_attributes_buttons', {
 					action: 'add_existing',
@@ -459,7 +460,7 @@ const attachProductAttributesTracks = () => {
 		},
 		{
 			eventName: 'click',
-			query: '.woocommerce_attribute_visible_on_product_page',
+			childQuery: '.woocommerce_attribute_visible_on_product_page',
 			callback: () => {
 				const visibleOnProductPage = document.querySelector(
 					'.woocommerce_attribute_visible_on_product_page'
@@ -473,7 +474,7 @@ const attachProductAttributesTracks = () => {
 		},
 		{
 			eventName: 'click',
-			query: '.woocommerce_attribute_used_for_variations',
+			childQuery: '.woocommerce_attribute_used_for_variations',
 			callback: () => {
 				const usedForVariations = document.querySelector(
 					'.woocommerce_attribute_used_for_variations'

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
@@ -430,17 +430,6 @@ const attachProductAttributesTracks = () => {
 			}
 		} );
 
-	document
-		.querySelector( '#product_attributes .attribute_taxonomy' )
-		?.addEventListener( 'click', () => {
-			recordEvent( 'product_attributes_buttons', {
-				action: 'add_existing',
-				empty_state:
-					document.querySelectorAll( '.woocommerce_attribute' )
-						.length === 0,
-			} );
-		} );
-
 	const attributesSection = '#product_attributes';
 
 	// We attach the events in this way because the buttons are added dynamically.

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/utils.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/utils.ts
@@ -11,7 +11,7 @@ export function attachEventListenerToParentForChildren(
 	children: Array< {
 		eventName: 'click' | 'change';
 		childQuery: string;
-		callback: () => void;
+		callback: ( clickedElement: Element ) => void;
 	} >
 ) {
 	const parent = document.querySelector( parentQuery );
@@ -24,7 +24,7 @@ export function attachEventListenerToParentForChildren(
 				event.type === eventName &&
 				( event.target as Element ).matches( childQuery )
 			) {
-				callback();
+				callback( event.target as Element );
 			}
 		} );
 	};

--- a/plugins/woocommerce/changelog/add-37163_add_tracks_events_to_attributes_tab
+++ b/plugins/woocommerce/changelog/add-37163_add_tracks_events_to_attributes_tab
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add tracks events to attributes tab

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -663,6 +663,10 @@ jQuery( function ( $ ) {
 
 				$parent.remove();
 
+				window.wcTracks.recordEvent( 'product_attributes_buttons', {
+					action: 'remove_attribute',
+				} );
+
 				if (
 					! $( '.woocommerce_attribute_data' ).is( ':visible' ) &&
 					! $( 'div.add-global-attribute-container' ).hasClass(

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -503,6 +503,9 @@ jQuery( function ( $ ) {
 					selectedAttributes
 				);
 			}
+			window.wcTracks.recordEvent( 'product_attributes_buttons', {
+				action: 'add_existing',
+			} );
 		}
 		$( this ).val( null );
 		$( this ).trigger( 'change' );
@@ -528,6 +531,13 @@ jQuery( function ( $ ) {
 		add_attribute( this, attribute );
 		$( 'select.attribute_taxonomy' ).val( null );
 		$( 'select.attribute_taxonomy' ).trigger( 'change' );
+
+		// We record the event only when an existing attribute is added.
+		if ( attribute !== '' ) {
+			window.wcTracks.recordEvent( 'product_attributes_buttons', {
+				action: 'add_existing',
+			} );
+		}
 
 		return false;
 	} );

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute-inner.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute-inner.php
@@ -87,13 +87,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</tr>
 	<tr>
 		<td>
-			<label><input type="checkbox" class="checkbox" <?php checked( $attribute->get_visible(), true ); ?> name="attribute_visibility[<?php echo esc_attr( $i ); ?>]" value="1" /> <?php esc_html_e( 'Visible on the product page', 'woocommerce' ); ?></label>
+			<label><input type="checkbox" class="woocommerce_attribute_visible_on_product_page checkbox" <?php checked( $attribute->get_visible(), true ); ?> name="attribute_visibility[<?php echo esc_attr( $i ); ?>]" value="1" /> <?php esc_html_e( 'Visible on the product page', 'woocommerce' ); ?></label>
 		</td>
 	</tr>
 	<tr>
 		<td>
 			<div class="enable_variation show_if_variable">
-				<label><input type="checkbox" class="checkbox" <?php checked( $attribute->get_variation(), true ); ?> <?php echo esc_attr( isset( $is_variations_screen ) ? 'disabled' : '' ); ?> name="attribute_variation[<?php echo esc_attr( $i ); ?>]" value="1" /> <?php esc_html_e( 'Used for variations', 'woocommerce' ); ?></label>
+				<label><input type="checkbox" class="woocommerce_attribute_used_for_variations checkbox" <?php checked( $attribute->get_variation(), true ); ?> <?php echo esc_attr( isset( $is_variations_screen ) ? 'disabled' : '' ); ?> name="attribute_variation[<?php echo esc_attr( $i ); ?>]" value="1" /> <?php esc_html_e( 'Used for variations', 'woocommerce' ); ?></label>
 				<?php
 				if ( isset( $is_variations_screen ) ) {
 					?>


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds Tracks events to the attributes tab:
- The new "Add new" button in the empty state.
- The new "Add new" button when there's at least one attribute/form added.
- The new "Add existing" dropdown in the empty state.
- The new "Add existing" dropdown when there's at least one attribute/form added.
 
Closes #37163.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the logging of Tracks event to the browser dev console: `localStorage.setItem( 'debug', 'wc-admin:*' )`
    * Also, verify Tracks events actually get logged by using the Tracks Live View (make sure tracking is enabled for your site)
2. Create a global attribute.
3. Go to `Products` > `Add New` and select a `Variable product`.  
4. Go to the `Attributes` tab and press `Add new`.
5. Verify that the event `wcadmin_product_attributes_buttons` is being recorded with the action `add_first_attribute`.
6. Now remove the attribute and verify that the event is being recorded under the `Network` tab in the browser's dev tools.
7. Add an existing attribute and verify that the action: `add_existing` is being sent.

<!-- End testing instructions -->