### PR TITLE
Create orders as 'auto-draft' by default in admin

### DIFF
--- a/plugins/woocommerce/changelog/fix-36749
+++ b/plugins/woocommerce/changelog/fix-36749
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Create orders as 'auto-draft' by default in admin.

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -638,7 +638,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			}
 
 			// If the old status is set but unknown (e.g. draft) assume its pending for action usage.
-			if ( $old_status && ! in_array( 'wc-' . $old_status, $this->get_valid_statuses(), true ) && ! in_array( $old_status, $status_exceptions, true ) ) {
+			if ( $old_status && ( ( ! in_array( 'wc-' . $old_status, $this->get_valid_statuses(), true ) && ! in_array( $old_status, $status_exceptions, true ) ) || 'auto-draft' === $old_status ) ) {
 				$old_status = 'pending';
 			}
 		}

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -638,7 +638,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			}
 
 			// If the old status is set but unknown (e.g. draft) assume its pending for action usage.
-			if ( $old_status && ( ( ! in_array( 'wc-' . $old_status, $this->get_valid_statuses(), true ) && ! in_array( $old_status, $status_exceptions, true ) ) || 'auto-draft' === $old_status ) ) {
+			if ( $old_status && ( 'auto-draft' === $old_status || ( ! in_array( 'wc-' . $old_status, $this->get_valid_statuses(), true ) && ! in_array( $old_status, $status_exceptions, true ) ) ) ) {
 				$old_status = 'pending';
 			}
 		}

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -471,7 +471,7 @@ class ListTable extends WP_List_Table {
 				$view_counts[ $slug ] = $total_in_status;
 			}
 
-			if ( ( get_post_status_object( $slug ) )->show_in_admin_all_list ) {
+			if ( ( get_post_status_object( $slug ) )->show_in_admin_all_list && 'auto-draft' !== $slug ) {
 				$all_count += $total_in_status;
 			}
 		}
