### PR TITLE
Remove section re running tests under PHP 8

### DIFF
--- a/plugins/woocommerce/changelog/update-test-docs-php-8
+++ b/plugins/woocommerce/changelog/update-test-docs-php-8
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: No changelog entry needed, this is an update to developer-facing documentation only.
+
+

--- a/plugins/woocommerce/tests/README.md
+++ b/plugins/woocommerce/tests/README.md
@@ -97,32 +97,6 @@ $ tests/bin/install.sh woocommerce_tests_1 root root
 
 Note that `woocommerce_tests` changed to `woocommerce_tests_1` as the `woocommerce_tests` database already exists due to the prior command.
 
-### Running tests in PHP 8
-
-WooCommerce currently supports PHP versions from 7.0 up to 8.0, and this poses an issue with PHPUnit:
-
-* The latest PHPUnit version that supports PHP 7.0 is 6.5.14
-* The latest PHPUnit version that WordPress (and thus WooCommerce) supports is 7.5.20, but that version doesn't work on PHP 8
-
-To workaround this, the testing strategy used by WooCommerce is as follows:
-
-* We normally use PHPUnit 6.5.14
-* For PHP 8 we use [a custom fork of PHPUnit 7.5.20 with support for PHP 8](https://github.com/woocommerce/phpunit/pull/1). WooCommerce's GitHub Actions CI workflow is configured to use this fork instead of the old version 6 when running in PHP 8.
-
-If you want to run the tests locally under PHP 8 you'll need to temporarily modify `composer.json` to use the custom PHPUnit fork in the same way that the GitHub Actions CI workflow file does. These are the commands that you'll need (run them after a regular `composer install` from within the `plugins/woocommerce` directory):
-
-```shell
-curl -L https://github.com/woocommerce/phpunit/archive/add-compatibility-with-php8-to-phpunit-7.zip -o /tmp/phpunit-7.5-fork.zip
-unzip -d /tmp/phpunit-7.5-fork /tmp/phpunit-7.5-fork.zip
-composer bin phpunit config --unset platform
-composer bin phpunit config repositories.0 '{"type": "path", "url": "/tmp/phpunit-7.5-fork/phpunit-add-compatibility-with-php8-to-phpunit-7", "options": {"symlink": false}}'
-composer bin phpunit require --dev -W phpunit/phpunit:@dev --ignore-platform-reqs
-rm -rf ./vendor/phpunit/
-composer dump-autoload
-```
-
-Just remember that you can't include the modified `composer.json` in any commit!
-
 ## Writing Tests
 
 There are three different unit test directories:


### PR DESCRIPTION
This information (about how to run the tests under PHP 8, using a custom fork of PhpUnit) became obsolete since improvements made via [PR#36273](http://github.com/woocommerce/woocommerce/pull/36273) were merged.

### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Removes section of `tests/README.md` that we no longer need, thanks to [PR#36273](http://github.com/woocommerce/woocommerce/pull/36273). See also related internal discussion at p1680592246028539/1680548063.011089-slack-C0E1AV8T0.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Review the change.
2. Confirm it makes sense.

<!-- End testing instructions -->