### PR TITLE
ChatGPT POC: Update design

### DIFF
--- a/plugins/woocommerce/assets/images/icons/accordion-expanded-tip-up.svg
+++ b/plugins/woocommerce/assets/images/icons/accordion-expanded-tip-up.svg
@@ -1,0 +1,4 @@
+<svg width="22" height="13" viewBox="0 0 22 13" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11 2.0001L22 13.0001H0L11 2.0001Z" fill="#F6F7F7"/>
+<path d="M21 11.65L11 1.65L1 11.65" stroke="#C3C4C7"/>
+</svg>

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8056,6 +8056,9 @@ table.bar_chart {
 		&::before {
 			content: "\f335";
 
+			position: relative;
+			left: 2px;
+
 			font-family: "dashicons";
 			font-size: 1.5em;
 
@@ -8071,6 +8074,11 @@ table.bar_chart {
 	label[for="woocommerce-product-description-gpt-voice-tone"],
 	#woocommerce-product-description-gpt-voice-tone-wrapper {
 		grid-row: 3;
+	}
+
+	#woocommerce-product-description-gpt-about-wrapper,
+	#woocommerce-product-description-gpt-voice-tone-wrapper {
+		grid-column: span 2;
 	}
 
 	#woocommerce-product-description-gpt-voice-tone-description {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8032,23 +8032,23 @@ table.bar_chart {
 	}
 
 	label[for="woocommerce-product-description-gpt-about"] {
-		grid-column: 1 / 2;
-		grid-row: 1 / 2;
+		grid-column: 1;
+		grid-row: 1;
 	}
 
 	#woocommerce-product-description-gpt-about-wrapper {
-		grid-column: 2 / 3;
-		grid-row: 1 / 2;
+		grid-column: 2;
+		grid-row: 1;
 	}
 
 	label[for="woocommerce-product-description-gpt-voice-tone"] {
-		grid-column: 1 / 2;
-		grid-row: 2 / 3;
+		grid-column: 1;
+		grid-row: 2;
 	}
 
 	#woocommerce-product-description-gpt-voice-tone-wrapper {
-		grid-column: 2 / 3;
-		grid-row: 2 / 3;
+		grid-column: 2;
+		grid-row: 2;
 	}
 
 	#woocommerce-product-description-gpt-voice-tone-description {
@@ -8058,15 +8058,15 @@ table.bar_chart {
 	}
 
 	#woocommerce-product-description-gpt-action-accept {
-		grid-column: 2 / 3;
-		grid-row: 3 / 4;
+		grid-column: 2;
+		grid-row: 3;
 
 		justify-self: left;
 	}
 
 	#woocommerce-product-description-gpt-hide {
