### PR TITLE
Add a11y support to collapsible content component

### DIFF
--- a/packages/js/components/changelog/add-37330
+++ b/packages/js/components/changelog/add-37330
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Improve a11y support to collapsible content component

--- a/packages/js/components/src/collapsible-content/collapsible-content.tsx
+++ b/packages/js/components/src/collapsible-content/collapsible-content.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { useInstanceId } from '@wordpress/compose';
 import { createElement, useState } from '@wordpress/element';
 import { Icon, chevronDown, chevronUp } from '@wordpress/icons';
 
@@ -33,27 +34,46 @@ export const CollapsibleContent: React.FC< CollapsedProps > = ( {
 		return persistRender ? 'visually-hidden' : 'hidden';
 	};
 
+	const collapsibleToggleId = useInstanceId(
+		CollapsibleContent,
+		'collapsible_toggle'
+	) as string;
+	const collapsibleContentId = useInstanceId(
+		CollapsibleContent,
+		'collapsible_content'
+	) as string;
+
+	const displayState = getState();
+
 	return (
-		<div
-			aria-expanded={ collapsed ? 'false' : 'true' }
-			className={ `woocommerce-collapsible-content` }
-		>
+		<div className="woocommerce-collapsible-content">
 			<button
+				type="button"
+				id={ collapsibleToggleId }
 				className="woocommerce-collapsible-content__toggle"
 				onClick={ () => setCollapsed( ! collapsed ) }
+				aria-expanded={ collapsed ? 'false' : 'true' }
+				aria-controls={
+					displayState !== 'hidden' ? collapsibleContentId : undefined
+				}
 			>
 				<div>
 					<span>{ toggleText }</span>
+
 					<Icon
 						icon={ collapsed ? chevronDown : chevronUp }
 						size={ 16 }
 					/>
 				</div>
 			</button>
-			<DisplayState state={ getState() }>
+
+			<DisplayState state={ displayState }>
 				<div
 					{ ...props }
 					className="woocommerce-collapsible-content__content"
+					id={ collapsibleContentId }
+					role="region"
+					aria-labelledby={ collapsibleToggleId }
 				>
 					{ children }
 				</div>

--- a/packages/js/components/src/collapsible-content/collapsible-content.tsx
+++ b/packages/js/components/src/collapsible-content/collapsible-content.tsx
@@ -36,11 +36,11 @@ export const CollapsibleContent: React.FC< CollapsedProps > = ( {
 
 	const collapsibleToggleId = useInstanceId(
 		CollapsibleContent,
-		'collapsible_toggle'
+		'woocommerce-collapsible-content__toggle'
 	) as string;
 	const collapsibleContentId = useInstanceId(
 		CollapsibleContent,
-		'collapsible_content'
+		'woocommerce-collapsible-content__content'
 	) as string;
 
 	const displayState = getState();


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/37330

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Run `pnpm --filter="storybook" storybook`
2. Visit `http://localhost:6007/?path=/story/woocommerce-admin-components-collapsiblecontent--basic`
3. When testing with VoiceOver or NVDA the screen reader should read the title and content with their corresponding collapsible state.

<!-- End testing instructions -->