### PR TITLE
Fix release post contributors

### DIFF
--- a/tools/release-posts/commands/release-post/release-post-release.ts
+++ b/tools/release-posts/commands/release-post/release-post-release.ts
@@ -182,8 +182,8 @@ const program = new Command()
 		const title = `WooCommerce ${ currentVersion } Released`;
 
 		const contributors = await generateContributors(
-			currentVersion,
-			previousVersion.toString()
+			currentBranch,
+			previousBranch
 		);
 
 		const postVariables = {

--- a/tools/release-posts/commands/release-post/release-post-release.ts
+++ b/tools/release-posts/commands/release-post/release-post-release.ts
@@ -194,6 +194,7 @@ const program = new Command()
 				schema: schemaChanges,
 			},
 			displayVersion: currentVersion,
+			currentBranch,
 		};
 
 		const html =

--- a/tools/release-posts/templates/release.ejs
+++ b/tools/release-posts/templates/release.ejs
@@ -11,19 +11,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
-<ul>
-  <% for ( const packageName in contributors ) { %>    
-    <% const {org, repo, contributors: packageContributors, totalCommits, baseRef, headRef} = contributors[packageName] %>
-    <% if ( packageContributors ) { %>
-      <li>
-        <a target="_blank" href="https://github.com/<%= org %>/<%= repo %>/compare/<%= baseRef %>...<%= headRef %>">
-          <%= totalCommits %> commits from <%= packageContributors.length %> contributors
-        </a> 
-        in <%= packageName %>.
-      </li>
-    <% } %>
-  <% } %>
-</ul>
+<ul><% for ( const packageName in contributors ) { %><% const {org, repo, contributors: packageContributors, totalCommits, baseRef, headRef} = contributors[packageName] %><% if ( packageContributors ) { %><li><a href="https://github.com/<%= org %>/<%= repo %>/compare/<%= baseRef %>...<%= headRef %>"><%= totalCommits %> commits from <%= packageContributors.length %> contributors</a> in <%= packageName %>.</li><% } %><% } %></ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->

--- a/tools/release-posts/templates/release.ejs
+++ b/tools/release-posts/templates/release.ejs
@@ -17,7 +17,7 @@
 <!-- wp:paragraph -->
 <p>
   As always, we recommend creating a backup of your site and making sure that your theme and any other plugins are compatible before updating. 
-  You can check out <a href="https://docs.woocommerce.com/document/how-to-update-woocommerce/" target="_blank">this update guide</a> for more information.
+  You can check out <a href="https://docs.woocommerce.com/document/how-to-update-woocommerce/">this update guide</a> for more information.
 </p>
 <!-- /wp:paragraph -->
 
@@ -32,7 +32,7 @@
 <!-- wp:paragraph -->
 <p>
   These are just some of the changes that are included in WooCommerce <%= displayVersion %>. 
-  You can find the complete changelog for this release in the <a href="https://github.com/woocommerce/woocommerce/blob/<%= currentBranch %>/plugins/woocommerce/readme.txt" target="_blank">readme.txt file</a>.
+  You can find the complete changelog for this release in the <a href="https://github.com/woocommerce/woocommerce/blob/<%= currentBranch %>/plugins/woocommerce/readme.txt">readme.txt file</a>.
 </p>
 <!-- /wp:paragraph -->
 

--- a/tools/release-posts/templates/release.ejs
+++ b/tools/release-posts/templates/release.ejs
@@ -44,7 +44,7 @@
 <!-- wp:paragraph -->
 <p>
   These are just some of the changes that are included in WooCommerce <%= displayVersion %>. 
-  You can find the complete changelog for this release in the <a href="https://github.com/woocommerce/woocommerce/blob/release/<%= displayVersion %>/changelog.txt" target="_blank">changelog.txt file</a>.
+  You can find the complete changelog for this release in the <a href="https://github.com/woocommerce/woocommerce/blob/<%= currentBranch %>/plugins/woocommerce/readme.txt" target="_blank">readme.txt file</a>.
 </p>
 <!-- /wp:paragraph -->
 


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

When releasing 7.6 I noticed that the `release-post` tool exits with an error when trying to generate the release post, notably at the part where it's collecting the contributor list. This PR fixes this and adds a few other tweaks that made the generated post more useful, such as removing whitespace to enable proper copy/paste in the block editor. 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. check out `trunk`
2. `cd` into `tools/release-post`
3. run `pnpm run release-post -- "7.6.0" "7.5.1" --outputOnly`
4. notice how this fails when trying to collect the contributor list
5. check out this branch and repeat the process
6. notice how the release post is now being generated

<!-- End testing instructions -->