### PR TITLE
Create product shipping dimensions block

### DIFF
--- a/packages/js/product-editor/changelog/add-37408
+++ b/packages/js/product-editor/changelog/add-37408
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Create woocommerce/product-shipping-dimensions-fields block

--- a/packages/js/product-editor/src/blocks/shipping-dimensions/block.json
+++ b/packages/js/product-editor/src/blocks/shipping-dimensions/block.json
@@ -8,7 +8,7 @@
 	"keywords": [ "products", "shipping", "dimensions" ],
 	"textdomain": "default",
 	"attributes": {
-		"name": {
+		"__contentEditable": {
 			"type": "string",
 			"__experimentalRole": "content"
 		}

--- a/packages/js/product-editor/src/blocks/shipping-dimensions/block.json
+++ b/packages/js/product-editor/src/blocks/shipping-dimensions/block.json
@@ -1,0 +1,25 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "woocommerce/product-shipping-dimensions-fields",
+	"title": "Product shipping dimensions fields",
+	"category": "woocommerce",
+	"description": "The product shipping dimensions fields.",
+	"keywords": [ "products", "shipping", "dimensions" ],
+	"textdomain": "default",
+	"attributes": {
+		"name": {
+			"type": "string",
+			"__experimentalRole": "content"
+		}
+	},
+	"supports": {
+		"align": false,
+		"html": false,
+		"multiple": false,
+		"reusable": false,
+		"inserter": false,
+		"lock": false
+	},
+	"editorStyle": "file:./editor.css"
+}

--- a/packages/js/product-editor/src/blocks/shipping-dimensions/edit.tsx
+++ b/packages/js/product-editor/src/blocks/shipping-dimensions/edit.tsx
@@ -32,9 +32,7 @@ import {
 import { useValidation } from '../../hooks/use-validation';
 
 export function Edit( {}: BlockEditProps< ShippingDimensionsBlockAttributes > ) {
-	const blockProps = useBlockProps( {
-		className: 'wp-block-woocommerce-product-shipping-dimensions-fields',
-	} );
+	const blockProps = useBlockProps();
 
 	const [ dimensions, setDimensions ] =
 		useEntityProp< Partial< ProductDimensions > | null >(

--- a/packages/js/product-editor/src/blocks/shipping-dimensions/edit.tsx
+++ b/packages/js/product-editor/src/blocks/shipping-dimensions/edit.tsx
@@ -1,0 +1,247 @@
+/**
+ * External dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+import { BlockEditProps } from '@wordpress/blocks';
+import { OPTIONS_STORE_NAME, ProductDimensions } from '@woocommerce/data';
+import { useInstanceId } from '@wordpress/compose';
+import { useEntityProp } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+import {
+	createElement,
+	createInterpolateElement,
+	useState,
+} from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import classNames from 'classnames';
+import {
+	BaseControl,
+	// @ts-expect-error `__experimentalInputControl` does exist.
+	__experimentalInputControl as InputControl,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { ShippingDimensionsBlockAttributes } from './types';
+import { useProductHelper } from '../../hooks/use-product-helper';
+import {
+	HighlightSides,
+	ShippingDimensionsImage,
+} from '../../components/shipping-dimensions-image';
+import { useValidation } from '../../hooks/use-validation';
+
+export function Edit( {}: BlockEditProps< ShippingDimensionsBlockAttributes > ) {
+	const blockProps = useBlockProps( {
+		className: 'wp-block-woocommerce-product-shipping-dimensions-fields',
+	} );
+
+	const [ dimensions, setDimensions ] =
+		useEntityProp< Partial< ProductDimensions > | null >(
+			'postType',
+			'product',
+			'dimensions'
+		);
+
+	const [ weight, setWeight ] = useEntityProp< string | null >(
+		'postType',
+		'product',
+		'weight'
+	);
+
+	const [ highlightSide, setHighlightSide ] = useState< HighlightSides >();
+
+	const { formatNumber, parseNumber } = useProductHelper();
+
+	const { dimensionUnit, weightUnit } = useSelect( ( select ) => {
+		const { getOption } = select( OPTIONS_STORE_NAME );
+		return {
+			dimensionUnit: getOption( 'woocommerce_dimension_unit' ),
+			weightUnit: getOption( 'woocommerce_weight_unit' ),
+		};
+	}, [] );
+
+	function getDimensionsControlProps(
+		name: keyof ProductDimensions,
+		side: HighlightSides
+	) {
+		return {
+			name: `dimensions.${ name }`,
+			value: dimensions
+				? formatNumber( String( dimensions[ name ] ) )
+				: undefined,
+			onChange: ( value: string ) =>
+				setDimensions( {
+					...( dimensions ?? {} ),
+					[ name ]: parseNumber( value ),
+				} ),
+			onFocus: () => setHighlightSide( side ),
+			onBlur: () => setHighlightSide( undefined ),
+			suffix: dimensionUnit,
+		};
+	}
+
+	const dimensionsWidthProps = {
+		...getDimensionsControlProps( 'width', 'A' ),
+		id: useInstanceId(
+			BaseControl,
+			`product_shipping_dimensions_width`
+		) as string,
+	};
+	const dimensionsLengthProps = {
+		...getDimensionsControlProps( 'length', 'B' ),
+		id: useInstanceId(
+			BaseControl,
+			`product_shipping_dimensions_length`
+		) as string,
+	};
+	const dimensionsHeightProps = {
+		...getDimensionsControlProps( 'height', 'C' ),
+		id: useInstanceId(
+			BaseControl,
+			`product_shipping_dimensions_height`
+		) as string,
+	};
+	const weightProps = {
+		id: useInstanceId( BaseControl, `product_shipping_weight` ) as string,
+		name: 'weight',
+		value: formatNumber( String( weight ) ),
+		onChange: ( value: string ) => setWeight( parseNumber( value ) ),
+		suffix: weightUnit,
+	};
+
+	const isDimensionsWidthValid = useValidation(
+		'product/dimensions/width',
+		function validator() {
+			if ( dimensions?.width && +dimensions.width <= 0 ) {
+				return false;
+			}
+			return true;
+		}
+	);
+	const isDimensionsLengthValid = useValidation(
+		'product/dimensions/length',
+		function validator() {
+			if ( dimensions?.length && +dimensions.length <= 0 ) {
+				return false;
+			}
+			return true;
+		}
+	);
+	const isDimensionsHeightValid = useValidation(
+		'product/dimensions/height',
+		function validator() {
+			if ( dimensions?.height && +dimensions.height <= 0 ) {
+				return false;
+			}
+			return true;
+		}
+	);
+	const isWeightValid = useValidation(
+		'product/weight',
+		function validator() {
+			if ( weight && +weight <= 0 ) {
+				return false;
+			}
+			return true;
+		}
+	);
+
+	return (
+		<div { ...blockProps }>
+			<h4>{ __( 'Dimensions', 'woocommerce' ) }</h4>
+
+			<div className="wp-block-columns">
+				<div className="wp-block-column">
+					<BaseControl
+						id={ dimensionsWidthProps.id }
+						label={ createInterpolateElement(
+							__( 'Width <Side />', 'woocommerce' ),
+							{ Side: <span>A</span> }
+						) }
+						className={ classNames( {
+							'has-error': ! isDimensionsWidthValid,
+						} ) }
+						help={
+							isDimensionsWidthValid
+								? undefined
+								: __(
+										'Width must be higher than zero.',
+										'woocommerce'
+								  )
+						}
+					>
+						<InputControl { ...dimensionsWidthProps } />
+					</BaseControl>
+
+					<BaseControl
+						id={ dimensionsLengthProps.id }
+						label={ createInterpolateElement(
+							__( 'Length <Side />', 'woocommerce' ),
+							{ Side: <span>B</span> }
+						) }
+						className={ classNames( {
+							'has-error': ! isDimensionsLengthValid,
+						} ) }
+						help={
+							isDimensionsLengthValid
+								? undefined
+								: __(
+										'Length must be higher than zero.',
+										'woocommerce'
+								  )
+						}
+					>
+						<InputControl { ...dimensionsLengthProps } />
+					</BaseControl>
+
+					<BaseControl
+						id={ dimensionsHeightProps.id }
+						label={ createInterpolateElement(
+							__( 'Height <Side />', 'woocommerce' ),
+							{ Side: <span>C</span> }
+						) }
+						className={ classNames( {
+							'has-error': ! isDimensionsHeightValid,
+						} ) }
+						help={
+							isDimensionsHeightValid
+								? undefined
+								: __(
+										'Height must be higher than zero.',
+										'woocommerce'
+								  )
+						}
+					>
+						<InputControl { ...dimensionsHeightProps } />
+					</BaseControl>
+
+					<BaseControl
+						id={ weightProps.id }
+						label={ __( 'Weight', 'woocommerce' ) }
+						className={ classNames( {
+							'has-error': ! isWeightValid,
+						} ) }
+						help={
+							isWeightValid
+								? undefined
+								: __(
+										'Weight must be higher than zero.',
+										'woocommerce'
+								  )
+						}
+					>
+						<InputControl { ...weightProps } />
+					</BaseControl>
+				</div>
+
+				<div className="wp-block-column">
+					<ShippingDimensionsImage
+						highlight={ highlightSide }
+						className="wp-block-woocommerce-product-shipping-dimensions-fields__dimensions-image"
+					/>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/packages/js/product-editor/src/blocks/shipping-dimensions/editor.scss
+++ b/packages/js/product-editor/src/blocks/shipping-dimensions/editor.scss
@@ -1,0 +1,36 @@
+.wp-block-woocommerce-product-shipping-dimensions-fields {
+	.components-base-control {
+		margin-bottom: $gap;
+
+		&__field {
+			.components-base-control__label > span {
+				color: $gray-700;
+			}
+
+			.components-input-control__suffix {
+				flex-shrink: 0;
+				color: $gray-700;
+			}
+		}
+	}
+
+	.has-error {
+		.components-base-control {
+			margin-bottom: 0;
+
+			.components-input-control__backdrop {
+				border-color: $studio-red-50;
+			}
+		}
+
+		.components-base-control__help {
+			color: $studio-red-50;
+		}
+	}
+
+	&__dimensions-image {
+		width: 100%;
+		height: 100%;
+		padding: $gap;
+	}
+}

--- a/packages/js/product-editor/src/blocks/shipping-dimensions/index.ts
+++ b/packages/js/product-editor/src/blocks/shipping-dimensions/index.ts
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import { createElement } from '@wordpress/element';
+import { BlockConfiguration } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { initBlock } from '../../utils/init-blocks';
+import blockConfiguration from './block.json';
+import { Edit } from './edit';
+import { ShippingDimensionsBlockAttributes } from './types';
+
+const { name, ...metadata } =
+	blockConfiguration as BlockConfiguration< ShippingDimensionsBlockAttributes >;
+
+export { metadata, name };
+
+export const settings: Partial<
+	BlockConfiguration< ShippingDimensionsBlockAttributes >
+> = {
+	example: {},
+	edit: Edit,
+};
+
+export function init() {
+	return initBlock( { name, metadata, settings } );
+}

--- a/packages/js/product-editor/src/blocks/shipping-dimensions/types.ts
+++ b/packages/js/product-editor/src/blocks/shipping-dimensions/types.ts
@@ -1,0 +1,8 @@
+/**
+ * External dependencies
+ */
+import { BlockAttributes } from '@wordpress/blocks';
+
+export interface ShippingDimensionsBlockAttributes extends BlockAttributes {
+	name: string;
+}

--- a/packages/js/product-editor/src/blocks/shipping-dimensions/types.ts
+++ b/packages/js/product-editor/src/blocks/shipping-dimensions/types.ts
@@ -4,5 +4,5 @@
 import { BlockAttributes } from '@wordpress/blocks';
 
 export interface ShippingDimensionsBlockAttributes extends BlockAttributes {
-	name: string;
+	__contentEditable: string;
 }

--- a/packages/js/product-editor/src/components/editor/init-blocks.ts
+++ b/packages/js/product-editor/src/components/editor/init-blocks.ts
@@ -26,6 +26,7 @@ import { init as initSku } from '../../blocks/inventory-sku';
 import { init as initConditional } from '../../blocks/conditional';
 import { init as initLowStockQty } from '../../blocks/inventory-email';
 import { init as initCheckbox } from '../../blocks/checkbox';
+import { init as initShippingDimensions } from '../../blocks/shipping-dimensions';
 
 export const initBlocks = () => {
 	const coreBlocks = __experimentalGetCoreBlocks();
@@ -50,4 +51,5 @@ export const initBlocks = () => {
 	initConditional();
 	initLowStockQty();
 	initCheckbox();
+	initShippingDimensions();
 };

--- a/packages/js/product-editor/src/components/index.ts
+++ b/packages/js/product-editor/src/components/index.ts
@@ -22,3 +22,8 @@ export {
 export { ProductMVPCESFooter as __experimentalProductMVPCESFooter } from './product-mvp-ces-footer';
 export { ProductMVPFeedbackModal as __experimentalProductMVPFeedbackModal } from './product-mvp-feedback-modal';
 export { ProductMVPFeedbackModalContainer as __experimentalProductMVPFeedbackModalContainer } from './product-mvp-feedback-modal-container';
+export {
+	ShippingDimensionsImage as __experimentalShippingDimensionsImage,
+	type ShippingDimensionsImageProps,
+	type HighlightSides,
+} from './shipping-dimensions-image';

--- a/packages/js/product-editor/src/components/shipping-dimensions-image/index.ts
+++ b/packages/js/product-editor/src/components/shipping-dimensions-image/index.ts
@@ -1,1 +1,2 @@
 export * from './shipping-dimensions-image';
+export * from './types';

--- a/packages/js/product-editor/src/components/shipping-dimensions-image/shipping-dimensions-image.tsx
+++ b/packages/js/product-editor/src/components/shipping-dimensions-image/shipping-dimensions-image.tsx
@@ -1,6 +1,12 @@
-export type ShippingDimensionsImageProps = React.SVGProps< SVGSVGElement > & {
-	highlight?: 'A' | 'B' | 'C';
-};
+/**
+ * External dependencies
+ */
+import { createElement } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { ShippingDimensionsImageProps } from './types';
 
 export function ShippingDimensionsImage( {
 	highlight,

--- a/packages/js/product-editor/src/components/shipping-dimensions-image/types.ts
+++ b/packages/js/product-editor/src/components/shipping-dimensions-image/types.ts
@@ -1,0 +1,5 @@
+export type HighlightSides = 'A' | 'B' | 'C';
+
+export type ShippingDimensionsImageProps = React.SVGProps< SVGSVGElement > & {
+	highlight?: HighlightSides;
+};

--- a/packages/js/product-editor/src/style.scss
+++ b/packages/js/product-editor/src/style.scss
@@ -1,5 +1,6 @@
 @import 'blocks/schedule-sale/editor.scss';
 @import 'blocks/track-inventory/editor.scss';
+@import 'blocks/shipping-dimensions/editor.scss';
 @import 'components/editor/style.scss';
 @import 'components/product-section-layout/style.scss';
 @import 'components/edit-product-link-modal/style.scss';

--- a/plugins/woocommerce-admin/client/products/fills/shipping-section/shipping-section-fills.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/shipping-section/shipping-section-fills.tsx
@@ -7,6 +7,8 @@ import {
 	__experimentalWooProductFieldItem as WooProductFieldItem,
 	__experimentalProductSectionLayout as ProductSectionLayout,
 	__experimentalUseProductHelper as useProductHelper,
+	__experimentalShippingDimensionsImage as ShippingDimensionsImage,
+	ShippingDimensionsImageProps,
 } from '@woocommerce/product-editor';
 import { PartialProduct, OPTIONS_STORE_NAME } from '@woocommerce/data';
 import { useSelect } from '@wordpress/data';
@@ -27,10 +29,6 @@ import {
 	ShippingDimensionsPropsType,
 } from './index';
 import { PLUGIN_ID } from '../constants';
-import {
-	ShippingDimensionsImage,
-	ShippingDimensionsImageProps,
-} from '../../fields/shipping-dimensions-image';
 
 import './shipping-section.scss';
 

--- a/plugins/woocommerce-admin/client/products/fills/shipping-section/types.ts
+++ b/plugins/woocommerce-admin/client/products/fills/shipping-section/types.ts
@@ -2,11 +2,7 @@
  * External dependencies
  */
 import { PartialProduct } from '@woocommerce/data';
-
-/**
- * Internal dependencies
- */
-import { ShippingDimensionsImageProps } from '../../fields/shipping-dimensions-image';
+import { HighlightSides } from '@woocommerce/product-editor';
 
 export type ProductShippingSectionPropsType = {
 	product?: PartialProduct;
@@ -20,7 +16,5 @@ export type DimensionPropsType = {
 
 export type ShippingDimensionsPropsType = {
 	dimensionProps: DimensionPropsType;
-	setHighlightSide: (
-		side: ShippingDimensionsImageProps[ 'highlight' ]
-	) => void;
+	setHighlightSide: ( side: HighlightSides ) => void;
 };

--- a/plugins/woocommerce/changelog/add-37408
+++ b/plugins/woocommerce/changelog/add-37408
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Register woocommerce/product-shipping-dimensions-fields block

--- a/plugins/woocommerce/includes/class-wc-post-types.php
+++ b/plugins/woocommerce/includes/class-wc-post-types.php
@@ -694,7 +694,7 @@ class WC_Post_Types {
 									),
 									array(
 										array(
-											'core/image',
+											'woocommerce/product-shipping-dimensions-fields'
 										),
 									),
 								),

--- a/plugins/woocommerce/includes/class-wc-post-types.php
+++ b/plugins/woocommerce/includes/class-wc-post-types.php
@@ -694,7 +694,7 @@ class WC_Post_Types {
 									),
 									array(
 										array(
-											'woocommerce/product-shipping-dimensions-fields'
+											'woocommerce/product-shipping-dimensions-fields',
 										),
 									),
 								),


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/37408

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Got to `/wp-admin/tools.php?page=woocommerce-admin-test-helper`
2. Under Features tab make sure to enable `product-block-editor`
3. Then visit `/wp-admin/admin.php?page=wc-admin&path=/add-product`
4. Under the Shipping tab in the Fees & dimensions section the shipping dimensions fields should be shown
5. Dimensions block/field should be visible within the Shipping section rendered through the template
6. The box image should highlight correctly when the width, length, and height fields are in focus.

https://user-images.githubusercontent.com/13334210/231542494-2e947213-c102-45c1-813f-81a202618b52.mov

<!-- End testing instructions -->