### PR TITLE
Add "Rewrite", "Simplify" and "make longer" buttons

### DIFF
--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8041,7 +8041,7 @@ table.bar_chart {
 		grid-column: 1;
 	}
 
-	#woocommerce-product-description-gpt-action-accept {
+	.woocommerce-gpt-actions-wrapper {
 		grid-column: 2;
 	}
 
@@ -8087,10 +8087,16 @@ table.bar_chart {
 		color: #2C3338;
 	}
 
-	#woocommerce-product-description-gpt-action-accept {
+	.woocommerce-gpt-actions-wrapper {
 		grid-row: 4;
 
 		justify-self: left;
+	}
+
+	.woocommerce-gpt-actions-wrapper {
+		.button-tertiary {
+			border: none !important;
+		}
 	}
 
 	@media only screen and (max-width: 1200px) {
@@ -8124,7 +8130,7 @@ table.bar_chart {
 			grid-row: 5;
 		}
 
-		#woocommerce-product-description-gpt-action-accept {
+		.woocommerce-gpt-actions-wrapper {
 			grid-column: 1;
 			grid-row: 6;
 		}

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -206,33 +206,33 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 
 				$params = array(
 					/* translators: %s: decimal */
-					'i18n_decimal_error'                => sprintf( __( 'Please enter a value with one decimal point (%s) without thousand separators.', 'woocommerce' ), $decimal ),
+					'i18n_decimal_error'                   => sprintf( __( 'Please enter a value with one decimal point (%s) without thousand separators.', 'woocommerce' ), $decimal ),
 					/* translators: %s: price decimal separator */
-					'i18n_mon_decimal_error'            => sprintf( __( 'Please enter a value with one monetary decimal point (%s) without thousand separators and currency symbols.', 'woocommerce' ), wc_get_price_decimal_separator() ),
-					'i18n_country_iso_error'            => __( 'Please enter in country code with two capital letters.', 'woocommerce' ),
-					'i18n_sale_less_than_regular_error' => __( 'Please enter in a value less than the regular price.', 'woocommerce' ),
-					'i18n_delete_product_notice'        => __( 'This product has produced sales and may be linked to existing orders. Are you sure you want to delete it?', 'woocommerce' ),
-					'i18n_remove_personal_data_notice'  => __( 'This action cannot be reversed. Are you sure you wish to erase personal data from the selected orders?', 'woocommerce' ),
-					'i18n_confirm_delete'               => __( 'Are you sure you wish to delete this item?', 'woocommerce' ),
-					'decimal_point'                     => $decimal,
-					'mon_decimal_point'                 => wc_get_price_decimal_separator(),
-					'ajax_url'                          => admin_url( 'admin-ajax.php' ),
-					'strings'                           => array(
+					'i18n_mon_decimal_error'               => sprintf( __( 'Please enter a value with one monetary decimal point (%s) without thousand separators and currency symbols.', 'woocommerce' ), wc_get_price_decimal_separator() ),
+					'i18n_country_iso_error'               => __( 'Please enter in country code with two capital letters.', 'woocommerce' ),
+					'i18n_sale_less_than_regular_error'    => __( 'Please enter in a value less than the regular price.', 'woocommerce' ),
+					'i18n_delete_product_notice'           => __( 'This product has produced sales and may be linked to existing orders. Are you sure you want to delete it?', 'woocommerce' ),
+					'i18n_remove_personal_data_notice'     => __( 'This action cannot be reversed. Are you sure you wish to erase personal data from the selected orders?', 'woocommerce' ),
+					'i18n_confirm_delete'                  => __( 'Are you sure you wish to delete this item?', 'woocommerce' ),
+					'decimal_point'                        => $decimal,
+					'mon_decimal_point'                    => wc_get_price_decimal_separator(),
+					'ajax_url'                             => admin_url( 'admin-ajax.php' ),
+					'strings'                              => array(
 						'import_products' => __( 'Import', 'woocommerce' ),
 						'export_products' => __( 'Export', 'woocommerce' ),
 					),
-					'nonces'                            => array(
+					'nonces'                               => array(
 						'gateway_toggle' => wp_create_nonce( 'woocommerce-toggle-payment-gateway-enabled' ),
 					),
-					'urls'                              => array(
+					'urls'                                 => array(
 						'add_product'     => Features::is_enabled( 'new-product-management-experience' ) || Features::is_enabled( 'product-block-editor' ) ? esc_url_raw( admin_url( 'admin.php?page=wc-admin&path=/add-product' ) ) : null,
 						'import_products' => current_user_can( 'import' ) ? esc_url_raw( admin_url( 'edit.php?post_type=product&page=product_importer' ) ) : null,
 						'export_products' => current_user_can( 'export' ) ? esc_url_raw( admin_url( 'edit.php?post_type=product&page=product_exporter' ) ) : null,
 					),
-					'i18n_product_description_gpt_writing'             => __( 'Writing description&hellip;', 'woocommerce' ),
-					'i18n_product_description_gpt_simplifying'         => __( 'Simplifying description&hellip;', 'woocommerce' ),
-					'i18n_product_description_gpt_rewriting'           => __( 'Rewriting description&hellip;', 'woocommerce' ),
-					'i18n_product_description_gpt_more'                => __( 'Making the description longer&hellip;', 'woocommerce' ),
+					'i18n_product_description_gpt_writing' => __( 'Writing description&hellip;', 'woocommerce' ),
+					'i18n_product_description_gpt_simplifying' => __( 'Simplifying description&hellip;', 'woocommerce' ),
+					'i18n_product_description_gpt_rewriting' => __( 'Rewriting description&hellip;', 'woocommerce' ),
+					'i18n_product_description_gpt_more' => __( 'Making the description longer&hellip;', 'woocommerce' ),
 					'i18n_product_description_gpt_generating_content'  => __( 'Please wait&hellip;', 'woocommerce' ),
 				);
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -229,7 +229,10 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 						'import_products' => current_user_can( 'import' ) ? esc_url_raw( admin_url( 'edit.php?post_type=product&page=product_importer' ) ) : null,
 						'export_products' => current_user_can( 'export' ) ? esc_url_raw( admin_url( 'edit.php?post_type=product&page=product_exporter' ) ) : null,
 					),
-					'i18n_product_description_gpt_generating' => __( 'Writing description&hellip;', 'woocommerce' ),
+					'i18n_product_description_gpt_writing'             => __( 'Writing description&hellip;', 'woocommerce' ),
+					'i18n_product_description_gpt_simplifying'         => __( 'Simplifying description&hellip;', 'woocommerce' ),
+					'i18n_product_description_gpt_rewriting'           => __( 'Rewriting description&hellip;', 'woocommerce' ),
+					'i18n_product_description_gpt_more'                => __( 'Making the description longer&hellip;', 'woocommerce' ),
 					'i18n_product_description_gpt_generating_content'  => __( 'Please wait&hellip;', 'woocommerce' ),
 				);
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -232,7 +232,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					'i18n_product_description_gpt_writing' => __( 'Writing description&hellip;', 'woocommerce' ),
 					'i18n_product_description_gpt_simplifying' => __( 'Simplifying description&hellip;', 'woocommerce' ),
 					'i18n_product_description_gpt_rewriting' => __( 'Rewriting description&hellip;', 'woocommerce' ),
-					'i18n_product_description_gpt_more' => __( 'Making the description longer&hellip;', 'woocommerce' ),
+					'i18n_product_description_gpt_more'    => __( 'Making the description longer&hellip;', 'woocommerce' ),
 					'i18n_product_description_gpt_generating_content'  => __( 'Please wait&hellip;', 'woocommerce' ),
 				);
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -492,9 +492,22 @@ class WC_Admin_Menus {
 							esc_html__( 'Relaxed, informal, conversational tone. Like chatting with a friend.', 'woocommerce' ) .
 						'</p>' .
 						'</div>' .
+						'<div class="woocommerce-gpt-actions-wrapper">' .
 						'<button id="woocommerce-product-description-gpt-action-accept" class="button button-primary" type="button">' .
 							esc_html__( 'Write description', 'woocommerce' ) .
 						'</button>' .
+						'<div class="woocommerce-gpt-extra-actions-wrapper hidden">' .
+						'<button id="woocommerce-product-description-gpt-action-simplify" class="button button-tertiary" type="button">' .
+							esc_html__( 'Simplify it', 'woocommerce' ) .
+						'</button>' .
+						'<button id="woocommerce-product-description-gpt-action-longer" class="button button-tertiary" type="button">' .
+							esc_html__( 'Make it longer', 'woocommerce' ) .
+						'</button>' .
+						'<button id="woocommerce-product-description-gpt-action-rewrite" class="button button-primary" type="button">' .
+							esc_html__( 'Rewrite', 'woocommerce' ) .
+						'</button>' .
+						'</div>' .
+						'</div>' .
 					'</div>';
 				$content = $gpt_form . $content;
 			}

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -493,17 +493,17 @@ class WC_Admin_Menus {
 						'</p>' .
 						'</div>' .
 						'<div class="woocommerce-gpt-actions-wrapper">' .
-						'<button id="woocommerce-product-description-gpt-action-accept" class="button button-primary" type="button">' .
+						'<button id="woocommerce-product-description-gpt-action-accept" class="button button-primary gpt-action" action="write" type="button">' .
 							esc_html__( 'Write description', 'woocommerce' ) .
 						'</button>' .
 						'<div class="woocommerce-gpt-extra-actions-wrapper hidden">' .
-						'<button id="woocommerce-product-description-gpt-action-simplify" class="button button-tertiary" type="button">' .
+						'<button id="woocommerce-product-description-gpt-action-simplify" class="button button-tertiary gpt-action" action="simplify" type="button">' .
 							esc_html__( 'Simplify it', 'woocommerce' ) .
 						'</button>' .
-						'<button id="woocommerce-product-description-gpt-action-longer" class="button button-tertiary" type="button">' .
+						'<button id="woocommerce-product-description-gpt-action-longer" class="button button-tertiary gpt-action" action="more" type="button">' .
 							esc_html__( 'Make it longer', 'woocommerce' ) .
 						'</button>' .
-						'<button id="woocommerce-product-description-gpt-action-rewrite" class="button button-primary" type="button">' .
+						'<button id="woocommerce-product-description-gpt-action-rewrite" class="button button-primary gpt-action" action="rewrite" type="button">' .
 							esc_html__( 'Rewrite', 'woocommerce' ) .
 						'</button>' .
 						'</div>' .


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds the buttons `Simplify it`, `Make it longer` and `Rewrite`, to the ChatGPT PoC.

We're sending all the params but they should be processed on the PHP side. Since that's not implemented, the response will be quite similar to the first one.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Press `Write it for me (beta)` and verify the buttons are there.
2. Press them, the waiting text should vary depending on the pressed button.


<!-- End testing instructions -->