### PR TITLE
Monorepo Utils: Move postinstall build to local package.json

### DIFF
--- a/.github/workflows/pr-highlight-changes.yml
+++ b/.github/workflows/pr-highlight-changes.yml
@@ -22,7 +22,7 @@ jobs:
               run: |
                   npm install -g pnpm@7
                   npm -g i @wordpress/env@5.1.0
-                  pnpm install --filter monorepo-utils --filter code-analyzer --filter cli-core
+                  pnpm install --filter code-analyzer --filter cli-core
             - name: Run analyzer
               id: run
               working-directory: tools/code-analyzer

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"test": "pnpm exec turbo run turbo:test",
 		"clean": "pnpm store prune && git clean -fx **/node_modules && pnpm i",
 		"preinstall": "npx only-allow pnpm",
-		"postinstall": "pnpm git:update-hooks && pnpm run --filter='./tools/monorepo-utils' build",
+		"postinstall": "pnpm git:update-hooks",
 		"git:update-hooks": "rm -r .git/hooks && mkdir -p .git/hooks && husky install",
 		"create-extension": "node ./tools/create-extension/index.js",
 		"cherry-pick": "node ./tools/cherry-pick/bin/run",

--- a/tools/monorepo-utils/bin/run
+++ b/tools/monorepo-utils/bin/run
@@ -1,5 +1,25 @@
 #!/usr/bin/env node
 
+const { existsSync } = require( 'fs' );
+const chalk = require( 'chalk' );
+const path = require( 'path' );
+
+const nodeModulesDirectory = path.join( __dirname, '../', 'node_modules' );
+
+if ( ! existsSync( nodeModulesDirectory ) ) {
+	console.log(
+		chalk.red(
+			'The @woocommerce/monorepo-utils must be built before running the CLI.'
+		)
+	);
+	console.log(
+		chalk.yellow(
+			'run `pnpm run build` from the root of the monorepo-utils package. or `pnpm install --filter monorepo-utils` from project root.'
+		)
+	);
+	process.exit( 1 );
+}
+
 const { program } = require( '../dist/index' );
 
 program.parse( process.argv );

--- a/tools/monorepo-utils/package.json
+++ b/tools/monorepo-utils/package.json
@@ -25,6 +25,7 @@
 		"build": "tsc",
 		"start": "tsc --watch",
 		"lint": "eslint . --ext .ts",
+		"postinstall": "pnpm run build",
 		"test": "jest"
 	},
 	"engines": {


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The Monorepo Utils package was being built on a postinstall script at the root level. This caused problems when developers or processes wished to only install a portion of the monorepo, such as `woocommerce`. The postinstall script would attempt to build the Monorepo Utils package despite its dependencies not having been installed.

This PR moves the postinstall script to the Monorepo Utils package itself. This poses its own problem because we make the script available at the root level so I've added a check when running the command to see if install has occcured.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Confirm the error exists on `trunk`

1. Remove `tools/monorepo-utils/node_modules` and `tools/monorepo-utils/dist` folder to simulate that package not having been installed.
2. Install an unrelated portion of the monorepo and watch the build fail, `pnpm install --filter package-release`

#### Confirm the fix

1. Switch to this branch and try again to install an unrelated portion of the monorepo, `pnpm install --filter package-release`. This should install without error.
2. Try to run the monorepo utils without having been built, there should be an informative error message.
3. Now run `pnpm install` to install all the things, including Monorepo Utils and firing off its `build` step as well.

<!-- End testing instructions -->