### PR TITLE
ChatGPT POC: Tweak style of extra action buttons

### DIFF
--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -8099,6 +8099,16 @@ table.bar_chart {
 		}
 	}
 
+	.woocommerce-gpt-extra-actions-wrapper {
+		gap: 12px;
+
+		// when jQuery show() is used, it sets the style to `block`, so override that
+		&[style*='block'] {
+			display: flex !important;
+			flex-wrap: wrap;
+		}
+	}
+
 	@media only screen and (max-width: 1200px) {
 		grid-template-columns: calc(100% - 24px - 21px) auto;
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR puts a gap between the extra action buttons, so they aren't directly next to each other.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Having the OpenAI API key configured in Advanced > Features, go to the product editor
Click "Write it for me (beta)"
2. Enter "About this product" and click "Write it for me (beta).
3. Make sure the extra action buttons ("Simply it", "Make it longer", "Rewrite") display properly with a small gap between them.

<!-- End testing instructions -->