### PR TITLE
Create default pages in store locale language

### DIFF
--- a/plugins/woocommerce/changelog/fix-34420
+++ b/plugins/woocommerce/changelog/fix-34420
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Create default pages in store locale language

--- a/plugins/woocommerce/changelog/fix-34420
+++ b/plugins/woocommerce/changelog/fix-34420
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Create default pages in store locale language
+When creating default storefront pages, the site language (and not the language of the current user) should be used.

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -710,6 +710,9 @@ class WC_Install {
 	 * Create pages that the plugin relies on, storing page IDs in variables.
 	 */
 	public static function create_pages() {
+		// Set the locale to the store locale to ensure pages are created in the correct language.
+		wc_switch_to_site_locale();
+
 		include_once dirname( __FILE__ ) . '/admin/wc-admin-functions.php';
 
 		/**
@@ -780,6 +783,9 @@ class WC_Install {
 				! empty( $page['post_status'] ) ? $page['post_status'] : 'publish'
 			);
 		}
+
+		// Restore the locale to the default locale.
+		wc_restore_locale();
 	}
 
 	/**

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -2211,7 +2211,9 @@ function wc_get_permalink_structure() {
  * @since 3.1.0
  */
 function wc_switch_to_site_locale() {
-	if ( function_exists( 'switch_to_locale' ) ) {
+	global $wp_locale_switcher;
+
+	if ( function_exists( 'switch_to_locale' ) && isset( $wp_locale_switcher ) ) {
 		switch_to_locale( get_locale() );
 
 		// Filter on plugin_locale so load_plugin_textdomain loads the correct locale.
@@ -2228,7 +2230,9 @@ function wc_switch_to_site_locale() {
  * @since 3.1.0
  */
 function wc_restore_locale() {
-	if ( function_exists( 'restore_previous_locale' ) ) {
+	global $wp_locale_switcher;
+
+	if ( function_exists( 'restore_previous_locale' ) && isset( $wp_locale_switcher ) ) {
 		restore_previous_locale();
 
 		// Remove filter.


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34420 .

This PR fixes the store locale language issues when creating default pages.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set site language to Spanish.
2. Delete the default pages (if there are any).
3. Set language for admin user to English-US.
4. Create WC default pages from Status > Tools menu.
5. Run `wp post list --post_type=page --fields=post_title,post_name`
6. Page titles and names should be created in store locale language (Spanish).

<!-- End testing instructions -->