### PR TITLE
Fix invalid return callback ref warning

### DIFF
--- a/packages/js/experimental/changelog/fix-37654-invalid-return-callback-ref
+++ b/packages/js/experimental/changelog/fix-37654-invalid-return-callback-ref
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix invalid return callback ref warning

--- a/packages/js/experimental/src/inbox-note/test/inbox-note.tsx
+++ b/packages/js/experimental/src/inbox-note/test/inbox-note.tsx
@@ -23,6 +23,8 @@ jest.mock( 'react-visibility-sensor', () =>
 	} )
 );
 
+window.open = jest.fn();
+
 describe( 'InboxNoteCard', () => {
 	const note = {
 		id: 1,

--- a/packages/js/experimental/src/inbox-note/test/use-callback-on-link-click.tsx
+++ b/packages/js/experimental/src/inbox-note/test/use-callback-on-link-click.tsx
@@ -42,4 +42,17 @@ describe( 'useCallbackOnLinkClick hook', () => {
 		userEvent.click( getByText( 'Button' ) );
 		expect( callback ).not.toHaveBeenCalled();
 	} );
+
+	it( 'should remove listener on unmount', () => {
+		const listener = jest.fn();
+		const { getByText, unmount } = render(
+			<TestComp callback={ jest.fn() } />
+		);
+		const span = getByText( 'Some Text' );
+		jest.spyOn( span, 'removeEventListener' ).mockImplementation(
+			listener
+		);
+		unmount();
+		expect( listener ).toHaveBeenCalledTimes( 1 );
+	} );
 } );

--- a/packages/js/experimental/src/inbox-note/use-callback-on-link-click.ts
+++ b/packages/js/experimental/src/inbox-note/use-callback-on-link-click.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useCallback } from '@wordpress/element';
+import { useCallback, useEffect, useRef } from '@wordpress/element';
 
 export function useCallbackOnLinkClick( onClick: ( link: string ) => void ) {
 	const onNodeClick = useCallback(
@@ -20,17 +20,21 @@ export function useCallbackOnLinkClick( onClick: ( link: string ) => void ) {
 		[ onClick ]
 	);
 
-	return useCallback(
-		( node: HTMLElement ) => {
+	const nodeRef = useRef< HTMLElement | null >( null );
+
+	useEffect( () => {
+		const node = nodeRef.current;
+		if ( node ) {
+			node.addEventListener( 'click', onNodeClick );
+		}
+		return () => {
 			if ( node ) {
-				node.addEventListener( 'click', onNodeClick );
+				node.removeEventListener( 'click', onNodeClick );
 			}
-			return () => {
-				if ( node ) {
-					node.removeEventListener( 'click', onNodeClick );
-				}
-			};
-		},
-		[ onNodeClick ]
-	);
+		};
+	}, [ onNodeClick ] );
+
+	return useCallback( ( node: HTMLElement ) => {
+		nodeRef.current = node;
+	}, [] );
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #37654

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Testing tracks on inbox note body link clicks

1. Open developer console and enable tracks debugging with `localStorage.setItem( 'debug', 'wc-admin:tracks' );`
2. In PhpMyAdmin or adminer or any SQL tool you have, run the following SQL: <br/>
```
INSERT INTO `wp_wc_admin_notes` (`name`, `type`, `locale`, `title`, `content`, `content_data`, `status`, `source`, `date_created`, `date_reminder`, `is_snoozable`, `layout`, `image`, `is_deleted`, `is_read`, `icon`)
VALUES ('testing-note', 'info', 'en_US', 'Testing note', 'Hey there, click on this <a href=\"https://google.com\" target=\"_blank\">link</a>.', '{}', 'unactioned', 'local', now(), NULL, '0', '', NULL, '0', '0', 'info');
```
3. Go to WooCommerce > Home, observe that you have an inbox note with `Hey there, click on this link.`.
5. Click on `link` in the inbox note
6. Observe the developer console does not produce the warning as mentioned in the issue
7. Observe the developer console outputs `wcadmin_inbox_action_click {note_name: 'testing-note', note_title: 'Testing note', note_content_inner_link: 'https://google.com/'} `

#### Running test

1. Run `pnpm -w exec turbo run turbo:test --filter=@woocommerce/experimental -- packages/js/experimental/src/inbox-note/test/`
2. Observe the tests passes

<!-- End testing instructions -->