### PR TITLE
Refactoring LayoutContext and implementing with product editor

### DIFF
--- a/packages/js/admin-layout/changelog/update-layout-context-for-blocks
+++ b/packages/js/admin-layout/changelog/update-layout-context-for-blocks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Adding LayoutContext component and hook.

--- a/packages/js/admin-layout/src/components/LayoutContext/index.ts
+++ b/packages/js/admin-layout/src/components/LayoutContext/index.ts
@@ -1,0 +1,1 @@
+export * from './layout-context';

--- a/packages/js/admin-layout/src/components/LayoutContext/layout-context.tsx
+++ b/packages/js/admin-layout/src/components/LayoutContext/layout-context.tsx
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { createElement, createContext, useContext } from '@wordpress/element';
+
+export type LayoutContextType = {
+	layoutString: string;
+	updateLayoutPath: ( item: string ) => LayoutContextType;
+	layoutPath: string[];
+};
+
+type LayoutContextProviderProps = {
+	children: React.ReactNode;
+	value: LayoutContextType;
+};
+
+export const LayoutContext = createContext< LayoutContextType | undefined >(
+	undefined
+);
+
+export const getLayoutContextValue = (
+	layoutPath: LayoutContextType[ 'layoutPath' ] = []
+) => {
+	return {
+		layoutPath: [ ...layoutPath ],
+		updateLayoutPath: ( item: string ) => {
+			const newLayoutPath = [ ...layoutPath, item ];
+
+			return {
+				...getLayoutContextValue( newLayoutPath ),
+				layoutPath: newLayoutPath,
+			};
+		},
+		layoutString: layoutPath.join( '/' ),
+	};
+};
+
+export const LayoutContextProvider: React.FC< LayoutContextProviderProps > = ( {
+	children,
+	value,
+} ) => (
+	<LayoutContext.Provider value={ value }>
+		{ children }
+	</LayoutContext.Provider>
+);
+
+export const useLayoutContext = () => {
+	const layoutContext = useContext( LayoutContext );
+
+	if ( layoutContext === undefined ) {
+		throw new Error(
+			'useLayoutContext must be used within a LayoutContextProvider'
+		);
+	}
+
+	return layoutContext;
+};

