### PR TITLE
Exclude empty attributes in count for wcadmin_product_update Tracks event

### DIFF
--- a/plugins/woocommerce/changelog/fix-empty-attributes-tracking
+++ b/plugins/woocommerce/changelog/fix-empty-attributes-tracking
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Exclude empty attributes from the attribute count when tracking product updates.

--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -162,8 +162,19 @@ class WC_Products_Tracking {
 						description_value  = $( '.block-editor-rich-text__editable' ).text();
 					}
 
+					// We can't just check the number of '.woocommerce_attribute' elements because
+					// there might be empty ones, which get stripped out when saved. So, we'll check
+					// whether the name and values have been filled out.
+					var numberOfAttributes = $( '.woocommerce_attribute' ).filter( function () {
+						var attributeElement = $( this );
+						var attributeName = attributeElement.find( 'input.attribute_name' ).val();
+						var attributeValues = attributeElement.find( 'textarea[name^=\"attribute_values\"]' ).val();
+
+						return attributeName !== '' && attributeValues !== '';
+					} ).length;
+
 					var properties = {
-						attributes:				$( '.woocommerce_attribute' ).length,
+						attributes:				numberOfAttributes,
 						categories:				$( '[name=\"tax_input[product_cat][]\"]:checked' ).length,
 						cross_sells:			$( '#crosssell_ids option' ).length ? 'Yes' : 'No',
 						description:			description_value.trim() !== '' ? 'Yes' : 'No',


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Previously, when logging the `wcadmin_product_update` Tracks event, we were miscounting the number of attributes in cases where there was an empty attribute in the list (this happens by default if there are no global attributes; we add a placeholder attribute automatically for the user to fill out).

To reproduce this:

1. Make sure you have no global attributes.
2. Filter the Network tab by `t.gif?attributes=`
2. Add a new product.
3. Save the product.
4. Update the product.
5. Verify that `wcadmin_product_update` has been logged with `attributes=1`.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Make sure you have no global attributes.
2. Filter the Network tab by `t.gif?attributes=`
2. Add a new product.
3. Save the product.
4. Update the product.
5. Verify that `wcadmin_product_update` has been logged with `attributes=0`.
6. Save some attributes to the product and update the product.
7. Verify that `wcadmin_product_update` has been logged with `attributes` set to the correct value.

<!-- End testing instructions -->