### PR TITLE
Code Freeze CLI: Make sure a default value exists for override

### DIFF
--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -14,7 +14,7 @@ on:
                 description: 'Slack Channel Override: The channel ID to send the Slack ping about the freeze'
 
 env:
-    TIME_OVERRIDE: ( ${{ inputs.timeOverride }} || 'now' )
+    TIME_OVERRIDE: ${{ inputs.timeOverride || 'now' }}
     GIT_COMMITTER_NAME: 'WooCommerce Bot'
     GIT_COMMITTER_EMAIL: 'no-reply@woocommerce.com'
     GIT_AUTHOR_NAME: 'WooCommerce Bot'

--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -14,7 +14,7 @@ on:
                 description: 'Slack Channel Override: The channel ID to send the Slack ping about the freeze'
 
 env:
-    TIME_OVERRIDE: ${{ inputs.timeOverride }}
+    TIME_OVERRIDE: ${{ inputs.timeOverride }} || 'now'
     GIT_COMMITTER_NAME: 'WooCommerce Bot'
     GIT_COMMITTER_EMAIL: 'no-reply@woocommerce.com'
     GIT_AUTHOR_NAME: 'WooCommerce Bot'
@@ -41,12 +41,6 @@ jobs:
 
             - name: 'Check whether today is the code freeze day'
               id: check-freeze
-              if: ! $TIME_OVERRIDE
-              run: pnpm utils code-freeze verify-day -g
-
-            - name: 'Check whether today is the code freeze day with override'
-              id: check-freeze
-              if: $TIME_OVERRIDE
               run: pnpm utils code-freeze verify-day -g -o $TIME_OVERRIDE
 
     maybe-create-next-milestone-and-release-branch:

--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -14,7 +14,7 @@ on:
                 description: 'Slack Channel Override: The channel ID to send the Slack ping about the freeze'
 
 env:
-    TIME_OVERRIDE: ${{ inputs.timeOverride }} || 'now'
+    TIME_OVERRIDE: ${{ inputs.timeOverride }}
     GIT_COMMITTER_NAME: 'WooCommerce Bot'
     GIT_COMMITTER_EMAIL: 'no-reply@woocommerce.com'
     GIT_AUTHOR_NAME: 'WooCommerce Bot'
@@ -41,7 +41,7 @@ jobs:
 
             - name: 'Check whether today is the code freeze day'
               id: check-freeze
-              run: pnpm utils code-freeze verify-day -g -o $TIME_OVERRIDE
+              run: pnpm utils code-freeze verify-day -g -o ($TIME_OVERRIDE || 'now')
 
     maybe-create-next-milestone-and-release-branch:
         name: 'Maybe create next milestone and release branch'

--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -14,7 +14,7 @@ on:
                 description: 'Slack Channel Override: The channel ID to send the Slack ping about the freeze'
 
 env:
-    TIME_OVERRIDE: ${{ inputs.timeOverride }}
+    TIME_OVERRIDE: ( ${{ inputs.timeOverride }} || 'now' )
     GIT_COMMITTER_NAME: 'WooCommerce Bot'
     GIT_COMMITTER_EMAIL: 'no-reply@woocommerce.com'
     GIT_AUTHOR_NAME: 'WooCommerce Bot'
@@ -41,7 +41,7 @@ jobs:
 
             - name: 'Check whether today is the code freeze day'
               id: check-freeze
-              run: pnpm utils code-freeze verify-day -g -o ($TIME_OVERRIDE || 'now')
+              run: pnpm utils code-freeze verify-day -g -o $TIME_OVERRIDE
 
     maybe-create-next-milestone-and-release-branch:
         name: 'Maybe create next milestone and release branch'

--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -41,6 +41,12 @@ jobs:
 
             - name: 'Check whether today is the code freeze day'
               id: check-freeze
+              if: ! $TIME_OVERRIDE
+              run: pnpm utils code-freeze verify-day -g
+
+            - name: 'Check whether today is the code freeze day with override'
+              id: check-freeze
+              if: $TIME_OVERRIDE
               run: pnpm utils code-freeze verify-day -g -o $TIME_OVERRIDE
 
     maybe-create-next-milestone-and-release-branch:


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The regularly scheduled Code Freeze action [failed](https://github.com/woocommerce/woocommerce/actions/runs/4726688936/jobs/8386523419) because the command line argument `override` was missing. We [tested](https://github.com/woocommerce/woocommerce/pull/37589) this functionality using Github Actions inputs as the override when firing the actions. The cron job that fires the action has no value for `override` which was a scenario we didn't test.

This PR adds a default value for the `TIME_OVERRIDE` environment variable, which the CLI command expects when supplying the `--override` flag.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add this branch to your forked WooCommerce repository.
2. Enable Actions
3. In your fork, fire the `Release: Code freeze` action and be sure to point to this branch.
4. Leave the "Time Override" value to `now` and see the first check if today is code freeze pass. Check the logs to see the command passed was correct, ie `./tools/monorepo-utils/bin/run "code-freeze" "verify-day" "-g" "-o" "now"`.
5. Repeat the same thing, this time delete the "Time Override" field so its an empty string. The first check should pass and the command will also be `./tools/monorepo-utils/bin/run "code-freeze" "verify-day" "-g" "-o" "now"`.

<!-- End testing instructions -->