### PR TITLE
add: new core profiler scaffolding in xstate

### DIFF
--- a/plugins/woocommerce-admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/index.tsx
@@ -1,0 +1,337 @@
+/**
+ * External dependencies
+ */
+import { createMachine, assign } from 'xstate';
+import { useMachine } from '@xstate/react';
+import { useEffect } from '@wordpress/element';
+import { ExtensionList } from '@woocommerce/data';
+
+/**
+ * Internal dependencies
+ */
+import { IntroOptIn } from './pages/IntroOptIn';
+import { UserProfile } from './pages/UserProfile';
+import { BusinessInfo } from './pages/BusinessInfo';
+import { BusinessLocation } from './pages/BusinessLocation';
+
+/** Uncomment below to display xstate inspector during development */
+// import { inspect } from '@xstate/inspect';
+// inspect( {
+// 	// url: 'https://stately.ai/viz?inspect', // (default)
+// 	iframe: false, // open in new window
+// } );
+
+// TODO: Typescript support can be improved, but for now lets write the types ourselves
+// https://stately.ai/blog/introducing-typescript-typegen-for-xstate
+
+export type IntroOptInEvent =
+	| { type: 'INTRO_COMPLETED'; payload: { optInDataSharing: boolean } } // can be true or false depending on whether the user opted in or not
+	| { type: 'INTRO_SKIPPED'; payload: { optInDataSharing: false } }; // always false for now
+
+export type UserProfileEvent =
+	| {
+			type: 'USER_PROFILE_COMPLETED';
+			payload: {
+				userProfile: CoreProfilerStateMachineContext[ 'userProfile' ];
+			}; // TODO: fill in the types for this when developing this page
+	  }
+	| {
+			type: 'USER_PROFILE_SKIPPED';
+			payload: { userProfile: { skipped: true } };
+	  };
+
+export type BusinessInfoEvent = {
+	type: 'BUSINESS_INFO_COMPLETED';
+	payload: {
+		businessInfo: CoreProfilerStateMachineContext[ 'businessInfo' ];
+	};
+};
+
+export type BusinessLocationEvent = {
+	type: 'BUSINESS_LOCATION_COMPLETED';
+	payload: {
+		businessInfo: CoreProfilerStateMachineContext[ 'businessInfo' ];
+	};
+};
+
+export type ExtensionsEvent = {
+	type: 'EXTENSIONS_COMPLETED';
+	payload: {
+		extensionsSelected: CoreProfilerStateMachineContext[ 'extensionsSelected' ];
+	};
+};
+
+export type CoreProfilerStateMachineContext = {
+	optInDataSharing: boolean;
+	userProfile: { foo: { bar: 'qux' }; skipped: false } | { skipped: true };
+	geolocatedLocation: {
+		location: string;
+	};
+	extensionsAvailable: ExtensionList[ 'plugins' ] | [];
+	extensionsSelected: string[]; // extension slugs
+	businessInfo: { foo?: { bar: 'qux' }; location: string };
+};
+
+const Extensions = ( {
+	context,
+	sendEvent,
+}: {
+	context: CoreProfilerStateMachineContext;
+	sendEvent: ( payload: ExtensionsEvent ) => void;
+} ) => {
+	return (
+		// TOOD: we need to fetch the extensions list from the API as part of initializing the profiler
+		<>
+			<div>Extensions</div>
+			<div>{ context.extensionsAvailable }</div>
+			<button
+				onClick={ () =>
+					sendEvent( {
+						type: 'EXTENSIONS_COMPLETED',
+						payload: {
+							extensionsSelected: [ 'woocommerce-payments' ],
+						},
+					} )
+				}
+			>
+				Next
+			</button>
+		</>
+	);
+};
+
+const coreProfilerStateMachineDefinition = createMachine( {
+	id: 'coreProfiler',
+	initial: 'initializing',
+	context: {
+		// these are the default values if the user skips everything
+		optInDataSharing: false,
+		userProfile: { skipped: true },
+		geolocatedLocation: { location: 'US:CA' },
+		businessInfo: { location: 'US:CA' },
+		extensionsAvailable: [],
+		extensionsSelected: [],
+	} as CoreProfilerStateMachineContext,
+	states: {
+		initializing: {
+			on: {
+				INITIALIZATION_COMPLETE: 'introOptIn',
+			},
+			invoke: [
+				{
+					src: 'initializeProfiler',
+				},
+			],
+			meta: {
+				progress: 0,
+			},
+		},
+		introOptIn: {
+			on: {
+				INTRO_COMPLETED: {
+					target: 'userProfile',
+					actions: [
+						assign( {
+							optInDataSharing: (
+								_context,
+								event: IntroOptInEvent
+							) => event.payload.optInDataSharing, // sets context.optInDataSharing to the payload of the event
+						} ),
+					],
+				},
+				INTRO_SKIPPED: {
+					// if the user skips the intro, we set the optInDataSharing to false and go to the Business Location page
+					target: 'skipFlowBusinessLocation',
+					actions: [
+						assign( {
+							optInDataSharing: (
+								context,
+								event: IntroOptInEvent
+							) => event.payload.optInDataSharing, // sets context.optInDataSharing to the payload of the event, which is always false
+						} ),
+					],
+				},
+			},
+			meta: {
+				progress: 20,
+				component: IntroOptIn,
+			},
+		},
+		userProfile: {
+			on: {
+				USER_PROFILE_COMPLETED: {
+					target: 'preBusinessInfo',
+					actions: [
+						assign( {
+							userProfile: ( context, event: UserProfileEvent ) =>
+								event.payload.userProfile, // sets context.userProfile to the payload of the event
+						} ),
+					],
+				},
+				USER_PROFILE_SKIPPED: {
+					target: 'preBusinessInfo',
+					actions: [
+						assign( {
+							userProfile: ( context, event: UserProfileEvent ) =>
+								event.payload.userProfile, // assign context.userProfile to the payload of the event
+						} ),
+					],
+				},
+			},
+			meta: {
+				progress: 40,
+				component: UserProfile,
+			},
+		},
+		preBusinessInfo: {
+			always: [
+				// immediately transition to businessInfo without any events as long as geolocation parallel has completed
+				{
+					target: 'businessInfo',
+					cond: () => true, // TODO: use a custom function to check on the parallel state using meta when we implement that. https://xstate.js.org/docs/guides/guards.html#guards-condition-functions
+				},
+			],
+			meta: {
+				progress: 50,
+			},
+		},
+		businessInfo: {
+			on: {
+				BUSINESS_INFO_COMPLETED: {
+					target: 'preExtensions',
+					actions: [
+						assign( {
+							businessInfo: (
+								_context,
+								event: BusinessInfoEvent
+							) => event.payload.businessInfo, // assign context.businessInfo to the payload of the event
+						} ),
+					],
+				},
+			},
+			meta: {
+				progress: 60,
+				component: BusinessInfo,
+			},
+		},
+		skipFlowBusinessLocation: {
+			on: {
+				BUSINESS_LOCATION_COMPLETED: {
+					target: 'settingUpStore',
+					actions: [
+						assign( {
+							businessInfo: (
+								_context,
+								event: BusinessLocationEvent
+							) => event.payload.businessInfo, // assign context.businessInfo to the payload of the event
+						} ),
+					],
+				},
+			},
+			meta: {
+				progress: 80,
+				component: BusinessLocation,
+			},
+		},
+		preExtensions: {
+			always: [
+				// immediately transition to extensions without any events as long as extensions fetching parallel has completed
+				{
+					target: 'extensions',
+					cond: () => true, // TODO: use a custom function to check on the parallel state using meta when we implement that. https://xstate.js.org/docs/guides/guards.html#guards-condition-functions
+				},
+			],
+			// add exit action to filter the extensions using a custom function here and assign it to context.extensionsAvailable
+			exit: assign( {
+				extensionsAvailable: ( context ) => {
+					return context.extensionsAvailable.filter( () => true );
+				}, // TODO : define an extensible filter function here
+			} ),
+			meta: {
+				progress: 70,
+			},
+		},
+		extensions: {
+			on: {
+				EXTENSIONS_COMPLETED: {
+					target: 'settingUpStore',
+				},
+			},
+			meta: {
+				progress: 80,
+				component: Extensions,
+			},
+		},
+		settingUpStore: {},
+	},
+} );
+
+const CoreProfilerController = ( {} ) => {
+	const [ state, send ] = useMachine(
+		coreProfilerStateMachineDefinition.withConfig( {
+			services: {
+				initializeProfiler: () => ( sendBack ) => {
+					const interval = setInterval( () => {
+						sendBack( {
+							type: 'INITIALIZATION_COMPLETE',
+						} );
+					}, 1000 );
+
+					return () => {
+						clearInterval( interval );
+					};
+				},
+			},
+		} ),
+		{ devTools: true }
+	);
+
+	const currentNodeMeta = state.meta[ `coreProfiler.${ state.value }` ]
+		? state.meta[ `coreProfiler.${ state.value }` ]
+		: undefined;
+	const navigationProgress = currentNodeMeta?.progress; // This value is defined in each state node's meta tag, we can assume it is 0-100
+	const CurrentComponent =
+		currentNodeMeta?.component ?? ( () => <div>Insert Spinner</div> ); // If no component is defined for the state then its a loading state
+
+	useEffect( () => {
+		document.body.classList.remove( 'woocommerce-admin-is-loading' );
+		document.body.classList.add( 'woocommerce-profile-wizard__body' );
+		document.body.classList.add( 'woocommerce-admin-full-screen' );
+		document.body.classList.add( 'is-wp-toolbar-disabled' );
+		return () => {
+			document.body.classList.remove(
+				'woocommerce-profile-wizard__body'
+			);
+			document.body.classList.remove( 'woocommerce-admin-full-screen' );
+			document.body.classList.remove( 'is-wp-toolbar-disabled' );
+		};
+	} );
+
+	return (
+		<>
+			<div>Core Profiler Placeholder</div>
+			<div>{ `${ navigationProgress }% complete` }</div>
+			<div
+				className={ `woocommerce-profile-wizard__container ${ state.value }` }
+			>
+				<div>{ `Current State: ${ state.value }` }</div>
+				<div>
+					{ `Context values: ${ JSON.stringify(
+						state.context,
+						null,
+						2
+					) }` }
+				</div>
+				<div>
+					{
+						<CurrentComponent
+							sendEvent={ send }
+							context={ state.context }
+						/>
+					}
+				</div>
+			</div>
+		</>
+	);
+};
+export default CoreProfilerController;

