### PR TITLE
skip k6 api order RUD tests on non-existant order when C test fails

### DIFF
--- a/plugins/woocommerce/changelog/fix-k6-api-40X-errors
+++ b/plugins/woocommerce/changelog/fix-k6-api-40X-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+skip k6 api order RUD tests on non-existant order when C test fails

--- a/plugins/woocommerce/tests/performance/requests/api/orders.js
+++ b/plugins/woocommerce/tests/performance/requests/api/orders.js
@@ -92,62 +92,70 @@ export function ordersAPI() {
 	} );
 
 	group( 'API Retrieve Order', function () {
-		response = http.get(
-			`${ base_url }/wp-json/wc/v3/orders/${ post_id }`,
-			{
-				headers: requestHeaders,
-				tags: { name: 'API - Retrieve Order' },
-			}
-		);
-		check( response, {
-			'status is 200': ( r ) => r.status === 200,
-			'body contains: Order ID': ( response ) =>
-				response.body.includes( `"id":${ post_id }` ),
-		} );
+		if ( post_id ) {
+			response = http.get(
+				`${ base_url }/wp-json/wc/v3/orders/${ post_id }`,
+				{
+					headers: requestHeaders,
+					tags: { name: 'API - Retrieve Order' },
+				}
+			);
+			check( response, {
+				'status is 200': ( r ) => r.status === 200,
+				'body contains: Order ID': ( response ) =>
+					response.body.includes( `"id":${ post_id }` ),
+			} );
+		}
 	} );
 
 	group( 'API List Orders', function () {
-		response = http.get( `${ base_url }/wp-json/wc/v3/orders`, {
-			headers: requestHeaders,
-			tags: { name: 'API - List Orders' },
-		} );
-		check( response, {
-			'status is 200': ( r ) => r.status === 200,
-			'body contains: Order ID': ( response ) =>
-				response.body.includes( '[{"id":' ),
-		} );
+		if ( post_id ) {
+			response = http.get( `${ base_url }/wp-json/wc/v3/orders`, {
+				headers: requestHeaders,
+				tags: { name: 'API - List Orders' },
+			} );
+			check( response, {
+				'status is 200': ( r ) => r.status === 200,
+				'body contains: Order ID': ( response ) =>
+					response.body.includes( '[{"id":' ),
+			} );
+		}
 	} );
 
 	group( 'API Update Order', function () {
-		response = http.put(
-			`${ base_url }/wp-json/wc/v3/orders/${ post_id }`,
-			JSON.stringify( updateData ),
-			{
-				headers: requestHeaders,
-				tags: { name: 'API - Update Order (Status)' },
-			}
-		);
-		check( response, {
-			'status is 200': ( r ) => r.status === 200,
-			"body contains: 'Completed' Status": ( response ) =>
-				response.body.includes( '"status":"completed"' ),
-		} );
+		if ( post_id ) {
+			response = http.put(
+				`${ base_url }/wp-json/wc/v3/orders/${ post_id }`,
+				JSON.stringify( updateData ),
+				{
+					headers: requestHeaders,
+					tags: { name: 'API - Update Order (Status)' },
+				}
+			);
+			check( response, {
+				'status is 200': ( r ) => r.status === 200,
+				"body contains: 'Completed' Status": ( response ) =>
+					response.body.includes( '"status":"completed"' ),
+			} );
+		}
 	} );
 
 	group( 'API Delete Order', function () {
-		response = http.del(
-			`${ base_url }/wp-json/wc/v3/orders/${ post_id }`,
-			JSON.stringify( { force: true } ),
-			{
-				headers: requestHeaders,
-				tags: { name: 'API - Delete Order' },
-			}
-		);
-		check( response, {
-			'status is 200': ( r ) => r.status === 200,
-			'body contains: Order ID': ( response ) =>
-				response.body.includes( `"id":${ post_id }` ),
-		} );
+		if ( post_id ) {
+			response = http.del(
+				`${ base_url }/wp-json/wc/v3/orders/${ post_id }`,
+				JSON.stringify( { force: true } ),
+				{
+					headers: requestHeaders,
+					tags: { name: 'API - Delete Order' },
+				}
+			);
+			check( response, {
+				'status is 200': ( r ) => r.status === 200,
+				'body contains: Order ID': ( response ) =>
+					response.body.includes( `"id":${ post_id }` ),
+			} );
+		}
 	} );
 
 	group( 'API Batch Create Orders', function () {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the k6 api order tests to skip the retrieve, list, update, and delete tests when the create test fails. When the create test fails `post_id` is `null` and the following tests fail with `40X` statuses. The response time for these requests are included in the k6 test results which skews the test results. Also, skipping the tests allows for more test iterations.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. This issue doesn't seem to appear on a new test site with a small number of orders
2. If your test site has less than 10K orders, use [Smooth Generator](https://github.com/woocommerce/wc-smooth-generator) to add 10K orders to your test install
3. Run the k6 tests in `trunk` in the `tests/performance` folder with `k6 run tests/wc-baseline-load.js`.
4. Search your test server access logs for `wp-json/wc/v3/orders/null`
5. If none are found you may need a higher number of orders
6. Switch to this branch and re-run the tests
7. Your test server access logs should not have new entries with `wp-json/wc/v3/orders/null`

<!-- End testing instructions -->