### PR TITLE
WC_Data: Add method `delete_matched_meta_data`

### DIFF
--- a/plugins/woocommerce/changelog/fix-37650-delete-meta-data
+++ b/plugins/woocommerce/changelog/fix-37650-delete-meta-data
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add method delete_matched_meta_data to WC_Data objects

--- a/plugins/woocommerce/changelog/fix-37650-delete-meta-data
+++ b/plugins/woocommerce/changelog/fix-37650-delete-meta-data
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-Add method delete_matched_meta_data to WC_Data objects
+Add method delete_meta_data_value to WC_Data objects

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
@@ -509,6 +509,26 @@ abstract class WC_Data {
 	/**
 	 * Delete meta data.
 	 *
+	 * @since 7.7.0
+	 * @param string $key   Meta key.
+	 * @param mixed  $value Meta value. Entries will only be removed that match the value.
+	 */
+	public function delete_matched_meta_data( $key, $value ) {
+		$this->maybe_read_meta_data();
+		$array_keys = array_keys( wp_list_pluck( $this->meta_data, 'key' ), $key, true );
+
+		if ( $array_keys ) {
+			foreach ( $array_keys as $array_key ) {
+				if ( $value === $this->meta_data[ $array_key ]->value ) {
+					$this->meta_data[ $array_key ]->value = null;
+				}
+			}
+		}
+	}
+
+	/**
+	 * Delete meta data.
+	 *
 	 * @since 2.6.0
 	 * @param int $mid Meta ID.
 	 */

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
@@ -507,7 +507,7 @@ abstract class WC_Data {
 	}
 
 	/**
-	 * Delete meta data.
+	 * Delete meta data with a matching value.
 	 *
 	 * @since 7.7.0
 	 * @param string $key   Meta key.

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
@@ -513,7 +513,7 @@ abstract class WC_Data {
 	 * @param string $key   Meta key.
 	 * @param mixed  $value Meta value. Entries will only be removed that match the value.
 	 */
-	public function delete_matched_meta_data( $key, $value ) {
+	public function delete_meta_data_value( $key, $value ) {
 		$this->maybe_read_meta_data();
 		$array_keys = array_keys( wp_list_pluck( $this->meta_data, 'key' ), $key, true );
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/crud/data.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/crud/data.php
@@ -325,6 +325,30 @@ class WC_Tests_CRUD_Data extends WC_Unit_Test_Case {
 		$this->assertEmpty( $object->get_meta( 'test_meta_key' ) );
 	}
 
+	/**
+	 * Test deleting meta selectively.
+	 */
+	public function test_delete_matched_meta_data() {
+		$object    = $this->create_test_post();
+		$object_id = $object->get_id();
+		add_metadata( 'post', $object_id, 'test_meta_key', 'val1' );
+		add_metadata( 'post', $object_id, 'test_meta_key', 'val2' );
+		add_metadata( 'post', $object_id, 'test_meta_key', array( 'foo', 'bar' ) );
+		$object = new WC_Mock_WC_Data( $object_id );
+
+		$this->assertCount( 3, $object->get_meta( 'test_meta_key', false ) );
+
+		$object->delete_matched_meta_data( 'test_meta_key', 'val1' );
+		$this->assertCount( 2, $object->get_meta( 'test_meta_key', false ) );
+
+		$object->delete_matched_meta_data( 'test_meta_key', array( 'bar', 'baz' ) );
+		$this->assertCount( 2, $object->get_meta( 'test_meta_key', false ) );
+
+		$object->delete_matched_meta_data( 'test_meta_key', array( 'foo', 'bar' ) );
+		$this->assertCount( 1, $object->get_meta( 'test_meta_key', false ) );
+
+		$this->assertEquals( 'val2', $object->get_meta( 'test_meta_key' ) );
+	}
 
 	/**
 	 * Test saving metadata (Actually making sure changes are written to DB).

--- a/plugins/woocommerce/tests/legacy/unit-tests/crud/data.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/crud/data.php
@@ -328,7 +328,7 @@ class WC_Tests_CRUD_Data extends WC_Unit_Test_Case {
 	/**
 	 * Test deleting meta selectively.
 	 */
-	public function test_delete_matched_meta_data() {
+	public function test_delete_meta_data_value() {
 		$object    = $this->create_test_post();
 		$object_id = $object->get_id();
 		add_metadata( 'post', $object_id, 'test_meta_key', 'val1' );
@@ -338,13 +338,13 @@ class WC_Tests_CRUD_Data extends WC_Unit_Test_Case {
 
 		$this->assertCount( 3, $object->get_meta( 'test_meta_key', false ) );
 
-		$object->delete_matched_meta_data( 'test_meta_key', 'val1' );
+		$object->delete_meta_data_value( 'test_meta_key', 'val1' );
 		$this->assertCount( 2, $object->get_meta( 'test_meta_key', false ) );
 
-		$object->delete_matched_meta_data( 'test_meta_key', array( 'bar', 'baz' ) );
+		$object->delete_meta_data_value( 'test_meta_key', array( 'bar', 'baz' ) );
 		$this->assertCount( 2, $object->get_meta( 'test_meta_key', false ) );
 
-		$object->delete_matched_meta_data( 'test_meta_key', array( 'foo', 'bar' ) );
+		$object->delete_meta_data_value( 'test_meta_key', array( 'foo', 'bar' ) );
 		$this->assertCount( 1, $object->get_meta( 'test_meta_key', false ) );
 
 		$this->assertEquals( 'val2', $object->get_meta( 'test_meta_key' ) );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Brings the CRUD layer's meta data handling closer to parity with WP by allowing for selectively deleting meta entries with a specific key only if they contain a specific value.

This functionality is introduced in a new method instead of updating the existing `delete_meta_data` method because of PHP 8+ compatibility concerns related to changing method signatures.

Fixes #37650

### How to test the changes in this Pull Request:

You can test this using wp-cli:

```
wp shell

wp> $order = new \WC_Order()
=> ... {returns entire order object}

wp> $order->add_meta_data( 'foo', 'bar' )
wp> $order->add_meta_data( 'foo', 'baz' )
wp> $order->get_meta( 'foo', false )
=> array(2) ... {shows two entries, one with 'bar' and one with 'baz'}

wp> $order->delete_matched_meta_data( 'foo', 'bar' )
wp> $order->get_meta( 'foo', false )
=> array(1) ... {only the 'baz' entry remains}

wp> $order->add_meta_data( 'foo', 'bar' )
wp> $order->delete_meta_data( 'foo' )
wp> $order->get_meta( 'foo', false )
=> array(0) ... {all 'foo' meta entries are deleted}
```