### PR TITLE
Fix for the e2e variable product test

### DIFF
--- a/plugins/woocommerce/changelog/e2e-dismiss-tour-product-variations
+++ b/plugins/woocommerce/changelog/e2e-dismiss-tour-product-variations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Update to the merchant variable product e2e test

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
@@ -75,42 +75,32 @@ test.describe( 'Add New Variable Product Page', () => {
 		await resetVariableProductTour( baseURL, browser );
 	} );
 
-	test( 'shows the variable product tour', async ( { page } ) => {
-		await page.goto( 'wp-admin/post-new.php?post_type=product' );
-		await page.selectOption( '#product-type', 'variable' );
-
-		// because of the way that the tour is dynamically positioned,
-		// Playwright can't automatically scroll the button into view,
-		// so we will manually scroll the attributes tab into view,
-		// which will cause the tour to be scrolled into view as well
-		await page
-			.locator( '.attribute_tab' )
-			.getByRole( 'link', { name: 'Attributes' } )
-			.scrollIntoViewIfNeeded();
-
-		// the tour only seems to display when not running headless, so just make sure
-		if ( await page.locator( '.components-card-header' ).nth(1).isVisible() ) {
-		// dismiss the variable product tour
-		await page
-			.getByRole( 'button', { name: 'Close Tour' } )
-			.click();
-
-		// wait for the tour's dismissal to be saved
-		await page.waitForResponse(
-			( response ) =>
-				response.url().includes( '/users/' ) &&
-				response.status() === 200
-		);
-
-		}
-	} );
-
 	test( 'can create product, attributes and variations, edit variations and delete variations', async ( {
 		page,
 	} ) => {
 		await page.goto( productPageURL );
 		await page.fill( '#title', variableProductName );
 		await page.selectOption( '#product-type', 'variable' );
+
+		await page
+			.locator( '.attribute_tab' )
+			.getByRole( 'link', { name: 'Attributes' } )
+			.scrollIntoViewIfNeeded();
+
+		// the tour only seems to display when not running headless, so just make sure
+		if ( await page.locator( '.woocommerce-tour-kit-step__heading' ).isVisible() ) {
+			// dismiss the variable product tour
+			await page
+				.getByRole( 'button', { name: 'Close Tour' } )
+				.click();
+
+			// wait for the tour's dismissal to be saved
+			await page.waitForResponse(
+				( response ) =>
+					response.url().includes( '/users/' ) &&
+					response.status() === 200
+			);
+		}
 
 		await page.click( 'a[href="#product_attributes"]' );
 
@@ -251,7 +241,28 @@ test.describe( 'Add New Variable Product Page', () => {
 	} ) => {
 		await page.goto( productPageURL );
 		await page.fill( '#title', manualVariableProduct );
-		await page.selectOption( '#product-type', 'variable', { force: true } );
+		await page.selectOption( '#product-type', 'variable' );
+
+		await page
+			.locator( '.attribute_tab' )
+			.getByRole( 'link', { name: 'Attributes' } )
+			.scrollIntoViewIfNeeded();
+
+		// the tour only seems to display when not running headless, so just make sure
+		if ( await page.locator( '.woocommerce-tour-kit-step__heading' ).isVisible() ) {
+			// dismiss the variable product tour
+			await page
+				.getByRole( 'button', { name: 'Close Tour' } )
+				.click();
+
+			// wait for the tour's dismissal to be saved
+			await page.waitForResponse(
+				( response ) =>
+					response.url().includes( '/users/' ) &&
+					response.status() === 200
+			);
+		}
+
 		await page.click( 'a[href="#product_attributes"]' );
 		// add 3 attributes
 		for ( let i = 0; i < 3; i++ ) {


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The `merchant/create-variable-product.spec.js` tests have been really flaky lately due to a new product tour being introduced.  This change should deal with the tour before running the tests.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure tests pass in CI (on this PR)
2. Pull this branch
3. `pnpm run env:start`
4. `pnpm run test:e2e-pw`

<!-- End testing instructions -->