### PR TITLE
Remove woorelease config

### DIFF
--- a/plugins/woocommerce-beta-tester/changelog/update-beta-tester-woorelease
+++ b/plugins/woocommerce-beta-tester/changelog/update-beta-tester-woorelease
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+Comment: This PR removes the Woorelease config. No change entry is necessary.
+

--- a/plugins/woocommerce-beta-tester/package.json
+++ b/plugins/woocommerce-beta-tester/package.json
@@ -78,11 +78,6 @@
 		"node": "^16.13.1",
 		"pnpm": "^7.13.3"
 	},
-	"woorelease": {
-		"svn_reauth": "true",
-		"wp_org_slug": "woocommerce-beta-tester",
-		"build_step": "pnpm run build:zip"
-	},
 	"lint-staged": {
 		"*.php": [
 			"php -d display_errors=1 -l",


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR removes the Woorelease config from the beta tester's `package.json` file. As we no longer release beta tester to .org, this should prevent us from accidentally releasing it there. The new means of releasing the beta tester plugin was introduced in #36387.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Just verify that the config has been removed and that  the json still appears valid.
2.
3.

<!-- End testing instructions -->