### PR TITLE
Split the `can create product, attributes and variations, edit variations and delete variations` E2E test into smaller tests

### DIFF
--- a/plugins/woocommerce/changelog/e2e-split-variable-product-test
+++ b/plugins/woocommerce/changelog/e2e-split-variable-product-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Split can create product, attributes and variations, edit variations and delete variations into smaller tests to avoid timing out

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
@@ -222,7 +222,7 @@ test.describe( 'Add New Variable Product Page', () => {
 		page,
 	} ) => {
 		await test.step(
-			'Go to the product page, and reset the variable product tour.',
+			'Go to "Products > Add new" page, and reset the variable product tour.',
 			async () => {
 				await resetVariableProductTour( page );
 			}

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
@@ -67,7 +67,7 @@ async function resetVariableProductTour( baseURL, browser ) {
 	);
 }
 
-test.describe( 'Add New Variable Product Page', () => {
+test.describe.serial( 'Add New Variable Product Page', () => {
 	test.use( { storageState: process.env.ADMINSTATE } );
 
 	test.afterAll( async ( { baseURL, browser } ) => {
@@ -75,165 +75,377 @@ test.describe( 'Add New Variable Product Page', () => {
 		await resetVariableProductTour( baseURL, browser );
 	} );
 
-	test( 'can create product, attributes and variations, edit variations and delete variations', async ( {
+	// test( 'can create product, attributes and variations, edit variations and delete variations', async ( {
+	// 	page,
+	// } ) => {
+	// 	await page.goto( productPageURL );
+	// 	await page.fill( '#title', variableProductName );
+	// 	await page.selectOption( '#product-type', 'variable' );
+
+	// 	await page
+	// 		.locator( '.attribute_tab' )
+	// 		.getByRole( 'link', { name: 'Attributes' } )
+	// 		.scrollIntoViewIfNeeded();
+
+	// 	// the tour only seems to display when not running headless, so just make sure
+	// 	if ( await page.locator( '.woocommerce-tour-kit-step__heading' ).isVisible() ) {
+	// 		// dismiss the variable product tour
+	// 		await page
+	// 			.getByRole( 'button', { name: 'Close Tour' } )
+	// 			.click();
+
+	// 		// wait for the tour's dismissal to be saved
+	// 		await page.waitForResponse(
+	// 			( response ) =>
+	// 				response.url().includes( '/users/' ) &&
+	// 				response.status() === 200
+	// 		);
+	// 	}
+
+	// 	await page.click( 'a[href="#product_attributes"]' );
+
+	// 	// add 3 attributes
+	// 	for ( let i = 0; i < 3; i++ ) {
+	// 		if ( i > 0 ) {
+	// 			await page.getByRole( 'button', { name: 'Add' } )
+	// 			.nth(2)
+	// 			.click();
+	// 		}
+	// 		await page.waitForSelector(
+	// 			`input[name="attribute_names[${ i }]"]`
+	// 		);
+
+	// 		await page
+	// 			.locator( `input[name="attribute_names[${ i }]"]` )
+	// 			.first()
+	// 			.type( `attr #${ i + 1 }` );
+	// 		await page
+	// 			.locator( `textarea[name="attribute_values[${ i }]"]` )
+	// 			.first()
+	// 			.type( 'val1 | val2' );
+	// 	}
+
+	// 	await page.getByRole( 'button', { name: 'Save attributes'} ).click( { clickCount: 3 });
+
+	// 	// wait for the tour's dismissal to be saved
+	// 	await page.waitForResponse(
+	// 		( response ) =>
+	// 			response.url().includes( '/post.php' ) &&
+	// 			response.status() === 200
+	// 	);
+
+	// 	// Save before going to the Variations tab to prevent variations from all attributes to be automatically created
+	// 	await page.locator( '#save-post' ).click();
+	// 	await expect(
+	// 		page.getByText( 'Product draft updated. ' )
+	// 	).toBeVisible();
+
+	// 	await page.click( 'a[href="#variable_product_options"]' );
+
+	// 	// event listener for handling the link_all_variations confirmation dialog
+	// 	page.on( 'dialog', ( dialog ) => dialog.accept() );
+
+	// 	// generate variations from all attributes
+	// 	await page.click( 'button.generate_variations' );
+
+	// 	// verify variations have the correct attribute values
+	// 	for ( let i = 0; i < 8; i++ ) {
+	// 		const val1 = 'val1';
+	// 		const val2 = 'val2';
+	// 		const attr3 = !! ( i % 2 ); // 0-1,4-5 / 2-3,6-7
+	// 		const attr2 = i % 4 > 1; // 0-3 / 4-7
+	// 		const attr1 = i > 3;
+	// 		await expect(
+	// 			page.locator( `select[name="attribute_attr-1[${ i }]"]` )
+	// 		).toHaveValue( attr1 ? val2 : val1 );
+	// 		await expect(
+	// 			page.locator( `select[name="attribute_attr-2[${ i }]"]` )
+	// 		).toHaveValue( attr2 ? val2 : val1 );
+	// 		await expect(
+	// 			page.locator( `select[name="attribute_attr-3[${ i }]"]` )
+	// 		).toHaveValue( attr3 ? val2 : val1 );
+	// 	}
+
+	// 	await page.locator( '#save-post' ).click();
+	// 	await expect( page.locator( '#message.notice-success' ) ).toContainText(
+	// 		'Product draft updated.'
+	// 	);
+
+	// 	// set variation attributes and bulk edit variations
+	// 	await page.click( 'a[href="#variable_product_options"]' );
+
+	// 	// set the variation attributes
+	// 	await page.click(
+	// 		'#variable_product_options .toolbar-top a.expand_all'
+	// 	);
+	// 	await page.check( 'input[name="variable_is_virtual[0]"]' );
+	// 	await page.fill(
+	// 		'input[name="variable_regular_price[0]"]',
+	// 		variationOnePrice
+	// 	);
+	// 	await page.check( 'input[name="variable_is_virtual[1]"]' );
+	// 	await page.fill(
+	// 		'input[name="variable_regular_price[1]"]',
+	// 		variationTwoPrice
+	// 	);
+	// 	await page.check( 'input[name="variable_manage_stock[2]"]' );
+	// 	await page.fill(
+	// 		'input[name="variable_regular_price[2]"]',
+	// 		variationThreePrice
+	// 	);
+	// 	await page.fill( 'input[name="variable_weight[2]"]', productWeight );
+	// 	await page.fill( 'input[name="variable_length[2]"]', productLength );
+	// 	await page.fill( 'input[name="variable_width[2]"]', productWidth );
+	// 	await page.fill( 'input[name="variable_height[2]"]', productHeight );
+	// 	await page.keyboard.press( 'ArrowUp' );
+	// 	await page.click( 'button.save-variation-changes' );
+
+	// 	// bulk-edit variations
+	// 	await page.click(
+	// 		'#variable_product_options .toolbar-top a.expand_all'
+	// 	);
+	// 	for ( let i = 0; i < 4; i++ ) {
+	// 		const checkBox = page.locator(
+	// 			`input[name="variable_is_downloadable[${ i }]"]`
+	// 		);
+	// 		await expect( checkBox ).not.toBeChecked();
+	// 	}
+	// 	await page.selectOption( '#field_to_edit', 'toggle_downloadable', {
+	// 		force: true,
+	// 	} );
+	// 	await page.click(
+	// 		'#variable_product_options .toolbar-top a.expand_all'
+	// 	);
+	// 	for ( let i = 0; i < 4; i++ ) {
+	// 		const checkBox = await page.locator(
+	// 			`input[name="variable_is_downloadable[${ i }]"]`
+	// 		);
+	// 		await expect( checkBox ).toBeChecked();
+	// 	}
+
+	// 	await page.locator( '#save-post' ).click();
+
+	// 	// delete all variations
+	// 	await page.click( 'a[href="#variable_product_options"]' );
+	// 	await page.waitForLoadState( 'networkidle' );
+	// 	await page.selectOption( '#field_to_edit', 'delete_all' );
+	// 	await page.waitForSelector( '.woocommerce_variation', {
+	// 		state: 'detached',
+	// 	} );
+	// 	const variationsCount = await page.$$( '.woocommerce_variation' );
+	// 	await expect( variationsCount ).toHaveLength( 0 );
+	// } );
+
+	test( 'can create product, attributes and variations', async ( {
 		page,
 	} ) => {
-		await page.goto( productPageURL );
-		await page.fill( '#title', variableProductName );
-		await page.selectOption( '#product-type', 'variable' );
+		await test.step( 'Go to "Products > Add New page".', async () => {
+			await page.goto( productPageURL );
+		} );
 
-		await page
-			.locator( '.attribute_tab' )
-			.getByRole( 'link', { name: 'Attributes' } )
-			.scrollIntoViewIfNeeded();
+		await test.step(
+			`Type "${ variableProductName }" into the "Product name" input field.`,
+			async () => {
+				await page.fill( '#title', variableProductName );
+			}
+		);
+
+		await test.step(
+			'Select the "Variable product" product type.',
+			async () => {
+				await page.selectOption( '#product-type', 'variable' );
+			}
+		);
+
+		await test.step( 'Click on the "Attributes" tab.', async () => {
+			await page
+				.locator( '.attribute_tab' )
+				.getByRole( 'link', { name: 'Attributes' } )
+				.scrollIntoViewIfNeeded();
+		} );
 
 		// the tour only seems to display when not running headless, so just make sure
-		if ( await page.locator( '.woocommerce-tour-kit-step__heading' ).isVisible() ) {
-			// dismiss the variable product tour
-			await page
-				.getByRole( 'button', { name: 'Close Tour' } )
-				.click();
-
-			// wait for the tour's dismissal to be saved
-			await page.waitForResponse(
-				( response ) =>
-					response.url().includes( '/users/' ) &&
-					response.status() === 200
-			);
-		}
-
-		await page.click( 'a[href="#product_attributes"]' );
-
-		// add 3 attributes
-		for ( let i = 0; i < 3; i++ ) {
-			if ( i > 0 ) {
-				await page.getByRole( 'button', { name: 'Add' } )
-				.nth(2)
-				.click();
+		const tourWasDisplayed = await test.step(
+			'See if the tour was displayed.',
+			async () => {
+				return await page
+					.locator( '.woocommerce-tour-kit-step__heading' )
+					.isVisible();
 			}
-			await page.waitForSelector(
-				`input[name="attribute_names[${ i }]"]`
+		);
+
+		if ( tourWasDisplayed ) {
+			await test.step( 'Tour was displayed, so dismiss it.', async () => {
+				await page
+					.getByRole( 'button', { name: 'Close Tour' } )
+					.click();
+			} );
+
+			await test.step(
+				"Wait for the tour's dismissal to be saved",
+				async () => {
+					await page.waitForResponse(
+						( response ) =>
+							response.url().includes( '/users/' ) &&
+							response.status() === 200
+					);
+				}
 			);
-
-			await page
-				.locator( `input[name="attribute_names[${ i }]"]` )
-				.first()
-				.type( `attr #${ i + 1 }` );
-			await page
-				.locator( `textarea[name="attribute_values[${ i }]"]` )
-				.first()
-				.type( 'val1 | val2' );
 		}
 
-		await page.getByRole( 'button', { name: 'Save attributes'} ).click( { clickCount: 3 });
+		await test.step( 'Add 3 attributes.', async () => {
+			for ( let i = 0; i < 3; i++ ) {
+				if ( i > 0 ) {
+					await test.step( "Click 'Add'.", async () => {
+						await page
+							.locator( '.add-attribute-container' )
+							.getByRole( 'button', { name: 'Add' } )
+							.click();
+					} );
+				}
 
-		// wait for the tour's dismissal to be saved
-		await page.waitForResponse(
-			( response ) =>
-				response.url().includes( '/post.php' ) &&
-				response.status() === 200
-		);
+				await test.step(
+					`Add the attribute "attr #${
+						i + 1
+					}" with values "val1 | val2"`,
+					async () => {
+						await test.step(
+							'Wait for the "Attribute name" input field to appear.',
+							async () => {
+								await page.waitForSelector(
+									`input[name="attribute_names[${ i }]"]`
+								);
+							}
+						);
 
-		// Save before going to the Variations tab to prevent variations from all attributes to be automatically created
-		await page.locator( '#save-post' ).click();
-		await expect(
-			page.getByText( 'Product draft updated. ' )
-		).toBeVisible();
+						await test.step(
+							`Type "attr #${
+								i + 1
+							}" in the "Attribute name" input field.`,
+							async () => {
+								await page
+									.locator(
+										`input[name="attribute_names[${ i }]"]`
+									)
+									.first()
+									.type( `attr #${ i + 1 }` );
+							}
+						);
 
-		await page.click( 'a[href="#variable_product_options"]' );
+						await test.step(
+							'Type the attribute values "val1 | val2".',
+							async () => {
+								await page
+									.locator(
+										`textarea[name="attribute_values[${ i }]"]`
+									)
+									.first()
+									.type( 'val1 | val2' );
+							}
+						);
 
-		// event listener for handling the link_all_variations confirmation dialog
-		page.on( 'dialog', ( dialog ) => dialog.accept() );
+						await test.step(
+							'Click "Save attributes".',
+							async () => {
+								await page
+									.getByRole( 'button', {
+										name: 'Save attributes',
+									} )
+									.click( { clickCount: 3 } );
+							}
+						);
 
-		// generate variations from all attributes
-		await page.click( 'button.generate_variations' );
-
-		// verify variations have the correct attribute values
-		for ( let i = 0; i < 8; i++ ) {
-			const val1 = 'val1';
-			const val2 = 'val2';
-			const attr3 = !! ( i % 2 ); // 0-1,4-5 / 2-3,6-7
-			const attr2 = i % 4 > 1; // 0-3 / 4-7
-			const attr1 = i > 3;
-			await expect(
-				page.locator( `select[name="attribute_attr-1[${ i }]"]` )
-			).toHaveValue( attr1 ? val2 : val1 );
-			await expect(
-				page.locator( `select[name="attribute_attr-2[${ i }]"]` )
-			).toHaveValue( attr2 ? val2 : val1 );
-			await expect(
-				page.locator( `select[name="attribute_attr-3[${ i }]"]` )
-			).toHaveValue( attr3 ? val2 : val1 );
-		}
-
-		await page.locator( '#save-post' ).click();
-		await expect( page.locator( '#message.notice-success' ) ).toContainText(
-			'Product draft updated.'
-		);
-
-		// set variation attributes and bulk edit variations
-		await page.click( 'a[href="#variable_product_options"]' );
-
-		// set the variation attributes
-		await page.click(
-			'#variable_product_options .toolbar-top a.expand_all'
-		);
-		await page.check( 'input[name="variable_is_virtual[0]"]' );
-		await page.fill(
-			'input[name="variable_regular_price[0]"]',
-			variationOnePrice
-		);
-		await page.check( 'input[name="variable_is_virtual[1]"]' );
-		await page.fill(
-			'input[name="variable_regular_price[1]"]',
-			variationTwoPrice
-		);
-		await page.check( 'input[name="variable_manage_stock[2]"]' );
-		await page.fill(
-			'input[name="variable_regular_price[2]"]',
-			variationThreePrice
-		);
-		await page.fill( 'input[name="variable_weight[2]"]', productWeight );
-		await page.fill( 'input[name="variable_length[2]"]', productLength );
-		await page.fill( 'input[name="variable_width[2]"]', productWidth );
-		await page.fill( 'input[name="variable_height[2]"]', productHeight );
-		await page.keyboard.press( 'ArrowUp' );
-		await page.click( 'button.save-variation-changes' );
-
-		// bulk-edit variations
-		await page.click(
-			'#variable_product_options .toolbar-top a.expand_all'
-		);
-		for ( let i = 0; i < 4; i++ ) {
-			const checkBox = page.locator(
-				`input[name="variable_is_downloadable[${ i }]"]`
-			);
-			await expect( checkBox ).not.toBeChecked();
-		}
-		await page.selectOption( '#field_to_edit', 'toggle_downloadable', {
-			force: true,
+						await test.step(
+							"Wait for the tour's dismissal to be saved",
+							async () => {
+								await page.waitForResponse(
+									( response ) =>
+										response
+											.url()
+											.includes( '/post.php' ) &&
+										response.status() === 200
+								);
+							}
+						);
+					}
+				);
+			}
 		} );
-		await page.click(
-			'#variable_product_options .toolbar-top a.expand_all'
+
+		await test.step(
+			'Save before going to the Variations tab to prevent variations from all attributes to be automatically created.',
+			async () => {
+				await page.locator( '#save-post' ).click();
+			}
 		);
-		for ( let i = 0; i < 4; i++ ) {
-			const checkBox = await page.locator(
-				`input[name="variable_is_downloadable[${ i }]"]`
-			);
-			await expect( checkBox ).toBeChecked();
-		}
 
-		await page.locator( '#save-post' ).click();
+		await test.step(
+			'Expect the "Product draft updated." notice to appear.',
+			async () => {
+				await expect(
+					page.getByText( 'Product draft updated. ' )
+				).toBeVisible();
+			}
+		);
 
-		// delete all variations
-		await page.click( 'a[href="#variable_product_options"]' );
-		await page.waitForLoadState( 'networkidle' );
-		await page.selectOption( '#field_to_edit', 'delete_all' );
-		await page.waitForSelector( '.woocommerce_variation', {
-			state: 'detached',
+		await test.step( 'Click on the "Variations" tab.', async () => {
+			await page.click( 'a[href="#variable_product_options"]' );
 		} );
-		const variationsCount = await page.$$( '.woocommerce_variation' );
-		await expect( variationsCount ).toHaveLength( 0 );
+
+		await test.step(
+			'Create event listener for handling the link_all_variations confirmation dialog.',
+			async () => {
+				page.on( 'dialog', ( dialog ) => dialog.accept() );
+			}
+		);
+
+		await test.step(
+			'Click on the "Generate variations" button.',
+			async () => {
+				await page.click( 'button.generate_variations' );
+			}
+		);
+
+		await test.step(
+			'Expect variations to have the correct attribute values',
+			async () => {
+				for ( let i = 0; i < 8; i++ ) {
+					const val1 = 'val1';
+					const val2 = 'val2';
+					const attr3 = !! ( i % 2 ); // 0-1,4-5 / 2-3,6-7
+					const attr2 = i % 4 > 1; // 0-3 / 4-7
+					const attr1 = i > 3;
+					await expect(
+						page.locator(
+							`select[name="attribute_attr-1[${ i }]"]`
+						)
+					).toHaveValue( attr1 ? val2 : val1 );
+					await expect(
+						page.locator(
+							`select[name="attribute_attr-2[${ i }]"]`
+						)
+					).toHaveValue( attr2 ? val2 : val1 );
+					await expect(
+						page.locator(
+							`select[name="attribute_attr-3[${ i }]"]`
+						)
+					).toHaveValue( attr3 ? val2 : val1 );
+				}
+			}
+		);
+
+		await test.step( 'Click "Save Draft" button.', async () => {
+			await page.locator( '#save-post' ).click();
+		} );
+
+		await test.step(
+			'Expect the "Product draft updated." notice to appear.',
+			async () => {
+				await expect(
+					page.locator( '#message.notice-success' )
+				).toContainText( 'Product draft updated.' );
+			}
+		);
 	} );
 
 	test( 'can manually add a variation, manage stock levels, set variation defaults and remove a variation', async ( {
@@ -249,11 +461,13 @@ test.describe( 'Add New Variable Product Page', () => {
 			.scrollIntoViewIfNeeded();
 
 		// the tour only seems to display when not running headless, so just make sure
-		if ( await page.locator( '.woocommerce-tour-kit-step__heading' ).isVisible() ) {
-			// dismiss the variable product tour
+		if (
 			await page
-				.getByRole( 'button', { name: 'Close Tour' } )
-				.click();
+				.locator( '.woocommerce-tour-kit-step__heading' )
+				.isVisible()
+		) {
+			// dismiss the variable product tour
+			await page.getByRole( 'button', { name: 'Close Tour' } ).click();
 
 			// wait for the tour's dismissal to be saved
 			await page.waitForResponse(

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
@@ -16,6 +16,8 @@ const defaultAttributes = [ 'val2', 'val1', 'val2' ];
 const stockAmount = '100';
 const lowStockAmount = '10';
 
+let variableProductId;
+
 async function deleteProductsAddedByTests( baseURL ) {
 	const api = new wcApi( {
 		url: baseURL,
@@ -67,174 +69,13 @@ async function resetVariableProductTour( baseURL, browser ) {
 	);
 }
 
-test.describe.serial( 'Add New Variable Product Page', () => {
+test.describe( 'Add New Variable Product Page', () => {
 	test.use( { storageState: process.env.ADMINSTATE } );
 
 	test.afterAll( async ( { baseURL, browser } ) => {
 		await deleteProductsAddedByTests( baseURL );
 		await resetVariableProductTour( baseURL, browser );
 	} );
-
-	// test( 'can create product, attributes and variations, edit variations and delete variations', async ( {
-	// 	page,
-	// } ) => {
-	// 	await page.goto( productPageURL );
-	// 	await page.fill( '#title', variableProductName );
-	// 	await page.selectOption( '#product-type', 'variable' );
-
-	// 	await page
-	// 		.locator( '.attribute_tab' )
-	// 		.getByRole( 'link', { name: 'Attributes' } )
-	// 		.scrollIntoViewIfNeeded();
-
-	// 	// the tour only seems to display when not running headless, so just make sure
-	// 	if ( await page.locator( '.woocommerce-tour-kit-step__heading' ).isVisible() ) {
-	// 		// dismiss the variable product tour
-	// 		await page
-	// 			.getByRole( 'button', { name: 'Close Tour' } )
-	// 			.click();
-
-	// 		// wait for the tour's dismissal to be saved
-	// 		await page.waitForResponse(
-	// 			( response ) =>
-	// 				response.url().includes( '/users/' ) &&
-	// 				response.status() === 200
-	// 		);
-	// 	}
-
-	// 	await page.click( 'a[href="#product_attributes"]' );
-
-	// 	// add 3 attributes
-	// 	for ( let i = 0; i < 3; i++ ) {
-	// 		if ( i > 0 ) {
-	// 			await page.getByRole( 'button', { name: 'Add' } )
-	// 			.nth(2)
-	// 			.click();
-	// 		}
-	// 		await page.waitForSelector(
-	// 			`input[name="attribute_names[${ i }]"]`
-	// 		);
-
-	// 		await page
-	// 			.locator( `input[name="attribute_names[${ i }]"]` )
-	// 			.first()
-	// 			.type( `attr #${ i + 1 }` );
-	// 		await page
-	// 			.locator( `textarea[name="attribute_values[${ i }]"]` )
-	// 			.first()
-	// 			.type( 'val1 | val2' );
-	// 	}
-
-	// 	await page.getByRole( 'button', { name: 'Save attributes'} ).click( { clickCount: 3 });
-
-	// 	// wait for the tour's dismissal to be saved
-	// 	await page.waitForResponse(
-	// 		( response ) =>
-	// 			response.url().includes( '/post.php' ) &&
-	// 			response.status() === 200
-	// 	);
-
-	// 	// Save before going to the Variations tab to prevent variations from all attributes to be automatically created
-	// 	await page.locator( '#save-post' ).click();
-	// 	await expect(
-	// 		page.getByText( 'Product draft updated. ' )
-	// 	).toBeVisible();
-
-	// 	await page.click( 'a[href="#variable_product_options"]' );
-
-	// 	// event listener for handling the link_all_variations confirmation dialog
-	// 	page.on( 'dialog', ( dialog ) => dialog.accept() );
-
-	// 	// generate variations from all attributes
-	// 	await page.click( 'button.generate_variations' );
-
-	// 	// verify variations have the correct attribute values
-	// 	for ( let i = 0; i < 8; i++ ) {
-	// 		const val1 = 'val1';
-	// 		const val2 = 'val2';
-	// 		const attr3 = !! ( i % 2 ); // 0-1,4-5 / 2-3,6-7
-	// 		const attr2 = i % 4 > 1; // 0-3 / 4-7
-	// 		const attr1 = i > 3;
-	// 		await expect(
-	// 			page.locator( `select[name="attribute_attr-1[${ i }]"]` )
-	// 		).toHaveValue( attr1 ? val2 : val1 );
-	// 		await expect(
-	// 			page.locator( `select[name="attribute_attr-2[${ i }]"]` )
-	// 		).toHaveValue( attr2 ? val2 : val1 );
-	// 		await expect(
-	// 			page.locator( `select[name="attribute_attr-3[${ i }]"]` )
-	// 		).toHaveValue( attr3 ? val2 : val1 );
-	// 	}
-
-	// 	await page.locator( '#save-post' ).click();
-	// 	await expect( page.locator( '#message.notice-success' ) ).toContainText(
-	// 		'Product draft updated.'
-	// 	);
-
-	// 	// set variation attributes and bulk edit variations
-	// 	await page.click( 'a[href="#variable_product_options"]' );
-
-	// 	// set the variation attributes
-	// 	await page.click(
-	// 		'#variable_product_options .toolbar-top a.expand_all'
-	// 	);
-	// 	await page.check( 'input[name="variable_is_virtual[0]"]' );
-	// 	await page.fill(
-	// 		'input[name="variable_regular_price[0]"]',
-	// 		variationOnePrice
-	// 	);
-	// 	await page.check( 'input[name="variable_is_virtual[1]"]' );
-	// 	await page.fill(
-	// 		'input[name="variable_regular_price[1]"]',
-	// 		variationTwoPrice
-	// 	);
-	// 	await page.check( 'input[name="variable_manage_stock[2]"]' );
-	// 	await page.fill(
-	// 		'input[name="variable_regular_price[2]"]',
-	// 		variationThreePrice
-	// 	);
-	// 	await page.fill( 'input[name="variable_weight[2]"]', productWeight );
-	// 	await page.fill( 'input[name="variable_length[2]"]', productLength );
-	// 	await page.fill( 'input[name="variable_width[2]"]', productWidth );
-	// 	await page.fill( 'input[name="variable_height[2]"]', productHeight );
-	// 	await page.keyboard.press( 'ArrowUp' );
-	// 	await page.click( 'button.save-variation-changes' );
-
-	// 	// bulk-edit variations
-	// 	await page.click(
-	// 		'#variable_product_options .toolbar-top a.expand_all'
-	// 	);
-	// 	for ( let i = 0; i < 4; i++ ) {
-	// 		const checkBox = page.locator(
-	// 			`input[name="variable_is_downloadable[${ i }]"]`
-	// 		);
-	// 		await expect( checkBox ).not.toBeChecked();
-	// 	}
-	// 	await page.selectOption( '#field_to_edit', 'toggle_downloadable', {
-	// 		force: true,
-	// 	} );
-	// 	await page.click(
-	// 		'#variable_product_options .toolbar-top a.expand_all'
-	// 	);
-	// 	for ( let i = 0; i < 4; i++ ) {
-	// 		const checkBox = await page.locator(
-	// 			`input[name="variable_is_downloadable[${ i }]"]`
-	// 		);
-	// 		await expect( checkBox ).toBeChecked();
-	// 	}
-
-	// 	await page.locator( '#save-post' ).click();
-
-	// 	// delete all variations
-	// 	await page.click( 'a[href="#variable_product_options"]' );
-	// 	await page.waitForLoadState( 'networkidle' );
-	// 	await page.selectOption( '#field_to_edit', 'delete_all' );
-	// 	await page.waitForSelector( '.woocommerce_variation', {
-	// 		state: 'detached',
-	// 	} );
-	// 	const variationsCount = await page.$$( '.woocommerce_variation' );
-	// 	await expect( variationsCount ).toHaveLength( 0 );
-	// } );
 
 	test( 'can create product, attributes and variations', async ( {
 		page,
@@ -257,12 +98,20 @@ test.describe.serial( 'Add New Variable Product Page', () => {
 			}
 		);
 
-		await test.step( 'Click on the "Attributes" tab.', async () => {
-			await page
-				.locator( '.attribute_tab' )
-				.getByRole( 'link', { name: 'Attributes' } )
-				.scrollIntoViewIfNeeded();
-		} );
+		await test.step(
+			'Scroll into the "Attributes" tab and click it.',
+			async () => {
+				await page
+					.locator( '.attribute_tab' )
+					.getByRole( 'link', { name: 'Attributes' } )
+					.scrollIntoViewIfNeeded();
+
+				await page
+					.locator( '.attribute_tab' )
+					.getByRole( 'link', { name: 'Attributes' } )
+					.click();
+			}
+		);
 
 		// the tour only seems to display when not running headless, so just make sure
 		const tourWasDisplayed = await test.step(
@@ -388,20 +237,23 @@ test.describe.serial( 'Add New Variable Product Page', () => {
 			}
 		);
 
+		await test.step( 'Save the product ID.', async () => {
+			variableProductId = page
+				.url()
+				.match( /post=\d+/ )[ 0 ]
+				.replace( 'post=', '' );
+		} );
+
 		await test.step( 'Click on the "Variations" tab.', async () => {
 			await page.click( 'a[href="#variable_product_options"]' );
 		} );
 
 		await test.step(
-			'Create event listener for handling the link_all_variations confirmation dialog.',
-			async () => {
-				page.on( 'dialog', ( dialog ) => dialog.accept() );
-			}
-		);
-
-		await test.step(
 			'Click on the "Generate variations" button.',
 			async () => {
+				// event listener for handling the link_all_variations confirmation dialog
+				page.on( 'dialog', ( dialog ) => dialog.accept() );
+
 				await page.click( 'button.generate_variations' );
 			}
 		);
@@ -448,7 +300,264 @@ test.describe.serial( 'Add New Variable Product Page', () => {
 		);
 	} );
 
-	test( 'can manually add a variation, manage stock levels, set variation defaults and remove a variation', async ( {
+	test( 'can individually edit variations', async ( { page } ) => {
+		// mytodo setup: create variable product with the same attributes and variations
+
+		await test.step( 'Go to the "Edit product" page.', async () => {
+			await page.goto(
+				`/wp-admin/post.php?post=${ variableProductId }&action=edit`
+			);
+		} );
+
+		await test.step( 'Click on the "Variations" tab.', async () => {
+			await page.click( 'a[href="#variable_product_options"]' );
+		} );
+
+		await test.step( 'Expand all variations.', async () => {
+			await page.click(
+				'#variable_product_options .toolbar-top a.expand_all'
+			);
+		} );
+
+		await test.step( 'Set the first variation to be virtual.', async () => {
+			await page.check( 'input[name="variable_is_virtual[0]"]' );
+		} );
+
+		await test.step(
+			`Set regular price of first variation to ${ variationOnePrice }.`,
+			async () => {
+				await page.fill(
+					'input[name="variable_regular_price[0]"]',
+					variationOnePrice
+				);
+			}
+		);
+
+		await test.step(
+			'Set the second variation to be virtual.',
+			async () => {
+				await page.check( 'input[name="variable_is_virtual[1]"]' );
+			}
+		);
+
+		await test.step(
+			`Set regular price of second variation to ${ variationTwoPrice }.`,
+			async () => {
+				await page.fill(
+					'input[name="variable_regular_price[1]"]',
+					variationTwoPrice
+				);
+			}
+		);
+
+		await test.step(
+			'Check "Manage stock?" in the third variation.',
+			async () => {
+				await page.check( 'input[name="variable_manage_stock[2]"]' );
+			}
+		);
+
+		await test.step(
+			`Set regular price of third variation to ${ variationThreePrice }.`,
+			async () => {
+				await page.fill(
+					'input[name="variable_regular_price[2]"]',
+					variationThreePrice
+				);
+			}
+		);
+
+		await test.step(
+			'Set the weight and dimensions of the third variation.',
+			async () => {
+				await page.fill(
+					'input[name="variable_weight[2]"]',
+					productWeight
+				);
+				await page.fill(
+					'input[name="variable_length[2]"]',
+					productLength
+				);
+				await page.fill(
+					'input[name="variable_width[2]"]',
+					productWidth
+				);
+				await page.fill(
+					'input[name="variable_height[2]"]',
+					productHeight
+				);
+				await page.keyboard.press( 'ArrowUp' );
+			}
+		);
+
+		await test.step( 'Click "Save changes".', async () => {
+			await page.click( 'button.save-variation-changes' );
+			await page.waitForLoadState( 'networkidle' );
+		} );
+
+		await test.step( 'Click on the "Variations" tab.', async () => {
+			await page.click( 'a[href="#variable_product_options"]' );
+		} );
+
+		await test.step( 'Expand all variations.', async () => {
+			await page.click(
+				'#variable_product_options .toolbar-top a.expand_all'
+			);
+		} );
+
+		await test.step(
+			'Expect the first variation to be virtual.',
+			async () => {
+				await expect(
+					page.locator( 'input[name="variable_is_virtual[0]"]' )
+				).toBeChecked();
+			}
+		);
+
+		await test.step(
+			`Expect the price of the first variation to be ${ variationOnePrice }.`,
+			async () => {
+				await expect(
+					page.locator( 'input[name="variable_regular_price[0]"]' )
+				).toHaveValue( variationOnePrice );
+			}
+		);
+
+		await test.step(
+			'Expect the second variation to be virtual.',
+			async () => {
+				await expect(
+					page.locator( 'input[name="variable_is_virtual[1]"]' )
+				).toBeChecked();
+			}
+		);
+
+		await test.step(
+			`Expect the price of the second variation to be ${ variationTwoPrice }.`,
+			async () => {
+				await expect(
+					page.locator( 'input[name="variable_regular_price[1]"]' )
+				).toHaveValue( variationTwoPrice );
+			}
+		);
+
+		await test.step(
+			'Expect the "Manage stock?" checkbox of the third variation to be checked.',
+			async () => {
+				await expect(
+					page.locator( 'input[name="variable_manage_stock[2]"]' )
+				).toBeChecked();
+			}
+		);
+
+		await test.step(
+			`Expect the price of the third variation to be ${ variationThreePrice }.`,
+			async () => {
+				await expect(
+					page.locator( 'input[name="variable_regular_price[2]"]' )
+				).toHaveValue( variationThreePrice );
+			}
+		);
+
+		await test.step(
+			'Expect the weight and dimensions of the third variation to be correct.',
+			async () => {
+				await expect(
+					page.locator( 'input[name="variable_weight[2]"]' )
+				).toHaveValue( productWeight );
+
+				await expect(
+					page.locator( 'input[name="variable_length[2]"]' )
+				).toHaveValue( productLength );
+
+				await expect(
+					page.locator( 'input[name="variable_width[2]"]' )
+				).toHaveValue( productWidth );
+
+				await expect(
+					page.locator( 'input[name="variable_height[2]"]' )
+				).toHaveValue( productHeight );
+			}
+		);
+	} );
+
+	test( 'can bulk edit variations', async ( { page } ) => {
+		// mytodo setup: create variable product with the same attributes and variations
+
+		await test.step( 'Go to the "Edit product" page.', async () => {
+			await page.goto(
+				`/wp-admin/post.php?post=${ variableProductId }&action=edit`
+			);
+		} );
+
+		await test.step( 'Click on the "Variations" tab.', async () => {
+			await page.click( 'a[href="#variable_product_options"]' );
+		} );
+
+		await test.step(
+			'Select the \'Toggle "Downloadable"\' bulk action.',
+			async () => {
+				await page.selectOption(
+					'#field_to_edit',
+					'toggle_downloadable'
+				);
+			}
+		);
+
+		await test.step( 'Expand all variations.', async () => {
+			await page.click(
+				'#variable_product_options .toolbar-top a.expand_all'
+			);
+		} );
+
+		await test.step(
+			'Expect all "Downloadable" checkboxes to be checked.',
+			async () => {
+				const checkBoxes = page.locator(
+					'input[name^="variable_is_downloadable"]'
+				);
+				const count = await checkBoxes.count();
+
+				for ( let i = 0; i < count; i++ ) {
+					await expect( checkBoxes.nth( i ) ).toBeChecked();
+				}
+			}
+		);
+	} );
+
+	test( 'can delete all variations', async ( { page } ) => {
+		// mytodo setup: create variable product with the same attributes and variations
+
+		await test.step( 'Go to the "Edit product" page.', async () => {
+			await page.goto(
+				`/wp-admin/post.php?post=${ variableProductId }&action=edit`
+			);
+		} );
+
+		await test.step( 'Click on the "Variations" tab.', async () => {
+			await page.click( 'a[href="#variable_product_options"]' );
+		} );
+
+		await test.step(
+			'Select the bulk action "Delete all variations".',
+			async () => {
+				page.on( 'dialog', ( dialog ) => dialog.accept() );
+				await page.selectOption( '#field_to_edit', 'delete_all' );
+			}
+		);
+
+		await test.step(
+			'Expect that there are no more variations.',
+			async () => {
+				await expect(
+					page.locator( '.woocommerce_variation' )
+				).toHaveCount( 0 );
+			}
+		);
+	} );
+
+	// mytodo remove skip
+	test.skip( 'can manually add a variation, manage stock levels, set variation defaults and remove a variation', async ( {
 		page,
 	} ) => {
 		await page.goto( productPageURL );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
@@ -221,12 +221,13 @@ test.describe( 'Add New Variable Product Page', () => {
 	test( 'can create product, attributes and variations', async ( {
 		page,
 	} ) => {
-		await test.step(
-			'Go to "Products > Add new" page, and reset the variable product tour.',
-			async () => {
-				await resetVariableProductTour( page );
-			}
-		);
+		await test.step( 'Reset the variable product tour.', async () => {
+			await resetVariableProductTour( page );
+		} );
+
+		await test.step( 'Go to "Products > Add new" page.', async () => {
+			await page.goto( productPageURL );
+		} );
 
 		await test.step(
 			`Type "${ variableProductName }" into the "Product name" input field.`,

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
@@ -38,9 +38,8 @@ async function deleteProductsAddedByTests( baseURL ) {
 	const ids = varProducts
 		.map( ( { id } ) => id )
 		.concat( manualProducts.map( ( { id } ) => id ) )
-		.push( fixedVariableProductId ); // mytodo why not being deleted?
+		.concat( [ fixedVariableProductId ] );
 
-	console.log( `ids to delete: ${ ids }` ); // mytodo delete
 	await api.post( 'products/batch', { delete: ids } );
 }
 
@@ -492,26 +491,23 @@ test.describe( 'Add New Variable Product Page', () => {
 				}
 			);
 
-			await test.step(
-				'Set the weight and dimensions.',
-				async () => {
-					await thirdVariation
-						.getByRole( 'textbox', { name: 'Weight' } )
-						.type( productWeight );
+			await test.step( 'Set the weight and dimensions.', async () => {
+				await thirdVariation
+					.getByRole( 'textbox', { name: 'Weight' } )
+					.type( productWeight );
 
-					await thirdVariation
-						.getByRole( 'textbox', { name: 'Length' } )
-						.type( productLength );
+				await thirdVariation
+					.getByRole( 'textbox', { name: 'Length' } )
+					.type( productLength );
 
-					await thirdVariation
-						.getByRole( 'textbox', { name: 'Width' } )
-						.type( productWidth );
+				await thirdVariation
+					.getByRole( 'textbox', { name: 'Width' } )
+					.type( productWidth );
 
-					await thirdVariation
-						.getByRole( 'textbox', { name: 'Height' } )
-						.type( productHeight );
-				}
-			);
+				await thirdVariation
+					.getByRole( 'textbox', { name: 'Height' } )
+					.type( productHeight );
+			} );
 		} );
 
 		await test.step( 'Click "Save changes".', async () => {


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/37724.

The major change in this PR is the breaking down of the `can create product, attributes and variations, edit variations and delete variations` test into smaller tests, like so:

   <img width="399" alt="TO0LUpboUk" src="https://user-images.githubusercontent.com/4509348/232119378-e1787318-e825-4db4-b2f9-93df3401adea.png">

There are also these changes:

1.  Added `test.step()` to (hopefully) improve readability within the spec file, and in the Playwright or Allure HTML reports.

    With this change, the steps that used to look like this:

    <img width="422" alt="BprEHt2BsL" src="https://user-images.githubusercontent.com/4509348/232119255-7650bc80-56ba-4609-b576-c9ca51da60de.png">

    ...would now look like this:

    <img width="531" alt="OqI5ZyaYZl" src="https://user-images.githubusercontent.com/4509348/232119324-b55531b8-af38-44f1-9e6c-62d43516e781.png">

    However to limit the scope of this PR, it does not yet add `test.step()`'s to the `can manually add a variation, manage stock levels, set variation defaults and remove a variation` test.

1.  We need to have a way to make each of the smaller tests independent from one another. That's why the function [`createVariableProductFixture`](https://github.com/woocommerce/woocommerce/blob/e2e/split-variable-product-test/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js#L86) was created. It creates a fixture that will be used by each of the smaller tests, so they would no longer have to rely on the first test for creating the variable product.
1.  The resetting of the variable product tour now [happens at the beginning of the very first test](https://github.com/woocommerce/woocommerce/blob/e2e/split-variable-product-test/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js#L224-L229) (`can create product, attributes and variations`), instead of in the `afterAll` hook. This is due to the fact that only the first test relies on the tour to be displayed. The other tests do not.
1.  Updated some of the locators to using `page.getByRole()` for better readability.
1.  Added assertions to tests that turned out to be not having any after the split.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Assuming that your local environment is already running, and that you're in the `plugins/woocommerce` directory:

1. Run the tests individually to verify that they're not interdependent with each other. They should all pass:
   - `pnpm test:e2e-pw -g "can create product, attributes and variations"`
   - `pnpm test:e2e-pw -g "can individually edit variations"`
   - `pnpm test:e2e-pw -g "can bulk edit variations"`
   - `pnpm test:e2e-pw -g "can delete all variations"`
   - `pnpm test:e2e-pw -g "can manually add a variation, manage stock levels, set variation defaults and remove a variation"`
2. Run the entire `create-variable-product.spec.js` spec. It should pass.
   - `pnpm test:e2e-pw create-variable-product.spec.js`
