### PR TITLE
Remove install filter in the "Smoke test daily" workflow

### DIFF
--- a/.github/workflows/smoke-test-daily.yml
+++ b/.github/workflows/smoke-test-daily.yml
@@ -37,7 +37,6 @@ jobs:
             - name: Setup WooCommerce Monorepo
               uses: ./.github/actions/setup-woocommerce-monorepo
               with:
-                  install-filters: woocommerce
                   build: false
 
             - name: Download and install Chromium browser.
@@ -96,7 +95,6 @@ jobs:
             - name: Setup WooCommerce Monorepo
               uses: ./.github/actions/setup-woocommerce-monorepo
               with:
-                  install-filters: woocommerce
                   build: false
 
             - name: Download and install Chromium browser.
@@ -140,7 +138,6 @@ jobs:
             - name: Setup WooCommerce Monorepo
               uses: ./.github/actions/setup-woocommerce-monorepo
               with:
-                  install-filters: woocommerce
                   build: false
 
             - name: Download and install Chromium browser.

--- a/plugins/woocommerce/changelog/fix-install-filter-daily-tests
+++ b/plugins/woocommerce/changelog/fix-install-filter-daily-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove the "install-filters" input parameter in the "Smoke test daily" workflow.


### PR DESCRIPTION
Draft PR for now, awaiting confirmation from Atlas if the issue this PR addresses needs to be fixed on the "Smoke test workflow" file, or on any of the monorepo tools.

### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The "Smoke test daily" workflow started failing today (12 April) on the "Setup WooCommerce Monorepo" step with these [errors](https://github.com/woocommerce/woocommerce/actions/runs/4674298101/jobs/8279267669#step:3:412):

<img width="620" alt="Ofndp5nMwN" src="https://user-images.githubusercontent.com/4509348/231372028-f6274db5-6e22-436b-8c95-a3ff905bb360.png">

After investigating, these errors went away when the `install-filters` parameter was removed:
<img width="615" alt="V6Rk7lTq8P" src="https://user-images.githubusercontent.com/4509348/231372166-03abb505-1dfc-4b7e-976b-a4c4d3f308ea.png">

This PR therefore removes this `install-filters` parameter in the "Smoke test daily" workflow.

### How to test the changes in this Pull Request:

No need to test this PR. It's enough that the "Setup WooCommerce Monorepo" step from this [run](https://github.com/woocommerce/woocommerce/actions/runs/4674866947/jobs/8279436227) was successful, disregarding the failing tests.