### PR TITLE
Add close button for store alerts

### DIFF
--- a/plugins/woocommerce-admin/client/layout/store-alerts/index.js
+++ b/plugins/woocommerce-admin/client/layout/store-alerts/index.js
@@ -211,6 +211,12 @@ export class StoreAlerts extends Component {
 			await removeNote( alert.id );
 			this.previousAlert();
 			invalidateResolutionForStoreSelector( 'getNotes' );
+			recordEvent( 'store_alert_close', {
+				alert_id: alert.id,
+				alert_name: alert.name,
+				alert_title: alert.title,
+				alert_content: alert.content,
+			} );
 		};
 
 		return (

--- a/plugins/woocommerce-admin/client/layout/store-alerts/index.js
+++ b/plugins/woocommerce-admin/client/layout/store-alerts/index.js
@@ -16,7 +16,7 @@ import interpolateComponents from '@automattic/interpolate-components';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 import moment from 'moment';
-import { Icon, chevronLeft, chevronRight } from '@wordpress/icons';
+import { Icon, chevronLeft, chevronRight, close } from '@wordpress/icons';
 import { NOTES_STORE_NAME, QUERY_DEFAULTS } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { Text } from '@woocommerce/experimental';
@@ -66,12 +66,7 @@ export class StoreAlerts extends Component {
 	}
 
 	renderActions( alert ) {
-		const {
-			triggerNoteAction,
-			updateNote,
-			removeNote,
-			invalidateResolutionForStoreSelector,
-		} = this.props;
+		const { triggerNoteAction, updateNote } = this.props;
 		const actions = alert.actions.map( ( action ) => {
 			return (
 				<Button
@@ -172,19 +167,6 @@ export class StoreAlerts extends Component {
 		return (
 			<div className="woocommerce-store-alerts__actions">
 				{ actions }
-				{
-					<Button
-						key={ 'dismiss' }
-						variant="tertiary"
-						onClick={ async () => {
-							await removeNote( alert.id );
-							this.previousAlert();
-							invalidateResolutionForStoreSelector( 'getNotes' );
-						} }
-					>
-						{ __( 'Dismiss', 'woocommerce' ) }
-					</Button>
-				}
 				{ snooze }
 			</div>
 		);
@@ -220,6 +202,8 @@ export class StoreAlerts extends Component {
 			'is-alert-error': type === 'error',
 			'is-alert-update': type === 'update',
 		} );
+
+		const { removeNote, invalidateResolutionForStoreSelector } = this.props;
 
 		return (
 			<Card className={ className } size={ null }>
@@ -280,6 +264,15 @@ export class StoreAlerts extends Component {
 							</Button>
 						</div>
 					) }
+					<Button
+						onClick={ async () => {
+							await removeNote( alert.id );
+							this.previousAlert();
+							invalidateResolutionForStoreSelector( 'getNotes' );
+						} }
+					>
+						<Icon icon={ close } />
+					</Button>
 				</CardHeader>
 				<CardBody>
 					<div

--- a/plugins/woocommerce-admin/client/layout/store-alerts/index.js
+++ b/plugins/woocommerce-admin/client/layout/store-alerts/index.js
@@ -66,7 +66,12 @@ export class StoreAlerts extends Component {
 	}
 
 	renderActions( alert ) {
-		const { triggerNoteAction, updateNote } = this.props;
+		const {
+			triggerNoteAction,
+			updateNote,
+			removeNote,
+			invalidateResolutionForStoreSelector,
+		} = this.props;
 		const actions = alert.actions.map( ( action ) => {
 			return (
 				<Button
@@ -164,14 +169,24 @@ export class StoreAlerts extends Component {
 			/>
 		);
 
-		if ( actions || snooze ) {
-			return (
-				<div className="woocommerce-store-alerts__actions">
-					{ actions }
-					{ snooze }
-				</div>
-			);
-		}
+		return (
+			<div className="woocommerce-store-alerts__actions">
+				{ actions }
+				{
+					<Button
+						key={ 'dismiss' }
+						variant="tertiary"
+						onClick={ async () => {
+							await removeNote( alert.id );
+							invalidateResolutionForStoreSelector( 'getNotes' );
+						} }
+					>
+						{ __( 'Dismiss', 'woocommerce' ) }
+					</Button>
+				}
+				{ snooze }
+			</div>
+		);
 	}
 
 	getAlerts() {
@@ -303,11 +318,18 @@ export default compose(
 		};
 	} ),
 	withDispatch( ( dispatch ) => {
-		const { triggerNoteAction, updateNote } = dispatch( NOTES_STORE_NAME );
+		const {
+			triggerNoteAction,
+			updateNote,
+			removeNote,
+			invalidateResolutionForStoreSelector,
+		} = dispatch( NOTES_STORE_NAME );
 
 		return {
 			triggerNoteAction,
 			updateNote,
+			removeNote,
+			invalidateResolutionForStoreSelector,
 		};
 	} )
 )( StoreAlerts );

--- a/plugins/woocommerce-admin/client/layout/store-alerts/index.js
+++ b/plugins/woocommerce-admin/client/layout/store-alerts/index.js
@@ -164,12 +164,14 @@ export class StoreAlerts extends Component {
 			/>
 		);
 
-		return (
-			<div className="woocommerce-store-alerts__actions">
-				{ actions }
-				{ snooze }
-			</div>
-		);
+		if ( actions || snooze ) {
+			return (
+				<div className="woocommerce-store-alerts__actions">
+					{ actions }
+					{ snooze }
+				</div>
+			);
+		}
 	}
 
 	getAlerts() {

--- a/plugins/woocommerce-admin/client/layout/store-alerts/index.js
+++ b/plugins/woocommerce-admin/client/layout/store-alerts/index.js
@@ -207,6 +207,12 @@ export class StoreAlerts extends Component {
 
 		const { removeNote, invalidateResolutionForStoreSelector } = this.props;
 
+		const removeNoteAndInvalidate = async () => {
+			await removeNote( alert.id );
+			this.previousAlert();
+			invalidateResolutionForStoreSelector( 'getNotes' );
+		};
+
 		return (
 			<Card className={ className } size={ null }>
 				<CardHeader isBorderless>
@@ -218,63 +224,66 @@ export class StoreAlerts extends Component {
 					>
 						{ alert.title }
 					</Text>
-					{ numberOfAlerts > 1 && (
-						<div className="woocommerce-store-alerts__pagination">
-							<Button
-								onClick={ this.previousAlert }
-								disabled={ currentIndex === 0 }
-								label={ __( 'Previous Alert', 'woocommerce' ) }
-							>
-								<Icon
-									icon={ chevronLeft }
-									className="arrow-left-icon"
-								/>
-							</Button>
-							<span
-								className="woocommerce-store-alerts__pagination-label"
-								role="status"
-								aria-live="polite"
-							>
-								{ interpolateComponents( {
-									mixedString: __(
-										'{{current /}} of {{total /}}',
+					<div>
+						{ numberOfAlerts > 1 && (
+							<div className="woocommerce-store-alerts__pagination">
+								<Button
+									onClick={ this.previousAlert }
+									disabled={ currentIndex === 0 }
+									label={ __(
+										'Previous Alert',
 										'woocommerce'
-									),
-									components: {
-										current: (
-											<Fragment>
-												{ currentIndex + 1 }
-											</Fragment>
+									) }
+								>
+									<Icon
+										icon={ chevronLeft }
+										className="arrow-left-icon"
+									/>
+								</Button>
+								<span
+									className="woocommerce-store-alerts__pagination-label"
+									role="status"
+									aria-live="polite"
+								>
+									{ interpolateComponents( {
+										mixedString: __(
+											'{{current /}} of {{total /}}',
+											'woocommerce'
 										),
-										total: (
-											<Fragment>
-												{ numberOfAlerts }
-											</Fragment>
-										),
-									},
-								} ) }
-							</span>
-							<Button
-								onClick={ this.nextAlert }
-								disabled={ numberOfAlerts - 1 === currentIndex }
-								label={ __( 'Next Alert', 'woocommerce' ) }
-							>
-								<Icon
-									icon={ chevronRight }
-									className="arrow-right-icon"
-								/>
-							</Button>
-						</div>
-					) }
-					<Button
-						onClick={ async () => {
-							await removeNote( alert.id );
-							this.previousAlert();
-							invalidateResolutionForStoreSelector( 'getNotes' );
-						} }
-					>
-						<Icon icon={ close } />
-					</Button>
+										components: {
+											current: (
+												<Fragment>
+													{ currentIndex + 1 }
+												</Fragment>
+											),
+											total: (
+												<Fragment>
+													{ numberOfAlerts }
+												</Fragment>
+											),
+										},
+									} ) }
+								</span>
+								<Button
+									onClick={ this.nextAlert }
+									disabled={
+										numberOfAlerts - 1 === currentIndex
+									}
+									label={ __( 'Next Alert', 'woocommerce' ) }
+								>
+									<Icon
+										icon={ chevronRight }
+										className="arrow-right-icon"
+									/>
+								</Button>
+							</div>
+						) }
+						<Button
+							onClick={ removeNoteAndInvalidate }
+							icon={ close }
+							label={ __( 'Close', 'woocommerce' ) }
+						/>
+					</div>
 				</CardHeader>
 				<CardBody>
 					<div

--- a/plugins/woocommerce-admin/client/layout/store-alerts/index.js
+++ b/plugins/woocommerce-admin/client/layout/store-alerts/index.js
@@ -43,7 +43,7 @@ export class StoreAlerts extends Component {
 	}
 
 	previousAlert( event ) {
-		event.stopPropagation();
+		event?.stopPropagation();
 		const { currentIndex } = this.state;
 
 		if ( currentIndex > 0 ) {
@@ -178,6 +178,7 @@ export class StoreAlerts extends Component {
 						variant="tertiary"
 						onClick={ async () => {
 							await removeNote( alert.id );
+							this.previousAlert();
 							invalidateResolutionForStoreSelector( 'getNotes' );
 						} }
 					>

--- a/plugins/woocommerce-admin/client/layout/store-alerts/index.js
+++ b/plugins/woocommerce-admin/client/layout/store-alerts/index.js
@@ -29,6 +29,7 @@ import StoreAlertsPlaceholder from './placeholder';
 import { getAdminSetting } from '~/utils/admin-settings';
 
 import './style.scss';
+import { getScreenName } from '~/utils';
 
 export class StoreAlerts extends Component {
 	constructor( props ) {
@@ -212,10 +213,11 @@ export class StoreAlerts extends Component {
 			this.previousAlert();
 			invalidateResolutionForStoreSelector( 'getNotes' );
 			recordEvent( 'store_alert_close', {
-				alert_id: alert.id,
-				alert_name: alert.name,
-				alert_title: alert.title,
-				alert_content: alert.content,
+				note_name: alert.name,
+				note_title: alert.title,
+				note_type: alert.type,
+				note_content: alert.content,
+				screen: getScreenName(),
 			} );
 		};
 

--- a/plugins/woocommerce-admin/client/layout/store-alerts/style.scss
+++ b/plugins/woocommerce-admin/client/layout/store-alerts/style.scss
@@ -31,7 +31,7 @@
 			padding: 5px 16px;
 		}
 
-		+ .components-button {
+		~ .components-button {
 			margin-left: 10px;
 		}
 

--- a/plugins/woocommerce-admin/client/layout/store-alerts/test/index.js
+++ b/plugins/woocommerce-admin/client/layout/store-alerts/test/index.js
@@ -11,12 +11,14 @@ import { setAdminSetting } from '~/utils/admin-settings';
 
 const alerts = [
 	{
+		id: '1',
 		title: 'Alert title 1',
 		content: 'Alert content 1',
 		status: 'unactioned',
 		actions: [],
 	},
 	{
+		id: '2',
 		title: 'Alert title 2',
 		content: 'Alert content 2',
 		status: 'unactioned',
@@ -129,5 +131,27 @@ describe( 'StoreAlerts', () => {
 		expect( container.querySelector( 'h2' ).textContent ).toBe(
 			'Alert title 1'
 		);
+	} );
+
+	it( 'should dismiss the alert when clicking on the close button and navigate to previous one', async () => {
+		const removeNote = jest.fn();
+		const invalidateResolutionForStoreSelector = jest.fn();
+		const { getByLabelText, getByText } = render(
+			<StoreAlerts
+				alerts={ alerts }
+				removeNote={ removeNote }
+				invalidateResolutionForStoreSelector={
+					invalidateResolutionForStoreSelector
+				}
+			/>
+		);
+		expect( getByLabelText( 'Close' ) ).toBeInTheDocument();
+		fireEvent.click( getByLabelText( 'Next Alert' ) );
+		await fireEvent.click( getByLabelText( 'Close' ) );
+		expect( removeNote ).toBeCalledWith( '2' );
+		expect( invalidateResolutionForStoreSelector ).toBeCalledWith(
+			'getNotes'
+		);
+		expect( getByText( 'Alert title 1' ) ).toBeVisible();
 	} );
 } );

--- a/plugins/woocommerce-admin/client/layout/store-alerts/test/index.js
+++ b/plugins/woocommerce-admin/client/layout/store-alerts/test/index.js
@@ -80,38 +80,26 @@ describe( 'StoreAlerts', () => {
 	} );
 
 	it( 'should show the actions for an alert that contains actions', () => {
-		const { container } = render(
+		const { container, getByText } = render(
 			<StoreAlerts alerts={ [ alerts[ 1 ] ] } />
 		);
 
-		expect(
-			container.querySelector( '.components-button' ).textContent
-		).toBe( 'Click me!' );
-		expect(
-			container
-				.querySelector( '.components-button' )
-				.getAttribute( 'href' )
-		).toBe( '#' );
+		expect( getByText( 'Click me!' ) ).toBeVisible();
+		expect( getByText( 'Click me!' ).getAttribute( 'href' ) ).toBe( '#' );
 		expect(
 			container.querySelector( '.woocommerce-store-alerts__snooze' )
 		).not.toBeInTheDocument();
 	} );
 
 	it( 'should show the actions and snooze actions for snoozable alerts', () => {
-		const { container } = render(
+		const { container, getByText } = render(
 			<StoreAlerts
 				alerts={ [ { ...alerts[ 1 ], is_snoozable: true } ] }
 			/>
 		);
 
-		expect(
-			container.querySelector( '.components-button' ).textContent
-		).toBe( 'Click me!' );
-		expect(
-			container
-				.querySelector( '.components-button' )
-				.getAttribute( 'href' )
-		).toBe( '#' );
+		expect( getByText( 'Click me!' ) ).toBeVisible();
+		expect( getByText( 'Click me!' ).getAttribute( 'href' ) ).toBe( '#' );
 		expect(
 			container.querySelector( '.woocommerce-store-alerts__snooze' )
 		).toBeInTheDocument();

--- a/plugins/woocommerce/changelog/fix-undismissable-notice
+++ b/plugins/woocommerce/changelog/fix-undismissable-notice
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add fixed Dismiss message to Store Alerts


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We were having issues with [Undismissable notices](https://github.com/woocommerce/woocommerce/issues/36913).

Currently we have multiple messages that manually add a "Dismiss" button, which need to have a url to navigate to. This is not ideal because it can create a race condition, and also, navigating outside the home page when dismissing an alert doesn't make sense.

I'm adding an X button for all alerts which should always dismiss it.


Closes #36913 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Run the SQL commands `DELETE FROM wp_customer_wc_admin_notes;` and `DELETE FROM wp_customer_wc_admin_note_actions;`
2. Using WCA test helper, search for options including 'remote_inbox' and delete them. 
4. Install the plugin [woocommerce-gateway-eway version 3.3.0](https://github.com/woocommerce/woocommerce-gateway-eway/releases/tag/3.3.0).
5. Go to WooCommerce > Home.
6. You should see the 'Security vulnerability patched in WooCommerce Eway Gateway' banner message
7. Click the X button
8. Check if the message disappears.

<!-- End testing instructions -->