### PR TITLE
Fix Visual and Text tabs when the "Write it for me" form is shown

### DIFF
--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -1087,6 +1087,10 @@ jQuery( function ( $ ) {
 			keepAlive: true,
 		} );
 
+	// Store the original position of .wp-editor-tabs
+	const wpEditorTabs = $( '.wp-editor-tabs' ).first();
+	const originalPrevElement = wpEditorTabs.prev();
+
 	// Hook up "write it for me" button, and the hide button, to toggle the GPT form
 	$( '.wc-write-it-for-me, #woocommerce-product-description-gpt-hide' ).on(
 		'click',
@@ -1094,8 +1098,14 @@ jQuery( function ( $ ) {
 			const gptForm = $( '.woocommerce-gpt-integration' );
 
 			if ( gptForm.is( ':visible' ) ) {
+				// Move .wp-editor-tabs back to its original position
+				originalPrevElement.after( wpEditorTabs );
 				gptForm.slideUp( 'fast' );
 			} else {
+				// Move .wp-editor-tabs after the GPT form
+				$( '.wp-editor-tabs:first' ).insertAfter(
+					'.woocommerce-gpt-integration'
+				);
 				gptForm.slideDown( {
 					duration: 'fast',
 					start: function () {

--- a/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
+++ b/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
@@ -695,16 +695,5 @@
 				navigator.msMaxTouchPoints > 0
 			);
 		}
-		// Move editor tabs after chatgpt integration.
-		// $( '.wp-editor-tabs' ).insertAfter( '.woocommerce-gpt-integration' );
-		if (
-			! $( '.woocommerce-gpt-integration' )
-				.next()
-				.hasClass( '.wp-editor-tabs:first' )
-		) {
-			$( '.wp-editor-tabs:first' ).insertAfter(
-				'.woocommerce-gpt-integration'
-			);
-		}
 	} );
 } )( jQuery, woocommerce_admin );


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR fixes the `Product description` tabs.
The tabs `Visual` and `Text` will stay next to the `Add Media` and `Write it for me` buttons when the form is not shown.

![Screenshot 2023-04-17 at 10 54 27](https://user-images.githubusercontent.com/1314156/232505593-f2d444cf-37d3-4cd6-84a3-cb05c3b16aae.png)

And we move the tabs after the GPT form when it's being shown.

![Screenshot 2023-04-17 at 10 54 35](https://user-images.githubusercontent.com/1314156/232505989-31caca0b-103c-4d73-90b6-ee69962d2e8a.png)
 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to Products > Add New > Product description.
2. Verify the tabs looks like the photo.
3. Click `Write it for me (beta)` and verify that the tabs were moved after the form. 

<!-- End testing instructions -->