--- a/plugins/woocommerce-admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/index.tsx
@@ -104,7 +104,8 @@ const coreProfilerStateMachineDefinition = createMachine( {
 	id: 'coreProfiler',
 	initial: 'initializing',
 	context: {
-		// these are the default values if the user skips everything
+		// these are safe default values if for some reason the steps fail to complete correctly
+		// actual defaults displayed to the user should be handled in the steps themselves
 		optInDataSharing: false,
 		userProfile: { skipped: true },
 		geolocatedLocation: { location: 'US:CA' },
@@ -271,6 +272,7 @@ const CoreProfilerController = ( {} ) => {
 		coreProfilerStateMachineDefinition.withConfig( {
 			services: {
 				initializeProfiler: () => ( sendBack ) => {
+					// TODO: placeholder to simulate initialization time
 					const interval = setInterval( () => {
 						sendBack( {
 							type: 'INITIALIZATION_COMPLETE',
@@ -312,7 +314,7 @@ const CoreProfilerController = ( {} ) => {
 			<div>Core Profiler Placeholder</div>
 			<div>{ `${ navigationProgress }% complete` }</div>
 			<div
-				className={ `woocommerce-profile-wizard__container ${ state.value }` }
+				className={ `woocommerce-profile-wizard__container woocommerce-profile-wizard__step-${ state.value }` }
 			>
 				<div>{ `Current State: ${ state.value }` }</div>
 				<div>

--- a/plugins/woocommerce-admin/client/core-profiler/pages/BusinessInfo.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/pages/BusinessInfo.tsx
@@ -1,0 +1,34 @@
+/**
+ * Internal dependencies
+ */
+import { CoreProfilerStateMachineContext, BusinessInfoEvent } from '../index';
+
+export const BusinessInfo = ( {
+	context,
+	sendEvent,
+}: {
+	context: CoreProfilerStateMachineContext;
+	sendEvent: ( event: BusinessInfoEvent ) => void;
+} ) => {
+	return (
+		<>
+			<div>Business Info</div>
+			<div>{ context.geolocatedLocation.location }</div>
+			<button
+				onClick={ () =>
+					sendEvent( {
+						type: 'BUSINESS_INFO_COMPLETED',
+						payload: {
+							businessInfo: {
+								foo: { bar: 'qux' },
+								location: 'US:CA',
+							},
+						},
+					} )
+				}
+			>
+				Next
+			</button>
+		</>
+	);
+};

--- a/plugins/woocommerce-admin/client/core-profiler/pages/BusinessLocation.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/pages/BusinessLocation.tsx
@@ -1,0 +1,26 @@
+/**
+ * Internal dependencies
+ */
+import { BusinessLocationEvent } from '../index';
+
+export const BusinessLocation = ( {
+	sendEvent,
+}: {
+	sendEvent: ( event: BusinessLocationEvent ) => void;
+} ) => {
+	return (
+		<>
+			<div>Business Location</div>
+			<button
+				onClick={ () =>
+					sendEvent( {
+						type: 'BUSINESS_LOCATION_COMPLETED',
+						payload: { businessInfo: { location: 'Zanarkand' } },
+					} )
+				}
+			>
+				Next
+			</button>
+		</>
+	);
+};

--- a/plugins/woocommerce-admin/client/core-profiler/pages/IntroOptIn.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/pages/IntroOptIn.tsx
@@ -1,0 +1,36 @@
+/**
+ * Internal dependencies
+ */
+import { IntroOptInEvent } from '../index';
+
+export const IntroOptIn = ( {
+	sendEvent,
+}: {
+	sendEvent: ( event: IntroOptInEvent ) => void;
+} ) => {
+	return (
+		<>
+			<div>Intro Opt In</div>
+			<button
+				onClick={ () =>
+					sendEvent( {
+						type: 'INTRO_COMPLETED',
+						payload: { optInDataSharing: true },
+					} )
+				}
+			>
+				Next
+			</button>
+			<button
+				onClick={ () =>
+					sendEvent( {
+						type: 'INTRO_SKIPPED',
+						payload: { optInDataSharing: false },
+					} )
+				}
+			>
+				Skip
+			</button>
+		</>
+	);
+};

--- a/plugins/woocommerce-admin/client/core-profiler/pages/UserProfile.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/pages/UserProfile.tsx
@@ -1,0 +1,41 @@
+/**
+ * Internal dependencies
+ */
+import { UserProfileEvent } from '../index';
+
+export const UserProfile = ( {
+	sendEvent,
+}: {
+	sendEvent: ( event: UserProfileEvent ) => void;
+} ) => {
+	return (
+		<>
+			<div>User Profile</div>
+			<button
+				onClick={ () =>
+					sendEvent( {
+						type: 'USER_PROFILE_COMPLETED',
+						payload: {
+							userProfile: {
+								foo: { bar: 'qux' },
+								skipped: false,
+							},
+						},
+					} )
+				}
+			>
+				Next
+			</button>
+			<button
+				onClick={ () =>
+					sendEvent( {
+						type: 'USER_PROFILE_SKIPPED',
+						payload: { userProfile: { skipped: true } },
+					} )
+				}
+			>
+				Skip
+			</button>
+		</>
+	);
+};

--- a/plugins/woocommerce-admin/client/layout/controller.js
+++ b/plugins/woocommerce-admin/client/layout/controller.js
@@ -59,6 +59,11 @@ const MarketingOverviewMultichannel = lazy( () =>
 const ProfileWizard = lazy( () =>
 	import( /* webpackChunkName: "profile-wizard" */ '../profile-wizard' )
 );
+
+const CoreProfiler = lazy( () =>
+	import( /* webpackChunkName: "core-profiler" */ '../core-profiler' )
+);
+
 const SettingsGroup = lazy( () =>
 	import( /* webpackChunkName: "profile-wizard" */ '../settings' )
 );
@@ -250,6 +255,18 @@ export const getPages = () => {
 			breadcrumbs: [
 				...initialBreadcrumbs,
 				__( 'Setup Wizard', 'woocommerce' ),
+			],
+			capability: 'manage_woocommerce',
+		} );
+	}
+
+	if ( window.wcAdminFeatures[ 'core-profiler' ] ) {
+		pages.push( {
+			container: CoreProfiler,
+			path: '/profiler',
+			breadcrumbs: [
+				...initialBreadcrumbs,
+				__( 'Profiler', 'woocommerce' ),
 			],
 			capability: 'manage_woocommerce',
 		} );

--- a/plugins/woocommerce-admin/client/layout/controller.js
+++ b/plugins/woocommerce-admin/client/layout/controller.js
@@ -249,27 +249,27 @@ export const getPages = () => {
 	}
 
 	if ( window.wcAdminFeatures.onboarding ) {
-		pages.push( {
-			container: ProfileWizard,
-			path: '/setup-wizard',
-			breadcrumbs: [
-				...initialBreadcrumbs,
-				__( 'Setup Wizard', 'woocommerce' ),
-			],
-			capability: 'manage_woocommerce',
-		} );
-	}
-
-	if ( window.wcAdminFeatures[ 'core-profiler' ] ) {
-		pages.push( {
-			container: CoreProfiler,
-			path: '/profiler',
-			breadcrumbs: [
-				...initialBreadcrumbs,
-				__( 'Profiler', 'woocommerce' ),
-			],
-			capability: 'manage_woocommerce',
-		} );
+		if ( ! window.wcAdminFeatures[ 'core-profiler' ] ) {
+			pages.push( {
+				container: ProfileWizard,
+				path: '/setup-wizard',
+				breadcrumbs: [
+					...initialBreadcrumbs,
+					__( 'Setup Wizard', 'woocommerce' ),
+				],
+				capability: 'manage_woocommerce',
+			} );
+		} else {
+			pages.push( {
+				container: CoreProfiler,
+				path: '/setup-wizard',
+				breadcrumbs: [
+					...initialBreadcrumbs,
+					__( 'Profiler', 'woocommerce' ),
+				],
+				capability: 'manage_woocommerce',
+			} );
+		}
 	}
 
 	if ( window.wcAdminFeatures.settings ) {

--- a/plugins/woocommerce-admin/package.json
+++ b/plugins/woocommerce-admin/package.json
@@ -81,6 +81,7 @@
 		"@wordpress/url": "wp-6.0",
 		"@wordpress/viewport": "wp-6.0",
 		"@wordpress/warning": "wp-6.0",
+		"@xstate/react": "3.2.1",
 		"classnames": "^2.3.1",
 		"core-js": "^3.21.1",
 		"debug": "^4.3.3",
@@ -97,7 +98,8 @@
 		"react-router-dom": "^6.3.0",
 		"react-transition-group": "^4.4.2",
 		"react-visibility-sensor": "^5.1.1",
-		"redux": "^4.1.2"
+		"redux": "^4.1.2",
+		"xstate": "4.37.1"
 	},
 	"devDependencies": {
 		"@automattic/color-studio": "^2.5.0",
@@ -169,6 +171,7 @@
 		"@wordpress/prettier-config": "^1.1.2",
 		"@wordpress/scripts": "^12.6.1",
 		"@wordpress/stylelint-config": "^20.0.2",
+		"@xstate/inspect": "0.8.0",
 		"autoprefixer": "^10.4.2",
 		"await-exec": "^0.1.2",
 		"babel-jest": "^27.5.1",

--- a/plugins/woocommerce/changelog/add-scaffolding-for-new-core-profiler
+++ b/plugins/woocommerce/changelog/add-scaffolding-for-new-core-profiler
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Added scaffolding for new core profiler 

--- a/plugins/woocommerce/client/admin/config/core.json
+++ b/plugins/woocommerce/client/admin/config/core.json
@@ -4,6 +4,7 @@
 		"analytics": true,
 		"product-block-editor": false,
 		"coupons": true,
+		"core-profiler": false,
 		"customer-effort-score-tracks": true,
 		"import-products-task": true,
 		"experimental-fashion-sample-products": true,

--- a/plugins/woocommerce/client/admin/config/development.json
+++ b/plugins/woocommerce/client/admin/config/development.json
@@ -4,6 +4,7 @@
 		"analytics": true,
 		"product-block-editor": true,
 		"coupons": true,
+		"core-profiler": true,
 		"customer-effort-score-tracks": true,
 		"import-products-task": true,
 		"experimental-fashion-sample-products": true,

--- a/plugins/woocommerce/client/admin/config/development.json
+++ b/plugins/woocommerce/client/admin/config/development.json
@@ -4,7 +4,7 @@
 		"analytics": true,
 		"product-block-editor": true,
 		"coupons": true,
-		"core-profiler": true,
+		"core-profiler": false,
 		"customer-effort-score-tracks": true,
 		"import-products-task": true,
 		"experimental-fashion-sample-products": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -800,7 +800,7 @@ importers:
     dependencies:
       '@jest/globals': 27.5.1
       '@woocommerce/api': link:../api
-      '@woocommerce/e2e-utils': 0.1.6_lwdsu27pg5ztgtejufpr6ijesa
+      '@woocommerce/e2e-utils': 0.1.6_drwlo4y73cla4rzwrrjk6eyf6e
       '@wordpress/deprecated': 3.6.1
       config: 3.3.7
     devDependencies:
@@ -920,7 +920,7 @@ importers:
       '@automattic/puppeteer-utils': github.com/Automattic/puppeteer-utils/0f3ec50_react-native@0.70.0
       '@woocommerce/api': link:../api
       '@wordpress/deprecated': 3.6.1
-      '@wordpress/e2e-test-utils': 7.2.1_lbgvwpw4gzlmvdk3yuc5tcyftm
+      '@wordpress/e2e-test-utils': 7.2.1_hmvsd4hlimltsdqszkn2ou62si
       config: 3.3.7
       fishery: 1.4.0
     devDependencies:
@@ -1152,7 +1152,7 @@ importers:
       typescript: ^4.9.5
     dependencies:
       '@testing-library/jest-dom': 5.16.2
-      '@testing-library/react': 12.1.4_6l5554ty5ajsajah6yazvrjhoe
+      '@testing-library/react': 12.1.4_sfoxds7t5ydpegc3knd667wn6m
       '@wordpress/data': 6.6.1_react@17.0.2
       '@wordpress/i18n': 4.6.1
       '@wordpress/jest-console': 5.0.2_jest@27.5.1
@@ -1787,6 +1787,8 @@ importers:
       '@wordpress/url': wp-6.0
       '@wordpress/viewport': wp-6.0
       '@wordpress/warning': wp-6.0
+      '@xstate/inspect': 0.8.0
+      '@xstate/react': 3.2.1
       autoprefixer: ^10.4.2
       await-exec: ^0.1.2
       babel-jest: ^27.5.1
@@ -1861,6 +1863,7 @@ importers:
       webpack-fix-style-only-entries: ^0.6.1
       webpack-merge: ^5.8.0
       webpack-rtl-plugin: ^2.0.0
+      xstate: 4.37.1
     dependencies:
       '@automattic/explat-client': 0.0.3
       '@automattic/explat-client-react-helpers': 0.0.4
@@ -1895,6 +1898,7 @@ importers:
       '@wordpress/url': 3.7.1
       '@wordpress/viewport': 4.4.1_react@17.0.2
       '@wordpress/warning': 2.6.1
+      '@xstate/react': 3.2.1_zfwqbz6ktlkzcsj33ggowrqlp4
       classnames: 2.3.1
       core-js: 3.21.1
       debug: 4.3.3
@@ -1912,6 +1916,7 @@ importers:
       react-transition-group: 4.4.2_sfoxds7t5ydpegc3knd667wn6m
       react-visibility-sensor: 5.1.1_sfoxds7t5ydpegc3knd667wn6m
       redux: 4.1.2
+      xstate: 4.37.1
     devDependencies:
       '@automattic/color-studio': 2.5.0
       '@babel/cli': 7.17.6_@babel+core@7.17.8
@@ -1982,6 +1987,7 @@ importers:
       '@wordpress/prettier-config': 1.1.3
       '@wordpress/scripts': 12.6.1_c6qmhwnhjoryl2mlu436oznfja
       '@wordpress/stylelint-config': 20.0.2_gnuvbpze6hr4gjidcj2xbzgequ
+      '@xstate/inspect': 0.8.0_ws@8.13.0+xstate@4.37.1
       autoprefixer: 10.4.4_postcss@8.4.12
       await-exec: 0.1.2
       babel-jest: 27.5.1_@babel+core@7.17.8
@@ -2786,7 +2792,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.3
-      '@jridgewell/trace-mapping': 0.3.16
+      '@jridgewell/trace-mapping': 0.3.17
       commander: 4.1.1
       convert-source-map: 1.8.0
       fs-readdir-recursive: 1.1.0
@@ -10223,6 +10229,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - ts-node
+    dev: true
 
   /@jest/create-cache-key-function/27.5.1:
     resolution: {integrity: sha512-dmH1yW+makpTSURTy8VzdUwFnfQh1G8R+DxO2Ho2FFmBbKFEVm+3jWdvFhE2VqB/LATCTokkP0dotjyQyw5/AQ==}
@@ -10558,6 +10565,7 @@ packages:
       v8-to-istanbul: 9.1.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@jest/schemas/29.4.3:
     resolution: {integrity: sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==}
@@ -10721,6 +10729,7 @@ packages:
       graceful-fs: 4.2.9
       jest-haste-map: 29.5.0
       slash: 3.0.0
+    dev: true
 
   /@jest/transform/24.9.0:
     resolution: {integrity: sha512-TcQUmyNRxV94S0QpMOnZl0++6RMiqpbH/ZMccFB/amku6Uwvyb1cjYX7xkp5nGNkbX4QPH/FcB6q1HBTHynLmQ==}
@@ -10917,6 +10926,7 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.0
       '@jridgewell/sourcemap-codec': 1.4.14
+    dev: true
 
   /@jridgewell/trace-mapping/0.3.17:
     resolution: {integrity: sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==}
@@ -13531,7 +13541,7 @@ packages:
       interpret: 2.2.0
       json5: 2.2.3
       lazy-universal-dotenv: 3.0.1
-      picomatch: 2.3.1
+      picomatch: 2.3.0
       pkg-dir: 5.0.0
       pretty-hrtime: 1.0.3
       react: 17.0.2
@@ -15246,20 +15256,6 @@ packages:
       react-error-boundary: 3.1.4_react@17.0.2
     dev: true
 
-  /@testing-library/react/12.1.4_6l5554ty5ajsajah6yazvrjhoe:
-    resolution: {integrity: sha512-jiPKOm7vyUw311Hn/HlNQ9P8/lHNtArAx0PisXyFixDDvfl8DbD6EUdbshK5eqauvBSvzZd19itqQ9j3nferJA==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      react: '*'
-      react-dom: '*'
-    dependencies:
-      '@babel/runtime': 7.21.0
-      '@testing-library/dom': 8.11.3
-      '@types/react-dom': 17.0.17
-      react: 17.0.2
-      react-dom: 18.2.0_react@17.0.2
-    dev: false
-
   /@testing-library/react/12.1.4_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-jiPKOm7vyUw311Hn/HlNQ9P8/lHNtArAx0PisXyFixDDvfl8DbD6EUdbshK5eqauvBSvzZd19itqQ9j3nferJA==}
     engines: {node: '>=12'}
@@ -15272,7 +15268,6 @@ packages:
       '@types/react-dom': 17.0.17
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-    dev: true
 
   /@testing-library/user-event/13.5.0_gzufz4q333be4gqfrvipwvqt6a:
     resolution: {integrity: sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==}
@@ -15893,7 +15888,7 @@ packages:
       '@types/wordpress__components': 19.10.5_sfoxds7t5ydpegc3knd667wn6m
       '@types/wordpress__data': 6.0.2
       '@types/wordpress__keycodes': 2.3.1
-      '@wordpress/element': 4.20.0
+      '@wordpress/element': 4.4.1
       react-autosize-textarea: 7.1.0_sfoxds7t5ydpegc3knd667wn6m
     transitivePeerDependencies:
       - react
@@ -15907,7 +15902,7 @@ packages:
     dependencies:
       '@types/react': 17.0.50
       '@types/wordpress__components': 19.10.5_sfoxds7t5ydpegc3knd667wn6m
-      '@wordpress/element': 4.20.0
+      '@wordpress/element': 4.4.1
     transitivePeerDependencies:
       - react
       - react-dom
@@ -15919,7 +15914,7 @@ packages:
       '@types/tinycolor2': 1.4.3
       '@types/wordpress__notices': 3.5.0
       '@types/wordpress__rich-text': 3.4.6
-      '@wordpress/element': 4.20.0
+      '@wordpress/element': 4.4.1
       downshift: 6.1.12_react@17.0.2
       re-resizable: 6.9.5_prpqlkd37azqwypxturxi7uyci
     transitivePeerDependencies:
@@ -15934,7 +15929,7 @@ packages:
       '@types/tinycolor2': 1.4.3
       '@types/wordpress__notices': 3.5.0
       '@types/wordpress__rich-text': 3.4.6
-      '@wordpress/element': 4.20.0
+      '@wordpress/element': 4.4.1
       downshift: 6.1.12_react@17.0.2
       re-resizable: 6.9.5_sfoxds7t5ydpegc3knd667wn6m
     transitivePeerDependencies:
@@ -16003,7 +15998,7 @@ packages:
     dependencies:
       '@types/wordpress__block-editor': 7.0.0_sfoxds7t5ydpegc3knd667wn6m
       '@types/wordpress__core-data': 2.4.5
-      '@wordpress/element': 4.20.0
+      '@wordpress/element': 4.4.1
     transitivePeerDependencies:
       - react
       - react-dom
@@ -16748,14 +16743,14 @@ packages:
       prop-types: 15.8.1
       react: 17.0.2
 
-  /@woocommerce/e2e-utils/0.1.6_lwdsu27pg5ztgtejufpr6ijesa:
+  /@woocommerce/e2e-utils/0.1.6_drwlo4y73cla4rzwrrjk6eyf6e:
     resolution: {integrity: sha512-gWSEgFIjMqaqiiIyrpa1epIHkmBBAfk6WfRojva1f5ZmffSJCc0VbX2jQQRdFm1BuEYr8KGCCYo+q8NIjlMZ7g==}
     peerDependencies:
       '@woocommerce/api': ^0.2.0
     dependencies:
       '@woocommerce/api': link:packages/js/api
       '@wordpress/deprecated': 2.12.3
-      '@wordpress/e2e-test-utils': 4.16.1_d2bihccpwwyuin5554pd3vha7i
+      '@wordpress/e2e-test-utils': 4.16.1_eod7vs2qyqnfu2oldnxglnszkq
       config: 3.3.3
       faker: 5.5.3
       fishery: 1.4.0
@@ -16797,8 +16792,8 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@babel/runtime': 7.21.0
-      '@wordpress/dom-ready': 3.28.0
-      '@wordpress/i18n': 4.28.0
+      '@wordpress/dom-ready': 3.6.1
+      '@wordpress/i18n': 4.6.1
     dev: false
 
   /@wordpress/api-fetch/3.23.1_react-native@0.70.0:
@@ -16826,8 +16821,8 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@babel/runtime': 7.21.0
-      '@wordpress/i18n': 4.28.0
-      '@wordpress/url': 3.29.0
+      '@wordpress/i18n': 4.6.1
+      '@wordpress/url': 3.7.1
     dev: true
 
   /@wordpress/api-fetch/6.25.0:
@@ -16843,8 +16838,8 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@babel/runtime': 7.21.0
-      '@wordpress/i18n': 4.28.0
-      '@wordpress/url': 3.29.0
+      '@wordpress/i18n': 4.6.1
+      '@wordpress/url': 3.7.1
     dev: false
 
   /@wordpress/autop/3.19.0:
@@ -16972,8 +16967,8 @@ packages:
       '@babel/runtime': 7.21.0
       '@wordpress/babel-plugin-import-jsx-pragma': 3.2.0_@babel+core@7.21.3
       '@wordpress/browserslist-config': 4.1.3
-      '@wordpress/element': 4.20.0
-      '@wordpress/warning': 2.28.0
+      '@wordpress/element': 4.4.1
+      '@wordpress/warning': 2.6.1
       browserslist: 4.20.2
       core-js: 3.29.1
     transitivePeerDependencies:
@@ -17565,20 +17560,20 @@ packages:
       '@emotion/styled': 11.8.1_c2qm47vaialpqni522adyu6za4
       '@emotion/utils': 1.0.0
       '@use-gesture/react': 10.2.10_react@17.0.2
-      '@wordpress/a11y': 3.28.0
-      '@wordpress/compose': 5.17.0_react@17.0.2
-      '@wordpress/date': 4.28.0
-      '@wordpress/deprecated': 3.28.0
-      '@wordpress/dom': 3.28.0
-      '@wordpress/element': 4.20.0
+      '@wordpress/a11y': 3.6.1
+      '@wordpress/compose': 5.4.1_react@17.0.2
+      '@wordpress/date': 4.6.1
+      '@wordpress/deprecated': 3.6.1
+      '@wordpress/dom': 3.6.1
+      '@wordpress/element': 4.4.1
       '@wordpress/escape-html': 2.4.1
-      '@wordpress/hooks': 3.28.0
-      '@wordpress/i18n': 4.28.0
-      '@wordpress/icons': 8.4.0
+      '@wordpress/hooks': 3.6.1
+      '@wordpress/i18n': 4.6.1
+      '@wordpress/icons': 8.2.3
       '@wordpress/is-shallow-equal': 4.4.1
-      '@wordpress/keycodes': 3.28.0
+      '@wordpress/keycodes': 3.6.1
       '@wordpress/primitives': 3.4.1
-      '@wordpress/rich-text': 5.17.0_react@17.0.2
+      '@wordpress/rich-text': 5.4.2_react@17.0.2
       '@wordpress/warning': 2.6.1
       classnames: 2.3.1
       colord: 2.9.2
@@ -17619,21 +17614,21 @@ packages:
       '@emotion/styled': 11.8.1_6t3indjc5ssefvr44gr3wo2uqu
       '@emotion/utils': 1.0.0
       '@use-gesture/react': 10.2.10_react@17.0.2
-      '@wordpress/a11y': 3.28.0
-      '@wordpress/compose': 5.17.0_react@17.0.2
-      '@wordpress/date': 4.28.0
-      '@wordpress/deprecated': 3.28.0
-      '@wordpress/dom': 3.28.0
-      '@wordpress/element': 4.20.0
+      '@wordpress/a11y': 3.6.1
+      '@wordpress/compose': 5.4.1_react@17.0.2
+      '@wordpress/date': 4.6.1
+      '@wordpress/deprecated': 3.6.1
+      '@wordpress/dom': 3.6.1
+      '@wordpress/element': 4.4.1
       '@wordpress/escape-html': 2.28.0
-      '@wordpress/hooks': 3.28.0
-      '@wordpress/i18n': 4.28.0
-      '@wordpress/icons': 8.4.0
+      '@wordpress/hooks': 3.6.1
+      '@wordpress/i18n': 4.6.1
+      '@wordpress/icons': 8.2.3
       '@wordpress/is-shallow-equal': 4.28.0
-      '@wordpress/keycodes': 3.28.0
-      '@wordpress/primitives': 3.26.0
-      '@wordpress/rich-text': 5.17.0_react@17.0.2
-      '@wordpress/warning': 2.28.0
+      '@wordpress/keycodes': 3.6.1
+      '@wordpress/primitives': 3.4.1
+      '@wordpress/rich-text': 5.4.2_react@17.0.2
+      '@wordpress/warning': 2.6.1
       classnames: 2.3.1
       colord: 2.9.2
       dom-scroll-into-view: 1.2.1
@@ -17673,21 +17668,21 @@ packages:
       '@emotion/styled': 11.8.1_c2qm47vaialpqni522adyu6za4
       '@emotion/utils': 1.0.0
       '@use-gesture/react': 10.2.10_react@17.0.2
-      '@wordpress/a11y': 3.28.0
-      '@wordpress/compose': 5.17.0_react@17.0.2
-      '@wordpress/date': 4.28.0
-      '@wordpress/deprecated': 3.28.0
-      '@wordpress/dom': 3.28.0
-      '@wordpress/element': 4.20.0
+      '@wordpress/a11y': 3.6.1
+      '@wordpress/compose': 5.4.1_react@17.0.2
+      '@wordpress/date': 4.6.1
+      '@wordpress/deprecated': 3.6.1
+      '@wordpress/dom': 3.6.1
+      '@wordpress/element': 4.4.1
       '@wordpress/escape-html': 2.28.0
-      '@wordpress/hooks': 3.28.0
-      '@wordpress/i18n': 4.28.0
-      '@wordpress/icons': 8.4.0
+      '@wordpress/hooks': 3.6.1
+      '@wordpress/i18n': 4.6.1
+      '@wordpress/icons': 8.2.3
       '@wordpress/is-shallow-equal': 4.28.0
-      '@wordpress/keycodes': 3.28.0
-      '@wordpress/primitives': 3.26.0
-      '@wordpress/rich-text': 5.17.0_react@17.0.2
-      '@wordpress/warning': 2.28.0
+      '@wordpress/keycodes': 3.6.1
+      '@wordpress/primitives': 3.4.1
+      '@wordpress/rich-text': 5.4.2_react@17.0.2
+      '@wordpress/warning': 2.6.1
       classnames: 2.3.1
       colord: 2.9.2
       dom-scroll-into-view: 1.2.1
@@ -17727,21 +17722,21 @@ packages:
       '@emotion/styled': 11.8.1_c2qm47vaialpqni522adyu6za4
       '@emotion/utils': 1.0.0
       '@use-gesture/react': 10.2.10_react@17.0.2
-      '@wordpress/a11y': 3.28.0
-      '@wordpress/compose': 5.17.0_react@17.0.2
-      '@wordpress/date': 4.28.0
-      '@wordpress/deprecated': 3.28.0
-      '@wordpress/dom': 3.28.0
-      '@wordpress/element': 4.20.0
+      '@wordpress/a11y': 3.6.1
+      '@wordpress/compose': 5.4.1_react@17.0.2
+      '@wordpress/date': 4.6.1
+      '@wordpress/deprecated': 3.6.1
+      '@wordpress/dom': 3.6.1
+      '@wordpress/element': 4.4.1
       '@wordpress/escape-html': 2.28.0
-      '@wordpress/hooks': 3.28.0
-      '@wordpress/i18n': 4.28.0
-      '@wordpress/icons': 8.4.0
+      '@wordpress/hooks': 3.6.1
+      '@wordpress/i18n': 4.6.1
+      '@wordpress/icons': 8.2.3
       '@wordpress/is-shallow-equal': 4.28.0
-      '@wordpress/keycodes': 3.28.0
-      '@wordpress/primitives': 3.26.0
-      '@wordpress/rich-text': 5.17.0_react@17.0.2
-      '@wordpress/warning': 2.28.0
+      '@wordpress/keycodes': 3.6.1
+      '@wordpress/primitives': 3.4.1
+      '@wordpress/rich-text': 5.4.2_react@17.0.2
+      '@wordpress/warning': 2.6.1
       classnames: 2.3.1
       colord: 2.9.2
       dom-scroll-into-view: 1.2.1
@@ -17781,21 +17776,21 @@ packages:
       '@emotion/styled': 11.8.1_hhesyqfwklnojgamcachhyxace
       '@emotion/utils': 1.0.0
       '@use-gesture/react': 10.2.10_react@17.0.2
-      '@wordpress/a11y': 3.28.0
-      '@wordpress/compose': 5.17.0_react@17.0.2
-      '@wordpress/date': 4.28.0
-      '@wordpress/deprecated': 3.28.0
-      '@wordpress/dom': 3.28.0
-      '@wordpress/element': 4.20.0
+      '@wordpress/a11y': 3.6.1
+      '@wordpress/compose': 5.4.1_react@17.0.2
+      '@wordpress/date': 4.6.1
+      '@wordpress/deprecated': 3.6.1
+      '@wordpress/dom': 3.6.1
+      '@wordpress/element': 4.4.1
       '@wordpress/escape-html': 2.28.0
-      '@wordpress/hooks': 3.28.0
-      '@wordpress/i18n': 4.28.0
-      '@wordpress/icons': 8.4.0
+      '@wordpress/hooks': 3.6.1
+      '@wordpress/i18n': 4.6.1
+      '@wordpress/icons': 8.2.3
       '@wordpress/is-shallow-equal': 4.28.0
-      '@wordpress/keycodes': 3.28.0
-      '@wordpress/primitives': 3.26.0
-      '@wordpress/rich-text': 5.17.0_react@17.0.2
-      '@wordpress/warning': 2.28.0
+      '@wordpress/keycodes': 3.6.1
+      '@wordpress/primitives': 3.4.1
+      '@wordpress/rich-text': 5.4.2_react@17.0.2
+      '@wordpress/warning': 2.6.1
       classnames: 2.3.1
       colord: 2.9.2
       dom-scroll-into-view: 1.2.1
@@ -18099,11 +18094,11 @@ packages:
       '@babel/runtime': 7.21.0
       '@types/lodash': 4.14.184
       '@types/mousetrap': 1.6.9
-      '@wordpress/deprecated': 3.28.0
-      '@wordpress/dom': 3.28.0
-      '@wordpress/element': 4.20.0
+      '@wordpress/deprecated': 3.6.1
+      '@wordpress/dom': 3.6.1
+      '@wordpress/element': 4.4.1
       '@wordpress/is-shallow-equal': 4.28.0
-      '@wordpress/keycodes': 3.28.0
+      '@wordpress/keycodes': 3.6.1
       '@wordpress/priority-queue': 2.28.0
       clipboard: 2.0.10
       lodash: 4.17.21
@@ -18111,7 +18106,6 @@ packages:
       react: 17.0.2
       react-resize-aware: 3.1.1_react@17.0.2
       use-memo-one: 1.1.2_react@17.0.2
-    dev: false
 
   /@wordpress/compose/6.5.0_react@17.0.2:
     resolution: {integrity: sha512-gtZwEeFFHGltsr0vqwyrxPbAcA6lVfE36s59mZBh9KHeC/s590q2FPQz+9jSE5Y+uQmnXZCtahCrjvnpnaBIUg==}
@@ -18140,15 +18134,15 @@ packages:
       react: ^17.0.0
     dependencies:
       '@babel/runtime': 7.21.0
-      '@wordpress/api-fetch': 6.25.0
+      '@wordpress/api-fetch': 6.3.1
       '@wordpress/blocks': 11.18.0_react@17.0.2
-      '@wordpress/data': 6.15.0_react@17.0.2
-      '@wordpress/deprecated': 3.28.0
-      '@wordpress/element': 4.20.0
-      '@wordpress/html-entities': 3.28.0
-      '@wordpress/i18n': 4.28.0
+      '@wordpress/data': 6.6.1_react@17.0.2
+      '@wordpress/deprecated': 3.6.1
+      '@wordpress/element': 4.4.1
+      '@wordpress/html-entities': 3.6.1
+      '@wordpress/i18n': 4.6.1
       '@wordpress/is-shallow-equal': 4.28.0
-      '@wordpress/url': 3.29.0
+      '@wordpress/url': 3.7.1
       equivalent-key-map: 0.2.2
       lodash: 4.17.21
       memize: 1.1.0
@@ -18225,9 +18219,9 @@ packages:
       react: ^17.0.0
     dependencies:
       '@babel/runtime': 7.21.0
-      '@wordpress/api-fetch': 6.25.0
-      '@wordpress/data': 6.15.0_react@17.0.2
-      '@wordpress/deprecated': 3.28.0
+      '@wordpress/api-fetch': 6.3.1
+      '@wordpress/data': 6.6.1_react@17.0.2
+      '@wordpress/deprecated': 3.6.1
       react: 17.0.2
     dev: false
 
@@ -18282,9 +18276,9 @@ packages:
       react: ^17.0.0
     dependencies:
       '@babel/runtime': 7.21.0
-      '@wordpress/compose': 5.17.0_react@17.0.2
-      '@wordpress/deprecated': 3.28.0
-      '@wordpress/element': 4.20.0
+      '@wordpress/compose': 5.4.1_react@17.0.2
+      '@wordpress/deprecated': 3.6.1
+      '@wordpress/element': 4.4.1
       '@wordpress/is-shallow-equal': 4.28.0
       '@wordpress/priority-queue': 2.28.0
       '@wordpress/redux-routine': 4.28.0_redux@4.2.0
@@ -18397,8 +18391,7 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@babel/runtime': 7.21.0
-      '@wordpress/hooks': 3.28.0
-    dev: false
+      '@wordpress/hooks': 3.6.1
 
   /@wordpress/dom-ready/3.28.0:
     resolution: {integrity: sha512-PFFAnuPUouV0uSDZN6G/B8yksybtxzS/6H53OZJEA3h3EsNCicKRMGSowkumvLwXA23HV0K2Kht6JuS+bDECzA==}
@@ -18432,7 +18425,6 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.0
       lodash: 4.17.21
-    dev: false
 
   /@wordpress/e2e-test-utils/3.0.0_ddjhsfu4aotkh3cuzmpsln6ywq:
     resolution: {integrity: sha512-XMdR8DeKyDQRF5jKeUlOzP4pTRtoJuOLsNZRLUFUvnrs9y/7/hH17VmPbWp3TJGvV/eGKzO4+D+wJTsP9nJmIw==}
@@ -18449,25 +18441,6 @@ packages:
       node-fetch: 1.7.3
       puppeteer: 2.1.1
     transitivePeerDependencies:
-      - react-native
-    dev: false
-
-  /@wordpress/e2e-test-utils/4.16.1_d2bihccpwwyuin5554pd3vha7i:
-    resolution: {integrity: sha512-Dpsq5m0VSvjIhro2MjACSzkOkOf1jGEryzgEMW1ikbT6YI+motspHfGtisKXgYhZJOnjV4PwuEg+9lPVnd971g==}
-    engines: {node: '>=8'}
-    peerDependencies:
-      jest: '>=24'
-      puppeteer: '>=1.19.0'
-    dependencies:
-      '@babel/runtime': 7.21.0
-      '@wordpress/keycodes': 2.19.3
-      '@wordpress/url': 2.22.2_react-native@0.70.0
-      jest: 29.5.0
-      lodash: 4.17.21
-      node-fetch: 2.6.7
-      puppeteer: 2.1.1
-    transitivePeerDependencies:
-      - encoding
       - react-native
     dev: false
 
@@ -18490,7 +18463,7 @@ packages:
       - react-native
     dev: false
 
-  /@wordpress/e2e-test-utils/7.2.1_lbgvwpw4gzlmvdk3yuc5tcyftm:
+  /@wordpress/e2e-test-utils/7.2.1_hmvsd4hlimltsdqszkn2ou62si:
     resolution: {integrity: sha512-eqo4quzgGFArZLLocC5sPfdCLiiS9zMTCRs+Kn4Tl4lLDOLhTk9I1MZcBkvJJ0Qd75FEcdeLaqNaSYNCu6rgyw==}
     engines: {node: '>=12'}
     peerDependencies:
@@ -18498,11 +18471,11 @@ packages:
       puppeteer-core: '>=11'
     dependencies:
       '@babel/runtime': 7.21.0
-      '@wordpress/api-fetch': 6.25.0
-      '@wordpress/keycodes': 3.28.0
-      '@wordpress/url': 3.29.0
+      '@wordpress/api-fetch': 6.3.1
+      '@wordpress/keycodes': 3.6.1
+      '@wordpress/url': 3.7.1
       form-data: 4.0.0
-      jest: 29.5.0
+      jest: 27.5.1
       lodash: 4.17.21
       node-fetch: 2.6.7
       puppeteer-core: 19.7.3_typescript@4.9.5
@@ -18518,30 +18491,30 @@ packages:
       react-dom: ^17.0.0
     dependencies:
       '@babel/runtime': 7.21.0
-      '@wordpress/a11y': 3.28.0
-      '@wordpress/api-fetch': 6.25.0
+      '@wordpress/a11y': 3.6.1
+      '@wordpress/api-fetch': 6.3.1
       '@wordpress/block-editor': 8.6.0_eqi5qhcxfphl6j3pngzexvnehi
       '@wordpress/blocks': 11.18.0_react@17.0.2
-      '@wordpress/components': 19.12.0_eqi5qhcxfphl6j3pngzexvnehi
-      '@wordpress/compose': 5.17.0_react@17.0.2
+      '@wordpress/components': 19.8.5_eqi5qhcxfphl6j3pngzexvnehi
+      '@wordpress/compose': 5.4.1_react@17.0.2
       '@wordpress/core-data': 4.4.5_react@17.0.2
-      '@wordpress/data': 6.15.0_react@17.0.2
-      '@wordpress/date': 4.28.0
-      '@wordpress/deprecated': 3.28.0
-      '@wordpress/element': 4.20.0
-      '@wordpress/hooks': 3.28.0
-      '@wordpress/html-entities': 3.28.0
-      '@wordpress/i18n': 4.28.0
-      '@wordpress/icons': 8.4.0
-      '@wordpress/keyboard-shortcuts': 3.17.0_react@17.0.2
-      '@wordpress/keycodes': 3.28.0
+      '@wordpress/data': 6.6.1_react@17.0.2
+      '@wordpress/date': 4.6.1
+      '@wordpress/deprecated': 3.6.1
+      '@wordpress/element': 4.4.1
+      '@wordpress/hooks': 3.6.1
+      '@wordpress/html-entities': 3.6.1
+      '@wordpress/i18n': 4.6.1
+      '@wordpress/icons': 8.2.3
+      '@wordpress/keyboard-shortcuts': 3.4.1_react@17.0.2
+      '@wordpress/keycodes': 3.6.1
       '@wordpress/media-utils': 3.4.1
-      '@wordpress/notices': 3.28.0_react@17.0.2
+      '@wordpress/notices': 3.6.1_react@17.0.2
       '@wordpress/preferences': 1.3.0_eqi5qhcxfphl6j3pngzexvnehi
       '@wordpress/reusable-blocks': 3.17.0_mtk4wljkd5jimhszw4p7nnxuzm
-      '@wordpress/rich-text': 5.17.0_react@17.0.2
+      '@wordpress/rich-text': 5.4.2_react@17.0.2
       '@wordpress/server-side-render': 3.17.0_mtk4wljkd5jimhszw4p7nnxuzm
-      '@wordpress/url': 3.29.0
+      '@wordpress/url': 3.7.1
       '@wordpress/wordcount': 3.28.0
       classnames: 2.3.1
       lodash: 4.17.21
@@ -18609,7 +18582,6 @@ packages:
       lodash: 4.17.21
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-    dev: false
 
   /@wordpress/element/4.8.0:
     resolution: {integrity: sha512-f2Mb70xvGxZWNWh5pFhOoRgrd+tKs9Xk9hpDgRB7iPel/zbAIxNebr0Jqm5Nt+MDiDl/dogTPc9GyrkYCm9u0g==}
@@ -18841,7 +18813,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@babel/runtime': 7.21.0
-    dev: false
 
   /@wordpress/html-entities/3.28.0:
     resolution: {integrity: sha512-UAaU6au8UTrSkowkV33pE/EvdPov2mA9W51vh6t88KsJPzt4171EzIchGnQuzt04HuZLdLyWy2A+7JCOSbfhBA==}
@@ -18886,7 +18857,7 @@ packages:
     hasBin: true
     dependencies:
       '@babel/runtime': 7.21.0
-      '@wordpress/hooks': 3.28.0
+      '@wordpress/hooks': 3.6.1
       gettext-parser: 1.4.0
       lodash: 4.17.21
       memize: 1.1.0
@@ -18900,20 +18871,19 @@ packages:
     hasBin: true
     dependencies:
       '@babel/runtime': 7.21.0
-      '@wordpress/hooks': 3.28.0
+      '@wordpress/hooks': 3.6.1
       gettext-parser: 1.4.0
       lodash: 4.17.21
       memize: 1.1.0
       sprintf-js: 1.1.2
       tannin: 1.2.0
-    dev: false
 
   /@wordpress/icons/8.1.0:
     resolution: {integrity: sha512-fNq0Mnzzf03uxIwKqQeU/G48wElyypwkhcBZWYQRpmwLZrOR231dxUeK9mzPOSGlYbgM+YKK+k3lzysGmrJU0A==}
     engines: {node: '>=12'}
     dependencies:
       '@babel/runtime': 7.21.0
-      '@wordpress/element': 4.20.0
+      '@wordpress/element': 4.4.1
       '@wordpress/primitives': 3.4.1
     dev: false
 
@@ -18922,8 +18892,8 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@babel/runtime': 7.21.0
-      '@wordpress/element': 4.20.0
-      '@wordpress/primitives': 3.26.0
+      '@wordpress/element': 4.4.1
+      '@wordpress/primitives': 3.4.1
     dev: false
 
   /@wordpress/icons/8.4.0:
@@ -18951,17 +18921,17 @@ packages:
       react-dom: ^17.0.0
     dependencies:
       '@babel/runtime': 7.21.0
-      '@wordpress/a11y': 3.28.0
-      '@wordpress/components': 19.12.0_eqi5qhcxfphl6j3pngzexvnehi
-      '@wordpress/compose': 5.17.0_react@17.0.2
-      '@wordpress/data': 6.15.0_react@17.0.2
-      '@wordpress/deprecated': 3.28.0
-      '@wordpress/element': 4.20.0
-      '@wordpress/i18n': 4.28.0
-      '@wordpress/icons': 8.4.0
+      '@wordpress/a11y': 3.6.1
+      '@wordpress/components': 19.8.5_eqi5qhcxfphl6j3pngzexvnehi
+      '@wordpress/compose': 5.4.1_react@17.0.2
+      '@wordpress/data': 6.6.1_react@17.0.2
+      '@wordpress/deprecated': 3.6.1
+      '@wordpress/element': 4.4.1
+      '@wordpress/i18n': 4.6.1
+      '@wordpress/icons': 8.2.3
       '@wordpress/plugins': 4.4.3_react@17.0.2
       '@wordpress/preferences': 1.3.0_eqi5qhcxfphl6j3pngzexvnehi
-      '@wordpress/viewport': 4.17.0_react@17.0.2
+      '@wordpress/viewport': 4.4.1_react@17.0.2
       classnames: 2.3.1
       lodash: 4.17.21
       react: 17.0.2
@@ -19143,9 +19113,9 @@ packages:
       react: ^17.0.0
     dependencies:
       '@babel/runtime': 7.21.0
-      '@wordpress/data': 6.15.0_react@17.0.2
-      '@wordpress/element': 4.20.0
-      '@wordpress/keycodes': 3.28.0
+      '@wordpress/data': 6.6.1_react@17.0.2
+      '@wordpress/element': 4.4.1
+      '@wordpress/keycodes': 3.6.1
       lodash: 4.17.21
       react: 17.0.2
       rememo: 3.0.0
@@ -19171,7 +19141,7 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@babel/runtime': 7.21.0
-      '@wordpress/i18n': 4.28.0
+      '@wordpress/i18n': 4.6.1
       lodash: 4.17.21
     dev: false
 
@@ -19180,19 +19150,18 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@babel/runtime': 7.21.0
-      '@wordpress/i18n': 4.28.0
+      '@wordpress/i18n': 4.6.1
       lodash: 4.17.21
-    dev: false
 
   /@wordpress/media-utils/3.4.1:
     resolution: {integrity: sha512-WNAaMqqw6Eqy61KTWBy1NlgXSZH82Cm2SPVbz0v6yhJ4ktJmSRFm7Fd4mTMFS/L7NKTxwo+DFqEHlTGKj3lyzQ==}
     engines: {node: '>=12'}
     dependencies:
       '@babel/runtime': 7.21.0
-      '@wordpress/api-fetch': 6.25.0
+      '@wordpress/api-fetch': 6.3.1
       '@wordpress/blob': 3.28.0
-      '@wordpress/element': 4.20.0
-      '@wordpress/i18n': 4.28.0
+      '@wordpress/element': 4.4.1
+      '@wordpress/i18n': 4.6.1
       lodash: 4.17.21
     dev: false
 
@@ -19213,8 +19182,8 @@ packages:
       react: ^17.0.0
     dependencies:
       '@babel/runtime': 7.21.0
-      '@wordpress/a11y': 3.28.0
-      '@wordpress/data': 6.15.0_react@17.0.2
+      '@wordpress/a11y': 3.6.1
+      '@wordpress/data': 6.6.1_react@17.0.2
       lodash: 4.17.21
       react: 17.0.2
     dev: false
@@ -19244,10 +19213,10 @@ packages:
       react: ^17.0.0
     dependencies:
       '@babel/runtime': 7.21.0
-      '@wordpress/compose': 5.17.0_react@17.0.2
-      '@wordpress/element': 4.20.0
-      '@wordpress/hooks': 3.28.0
-      '@wordpress/icons': 8.4.0
+      '@wordpress/compose': 5.4.1_react@17.0.2
+      '@wordpress/element': 4.4.1
+      '@wordpress/hooks': 3.6.1
+      '@wordpress/icons': 8.2.3
       lodash: 4.17.21
       memize: 1.1.0
       react: 17.0.2
@@ -19280,7 +19249,7 @@ packages:
     peerDependencies:
       postcss: ^8.0.0
     dependencies:
-      '@wordpress/base-styles': 4.8.0
+      '@wordpress/base-styles': 4.3.1
       autoprefixer: 10.4.4_postcss@8.4.21
       postcss: 8.4.21
     dev: false
@@ -19393,7 +19362,7 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@babel/runtime': 7.21.0
-      '@wordpress/element': 4.20.0
+      '@wordpress/element': 4.4.1
       classnames: 2.3.1
     dev: false
 
@@ -19539,13 +19508,13 @@ packages:
       react: ^17.0.0
     dependencies:
       '@babel/runtime': 7.21.0
-      '@wordpress/a11y': 3.28.0
-      '@wordpress/compose': 5.17.0_react@17.0.2
-      '@wordpress/data': 6.15.0_react@17.0.2
-      '@wordpress/element': 4.20.0
+      '@wordpress/a11y': 3.6.1
+      '@wordpress/compose': 5.4.1_react@17.0.2
+      '@wordpress/data': 6.6.1_react@17.0.2
+      '@wordpress/element': 4.4.1
       '@wordpress/escape-html': 2.28.0
-      '@wordpress/i18n': 4.28.0
-      '@wordpress/keycodes': 3.28.0
+      '@wordpress/i18n': 4.6.1
+      '@wordpress/keycodes': 3.6.1
       lodash: 4.17.21
       memize: 1.1.0
       react: 17.0.2
@@ -19871,7 +19840,6 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.0
       lodash: 4.17.21
-    dev: false
 
   /@wordpress/viewport/4.17.0_react@17.0.2:
     resolution: {integrity: sha512-5FZCqXjsZjONoyCfjalRgdme//j4XJYHRXYh7ynoJW/qULq3YqZhyLtjFsEM4V+uuuURFSYnGnOD7V+K9wooPA==}
@@ -19893,8 +19861,8 @@ packages:
       react: ^17.0.0
     dependencies:
       '@babel/runtime': 7.21.0
-      '@wordpress/compose': 5.17.0_react@17.0.2
-      '@wordpress/data': 6.15.0_react@17.0.2
+      '@wordpress/compose': 5.4.1_react@17.0.2
+      '@wordpress/data': 6.6.1_react@17.0.2
       lodash: 4.17.21
       react: 17.0.2
     dev: false
@@ -19906,8 +19874,8 @@ packages:
       react: ^17.0.0
     dependencies:
       '@babel/runtime': 7.21.0
-      '@wordpress/compose': 5.17.0_react@17.0.2
-      '@wordpress/data': 6.15.0_react@17.0.2
+      '@wordpress/compose': 5.4.1_react@17.0.2
+      '@wordpress/data': 6.6.1_react@17.0.2
       lodash: 4.17.21
       react: 17.0.2
     dev: false
@@ -19927,7 +19895,6 @@ packages:
   /@wordpress/warning/2.6.1:
     resolution: {integrity: sha512-Xs37x0IkvNewPNKs1A8cnw5xLb+AqwUqqCsH4+5Sjat5GDqP86mHgLfRIlE4d6fBYg+q6tO7DVPG49TT3/wzgA==}
     engines: {node: '>=12'}
-    dev: false
 
   /@wordpress/wordcount/3.19.0:
     resolution: {integrity: sha512-x5M997RMrglq/XiGi55sO4fIPrGu20bob6h5goc9NKbbq68NTTDPrznfRbhQ+gTLLEV79AtUO/RPK3y9V9Pvkw==}
@@ -19940,6 +19907,41 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@babel/runtime': 7.21.0
+    dev: false
+
+  /@xstate/inspect/0.8.0_ws@8.13.0+xstate@4.37.1:
+    resolution: {integrity: sha512-wSkFeOnp+7dhn+zTThO0M4D2FEqZN9lGIWowJu5JLa2ojjtlzRwK8SkjcHZ4rLX8VnMev7kGjgQLrGs8kxy+hw==}
+    peerDependencies:
+      '@types/ws': ^8.0.0
+      ws: ^8.0.0
+      xstate: ^4.37.0
+    peerDependenciesMeta:
+      '@types/ws':
+        optional: true
+    dependencies:
+      fast-safe-stringify: 2.1.1
+      ws: 8.13.0
+      xstate: 4.37.1
+    dev: true
+
+  /@xstate/react/3.2.1_zfwqbz6ktlkzcsj33ggowrqlp4:
+    resolution: {integrity: sha512-L/mqYRxyBWVdIdSaXBHacfvS8NKn3sTKbPb31aRADbE9spsJ1p+tXil0GVQHPlzrmjGeozquLrxuYGiXsFNU7g==}
+    peerDependencies:
+      '@xstate/fsm': ^2.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      xstate: ^4.36.0
+    peerDependenciesMeta:
+      '@xstate/fsm':
+        optional: true
+      xstate:
+        optional: true
+    dependencies:
+      react: 17.0.2
+      use-isomorphic-layout-effect: 1.1.1_pxzommwrsowkd4kgag6q3sluym
+      use-sync-external-store: 1.2.0_react@17.0.2
+      xstate: 4.37.1
+    transitivePeerDependencies:
+      - '@types/react'
     dev: false
 
   /@xtuc/ieee754/1.2.0:
@@ -21009,6 +21011,7 @@ packages:
       slash: 3.0.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /babel-loader/8.2.3_7kihywspc3gmje7ccze4zrmvoq:
     resolution: {integrity: sha512-n4Zeta8NC3QAsuyiizu0GkmRcQ6clkV9WFUnUf1iXP//IeSKbWjofW3UHyZVwlOB4y039YQKefawyTn64Zwbuw==}
@@ -21197,6 +21200,7 @@ packages:
       '@babel/types': 7.21.3
       '@types/babel__core': 7.1.16
       '@types/babel__traverse': 7.14.2
+    dev: true
 
   /babel-plugin-macros/2.8.0:
     resolution: {integrity: sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==}
@@ -21780,6 +21784,7 @@ packages:
       '@babel/core': 7.21.3
       babel-plugin-jest-hoist: 29.5.0
       babel-preset-current-node-syntax: 1.0.1_@babel+core@7.21.3
+    dev: true
 
   /babel-runtime/6.26.0:
     resolution: {integrity: sha1-llxwWGaOgrVde/4E/yM3vItWR/4=}
@@ -22533,14 +22538,13 @@ packages:
   /caniuse-api/3.0.0:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
     dependencies:
-      browserslist: 4.21.4
-      caniuse-lite: 1.0.30001418
+      browserslist: 4.19.3
+      caniuse-lite: 1.0.30001146
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
 
   /caniuse-lite/1.0.30001146:
     resolution: {integrity: sha512-VAy5RHDfTJhpxnDdp2n40GPPLp3KqNrXz1QqFv4J64HvArKs8nuNMOWkB3ICOaBTU/Aj4rYAo/ytdQDDFF/Pug==}
-    dev: true
 
   /caniuse-lite/1.0.30001352:
     resolution: {integrity: sha512-GUgH8w6YergqPQDGWhJGt8GDRnY0L/iJVQcU3eJ46GYf52R8tk0Wxp0PymuFVZboJYXGiCqwozAYZNRjVj6IcA==}
@@ -26872,7 +26876,6 @@ packages:
 
   /fast-safe-stringify/2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
-    dev: false
 
   /fastest-levenshtein/1.0.12:
     resolution: {integrity: sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==}
@@ -27439,7 +27442,7 @@ packages:
       vue-template-compiler:
         optional: true
     dependencies:
-      '@babel/code-frame': 7.16.7
+      '@babel/code-frame': 7.18.6
       '@types/json-schema': 7.0.9
       chalk: 4.1.2
       chokidar: 3.5.3
@@ -27450,7 +27453,7 @@ packages:
       memfs: 3.3.0
       minimatch: 3.1.2
       schema-utils: 2.7.0
-      semver: 7.3.5
+      semver: 7.3.8
       tapable: 1.1.3
       typescript: 4.9.5
       webpack: 5.70.0
@@ -27470,7 +27473,7 @@ packages:
       vue-template-compiler:
         optional: true
     dependencies:
-      '@babel/code-frame': 7.16.7
+      '@babel/code-frame': 7.18.6
       '@types/json-schema': 7.0.9
       chalk: 4.1.2
       chokidar: 3.5.3
@@ -27481,7 +27484,7 @@ packages:
       memfs: 3.3.0
       minimatch: 3.1.2
       schema-utils: 2.7.0
-      semver: 7.3.5
+      semver: 7.3.8
       tapable: 1.1.3
       typescript: 4.9.5
       webpack: 4.46.0
@@ -27501,7 +27504,7 @@ packages:
       vue-template-compiler:
         optional: true
     dependencies:
-      '@babel/code-frame': 7.16.7
+      '@babel/code-frame': 7.18.6
       '@types/json-schema': 7.0.9
       chalk: 4.1.2
       chokidar: 3.5.3
@@ -27513,7 +27516,7 @@ packages:
       memfs: 3.3.0
       minimatch: 3.1.2
       schema-utils: 2.7.0
-      semver: 7.3.5
+      semver: 7.3.8
       tapable: 1.1.3
       typescript: 4.9.5
       webpack: 4.46.0_webpack-cli@3.3.12
@@ -29232,7 +29235,7 @@ packages:
       '@automattic/interpolate-components': 1.2.1_pxzommwrsowkd4kgag6q3sluym
       '@babel/runtime': 7.21.0
       '@tannin/sprintf': 1.2.0
-      '@wordpress/compose': 5.17.0_react@17.0.2
+      '@wordpress/compose': 5.4.1_react@17.0.2
       debug: 4.3.4
       events: 3.3.0
       hash.js: 1.1.7
@@ -30404,6 +30407,7 @@ packages:
     dependencies:
       execa: 5.1.1
       p-limit: 3.1.0
+    dev: true
 
   /jest-circus/26.6.3:
     resolution: {integrity: sha512-ACrpWZGcQMpbv13XbzRzpytEJlilP/Su0JtNCi5r/xLpOUhnaIJr8leYYpLEMgPFURZISEHrnnpmB54Q/UziPw==}
@@ -30490,6 +30494,7 @@ packages:
       stack-utils: 2.0.5
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /jest-cli/24.9.0:
     resolution: {integrity: sha512-+VLRKyitT3BWoMeSUIHRxV/2g8y9gw91Jh5z2UmXZzkZKpbC08CSehVxgHUwTpy+HwGcns/tqafQDJW7imYvGg==}
@@ -30595,34 +30600,6 @@ packages:
       - supports-color
       - ts-node
       - utf-8-validate
-
-  /jest-cli/29.5.0:
-    resolution: {integrity: sha512-L1KcP1l4HtfwdxXNFCL5bmUbLQiKrakMUriBEcc1Vfz6gx31ORKdreuWvmQVBit+1ss9NNR3yxjwfwzZNdQXJw==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/core': 29.5.0
-      '@jest/test-result': 29.5.0
-      '@jest/types': 29.5.0
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.9
-      import-local: 3.0.3
-      jest-config: 29.5.0
-      jest-util: 29.5.0
-      jest-validate: 29.5.0
-      prompts: 2.4.2
-      yargs: 17.5.1
-    transitivePeerDependencies:
-      - '@types/node'
-      - supports-color
-      - ts-node
-    dev: false
 
   /jest-cli/29.5.0_@types+node@16.18.21:
     resolution: {integrity: sha512-L1KcP1l4HtfwdxXNFCL5bmUbLQiKrakMUriBEcc1Vfz6gx31ORKdreuWvmQVBit+1ss9NNR3yxjwfwzZNdQXJw==}
@@ -30782,44 +30759,6 @@ packages:
       - supports-color
       - utf-8-validate
 
-  /jest-config/29.5.0:
-    resolution: {integrity: sha512-kvDUKBnNJPNBmFFOhDbm59iu1Fii1Q6SxyhXfvylq3UTHbg6o7j/g8k2dZyXWLvfdKB1vAPxNZnMgtKJcmu3kA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    peerDependencies:
-      '@types/node': '*'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      ts-node:
-        optional: true
-    dependencies:
-      '@babel/core': 7.21.3
-      '@jest/test-sequencer': 29.5.0
-      '@jest/types': 29.5.0
-      babel-jest: 29.5.0_@babel+core@7.21.3
-      chalk: 4.1.2
-      ci-info: 3.2.0
-      deepmerge: 4.3.0
-      glob: 7.2.3
-      graceful-fs: 4.2.9
-      jest-circus: 29.5.0
-      jest-environment-node: 29.5.0
-      jest-get-type: 29.4.3
-      jest-regex-util: 29.4.3
-      jest-resolve: 29.5.0
-      jest-runner: 29.5.0
-      jest-util: 29.5.0
-      jest-validate: 29.5.0
-      micromatch: 4.0.5
-      parse-json: 5.2.0
-      pretty-format: 29.5.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /jest-config/29.5.0_@types+node@16.18.21:
     resolution: {integrity: sha512-kvDUKBnNJPNBmFFOhDbm59iu1Fii1Q6SxyhXfvylq3UTHbg6o7j/g8k2dZyXWLvfdKB1vAPxNZnMgtKJcmu3kA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -30857,6 +30796,7 @@ packages:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /jest-dev-server/4.4.0:
     resolution: {integrity: sha512-STEHJ3iPSC8HbrQ3TME0ozGX2KT28lbT4XopPxUm2WimsX3fcB3YOptRh12YphQisMhfqNSNTZUmWyT3HEXS2A==}
@@ -31020,6 +30960,7 @@ packages:
       jest-get-type: 29.4.3
       jest-util: 29.5.0
       pretty-format: 29.5.0
+    dev: true
 
   /jest-environment-jsdom/24.9.0:
     resolution: {integrity: sha512-Zv9FV9NBRzLuALXjvRijO2351DRQeLYXtpD4xNvfoVFw21IOKNhZAEUKcbiEtjTkm2GsJ3boMVgkaR7rN8qetA==}
@@ -31761,6 +31702,7 @@ packages:
       jest-snapshot: 29.5.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /jest-resolve/24.9.0:
     resolution: {integrity: sha512-TaLeLVL1l08YFZAt3zaPtjiVvyy4oSA6CRe+0AFPPVX3Q/VI0giIWWoAvoS5L96vj9Dqxj4fB5p2qrHCmTU/MQ==}
@@ -32603,26 +32545,6 @@ packages:
       - supports-color
       - ts-node
       - utf-8-validate
-
-  /jest/29.5.0:
-    resolution: {integrity: sha512-juMg3he2uru1QoXX078zTa7pO85QyB9xajZc6bU+d9yEGwrKX6+vGmJQ3UdVZsvTEUARIdObzH68QItim6OSSQ==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/core': 29.5.0
-      '@jest/types': 29.5.0
-      import-local: 3.0.3
-      jest-cli: 29.5.0
-    transitivePeerDependencies:
-      - '@types/node'
-      - supports-color
-      - ts-node
-    dev: false
 
   /jest/29.5.0_@types+node@16.18.21:
     resolution: {integrity: sha512-juMg3he2uru1QoXX078zTa7pO85QyB9xajZc6bU+d9yEGwrKX6+vGmJQ3UdVZsvTEUARIdObzH68QItim6OSSQ==}
@@ -36510,7 +36432,7 @@ packages:
     resolution: {integrity: sha512-WyQFAdDZpExQh32j0U0feWisZ0dmOtPl44qYmJKkq9xFWY3p+4qnRzCHeNrkeRhwPHz9bQ3mo0/yVkaply0MNw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      browserslist: 4.21.4
+      browserslist: 4.19.3
       color: 3.2.1
       has: 1.0.3
       postcss: 7.0.39
@@ -36522,7 +36444,7 @@ packages:
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.21.4
+      browserslist: 4.19.3
       caniuse-api: 3.0.0
       colord: 2.9.2
       postcss: 8.4.12
@@ -36686,7 +36608,7 @@ packages:
       postcss: 8.4.21
       schema-utils: 3.1.1
       semver: 7.3.8
-      webpack: 5.70.0
+      webpack: 5.70.0_webpack-cli@3.3.12
 
   /postcss-loader/4.3.0_twwyhqqim6liv4fz2ggv7g4m5a:
     resolution: {integrity: sha512-M/dSoIiNDOo8Rk0mUqoj4kpGq91gcxCfb9PoyZVdZ76/AuhxylHDYZblNE8o+EQ9AMSASeMFEKxZf5aU6wlx1Q==}
@@ -36762,7 +36684,7 @@ packages:
     resolution: {integrity: sha512-U7e3r1SbvYzO0Jr3UT/zKBVgYYyhAz0aitvGIYOYK5CPmkNih+WDSsS5tvPrJ8YMQYlEMvsZIiqmn7HdFUaeEQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      browserslist: 4.21.4
+      browserslist: 4.19.3
       caniuse-api: 3.0.0
       cssnano-util-same-parent: 4.0.1
       postcss: 7.0.39
@@ -36775,7 +36697,7 @@ packages:
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.21.4
+      browserslist: 4.19.3
       caniuse-api: 3.0.0
       cssnano-utils: 3.1.0_postcss@8.4.12
       postcss: 8.4.12
@@ -36829,7 +36751,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       alphanum-sort: 1.0.2
-      browserslist: 4.21.4
+      browserslist: 4.19.3
       cssnano-util-get-arguments: 4.0.0
       postcss: 7.0.39
       postcss-value-parser: 3.3.1
@@ -36841,7 +36763,7 @@ packages:
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.21.4
+      browserslist: 4.19.3
       cssnano-utils: 3.1.0_postcss@8.4.12
       postcss: 8.4.12
       postcss-value-parser: 4.2.0
@@ -37087,7 +37009,7 @@ packages:
     resolution: {integrity: sha512-od18Uq2wCYn+vZ/qCOeutvHjB5jm57ToxRaMeNuf0nWVHaP9Hua56QyMF6fs/4FSUnVIw0CBPsU0K4LnBPwYwg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      browserslist: 4.21.4
+      browserslist: 4.19.3
       postcss: 7.0.39
       postcss-value-parser: 3.3.1
 
@@ -37097,7 +37019,7 @@ packages:
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.21.4
+      browserslist: 4.19.3
       postcss: 8.4.12
       postcss-value-parser: 4.2.0
     dev: true
@@ -37162,7 +37084,7 @@ packages:
     resolution: {integrity: sha512-gKWmR5aUulSjbzOfD9AlJiHCGH6AEVLaM0AV+aSioxUDd16qXP1PCh8d1/BGVvpdWn8k/HiK7n6TjeoXN1F7DA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      browserslist: 4.21.4
+      browserslist: 4.19.3
       caniuse-api: 3.0.0
       has: 1.0.3
       postcss: 7.0.39
@@ -37173,7 +37095,7 @@ packages:
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.21.4
+      browserslist: 4.19.3
       caniuse-api: 3.0.0
       postcss: 8.4.12
     dev: true
@@ -37834,6 +37756,7 @@ packages:
 
   /pure-rand/6.0.1:
     resolution: {integrity: sha512-t+x1zEHDjBwkDGY5v5ApnZ/utcd4XYDiJsaQQoptTXgUXX95sDg1elCdJghzicm7n2mbCBJ3uYWr6M22SO19rg==}
+    dev: true
 
   /q/1.5.1:
     resolution: {integrity: sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=}
@@ -38172,7 +38095,7 @@ packages:
       is-touch-device: 1.0.1
       lodash: 4.17.21
       moment: 2.29.4
-      object.assign: 4.1.4
+      object.assign: 4.1.2
       object.values: 1.1.5
       prop-types: 15.8.1
       raf: 3.4.1
@@ -41085,7 +41008,7 @@ packages:
     resolution: {integrity: sha512-7GlLk9JwlElY4Y6a/rmbH2MhVlTyVmiJd1PfTCqFaIBEGMYNsrO/v3SeGTdhBThLg4Z+NbOk/qFMwCa+J+3p/g==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      browserslist: 4.21.4
+      browserslist: 4.19.3
       postcss: 7.0.39
       postcss-selector-parser: 3.1.2
 
@@ -41095,7 +41018,7 @@ packages:
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.21.4
+      browserslist: 4.19.3
       postcss: 8.4.12
       postcss-selector-parser: 6.0.9
     dev: true
@@ -43435,6 +43358,7 @@ packages:
       '@jridgewell/trace-mapping': 0.3.17
       '@types/istanbul-lib-coverage': 2.0.3
       convert-source-map: 1.8.0
+    dev: true
 
   /v8flags/3.1.3:
     resolution: {integrity: sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==}
@@ -44819,6 +44743,9 @@ packages:
     engines: {node: '>=0.4.0'}
     dev: false
 
+  /xstate/4.37.1:
+    resolution: {integrity: sha512-MuB7s01nV5vG2CzaBg2msXLGz7JuS+x/NBkQuZAwgEYCnWA8iQMiRz2VGxD3pcFjZAOih3fOgDD3kDaFInEx+g==}
+
   /xtend/4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -44885,6 +44812,7 @@ packages:
   /yargs-parser/21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
+    dev: true
 
   /yargs-unparser/1.6.0:
     resolution: {integrity: sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==}
@@ -44963,6 +44891,7 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+    dev: true
 
   /yargs/4.8.1:
     resolution: {integrity: sha1-wMQpJMpKqmsObaFznfshZDn53cA=}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes 194-gh-woocommerce/team-ghidorah.

In this PR the rudimentary scaffolding for the new core profiler is introduced. The development work in this feature will also serve as an experimental testing ground for the usage of XState as a workflow framework. 

As this is only a rudimentary scaffold, it should not be visible to end users and the UI work included is minimal. There will be follow up PRs that will work on individual pages as well as other relevant features to make this feature complete.

This new core profiler is locked behind the feature flag `'core-profiler'` and is accessible by directly visiting this URL only: http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fprofiler

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

This feature is not required to be tested as the follow up PRs will have more comprehensive testing instructions.

For now, testing should determine that this feature is correctly feature flagged and the existing onboarding wizard still functions.

1. Enable the `'core-profiler'` feature flag using the WC Test Helper in WooCommerce Beta Tester plugin
2. Visit http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fprofiler to check that it loads
3. Feel free to step through it.
4. If you wish to see the XState visualizer, uncomment the code that invokes `@xstate/inspect`

https://user-images.githubusercontent.com/27843274/231448163-73b997dd-7c14-4abe-9db0-bfa34b574a82.mov


<!-- End testing instructions -->


### Reviewer's Focus

Reviewers of this PR should focus on the usability of the XState visualizer, and that the state machine matches up with the expected flows described in the Figma: Y5pUYSJPsGEud1vknUZhi8-fi-1-147&t=jNYlBt8fZ2IyKff1-0

The individual page event handlers should also be inspected to see if the provided event handlers and context information is sufficient to develop the pages. Optionally, these can also be improved as part of the development of the pages.

### Follow up work:

#### Supporting work on the state machine
1. Navigation Component 193-gh-woocommerce/team-ghidorah
2. Geolocation - Either using JS (203-gh-woocommerce/team-ghidorah) or the wccom geolocation API, determine the user's store location. The state of this should be tracked in a parallel state, beside the main workflow. The conditional guard in preBusinessInfo should also be updated to rely on this state.
3. [Extensions Fetching](https://github.com/woocommerce/woocommerce/issues/37992) - This should tie in with the existing @woocommerce/data/onboarding redux code to retrieve the available extensions. The state of this should be tracked in a parallel state, beside the main workflow. The conditional guard in preExtensions should be updated to rely on this state.
4. [URL Parsing](https://github.com/woocommerce/woocommerce/issues/37993). The state machine should be aware of the URL paths and update the paths accordingly when the pages are stepped through. When an individual page URL is navigated to directly, the initialization state should detect this and fire off the appropriate transition to redirect the user. The development of this should also consider the future work of accepting the Jetpack callback
5. Jetpack redirect out and callback. Details TBD
8. [Style the core profiler page](https://github.com/woocommerce/woocommerce/issues/37994) (without any pages rendered, so perhaps a spinner)
9. [Implement model based testing](https://github.com/woocommerce/woocommerce/issues/37995) https://css-tricks.com/model-based-testing-in-react-with-state-machines/
10. [Dev tooling improvements](https://github.com/woocommerce/woocommerce/issues/37996) e.g [eslint-plugin-xstate](https://www.npmjs.com/package/eslint-plugin-xstate), [dev env detection](https://github.com/woocommerce/woocommerce/pull/37628#discussion_r1165103112) and [typegen](https://github.com/woocommerce/woocommerce/pull/37628#discussion_r1165103308)

#### Pages
1. introOptIn  "Welcome to Woo!" Issue: 195-gh-woocommerce/team-ghidorah
2. userProfile "Which one of these best describes you?" Issue: 196-gh-woocommerce/team-ghidorah
3. businessInfo "Tell us a bit about your store" Issue: 197-gh-woocommerce/team-ghidorah
4. businessLocation "Where is your business located?" 198-gh-woocommerce/team-ghidorah