-		grid-column: 3 / 4;
-		grid-row: 1 / 2;
+		grid-column: 3;
+		grid-row: 1;
 
 		justify-self: right;
 

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8019,7 +8019,6 @@ table.bar_chart {
 		line-height: 16px;
 		display: flex;
 		align-items: center;
-		text-transform: uppercase;
 		padding-bottom: 20px;
 	}
 	.woocommerce-gpt-textarea {
@@ -8035,7 +8034,6 @@ table.bar_chart {
 		line-height: 16px;
 		display: flex;
 		align-items: center;
-		text-transform: uppercase;
 		padding: 20px 0;
 	}
 	.woocommerce-actions {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -7989,7 +7989,6 @@ table.bar_chart {
 }
 
 .woocommerce-gpt-integration {
-	width: 400px;
 	margin-bottom: 20px;
 
 	display: none;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8038,6 +8038,8 @@ table.bar_chart {
 
 	#woocommerce-product-description-gpt-voice-tone-description {
 		margin: 12px 0 0;
+
+		color: #2C3338;
 	}
 
 	#woocommerce-product-description-gpt-action-accept {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -7997,7 +7997,7 @@ table.bar_chart {
 	gap: 24px;
 
 	margin: 20px 0;
-	padding: 24px 16px;
+	padding: 16px 16px 24px;
 
 	background: #F6F7F7;
 	border: 1px solid #C3C4C7;
@@ -8006,8 +8006,9 @@ table.bar_chart {
 		content: url('../images/icons/accordion-expanded-tip-up.svg');
 
 		position: relative;
-		top: -36px;
-		left: 150px;
+		top: -28px;
+		left: 155px;
+		width: 21px;
 	}
 
 	label, a, .select-wrapper, .textarea-wrapper {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8037,35 +8037,6 @@ table.bar_chart {
 		padding: 20px 0;
 	}
 	.woocommerce-actions {
-		.woocommerce-action-buttons {
-			display: flex;
-			flex-direction: row;
-			align-items: flex-start;
-			padding: 2px;
-			width: 394px;
-			height: 36px;
-			background: #ffffff;
-			border: 1px solid #949494;
-			border-radius: 2px;
-			> button {
-				width: 99px;
-				align-self: stretch;
-				flex-grow: 1;
-				background-color: #fff;
-				border: none;
-				font-style: normal;
-				font-weight: 400;
-				font-size: 15px;
-				color: #949494;
-				cursor: pointer;
-			}
-			> button:hover,
-			> button.active {
-				color: #ffffff;
-				background: #1e1e1e;
-				border-radius: 1px;
-			}
-		}
 		.woocommerce-action-description {
 			font-size: 11px;
 			display: flex;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8027,41 +8027,13 @@ table.bar_chart {
 		}
 	}
 
-	.woocommerce-help-tip {
-		//position: absolute;
-	}
-
-	label[for="woocommerce-product-description-gpt-about"] {
+	label {
 		grid-column: 1;
-		grid-row: 2;
 	}
 
-	#woocommerce-product-description-gpt-about-wrapper {
-		grid-column: 2;
-		grid-row: 2;
-	}
-
-	label[for="woocommerce-product-description-gpt-voice-tone"] {
-		grid-column: 1;
-		grid-row: 3;
-	}
-
-	#woocommerce-product-description-gpt-voice-tone-wrapper {
-		grid-column: 2;
-		grid-row: 3;
-	}
-
-	#woocommerce-product-description-gpt-voice-tone-description {
-		margin: 12px 0 0;
-
-		color: #2C3338;
-	}
-
+	.field,
 	#woocommerce-product-description-gpt-action-accept {
 		grid-column: 2;
-		grid-row: 4;
-
-		justify-self: left;
 	}
 
 	#woocommerce-product-description-gpt-hide {
@@ -8080,5 +8052,27 @@ table.bar_chart {
 
 			color: #1D2327;
 		}
+	}
+
+	label[for="woocommerce-product-description-gpt-about"],
+	#woocommerce-product-description-gpt-about-wrapper {
+		grid-row: 2;
+	}
+
+	label[for="woocommerce-product-description-gpt-voice-tone"],
+	#woocommerce-product-description-gpt-voice-tone-wrapper {
+		grid-row: 3;
+	}
+
+	#woocommerce-product-description-gpt-voice-tone-description {
+		margin: 12px 0 0;
+
+		color: #2C3338;
+	}
+
+	#woocommerce-product-description-gpt-action-accept {
+		grid-row: 4;
+
+		justify-self: left;
 	}
 }

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8014,7 +8014,8 @@ table.bar_chart {
 
 	.select-wrapper {
 		select {
-			width: 100%;
+			width: calc(100% - 25px);
+			max-width: 500px;
 		}
 	}
 

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -7991,7 +7991,8 @@ table.bar_chart {
 .woocommerce-gpt-integration {
 	display: none;
 
-	grid-template-columns: 200px 400px auto;
+	// leave room in the 2nd column for tooltips
+	grid-template-columns: 180px calc( 400px + 25px ) auto;
 	gap: 24px;
 
 	margin: 20px 0;
@@ -8000,7 +8001,7 @@ table.bar_chart {
 	background: #F6F7F7;
 	border: 1px solid #C3C4C7;
 
-	label, textarea, .select-wrapper {
+	label, a, .select-wrapper, .textarea-wrapper {
 		align-self: baseline;
 	}
 
@@ -8016,16 +8017,27 @@ table.bar_chart {
 		}
 	}
 
+	.textarea-wrapper {
+		display: flex;
+
+		textarea {
+			width: 100%;
+			height: 72px;
+		}
+	}
+
+	.woocommerce-help-tip {
+		//position: absolute;
+	}
+
 	label[for="woocommerce-product-description-gpt-about"] {
 		grid-column: 1 / 2;
 		grid-row: 1 / 2;
 	}
 
-	#woocommerce-product-description-gpt-about {
+	#woocommerce-product-description-gpt-about-wrapper {
 		grid-column: 2 / 3;
 		grid-row: 1 / 2;
-
-		height: 72px;
 	}
 
 	label[for="woocommerce-product-description-gpt-voice-tone"] {
@@ -8056,7 +8068,6 @@ table.bar_chart {
 		grid-row: 1 / 2;
 
 		justify-self: right;
-		align-self: start;
 
 		text-decoration: none;
 
@@ -8066,7 +8077,7 @@ table.bar_chart {
 			font-family: "dashicons";
 			font-size: 1.5em;
 
-			color: #1E1E1E;
+			color: #1D2327;
 		}
 	}
 }

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -7992,6 +7992,8 @@ table.bar_chart {
 	width: 400px;
 	margin-bottom: 20px;
 
+	display: none;
+
 	span.woocommerce-beta-badge {
 		border-radius: 25px;
 		padding: 6px 15px;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -7992,7 +7992,8 @@ table.bar_chart {
 	display: none;
 
 	// leave room in the 2nd column for tooltips
-	grid-template-columns: 180px calc( 400px + 25px ) auto;
+	grid-template-columns: 180px minmax( calc(400px + 25px), 2000px ) auto;
+	justify-content: stretch;
 	gap: 24px;
 
 	margin: 20px 0;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -7989,10 +7989,30 @@ table.bar_chart {
 }
 
 .woocommerce-gpt-integration {
-	margin-bottom: 20px;
-
 	display: none;
+
 	grid-template-columns: 200px 400px auto;
+	gap: 24px;
+
+	margin: 20px 0;
+	padding: 24px 16px;
+
+	background: #F6F7F7;
+	border: 1px solid #C3C4C7;
+
+	label, textarea, .select-wrapper {
+		align-self: baseline;
+	}
+
+	label {
+		font-weight: bold;
+	}
+
+	.select-wrapper {
+		select {
+			width: 100%;
+		}
+	}
 
 	label[for="woocommerce-product-description-gpt-about"] {
 		grid-column: 1 / 2;
@@ -8002,6 +8022,8 @@ table.bar_chart {
 	#woocommerce-product-description-gpt-about {
 		grid-column: 2 / 3;
 		grid-row: 1 / 2;
+
+		height: 72px;
 	}
 
 	label[for="woocommerce-product-description-gpt-voice-tone"] {
@@ -8009,26 +8031,26 @@ table.bar_chart {
 		grid-row: 2 / 3;
 	}
 
-	#woocommerce-product-description-gpt-voice-tone {
+	#woocommerce-product-description-gpt-voice-tone-wrapper {
 		grid-column: 2 / 3;
 		grid-row: 2 / 3;
 	}
 
 	#woocommerce-product-description-gpt-voice-tone-description {
+		margin: 12px 0 0;
+	}
+
+	#woocommerce-product-description-gpt-action-accept {
 		grid-column: 2 / 3;
 		grid-row: 3 / 4;
+
+		justify-self: left;
 	}
 
-	.woocommerce-product-description-gpt-actions-container {
-		grid-column: 2 / 3;
-		grid-row: 4 / 5;
-	}
-
-	.woocommerce-product-description-gpt-hide-container {
+	#woocommerce-product-description-gpt-hide {
 		grid-column: 3 / 4;
 		grid-row: 1 / 2;
 
-		display: flex;
-		flex-direction: row-reverse;
+		justify-self: right;
 	}
 }

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -7992,7 +7992,7 @@ table.bar_chart {
 	display: none;
 
 	// leave room in the 2nd column for tooltips
-	grid-template-columns: 180px minmax( calc(400px + 25px), 2000px ) auto;
+	grid-template-columns: 180px minmax( calc(100% - 24px - 180px - 24px - 21px), 2000px ) auto;
 	justify-content: stretch;
 	gap: 24px;
 
@@ -8014,7 +8014,7 @@ table.bar_chart {
 
 	.select-wrapper {
 		select {
-			width: calc(100% - 25px);
+			width: 50%;
 			max-width: 500px;
 		}
 	}
@@ -8032,7 +8032,6 @@ table.bar_chart {
 		grid-column: 1;
 	}
 
-	.field,
 	#woocommerce-product-description-gpt-action-accept {
 		grid-column: 2;
 	}
@@ -8075,5 +8074,42 @@ table.bar_chart {
 		grid-row: 4;
 
 		justify-self: left;
+	}
+
+	@media only screen and (max-width: 1200px) {
+		grid-template-columns: calc(100% - 24px - 21px) auto;
+
+		.select-wrapper {
+			select {
+				width: calc(100% - 25px);
+				max-width: calc(100% - 25px);
+			}
+		}
+
+		#woocommerce-product-description-gpt-hide {
+			grid-column: 2;
+			grid-row: 1;
+		}
+
+		label[for="woocommerce-product-description-gpt-about"] {
+			grid-row: 2;
+		}
+
+		#woocommerce-product-description-gpt-about-wrapper {
+			grid-row: 3;
+		}
+
+		label[for="woocommerce-product-description-gpt-voice-tone"] {
+			grid-row: 4;
+		}
+
+		#woocommerce-product-description-gpt-voice-tone-wrapper {
+			grid-row: 5;
+		}
+
+		#woocommerce-product-description-gpt-action-accept {
+			grid-column: 1;
+			grid-row: 6;
+		}
 	}
 }

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8002,6 +8002,14 @@ table.bar_chart {
 	background: #F6F7F7;
 	border: 1px solid #C3C4C7;
 
+	&::before {
+		content: url('../images/icons/accordion-expanded-tip-up.svg');
+
+		position: relative;
+		top: -36px;
+		left: 150px;
+	}
+
 	label, a, .select-wrapper, .textarea-wrapper {
 		align-self: baseline;
 	}

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8033,22 +8033,22 @@ table.bar_chart {
 
 	label[for="woocommerce-product-description-gpt-about"] {
 		grid-column: 1;
-		grid-row: 1;
+		grid-row: 2;
 	}
 
 	#woocommerce-product-description-gpt-about-wrapper {
 		grid-column: 2;
-		grid-row: 1;
+		grid-row: 2;
 	}
 
 	label[for="woocommerce-product-description-gpt-voice-tone"] {
 		grid-column: 1;
-		grid-row: 2;
+		grid-row: 3;
 	}
 
 	#woocommerce-product-description-gpt-voice-tone-wrapper {
 		grid-column: 2;
-		grid-row: 2;
+		grid-row: 3;
 	}
 
 	#woocommerce-product-description-gpt-voice-tone-description {
@@ -8059,7 +8059,7 @@ table.bar_chart {
 
 	#woocommerce-product-description-gpt-action-accept {
 		grid-column: 2;
-		grid-row: 3;
+		grid-row: 4;
 
 		justify-self: left;
 	}

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8054,5 +8054,17 @@ table.bar_chart {
 		grid-row: 1 / 2;
 
 		justify-self: right;
+		align-self: start;
+
+		text-decoration: none;
+
+		&::before {
+			content: "\f335";
+
+			font-family: "dashicons";
+			font-size: 1.5em;
+
+			color: #1E1E1E;
+		}
 	}
 }

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -7992,55 +7992,43 @@ table.bar_chart {
 	margin-bottom: 20px;
 
 	display: none;
+	grid-template-columns: 200px 400px auto;
 
-	span.woocommerce-beta-badge {
-		border-radius: 25px;
-		padding: 6px 15px;
-		background-color: #f5e6ab;
-		color: #614200;
-		font-weight: 500;
-		font-size: 11px;
-		line-height: 16px;
-		margin-left: 15px;
-		text-decoration: none;
+	label[for="woocommerce-product-description-gpt-about"] {
+		grid-column: 1 / 2;
+		grid-row: 1 / 2;
 	}
 
-	a.woocommerce-hide-gpt-integration {
-		font-weight: 500;
-		font-size: 12px;
-		line-height: 16px;
-		margin-left: 15px;
-		text-decoration: none;
+	#woocommerce-product-description-gpt-about {
+		grid-column: 2 / 3;
+		grid-row: 1 / 2;
 	}
-	.woocommerce-textarea-title {
-		font-weight: 500;
-		font-size: 14px;
-		line-height: 16px;
+
+	label[for="woocommerce-product-description-gpt-voice-tone"] {
+		grid-column: 1 / 2;
+		grid-row: 2 / 3;
+	}
+
+	#woocommerce-product-description-gpt-voice-tone {
+		grid-column: 2 / 3;
+		grid-row: 2 / 3;
+	}
+
+	#woocommerce-product-description-gpt-voice-tone-description {
+		grid-column: 2 / 3;
+		grid-row: 3 / 4;
+	}
+
+	.woocommerce-product-description-gpt-actions-container {
+		grid-column: 2 / 3;
+		grid-row: 4 / 5;
+	}
+
+	.woocommerce-product-description-gpt-hide-container {
+		grid-column: 3 / 4;
+		grid-row: 1 / 2;
+
 		display: flex;
-		align-items: center;
-		padding-bottom: 20px;
-	}
-	.woocommerce-gpt-textarea {
-		width: 400px;
-		height: 72px;
-		border: 1px solid #949494;
-		border-radius: 2px;
-	}
-	.woocommerce-action-buttons-title {
-		font-style: normal;
-		font-weight: 500;
-		font-size: 14px;
-		line-height: 16px;
-		display: flex;
-		align-items: center;
-		padding: 20px 0;
-	}
-	.woocommerce-actions {
-		.woocommerce-action-description {
-			font-size: 11px;
-			display: flex;
-			color: #757575;
-			padding: 10px 0 20px;
-		}
+		flex-direction: row-reverse;
 	}
 }

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8006,6 +8006,8 @@ table.bar_chart {
 
 	label {
 		font-weight: bold;
+
+		color: #1D2327;
 	}
 
 	.select-wrapper {

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -1087,6 +1087,44 @@ jQuery( function ( $ ) {
 			keepAlive: true,
 		} );
 
+	// Hook up "write it for me" button, and the hide button, to toggle the GPT form
+	$( '.wc-write-it-for-me, #woocommerce-product-description-gpt-hide' ).on(
+		'click',
+		function () {
+			const gptForm = $( '.woocommerce-gpt-integration' );
+
+			if ( gptForm.is( ':visible' ) ) {
+				gptForm.slideUp( 'fast' );
+			} else {
+				gptForm.slideDown( {
+					duration: 'fast',
+					start: function () {
+						$( this ).css( 'display', 'grid' );
+					},
+				} );
+			}
+		}
+	);
+
+	// Add a descriptive tooltip to the "write it for me" about field
+	$( '#woocommerce-product-description-gpt-about-wrapper' )
+		.append( '<span class="woocommerce-help-tip" tabindex="-1"></span>' )
+		.find( '.woocommerce-help-tip' )
+		.attr( 'for', 'content' )
+		.attr(
+			'aria-label',
+			woocommerce_admin_meta_boxes.i18n_product_description_gpt_about_tip
+		)
+		.tipTip( {
+			attribute: 'data-tip',
+			content:
+				woocommerce_admin_meta_boxes.i18n_product_description_gpt_about_tip,
+			fadeIn: 50,
+			fadeOut: 50,
+			delay: 200,
+			keepAlive: true,
+		} );
+
 	// Add a descriptive tooltip to the product short description meta box title
 	$( '#postexcerpt > .postbox-header > .hndle' )
 		.append( '<span class="woocommerce-help-tip"></span>' )

--- a/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
+++ b/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
@@ -606,29 +606,36 @@
 			}
 		);
 
