### PR TITLE
e2e: Reset variable product tour after running variable product tests

### DIFF
--- a/plugins/woocommerce/changelog/update-e2e-reset-variable-product-tour
+++ b/plugins/woocommerce/changelog/update-e2e-reset-variable-product-tour
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Reset variable product tour after running e2e tests.

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
@@ -1,6 +1,8 @@
 const { test, expect } = require( '@playwright/test' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 
+const productPageURL = 'wp-admin/post-new.php?post_type=product';
+
 const variableProductName = 'Variable Product with Three Variations';
 const manualVariableProduct = 'Manual Variable Product';
 const variationOnePrice = '9.99';
@@ -40,7 +42,7 @@ async function deleteProductsAddedByTests( baseURL ) {
 async function resetVariableProductTour( baseURL, browser ) {
 	// Go to the product page, so that the `window.wp.data` module is available
 	const page = await browser.newPage( { baseURL: baseURL } );
-	await page.goto( 'wp-admin/post-new.php?post_type=product' );
+	await page.goto( productPageURL );
 
 	// Get the current user's ID and user preferences
 	const { id: userId, woocommerce_meta } = await page.evaluate( () => {
@@ -74,7 +76,7 @@ test.describe( 'Add New Variable Product Page', () => {
 	} );
 
 	test( 'shows the variable product tour', async ( { page } ) => {
-		await page.goto( 'wp-admin/post-new.php?post_type=product' );
+		await page.goto( productPageURL );
 		await page.selectOption( '#product-type', 'variable', { force: true } );
 
 		// because of the way that the tour is dynamically positioned,
@@ -102,7 +104,7 @@ test.describe( 'Add New Variable Product Page', () => {
 	test( 'can create product, attributes and variations, edit variations and delete variations', async ( {
 		page,
 	} ) => {
-		await page.goto( 'wp-admin/post-new.php?post_type=product' );
+		await page.goto( productPageURL );
 		await page.fill( '#title', variableProductName );
 		await page.selectOption( '#product-type', 'variable', { force: true } );
 
@@ -238,7 +240,7 @@ test.describe( 'Add New Variable Product Page', () => {
 	test( 'can manually add a variation, manage stock levels, set variation defaults and remove a variation', async ( {
 		page,
 	} ) => {
-		await page.goto( 'wp-admin/post-new.php?post_type=product' );
+		await page.goto( productPageURL );
 		await page.fill( '#title', manualVariableProduct );
 		await page.selectOption( '#product-type', 'variable', { force: true } );
 		await page.click( 'a[href="#product_attributes"]' );


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR resets the user preference that controls whether the variable product tour is shown, after running the variable product tests.

By doing this, the variable product tests can be re-run without having to reset the e2e environment, which results in faster development/testing iteration.

To accomplish this, I use `page.evaluate` in Playwright to make calls to the `core` data store using the `window.wp.data` module. This approach was used because there is no WC REST API exposed to update these user preferences.

I put the reset functionality right in the `afterAll` for the variable product tests to keep the implementation close to the tests and in-line with the approach already taken to delete the products created during these tests.

I also did some minor refactoring of the deletion cleanup code to make things a bit more maintainable.

Closes #37586.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

With a working e2e environment...

1. Run `pnpm playwright test --config=tests/e2e-pw/playwright.config.js ./tests/e2e-pw/tests/merchant/create-variable-product.spec.js` and verify tests pass.
2. Re-run the above command (without doing any sort of manual resetting) and verify tests pass again.

<!-- End testing instructions -->