### PR TITLE
Check min. WP and PHP versions before suggesting plugins

### DIFF
--- a/plugins/woocommerce/changelog/update-16525-check-php-version-for-extensions
+++ b/plugins/woocommerce/changelog/update-16525-check-php-version-for-extensions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Support min_php_version and min_wp_version for the free extensions feed

--- a/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
+++ b/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
@@ -21,50 +21,50 @@ class DefaultFreeExtensions {
 	 * @return array Default specs.
 	 */
 	public static function get_all() {
-		$bundles = [
-			[
+		$bundles = array(
+			array(
 				'key'     => 'obw/basics',
 				'title'   => __( 'Get the basics', 'woocommerce' ),
-				'plugins' => [
+				'plugins' => array(
 					self::get_plugin( 'woocommerce-payments' ),
 					self::get_plugin( 'woocommerce-services:shipping' ),
 					self::get_plugin( 'woocommerce-services:tax' ),
 					self::get_plugin( 'jetpack' ),
-				],
-			],
-			[
+				),
+			),
+			array(
 				'key'     => 'obw/grow',
 				'title'   => __( 'Grow your store', 'woocommerce' ),
-				'plugins' => [
+				'plugins' => array(
 					self::get_plugin( 'mailpoet' ),
 					self::get_plugin( 'codistoconnect' ),
 					self::get_plugin( 'google-listings-and-ads' ),
 					self::get_plugin( 'pinterest-for-woocommerce' ),
 					self::get_plugin( 'facebook-for-woocommerce' ),
 					self::get_plugin( 'tiktok-for-business:alt' ),
-				],
-			],
-			[
+				),
+			),
+			array(
 				'key'     => 'task-list/reach',
 				'title'   => __( 'Reach out to customers', 'woocommerce' ),
-				'plugins' => [
+				'plugins' => array(
 					self::get_plugin( 'mailpoet:alt' ),
 					self::get_plugin( 'mailchimp-for-woocommerce' ),
 					self::get_plugin( 'creative-mail-by-constant-contact' ),
-				],
-			],
-			[
+				),
+			),
+			array(
 				'key'     => 'task-list/grow',
 				'title'   => __( 'Grow your store', 'woocommerce' ),
-				'plugins' => [
+				'plugins' => array(
 					self::get_plugin( 'google-listings-and-ads:alt' ),
 					self::get_plugin( 'tiktok-for-business' ),
 					self::get_plugin( 'pinterest-for-woocommerce:alt' ),
 					self::get_plugin( 'facebook-for-woocommerce:alt' ),
 					self::get_plugin( 'codistoconnect:alt' ),
-				],
-			],
-		];
+				),
+			),
+		);
 
 		$bundles = wp_json_encode( $bundles );
 		return json_decode( $bundles );
@@ -78,88 +78,90 @@ class DefaultFreeExtensions {
 	 */
 	public static function get_plugin( $slug ) {
 		$plugins = array(
-			'google-listings-and-ads'           => [
-				'name'           => __( 'Google Listings & Ads', 'woocommerce' ),
-				'description'    => sprintf(
+			'google-listings-and-ads'           => array(
+				'name'            => __( 'Google Listings & Ads', 'woocommerce' ),
+				'description'     => sprintf(
 					/* translators: 1: opening product link tag. 2: closing link tag */
 					__( 'Drive sales with %1$sGoogle Listings and Ads%2$s', 'woocommerce' ),
 					'<a href="https://woocommerce.com/products/google-listings-and-ads" target="_blank">',
 					'</a>'
 				),
-				'image_url'      => plugins_url( '/assets/images/onboarding/google.svg', WC_PLUGIN_FILE ),
-				'manage_url'     => 'admin.php?page=wc-admin&path=%2Fgoogle%2Fstart',
-				'is_built_by_wc' => true,
-				'is_visible'     => [
-					[
+				'image_url'       => plugins_url( '/assets/images/onboarding/google.svg', WC_PLUGIN_FILE ),
+				'manage_url'      => 'admin.php?page=wc-admin&path=%2Fgoogle%2Fstart',
+				'is_built_by_wc'  => true,
+				'min_php_version' => '7.4',
+				'is_visible'      => array(
+					array(
 						'type'    => 'not',
-						'operand' => [
-							[
+						'operand' => array(
+							array(
 								'type'    => 'plugins_activated',
-								'plugins' => [ 'google-listings-and-ads' ],
-							],
-						],
-					],
-				],
-			],
-			'google-listings-and-ads:alt'       => [
+								'plugins' => array( 'google-listings-and-ads' ),
+							),
+						),
+					),
+				),
+			),
+			'google-listings-and-ads:alt'       => array(
 				'name'           => __( 'Google Listings & Ads', 'woocommerce' ),
 				'description'    => __( 'Reach more shoppers and drive sales for your store. Integrate with Google to list your products for free and launch paid ad campaigns.', 'woocommerce' ),
 				'image_url'      => plugins_url( '/assets/images/onboarding/google.svg', WC_PLUGIN_FILE ),
 				'manage_url'     => 'admin.php?page=wc-admin&path=%2Fgoogle%2Fstart',
 				'is_built_by_wc' => true,
-			],
-			'facebook-for-woocommerce'          => [
+			),
+			'facebook-for-woocommerce'          => array(
 				'name'           => __( 'Facebook for WooCommerce', 'woocommerce' ),
 				'description'    => __( 'List products and create ads on Facebook and Instagram with <a href="https://woocommerce.com/products/facebook/">Facebook for WooCommerce</a>', 'woocommerce' ),
 				'image_url'      => plugins_url( '/assets/images/onboarding/facebook.png', WC_PLUGIN_FILE ),
 				'manage_url'     => 'admin.php?page=wc-facebook',
 				'is_visible'     => false,
 				'is_built_by_wc' => false,
-			],
-			'facebook-for-woocommerce:alt'      => [
+			),
+			'facebook-for-woocommerce:alt'      => array(
 				'name'           => __( 'Facebook for WooCommerce', 'woocommerce' ),
 				'description'    => __( 'List products and create ads on Facebook and Instagram.', 'woocommerce' ),
 				'image_url'      => plugins_url( '/assets/images/onboarding/facebook.png', WC_PLUGIN_FILE ),
 				'manage_url'     => 'admin.php?page=wc-facebook',
 				'is_visible'     => false,
 				'is_built_by_wc' => false,
-			],
-			'pinterest-for-woocommerce'         => [
-				'name'           => __( 'Pinterest for WooCommerce', 'woocommerce' ),
-				'description'    => __( 'Get your products in front of Pinners searching for ideas and things to buy.', 'woocommerce' ),
-				'image_url'      => plugins_url( '/assets/images/onboarding/pinterest.png', WC_PLUGIN_FILE ),
-				'manage_url'     => 'admin.php?page=wc-admin&path=%2Fpinterest%2Flanding',
-				'is_built_by_wc' => true,
-			],
-			'pinterest-for-woocommerce:alt'     => [
+			),
+			'pinterest-for-woocommerce'         => array(
+				'name'            => __( 'Pinterest for WooCommerce', 'woocommerce' ),
+				'description'     => __( 'Get your products in front of Pinners searching for ideas and things to buy.', 'woocommerce' ),
+				'image_url'       => plugins_url( '/assets/images/onboarding/pinterest.png', WC_PLUGIN_FILE ),
+				'manage_url'      => 'admin.php?page=wc-admin&path=%2Fpinterest%2Flanding',
+				'min_php_version' => '7.3',
+				'is_built_by_wc'  => true,
+			),
+			'pinterest-for-woocommerce:alt'     => array(
 				'name'           => __( 'Pinterest for WooCommerce', 'woocommerce' ),
 				'description'    => __( 'Get your products in front of Pinterest users searching for ideas and things to buy. Get started with Pinterest and make your entire product catalog browsable.', 'woocommerce' ),
 				'image_url'      => plugins_url( '/assets/images/onboarding/pinterest.png', WC_PLUGIN_FILE ),
 				'manage_url'     => 'admin.php?page=wc-admin&path=%2Fpinterest%2Flanding',
 				'is_built_by_wc' => true,
-			],
-			'mailpoet'                          => [
+			),
+			'mailpoet'                          => array(
 				'name'           => __( 'MailPoet', 'woocommerce' ),
 				'description'    => __( 'Create and send purchase follow-up emails, newsletters, and promotional campaigns straight from your dashboard.', 'woocommerce' ),
 				'image_url'      => plugins_url( '/assets/images/onboarding/mailpoet.png', WC_PLUGIN_FILE ),
 				'manage_url'     => 'admin.php?page=mailpoet-newsletters',
 				'is_built_by_wc' => true,
-			],
-			'mailchimp-for-woocommerce'         => [
+			),
+			'mailchimp-for-woocommerce'         => array(
 				'name'           => __( 'Mailchimp', 'woocommerce' ),
 				'description'    => __( 'Send targeted campaigns, recover abandoned carts and much more with Mailchimp.', 'woocommerce' ),
 				'image_url'      => plugins_url( '/assets/images/onboarding/mailchimp-for-woocommerce.png', WC_PLUGIN_FILE ),
 				'manage_url'     => 'admin.php?page=mailchimp-woocommerce',
 				'is_built_by_wc' => false,
-			],
-			'creative-mail-by-constant-contact' => [
+			),
+			'creative-mail-by-constant-contact' => array(
 				'name'           => __( 'Creative Mail for WooCommerce', 'woocommerce' ),
 				'description'    => __( 'Create on-brand store campaigns, fast email promotions and customer retargeting with Creative Mail.', 'woocommerce' ),
 				'image_url'      => plugins_url( '/assets/images/onboarding/creative-mail-by-constant-contact.png', WC_PLUGIN_FILE ),
 				'manage_url'     => 'admin.php?page=creativemail',
 				'is_built_by_wc' => false,
-			],
-			'codistoconnect'                    => [
+			),
+			'codistoconnect'                    => array(
 				'name'           => __( 'Codisto for WooCommerce', 'woocommerce' ),
 				'description'    => sprintf(
 					/* translators: 1: opening product link tag. 2: closing link tag */
@@ -170,354 +172,354 @@ class DefaultFreeExtensions {
 				'image_url'      => plugins_url( '/assets/images/onboarding/codistoconnect.png', WC_PLUGIN_FILE ),
 				'manage_url'     => 'admin.php?page=codisto-settings',
 				'is_built_by_wc' => true,
-			],
-			'codistoconnect:alt'                => [
+			),
+			'codistoconnect:alt'                => array(
 				'name'           => __( 'Codisto for WooCommerce', 'woocommerce' ),
 				'description'    => __( 'Sell on Amazon, eBay, Walmart and more directly from WooCommerce.', 'woocommerce' ),
 				'image_url'      => plugins_url( '/assets/images/onboarding/codistoconnect.png', WC_PLUGIN_FILE ),
 				'manage_url'     => 'admin.php?page=codisto-settings',
 				'is_built_by_wc' => true,
-			],
-			'woocommerce-payments'              => [
+			),
+			'woocommerce-payments'              => array(
 				'description'    => sprintf(
 					/* translators: 1: opening product link tag. 2: closing link tag */
 					__( 'Accept credit cards and other popular payment methods with %1$sWooCommerce Payments%2$s', 'woocommerce' ),
 					'<a href="https://woocommerce.com/products/woocommerce-payments" target="_blank">',
 					'</a>'
 				),
-				'is_visible'     => [
-					[
+				'is_visible'     => array(
+					array(
 						'type'     => 'or',
-						'operands' => [
-							[
+						'operands' => array(
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'US',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'PR',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'AU',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'CA',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'DE',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'ES',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'FR',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'GB',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'IE',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'IT',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'NZ',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'AT',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'BE',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'NL',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'PL',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'PT',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'CH',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'HK',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'SG',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'CY',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'DK',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'EE',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'FI',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'GR',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'LU',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'LT',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'LV',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'NO',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'MT',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'SI',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'SK',
 								'operation' => '=',
-							],
-						],
-					],
+							),
+						),
+					),
 					DefaultPaymentGateways::get_rules_for_cbd( false ),
-				],
+				),
 				'is_built_by_wc' => true,
-			],
-			'woocommerce-services:shipping'     => [
+			),
+			'woocommerce-services:shipping'     => array(
 				'description'    => sprintf(
 				/* translators: 1: opening product link tag. 2: closing link tag */
 					__( 'Print shipping labels with %1$sWooCommerce Shipping%2$s', 'woocommerce' ),
 					'<a href="https://woocommerce.com/products/shipping" target="_blank">',
 					'</a>'
 				),
-				'is_visible'     => [
-					[
+				'is_visible'     => array(
+					array(
 						'type'      => 'base_location_country',
 						'value'     => 'US',
 						'operation' => '=',
-					],
-					[
+					),
+					array(
 						'type'    => 'not',
-						'operand' => [
-							[
+						'operand' => array(
+							array(
 								'type'    => 'plugins_activated',
-								'plugins' => [ 'woocommerce-services' ],
-							],
-						],
-					],
-					[
+								'plugins' => array( 'woocommerce-services' ),
+							),
+						),
+					),
+					array(
 						'type'     => 'or',
-						'operands' => [
-							[
-								[
+						'operands' => array(
+							array(
+								array(
 									'type'         => 'option',
-									'transformers' => [
-										[
+									'transformers' => array(
+										array(
 											'use'       => 'dot_notation',
-											'arguments' => [
+											'arguments' => array(
 												'path' => 'product_types',
-											],
-										],
-										[
+											),
+										),
+										array(
 											'use' => 'count',
-										],
-									],
+										),
+									),
 									'option_name'  => 'woocommerce_onboarding_profile',
 									'value'        => 1,
 									'default'      => array(),
 									'operation'    => '!=',
-								],
-							],
-							[
-								[
+								),
+							),
+							array(
+								array(
 									'type'         => 'option',
-									'transformers' => [
-										[
+									'transformers' => array(
+										array(
 											'use'       => 'dot_notation',
-											'arguments' => [
+											'arguments' => array(
 												'path' => 'product_types.0',
-											],
-										],
-									],
+											),
+										),
+									),
 									'option_name'  => 'woocommerce_onboarding_profile',
 									'value'        => 'downloads',
 									'default'      => '',
 									'operation'    => '!=',
-								],
-							],
-						],
-					],
-				],
+								),
+							),
+						),
+					),
+				),
 				'is_built_by_wc' => true,
-			],
-			'woocommerce-services:tax'          => [
+			),
+			'woocommerce-services:tax'          => array(
 				'description'    => sprintf(
 					/* translators: 1: opening product link tag. 2: closing link tag */
 					__( 'Get automated sales tax with %1$sWooCommerce Tax%2$s', 'woocommerce' ),
 					'<a href="https://woocommerce.com/products/tax" target="_blank">',
 					'</a>'
 				),
-				'is_visible'     => [
-					[
+				'is_visible'     => array(
+					array(
 						'type'     => 'or',
-						'operands' => [
-							[
+						'operands' => array(
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'US',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'FR',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'GB',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'DE',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'CA',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'AU',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'GR',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'BE',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'PT',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'DK',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'SE',
 								'operation' => '=',
-							],
-						],
-					],
-					[
+							),
+						),
+					),
+					array(
 						'type'    => 'not',
-						'operand' => [
-							[
+						'operand' => array(
+							array(
 								'type'    => 'plugins_activated',
-								'plugins' => [ 'woocommerce-services' ],
-							],
-						],
-					],
-				],
+								'plugins' => array( 'woocommerce-services' ),
+							),
+						),
+					),
+				),
 				'is_built_by_wc' => true,
-			],
-			'jetpack'                           => [
+			),
+			'jetpack'                           => array(
 				'description'    => sprintf(
 					/* translators: 1: opening product link tag. 2: closing link tag */
 					__( 'Enhance speed and security with %1$sJetpack%2$s', 'woocommerce' ),
 					'<a href="https://woocommerce.com/products/jetpack" target="_blank">',
 					'</a>'
 				),
-				'is_visible'     => [
-					[
+				'is_visible'     => array(
+					array(
 						'type'    => 'not',
-						'operand' => [
-							[
+						'operand' => array(
+							array(
 								'type'    => 'plugins_activated',
-								'plugins' => [ 'jetpack' ],
-							],
-						],
-					],
-				],
+								'plugins' => array( 'jetpack' ),
+							),
+						),
+					),
+				),
 				'is_built_by_wc' => false,
-			],
-			'mailpoet'                          => [
+			),
+			'mailpoet'                          => array(
 				'name'           => __( 'MailPoet', 'woocommerce' ),
 				'description'    => sprintf(
 					/* translators: 1: opening product link tag. 2: closing link tag */
@@ -526,242 +528,242 @@ class DefaultFreeExtensions {
 					'</a>'
 				),
 				'manage_url'     => 'admin.php?page=mailpoet-newsletters',
-				'is_visible'     => [
-					[
+				'is_visible'     => array(
+					array(
 						'type'    => 'not',
-						'operand' => [
-							[
+						'operand' => array(
+							array(
 								'type'    => 'plugins_activated',
-								'plugins' => [ 'mailpoet' ],
-							],
-						],
-					],
-				],
+								'plugins' => array( 'mailpoet' ),
+							),
+						),
+					),
+				),
 				'is_built_by_wc' => true,
-			],
-			'mailpoet:alt'                      => [
+			),
+			'mailpoet:alt'                      => array(
 				'name'           => __( 'MailPoet', 'woocommerce' ),
 				'description'    => __( 'Create and send purchase follow-up emails, newsletters, and promotional campaigns straight from your dashboard.', 'woocommerce' ),
 				'image_url'      => plugins_url( '/assets/images/onboarding/mailpoet.png', WC_PLUGIN_FILE ),
 				'manage_url'     => 'admin.php?page=mailpoet-newsletters',
 				'is_built_by_wc' => true,
-			],
-			'tiktok-for-business'               => [
+			),
+			'tiktok-for-business'               => array(
 				'name'           => __( 'TikTok for WooCommerce', 'woocommerce' ),
 				'image_url'      => plugins_url( '/assets/images/onboarding/tiktok.svg', WC_PLUGIN_FILE ),
 				'description'    =>
 					__( 'Grow your online sales by promoting your products on TikTok to over one billion monthly active users around the world.', 'woocommerce' ),
 				'manage_url'     => 'admin.php?page=tiktok',
-				'is_visible'     => [
-					[
+				'is_visible'     => array(
+					array(
 						'type'     => 'or',
-						'operands' => [
-							[
+						'operands' => array(
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'US',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'CA',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'MX',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'AT',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'BE',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'CZ',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'DK',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'FI',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'FR',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'DE',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'GR',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'HU',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'IE',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'IT',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'NL',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'PL',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'PT',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'RO',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'ES',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'SE',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'GB',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'CH',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'NO',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'AU',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'NZ',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'SG',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'MY',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'PH',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'ID',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'VN',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'TH',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'KR',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'IL',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'AE',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'RU',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'UA',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'TR',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'SA',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'BR',
 								'operation' => '=',
-							],
-							[
+							),
+							array(
 								'type'      => 'base_location_country',
 								'value'     => 'JP',
 								'operation' => '=',
-							],
-						],
-					],
-				],
+							),
+						),
+					),
+				),
 				'is_built_by_wc' => false,
-			],
-			'tiktok-for-business:alt'           => [
+			),
+			'tiktok-for-business:alt'           => array(
 				'name'           => __( 'TikTok for WooCommerce', 'woocommerce' ),
 				'image_url'      => plugins_url( '/assets/images/onboarding/tiktok.svg', WC_PLUGIN_FILE ),
 				'description'    => sprintf(
@@ -773,7 +775,7 @@ class DefaultFreeExtensions {
 				'manage_url'     => 'admin.php?page=tiktok',
 				'is_built_by_wc' => false,
 				'is_visible'     => false,
-			],
+			),
 		);
 
 		$plugin        = $plugins[ $slug ];

--- a/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
+++ b/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
@@ -21,50 +21,50 @@ class DefaultFreeExtensions {
 	 * @return array Default specs.
 	 */
 	public static function get_all() {
-		$bundles = array(
-			array(
+		$bundles = [
+			[
 				'key'     => 'obw/basics',
 				'title'   => __( 'Get the basics', 'woocommerce' ),
-				'plugins' => array(
+				'plugins' => [
 					self::get_plugin( 'woocommerce-payments' ),
 					self::get_plugin( 'woocommerce-services:shipping' ),
 					self::get_plugin( 'woocommerce-services:tax' ),
 					self::get_plugin( 'jetpack' ),
-				),
-			),
-			array(
+				],
+			],
+			[
 				'key'     => 'obw/grow',
 				'title'   => __( 'Grow your store', 'woocommerce' ),
-				'plugins' => array(
+				'plugins' => [
 					self::get_plugin( 'mailpoet' ),
 					self::get_plugin( 'codistoconnect' ),
 					self::get_plugin( 'google-listings-and-ads' ),
 					self::get_plugin( 'pinterest-for-woocommerce' ),
 					self::get_plugin( 'facebook-for-woocommerce' ),
 					self::get_plugin( 'tiktok-for-business:alt' ),
-				),
-			),
-			array(
+				],
+			],
+			[
 				'key'     => 'task-list/reach',
 				'title'   => __( 'Reach out to customers', 'woocommerce' ),
-				'plugins' => array(
+				'plugins' => [
 					self::get_plugin( 'mailpoet:alt' ),
 					self::get_plugin( 'mailchimp-for-woocommerce' ),
 					self::get_plugin( 'creative-mail-by-constant-contact' ),
-				),
-			),
-			array(
+				],
+			],
+			[
 				'key'     => 'task-list/grow',
 				'title'   => __( 'Grow your store', 'woocommerce' ),
-				'plugins' => array(
+				'plugins' => [
 					self::get_plugin( 'google-listings-and-ads:alt' ),
 					self::get_plugin( 'tiktok-for-business' ),
 					self::get_plugin( 'pinterest-for-woocommerce:alt' ),
 					self::get_plugin( 'facebook-for-woocommerce:alt' ),
 					self::get_plugin( 'codistoconnect:alt' ),
-				),
-			),
-		);
+				],
+			],
+		];
 
 		$bundles = wp_json_encode( $bundles );
 		return json_decode( $bundles );
@@ -78,7 +78,8 @@ class DefaultFreeExtensions {
 	 */
 	public static function get_plugin( $slug ) {
 		$plugins = array(
-			'google-listings-and-ads'           => array(
+			'google-listings-and-ads'           => [
+				'min_php_version' => '7.4',
 				'name'            => __( 'Google Listings & Ads', 'woocommerce' ),
 				'description'     => sprintf(
 					/* translators: 1: opening product link tag. 2: closing link tag */
@@ -89,79 +90,78 @@ class DefaultFreeExtensions {
 				'image_url'       => plugins_url( '/assets/images/onboarding/google.svg', WC_PLUGIN_FILE ),
 				'manage_url'      => 'admin.php?page=wc-admin&path=%2Fgoogle%2Fstart',
 				'is_built_by_wc'  => true,
-				'min_php_version' => '7.4',
-				'is_visible'      => array(
-					array(
+				'is_visible'      => [
+					[
 						'type'    => 'not',
-						'operand' => array(
-							array(
+						'operand' => [
+							[
 								'type'    => 'plugins_activated',
-								'plugins' => array( 'google-listings-and-ads' ),
-							),
-						),
-					),
-				),
-			),
-			'google-listings-and-ads:alt'       => array(
+								'plugins' => [ 'google-listings-and-ads' ],
+							],
+						],
+					],
+				],
+			],
+			'google-listings-and-ads:alt'       => [
 				'name'           => __( 'Google Listings & Ads', 'woocommerce' ),
 				'description'    => __( 'Reach more shoppers and drive sales for your store. Integrate with Google to list your products for free and launch paid ad campaigns.', 'woocommerce' ),
 				'image_url'      => plugins_url( '/assets/images/onboarding/google.svg', WC_PLUGIN_FILE ),
 				'manage_url'     => 'admin.php?page=wc-admin&path=%2Fgoogle%2Fstart',
 				'is_built_by_wc' => true,
-			),
-			'facebook-for-woocommerce'          => array(
+			],
+			'facebook-for-woocommerce'          => [
 				'name'           => __( 'Facebook for WooCommerce', 'woocommerce' ),
 				'description'    => __( 'List products and create ads on Facebook and Instagram with <a href="https://woocommerce.com/products/facebook/">Facebook for WooCommerce</a>', 'woocommerce' ),
 				'image_url'      => plugins_url( '/assets/images/onboarding/facebook.png', WC_PLUGIN_FILE ),
 				'manage_url'     => 'admin.php?page=wc-facebook',
 				'is_visible'     => false,
 				'is_built_by_wc' => false,
-			),
-			'facebook-for-woocommerce:alt'      => array(
+			],
+			'facebook-for-woocommerce:alt'      => [
 				'name'           => __( 'Facebook for WooCommerce', 'woocommerce' ),
 				'description'    => __( 'List products and create ads on Facebook and Instagram.', 'woocommerce' ),
 				'image_url'      => plugins_url( '/assets/images/onboarding/facebook.png', WC_PLUGIN_FILE ),
 				'manage_url'     => 'admin.php?page=wc-facebook',
 				'is_visible'     => false,
 				'is_built_by_wc' => false,
-			),
-			'pinterest-for-woocommerce'         => array(
+			],
+			'pinterest-for-woocommerce'         => [
 				'name'            => __( 'Pinterest for WooCommerce', 'woocommerce' ),
 				'description'     => __( 'Get your products in front of Pinners searching for ideas and things to buy.', 'woocommerce' ),
 				'image_url'       => plugins_url( '/assets/images/onboarding/pinterest.png', WC_PLUGIN_FILE ),
 				'manage_url'      => 'admin.php?page=wc-admin&path=%2Fpinterest%2Flanding',
-				'min_php_version' => '7.3',
 				'is_built_by_wc'  => true,
-			),
-			'pinterest-for-woocommerce:alt'     => array(
+				'min_php_version' => '7.3',
+			],
+			'pinterest-for-woocommerce:alt'     => [
 				'name'           => __( 'Pinterest for WooCommerce', 'woocommerce' ),
 				'description'    => __( 'Get your products in front of Pinterest users searching for ideas and things to buy. Get started with Pinterest and make your entire product catalog browsable.', 'woocommerce' ),
 				'image_url'      => plugins_url( '/assets/images/onboarding/pinterest.png', WC_PLUGIN_FILE ),
 				'manage_url'     => 'admin.php?page=wc-admin&path=%2Fpinterest%2Flanding',
 				'is_built_by_wc' => true,
-			),
-			'mailpoet'                          => array(
+			],
+			'mailpoet'                          => [
 				'name'           => __( 'MailPoet', 'woocommerce' ),
 				'description'    => __( 'Create and send purchase follow-up emails, newsletters, and promotional campaigns straight from your dashboard.', 'woocommerce' ),
 				'image_url'      => plugins_url( '/assets/images/onboarding/mailpoet.png', WC_PLUGIN_FILE ),
 				'manage_url'     => 'admin.php?page=mailpoet-newsletters',
 				'is_built_by_wc' => true,
-			),
-			'mailchimp-for-woocommerce'         => array(
+			],
+			'mailchimp-for-woocommerce'         => [
 				'name'           => __( 'Mailchimp', 'woocommerce' ),
 				'description'    => __( 'Send targeted campaigns, recover abandoned carts and much more with Mailchimp.', 'woocommerce' ),
 				'image_url'      => plugins_url( '/assets/images/onboarding/mailchimp-for-woocommerce.png', WC_PLUGIN_FILE ),
 				'manage_url'     => 'admin.php?page=mailchimp-woocommerce',
 				'is_built_by_wc' => false,
-			),
-			'creative-mail-by-constant-contact' => array(
+			],
+			'creative-mail-by-constant-contact' => [
 				'name'           => __( 'Creative Mail for WooCommerce', 'woocommerce' ),
 				'description'    => __( 'Create on-brand store campaigns, fast email promotions and customer retargeting with Creative Mail.', 'woocommerce' ),
 				'image_url'      => plugins_url( '/assets/images/onboarding/creative-mail-by-constant-contact.png', WC_PLUGIN_FILE ),
 				'manage_url'     => 'admin.php?page=creativemail',
 				'is_built_by_wc' => false,
-			),
-			'codistoconnect'                    => array(
+			],
+			'codistoconnect'                    => [
 				'name'           => __( 'Codisto for WooCommerce', 'woocommerce' ),
 				'description'    => sprintf(
 					/* translators: 1: opening product link tag. 2: closing link tag */
@@ -172,356 +172,356 @@ class DefaultFreeExtensions {
 				'image_url'      => plugins_url( '/assets/images/onboarding/codistoconnect.png', WC_PLUGIN_FILE ),
 				'manage_url'     => 'admin.php?page=codisto-settings',
 				'is_built_by_wc' => true,
-			),
-			'codistoconnect:alt'                => array(
+			],
+			'codistoconnect:alt'                => [
 				'name'           => __( 'Codisto for WooCommerce', 'woocommerce' ),
 				'description'    => __( 'Sell on Amazon, eBay, Walmart and more directly from WooCommerce.', 'woocommerce' ),
 				'image_url'      => plugins_url( '/assets/images/onboarding/codistoconnect.png', WC_PLUGIN_FILE ),
 				'manage_url'     => 'admin.php?page=codisto-settings',
 				'is_built_by_wc' => true,
-			),
-			'woocommerce-payments'              => array(
+			],
+			'woocommerce-payments'              => [
 				'description'    => sprintf(
 					/* translators: 1: opening product link tag. 2: closing link tag */
 					__( 'Accept credit cards and other popular payment methods with %1$sWooCommerce Payments%2$s', 'woocommerce' ),
 					'<a href="https://woocommerce.com/products/woocommerce-payments" target="_blank">',
 					'</a>'
 				),
-				'is_visible'     => array(
-					array(
+				'is_visible'     => [
+					[
 						'type'     => 'or',
-						'operands' => array(
-							array(
+						'operands' => [
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'US',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'PR',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'AU',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'CA',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'DE',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'ES',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'FR',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'GB',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'IE',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'IT',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'NZ',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'AT',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'BE',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'NL',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'PL',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'PT',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'CH',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'HK',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'SG',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'CY',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'DK',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'EE',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'FI',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'GR',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'LU',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'LT',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'LV',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'NO',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'MT',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'SI',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'SK',
 								'operation' => '=',
-							),
-						),
-					),
+							],
+						],
+					],
 					DefaultPaymentGateways::get_rules_for_cbd( false ),
-				),
-				'min_wp_version' => '5.9',
+				],
 				'is_built_by_wc' => true,
-			),
-			'woocommerce-services:shipping'     => array(
+				'min_wp_version' => '5.9',
+			],
+			'woocommerce-services:shipping'     => [
 				'description'    => sprintf(
 				/* translators: 1: opening product link tag. 2: closing link tag */
 					__( 'Print shipping labels with %1$sWooCommerce Shipping%2$s', 'woocommerce' ),
 					'<a href="https://woocommerce.com/products/shipping" target="_blank">',
 					'</a>'
 				),
-				'is_visible'     => array(
-					array(
+				'is_visible'     => [
+					[
 						'type'      => 'base_location_country',
 						'value'     => 'US',
 						'operation' => '=',
-					),
-					array(
+					],
+					[
 						'type'    => 'not',
-						'operand' => array(
-							array(
+						'operand' => [
+							[
 								'type'    => 'plugins_activated',
-								'plugins' => array( 'woocommerce-services' ),
-							),
-						),
-					),
-					array(
+								'plugins' => [ 'woocommerce-services' ],
+							],
+						],
+					],
+					[
 						'type'     => 'or',
-						'operands' => array(
-							array(
-								array(
+						'operands' => [
+							[
+								[
 									'type'         => 'option',
-									'transformers' => array(
-										array(
+									'transformers' => [
+										[
 											'use'       => 'dot_notation',
-											'arguments' => array(
+											'arguments' => [
 												'path' => 'product_types',
-											),
-										),
-										array(
+											],
+										],
+										[
 											'use' => 'count',
-										),
-									),
+										],
+									],
 									'option_name'  => 'woocommerce_onboarding_profile',
 									'value'        => 1,
 									'default'      => array(),
 									'operation'    => '!=',
-								),
-							),
-							array(
-								array(
+								],
+							],
+							[
+								[
 									'type'         => 'option',
-									'transformers' => array(
-										array(
+									'transformers' => [
+										[
 											'use'       => 'dot_notation',
-											'arguments' => array(
+											'arguments' => [
 												'path' => 'product_types.0',
-											),
-										),
-									),
+											],
+										],
+									],
 									'option_name'  => 'woocommerce_onboarding_profile',
 									'value'        => 'downloads',
 									'default'      => '',
 									'operation'    => '!=',
-								),
-							),
-						),
-					),
-				),
+								],
+							],
+						],
+					],
+				],
 				'is_built_by_wc' => true,
-			),
-			'woocommerce-services:tax'          => array(
+			],
+			'woocommerce-services:tax'          => [
 				'description'    => sprintf(
 					/* translators: 1: opening product link tag. 2: closing link tag */
 					__( 'Get automated sales tax with %1$sWooCommerce Tax%2$s', 'woocommerce' ),
 					'<a href="https://woocommerce.com/products/tax" target="_blank">',
 					'</a>'
 				),
-				'is_visible'     => array(
-					array(
+				'is_visible'     => [
+					[
 						'type'     => 'or',
-						'operands' => array(
-							array(
+						'operands' => [
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'US',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'FR',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'GB',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'DE',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'CA',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'AU',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'GR',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'BE',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'PT',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'DK',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'SE',
 								'operation' => '=',
-							),
-						),
-					),
-					array(
+							],
+						],
+					],
+					[
 						'type'    => 'not',
-						'operand' => array(
-							array(
+						'operand' => [
+							[
 								'type'    => 'plugins_activated',
-								'plugins' => array( 'woocommerce-services' ),
-							),
-						),
-					),
-				),
+								'plugins' => [ 'woocommerce-services' ],
+							],
+						],
+					],
+				],
 				'is_built_by_wc' => true,
-			),
-			'jetpack'                           => array(
+			],
+			'jetpack'                           => [
 				'description'    => sprintf(
 					/* translators: 1: opening product link tag. 2: closing link tag */
 					__( 'Enhance speed and security with %1$sJetpack%2$s', 'woocommerce' ),
 					'<a href="https://woocommerce.com/products/jetpack" target="_blank">',
 					'</a>'
 				),
-				'is_visible'     => array(
-					array(
+				'is_visible'     => [
+					[
 						'type'    => 'not',
-						'operand' => array(
-							array(
+						'operand' => [
+							[
 								'type'    => 'plugins_activated',
-								'plugins' => array( 'jetpack' ),
-							),
-						),
-					),
-				),
-				'min_wp_version' => '6.0',
+								'plugins' => [ 'jetpack' ],
+							],
+						],
+					],
+				],
 				'is_built_by_wc' => false,
-			),
-			'mailpoet'                          => array(
+				'min_wp_version' => '6.0',
+			],
+			'mailpoet'                          => [
 				'name'           => __( 'MailPoet', 'woocommerce' ),
 				'description'    => sprintf(
 					/* translators: 1: opening product link tag. 2: closing link tag */
@@ -530,242 +530,242 @@ class DefaultFreeExtensions {
 					'</a>'
 				),
 				'manage_url'     => 'admin.php?page=mailpoet-newsletters',
-				'is_visible'     => array(
-					array(
+				'is_visible'     => [
+					[
 						'type'    => 'not',
-						'operand' => array(
-							array(
+						'operand' => [
+							[
 								'type'    => 'plugins_activated',
-								'plugins' => array( 'mailpoet' ),
-							),
-						),
-					),
-				),
+								'plugins' => [ 'mailpoet' ],
+							],
+						],
+					],
+				],
 				'is_built_by_wc' => true,
-			),
-			'mailpoet:alt'                      => array(
+			],
+			'mailpoet:alt'                      => [
 				'name'           => __( 'MailPoet', 'woocommerce' ),
 				'description'    => __( 'Create and send purchase follow-up emails, newsletters, and promotional campaigns straight from your dashboard.', 'woocommerce' ),
 				'image_url'      => plugins_url( '/assets/images/onboarding/mailpoet.png', WC_PLUGIN_FILE ),
 				'manage_url'     => 'admin.php?page=mailpoet-newsletters',
 				'is_built_by_wc' => true,
-			),
-			'tiktok-for-business'               => array(
+			],
+			'tiktok-for-business'               => [
 				'name'           => __( 'TikTok for WooCommerce', 'woocommerce' ),
 				'image_url'      => plugins_url( '/assets/images/onboarding/tiktok.svg', WC_PLUGIN_FILE ),
 				'description'    =>
 					__( 'Grow your online sales by promoting your products on TikTok to over one billion monthly active users around the world.', 'woocommerce' ),
 				'manage_url'     => 'admin.php?page=tiktok',
-				'is_visible'     => array(
-					array(
+				'is_visible'     => [
+					[
 						'type'     => 'or',
-						'operands' => array(
-							array(
+						'operands' => [
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'US',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'CA',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'MX',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'AT',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'BE',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'CZ',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'DK',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'FI',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'FR',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'DE',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'GR',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'HU',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'IE',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'IT',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'NL',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'PL',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'PT',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'RO',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'ES',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'SE',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'GB',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'CH',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'NO',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'AU',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'NZ',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'SG',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'MY',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'PH',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'ID',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'VN',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'TH',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'KR',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'IL',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'AE',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'RU',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'UA',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'TR',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'SA',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'BR',
 								'operation' => '=',
-							),
-							array(
+							],
+							[
 								'type'      => 'base_location_country',
 								'value'     => 'JP',
 								'operation' => '=',
-							),
-						),
-					),
-				),
+							],
+						],
+					],
+				],
 				'is_built_by_wc' => false,
-			),
-			'tiktok-for-business:alt'           => array(
+			],
+			'tiktok-for-business:alt'           => [
 				'name'           => __( 'TikTok for WooCommerce', 'woocommerce' ),
 				'image_url'      => plugins_url( '/assets/images/onboarding/tiktok.svg', WC_PLUGIN_FILE ),
 				'description'    => sprintf(
@@ -777,7 +777,7 @@ class DefaultFreeExtensions {
 				'manage_url'     => 'admin.php?page=tiktok',
 				'is_built_by_wc' => false,
 				'is_visible'     => false,
-			),
+			],
 		);
 
 		$plugin        = $plugins[ $slug ];

--- a/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
+++ b/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
@@ -350,6 +350,7 @@ class DefaultFreeExtensions {
 					),
 					DefaultPaymentGateways::get_rules_for_cbd( false ),
 				),
+				'min_wp_version' => '5.9',
 				'is_built_by_wc' => true,
 			),
 			'woocommerce-services:shipping'     => array(
@@ -517,6 +518,7 @@ class DefaultFreeExtensions {
 						),
 					),
 				),
+				'min_wp_version' => '6.0',
 				'is_built_by_wc' => false,
 			),
 			'mailpoet'                          => array(

--- a/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/EvaluateExtension.php
+++ b/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/EvaluateExtension.php
@@ -30,6 +30,10 @@ class EvaluateExtension {
 			$extension->is_visible = true;
 		}
 
+		if ( isset( $extension->min_php_version ) ) {
+			$extension->is_visible = version_compare( PHP_VERSION, $extension->min_php_version, '>=' );
+		}
+
 		$installed_plugins       = PluginsHelper::get_installed_plugin_slugs();
 		$activated_plugins       = PluginsHelper::get_active_plugin_slugs();
 		$extension->is_installed = in_array( explode( ':', $extension->key )[0], $installed_plugins, true );

--- a/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/EvaluateExtension.php
+++ b/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/EvaluateExtension.php
@@ -21,6 +21,7 @@ class EvaluateExtension {
 	 * @return object The evaluated extension.
 	 */
 	public static function evaluate( $extension ) {
+		global $wp_version;
 		$rule_evaluator = new RuleEvaluator();
 
 		if ( isset( $extension->is_visible ) ) {
@@ -32,6 +33,10 @@ class EvaluateExtension {
 
 		if ( isset( $extension->min_php_version ) ) {
 			$extension->is_visible = version_compare( PHP_VERSION, $extension->min_php_version, '>=' );
+		}
+
+		if ( isset( $extension->min_wp_version ) ) {
+			$extension->is_visible = version_compare( $wp_version, $extension->min_wp_version, '>=' );
 		}
 
 		$installed_plugins       = PluginsHelper::get_installed_plugin_slugs();

--- a/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/EvaluateExtension.php
+++ b/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/EvaluateExtension.php
@@ -32,7 +32,7 @@ class EvaluateExtension {
 		}
 
 		// Run PHP and WP version chcecks.
-		if ( $extension->is_visible === true ) {
+		if ( true === $extension->is_visible ) {
 			if ( isset( $extension->min_php_version ) && ! version_compare( PHP_VERSION, $extension->min_php_version, '>=' ) ) {
 				$extension->is_visible = false;
 			}

--- a/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/EvaluateExtension.php
+++ b/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/EvaluateExtension.php
@@ -31,12 +31,15 @@ class EvaluateExtension {
 			$extension->is_visible = true;
 		}
 
-		if ( isset( $extension->min_php_version ) ) {
-			$extension->is_visible = version_compare( PHP_VERSION, $extension->min_php_version, '>=' );
-		}
+		// Run PHP and WP version chcecks.
+		if ( $extension->is_visible === true ) {
+			if ( isset( $extension->min_php_version ) && ! version_compare( PHP_VERSION, $extension->min_php_version, '>=' ) ) {
+				$extension->is_visible = false;
+			}
 
-		if ( isset( $extension->min_wp_version ) ) {
-			$extension->is_visible = version_compare( $wp_version, $extension->min_wp_version, '>=' );
+			if ( isset( $extension->min_wp_version ) && ! version_compare( $wp_version, $extension->min_wp_version, '>=' ) ) {
+				$extension->is_visible = false;
+			}
 		}
 
 		$installed_plugins       = PluginsHelper::get_installed_plugin_slugs();


### PR DESCRIPTION
This is a follow-up PR of https://github.com/woocommerce/woocommerce/pull/37611 with a fix.

The only difference is that this PR now checks PHP and WP versions when `is_visible` is [already](https://github.com/woocommerce/woocommerce/compare/update/16525-check-php-version-for-extensions?expand=1#diff-2f3016b95795e4ddd5bdda3de76f3b71604600347811b8e8c47bba6999ff9ba4R35) true.

### Testing Instructions

Follow the same instructions from https://github.com/woocommerce/woocommerce/pull/37611

