### PR TITLE
Add Woo Payments Feature Slot Fill on Homepage

### DIFF
--- a/plugins/woocommerce-admin/client/homescreen/layout.js
+++ b/plugins/woocommerce-admin/client/homescreen/layout.js
@@ -43,6 +43,7 @@ import '../dashboard/style.scss';
 import { getAdminSetting } from '~/utils/admin-settings';
 import { ProgressTitle } from '../task-lists';
 import { WooHomescreenHeaderBanner } from './header-banner-slot';
+import { WooHomescreenWCPayFeature } from './wcpay-feature-slot';
 
 const Tasks = lazy( () =>
 	import( /* webpackChunkName: "tasks" */ '../tasks' ).then( ( module ) => ( {
@@ -64,6 +65,7 @@ export const Layout = ( {
 } ) => {
 	const userPrefs = useUserPreferences();
 	const shouldShowStoreLinks = taskListComplete || isTaskListHidden;
+	const shouldShowWCPayFeature = taskListComplete || isTaskListHidden;
 	const hasTwoColumnContent =
 		shouldShowStoreLinks || window.wcAdminFeatures.analytics;
 	const isDashboardShown = ! query.task; // ?&task=<x> query param is used to show tasks instead of the homescreen
@@ -104,6 +106,7 @@ export const Layout = ( {
 							) }
 						/>
 					) }
+					{ shouldShowWCPayFeature && <WooHomescreenWCPayFeature /> }
 					{ <ActivityPanel /> }
 					{ hasTaskList && renderTaskList() }
 					<InboxPanel />

--- a/plugins/woocommerce-admin/client/homescreen/wcpay-feature-slot/index.ts
+++ b/plugins/woocommerce-admin/client/homescreen/wcpay-feature-slot/index.ts
@@ -1,0 +1,2 @@
+export * from './wcpay-feature-slot';
+export * from './utils';

--- a/plugins/woocommerce-admin/client/homescreen/wcpay-feature-slot/utils.tsx
+++ b/plugins/woocommerce-admin/client/homescreen/wcpay-feature-slot/utils.tsx
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { Slot, Fill } from '@wordpress/components';
+import {
+	createOrderedChildren,
+	sortFillsByOrder,
+} from '@woocommerce/components';
+
+export const EXPERIMENTAL_WC_HOMESCREEN_WC_PAY_FEATURE_SLOT_NAME =
+	'experimental_woocommerce_wcpay_feature';
+/**
+ * Create a Fill for WC Pay to add featured content to the homescreen.
+ *
+ * @slotFill WooHomescreenWCPayFeatureItem
+ * @scope woocommerce-admin
+ * @example
+ * const MyFill = () => (
+ * <Fill name="experimental_woocommerce_wcpay_feature">My fill</fill>
+ * );
+ *
+ * registerPlugin( 'my-extension', {
+ * render: MyFill,
+ * scope: 'woocommerce-admin',
+ * } );
+ * @param {Object} param0
+ * @param {Array}  param0.children - Node children.
+ * @param {Array}  param0.order    - Node order.
+ */
+export const WooHomescreenWCPayFeatureItem = ( {
+	children,
+	order = 1,
+}: {
+	children: React.ReactNode;
+	order?: number;
+} ) => {
+	return (
+		<Fill name={ EXPERIMENTAL_WC_HOMESCREEN_WC_PAY_FEATURE_SLOT_NAME }>
+			{ ( fillProps: Fill.Props ) => {
+				return createOrderedChildren( children, order, fillProps );
+			} }
+		</Fill>
+	);
+};
+
+WooHomescreenWCPayFeatureItem.Slot = ( {
+	fillProps,
+}: {
+	fillProps?: Slot.Props;
+} ) => (
+	<Slot
+		name={ EXPERIMENTAL_WC_HOMESCREEN_WC_PAY_FEATURE_SLOT_NAME }
+		fillProps={ fillProps }
+	>
+		{ sortFillsByOrder }
+	</Slot>
+);

--- a/plugins/woocommerce-admin/client/homescreen/wcpay-feature-slot/wcpay-feature-slot.tsx
+++ b/plugins/woocommerce-admin/client/homescreen/wcpay-feature-slot/wcpay-feature-slot.tsx
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import { useSlot } from '@woocommerce/experimental';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import {
+	EXPERIMENTAL_WC_HOMESCREEN_WC_PAY_FEATURE_SLOT_NAME,
+	WooHomescreenWCPayFeatureItem,
+} from './utils';
+
+export const WooHomescreenWCPayFeature = ( {
+	className,
+}: {
+	className: string;
+} ) => {
+	const slot = useSlot( EXPERIMENTAL_WC_HOMESCREEN_WC_PAY_FEATURE_SLOT_NAME );
+	const hasFills = Boolean( slot?.fills?.length );
+
+	if ( ! hasFills ) {
+		return null;
+	}
+	return (
+		<div
+			className={ classnames(
+				'woocommerce-homescreen__header',
+				className
+			) }
+		>
+			<WooHomescreenWCPayFeatureItem.Slot />
+		</div>
+	);
+};

--- a/plugins/woocommerce/changelog/add-wcpay-slotfill
+++ b/plugins/woocommerce/changelog/add-wcpay-slotfill
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add Woo Payments feature slotfill on homepage


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a Slot fill extensibility point intended for the Woo Payments plugin to display a feature banner above the "Things to do" task list. It is hidden when the user has the main task list shown.

<img width="1344" alt="Screen Shot 2023-04-18 at 4 30 05 am" src="https://user-images.githubusercontent.com/9312929/232603069-2b9663c6-f38b-4963-b11e-2c8abeeb9590.png">

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Pull down this branch on a fresh install of WooCommerce
2. Skip the onboarding wizard
3. See that the task lists appear as expected

#### Testing with a fill

1. Add the following code to `plugins/woocommerce-admin/client/homescreen/layout.js` to add an example 3PD fill:

```
/**
 * External dependencies
 */
import { registerPlugin } from '@wordpress/plugins';
import { Fill } from '@wordpress/components';

const MyFill = () => (
	<Fill name="experimental_woocommerce_wcpay_feature">
		<div className="woocommerce-experiments-placeholder-slotfill">
			<div className="placeholder-slotfill-content">
				Slotfill goes in here!
			</div>
		</div>
	</Fill>
);

registerPlugin( 'my-extension', {
	render: MyFill,
	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
	// @ts-ignore
	scope: 'woocommerce-admin',
} );

<!-- End testing instructions -->
```
3. See that the example fill **does not** appear because the task list is not completed.
4. Complete the main task list or hide it using the "3 dots" menu.
5. See that the example fill appears.