### PR TITLE
Print blocks-based element CSS classes only when a block theme is used

### DIFF
--- a/plugins/woocommerce/changelog/enchancement-37630-theme-element-class-name
+++ b/plugins/woocommerce/changelog/enchancement-37630-theme-element-class-name
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Print blocks-based CSS classes only when a FSE theme is used

--- a/plugins/woocommerce/includes/wc-conditional-functions.php
+++ b/plugins/woocommerce/includes/wc-conditional-functions.php
@@ -527,7 +527,7 @@ function wc_current_theme_supports_woocommerce_or_fse() {
 /**
  * Given an element name, returns a class name.
  *
- * If the WP-related function is not defined, return empty string.
+ * If the WP-related function is not defined or current theme is not a FSE theme, return empty string.
  *
  * @param string $element The name of the element.
  *
@@ -535,7 +535,7 @@ function wc_current_theme_supports_woocommerce_or_fse() {
  * @return string
  */
 function wc_wp_theme_get_element_class_name( $element ) {
-	if ( function_exists( 'wp_theme_get_element_class_name' ) ) {
+	if ( wc_current_theme_is_fse_theme() && function_exists( 'wp_theme_get_element_class_name' ) ) {
 		return wp_theme_get_element_class_name( $element );
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR aims to remove blocks-based CSS classes from elements when the current theme is not an FSE theme. This should minimize the footprint of FSE-related changes for legacy themes.

**Hint for the reviewer:** There is also a risk involved in this PR. Please check the issue description for details.

Closes #37630 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Use or spin up two stores, one with an FSE theme (e.g., TT2) and another with a non-FSE theme (e.g., Storefront). 
2. Visit a single's product page and inspect the add-to-cart button.
3. Notice that the `wp-element-button` class is only added in the FSE theme.

<!-- End testing instructions -->