### PR TITLE
Add Onboarding Heuristics Tracks Event

### DIFF
--- a/plugins/woocommerce-admin/client/profile-wizard/steps/industry.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/industry.js
@@ -96,6 +96,14 @@ class Industry extends Component {
 		return this.state.selected.map( ( industry ) => industry.slug );
 	}
 
+	componentDidMount() {
+		recordEvent( 'onboarding_site_heuristics', {
+			page_count: onboarding.pageCount,
+			post_count: onboarding.postCount,
+			is_block_theme: onboarding.isBlockTheme,
+		} );
+	}
+
 	componentDidUpdate() {
 		this.props.updateCurrentStepValues(
 			this.props.step.key,

--- a/plugins/woocommerce/changelog/add-onboarding-heuristics
+++ b/plugins/woocommerce/changelog/add-onboarding-heuristics
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add tracks event to gather onboarding heuristics

--- a/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingSetupWizard.php
+++ b/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingSetupWizard.php
@@ -230,6 +230,9 @@ class OnboardingSetupWizard {
 		$settings['onboarding']['euCountries']     = WC()->countries->get_european_union_countries();
 		$settings['onboarding']['localeInfo']      = include WC()->plugin_path() . '/i18n/locale-info.php';
 		$settings['onboarding']['profile']         = $profile;
+		$settings['onboarding']['pageCount']       = (int) ( wp_count_posts( 'page' ) )->publish;
+		$settings['onboarding']['postCount']       = (int) ( wp_count_posts( 'post' ) )->publish;
+		$settings['onboarding']['isBlockTheme']    = wc_current_theme_is_fse_theme();
 
 		return apply_filters( 'woocommerce_admin_onboarding_preloaded_data', $settings );
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a new Tracks event to gather heuristics for new onboarding features. I added it to the second step of the OBW because it's on of the first occasions after the user has agreed to tracking. We might want to look at a better way of doing it in the new core profiler

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Pull down this branch on a fresh install of WooCommerce
2. Add a page or post to the WordPress site
3. Add the following Tracks configuration in the dev console: `localStorage.setItem( 'debug', 'wc-admin:*' );`
4. In the Onboarding Wizard, choose any country on the first step
5. On the second step, observe the Tracks event: `wcadmin_onboarding_site_heuristics` contains correct values for `page_count`, `post_count`, and `is_block_theme` values.

<!-- End testing instructions -->