### PR TITLE
Fix disabled "Save attributes" button when editing a product

### DIFF
--- a/plugins/woocommerce/changelog/fix-disabled_save_attributes_button
+++ b/plugins/woocommerce/changelog/fix-disabled_save_attributes_button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix disabled "Save attributes" button

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes.js
@@ -187,4 +187,7 @@ jQuery( function ( $ ) {
 		'input, textarea',
 		jQuery.maybe_disable_save_button
 	);
+
+	// Maybe disable save buttons when editing products.
+	jQuery.maybe_disable_save_button();
 } );


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes a bug that occurred when editing a product; the `Save attributes` button was disabled, but it should be enabled.

![image (1)](https://user-images.githubusercontent.com/1314156/232834073-672028d2-0b15-4a2d-8b21-e10b6badbfe3.png)


A better solution would be to refactor that part to check whether any element was modified and then enable the `save` button, so that would be a nice refactor to do.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Edit a product with attributes.
2. Go to Product data > Attributes
3. The `Save attributes` button should be enabled.

![Screenshot 2023-04-18 at 12 57 47](https://user-images.githubusercontent.com/1314156/232834821-132b4673-6452-409a-a206-a3f31f85015e.png)
 

<!-- End testing instructions -->