### PR TITLE
Fix TT2 styles and typography in the single product's attributes table

### DIFF
--- a/plugins/woocommerce/changelog/fix-37636-attributes-table
+++ b/plugins/woocommerce/changelog/fix-37636-attributes-table
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed the attributes table styling in TT2 tabs content area

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
@@ -594,7 +594,8 @@ ul.wc-tabs {
 	font-size: var(--wp--preset--font-size--small);
 	margin-left: 1em;
 
-	h2 {
+	// Hide repeated heading.
+	h2:first-of-type {
 		display: none;
 	}
 }

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
@@ -598,6 +598,25 @@ ul.wc-tabs {
 	h2:first-of-type {
 		display: none;
 	}
+
+	// Attributes table styles.
+	table.woocommerce-product-attributes {
+		tbody {
+
+			td, th {
+				padding: 0.2rem 0.2rem 0.2rem 0;
+
+				p {
+					margin: 0;
+				}
+			}
+
+			th {
+				text-align: left;
+				padding-right: 1rem;
+			}
+		}
+	}
 }
 
 /**


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR aims to fix the styling in the attributes table in TT2 when viewing the tabs' content in a single product view.

Moreover, there seems to be an issue with the `h2` heading in TT2. They all get hidden, so this PR adds another fix to only hide the first `h2` inside the tab content (styling decision to avoid repetition on the tabs' headings.)

Closes #37636 

### Screenshots:

![Before](https://cdn-std.droplr.net/files/acc_1208648/qSEKSO)
![After](https://cdn-std.droplr.net/files/acc_1208648/1GyYin)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create or use an existing site with TT2 (or Tsubaki or Tazza)
2. Ensure you have at least one product with multiple attribute values. 
3. Visit the single product's page and notice the styling issues in the attributes table in the _Additional Information_ tab.
4. Apply this patch, and ensure the attributes table looks nice!

<!-- End testing instructions -->