### PR TITLE
Lock the product block editor template root

### DIFF
--- a/plugins/woocommerce/changelog/fix-37657
+++ b/plugins/woocommerce/changelog/fix-37657
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Lock the product block editor template root

--- a/plugins/woocommerce/includes/class-wc-post-types.php
+++ b/plugins/woocommerce/includes/class-wc-post-types.php
@@ -615,6 +615,7 @@ class WC_Post_Types {
 							),
 						),
 					),
+					'template_lock'       => 'all',
 				)
 			)
 		);


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Hides the block appender at the root of the editor by locking the template in the editor settings.

#### Before
<img width="762" alt="Screen Shot 2023-04-12 at 11 56 37 AM" src="https://user-images.githubusercontent.com/10561050/231560662-de7e429a-5ca6-44bc-8877-9355870a1b3e.png">


#### After

<img width="736" alt="Screen Shot 2023-04-12 at 12 06 13 PM" src="https://user-images.githubusercontent.com/10561050/231560648-8eda9519-f6be-4dee-a0df-837245530da6.png">


Closes #37657 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Got to `/wp-admin/tools.php?page=woocommerce-admin-test-helper`
2. Under the Features tab make sure to enable `product-block-editor`
3. Visit `/wp-admin/admin.php?page=wc-admin&path=/add-product`
4. Check that no appender "+" is added anywhere before or after clicking on various blocks/tabs

<!-- End testing instructions -->