--- a/packages/js/admin-layout/src/components/LayoutContext/layout-context.tsx
+++ b/packages/js/admin-layout/src/components/LayoutContext/layout-context.tsx
@@ -7,6 +7,7 @@ export type LayoutContextType = {
 	layoutString: string;
 	updateLayoutPath: ( item: string ) => LayoutContextType;
 	layoutPath: string[];
+	decendentOf: ( item: string ) => boolean;
 };
 
 type LayoutContextProviderProps = {
@@ -20,20 +21,19 @@ export const LayoutContext = createContext< LayoutContextType | undefined >(
 
 export const getLayoutContextValue = (
 	layoutPath: LayoutContextType[ 'layoutPath' ] = []
-) => {
-	return {
-		layoutPath: [ ...layoutPath ],
-		updateLayoutPath: ( item: string ) => {
-			const newLayoutPath = [ ...layoutPath, item ];
+): LayoutContextType => ( {
+	layoutPath: [ ...layoutPath ],
+	updateLayoutPath: ( item ) => {
+		const newLayoutPath = [ ...layoutPath, item ];
 
-			return {
-				...getLayoutContextValue( newLayoutPath ),
-				layoutPath: newLayoutPath,
-			};
-		},
-		layoutString: layoutPath.join( '/' ),
-	};
-};
+		return {
+			...getLayoutContextValue( newLayoutPath ),
+			layoutPath: newLayoutPath,
+		};
+	},
+	layoutString: layoutPath.join( '/' ),
+	decendentOf: ( item ) => layoutPath.includes( item ),
+} );
 
 export const LayoutContextProvider: React.FC< LayoutContextProviderProps > = ( {
 	children,

--- a/packages/js/admin-layout/src/components/LayoutContext/layout-context.tsx
+++ b/packages/js/admin-layout/src/components/LayoutContext/layout-context.tsx
@@ -7,7 +7,7 @@ export type LayoutContextType = {
 	layoutString: string;
 	updateLayoutPath: ( item: string ) => LayoutContextType;
 	layoutPath: string[];
-	decendentOf: ( item: string ) => boolean;
+	descendantOf: ( item: string ) => boolean;
 };
 
 type LayoutContextProviderProps = {
@@ -32,7 +32,7 @@ export const getLayoutContextValue = (
 		};
 	},
 	layoutString: layoutPath.join( '/' ),
-	decendentOf: ( item ) => layoutPath.includes( item ),
+	descendantOf: ( item ) => layoutPath.includes( item ),
 } );
 
 export const LayoutContextProvider: React.FC< LayoutContextProviderProps > = ( {
@@ -48,8 +48,7 @@ export const useLayoutContext = () => {
 	const layoutContext = useContext( LayoutContext );
 
 	if ( layoutContext === undefined ) {
-		// eslint-disable-next-line no-console
-		console.warn(
+		throw new Error(
 			'useLayoutContext must be used within a LayoutContextProvider'
 		);
 	}

--- a/packages/js/admin-layout/src/components/LayoutContext/layout-context.tsx
+++ b/packages/js/admin-layout/src/components/LayoutContext/layout-context.tsx
@@ -1,7 +1,12 @@
 /**
  * External dependencies
  */
-import { createElement, createContext, useContext } from '@wordpress/element';
+import {
+	createElement,
+	createContext,
+	useContext,
+	useMemo,
+} from '@wordpress/element';
 
 export type LayoutContextType = {
 	layoutString: string;
@@ -54,4 +59,10 @@ export const useLayoutContext = () => {
 	}
 
 	return layoutContext;
+};
+
+export const useExtendLayout = ( item: string ) => {
+	const { extendLayout } = useLayoutContext();
+
+	return useMemo( () => extendLayout( item ), [ extendLayout, item ] );
 };

--- a/packages/js/admin-layout/src/components/LayoutContext/layout-context.tsx
+++ b/packages/js/admin-layout/src/components/LayoutContext/layout-context.tsx
@@ -5,8 +5,8 @@ import { createElement, createContext, useContext } from '@wordpress/element';
 
 export type LayoutContextType = {
 	layoutString: string;
-	updateLayoutPath: ( item: string ) => LayoutContextType;
-	layoutPath: string[];
+	extendLayout: ( item: string ) => LayoutContextType;
+	layoutParts: string[];
 	isDescendantOf: ( item: string ) => boolean;
 };
 
@@ -20,19 +20,19 @@ export const LayoutContext = createContext< LayoutContextType | undefined >(
 );
 
 export const getLayoutContextValue = (
-	layoutPath: LayoutContextType[ 'layoutPath' ] = []
+	layoutParts: LayoutContextType[ 'layoutParts' ] = []
 ): LayoutContextType => ( {
-	layoutPath: [ ...layoutPath ],
-	updateLayoutPath: ( item ) => {
-		const newLayoutPath = [ ...layoutPath, item ];
+	layoutParts: [ ...layoutParts ],
+	extendLayout: ( item ) => {
+		const newLayoutPath = [ ...layoutParts, item ];
 
 		return {
 			...getLayoutContextValue( newLayoutPath ),
-			layoutPath: newLayoutPath,
+			layoutParts: newLayoutPath,
 		};
 	},
-	layoutString: layoutPath.join( '/' ),
-	isDescendantOf: ( item ) => layoutPath.includes( item ),
+	layoutString: layoutParts.join( '/' ),
+	isDescendantOf: ( item ) => layoutParts.includes( item ),
 } );
 
 export const LayoutContextProvider: React.FC< LayoutContextProviderProps > = ( {

--- a/packages/js/admin-layout/src/components/LayoutContext/layout-context.tsx
+++ b/packages/js/admin-layout/src/components/LayoutContext/layout-context.tsx
@@ -48,7 +48,8 @@ export const useLayoutContext = () => {
 	const layoutContext = useContext( LayoutContext );
 
 	if ( layoutContext === undefined ) {
-		throw new Error(
+		// eslint-disable-next-line no-console
+		console.warn(
 			'useLayoutContext must be used within a LayoutContextProvider'
 		);
 	}

--- a/packages/js/admin-layout/src/components/LayoutContext/layout-context.tsx
+++ b/packages/js/admin-layout/src/components/LayoutContext/layout-context.tsx
@@ -7,7 +7,7 @@ export type LayoutContextType = {
 	layoutString: string;
 	updateLayoutPath: ( item: string ) => LayoutContextType;
 	layoutPath: string[];
-	descendantOf: ( item: string ) => boolean;
+	isDescendantOf: ( item: string ) => boolean;
 };
 
 type LayoutContextProviderProps = {
@@ -32,7 +32,7 @@ export const getLayoutContextValue = (
 		};
 	},
 	layoutString: layoutPath.join( '/' ),
-	descendantOf: ( item ) => layoutPath.includes( item ),
+	isDescendantOf: ( item ) => layoutPath.includes( item ),
 } );
 
 export const LayoutContextProvider: React.FC< LayoutContextProviderProps > = ( {

--- a/packages/js/admin-layout/src/components/index.ts
+++ b/packages/js/admin-layout/src/components/index.ts
@@ -1,0 +1,1 @@
+export * from './LayoutContext';

--- a/packages/js/admin-layout/src/index.ts
+++ b/packages/js/admin-layout/src/index.ts
@@ -1,1 +1,2 @@
 export * from './plugins';
+export * from './components';

--- a/packages/js/customer-effort-score/changelog/update-layout-context-for-blocks
+++ b/packages/js/customer-effort-score/changelog/update-layout-context-for-blocks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Adding support for tracksProps to CES modal container.

--- a/packages/js/customer-effort-score/src/components/customer-effort-score-modal-container/index.tsx
+++ b/packages/js/customer-effort-score/src/components/customer-effort-score-modal-container/index.tsx
@@ -58,7 +58,9 @@ export const CustomerEffortScoreModalContainer: React.FC = () => {
 			score_combined: score + ( secondScore ?? 0 ),
 			comments: comments || '',
 			store_age: storeAgeInWeeks,
+			...visibleCESModalData.tracksProps,
 		} );
+
 		createSuccessNotice(
 			visibleCESModalData.onSubmitLabel ||
 				__(

--- a/packages/js/customer-effort-score/src/store/actions.js
+++ b/packages/js/customer-effort-score/src/store/actions.js
@@ -75,7 +75,8 @@ export function addCesSurvey( {
 export function showCesModal(
 	surveyProps = {},
 	props = {},
-	onSubmitNoticeProps = {}
+	onSubmitNoticeProps = {},
+	tracksProps = {}
 ) {
 	return {
 		type: TYPES.SHOW_CES_MODAL,
@@ -83,6 +84,7 @@ export function showCesModal(
 		onsubmit_label: surveyProps.onsubmitLabel || '',
 		props,
 		onSubmitNoticeProps,
+		tracksProps,
 	};
 }
 

--- a/packages/js/customer-effort-score/src/store/reducer.js
+++ b/packages/js/customer-effort-score/src/store/reducer.js
@@ -32,6 +32,7 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 				secondQuestion: action.surveyProps.secondQuestion,
 				onSubmitNoticeProps: action.onSubmitNoticeProps || {},
 				props: action.props,
+				tracksProps: action.tracksProps,
 			};
 			return {
 				...state,

--- a/packages/js/product-editor/changelog/update-layout-context-for-blocks
+++ b/packages/js/product-editor/changelog/update-layout-context-for-blocks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Adding LayoutContext support for tracks events context.

--- a/packages/js/product-editor/src/components/editor/editor.tsx
+++ b/packages/js/product-editor/src/components/editor/editor.tsx
@@ -52,11 +52,11 @@ type EditorProps = {
 
 export function Editor( { product, settings }: EditorProps ) {
 	const [ selectedTab, setSelectedTab ] = useState< string | null >( null );
-	const { updateLayoutPath } = useLayoutContext();
+	const { extendLayout } = useLayoutContext();
 
 	const updatedLayoutContext = useMemo(
-		() => updateLayoutPath( 'product-block-editor' ),
-		[ updateLayoutPath ]
+		() => extendLayout( 'product-block-editor' ),
+		[ extendLayout ]
 	);
 
 	return (

--- a/packages/js/product-editor/src/components/editor/editor.tsx
+++ b/packages/js/product-editor/src/components/editor/editor.tsx
@@ -9,6 +9,10 @@ import {
 } from '@wordpress/element';
 import { PluginArea } from '@wordpress/plugins';
 import {
+	LayoutContextProvider,
+	useLayoutContext,
+} from '@woocommerce/admin-layout';
+import {
 	EditorSettings,
 	EditorBlockListSettings,
 } from '@wordpress/block-editor';
@@ -47,41 +51,50 @@ type EditorProps = {
 
 export function Editor( { product, settings }: EditorProps ) {
 	const [ selectedTab, setSelectedTab ] = useState< string | null >( null );
+	const { updateLayoutPath } = useLayoutContext();
 
 	return (
-		<StrictMode>
-			<EntityProvider kind="postType" type="product" id={ product.id }>
-				<ShortcutProvider>
-					<FullscreenMode isActive={ false } />
-					<SlotFillProvider>
-						<InterfaceSkeleton
-							header={
-								<Header
-									productName={ product.name }
-									onTabSelect={ setSelectedTab }
-								/>
-							}
-							content={
-								<>
-									<BlockEditor
-										settings={ settings }
-										product={ product }
-										context={ {
-											selectedTab,
-											postType: 'product',
-											postId: product.id,
-										} }
+		<LayoutContextProvider
+			value={ updateLayoutPath( 'product-block-editor' ) }
+		>
+			<StrictMode>
+				<EntityProvider
+					kind="postType"
+					type="product"
+					id={ product.id }
+				>
+					<ShortcutProvider>
+						<FullscreenMode isActive={ false } />
+						<SlotFillProvider>
+							<InterfaceSkeleton
+								header={
+									<Header
+										productName={ product.name }
+										onTabSelect={ setSelectedTab }
 									/>
-									{ /* @ts-expect-error 'scope' does exist. @types/wordpress__plugins is outdated. */ }
-									<PluginArea scope="woocommerce-product-block-editor" />
-								</>
-							}
-						/>
+								}
+								content={
+									<>
+										<BlockEditor
+											settings={ settings }
+											product={ product }
+											context={ {
+												selectedTab,
+												postType: 'product',
+												postId: product.id,
+											} }
+										/>
+										{ /* @ts-expect-error 'scope' does exist. @types/wordpress__plugins is outdated. */ }
+										<PluginArea scope="woocommerce-product-block-editor" />
+									</>
+								}
+							/>
 
-						<Popover.Slot />
-					</SlotFillProvider>
-				</ShortcutProvider>
-			</EntityProvider>
-		</StrictMode>
+							<Popover.Slot />
+						</SlotFillProvider>
+					</ShortcutProvider>
+				</EntityProvider>
+			</StrictMode>
+		</LayoutContextProvider>
 	);
 }

--- a/packages/js/product-editor/src/components/editor/editor.tsx
+++ b/packages/js/product-editor/src/components/editor/editor.tsx
@@ -6,6 +6,7 @@ import {
 	StrictMode,
 	Fragment,
 	useState,
+	useMemo,
 } from '@wordpress/element';
 import { PluginArea } from '@wordpress/plugins';
 import {
@@ -53,10 +54,13 @@ export function Editor( { product, settings }: EditorProps ) {
 	const [ selectedTab, setSelectedTab ] = useState< string | null >( null );
 	const { updateLayoutPath } = useLayoutContext();
 
+	const updatedLayoutContext = useMemo(
+		() => updateLayoutPath( 'product-block-editor' ),
+		[ updateLayoutPath ]
+	);
+
 	return (
-		<LayoutContextProvider
-			value={ updateLayoutPath( 'product-block-editor' ) }
-		>
+		<LayoutContextProvider value={ updatedLayoutContext }>
 			<StrictMode>
 				<EntityProvider
 					kind="postType"

--- a/packages/js/product-editor/src/components/editor/editor.tsx
+++ b/packages/js/product-editor/src/components/editor/editor.tsx
@@ -6,12 +6,11 @@ import {
 	StrictMode,
 	Fragment,
 	useState,
-	useMemo,
 } from '@wordpress/element';
 import { PluginArea } from '@wordpress/plugins';
 import {
 	LayoutContextProvider,
-	useLayoutContext,
+	useExtendLayout,
 } from '@woocommerce/admin-layout';
 import {
 	EditorSettings,
@@ -52,12 +51,8 @@ type EditorProps = {
 
 export function Editor( { product, settings }: EditorProps ) {
 	const [ selectedTab, setSelectedTab ] = useState< string | null >( null );
-	const { extendLayout } = useLayoutContext();
 
-	const updatedLayoutContext = useMemo(
-		() => extendLayout( 'product-block-editor' ),
-		[ extendLayout ]
-	);
+	const updatedLayoutContext = useExtendLayout( 'product-block-editor' );
 
 	return (
 		<LayoutContextProvider value={ updatedLayoutContext }>

--- a/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
+++ b/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { lazy, useState, useEffect, useMemo } from '@wordpress/element';
+import { lazy, useState, useEffect } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { uniqueId, find } from 'lodash';
 import { Icon, help as helpIcon, external } from '@wordpress/icons';
@@ -20,7 +20,7 @@ import { recordEvent } from '@woocommerce/tracks';
 import { useSlot } from '@woocommerce/experimental';
 import {
 	LayoutContextProvider,
-	useLayoutContext,
+	useExtendLayout,
 } from '@woocommerce/admin-layout';
 
 /**
@@ -73,7 +73,6 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 	const hasExtendedNotifications = Boolean( fills?.length );
 	const { updateUserPreferences, ...userData } = useUserPreferences();
 	const activeSetupList = useActiveSetupTasklist();
-	const { extendLayout } = useLayoutContext();
 
 	useEffect( () => {
 		return addHistoryListener( () => {
@@ -82,10 +81,7 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 		} );
 	}, [] );
 
-	const updatedLayoutContext = useMemo(
-		() => extendLayout( 'activity-panel' ),
-		[ extendLayout ]
-	);
+	const updatedLayoutContext = useExtendLayout( 'activity-panel' );
 
 	const getPreviewSiteBtnTrackData = ( select, getOption ) => {
 		let trackData = {};

--- a/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
+++ b/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
@@ -2,13 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	lazy,
-	useState,
-	useContext,
-	useMemo,
-	useEffect,
-} from '@wordpress/element';
+import { lazy, useState, useEffect } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { uniqueId, find } from 'lodash';
 import { Icon, help as helpIcon, external } from '@wordpress/icons';
@@ -24,6 +18,10 @@ import {
 import { getHistory, addHistoryListener } from '@woocommerce/navigation';
 import { recordEvent } from '@woocommerce/tracks';
 import { useSlot } from '@woocommerce/experimental';
+import {
+	LayoutContextProvider,
+	useLayoutContext,
+} from '@woocommerce/admin-layout';
 
 /**
  * Internal dependencies
@@ -46,7 +44,6 @@ import { ABBREVIATED_NOTIFICATION_SLOT_NAME } from './panels/inbox/abbreviated-n
 import { getAdminSetting } from '~/utils/admin-settings';
 import { getUrlParams } from '~/utils';
 import { useActiveSetupTasklist } from '~/tasks';
-import { LayoutContext } from '~/layout';
 import { getSegmentsFromPath } from '~/utils/url-helpers';
 import { FeedbackIcon } from '~/products/images/feedback-icon';
 import { ProductFeedbackTour } from '~/guided-tours/add-product-feedback-tour';
@@ -76,11 +73,7 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 	const hasExtendedNotifications = Boolean( fills?.length );
 	const { updateUserPreferences, ...userData } = useUserPreferences();
 	const activeSetupList = useActiveSetupTasklist();
-	const layoutContext = useContext( LayoutContext );
-	const updatedLayoutContext = useMemo(
-		() => layoutContext.getExtendedContext( 'activity-panel' ),
-		[ layoutContext ]
-	);
+	const { updateLayoutPath } = useLayoutContext();
 
 	useEffect( () => {
 		return addHistoryListener( () => {
@@ -457,7 +450,7 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 	const showHelpHighlightTooltip = shouldShowHelpTooltip();
 
 	return (
-		<LayoutContext.Provider value={ updatedLayoutContext }>
+		<LayoutContextProvider value={ updateLayoutPath( 'activity-panel' ) }>
 			<div>
 				<H id={ headerId } className="screen-reader-text">
 					{ __( 'Store Activity', 'woocommerce' ) }
@@ -510,7 +503,7 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 					/>
 				) : null }
 			</div>
-		</LayoutContext.Provider>
+		</LayoutContextProvider>
 	);
 };
 

--- a/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
+++ b/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { lazy, useState, useEffect } from '@wordpress/element';
+import { lazy, useState, useEffect, useMemo } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { uniqueId, find } from 'lodash';
 import { Icon, help as helpIcon, external } from '@wordpress/icons';
@@ -81,6 +81,11 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 			clearPanel();
 		} );
 	}, [] );
+
+	const updatedLayoutContext = useMemo(
+		() => updateLayoutPath( 'activity-panel' ),
+		[ updateLayoutPath ]
+	);
 
 	const getPreviewSiteBtnTrackData = ( select, getOption ) => {
 		let trackData = {};
@@ -450,7 +455,7 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 	const showHelpHighlightTooltip = shouldShowHelpTooltip();
 
 	return (
-		<LayoutContextProvider value={ updateLayoutPath( 'activity-panel' ) }>
+		<LayoutContextProvider value={ updatedLayoutContext }>
 			<div>
 				<H id={ headerId } className="screen-reader-text">
 					{ __( 'Store Activity', 'woocommerce' ) }

--- a/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
+++ b/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
@@ -73,7 +73,7 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 	const hasExtendedNotifications = Boolean( fills?.length );
 	const { updateUserPreferences, ...userData } = useUserPreferences();
 	const activeSetupList = useActiveSetupTasklist();
-	const { updateLayoutPath } = useLayoutContext();
+	const { extendLayout } = useLayoutContext();
 
 	useEffect( () => {
 		return addHistoryListener( () => {
@@ -83,8 +83,8 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 	}, [] );
 
 	const updatedLayoutContext = useMemo(
-		() => updateLayoutPath( 'activity-panel' ),
-		[ updateLayoutPath ]
+		() => extendLayout( 'activity-panel' ),
+		[ extendLayout ]
 	);
 
 	const getPreviewSiteBtnTrackData = ( select, getOption ) => {

--- a/plugins/woocommerce-admin/client/activity-panel/test/index.js
+++ b/plugins/woocommerce-admin/client/activity-panel/test/index.js
@@ -24,7 +24,7 @@ jest.mock( '@woocommerce/admin-layout', () => ( {
 		layoutPath: [ 'home' ],
 		layoutString: 'home',
 		updateLayoutPath: () => {},
-		descendantOf: () => false,
+		isDescendantOf: () => false,
 	} ),
 } ) );
 

--- a/plugins/woocommerce-admin/client/activity-panel/test/index.js
+++ b/plugins/woocommerce-admin/client/activity-panel/test/index.js
@@ -23,7 +23,7 @@ jest.mock( '@woocommerce/admin-layout', () => ( {
 	useLayoutContext: jest.fn().mockReturnValue( {
 		layoutPath: [ 'home' ],
 		layoutString: 'home',
-		updateLayoutPath: () => {},
+		extendLayout: () => {},
 		isDescendantOf: () => false,
 	} ),
 } ) );

--- a/plugins/woocommerce-admin/client/activity-panel/test/index.js
+++ b/plugins/woocommerce-admin/client/activity-panel/test/index.js
@@ -18,15 +18,19 @@ import { useState } from '@wordpress/element';
 import { ActivityPanel } from '../activity-panel';
 import { Panel } from '../panel';
 
-jest.mock( '@woocommerce/admin-layout', () => ( {
-	...jest.requireActual( '@woocommerce/admin-layout' ),
-	useLayoutContext: jest.fn().mockReturnValue( {
+jest.mock( '@woocommerce/admin-layout', () => {
+	const mockContext = {
 		layoutPath: [ 'home' ],
 		layoutString: 'home',
 		extendLayout: () => {},
 		isDescendantOf: () => false,
-	} ),
-} ) );
+	};
+	return {
+		...jest.requireActual( '@woocommerce/admin-layout' ),
+		useLayoutContext: jest.fn().mockReturnValue( mockContext ),
+		useExtendLayout: jest.fn().mockReturnValue( mockContext ),
+	};
+} );
 
 jest.mock( '@woocommerce/data', () => ( {
 	...jest.requireActual( '@woocommerce/data' ),

--- a/plugins/woocommerce-admin/client/activity-panel/test/index.js
+++ b/plugins/woocommerce-admin/client/activity-panel/test/index.js
@@ -18,6 +18,16 @@ import { useState } from '@wordpress/element';
 import { ActivityPanel } from '../activity-panel';
 import { Panel } from '../panel';
 
+jest.mock( '@woocommerce/admin-layout', () => ( {
+	...jest.requireActual( '@woocommerce/admin-layout' ),
+	useLayoutContext: jest.fn().mockReturnValue( {
+		layoutPath: [ 'home' ],
+		layoutString: 'home',
+		updateLayoutPath: () => {},
+		descendantOf: () => false,
+	} ),
+} ) );
+
 jest.mock( '@woocommerce/data', () => ( {
 	...jest.requireActual( '@woocommerce/data' ),
 	useUser: jest.fn().mockReturnValue( { currentUserCan: () => true } ),

--- a/plugins/woocommerce-admin/client/products/fills/more-menu-items/feedback-menu-item.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/more-menu-items/feedback-menu-item.tsx
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { MenuItem } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { STORE_KEY as CES_STORE_KEY } from '@woocommerce/customer-effort-score';
+import { useLayoutContext } from '@woocommerce/admin-layout';
 
 /**
  * Internal dependencies
@@ -13,6 +14,7 @@ import { FeedbackIcon } from '../../images/feedback-icon';
 
 export const FeedbackMenuItem = ( { onClose }: { onClose: () => void } ) => {
 	const { showCesModal } = useDispatch( CES_STORE_KEY );
+	const { layoutPath } = useLayoutContext();
 
 	return (
 		<MenuItem
@@ -33,10 +35,17 @@ export const FeedbackMenuItem = ( { onClose }: { onClose: () => void } ) => {
 							'woocommerce'
 						),
 					},
-					{ shouldShowComments: () => true },
+					{
+						shouldShowComments: () => true,
+					},
 					{
 						type: 'snackbar',
 						icon: <span>🌟</span>,
+					},
+					{
+						block_editor: layoutPath.includes(
+							'product-block-editor'
+						),
 					}
 				);
 				onClose();

--- a/plugins/woocommerce-admin/client/products/fills/more-menu-items/feedback-menu-item.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/more-menu-items/feedback-menu-item.tsx
@@ -14,7 +14,7 @@ import { FeedbackIcon } from '../../images/feedback-icon';
 
 export const FeedbackMenuItem = ( { onClose }: { onClose: () => void } ) => {
 	const { showCesModal } = useDispatch( CES_STORE_KEY );
-	const { decendentOf } = useLayoutContext();
+	const { descendantOf } = useLayoutContext();
 
 	return (
 		<MenuItem
@@ -43,7 +43,7 @@ export const FeedbackMenuItem = ( { onClose }: { onClose: () => void } ) => {
 						icon: <span>🌟</span>,
 					},
 					{
-						block_editor: decendentOf( 'product-block-editor' ),
+						block_editor: descendantOf( 'product-block-editor' ),
 					}
 				);
 				onClose();

--- a/plugins/woocommerce-admin/client/products/fills/more-menu-items/feedback-menu-item.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/more-menu-items/feedback-menu-item.tsx
@@ -14,7 +14,7 @@ import { FeedbackIcon } from '../../images/feedback-icon';
 
 export const FeedbackMenuItem = ( { onClose }: { onClose: () => void } ) => {
 	const { showCesModal } = useDispatch( CES_STORE_KEY );
-	const { descendantOf } = useLayoutContext();
+	const { isDescendantOf } = useLayoutContext();
 
 	return (
 		<MenuItem
@@ -43,7 +43,7 @@ export const FeedbackMenuItem = ( { onClose }: { onClose: () => void } ) => {
 						icon: <span>🌟</span>,
 					},
 					{
-						block_editor: descendantOf( 'product-block-editor' ),
+						block_editor: isDescendantOf( 'product-block-editor' ),
 					}
 				);
 				onClose();

--- a/plugins/woocommerce-admin/client/products/fills/more-menu-items/feedback-menu-item.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/more-menu-items/feedback-menu-item.tsx
@@ -14,7 +14,7 @@ import { FeedbackIcon } from '../../images/feedback-icon';
 
 export const FeedbackMenuItem = ( { onClose }: { onClose: () => void } ) => {
 	const { showCesModal } = useDispatch( CES_STORE_KEY );
-	const { layoutPath } = useLayoutContext();
+	const { decendentOf } = useLayoutContext();
 
 	return (
 		<MenuItem
@@ -43,9 +43,7 @@ export const FeedbackMenuItem = ( { onClose }: { onClose: () => void } ) => {
 						icon: <span>🌟</span>,
 					},
 					{
-						block_editor: layoutPath.includes(
-							'product-block-editor'
-						),
+						block_editor: decendentOf( 'product-block-editor' ),
 					}
 				);
 				onClose();

--- a/plugins/woocommerce-admin/client/shipping/experimental-woocommerce-services-item.tsx
+++ b/plugins/woocommerce-admin/client/shipping/experimental-woocommerce-services-item.tsx
@@ -6,27 +6,23 @@ import { Button, ExternalLink } from '@wordpress/components';
 import { Pill } from '@woocommerce/components';
 import { getNewPath, navigateTo } from '@woocommerce/navigation';
 import { recordEvent } from '@woocommerce/tracks';
-import { useContext, useMemo } from '@wordpress/element';
+import { useLayoutContext } from '@woocommerce/admin-layout';
 
 /**
  * Internal dependencies
  */
 import './woocommerce-services-item.scss';
 import WooIcon from './woo-icon.svg';
-import { LayoutContext } from '~/layout';
 
 const WooCommerceServicesItem: React.FC< {
 	isWCSInstalled: boolean | undefined;
 } > = ( { isWCSInstalled } ) => {
-	const layoutContext = useContext( LayoutContext );
-	const updatedLayoutContext = useMemo(
-		() => layoutContext.getExtendedContext( 'wc-settings' ),
-		[ layoutContext ]
-	);
+	const { layoutString } = useLayoutContext();
+
 	const handleSetupClick = () => {
 		recordEvent( 'tasklist_click', {
 			task_name: 'shipping-recommendation',
-			context: updatedLayoutContext.toString(),
+			context: `${ layoutString }/wc-settings`,
 		} );
 		navigateTo( {
 			url: getNewPath( { task: 'shipping-recommendation' }, '/', {} ),

--- a/plugins/woocommerce-admin/client/shipping/test/experimental-shipping-recommendations.tsx
+++ b/plugins/woocommerce-admin/client/shipping/test/experimental-shipping-recommendations.tsx
@@ -22,7 +22,7 @@ jest.mock( '@woocommerce/admin-layout', () => ( {
 	useLayoutContext: jest.fn().mockReturnValue( {
 		layoutPath: [ 'home' ],
 		layoutString: 'home',
-		updateLayoutPath: () => {},
+		extendLayout: () => {},
 		isDescendantOf: () => false,
 	} ),
 } ) );

--- a/plugins/woocommerce-admin/client/shipping/test/experimental-shipping-recommendations.tsx
+++ b/plugins/woocommerce-admin/client/shipping/test/experimental-shipping-recommendations.tsx
@@ -17,15 +17,19 @@ jest.mock( '../../settings-recommendations/dismissable-list', () => ( {
 	DismissableList: ( ( { children } ) => children ) as React.FC,
 	DismissableListHeading: ( ( { children } ) => children ) as React.FC,
 } ) );
-jest.mock( '@woocommerce/admin-layout', () => ( {
-	...jest.requireActual( '@woocommerce/admin-layout' ),
-	useLayoutContext: jest.fn().mockReturnValue( {
+jest.mock( '@woocommerce/admin-layout', () => {
+	const mockContext = {
 		layoutPath: [ 'home' ],
 		layoutString: 'home',
 		extendLayout: () => {},
 		isDescendantOf: () => false,
-	} ),
-} ) );
+	};
+	return {
+		...jest.requireActual( '@woocommerce/admin-layout' ),
+		useLayoutContext: jest.fn().mockReturnValue( mockContext ),
+		useExtendLayout: jest.fn().mockReturnValue( mockContext ),
+	};
+} );
 
 const defaultSelectReturn = {
 	getActivePlugins: () => [],

--- a/plugins/woocommerce-admin/client/shipping/test/experimental-shipping-recommendations.tsx
+++ b/plugins/woocommerce-admin/client/shipping/test/experimental-shipping-recommendations.tsx
@@ -17,6 +17,15 @@ jest.mock( '../../settings-recommendations/dismissable-list', () => ( {
 	DismissableList: ( ( { children } ) => children ) as React.FC,
 	DismissableListHeading: ( ( { children } ) => children ) as React.FC,
 } ) );
+jest.mock( '@woocommerce/admin-layout', () => ( {
+	...jest.requireActual( '@woocommerce/admin-layout' ),
+	useLayoutContext: jest.fn().mockReturnValue( {
+		layoutPath: [ 'home' ],
+		layoutString: 'home',
+		updateLayoutPath: () => {},
+		descendantOf: () => false,
+	} ),
+} ) );
 
 const defaultSelectReturn = {
 	getActivePlugins: () => [],

--- a/plugins/woocommerce-admin/client/shipping/test/experimental-shipping-recommendations.tsx
+++ b/plugins/woocommerce-admin/client/shipping/test/experimental-shipping-recommendations.tsx
@@ -23,7 +23,7 @@ jest.mock( '@woocommerce/admin-layout', () => ( {
 		layoutPath: [ 'home' ],
 		layoutString: 'home',
 		updateLayoutPath: () => {},
-		descendantOf: () => false,
+		isDescendantOf: () => false,
 	} ),
 } ) );
 

--- a/plugins/woocommerce-admin/client/shipping/test/experimental-woocommerce-services-item.tsx
+++ b/plugins/woocommerce-admin/client/shipping/test/experimental-woocommerce-services-item.tsx
@@ -13,15 +13,19 @@ jest.mock( '@woocommerce/tracks', () => ( {
 	recordEvent: jest.fn(),
 } ) );
 
-jest.mock( '@woocommerce/admin-layout', () => ( {
-	...jest.requireActual( '@woocommerce/admin-layout' ),
-	useLayoutContext: jest.fn().mockReturnValue( {
+jest.mock( '@woocommerce/admin-layout', () => {
+	const mockContext = {
 		layoutPath: [ 'root' ],
 		layoutString: 'root',
 		extendLayout: () => {},
 		isDescendantOf: () => false,
-	} ),
-} ) );
+	};
+	return {
+		...jest.requireActual( '@woocommerce/admin-layout' ),
+		useLayoutContext: jest.fn().mockReturnValue( mockContext ),
+		useExtendLayout: jest.fn().mockReturnValue( mockContext ),
+	};
+} );
 
 describe( 'WooCommerceServicesItem', () => {
 	it( 'should render WCS item with CTA = "Get started" when WCS is not installed', () => {

--- a/plugins/woocommerce-admin/client/shipping/test/experimental-woocommerce-services-item.tsx
+++ b/plugins/woocommerce-admin/client/shipping/test/experimental-woocommerce-services-item.tsx
@@ -13,6 +13,16 @@ jest.mock( '@woocommerce/tracks', () => ( {
 	recordEvent: jest.fn(),
 } ) );
 
+jest.mock( '@woocommerce/admin-layout', () => ( {
+	...jest.requireActual( '@woocommerce/admin-layout' ),
+	useLayoutContext: jest.fn().mockReturnValue( {
+		layoutPath: [ 'root' ],
+		layoutString: 'root',
+		updateLayoutPath: () => {},
+		descendantOf: () => false,
+	} ),
+} ) );
+
 describe( 'WooCommerceServicesItem', () => {
 	it( 'should render WCS item with CTA = "Get started" when WCS is not installed', () => {
 		render( <WooCommerceServicesItem isWCSInstalled={ false } /> );

--- a/plugins/woocommerce-admin/client/shipping/test/experimental-woocommerce-services-item.tsx
+++ b/plugins/woocommerce-admin/client/shipping/test/experimental-woocommerce-services-item.tsx
@@ -19,7 +19,7 @@ jest.mock( '@woocommerce/admin-layout', () => ( {
 		layoutPath: [ 'root' ],
 		layoutString: 'root',
 		updateLayoutPath: () => {},
-		descendantOf: () => false,
+		isDescendantOf: () => false,
 	} ),
 } ) );
 

--- a/plugins/woocommerce-admin/client/shipping/test/experimental-woocommerce-services-item.tsx
+++ b/plugins/woocommerce-admin/client/shipping/test/experimental-woocommerce-services-item.tsx
@@ -18,7 +18,7 @@ jest.mock( '@woocommerce/admin-layout', () => ( {
 	useLayoutContext: jest.fn().mockReturnValue( {
 		layoutPath: [ 'root' ],
 		layoutString: 'root',
-		updateLayoutPath: () => {},
+		extendLayout: () => {},
 		isDescendantOf: () => false,
 	} ),
 } ) );

--- a/plugins/woocommerce-admin/client/tasks/task-list-item.tsx
+++ b/plugins/woocommerce-admin/client/tasks/task-list-item.tsx
@@ -10,14 +10,14 @@ import {
 } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { TaskItem, useSlot } from '@woocommerce/experimental';
-import { useCallback, useContext, useEffect } from '@wordpress/element';
+import { useCallback, useEffect } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { WooOnboardingTaskListItem } from '@woocommerce/onboarding';
+import { useLayoutContext } from '@woocommerce/admin-layout';
 
 /**
  * Internal dependencies
  */
-import { LayoutContext } from '~/layout';
 import './task-list.scss';
 
 export type TaskListItemProps = {
@@ -36,7 +36,7 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 	task,
 } ) => {
 	const { createNotice } = useDispatch( 'core/notices' );
-	const layoutContext = useContext( LayoutContext );
+	const { layoutString } = useLayoutContext();
 
 	const {
 		dismissTask,
@@ -67,7 +67,7 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 			recordEvent( 'tasklist_item_view', {
 				task_name: id,
 				is_complete: isComplete,
-				context: layoutContext.toString(),
+				context: layoutString,
 			} );
 		}
 		// run the effect only when component mounts
@@ -132,7 +132,7 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 	const trackClick = () => {
 		recordEvent( 'tasklist_click', {
 			task_name: id,
-			context: layoutContext.toString(),
+			context: layoutString,
 		} );
 
 		if ( ! isComplete ) {

--- a/plugins/woocommerce-admin/client/tasks/task-list.tsx
+++ b/plugins/woocommerce-admin/client/tasks/task-list.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { useEffect, useRef, useState, useContext } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import { Card, CardHeader } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { Badge } from '@woocommerce/components';
@@ -13,6 +13,7 @@ import {
 } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { Text, List, CollapsibleList } from '@woocommerce/experimental';
+import { useLayoutContext } from '@woocommerce/admin-layout';
 
 /**
  * Internal dependencies
@@ -21,7 +22,6 @@ import { TaskListItem } from './task-list-item';
 import { TaskListMenu } from './task-list-menu';
 import './task-list.scss';
 import { ProgressHeader } from '~/task-lists/progress-header';
-import { LayoutContext } from '~/layout';
 
 export type TaskListProps = TaskListType & {
 	query: {
@@ -52,7 +52,7 @@ export const TaskList: React.FC< TaskListProps > = ( {
 	} );
 	const prevQueryRef = useRef( query );
 	const visibleTasks = getVisibleTasks( tasks );
-	const layoutContext = useContext( LayoutContext );
+	const { layoutString } = useLayoutContext();
 
 	const incompleteTasks = tasks.filter(
 		( task ) => ! task.isComplete && ! task.isDismissed
@@ -66,7 +66,7 @@ export const TaskList: React.FC< TaskListProps > = ( {
 		recordEvent( eventPrefix + 'view', {
 			number_tasks: visibleTasks.length,
 			store_connected: profileItems.wccom_connected,
-			context: layoutContext.toString(),
+			context: layoutString,
 		} );
 	};
 

--- a/plugins/woocommerce-admin/client/tasks/test/task-list-item.test.tsx
+++ b/plugins/woocommerce-admin/client/tasks/test/task-list-item.test.tsx
@@ -26,7 +26,7 @@ jest.mock( '@woocommerce/admin-layout', () => ( {
 	useLayoutContext: jest.fn().mockReturnValue( {
 		layoutPath: [ 'home' ],
 		layoutString: 'home',
-		updateLayoutPath: () => {},
+		extendLayout: () => {},
 		isDescendantOf: () => false,
 	} ),
 } ) );

--- a/plugins/woocommerce-admin/client/tasks/test/task-list-item.test.tsx
+++ b/plugins/woocommerce-admin/client/tasks/test/task-list-item.test.tsx
@@ -27,7 +27,7 @@ jest.mock( '@woocommerce/admin-layout', () => ( {
 		layoutPath: [ 'home' ],
 		layoutString: 'home',
 		updateLayoutPath: () => {},
-		descendantOf: () => false,
+		isDescendantOf: () => false,
 	} ),
 } ) );
 

--- a/plugins/woocommerce-admin/client/tasks/test/task-list-item.test.tsx
+++ b/plugins/woocommerce-admin/client/tasks/test/task-list-item.test.tsx
@@ -21,6 +21,15 @@ jest.mock( '@wordpress/data', () => {
 		useDispatch: jest.fn(),
 	};
 } );
+jest.mock( '@woocommerce/admin-layout', () => ( {
+	...jest.requireActual( '@woocommerce/admin-layout' ),
+	useLayoutContext: jest.fn().mockReturnValue( {
+		layoutPath: [ 'home' ],
+		layoutString: 'home',
+		updateLayoutPath: () => {},
+		descendantOf: () => false,
+	} ),
+} ) );
 
 const mockDispatch = {
 	createNotice: jest.fn(),
@@ -34,6 +43,7 @@ const mockDispatch = {
 jest.mock( '@woocommerce/tracks', () => ( {
 	recordEvent: jest.fn(),
 } ) );
+
 jest.mock( '@woocommerce/data', () => {
 	const originalModule = jest.requireActual( '@woocommerce/data' );
 	return {
@@ -131,7 +141,7 @@ describe( 'TaskListItem', () => {
 
 		expect( recordEvent ).toHaveBeenCalledTimes( 1 );
 		expect( recordEvent ).toHaveBeenCalledWith( 'tasklist_item_view', {
-			context: 'root',
+			context: 'home',
 			is_complete: task.isComplete,
 			task_name: task.id,
 		} );

--- a/plugins/woocommerce-admin/client/tasks/test/task-list-item.test.tsx
+++ b/plugins/woocommerce-admin/client/tasks/test/task-list-item.test.tsx
@@ -21,15 +21,19 @@ jest.mock( '@wordpress/data', () => {
 		useDispatch: jest.fn(),
 	};
 } );
-jest.mock( '@woocommerce/admin-layout', () => ( {
-	...jest.requireActual( '@woocommerce/admin-layout' ),
-	useLayoutContext: jest.fn().mockReturnValue( {
+jest.mock( '@woocommerce/admin-layout', () => {
+	const mockContext = {
 		layoutPath: [ 'home' ],
 		layoutString: 'home',
 		extendLayout: () => {},
 		isDescendantOf: () => false,
-	} ),
-} ) );
+	};
+	return {
+		...jest.requireActual( '@woocommerce/admin-layout' ),
+		useLayoutContext: jest.fn().mockReturnValue( mockContext ),
+		useExtendLayout: jest.fn().mockReturnValue( mockContext ),
+	};
+} );
 
 const mockDispatch = {
 	createNotice: jest.fn(),

--- a/plugins/woocommerce-admin/client/tasks/test/task-list.test.tsx
+++ b/plugins/woocommerce-admin/client/tasks/test/task-list.test.tsx
@@ -29,6 +29,15 @@ jest.mock( '@woocommerce/components', () => ( {
 		.fn()
 		.mockImplementation( ( { count } ) => <div>Count:{ count }</div> ),
 } ) );
+jest.mock( '@woocommerce/admin-layout', () => ( {
+	...jest.requireActual( '@woocommerce/admin-layout' ),
+	useLayoutContext: jest.fn().mockReturnValue( {
+		layoutPath: [ 'home' ],
+		layoutString: 'home',
+		updateLayoutPath: () => {},
+		descendantOf: () => false,
+	} ),
+} ) );
 
 const tasks: { [ key: string ]: TaskType[] } = {
 	setup: [
@@ -148,7 +157,7 @@ describe( 'TaskList', () => {
 		);
 		expect( recordEvent ).toHaveBeenCalledTimes( 1 );
 		expect( recordEvent ).toHaveBeenCalledWith( 'tasklist_view', {
-			context: 'root',
+			context: 'home',
 			number_tasks: 0,
 			store_connected: null,
 		} );
@@ -171,7 +180,7 @@ describe( 'TaskList', () => {
 		);
 		expect( recordEvent ).toHaveBeenCalledTimes( 1 );
 		expect( recordEvent ).toHaveBeenCalledWith( 'extended_tasklist_view', {
-			context: 'root',
+			context: 'home',
 			number_tasks: 0,
 			store_connected: null,
 		} );

--- a/plugins/woocommerce-admin/client/tasks/test/task-list.test.tsx
+++ b/plugins/woocommerce-admin/client/tasks/test/task-list.test.tsx
@@ -29,15 +29,19 @@ jest.mock( '@woocommerce/components', () => ( {
 		.fn()
 		.mockImplementation( ( { count } ) => <div>Count:{ count }</div> ),
 } ) );
-jest.mock( '@woocommerce/admin-layout', () => ( {
-	...jest.requireActual( '@woocommerce/admin-layout' ),
-	useLayoutContext: jest.fn().mockReturnValue( {
+jest.mock( '@woocommerce/admin-layout', () => {
+	const mockContext = {
 		layoutPath: [ 'home' ],
 		layoutString: 'home',
 		extendLayout: () => {},
 		isDescendantOf: () => false,
-	} ),
-} ) );
+	};
+	return {
+		...jest.requireActual( '@woocommerce/admin-layout' ),
+		useLayoutContext: jest.fn().mockReturnValue( mockContext ),
+		useExtendLayout: jest.fn().mockReturnValue( mockContext ),
+	};
+} );
 
 const tasks: { [ key: string ]: TaskType[] } = {
 	setup: [

--- a/plugins/woocommerce-admin/client/tasks/test/task-list.test.tsx
+++ b/plugins/woocommerce-admin/client/tasks/test/task-list.test.tsx
@@ -35,7 +35,7 @@ jest.mock( '@woocommerce/admin-layout', () => ( {
 		layoutPath: [ 'home' ],
 		layoutString: 'home',
 		updateLayoutPath: () => {},
-		descendantOf: () => false,
+		isDescendantOf: () => false,
 	} ),
 } ) );
 

--- a/plugins/woocommerce-admin/client/tasks/test/task-list.test.tsx
+++ b/plugins/woocommerce-admin/client/tasks/test/task-list.test.tsx
@@ -34,7 +34,7 @@ jest.mock( '@woocommerce/admin-layout', () => ( {
 	useLayoutContext: jest.fn().mockReturnValue( {
 		layoutPath: [ 'home' ],
 		layoutString: 'home',
-		updateLayoutPath: () => {},
+		extendLayout: () => {},
 		isDescendantOf: () => false,
 	} ),
 } ) );

--- a/plugins/woocommerce-admin/client/two-column-tasks/task-list.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/task-list.tsx
@@ -2,13 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	useEffect,
-	useRef,
-	useState,
-	createElement,
-	useContext,
-} from '@wordpress/element';
+import { useEffect, useRef, useState, createElement } from '@wordpress/element';
 import { Button, Card } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { EllipsisMenu } from '@woocommerce/components';
@@ -25,6 +19,7 @@ import {
 import { recordEvent } from '@woocommerce/tracks';
 import { List, useSlot } from '@woocommerce/experimental';
 import classnames from 'classnames';
+import { useLayoutContext } from '@woocommerce/admin-layout';
 
 /**
  * Internal dependencies
@@ -36,7 +31,7 @@ import TaskListCompleted from './completed';
 import { ProgressHeader } from '~/task-lists/progress-header';
 import { TaskListItemTwoColumn } from './task-list-item-two-column';
 import { TaskListCompletedHeader } from './completed-header';
-import { LayoutContext } from '~/layout';
+
 import { ExperimentalWooTaskListFooter } from './footer-slot';
 import {
 	TaskListCompletionSlot,
@@ -84,7 +79,7 @@ export const TaskList: React.FC< TaskListProps > = ( {
 	} >( {} );
 	const [ activeTaskId, setActiveTaskId ] = useState( '' );
 	const [ showDismissModal, setShowDismissModal ] = useState( false );
-	const layoutContext = useContext( LayoutContext );
+	const { layoutString } = useLayoutContext();
 
 	const prevQueryRef = useRef( query );
 
@@ -97,7 +92,7 @@ export const TaskList: React.FC< TaskListProps > = ( {
 		recordEvent( `${ listEventPrefix }view`, {
 			number_tasks: visibleTasks.length,
 			store_connected: profileItems.wccom_connected,
-			context: layoutContext.toString(),
+			context: layoutString,
 		} );
 	};
 
@@ -207,7 +202,7 @@ export const TaskList: React.FC< TaskListProps > = ( {
 	const trackClick = ( task: TaskType ) => {
 		recordEvent( `${ listEventPrefix }click`, {
 			task_name: task.id,
-			context: layoutContext.toString(),
+			context: layoutString,
 		} );
 	};
 

--- a/plugins/woocommerce-admin/client/two-column-tasks/test/task-list.test.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/test/task-list.test.tsx
@@ -38,6 +38,15 @@ jest.mock( '@woocommerce/data', () => ( {
 		updateUserPreferences: jest.fn(),
 	} ),
 } ) );
+jest.mock( '@woocommerce/admin-layout', () => ( {
+	...jest.requireActual( '@woocommerce/admin-layout' ),
+	useLayoutContext: jest.fn().mockReturnValue( {
+		layoutPath: [ 'home' ],
+		layoutString: 'home',
+		updateLayoutPath: () => {},
+		descendantOf: () => false,
+	} ),
+} ) );
 
 const tasks: { [ key: string ]: TaskType[] } = {
 	setup: [
@@ -158,7 +167,7 @@ describe( 'TaskList', () => {
 		);
 		expect( recordEvent ).toHaveBeenCalledTimes( 1 );
 		expect( recordEvent ).toHaveBeenCalledWith( 'tasklist_view', {
-			context: 'root',
+			context: 'home',
 			number_tasks: 0,
 			store_connected: null,
 		} );
@@ -181,7 +190,7 @@ describe( 'TaskList', () => {
 		);
 		expect( recordEvent ).toHaveBeenCalledTimes( 1 );
 		expect( recordEvent ).toHaveBeenCalledWith( 'tasklist_view', {
-			context: 'root',
+			context: 'home',
 			number_tasks: 0,
 			store_connected: null,
 		} );
@@ -205,7 +214,7 @@ describe( 'TaskList', () => {
 		);
 		expect( recordEvent ).toHaveBeenCalledTimes( 1 );
 		expect( recordEvent ).toHaveBeenCalledWith( 'extended_tasklist_view', {
-			context: 'root',
+			context: 'home',
 			number_tasks: 0,
 			store_connected: null,
 		} );

--- a/plugins/woocommerce-admin/client/two-column-tasks/test/task-list.test.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/test/task-list.test.tsx
@@ -41,9 +41,9 @@ jest.mock( '@woocommerce/data', () => ( {
 jest.mock( '@woocommerce/admin-layout', () => ( {
 	...jest.requireActual( '@woocommerce/admin-layout' ),
 	useLayoutContext: jest.fn().mockReturnValue( {
-		layoutPath: [ 'home' ],
+		layoutParts: [ 'home' ],
 		layoutString: 'home',
-		updateLayoutPath: () => {},
+		extendLayout: () => {},
 		isDescendantOf: () => false,
 	} ),
 } ) );

--- a/plugins/woocommerce-admin/client/two-column-tasks/test/task-list.test.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/test/task-list.test.tsx
@@ -38,15 +38,19 @@ jest.mock( '@woocommerce/data', () => ( {
 		updateUserPreferences: jest.fn(),
 	} ),
 } ) );
-jest.mock( '@woocommerce/admin-layout', () => ( {
-	...jest.requireActual( '@woocommerce/admin-layout' ),
-	useLayoutContext: jest.fn().mockReturnValue( {
-		layoutParts: [ 'home' ],
+jest.mock( '@woocommerce/admin-layout', () => {
+	const mockContext = {
+		layoutPath: [ 'home' ],
 		layoutString: 'home',
 		extendLayout: () => {},
 		isDescendantOf: () => false,
-	} ),
-} ) );
+	};
+	return {
+		...jest.requireActual( '@woocommerce/admin-layout' ),
+		useLayoutContext: jest.fn().mockReturnValue( mockContext ),
+		useExtendLayout: jest.fn().mockReturnValue( mockContext ),
+	};
+} );
 
 const tasks: { [ key: string ]: TaskType[] } = {
 	setup: [

--- a/plugins/woocommerce-admin/client/two-column-tasks/test/task-list.test.tsx
+++ b/plugins/woocommerce-admin/client/two-column-tasks/test/task-list.test.tsx
@@ -44,7 +44,7 @@ jest.mock( '@woocommerce/admin-layout', () => ( {
 		layoutPath: [ 'home' ],
 		layoutString: 'home',
 		updateLayoutPath: () => {},
-		descendantOf: () => false,
+		isDescendantOf: () => false,
 	} ),
 } ) );
 

--- a/plugins/woocommerce/changelog/update-layout-context-for-blocks
+++ b/plugins/woocommerce/changelog/update-layout-context-for-blocks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Updating the usage of LayoutContext and moving to admin-layout package.


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

As per the issue, we occasionally have the need to know "where we are" in the application, when using common components across different sections. Without complex prop drilling we can use the `LayoutContext` component. In this PR I've moved this to the `admin-layout` package, refactored the component, updated references, and implemented on the blocks editor.

Closes #37740 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout branch and enable the `new-product-management-experience` feature flag.
2. Run `localStorage.setItem( 'debug', 'wc-admin:tracks' );` in the console.
3. Navigate to WooCommerce -> Home
4. Ensure the `wcadmin_tasklist_view` event fires with the property `context: woocommerce-home`
5. Click on "Add Product" item in task list, and ensure that `wcadmin_tasklist_click` event fires with the same `context` property.
6. Navigate to the Customers screen and click the "Finish Setup" button in the Activity Panel to display the task list in the side bar.
7. Ensure the `wcadmin_tasklist_view` event fires, but this time the `context` property should be `woocommerce-analytics-customers/activity-panel`
8. Click the "Add a product" task again and ensure the `wcadmin_tasklist_click` has the same context property.
9. Navigate to Products -> Add New, and you should see the old React product editor.
10. Click the "More" menu within the Header and click "Share feedback"
11. Enter any information and click "Share"
12. The `wcadmin_ces_feedback` even should fire with the `block_editor: false` property.
13. Enable the `block-editor-feature-enabled` feature flag, and refresh the product editor to see the new product block editor.
14. Hit the more menu again, and complete the "Share feedback" modal again.
15. After clicking "Share" you should see the same `wcadmin_ces_feedback` event, but with `block_editor` equal to `true`.

<!-- End testing instructions -->