### PR TITLE
ChatGPT POC: set default temperature to 1, allow filter override

### DIFF
--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -3264,7 +3264,7 @@ class WC_AJAX {
 		$post_data = array(
 			"messages" => $messages,
 			"model" => "gpt-3.5-turbo",
-			"temperature" => 0.7
+			"temperature" => apply_filters( 'experimental_woocommerce_chatgpt_product_description_temperature', 1 )
 		);
 		$post_data_json = json_encode($post_data);
 		curl_setopt($ch, CURLOPT_POSTFIELDS, $post_data_json);


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR changes the default temperature to `1`, and allows it to be overridden via a filter, `experimental_woocommerce_chatgpt_product_description_temperature`

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Having the OpenAI API key configured in Advanced > Features, go to the product editor
2. Click "Write it for me (beta)"
3. Fill out "About your product" and click "Write description"
4. Verify generated description is reasonable.
5. Change the temperature to `2` via a filter...

```
add_filter( 'experimental_woocommerce_chatgpt_product_description_temperature', function() { return 2; } );
```

6. Reload the page and repeat steps 1-3.
7. Verify generated description takes a lot longer to generate, is incoherent, and not really useable. 😄

<!-- End testing instructions -->