### PR TITLE
Revert "Check min. WP and PHP versions before suggesting plugins"

### DIFF
--- a/plugins/woocommerce/changelog/update-16525-check-php-version-for-extensions
+++ b/plugins/woocommerce/changelog/update-16525-check-php-version-for-extensions
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Support min_php_version and min_wp_version for the free extensions feed

--- a/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
+++ b/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
@@ -79,18 +79,17 @@ class DefaultFreeExtensions {
 	public static function get_plugin( $slug ) {
 		$plugins = array(
 			'google-listings-and-ads'           => [
-				'min_php_version' => '7.4',
-				'name'            => __( 'Google Listings & Ads', 'woocommerce' ),
-				'description'     => sprintf(
+				'name'           => __( 'Google Listings & Ads', 'woocommerce' ),
+				'description'    => sprintf(
 					/* translators: 1: opening product link tag. 2: closing link tag */
 					__( 'Drive sales with %1$sGoogle Listings and Ads%2$s', 'woocommerce' ),
 					'<a href="https://woocommerce.com/products/google-listings-and-ads" target="_blank">',
 					'</a>'
 				),
-				'image_url'       => plugins_url( '/assets/images/onboarding/google.svg', WC_PLUGIN_FILE ),
-				'manage_url'      => 'admin.php?page=wc-admin&path=%2Fgoogle%2Fstart',
-				'is_built_by_wc'  => true,
-				'is_visible'      => [
+				'image_url'      => plugins_url( '/assets/images/onboarding/google.svg', WC_PLUGIN_FILE ),
+				'manage_url'     => 'admin.php?page=wc-admin&path=%2Fgoogle%2Fstart',
+				'is_built_by_wc' => true,
+				'is_visible'     => [
 					[
 						'type'    => 'not',
 						'operand' => [
@@ -126,12 +125,11 @@ class DefaultFreeExtensions {
 				'is_built_by_wc' => false,
 			],
 			'pinterest-for-woocommerce'         => [
-				'name'            => __( 'Pinterest for WooCommerce', 'woocommerce' ),
-				'description'     => __( 'Get your products in front of Pinners searching for ideas and things to buy.', 'woocommerce' ),
-				'image_url'       => plugins_url( '/assets/images/onboarding/pinterest.png', WC_PLUGIN_FILE ),
-				'manage_url'      => 'admin.php?page=wc-admin&path=%2Fpinterest%2Flanding',
-				'is_built_by_wc'  => true,
-				'min_php_version' => '7.3',
+				'name'           => __( 'Pinterest for WooCommerce', 'woocommerce' ),
+				'description'    => __( 'Get your products in front of Pinners searching for ideas and things to buy.', 'woocommerce' ),
+				'image_url'      => plugins_url( '/assets/images/onboarding/pinterest.png', WC_PLUGIN_FILE ),
+				'manage_url'     => 'admin.php?page=wc-admin&path=%2Fpinterest%2Flanding',
+				'is_built_by_wc' => true,
 			],
 			'pinterest-for-woocommerce:alt'     => [
 				'name'           => __( 'Pinterest for WooCommerce', 'woocommerce' ),
@@ -351,7 +349,6 @@ class DefaultFreeExtensions {
 					DefaultPaymentGateways::get_rules_for_cbd( false ),
 				],
 				'is_built_by_wc' => true,
-				'min_wp_version' => '5.9',
 			],
 			'woocommerce-services:shipping'     => [
 				'description'    => sprintf(
@@ -519,7 +516,6 @@ class DefaultFreeExtensions {
 					],
 				],
 				'is_built_by_wc' => false,
-				'min_wp_version' => '6.0',
 			],
 			'mailpoet'                          => [
 				'name'           => __( 'MailPoet', 'woocommerce' ),

--- a/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/EvaluateExtension.php
+++ b/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/EvaluateExtension.php
@@ -21,7 +21,6 @@ class EvaluateExtension {
 	 * @return object The evaluated extension.
 	 */
 	public static function evaluate( $extension ) {
-		global $wp_version;
 		$rule_evaluator = new RuleEvaluator();
 
 		if ( isset( $extension->is_visible ) ) {
@@ -29,14 +28,6 @@ class EvaluateExtension {
 			$extension->is_visible = $is_visible;
 		} else {
 			$extension->is_visible = true;
-		}
-
-		if ( isset( $extension->min_php_version ) ) {
-			$extension->is_visible = version_compare( PHP_VERSION, $extension->min_php_version, '>=' );
-		}
-
-		if ( isset( $extension->min_wp_version ) ) {
-			$extension->is_visible = version_compare( $wp_version, $extension->min_wp_version, '>=' );
 		}
 
 		$installed_plugins       = PluginsHelper::get_installed_plugin_slugs();


### PR DESCRIPTION
Reverts woocommerce/woocommerce#37611

I think #37611 breaks the obw e2e tests. https://github.com/woocommerce/woocommerce/actions/runs/4675436477/jobs/8280566075?pr=37672

https://github.com/woocommerce/woocommerce/pull/37611/files#diff-2f3016b95795e4ddd5bdda3de76f3b71604600347811b8e8c47bba6999ff9ba4R35

The rule evaluated result is mistakenly overwritten by PHP version check result.

## Test instructions

1. In the latest trunk
2. Go to obw and choose a **non-eligible** WCPay country
3. Go to `Onboarding wizard > Business Detail > Free features` tab (/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=business-details)
4. Observe that WCPay is shown
5. Check out this branch
6. Observe that WCPay is not shown.
