### PR TITLE
Record tracks on product edit/update

### DIFF
--- a/packages/js/data/changelog/add-37656
+++ b/packages/js/data/changelog/add-37656
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add auto draft status to product status type

--- a/packages/js/data/src/products/types.ts
+++ b/packages/js/data/src/products/types.ts
@@ -11,6 +11,7 @@ import { BaseQueryParams } from '../types';
 
 export type ProductType = 'simple' | 'grouped' | 'external' | 'variable';
 export type ProductStatus =
+	| 'auto-draft'
 	| 'deleted'
 	| 'draft'
 	| 'pending'

--- a/packages/js/product-editor/changelog/add-37656
+++ b/packages/js/product-editor/changelog/add-37656
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add tracks events on product edit and update

--- a/packages/js/product-editor/src/components/header/hooks/use-preview/use-preview.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-preview/use-preview.tsx
@@ -26,7 +26,7 @@ export function usePreview( {
 		'product',
 		'id'
 	);
-	const [ productStatus ] = useEntityProp< ProductStatus | 'auto-draft' >(
+	const [ productStatus ] = useEntityProp< ProductStatus >(
 		'postType',
 		'product',
 		'status'

--- a/packages/js/product-editor/src/components/header/hooks/use-publish/use-publish.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-publish/use-publish.tsx
@@ -23,7 +23,7 @@ export function usePublish( {
 		'product',
 		'id'
 	);
-	const [ productStatus ] = useEntityProp< ProductStatus | 'auto-draft' >(
+	const [ productStatus ] = useEntityProp< ProductStatus >(
 		'postType',
 		'product',
 		'status'

--- a/packages/js/product-editor/src/components/header/hooks/use-save-draft/use-save-draft.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-save-draft/use-save-draft.tsx
@@ -25,7 +25,7 @@ export function useSaveDraft( {
 		'product',
 		'id'
 	);
-	const [ productStatus ] = useEntityProp< ProductStatus | 'auto-draft' >(
+	const [ productStatus ] = useEntityProp< ProductStatus >(
 		'postType',
 		'product',
 		'status'

--- a/packages/js/product-editor/src/components/header/preview-button/preview-button.tsx
+++ b/packages/js/product-editor/src/components/header/preview-button/preview-button.tsx
@@ -20,7 +20,7 @@ export function PreviewButton( {
 	Button.AnchorProps,
 	'aria-disabled' | 'variant' | 'href' | 'children'
 > ) {
-	const [ productStatus ] = useEntityProp< ProductStatus | 'auto-draft' >(
+	const [ productStatus ] = useEntityProp< ProductStatus >(
 		'postType',
 		'product',
 		'status'

--- a/packages/js/product-editor/src/components/header/publish-button/publish-button.tsx
+++ b/packages/js/product-editor/src/components/header/publish-button/publish-button.tsx
@@ -6,31 +6,25 @@ import { Button } from '@wordpress/components';
 import { createElement } from '@wordpress/element';
 import { getNewPath, navigateTo } from '@woocommerce/navigation';
 import { MouseEvent } from 'react';
-import { Product } from '@woocommerce/data';
-import { recordEvent } from '@woocommerce/tracks';
-import { useDispatch, useSelect } from '@wordpress/data';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore No types for this exist yet.
-// eslint-disable-next-line @woocommerce/dependency-group
-import { useEntityId } from '@wordpress/core-data';
+import { Product, ProductStatus } from '@woocommerce/data';
+import { useDispatch } from '@wordpress/data';
+import { useEntityProp } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
+import { recordProductEvent } from '../../../utils/record-product-event';
 import { usePublish } from '../hooks/use-publish';
 
 export function PublishButton(
 	props: Omit< Button.ButtonProps, 'aria-disabled' | 'variant' | 'children' >
 ) {
-	const productId = useEntityId( 'postType', 'product' );
-	const product: Product = useSelect( ( select ) =>
-		select( 'core' ).getEditedEntityRecord(
-			'postType',
-			'product',
-			productId
-		)
+	const [ productStatus ] = useEntityProp< ProductStatus | 'auto-draft' >(
+		'postType',
+		'product',
+		'status'
 	);
-	const { downloadable, id, manage_stock, status, type, virtual } = product;
+
 
 	const isCreating = status === 'auto-draft';
 
@@ -40,14 +34,8 @@ export function PublishButton(
 	const publishButtonProps = usePublish( {
 		...props,
 		onPublishSuccess( savedProduct: Product ) {
-			recordEvent( 'product_update', {
-				new_product_page: true,
-				product_id: id,
-				product_type: type,
-				is_downloadable: downloadable,
-				is_virtual: virtual,
-				manage_stock,
-			} );
+			recordProductEvent( 'product_update', savedProduct );
+
 			const noticeContent = isCreating
 				? __( 'Product successfully created.', 'woocommerce' )
 				: __( 'Product published.', 'woocommerce' );
@@ -70,7 +58,7 @@ export function PublishButton(
 
 			createSuccessNotice( noticeContent, noticeOptions );
 
-			if ( status === 'auto-draft' ) {
+			if ( productStatus === 'auto-draft' ) {
 				const url = getNewPath( {}, `/product/${ savedProduct.id }` );
 				navigateTo( { url } );
 			}

--- a/packages/js/product-editor/src/components/header/publish-button/publish-button.tsx
+++ b/packages/js/product-editor/src/components/header/publish-button/publish-button.tsx
@@ -19,14 +19,13 @@ import { usePublish } from '../hooks/use-publish';
 export function PublishButton(
 	props: Omit< Button.ButtonProps, 'aria-disabled' | 'variant' | 'children' >
 ) {
-	const [ productStatus ] = useEntityProp< ProductStatus | 'auto-draft' >(
+	const [ productStatus ] = useEntityProp< ProductStatus >(
 		'postType',
 		'product',
 		'status'
 	);
 
-
-	const isCreating = status === 'auto-draft';
+	const isCreating = productStatus === 'auto-draft';
 
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( 'core/notices' );

--- a/packages/js/product-editor/src/components/header/save-draft-button/save-draft-button.tsx
+++ b/packages/js/product-editor/src/components/header/save-draft-button/save-draft-button.tsx
@@ -18,7 +18,7 @@ import { useSaveDraft } from '../hooks/use-save-draft';
 export function SaveDraftButton(
 	props: Omit< Button.ButtonProps, 'aria-disabled' | 'variant' | 'children' >
 ) {
-	const [ productStatus ] = useEntityProp< ProductStatus | 'auto-draft' >(
+	const [ productStatus ] = useEntityProp< ProductStatus >(
 		'postType',
 		'product',
 		'status'

--- a/packages/js/product-editor/src/components/header/save-draft-button/save-draft-button.tsx
+++ b/packages/js/product-editor/src/components/header/save-draft-button/save-draft-button.tsx
@@ -1,13 +1,17 @@
 /**
  * External dependencies
  */
-import { Product, ProductStatus } from '@woocommerce/data';
-import { getNewPath, navigateTo } from '@woocommerce/navigation';
-import { Button } from '@wordpress/components';
-import { useEntityProp } from '@wordpress/core-data';
-import { useDispatch } from '@wordpress/data';
-import { createElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+import { createElement } from '@wordpress/element';
+import { getNewPath, navigateTo } from '@woocommerce/navigation';
+import { Product } from '@woocommerce/data';
+import { recordEvent } from '@woocommerce/tracks';
+import { useDispatch, useSelect } from '@wordpress/data';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore No types for this exist yet.
+// eslint-disable-next-line @woocommerce/dependency-group
+import { useEntityId } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -17,11 +21,15 @@ import { useSaveDraft } from '../hooks/use-save-draft';
 export function SaveDraftButton(
 	props: Omit< Button.ButtonProps, 'aria-disabled' | 'variant' | 'children' >
 ) {
-	const [ productStatus ] = useEntityProp< ProductStatus | 'auto-draft' >(
-		'postType',
-		'product',
-		'status'
+	const productId = useEntityId( 'postType', 'product' );
+	const product: Product = useSelect( ( select ) =>
+		select( 'core' ).getEditedEntityRecord(
+			'postType',
+			'product',
+			productId
+		)
 	);
+	const { downloadable, id, manage_stock, status, type, virtual } = product;
 
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( 'core/notices' );
@@ -29,11 +37,20 @@ export function SaveDraftButton(
 	const saveDraftButtonProps = useSaveDraft( {
 		...props,
 		onSaveSuccess( savedProduct: Product ) {
+			recordEvent( 'product_edit', {
+				new_product_page: true,
+				product_id: id,
+				product_type: type,
+				is_downloadable: downloadable,
+				is_virtual: virtual,
+				manage_stock,
+			} );
+
 			createSuccessNotice(
 				__( 'Product saved as draft.', 'woocommerce' )
 			);
 
-			if ( productStatus === 'auto-draft' ) {
+			if ( status === 'auto-draft' ) {
 				const url = getNewPath( {}, `/product/${ savedProduct.id }` );
 				navigateTo( { url } );
 			}

--- a/packages/js/product-editor/src/components/header/save-draft-button/save-draft-button.tsx
+++ b/packages/js/product-editor/src/components/header/save-draft-button/save-draft-button.tsx
@@ -5,31 +5,24 @@ import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { createElement } from '@wordpress/element';
 import { getNewPath, navigateTo } from '@woocommerce/navigation';
-import { Product } from '@woocommerce/data';
-import { recordEvent } from '@woocommerce/tracks';
-import { useDispatch, useSelect } from '@wordpress/data';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore No types for this exist yet.
-// eslint-disable-next-line @woocommerce/dependency-group
-import { useEntityId } from '@wordpress/core-data';
+import { Product, ProductStatus } from '@woocommerce/data';
+import { useDispatch } from '@wordpress/data';
+import { useEntityProp } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
+import { recordProductEvent } from '../../../utils/record-product-event';
 import { useSaveDraft } from '../hooks/use-save-draft';
 
 export function SaveDraftButton(
 	props: Omit< Button.ButtonProps, 'aria-disabled' | 'variant' | 'children' >
 ) {
-	const productId = useEntityId( 'postType', 'product' );
-	const product: Product = useSelect( ( select ) =>
-		select( 'core' ).getEditedEntityRecord(
-			'postType',
-			'product',
-			productId
-		)
+	const [ productStatus ] = useEntityProp< ProductStatus | 'auto-draft' >(
+		'postType',
+		'product',
+		'status'
 	);
-	const { downloadable, id, manage_stock, status, type, virtual } = product;
 
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( 'core/notices' );
@@ -37,20 +30,13 @@ export function SaveDraftButton(
 	const saveDraftButtonProps = useSaveDraft( {
 		...props,
 		onSaveSuccess( savedProduct: Product ) {
-			recordEvent( 'product_edit', {
-				new_product_page: true,
-				product_id: id,
-				product_type: type,
-				is_downloadable: downloadable,
-				is_virtual: virtual,
-				manage_stock,
-			} );
+			recordProductEvent( 'product_edit', savedProduct );
 
 			createSuccessNotice(
 				__( 'Product saved as draft.', 'woocommerce' )
 			);
 
-			if ( status === 'auto-draft' ) {
+			if ( productStatus === 'auto-draft' ) {
 				const url = getNewPath( {}, `/product/${ savedProduct.id }` );
 				navigateTo( { url } );
 			}

--- a/packages/js/product-editor/src/utils/record-product-event.ts
+++ b/packages/js/product-editor/src/utils/record-product-event.ts
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import { Product } from '@woocommerce/data';
+import { recordEvent } from '@woocommerce/tracks';
+
+export function recordProductEvent( eventName: string, product: Product ) {
+	const { downloadable, id, manage_stock, type, virtual } = product;
+
+	recordEvent( eventName, {
+		new_product_page: true,
+		product_id: id,
+		product_type: type,
+		is_downloadable: downloadable,
+		is_virtual: virtual,
+		manage_stock,
+	} );
+}


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds the tracks events when saving a draft or saving/publishing a product.

<img width="612" alt="Screen Shot 2023-04-17 at 4 46 34 PM" src="https://user-images.githubusercontent.com/10561050/232635976-71963bd0-c4d9-4da5-a19e-ada102a3c31c.png">
<img width="607" alt="Screen Shot 2023-04-17 at 4 24 54 PM" src="https://user-images.githubusercontent.com/10561050/232635978-77a049be-69c7-4c42-b8ab-cb19b38f9f3d.png">


Closes #37656  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1.. Navigate to Tools -> WCA Test Helper -> Features and enable the new product blocks editing experience
2. Navigate to Products -> Add new
3. Open your console
4. Run `localStorage.setItem( 'debug', 'wc-admin:tracks' );` in the console.
5. Make some edits to the product
6. Click "Save draft"
7. Note that the `wcadmin_product_edit` and its properties are shown in the console
8. Make some edits to the product
9. Click "Publish" or "Save"
10. Note that the `wcadmin_product_update` and its properties are shown in the console

<!-- End testing instructions -->