### PR TITLE
Fix issue that breaks the WooCommerce Home Page when Gutenberg 15.5 is active

### DIFF
--- a/packages/js/data/changelog/fix-gutengerg15-5-update-issues
+++ b/packages/js/data/changelog/fix-gutengerg15-5-update-issues
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix incorrect usage of dispatch, useSelect, and setState calls in homescreen along with settings and onboarding package

--- a/packages/js/data/src/onboarding/with-onboarding-hydration.tsx
+++ b/packages/js/data/src/onboarding/with-onboarding-hydration.tsx
@@ -50,6 +50,7 @@ export const withOnboardingHydration = ( data: {
 				if (
 					profileItems &&
 					! hydratedProfileItems &&
+					// Ensure that profile items have finished resolving to prevent race conditions
 					! isResolvingGroup &&
 					! hasFinishedResolutionGroup
 				) {

--- a/packages/js/data/src/onboarding/with-onboarding-hydration.tsx
+++ b/packages/js/data/src/onboarding/with-onboarding-hydration.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { createHigherOrderComponent } from '@wordpress/compose';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { createElement, useEffect, useRef } from '@wordpress/element';
 
 /**
@@ -19,8 +19,24 @@ export const withOnboardingHydration = ( data: {
 	return createHigherOrderComponent< Record< string, unknown > >(
 		( OriginalComponent ) => ( props ) => {
 			const onboardingRef = useRef( data );
+
+			const { isResolvingGroup, hasFinishedResolutionGroup } = useSelect(
+				( select ) => {
+					const { isResolving, hasFinishedResolution } =
+						select( STORE_NAME );
+					return {
+						isResolvingGroup: isResolving( 'getProfileItems', [] ),
+						hasFinishedResolutionGroup: hasFinishedResolution(
+							'getProfileItems',
+							[]
+						),
+					};
+				}
+			);
+
 			const { startResolution, finishResolution, setProfileItems } =
 				useDispatch( STORE_NAME );
+
 			useEffect( () => {
 				if ( ! onboardingRef.current ) {
 					return;
@@ -31,14 +47,25 @@ export const withOnboardingHydration = ( data: {
 					return;
 				}
 
-				if ( profileItems && ! hydratedProfileItems ) {
+				if (
+					profileItems &&
+					! hydratedProfileItems &&
+					! isResolvingGroup &&
+					! hasFinishedResolutionGroup
+				) {
 					startResolution( 'getProfileItems', [] );
 					setProfileItems( profileItems, true );
 					finishResolution( 'getProfileItems', [] );
 
 					hydratedProfileItems = true;
 				}
-			}, [ finishResolution, setProfileItems, startResolution ] );
+			}, [
+				finishResolution,
+				setProfileItems,
+				startResolution,
+				isResolvingGroup,
+				hasFinishedResolutionGroup,
+			] );
 
 			return <OriginalComponent { ...props } />;
 		},

--- a/packages/js/data/src/settings/index.ts
+++ b/packages/js/data/src/settings/index.ts
@@ -10,7 +10,7 @@ import { SelectFromMap, DispatchFromMap } from '@automattic/data-stores';
 /**
  * Internal dependencies
  */
-import { WPDataSelectors } from '../types';
+import { WPDataSelectors, WPDataActions } from '../types';
 import { STORE_NAME } from './constants';
 import * as selectors from './selectors';
 import * as actions from './actions';
@@ -33,7 +33,7 @@ export const SETTINGS_STORE_NAME = STORE_NAME;
 declare module '@wordpress/data' {
 	function dispatch(
 		key: typeof STORE_NAME
-	): DispatchFromMap< typeof actions >;
+	): DispatchFromMap< typeof actions > & WPDataActions;
 	function select(
 		key: typeof STORE_NAME
 	): SelectFromMap< typeof selectors > & WPDataSelectors;

--- a/packages/js/data/src/settings/with-settings-hydration.tsx
+++ b/packages/js/data/src/settings/with-settings-hydration.tsx
@@ -35,7 +35,8 @@ export const withSettingsHydration = ( group: string, settings: Settings ) =>
 							[ group ]
 						),
 					};
-				}
+				},
+				[]
 			);
 			useEffect( () => {
 				if ( ! settingsRef.current ) {

--- a/plugins/woocommerce-admin/client/homescreen/index.tsx
+++ b/plugins/woocommerce-admin/client/homescreen/index.tsx
@@ -3,7 +3,6 @@
  */
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
-import { identity } from 'lodash';
 import {
 	ONBOARDING_STORE_NAME,
 	withOnboardingHydration,
@@ -50,10 +49,8 @@ const withSelectHandler = ( select: WCDataSelector ) => {
 };
 
 export default compose(
-	onboardingData.profile
-		? withOnboardingHydration( {
-				profileItems: onboardingData.profile,
-		  } )
-		: identity,
+	withOnboardingHydration( {
+		profileItems: onboardingData.profile,
+	} ),
 	withSelect( withSelectHandler )
 )( Homescreen );

--- a/plugins/woocommerce-admin/client/homescreen/layout.js
+++ b/plugins/woocommerce-admin/client/homescreen/layout.js
@@ -8,6 +8,7 @@ import {
 	useLayoutEffect,
 	useRef,
 	useState,
+	useEffect,
 } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
@@ -76,9 +77,11 @@ export const Layout = ( {
 		( userPrefs.homepage_layout || defaultHomescreenLayout ) ===
 			'two_columns' && hasTwoColumnContent;
 
-	if ( isBatchUpdating && ! showInbox ) {
-		setShowInbox( true );
-	}
+	useEffect( () => {
+		if ( isBatchUpdating && ! showInbox ) {
+			setShowInbox( true );
+		}
+	}, [ isBatchUpdating, showInbox ] );
 
 	const isWideViewport = useRef( true );
 	const maybeToggleColumns = useCallback( () => {

--- a/plugins/woocommerce-admin/client/homescreen/layout.js
+++ b/plugins/woocommerce-admin/client/homescreen/layout.js
@@ -7,8 +7,6 @@ import {
 	useCallback,
 	useLayoutEffect,
 	useRef,
-	useState,
-	useEffect,
 } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
@@ -54,7 +52,6 @@ const Tasks = lazy( () =>
 
 export const Layout = ( {
 	defaultHomescreenLayout,
-	isBatchUpdating,
 	query,
 	taskListComplete,
 	hasTaskList,

--- a/plugins/woocommerce-admin/client/homescreen/layout.js
+++ b/plugins/woocommerce-admin/client/homescreen/layout.js
@@ -69,19 +69,12 @@ export const Layout = ( {
 	const shouldShowStoreLinks = taskListComplete || isTaskListHidden;
 	const hasTwoColumnContent =
 		shouldShowStoreLinks || window.wcAdminFeatures.analytics;
-	const [ showInbox, setShowInbox ] = useState( true );
 	const isDashboardShown = ! query.task; // ?&task=<x> query param is used to show tasks instead of the homescreen
 	const activeSetupTaskList = useActiveSetupTasklist();
 
 	const twoColumns =
 		( userPrefs.homepage_layout || defaultHomescreenLayout ) ===
 			'two_columns' && hasTwoColumnContent;
-
-	useEffect( () => {
-		if ( isBatchUpdating && ! showInbox ) {
-			setShowInbox( true );
-		}
-	}, [ isBatchUpdating, showInbox ] );
 
 	const isWideViewport = useRef( true );
 	const maybeToggleColumns = useCallback( () => {

--- a/plugins/woocommerce/changelog/fix-gutengerg15-5-update-issues
+++ b/plugins/woocommerce/changelog/fix-gutengerg15-5-update-issues
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix incorrect usage of dispatch, useSelect, and setState calls in homescreen along with settings and onboarding package


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #37640.

In the linked issue you can see the report on how when Gutenberg 15.5 is active, the WooCommerce home page is broken. This release of Gutenberg updated some behaviour for the `useSelect` API, and while I'm not 100% sure - it impacts the (arguably incorrect) usage of `registry.dispatch` in provided `useSelect` callbacks.

I was able to resolve the error by ensuring any dispatch calls are in a `useEffect` (they are side-effects so _should_ be). 

There were also a couple other incorrect calls to a `setState` function outside of an effect that I fixed in this PR.

Very important:

- This likely has subtle impact on behaviours, I don't know what those are, nor did I test extensively. I focused on fixing the error and providing a potential path forward. Followup is needed.
- The usage of legacy HOCs and React class components in the codebase is going to be more problematic as time goes on (due to changes with React concurrency mode, suspense etc). I strongly recommend setting some time to refactor away from them.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Activate Gutenberg 15.5
2. Verify the WooCommerce Admin Home page loads without issues.
3. Verify that skipping the onboarding wizard works without issue, and also with completing the onboarding wizard
4. Verify that homescreen's inbox notes are displayed as usual
5. Verify steps 2 - 5 still apply with Gutenberg plugin disabled

<!-- End testing instructions -->