### PR TITLE
[E2E] Fix `wp-content/upgrade` folder permissions to fix recently failing daily and release tests

### DIFF
--- a/plugins/woocommerce/changelog/e2e-release-fix-upload-test
+++ b/plugins/woocommerce/changelog/e2e-release-fix-upload-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix recent failures in "Smoke test release" workflow.

--- a/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
+++ b/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
@@ -8,7 +8,9 @@ echo -e 'Normalize permissions for wp-content directory \n'
 docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u www-data -e HOME=/tmp tests-wordpress sh -c "chmod -c ugo+w /var/www/html/wp-config.php \
 && chmod -c ugo+w /var/www/html/wp-content \
 && chmod -c ugo+w /var/www/html/wp-content/themes \
-&& chmod -c ugo+w /var/www/html/wp-content/plugins"
+&& chmod -c ugo+w /var/www/html/wp-content/plugins \
+&& mkdir -p /var/www/html/wp-content/upgrade \
+&& chmod -c ugo+w /var/www/html/wp-content/upgrade"
 
 docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u www-data -e HOME=/tmp tests-cli sh -c "ls \
 && wp theme install twentynineteen --activate \


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR fixes the recent failures in the "Smoke test daily" and "Smoke test release" workflows.

The failure was caused by having no write permissions to the `/var/www/html/wp-content/upgrade` folder in the `wp-env` container. The error being displayed was:

<img width="610" alt="FTY8zhf394" src="https://user-images.githubusercontent.com/4509348/232712935-3f676617-6ceb-4d71-b410-8113792f0ea7.png">


That folder is needed by the "Smoke test release" and "Smoke test daily" workflows when uploading [these plugins](https://github.com/woocommerce/woocommerce/blob/trunk/.github/workflows/smoke-test-release.yml#L572-L590) to be tested alongside WooCommerce. 

To fix the issue, this  PR adds a few lines in `plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh` to ensure that the folder `/var/www/html/wp-content/upgrade` has write permissions during environment setup.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Testing the "Smoke test release" workflow

1. Go to the [Smoke test release](https://github.com/woocommerce/woocommerce/actions/workflows/smoke-test-release.yml) workflow page.
2. Select this branch ( `e2e/release-fix-plugin-upload` ).
3. Enter `7.6.0` as the release tag.
4. Start running the workflow.
5. In the workflow run page, click on one of the `With ${PLUGIN_NAME}` jobs, and verify that the step `Run 'Upload plugin' test` passes. 
6. Note: The other E2E tests may fail because there are changes in `trunk` that are not yet in `7.6.0`. As long as you see the `Run 'Upload plugin' test` step passing, then that meant the fix was able to upload the plugin and pass the `can upload and activate ${PLUGIN_NAME}` test.
   <img width="600" alt="UU0oysPxMe" src="https://user-images.githubusercontent.com/4509348/232720344-e002759d-5c9e-4828-8f19-78feefe132f6.png">
 
#### Testing the "Smoke test daily" workflow

1. Go to the [Smoke test daily](https://github.com/woocommerce/woocommerce/actions/workflows/smoke-test-daily.yml) workflow page.
1. Select this branch ( `e2e/release-fix-plugin-upload` ).
1. Start running the workflow.
1. In the workflow run page, click on one of the `Smoke tests on trunk with ${PLUGIN_NAME} plugin installed` jobs, and verify that the step `Run 'Upload plugin' test` passes. 
2. Note: Other E2E tests may fail because of discrepancies between `trunk` and the `nightly` build. As long as you see the `Run 'Upload plugin' test` step passing, then that meant the fix was able to upload the plugin and pass the `can upload and activate ${PLUGIN_NAME}` test.

#### Testing the `upload-plugin.spec.js` locally.
Assuming you already have the local E2E environment running, and that you're in the `plugins/woocommerce` folder:
1. Run the `upload-plugin.spec.js` spec, and it should pass:
   ```
   export GITHUB_TOKEN="your_github_token"
   export PLUGIN_NAME="WooCommerce Payments"
   export PLUGIN_REPOSITORY="automattic/woocommerce-payments"
   pnpm test:e2e-pw "upload-plugin.spec.js"
   ```

