### PR TITLE
Register server-side tracking during rest requests

### DIFF
--- a/plugins/woocommerce/changelog/fix-37659
+++ b/plugins/woocommerce/changelog/fix-37659
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Register server-side tracking during rest requests

--- a/plugins/woocommerce/includes/admin/class-wc-admin.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin.php
@@ -29,7 +29,6 @@ class WC_Admin {
 		add_action( 'admin_footer', 'wc_print_js', 25 );
 		add_filter( 'admin_footer_text', array( $this, 'admin_footer_text' ), 1 );
 		add_action( 'init', array( 'WC_Site_Tracking', 'init' ) );
-		add_action( 'rest_api_init', array( 'WC_Site_Tracking', 'init' ) );
 
 		// Disable WXR export of schedule action posts.
 		add_filter( 'action_scheduler_post_type_args', array( $this, 'disable_webhook_post_export' ) );
@@ -67,12 +66,6 @@ class WC_Admin {
 		include_once __DIR__ . '/class-wc-admin-pointers.php';
 		include_once __DIR__ . '/class-wc-admin-importers.php';
 		include_once __DIR__ . '/class-wc-admin-exporters.php';
-
-		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks.php';
-		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-event.php';
-		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-client.php';
-		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-footer-pixel.php';
-		include_once WC_ABSPATH . 'includes/tracks/class-wc-site-tracking.php';
 
 		// Help Tabs.
 		if ( apply_filters( 'woocommerce_enable_admin_help_tab', true ) ) {

--- a/plugins/woocommerce/includes/admin/class-wc-admin.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin.php
@@ -28,7 +28,6 @@ class WC_Admin {
 		add_action( 'admin_init', array( $this, 'admin_redirects' ) );
 		add_action( 'admin_footer', 'wc_print_js', 25 );
 		add_filter( 'admin_footer_text', array( $this, 'admin_footer_text' ), 1 );
-		add_action( 'init', array( 'WC_Site_Tracking', 'init' ) );
 
 		// Disable WXR export of schedule action posts.
 		add_filter( 'action_scheduler_post_type_args', array( $this, 'disable_webhook_post_export' ) );

--- a/plugins/woocommerce/includes/admin/class-wc-admin.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin.php
@@ -29,6 +29,7 @@ class WC_Admin {
 		add_action( 'admin_footer', 'wc_print_js', 25 );
 		add_filter( 'admin_footer_text', array( $this, 'admin_footer_text' ), 1 );
 		add_action( 'init', array( 'WC_Site_Tracking', 'init' ) );
+		add_action( 'rest_api_init', array( 'WC_Site_Tracking', 'init' ) );
 
 		// Disable WXR export of schedule action posts.
 		add_filter( 'action_scheduler_post_type_args', array( $this, 'disable_webhook_post_export' ) );

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -394,8 +394,6 @@ final class WooCommerce {
 				return defined( 'DOING_CRON' );
 			case 'frontend':
 				return ( ! is_admin() || defined( 'DOING_AJAX' ) ) && ! defined( 'DOING_CRON' ) && ! $this->is_rest_api_request();
-			case 'rest':
-				return $this->is_rest_api_request();
 		}
 	}
 
@@ -536,6 +534,15 @@ final class WooCommerce {
 		include_once WC_ABSPATH . 'includes/class-wc-register-wp-admin-settings.php';
 
 		/**
+		 * Tracks.
+		 */
+		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks.php';
+		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-event.php';
+		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-client.php';
+		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-footer-pixel.php';
+		include_once WC_ABSPATH . 'includes/tracks/class-wc-site-tracking.php';
+
+		/**
 		 * WCCOM Site.
 		 */
 		include_once WC_ABSPATH . 'includes/wccom-site/class-wc-wccom-site.php';
@@ -551,14 +558,6 @@ final class WooCommerce {
 
 		if ( $this->is_request( 'admin' ) ) {
 			include_once WC_ABSPATH . 'includes/admin/class-wc-admin.php';
-		}
-
-		if ( $this->is_request( 'admin' ) || $this->is_request( 'rest' ) ) {
-			include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks.php';
-			include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-event.php';
-			include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-client.php';
-			include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-footer-pixel.php';
-			include_once WC_ABSPATH . 'includes/tracks/class-wc-site-tracking.php';
 		}
 
 		if ( $this->is_request( 'frontend' ) ) {

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -221,7 +221,7 @@ final class WooCommerce {
 		add_action( 'init', array( 'WC_Emails', 'init_transactional_emails' ) );
 		add_action( 'init', array( $this, 'add_image_sizes' ) );
 		add_action( 'init', array( $this, 'load_rest_api' ) );
-		add_action( 'rest_api_init', array( 'WC_Site_Tracking', 'init' ) );
+		add_action( 'init', array( 'WC_Site_Tracking', 'init' ) );
 		add_action( 'switch_blog', array( $this, 'wpdb_table_fix' ), 0 );
 		add_action( 'activated_plugin', array( $this, 'activated_plugin' ) );
 		add_action( 'deactivated_plugin', array( $this, 'deactivated_plugin' ) );

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -221,6 +221,7 @@ final class WooCommerce {
 		add_action( 'init', array( 'WC_Emails', 'init_transactional_emails' ) );
 		add_action( 'init', array( $this, 'add_image_sizes' ) );
 		add_action( 'init', array( $this, 'load_rest_api' ) );
+		add_action( 'rest_api_init', array( 'WC_Site_Tracking', 'init' ) );
 		add_action( 'switch_blog', array( $this, 'wpdb_table_fix' ), 0 );
 		add_action( 'activated_plugin', array( $this, 'activated_plugin' ) );
 		add_action( 'deactivated_plugin', array( $this, 'deactivated_plugin' ) );
@@ -548,8 +549,16 @@ final class WooCommerce {
 			include_once WC_ABSPATH . 'includes/class-wc-cli.php';
 		}
 
-		if ( $this->is_request( 'admin' ) || $this->is_request( 'rest' ) ) {
+		if ( $this->is_request( 'admin' ) ) {
 			include_once WC_ABSPATH . 'includes/admin/class-wc-admin.php';
+		}
+
+		if ( $this->is_request( 'admin' ) || $this->is_request( 'rest' ) ) {
+			include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks.php';
+			include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-event.php';
+			include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-client.php';
+			include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-footer-pixel.php';
+			include_once WC_ABSPATH . 'includes/tracks/class-wc-site-tracking.php';
 		}
 
 		if ( $this->is_request( 'frontend' ) ) {

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -393,6 +393,8 @@ final class WooCommerce {
 				return defined( 'DOING_CRON' );
 			case 'frontend':
 				return ( ! is_admin() || defined( 'DOING_AJAX' ) ) && ! defined( 'DOING_CRON' ) && ! $this->is_rest_api_request();
+			case 'rest':
+				return $this->is_rest_api_request();
 		}
 	}
 
@@ -546,7 +548,7 @@ final class WooCommerce {
 			include_once WC_ABSPATH . 'includes/class-wc-cli.php';
 		}
 
-		if ( $this->is_request( 'admin' ) ) {
+		if ( $this->is_request( 'admin' ) || $this->is_request( 'rest' ) ) {
 			include_once WC_ABSPATH . 'includes/admin/class-wc-admin.php';
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Tracking scripts were only registered during admin requests and not during REST requests.  This was preventing tracking functions from being triggered when a product was published via the REST API.  The same is true of other tracks being registered in the `WC_Site_Tracking` class.

Closes #37659 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure you have opted into tracks under `wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com`
2. Navigate to Tools -> WCA Test Helper -> Features and enable the new product blocks editing experience
3. Navigate to Products -> Add new
4. Publish a product
5. Navigate to `wp-admin/admin.php?page=wc-status&tab=logs`
6. Look for the latest tracks log in the dropdown
7. See the `wcadmin_product_add_publish` event was triggered

<!-- End testing instructions -->