### PR TITLE
Fix URL and assertions in merchant/add-order perf tests

### DIFF
--- a/plugins/woocommerce/changelog/fix-k6-order-id-hpos
+++ b/plugins/woocommerce/changelog/fix-k6-order-id-hpos
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Correct URL and assertion in merchant/add-order perf test.

--- a/plugins/woocommerce/tests/performance/requests/merchant/add-order.js
+++ b/plugins/woocommerce/tests/performance/requests/merchant/add-order.js
@@ -50,6 +50,7 @@ let admin_created_order_assert;
 let admin_open_order_base;
 let admin_open_order_assert;
 let admin_update_order_base;
+let admin_update_order;
 let admin_update_order_id;
 let admin_update_order_params;
 let admin_update_order_assert;
@@ -375,14 +376,15 @@ export function addOrder() {
 		] );
 
 		if ( cot_status === true ) {
-			admin_update_order_base = `${ admin_update_order_base }&id=${ hpos_post_id }`;
+			admin_update_order = `${ admin_update_order_base }&id=${ hpos_post_id }`;
 			admin_update_order_params = cotOrderParams.toString();
 		} else {
+			admin_update_order = admin_update_order_base;
 			admin_update_order_params = orderParams.toString();
 		}
 
 		response = http.post(
-			`${ base_url }/wp-admin/${ admin_update_order_base }`,
+			`${ base_url }/wp-admin/${ admin_update_order }`,
 			admin_update_order_params.toString(),
 			{
 				headers: requestHeaders,

--- a/plugins/woocommerce/tests/performance/requests/merchant/add-order.js
+++ b/plugins/woocommerce/tests/performance/requests/merchant/add-order.js
@@ -57,9 +57,9 @@ let admin_update_order_assert;
 if ( cot_status === true ) {
 	admin_new_order_base = 'admin.php?page=wc-orders&action=new';
 	admin_update_order_base = 'admin.php?page=wc-orders&action=edit';
-	admin_new_order_assert = 'post_status" type="hidden" value="auto-draft';
+	admin_new_order_assert = 'post_status" type="hidden" value="pending';
 	admin_open_order_assert = 'post_status" type="hidden" value="pending';
-	admin_created_order_assert = 'changed from auto-draft to';
+	admin_created_order_assert = 'Order updated.';
 	admin_update_order_assert = 'changed from Pending payment to Completed';
 } else {
 	admin_new_order_base = 'post-new.php?post_type=shop_order';


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
`admin_update_order_base` is used in the file in various places, but when the tests are running in HPOS mode, this variable gets overridden with a version that includes the `&id=...` querystring var.

This is later used in a few other places ([example](https://github.com/woocommerce/woocommerce/blob/580d717ec2b935709caf5b74ca2321ca3bde8acd/plugins/woocommerce/tests/performance/requests/merchant/add-order.js#L415)) which results in the request being made to a URL with repeated `&id=...&id=...` arg.

These are a few entries from my nginx access log during a local test:

```
127.0.0.1 - - [13/Apr/2023:14:36:35 -0500] "GET /wp-admin/admin.php?page=wc-orders&action=edit&id=10622&id=10622&action=edit HTTP/2.0" 200 1341444 "-" "k6/0.43.1 (https://k6.io/)"
127.0.0.1 - - [13/Apr/2023:14:36:35 -0500] "POST /wp-admin/admin.php?page=wc-orders&action=edit&id=10622&id=10622 HTTP/2.0" 200 1894610 "-" "k6/0.43.1 (https://k6.io/)"
```

This can cause problems when combined with deletion of orders, as the `id` might remain in the URL, which produces an error.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Initialize the test environment or use an already-configured test instance. To do the former, follow [the docs](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/tests/performance/README.md).
2. Enable NGINX access logs in your test instance, if necessary.
3. Run `k6 run tests/wc-baseline-load.js` in HPOS mode (`cot_status = true` in `config.js`).
4. On `trunk`, confirm that the logs to confirm that you have entries with multiple `id` parameters in the querystring when groups in `merchant/add-order` are executed.
   Also, a few checks ("'Add new order' header" and "'Order updated' confirmation") are not passing.
5. On this branch, confirm that the logs don't contain such ID duplication and the checks should be passing.


<!-- End testing instructions -->