### PR TITLE
Delete shipping zone count cache in Shipping Task

### DIFF
--- a/plugins/woocommerce/changelog/update-37690-shipping-task-is-not-marked-as-completed
+++ b/plugins/woocommerce/changelog/update-37690-shipping-task-is-not-marked-as-completed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Delete shipping zone count transient on woocommerce_shipping_zone_method_added and woocommerce_after_shipping_zone_object_save

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Shipping.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Shipping.php
@@ -26,6 +26,8 @@ class Shipping extends Task {
 		// when a new zone is added or an existing one has been changed.
 		add_action( 'wp_ajax_woocommerce_shipping_zones_save_changes', array( __CLASS__, 'delete_zone_count_transient' ), 9 );
 		add_action( 'wp_ajax_woocommerce_shipping_zone_methods_save_changes', array( __CLASS__, 'delete_zone_count_transient' ), 9 );
+		add_action( 'woocommerce_shipping_zone_method_added', array( __CLASS__, 'delete_zone_count_transient' ), 9 );
+		add_action( 'woocommerce_after_shipping_zone_object_save', array( __CLASS__, 'delete_zone_count_transient' ), 9 );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #37690  .

This PR deletes shipping zone count transient on `woocommerce_shipping_zone_method_added` and `woocommerce_after_shipping_zone_object_save` action to fix the bug described in the issue.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Checkout this branch
2. Start the OBW and choose `United Kindom` as your store country
3. Complete the OBW.
4. Go to `WooCommerce -> Home`
5. Click `Add shipping cost` task.
6. Complete the task
7. You're automatically redirected to `WooCommerce -> Home`
8. Confirm `Add shipping cost` is either marked as completed or not shown.

<!-- End testing instructions -->