### PR TITLE
Fix checkbox label styling on product page tabs

### DIFF
--- a/plugins/woocommerce/changelog/fix-checkbox-labels
+++ b/plugins/woocommerce/changelog/fix-checkbox-labels
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix styling of checkbox (and other input) labels on product page tabs.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -6706,7 +6706,7 @@ table.bar_chart {
 	}
 
 	.woocommerce_options_panel {
-		.description {
+		:not(input) + .description {
 			display: block;
 			clear: both;
 			margin-left: 0;


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes the styling of checkbox labels on the product page tabs for smaller viewports (`max-width: 1280px`).

This is not a new bug... it has existed since at least `2.5.0` (I went back to that version and could reproduce it). To be honest, I'm not really sure why a very visible issue like this hasn't been fixed ever. Maybe I'm one of the few that regularly use a smaller viewport?

#### Before

<img width="790" alt="Screenshot 2023-04-18 at 10 04 42" src="https://user-images.githubusercontent.com/2098816/232827383-ab595940-6755-4403-b63c-30e81b6b47fb.png">

#### After

<img width="790" alt="Screenshot 2023-04-18 at 11 18 00" src="https://user-images.githubusercontent.com/2098816/232827419-5e730d01-b5dc-46cd-a2a4-6ebb4935f7a1.png">


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to Products > Add New (`/wp-admin/post-new.php?post_type=product`)
2. Go to the Inventory tab
3. Verify the checkboxes are displayed correctly on both larger and smaller viewports. The checkbox label should always start right next to the checkbox, never fully below it.

<!-- End testing instructions -->