### PR TITLE
Invert the useValidation hook behavior to return an error instead of a boolean value

### DIFF
--- a/packages/js/product-editor/changelog/add-37663
+++ b/packages/js/product-editor/changelog/add-37663
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Invert the useValidation hook behavior to return an error instead of a boolean value

--- a/packages/js/product-editor/src/blocks/schedule-sale/edit.tsx
+++ b/packages/js/product-editor/src/blocks/schedule-sale/edit.tsx
@@ -83,12 +83,43 @@ export function Edit( {}: BlockEditProps< ScheduleSalePricingBlockAttributes > )
 		}
 	}, [ dateOnSaleFromGmt, dateOnSaleToGmt ] );
 
-	const isDateOnSaleToGmtValid = useValidation(
+	const _dateOnSaleFrom = moment( dateOnSaleFromGmt, moment.ISO_8601, true );
+	const _dateOnSaleTo = moment( dateOnSaleToGmt, moment.ISO_8601, true );
+
+	const dateOnSaleFromGmtValidationError = useValidation(
+		'product/date_on_sale_from_gmt',
+		function dateOnSaleFromValidator() {
+			if ( showScheduleSale && dateOnSaleFromGmt ) {
+				if ( ! _dateOnSaleFrom.isValid() ) {
+					return __( 'Please enter a valid date.', 'woocommerce' );
+				}
+
+				if ( _dateOnSaleFrom.isAfter( _dateOnSaleTo ) ) {
+					return __(
+						'The start date of the sale must be before the end date.',
+						'woocommerce'
+					);
+				}
+			}
+		}
+	);
+
+	const dateOnSaleToGmtValidationError = useValidation(
 		'product/date_on_sale_to_gmt',
-		() =>
-			! showScheduleSale ||
-			! dateOnSaleToGmt ||
-			moment( dateOnSaleFromGmt ).isBefore( dateOnSaleToGmt )
+		function dateOnSaleToValidator() {
+			if ( showScheduleSale && dateOnSaleToGmt ) {
+				if ( ! _dateOnSaleTo.isValid() ) {
+					return __( 'Please enter a valid date.', 'woocommerce' );
+				}
+
+				if ( _dateOnSaleTo.isBefore( _dateOnSaleFrom ) ) {
+					return __(
+						'The end date of the sale must be after the start date.',
+						'woocommerce'
+					);
+				}
+			}
+		}
 	);
 
 	return (
@@ -112,6 +143,10 @@ export function Edit( {}: BlockEditProps< ScheduleSalePricingBlockAttributes > )
 							dateTimeFormat={ dateTimeFormat }
 							currentDate={ dateOnSaleFromGmt }
 							onChange={ setDateOnSaleFromGmt }
+							className={
+								dateOnSaleFromGmtValidationError && 'has-error'
+							}
+							help={ dateOnSaleFromGmtValidationError as string }
 						/>
 					</div>
 
@@ -132,16 +167,9 @@ export function Edit( {}: BlockEditProps< ScheduleSalePricingBlockAttributes > )
 								)
 							}
 							className={
-								isDateOnSaleToGmtValid ? undefined : 'has-error'
+								dateOnSaleToGmtValidationError && 'has-error'
 							}
-							help={
-								isDateOnSaleToGmtValid
-									? undefined
-									: __(
-											'To date must be greater than From date.',
-											'woocommerce'
-									  )
-							}
+							help={ dateOnSaleToGmtValidationError as string }
 						/>
 					</div>
 				</div>

--- a/packages/js/product-editor/src/blocks/shipping-dimensions/edit.tsx
+++ b/packages/js/product-editor/src/blocks/shipping-dimensions/edit.tsx
@@ -108,40 +108,36 @@ export function Edit( {}: BlockEditProps< ShippingDimensionsBlockAttributes > ) 
 		suffix: weightUnit,
 	};
 
