### PR TITLE
ChatGPT POC: Fix visual issues

### DIFF
--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -7986,6 +7986,17 @@ table.bar_chart {
 		margin: 0px 12px 12px;
 		width: calc(100% - 24px);
 	}
+
+	// hacks to fix visuals with "write it for me" button present
+	.wp-editor-tools {
+		top: -1px !important;
+		border-bottom: 0 !important;
+	}
+	.wp-switch-editor
+	{
+		position: relative;
+		z-index: 1;
+	}
 }
 
 .woocommerce-gpt-integration {

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -444,8 +444,8 @@ class WC_Admin_Menus {
 	/**
 	 * Add gpt button to the editor.
 	 */
-	public function add_gpt_button() {
-		if ( ! current_user_can( 'edit_posts' ) && ! current_user_can( 'edit_pages' ) ) {
+	public function add_gpt_button( $editor_id ) {
+		if ( $editor_id !== 'content' || ( ! current_user_can( 'edit_posts' ) && ! current_user_can( 'edit_pages' ) ) ) {
 			return;
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes a few minor visual issues.

* Removed the border under the "Media" and "Write it for me (beta)" buttons when the form is expanded
* Remove the border under the "Visual" editor tab
* Only add the "Write it for me (beta)" button to the description (content) editor (it was getting added to the short description editor as well)

I'm not proud of the way I fixed them, but it is good enough for a POC.

#### Before

<img width="779" alt="Screenshot 2023-04-17 at 10 07 52" src="https://user-images.githubusercontent.com/2098816/232644215-e04514f4-7d56-4a9a-9f70-27a866e4cca3.png">

#### After

<img width="790" alt="Screenshot 2023-04-17 at 21 16 32" src="https://user-images.githubusercontent.com/2098816/232644180-4e632c34-dbd2-4658-a3c4-7c70a6fd5dd5.png">


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Having the OpenAI API key configured in Advanced > Features, go to the product editor
2. Click on "Write it for me (beta)" -- the form should appear and there should be no offending borders (see above)
3. Click on "Write it for me (beta)" or the "X" -- the form should hide and things should look alright

<!-- End testing instructions -->