-		$( '.woocommerce-gpt-action-accept' ).on( 'click', function () {
-			$.ajax( {
-				url: woocommerce_admin_meta_boxes.ajax_url,
-				type: 'POST',
-				data: {
-					action: 'woocommerce_generate_product_description',
-					product_description: $( '.woocommerce-gpt-textarea' ).val(),
-					tone: 'casual', // TODO fetch this from the selected option
-				},
-				success: function ( response ) {
-					if ( tinyMCE.activeEditor ) {
-						tinyMCE.activeEditor.setContent( response );
-					} else {
-						$( '#wp-content-editor-container .wp-editor-area' ).val(
-							response
-						);
-					}
-				},
-				error: function ( err ) {
-					console.log( err );
-				},
-			} );
-		} );
+		$( '#woocommerce-product-description-gpt-action-accept' ).on(
+			'click',
+			function () {
+				$.ajax( {
+					url: woocommerce_admin_meta_boxes.ajax_url,
+					type: 'POST',
+					data: {
+						action: 'woocommerce_generate_product_description',
+						product_description: $(
+							'#woocommerce-product-description-gpt-about'
+						).val(),
+						tone: $(
+							'#woocommerce-product-description-gpt-voice-tone'
+						).val(),
+					},
+					success: function ( response ) {
+						if ( tinyMCE.activeEditor ) {
+							tinyMCE.activeEditor.setContent( response );
+						} else {
+							$(
+								'#wp-content-editor-container .wp-editor-area'
+							).val( response );
+						}
+					},
+					error: function ( err ) {
+						console.log( err );
+					},
+				} );
+			}
+		);
 
 		$( '#wpbody' ).on( 'click', '#doaction, #doaction2', function () {
 			var action = $( this ).is( '#doaction' )

--- a/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
+++ b/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
@@ -39,7 +39,9 @@
 		}
 
 		// Hook up "write it for me" button
-		$( '.wc-write-it-for-me' ).on( 'click', function () {
+		$(
+			'.wc-write-it-for-me, #woocommerce-product-description-gpt-hide'
+		).on( 'click', function () {
 			const gptForm = $( '.woocommerce-gpt-integration' );
 
 			if ( gptForm.is( ':visible' ) ) {

--- a/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
+++ b/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
@@ -40,7 +40,18 @@
 
 		// Hook up "write it for me" button
 		$( '.wc-write-it-for-me' ).on( 'click', function () {
-			$( '.woocommerce-gpt-integration' ).slideToggle( 'fast' );
+			const gptForm = $( '.woocommerce-gpt-integration' );
+
+			if ( gptForm.is( ':visible' ) ) {
+				gptForm.slideUp( 'fast' );
+			} else {
+				gptForm.slideDown( {
+					duration: 'fast',
+					start: function () {
+						$( this ).css( 'display', 'grid' );
+					},
+				} );
+			}
 		} );
 
 		// Progress indicators when showing steps.

--- a/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
+++ b/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
@@ -38,6 +38,11 @@
 			$title_action.hide();
 		}
 
+		// Hook up "write it for me" button
+		$( '.wc-write-it-for-me' ).on( 'click', function () {
+			$( '.woocommerce-gpt-integration' ).slideToggle( 'fast' );
+		} );
+
 		// Progress indicators when showing steps.
 		$( '.woocommerce-progress-form-wrapper .button-next' ).on(
 			'click',

--- a/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
+++ b/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
@@ -56,6 +56,27 @@
 			}
 		} );
 
+		// Add a descriptive tooltip to the "write it for me" about field
+		$( '#woocommerce-product-description-gpt-about-wrapper' )
+			.append(
+				'<span class="woocommerce-help-tip" tabindex="-1"></span>'
+			)
+			.find( '.woocommerce-help-tip' )
+			.attr( 'for', 'content' )
+			.attr(
+				'aria-label',
+				woocommerce_admin_meta_boxes.i18n_product_description_gpt_about_tip
+			)
+			.tipTip( {
+				attribute: 'data-tip',
+				content:
+					woocommerce_admin_meta_boxes.i18n_product_description_gpt_about_tip,
+				fadeIn: 50,
+				fadeOut: 50,
+				delay: 200,
+				keepAlive: true,
+			} );
+
 		// Progress indicators when showing steps.
 		$( '.woocommerce-progress-form-wrapper .button-next' ).on(
 			'click',

--- a/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
+++ b/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
@@ -38,45 +38,6 @@
 			$title_action.hide();
 		}
 
-		// Hook up "write it for me" button
-		$(
-			'.wc-write-it-for-me, #woocommerce-product-description-gpt-hide'
-		).on( 'click', function () {
-			const gptForm = $( '.woocommerce-gpt-integration' );
-
-			if ( gptForm.is( ':visible' ) ) {
-				gptForm.slideUp( 'fast' );
-			} else {
-				gptForm.slideDown( {
-					duration: 'fast',
-					start: function () {
-						$( this ).css( 'display', 'grid' );
-					},
-				} );
-			}
-		} );
-
-		// Add a descriptive tooltip to the "write it for me" about field
-		$( '#woocommerce-product-description-gpt-about-wrapper' )
-			.append(
-				'<span class="woocommerce-help-tip" tabindex="-1"></span>'
-			)
-			.find( '.woocommerce-help-tip' )
-			.attr( 'for', 'content' )
-			.attr(
-				'aria-label',
-				woocommerce_admin_meta_boxes.i18n_product_description_gpt_about_tip
-			)
-			.tipTip( {
-				attribute: 'data-tip',
-				content:
-					woocommerce_admin_meta_boxes.i18n_product_description_gpt_about_tip,
-				fadeIn: 50,
-				fadeOut: 50,
-				delay: 200,
-				keepAlive: true,
-			} );
-
 		// Progress indicators when showing steps.
 		$( '.woocommerce-progress-form-wrapper .button-next' ).on(
 			'click',

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -437,6 +437,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					/* translators: %1$s: maximum file size */
 					'i18n_product_image_tip'             => sprintf( __( 'For best results, upload JPEG or PNG files that are 1000 by 1000 pixels or larger. Maximum upload file size: %1$s.', 'woocommerce' ) , size_format( wp_max_upload_size() ) ),
 					'i18n_remove_used_attribute_confirmation_message' => __( 'If you remove this attribute, customers will no longer be able to purchase some variations of this product.', 'woocommerce' ),
+					'i18n_product_description_gpt_about_tip' => __( 'Describe the item’s unique features and benefits and who’s the ideal customer.', 'woocommerce' ),
 				);
 
 				wp_localize_script( 'wc-admin-meta-boxes', 'woocommerce_admin_meta_boxes', $params );

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -490,7 +490,9 @@ class WC_Admin_Menus {
 						'<button id="woocommerce-product-description-gpt-action-accept" class="button button-primary" type="button">' .
 							esc_html__( 'Write description', 'woocommerce' ) .
 						'</button>' .
-						'<a id="woocommerce-product-description-gpt-hide" href="#">X</a>' .
+						'<a id="woocommerce-product-description-gpt-hide" href="#" title="' .
+							esc_html__( 'Hide', 'woocommerce' ) .
+						'"></a>' .
 					'</div>';
 				$content = $gpt_form . $content;
 			}

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -472,7 +472,9 @@ class WC_Admin_Menus {
 						'<label for="woocommerce-product-description-gpt-about">' .
 							esc_html__( 'About your product', 'woocommerce' ) .
 						'</label>' .
-						'<textarea id="woocommerce-product-description-gpt-about" placeholder="' . esc_html__( 'e.g. organic and sustainable skin cleanser for women', 'woocommerce' ) . '"></textarea>' .
+						'<div id="woocommerce-product-description-gpt-about-wrapper" class="textarea-wrapper">' .
+							'<textarea id="woocommerce-product-description-gpt-about" placeholder="' . esc_html__( 'e.g. organic and sustainable skin cleanser for women', 'woocommerce' ) . '"></textarea>' .
+						'</div>' .
 						'<label for="woocommerce-product-description-gpt-voice-tone">' .
 							esc_html__( 'Tone of voice', 'woocommerce' ) .
 						'</label>' .

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -449,7 +449,7 @@ class WC_Admin_Menus {
 			return;
 		}
 
-		echo '<button class="button wp-media-button" type="button">' . esc_html__( 'Write it for me (beta)', 'woocommerce' ) . '</button>';
+		echo '<button class="button wp-media-button wc-write-it-for-me" type="button">' . esc_html__( 'Write it for me (beta)', 'woocommerce' ) . '</button>';
 
 	}
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -469,13 +469,6 @@ class WC_Admin_Menus {
 			if ( $editor_container_position !== false ) {
 				$gpt_form =
 					'<div class="woocommerce-gpt-integration">' .
-						'<div class="woocommerce-gpt-integration__title">' .
-							'<h3>' .
-								esc_html__( 'Write a description', 'woocommerce' ) .
-								'<span class="woocommerce-beta-badge">BETA</span>' .
-								'<a class="woocommerce-hide-gpt-integration" href="#">hide</a>' .
-							'</h3>' .
-						'</div>' .
 						'<span class="woocommerce-textarea-title">' .
 							esc_html__( 'ABOUT YOUR PRODUCT', 'woocommerce' ) .
 						'</span>' .

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -469,22 +469,22 @@ class WC_Admin_Menus {
 			if ( $editor_container_position !== false ) {
 				$gpt_form =
 					'<div class="woocommerce-gpt-integration">' .
-						'<span class="woocommerce-textarea-title">' .
+						'<label for="woocommerce-product-description-gpt-about" class="woocommerce-textarea-title">' .
 							esc_html__( 'About your product', 'woocommerce' ) .
-						'</span>' .
-						'<textarea class="woocommerce-gpt-textarea" placeholder="' . esc_html__( 'e.g. organic and sustainable skin cleanser for women', 'woocommerce' ) . '"></textarea>' .
-						'<span class="woocommerce-action-buttons-title">' .
+						'</label>' .
+						'<textarea id="woocommerce-product-description-gpt-about" class="woocommerce-gpt-textarea" placeholder="' . esc_html__( 'e.g. organic and sustainable skin cleanser for women', 'woocommerce' ) . '"></textarea>' .
+						'<label for="woocommerce-product-description-gpt-voice-tone" class="woocommerce-action-buttons-title">' .
 							esc_html__( 'Tone of voice', 'woocommerce' ) .
-						'</span>' .
-						'<select class="woocommerce-gpt-voice-tone">' .
+						'</label>' .
+						'<select id="woocommerce-product-description-gpt-voice-tone" aria-describedby="woocommerce-product-description-gpt-voice-tone-description" class="woocommerce-gpt-voice-tone">' .
 							'<option value="casual">' . esc_html__( 'Casual', 'woocommerce' ) . '</option>' .
 							'<option value="formal">' . esc_html__( 'Formal', 'woocommerce' ) . '</option>' .
 							'<option value="flowery">' . esc_html__( 'Flowery', 'woocommerce' ) . '</option>' .
 							'<option value="convincing">' . esc_html__( 'Convincing', 'woocommerce' ) . '</option>' .
 						'</select>' .
-						'<span class="woocommerce-action-description">' .
+						'<p id="woocommerce-product-description-gpt-voice-tone-description" class="woocommerce-action-description">' .
 							esc_html__( 'Relaxed, informal, conversational tone. Like chatting with a friend.', 'woocommerce' ) .
-						'</span>' .
+						'</p>' .
 						'<button class="button button-primary woocommerce-gpt-action-accept" type="button">' .
 							esc_html__( 'Write description', 'woocommerce' ) .
 						'</button>' .

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -469,25 +469,30 @@ class WC_Admin_Menus {
 			if ( $editor_container_position !== false ) {
 				$gpt_form =
 					'<div class="woocommerce-gpt-integration">' .
-						'<label for="woocommerce-product-description-gpt-about" class="woocommerce-textarea-title">' .
+						'<label for="woocommerce-product-description-gpt-about">' .
 							esc_html__( 'About your product', 'woocommerce' ) .
 						'</label>' .
-						'<textarea id="woocommerce-product-description-gpt-about" class="woocommerce-gpt-textarea" placeholder="' . esc_html__( 'e.g. organic and sustainable skin cleanser for women', 'woocommerce' ) . '"></textarea>' .
-						'<label for="woocommerce-product-description-gpt-voice-tone" class="woocommerce-action-buttons-title">' .
+						'<textarea id="woocommerce-product-description-gpt-about" placeholder="' . esc_html__( 'e.g. organic and sustainable skin cleanser for women', 'woocommerce' ) . '"></textarea>' .
+						'<label for="woocommerce-product-description-gpt-voice-tone">' .
 							esc_html__( 'Tone of voice', 'woocommerce' ) .
 						'</label>' .
-						'<select id="woocommerce-product-description-gpt-voice-tone" aria-describedby="woocommerce-product-description-gpt-voice-tone-description" class="woocommerce-gpt-voice-tone">' .
+						'<select id="woocommerce-product-description-gpt-voice-tone" aria-describedby="woocommerce-product-description-gpt-voice-tone-description">' .
 							'<option value="casual">' . esc_html__( 'Casual', 'woocommerce' ) . '</option>' .
 							'<option value="formal">' . esc_html__( 'Formal', 'woocommerce' ) . '</option>' .
 							'<option value="flowery">' . esc_html__( 'Flowery', 'woocommerce' ) . '</option>' .
 							'<option value="convincing">' . esc_html__( 'Convincing', 'woocommerce' ) . '</option>' .
 						'</select>' .
-						'<p id="woocommerce-product-description-gpt-voice-tone-description" class="woocommerce-action-description">' .
+						'<p id="woocommerce-product-description-gpt-voice-tone-description">' .
 							esc_html__( 'Relaxed, informal, conversational tone. Like chatting with a friend.', 'woocommerce' ) .
 						'</p>' .
-						'<button class="button button-primary woocommerce-gpt-action-accept" type="button">' .
-							esc_html__( 'Write description', 'woocommerce' ) .
-						'</button>' .
+						'<div class="woocommerce-product-description-gpt-actions-container">' .
+							'<button class="button button-primary woocommerce-gpt-action-accept" type="button">' .
+								esc_html__( 'Write description', 'woocommerce' ) .
+							'</button>' .
+						'</div>' .
+						'<div class="woocommerce-product-description-gpt-hide-container">' .
+							'<a id="woocommerce-product-description-gpt-hide" href="#">X</a>' .
+						'</div>' .
 					'</div>';
 				$content = $gpt_form . $content;
 			}

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -470,12 +470,12 @@ class WC_Admin_Menus {
 				$gpt_form =
 					'<div class="woocommerce-gpt-integration">' .
 						'<span class="woocommerce-textarea-title">' .
-							esc_html__( 'ABOUT YOUR PRODUCT', 'woocommerce' ) .
+							esc_html__( 'About your product', 'woocommerce' ) .
 						'</span>' .
 						'<textarea class="woocommerce-gpt-textarea" placeholder="' . esc_html__( 'e.g. organic and sustainable skin cleanser for women', 'woocommerce' ) . '"></textarea>' .
 						'<div class="woocommerce-actions">' .
 							'<span class="woocommerce-action-buttons-title">' .
-								esc_html__( 'TONE OF VOICE', 'woocommerce' ) .
+								esc_html__( 'Tone of voice', 'woocommerce' ) .
 							'</span>' .
 							'<div class="woocommerce-action-buttons">' .
 								'<button class="woocommerce-gpt-action-casual active" type="button">' .

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -469,17 +469,20 @@ class WC_Admin_Menus {
 			if ( $editor_container_position !== false ) {
 				$gpt_form =
 					'<div class="woocommerce-gpt-integration">' .
+						'<a id="woocommerce-product-description-gpt-hide" href="#" title="' .
+							esc_html__( 'Hide', 'woocommerce' ) .
+						'"></a>' .
 						'<label for="woocommerce-product-description-gpt-about">' .
 							esc_html__( 'About your product', 'woocommerce' ) .
 						'</label>' .
-						'<div id="woocommerce-product-description-gpt-about-wrapper" class="textarea-wrapper">' .
+						'<div id="woocommerce-product-description-gpt-about-wrapper" class="textarea-wrapper field">' .
 							'<textarea id="woocommerce-product-description-gpt-about" placeholder="' . esc_html__( 'e.g. organic and sustainable skin cleanser for women', 'woocommerce' ) . '"></textarea>' .
 						'</div>' .
 						'<label for="woocommerce-product-description-gpt-voice-tone">' .
 							esc_html__( 'Tone of voice', 'woocommerce' ) .
 						'</label>' .
 						'<div id="woocommerce-product-description-gpt-voice-tone-wrapper" class="select-wrapper">'.
-						'<select id="woocommerce-product-description-gpt-voice-tone" aria-describedby="woocommerce-product-description-gpt-voice-tone-description">' .
+						'<select id="woocommerce-product-description-gpt-voice-tone" class="field" aria-describedby="woocommerce-product-description-gpt-voice-tone-description">' .
 							'<option value="casual">' . esc_html__( 'Casual', 'woocommerce' ) . '</option>' .
 							'<option value="formal">' . esc_html__( 'Formal', 'woocommerce' ) . '</option>' .
 							'<option value="flowery">' . esc_html__( 'Flowery', 'woocommerce' ) . '</option>' .
@@ -492,9 +495,6 @@ class WC_Admin_Menus {
 						'<button id="woocommerce-product-description-gpt-action-accept" class="button button-primary" type="button">' .
 							esc_html__( 'Write description', 'woocommerce' ) .
 						'</button>' .
-						'<a id="woocommerce-product-description-gpt-hide" href="#" title="' .
-							esc_html__( 'Hide', 'woocommerce' ) .
-						'"></a>' .
 					'</div>';
 				$content = $gpt_form . $content;
 			}

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -473,28 +473,18 @@ class WC_Admin_Menus {
 							esc_html__( 'About your product', 'woocommerce' ) .
 						'</span>' .
 						'<textarea class="woocommerce-gpt-textarea" placeholder="' . esc_html__( 'e.g. organic and sustainable skin cleanser for women', 'woocommerce' ) . '"></textarea>' .
-						'<div class="woocommerce-actions">' .
-							'<span class="woocommerce-action-buttons-title">' .
-								esc_html__( 'Tone of voice', 'woocommerce' ) .
-							'</span>' .
-							'<div class="woocommerce-action-buttons">' .
-								'<button class="woocommerce-gpt-action-casual active" type="button">' .
-									esc_html__( 'Casual', 'woocommerce' ) .
-								'</button>' .
-								'<button class="woocommerce-gpt-action-formal" type="button">' .
-									esc_html__( 'Formal', 'woocommerce' ) .
-								'</button>' .
-								'<button class="woocommerce-gpt-action-flowery" type="button">' .
-									esc_html__( 'Flowery', 'woocommerce' ) .
-								'</button>' .
-								'<button class="woocommerce-gpt-action-convincing" type="button">' .
-									esc_html__( 'Convincing', 'woocommerce' ) .
-								'</button>' .
-							'</div>' .
-							'<span class="woocommerce-action-description">' .
-								esc_html__( 'Relaxed, informal, conversational tone. Like chatting with a friend.', 'woocommerce' ) .
-							'</span>' .
-						'</div>' .
+						'<span class="woocommerce-action-buttons-title">' .
+							esc_html__( 'Tone of voice', 'woocommerce' ) .
+						'</span>' .
+						'<select class="woocommerce-gpt-voice-tone">' .
+							'<option value="casual">' . esc_html__( 'Casual', 'woocommerce' ) . '</option>' .
+							'<option value="formal">' . esc_html__( 'Formal', 'woocommerce' ) . '</option>' .
+							'<option value="flowery">' . esc_html__( 'Flowery', 'woocommerce' ) . '</option>' .
+							'<option value="convincing">' . esc_html__( 'Convincing', 'woocommerce' ) . '</option>' .
+						'</select>' .
+						'<span class="woocommerce-action-description">' .
+							esc_html__( 'Relaxed, informal, conversational tone. Like chatting with a friend.', 'woocommerce' ) .
+						'</span>' .
 						'<button class="button button-primary woocommerce-gpt-action-accept" type="button">' .
 							esc_html__( 'Write description', 'woocommerce' ) .
 						'</button>' .

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -476,6 +476,7 @@ class WC_Admin_Menus {
 						'<label for="woocommerce-product-description-gpt-voice-tone">' .
 							esc_html__( 'Tone of voice', 'woocommerce' ) .
 						'</label>' .
+						'<div id="woocommerce-product-description-gpt-voice-tone-wrapper" class="select-wrapper">'.
 						'<select id="woocommerce-product-description-gpt-voice-tone" aria-describedby="woocommerce-product-description-gpt-voice-tone-description">' .
 							'<option value="casual">' . esc_html__( 'Casual', 'woocommerce' ) . '</option>' .
 							'<option value="formal">' . esc_html__( 'Formal', 'woocommerce' ) . '</option>' .
@@ -485,14 +486,11 @@ class WC_Admin_Menus {
 						'<p id="woocommerce-product-description-gpt-voice-tone-description">' .
 							esc_html__( 'Relaxed, informal, conversational tone. Like chatting with a friend.', 'woocommerce' ) .
 						'</p>' .
-						'<div class="woocommerce-product-description-gpt-actions-container">' .
-							'<button class="button button-primary woocommerce-gpt-action-accept" type="button">' .
-								esc_html__( 'Write description', 'woocommerce' ) .
-							'</button>' .
 						'</div>' .
-						'<div class="woocommerce-product-description-gpt-hide-container">' .
-							'<a id="woocommerce-product-description-gpt-hide" href="#">X</a>' .
-						'</div>' .
+						'<button id="woocommerce-product-description-gpt-action-accept" class="button button-primary" type="button">' .
+							esc_html__( 'Write description', 'woocommerce' ) .
+						'</button>' .
+						'<a id="woocommerce-product-description-gpt-hide" href="#">X</a>' .
 					'</div>';
 				$content = $gpt_form . $content;
 			}


### PR DESCRIPTION

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR updates the design of the ChatGPT POC, largely based on the feedback in the comments of 83-gh-woocommerce/mothra-private

The following changes were made from that proposed design:

- Positioning of the X (hide) button, to avoid it being confused with an action for the "About your product" field
- Positioning of the tooltip for the "About your product" field, to place it on the right as is the convention in the rest of the UI
- "Tone of voice" dropdown is only 50% width on larger viewports, as a very long dropdown with very short options in it looks a bit off

As this is a POC, some shortcuts were taken in the CSS coding (hardcoded values, etc.).

The layout is responsive.

<img width="797" alt="Screenshot 2023-04-16 at 17 17 59" src="https://user-images.githubusercontent.com/2098816/232342712-6821e77c-e7d1-4cd0-94b8-7bcea93bd9fb.png">

<img width="354" alt="Screenshot 2023-04-16 at 17 18 25" src="https://user-images.githubusercontent.com/2098816/232342717-21532bd9-6d63-4747-a242-3180f7c4cd30.png">

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Go to Products > Add New
2. Click on "Write it for me (beta)" -- the form should appear
3. Click on "Write it for me (beta)" or the "X" -- the form should hide

<!-- End testing instructions -->