@@ -550,8 +550,9 @@ class ListTable extends WP_List_Table {
 			array_merge(
 				wc_get_order_statuses(),
 				array(
-					'trash' => ( get_post_status_object( 'trash' ) )->label,
-					'draft' => ( get_post_status_object( 'draft' ) )->label,
+					'trash'      => ( get_post_status_object( 'trash' ) )->label,
+					'draft'      => ( get_post_status_object( 'draft' ) )->label,
+					'auto-draft' => ( get_post_status_object( 'auto-draft' ) )->label,
 				)
 			),
 			array_flip( get_post_stati( array( 'show_in_admin_status_list' => true ) ) )
@@ -916,7 +917,7 @@ class ListTable extends WP_List_Table {
 		}
 
 		// Gracefully handle legacy statuses.
-		if ( in_array( $order->get_status(), array( 'trash', 'draft' ), true ) ) {
+		if ( in_array( $order->get_status(), array( 'trash', 'draft', 'auto-draft' ), true ) ) {
 			$status_name = ( get_post_status_object( $order->get_status() ) )->label;
 		} else {
 			$status_name = wc_get_order_status_name( $order->get_status() );

--- a/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
@@ -286,8 +286,13 @@ class PageController {
 
 		$this->order = new $order_class_name();
 		$this->order->set_object_read( false );
-		$this->order->set_status( 'pending' );
+		$this->order->set_status( 'auto-draft' );
 		$this->order->save();
+
+		// Schedule auto-draft cleanup. We re-use the WP event here on purpose.
+		if ( ! wp_next_scheduled( 'wp_scheduled_auto_draft_delete' ) ) {
+			wp_schedule_event( time(), 'daily', 'wp_scheduled_auto_draft_delete' );
+		}
 
 		$theorder = $this->order;
 	}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -79,6 +79,8 @@ class DataSynchronizer implements BatchProcessorInterface {
 		self::add_action( 'deleted_post', array( $this, 'handle_deleted_post' ), 10, 2 );
 		self::add_action( 'woocommerce_new_order', array( $this, 'handle_updated_order' ), 100 );
 		self::add_action( 'woocommerce_update_order', array( $this, 'handle_updated_order' ), 100 );
+		self::add_action( 'wp_scheduled_auto_draft_delete', array( $this, 'delete_auto_draft_orders' ) );
+
 		self::add_filter( 'woocommerce_feature_description_tip', array( $this, 'handle_feature_description_tip' ), 10, 3 );
 	}
 
@@ -465,6 +467,45 @@ ORDER BY orders.id ASC
 		if ( ! $this->custom_orders_table_is_authoritative() && $this->data_sync_is_enabled() ) {
 			$this->posts_to_cot_migrator->migrate_orders( array( $order_id ) );
 		}
+	}
+
+	/**
+	 * Handles deletion of auto-draft orders in sync with WP's own auto-draft deletion.
+	 *
+	 * @since 7.7.0
+	 *
+	 * @return void
+	 */
+	private function delete_auto_draft_orders() {
+		if ( ! $this->custom_orders_table_is_authoritative() ) {
+			return;
+		}
+
+		// Fetch auto-draft orders older than 1 week.
+		$to_delete = wc_get_orders(
+			array(
+				'date_query' => array(
+					array(
+						'column' => 'date_created',
+						'before' => '-1 week',
+					),
+				),
+				'orderby'    => 'date',
+				'order'      => 'ASC',
+				'status'     => 'auto-draft',
+			)
+		);
+
+		foreach ( $to_delete as $order ) {
+			$order->delete( true );
+		}
+
+		/**
+		 * Fires after schedueld deletion of auto-draft orders has been completed.
+		 *
+		 * @since 7.7.0
+		 */
+		do_action( 'woocommerce_scheduled_auto_draft_delete' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -79,7 +79,7 @@ class DataSynchronizer implements BatchProcessorInterface {
 		self::add_action( 'deleted_post', array( $this, 'handle_deleted_post' ), 10, 2 );
 		self::add_action( 'woocommerce_new_order', array( $this, 'handle_updated_order' ), 100 );
 		self::add_action( 'woocommerce_update_order', array( $this, 'handle_updated_order' ), 100 );
-		self::add_action( 'wp_scheduled_auto_draft_delete', array( $this, 'delete_auto_draft_orders' ) );
+		self::add_action( 'wp_scheduled_auto_draft_delete', array( $this, 'delete_auto_draft_orders' ), 9 );
 
 		self::add_filter( 'woocommerce_feature_description_tip', array( $this, 'handle_feature_description_tip' ), 10, 3 );
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
When CPT is authoritative, adding new orders in the admin results in the underlying post being created as 'auto-draft' until explicitly saved. This keeps the orders list tidier and allows WP to automatically clear up those orders after a while during a scheduled deletion.

This PR adds the same functionality to HPOS authoritative.

Closes #36749.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Test that new orders are created as 'auto-draft' by default
1. Make HPOS authoritative: to do so, go to WooCommerce > Settings > Advanced > Features and make sure "Enable the high performance order storage feature." is checked off. Similarly, make sure "Use the WooCommerce orders tables" is selected in WooCommerce > Settings > Advanced > Custom data stores.
2. Go to WooCommerce > Orders.
3. Click "Add order" at the top and take note of the order ID in the details metabox. Do not save the order.
5. Return to WooCommerce > Orders.
6. Confirm that the new order is not listed when the "All" filter is active.
7. Confirm that there's an "Auto Draft" status in the top filter on this screen.
8. Click "Auto Draft" and make sure the order created in step 3 is listed here.
9. Repeat step 3 but now do save the order, after having chosen a status in the "Status" dropdown.
10. Confirm that the order is listed under its respective status in WooCommerce > Orders.

#### Test that auto-draft orders are deleted after a while
We're using WP-CLI for this as we need to "fake" an old order.

1. Make sure HPOS is authoritative as above.
2. Use `wp shell` in your test site's WP dir, to run the following set of commands/code:
   ```
   > $order = new \WC_Order();
   > $order->set_date_created( '2023-04-01 00:00:00' );
   > $order->set_status( 'auto-draft' );
   > $order->save();
   ```
   Take note of the order ID that gets printed when the last command is executed (it should look something like `=> int(8031)`.
3. Go to WooCommerce > Orders > Auto Draft.
4. Confirm the order with the ID from step 2 is listed.
5. Manually run the "wp_scheduled_auto_draft_delete" scheduled hook. To do so, you can invoke `do_action( 'wp_scheduled_auto_draft_delete' );` in a `wp shell`, or you can use a plugin such as [WP Crontrol](https://wordpress.org/plugins/wp-crontrol/).
   If using the latter, go to Tools > Cron Events. Choose "WordPress core events" and find the row with hook `wp_scheduled_auto_draft_delete`. Click "Run now".
6. Go to WooCommerce > Orders > Auto Draft and confirm that the order from step 2 is no longer listed.

<!-- End testing instructions -->