-	const isDimensionsWidthValid = useValidation(
+	const dimensionsWidthValidationError = useValidation(
 		'product/dimensions/width',
-		function validator() {
+		function dimensionsWidthValidator() {
 			if ( dimensions?.width && +dimensions.width <= 0 ) {
-				return false;
+				return __( 'Width must be higher than zero.', 'woocommerce' );
 			}
-			return true;
 		}
 	);
-	const isDimensionsLengthValid = useValidation(
+	const dimensionsLengthValidationError = useValidation(
 		'product/dimensions/length',
-		function validator() {
+		function dimensionsLengthValidator() {
 			if ( dimensions?.length && +dimensions.length <= 0 ) {
-				return false;
+				return __( 'Length must be higher than zero.', 'woocommerce' );
 			}
-			return true;
 		}
 	);
-	const isDimensionsHeightValid = useValidation(
+	const dimensionsHeightValidationError = useValidation(
 		'product/dimensions/height',
-		function validator() {
+		function dimensionsHeightValidator() {
 			if ( dimensions?.height && +dimensions.height <= 0 ) {
-				return false;
+				return __( 'Height must be higher than zero.', 'woocommerce' );
 			}
-			return true;
 		}
 	);
-	const isWeightValid = useValidation(
+	const weightValidationError = useValidation(
 		'product/weight',
-		function validator() {
+		function weightValidator() {
 			if ( weight && +weight <= 0 ) {
-				return false;
+				return __( 'Weight must be higher than zero.', 'woocommerce' );
 			}
-			return true;
 		}
 	);
 
@@ -158,16 +154,9 @@ export function Edit( {}: BlockEditProps< ShippingDimensionsBlockAttributes > ) 
 							{ Side: <span>A</span> }
 						) }
 						className={ classNames( {
-							'has-error': ! isDimensionsWidthValid,
+							'has-error': dimensionsWidthValidationError,
 						} ) }
-						help={
-							isDimensionsWidthValid
-								? undefined
-								: __(
-										'Width must be higher than zero.',
-										'woocommerce'
-								  )
-						}
+						help={ dimensionsWidthValidationError }
 					>
 						<InputControl { ...dimensionsWidthProps } />
 					</BaseControl>
@@ -179,16 +168,9 @@ export function Edit( {}: BlockEditProps< ShippingDimensionsBlockAttributes > ) 
 							{ Side: <span>B</span> }
 						) }
 						className={ classNames( {
-							'has-error': ! isDimensionsLengthValid,
+							'has-error': dimensionsLengthValidationError,
 						} ) }
-						help={
-							isDimensionsLengthValid
-								? undefined
-								: __(
-										'Length must be higher than zero.',
-										'woocommerce'
-								  )
-						}
+						help={ dimensionsLengthValidationError }
 					>
 						<InputControl { ...dimensionsLengthProps } />
 					</BaseControl>
@@ -200,16 +182,9 @@ export function Edit( {}: BlockEditProps< ShippingDimensionsBlockAttributes > ) 
 							{ Side: <span>C</span> }
 						) }
 						className={ classNames( {
-							'has-error': ! isDimensionsHeightValid,
+							'has-error': dimensionsHeightValidationError,
 						} ) }
-						help={
-							isDimensionsHeightValid
-								? undefined
-								: __(
-										'Height must be higher than zero.',
-										'woocommerce'
-								  )
-						}
+						help={ dimensionsHeightValidationError }
 					>
 						<InputControl { ...dimensionsHeightProps } />
 					</BaseControl>
@@ -218,16 +193,9 @@ export function Edit( {}: BlockEditProps< ShippingDimensionsBlockAttributes > ) 
 						id={ weightProps.id }
 						label={ __( 'Weight', 'woocommerce' ) }
 						className={ classNames( {
-							'has-error': ! isWeightValid,
+							'has-error': weightValidationError,
 						} ) }
-						help={
-							isWeightValid
-								? undefined
-								: __(
-										'Weight must be higher than zero.',
-										'woocommerce'
-								  )
-						}
+						help={ weightValidationError }
 					>
 						<InputControl { ...weightProps } />
 					</BaseControl>

--- a/packages/js/product-editor/src/blocks/shipping-dimensions/edit.tsx
+++ b/packages/js/product-editor/src/blocks/shipping-dimensions/edit.tsx
@@ -112,7 +112,7 @@ export function Edit( {}: BlockEditProps< ShippingDimensionsBlockAttributes > ) 
 		'product/dimensions/width',
 		function dimensionsWidthValidator() {
 			if ( dimensions?.width && +dimensions.width <= 0 ) {
-				return __( 'Width must be higher than zero.', 'woocommerce' );
+				return __( 'Width must be greater than zero.', 'woocommerce' );
 			}
 		}
 	);
@@ -120,7 +120,7 @@ export function Edit( {}: BlockEditProps< ShippingDimensionsBlockAttributes > ) 
 		'product/dimensions/length',
 		function dimensionsLengthValidator() {
 			if ( dimensions?.length && +dimensions.length <= 0 ) {
-				return __( 'Length must be higher than zero.', 'woocommerce' );
+				return __( 'Length must be greater than zero.', 'woocommerce' );
 			}
 		}
 	);
