### PR TITLE
Re-add woocommerce_after_product_attribute_settings hook

### DIFF
--- a/plugins/woocommerce/changelog/fix-readd-action-hook
+++ b/plugins/woocommerce/changelog/fix-readd-action-hook
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Re-add action hook which was removed by mistake
+
+

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute-inner.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute-inner.php
@@ -104,5 +104,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 			</div>
 		</td>
 	</tr>
+	<?php
+	if ( ! isset( $is_variations_screen ) ) {
+		/**
+		 * Hook to display custom attribute terms.
+		 *
+		 * @since 3.4.0
+		 * @param WC_Product_Attribute $attribute Attribute object.
+		 * @param number $i Attribute index.
+		 */
+		do_action( 'woocommerce_after_product_attribute_settings', $attribute, $i );
+	}
+	?>
 	</tbody>
 </table>


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Re-add woocommerce_after_product_attribute_settings hook. This was removed by mistake in a refactor.

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to the product editor.
2. Add some attributes.
3. Check that the hook is being called for each attribute.

<!-- End testing instructions -->