### PR TITLE
Monorepo Utils: Fix permisions

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"url": "https://github.com/woocommerce/woocommerce/issues"
 	},
 	"bin": {
-		"utils": "./tools/monorepo-utils/dist/index.js"
+		"utils": "./tools/monorepo-utils/bin/run"
 	},
 	"scripts": {
 		"build": "pnpm exec turbo run turbo:build",
@@ -30,7 +30,7 @@
 		"create-extension": "node ./tools/create-extension/index.js",
 		"cherry-pick": "node ./tools/cherry-pick/bin/run",
 		"sync-dependencies": "pnpm exec syncpack -- fix-mismatches",
-		"utils": "./tools/monorepo-utils/dist/index.js"
+		"utils": "./tools/monorepo-utils/bin/run"
 	},
 	"devDependencies": {
 		"@babel/preset-env": "^7.20.2",

--- a/tools/monorepo-utils/bin/run
+++ b/tools/monorepo-utils/bin/run
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
 
-const program = require( '../dist/index' );
+const { program } = require( '../dist/index' );
 
 program.parse( process.argv );

--- a/tools/monorepo-utils/bin/run
+++ b/tools/monorepo-utils/bin/run
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+const program = require( '../dist/index' );
+
+program.parse( process.argv );

--- a/tools/monorepo-utils/src/index.ts
+++ b/tools/monorepo-utils/src/index.ts
@@ -9,9 +9,7 @@ import { Command } from '@commander-js/extra-typings';
  */
 import CodeFreeze from './code-freeze/commands';
 
-const program = new Command()
+export const program = new Command()
 	.name( 'utils' )
 	.description( 'Monorepo utilities' )
 	.addCommand( CodeFreeze );
-
-program.parse( process.argv );

--- a/tools/monorepo-utils/src/index.ts
+++ b/tools/monorepo-utils/src/index.ts
@@ -1,4 +1,3 @@
-#! /usr/bin/env node
 /**
  * External dependencies
  */


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The resulting javascript file from Monorepo Utils build command lacked executable permissions. You can verify on `trunk`:

```
pnpm install --filter monorepo-utils
ls -l tools/monorepo-utils/dist/index.js # See no permissions
pnpm run utils code-freeze verify-day # errors out
```

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout this branch
2. Install script dependencies, `pnpm install --filter monorepo-utils`
3. Verify script runs without error, `pnpm run utils code-freeze verify-day`

<!-- End testing instructions -->