@@ -128,7 +128,7 @@ export function Edit( {}: BlockEditProps< ShippingDimensionsBlockAttributes > ) 
 		'product/dimensions/height',
 		function dimensionsHeightValidator() {
 			if ( dimensions?.height && +dimensions.height <= 0 ) {
-				return __( 'Height must be higher than zero.', 'woocommerce' );
+				return __( 'Height must be greater than zero.', 'woocommerce' );
 			}
 		}
 	);
@@ -136,7 +136,7 @@ export function Edit( {}: BlockEditProps< ShippingDimensionsBlockAttributes > ) 
 		'product/weight',
 		function weightValidator() {
 			if ( weight && +weight <= 0 ) {
-				return __( 'Weight must be higher than zero.', 'woocommerce' );
+				return __( 'Weight must be greater than zero.', 'woocommerce' );
 			}
 		}
 	);

--- a/packages/js/product-editor/src/blocks/shipping-fee/edit.tsx
+++ b/packages/js/product-editor/src/blocks/shipping-fee/edit.tsx
@@ -74,13 +74,12 @@ export function Edit( {
 
 	const shippingClassControlId = useInstanceId( BaseControl ) as string;
 
-	const isShippingClassValid = useValidation(
+	const shippingClassValidationError = useValidation(
 		'product/shipping_class',
 		function shippingClassValidator() {
 			if ( option === FOLLOW_CLASS_OPTION_VALUE && ! shippingClass ) {
-				return false;
+				return __( 'The shipping class is required.', 'woocommerce' );
 			}
-			return true;
 		}
 	);
 
@@ -120,7 +119,7 @@ export function Edit( {
 				<div className="wp-block-columns">
 					<div
 						className={ classNames( 'wp-block-column', {
-							'has-error': ! isShippingClassValid,
+							'has-error': shippingClassValidationError,
 						} ) }
 					>
 						<SelectControl
@@ -130,42 +129,37 @@ export function Edit( {
 							onChange={ setShippingClass }
 							label={ __( 'Shipping class', 'woocommerce' ) }
 							help={
-								isShippingClassValid
-									? createInterpolateElement(
-											__(
-												'Manage shipping classes and rates in <Link>global settings</Link>.',
-												'woocommerce'
-											),
-											{
-												Link: (
-													<Link
-														href={ getNewPath(
-															{
-																tab: 'shipping',
-																section:
-																	'classes',
-															},
-															'',
-															{},
-															'wc-settings'
-														) }
-														target="_blank"
-														type="external"
-														onClick={ () => {
-															recordEvent(
-																'product_shipping_global_settings_link_click'
-															);
-														} }
-													>
-														<Fragment />
-													</Link>
-												),
-											}
-									  )
-									: __(
-											'The shipping class is required.',
-											'woocommerce'
-									  )
+								shippingClassValidationError ||
+								createInterpolateElement(
+									__(
+										'Manage shipping classes and rates in <Link>global settings</Link>.',
+										'woocommerce'
+									),
+									{
+										Link: (
+											<Link
+												href={ getNewPath(
+													{
+														tab: 'shipping',
+														section: 'classes',
+													},
+													'',
+													{},
+													'wc-settings'
+												) }
+												target="_blank"
+												type="external"
+												onClick={ () => {
+													recordEvent(
+														'product_shipping_global_settings_link_click'
+													);
+												} }
+											>
+												<Fragment />
+											</Link>
+										),
+									}
+								)
 							}
 						>
 							{ shippingClasses.map( ( { slug, name } ) => (

--- a/packages/js/product-editor/src/blocks/track-inventory/edit.tsx
+++ b/packages/js/product-editor/src/blocks/track-inventory/edit.tsx
@@ -37,13 +37,20 @@ export function Edit( {}: BlockEditProps< TrackInventoryBlockAttributes > ) {
 		'stock_quantity'
 	);
 
-	const stockQuantityId = useInstanceId( BaseControl ) as string;
+	const stockQuantityId = useInstanceId(
+		BaseControl,
+		'product_stock_quantity'
+	) as string;
 
-	const isStockQuantityValid = useValidation(
+	const stockQuantityValidationError = useValidation(
 		'product/stock_quantity',
 		function stockQuantityValidator() {
-			if ( ! manageStock ) return true;
-			return Boolean( stockQuantity && stockQuantity >= 0 );
+			if ( manageStock && stockQuantity && stockQuantity < 0 ) {
+				return __(
+					'Stock quantity must be a positive number.',
+					'woocommerce'
+				);
+			}
 		}
 	);
 
@@ -70,18 +77,12 @@ export function Edit( {}: BlockEditProps< TrackInventoryBlockAttributes > ) {
 						<BaseControl
 							id={ stockQuantityId }
 							className={
-								isStockQuantityValid ? undefined : 'has-error'
+								stockQuantityValidationError && 'has-error'
 							}
-							help={
-								isStockQuantityValid
-									? undefined
-									: __(
-											'Stock quantity must be a positive number.',
-											'woocommerce'
-									  )
-							}
+							help={ stockQuantityValidationError ?? '' }
 						>
 							<InputControl
+								id={ stockQuantityId }
 								name="stock_quantity"
 								label={ __(
 									'Available quantity',

--- a/packages/js/product-editor/src/components/details-name-block/style.scss
+++ b/packages/js/product-editor/src/components/details-name-block/style.scss
@@ -23,3 +23,15 @@
 .woocommerce-product-form__required-input {
 	color: #CC1818;
 }
+
+.wp-block-woocommerce-product-name {
+	.has-error {
+		.components-base-control .components-input-control__backdrop {
+			border-color: $studio-red-50;
+		}
+
+		.components-base-control__help {
+			color: $studio-red-50;
+		}
+	}
+}

--- a/packages/js/product-editor/src/hooks/index.ts
+++ b/packages/js/product-editor/src/hooks/index.ts
@@ -2,3 +2,7 @@ export { useProductHelper as __experimentalUseProductHelper } from './use-produc
 export { useProductMVPCESFooter as __experimentalUseProductMVPCESFooter } from './use-product-mvp-ces-footer';
 export { useVariationsOrder as __experimentalUseVariationsOrder } from './use-variations-order';
 export { useCurrencyInputProps as __experimentalUseCurrencyInputProps } from './use-currency-input-props';
+export {
+	useValidation as __experimentalUseValidation,
+	ValidationError,
+} from './use-validation';

--- a/packages/js/product-editor/src/hooks/use-validation/README.md
+++ b/packages/js/product-editor/src/hooks/use-validation/README.md
@@ -18,7 +18,7 @@ const product = ...;
 
 const validateTitle = useCallback( (): ValidationError => {
 	if ( product.title.length < 2 ) {
-		return __( 'Title must be greater than 1', 'text-domain' );
+		return __( 'Title must be more than 1 character', 'text-domain' );
 	}
 }, [ product.title ] );
 

--- a/packages/js/product-editor/src/hooks/use-validation/README.md
+++ b/packages/js/product-editor/src/hooks/use-validation/README.md
@@ -8,6 +8,7 @@ Syncronous validation
 
 ```typescript
 import { useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import {
 	__experimentalUseValidation as useValidation,
 	ValidationError
@@ -17,7 +18,7 @@ const product = ...;
 
 const validateTitle = useCallback( (): ValidationError => {
 	if ( product.title.length < 2 ) {
-		return 'Title must be greater than 1';
+		return __( 'Title must be greater than 1', 'text-domain' );
 	}
 }, [ product.title ] );
 

--- a/packages/js/product-editor/src/hooks/use-validation/README.md
+++ b/packages/js/product-editor/src/hooks/use-validation/README.md
@@ -8,34 +8,38 @@ Syncronous validation
 
 ```typescript
 import { useCallback } from '@wordpress/element';
-import { useValidation } from '@woocommerce/product-editor';
+import {
+	__experimentalUseValidation as useValidation,
+	ValidationError
+} from '@woocommerce/product-editor';
 
 const product = ...;
 
-const validateTitle = useCallback( (): boolean => {
+const validateTitle = useCallback( (): ValidationError => {
 	if ( product.title.length < 2 ) {
-		return false;
+		return 'Title must be greater than 1';
 	}
-	return true;
 }, [ product.title ] );
 
-const isTitleValid = useValidation( 'product/title', validateTitle );
+const validationError = useValidation( 'product/title', validateTitle );
 ```
 
 Asyncronous validation
 
 ```typescript
 import { useCallback } from '@wordpress/element';
-import { useValidation } from '@woocommerce/product-editor';
+import {
+	__experimentalUseValidation as useValidation,
+	ValidationError
+} from '@woocommerce/product-editor';
 
 const product = ...;
 
-const validateSlug = useCallback( async (): Promise< boolean > => {
+const validateSlug = useCallback( async (): Promise< ValidationError > => {
 	return fetch( `.../validate-slug?slug=${ product.slug }` )
 		.then( ( response ) => response.json() )
-		.then( ( { isValid } ) => isValid )
-		.catch( () => false );
+		.then( ( { errorMessage } ) => errorMessage );
 }, [ product.slug ] );
 
-const isSlugValid = useValidation( 'product/slug', validateSlug );
+const validationError = useValidation( 'product/slug', validateSlug );
 ```

--- a/packages/js/product-editor/src/hooks/use-validation/index.ts
+++ b/packages/js/product-editor/src/hooks/use-validation/index.ts
@@ -1,1 +1,2 @@
 export * from './use-validation';
+export * from './types';

--- a/packages/js/product-editor/src/hooks/use-validation/types.ts
+++ b/packages/js/product-editor/src/hooks/use-validation/types.ts
@@ -1,0 +1,1 @@
+export type ValidationError = undefined | string | Error;


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/37663
Closes https://github.com/woocommerce/woocommerce/issues/37706
Closes https://github.com/woocommerce/woocommerce/issues/37707

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Got to `/wp-admin/tools.php?page=woocommerce-admin-test-helper`
2. Under Features tab make sure to enable `product-block-editor`
3. Then visit `/wp-admin/admin.php?page=wc-admin&path=/add-product`
4. Validations should remains as usual

<!-- End testing instructions -->