### PR TITLE
Fix E2E test

### DIFF
--- a/plugins/woocommerce/.wp-env.json
+++ b/plugins/woocommerce/.wp-env.json
@@ -10,7 +10,7 @@
         "ALTERNATE_WP_CRON": true
     },
     "mappings": {
-        "wp-cli.yml": ".\/tests\/wp-cli.yml"
+        "wp-cli.yml": "./tests/wp-cli.yml"
     },
     "env": {
         "development": [],
@@ -18,12 +18,12 @@
             "port": 8086,
             "plugins": [
                 ".",
-                "https:\/\/downloads.wordpress.org\/plugin\/akismet.zip",
-                "https:\/\/github.com\/WP-API\/Basic-Auth\/archive\/master.zip",
-                "https:\/\/downloads.wordpress.org\/plugin\/wp-mail-logging.zip"
+                "https://downloads.wordpress.org/plugin/akismet.zip",
+                "https://github.com/WP-API/Basic-Auth/archive/master.zip",
+                "https://downloads.wordpress.org/plugin/wp-mail-logging.zip"
             ],
             "themes": [
-                "https:\/\/downloads.wordpress.org\/theme\/twentynineteen.zip"
+                "https://downloads.wordpress.org/theme/twentynineteen.zip"
             ],
             "config": {
                 "WP_TESTS_DOMAIN": "localhost:8086",

--- a/plugins/woocommerce/.wp-env.json
+++ b/plugins/woocommerce/.wp-env.json
@@ -18,7 +18,12 @@
             "port": 8086,
             "plugins": [
                 ".",
-                "https://downloads.wordpress.org/plugin/akismet.zip"
+                "https:\/\/downloads.wordpress.org\/plugin\/akismet.zip",
+                "https:\/\/github.com\/WP-API\/Basic-Auth\/archive\/master.zip",
+                "https:\/\/downloads.wordpress.org\/plugin\/wp-mail-logging.zip"
+            ],
+            "themes": [
+                "https:\/\/downloads.wordpress.org\/theme\/twentynineteen.zip"
             ],
             "config": {
                 "WP_TESTS_DOMAIN": "localhost:8086",

--- a/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
+++ b/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
@@ -6,11 +6,15 @@ ENABLE_TRACKING="${ENABLE_TRACKING:-0}"
 
 echo -r 'Check Dir/File owners\n'
 docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u www-data -e HOME=/tmp tests-wordpress sh -c "ls -ld /var/www/html/wp-content \
-&& ls -ld /var/www/html/wp-config.php"
+&& ls -ld /var/www/html/wp-config.php \
+&& ls -ld /var/www/html/wp-content/themes \
+&& ls -ld /var/www/html/wp-content/plugins "
+
+echo -e 'Normalize permissions for wp-config.php \n'
+docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u $(id -u) -e HOME=/tmp tests-wordpress sh -c "chmod -c ugo+w /var/www/html/wp-config.php"
 
 echo -e 'Normalize permissions for wp-content directory \n'
-docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u www-data -e HOME=/tmp tests-wordpress sh -c "chmod -c ugo+w /var/www/html/wp-config.php \
-&& chmod -c ugo+w /var/www/html/wp-content \
+docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u $(id -u) -e HOME=/tmp tests-wordpress sh -c " && chmod -c ugo+w /var/www/html/wp-content \
 && chmod -c ugo+w /var/www/html/wp-content/themes \
 && chmod -c ugo+w /var/www/html/wp-content/plugins \
 && mkdir -p /var/www/html/wp-content/upgrade \

--- a/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
+++ b/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
@@ -12,15 +12,7 @@ docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u www-data
 && ls -ld /var/www/html"
 
 echo -e 'Normalize permissions for /var/www/html & wp-config.php  \n'
-docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u www-data -e HOME=/tmp tests-wordpress sh -c "chmod -c ugo+w /var/www/html/wp-config.php && chmod -c ugo+w /var/www/html"
-
-echo -e 'Normalize permissions for wp-content directory \n'
-docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u www-data -e HOME=/tmp tests-wordpress sh -c "chmod -c ugo+w /var/www/html/wp-content \
-&& chmod -c ugo+w /var/www/html/wp-content/themes \
-&& chmod -c ugo+w /var/www/html/wp-content/plugins \
-&& mkdir -p /var/www/html/wp-content/upgrade \
-&& chmod -c ugo+w /var/www/html \
-&& chmod -c ugo+w /var/www/html/wp-content/upgrade"
+docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u www-data -e HOME=/tmp tests-wordpress sh -c "chmod -c ugo+w /var/www/html/wp-config.php"
 
 docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u $(id -u) -e HOME=/tmp tests-cli sh -c "ls \
 && wp theme install twentynineteen --activate \

--- a/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
+++ b/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
@@ -22,7 +22,7 @@ docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u www-data
 && chmod -c ugo+w /var/www/html \
 && chmod -c ugo+w /var/www/html/wp-content/upgrade"
 
-docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u www-data -e HOME=/tmp tests-cli sh -c "ls \
+docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u $(id -u) -e HOME=/tmp tests-cli sh -c "ls \
 && wp theme install twentynineteen --activate \
 && wp plugin install https://github.com/WP-API/Basic-Auth/archive/master.zip --activate \
 && wp plugin install wp-mail-logging --activate \

--- a/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
+++ b/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
@@ -8,13 +8,13 @@ echo -r 'Check Dir/File owners\n'
 docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u www-data -e HOME=/tmp tests-wordpress sh -c "ls -ld /var/www/html/wp-content \
 && ls -ld /var/www/html/wp-config.php \
 && ls -ld /var/www/html/wp-content/themes \
-&& ls -ld /var/www/html/wp-content/plugins "
+&& ls -ld /var/www/html/wp-content/plugins"
 
 echo -e 'Normalize permissions for wp-config.php \n'
 docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u www-data -e HOME=/tmp tests-wordpress sh -c "chmod -c ugo+w /var/www/html/wp-config.php"
 
 echo -e 'Normalize permissions for wp-content directory \n'
-docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u $(id -u) -e HOME=/tmp tests-wordpress sh -c "chmod -c ugo+w /var/www/html/wp-content \
+docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u www-data -e HOME=/tmp tests-wordpress sh -c "chmod -c ugo+w /var/www/html/wp-content \
 && chmod -c ugo+w /var/www/html/wp-content/themes \
 && chmod -c ugo+w /var/www/html/wp-content/plugins \
 && mkdir -p /var/www/html/wp-content/upgrade \
@@ -50,3 +50,6 @@ if [ $ENABLE_TRACKING == 1 ]; then
 	echo 'Enable tracking'
 	docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u $(id -u) -e HOME=/tmp tests-cli sh -c "wp option update woocommerce_allow_tracking 'yes'"
 fi
+
+echo -e 'Get contents of My Account Page\n'
+curl -L http://localhost:8086/my-account

--- a/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
+++ b/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
@@ -11,7 +11,7 @@ docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u www-data
 && ls -ld /var/www/html/wp-content/plugins "
 
 echo -e 'Normalize permissions for wp-config.php \n'
-docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u $(id -u) -e HOME=/tmp tests-wordpress sh -c "chmod -c ugo+w /var/www/html/wp-config.php"
+docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u www-data -e HOME=/tmp tests-wordpress sh -c "chmod -c ugo+w /var/www/html/wp-config.php"
 
 echo -e 'Normalize permissions for wp-content directory \n'
 docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u $(id -u) -e HOME=/tmp tests-wordpress sh -c " && chmod -c ugo+w /var/www/html/wp-content \

--- a/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
+++ b/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
@@ -12,11 +12,8 @@ else
     user=$(id -u)
 fi
 
-echo -e 'Normalize permissions for /var/www/html & wp-config.php \n'
-docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u $user -e HOME=/tmp tests-wordpress sh -c "chmod -c ugo+w /var/www/html/wp-config.php"
-
-echo -e 'Normalize permissions for multiple directories \n'
-docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u $user -e HOME=/tmp tests-wordpress sh -c "chmod -c ugo+w /var/www/html/wp-content \
+echo -e 'Normalize permissions for necessary directories \n'
+docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u $(id -u) -e HOME=/tmp tests-wordpress sh -c "chmod -c ugo+w /var/www/html/wp-content \
 && chmod -c ugo+w /var/www/html/wp-content/themes \
 && chmod -c ugo+w /var/www/html/wp-content/plugins \
 && mkdir -p /var/www/html/wp-content/upgrade \

--- a/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
+++ b/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
@@ -4,14 +4,6 @@ ENABLE_HPOS="${ENABLE_HPOS:-0}"
 ENABLE_NEW_PRODUCT_EDITOR="${ENABLE_NEW_PRODUCT_EDITOR:-0}"
 ENABLE_TRACKING="${ENABLE_TRACKING:-0}"
 
-if [[ $(uname) == "Darwin" ]]; then
-    # Set variable for macOS
-    user=www-data
-else
-    # Set variable for Linux
-    user=$(id -u)
-fi
-
 echo -e 'Normalize permissions for necessary directories \n'
 docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u $(id -u) -e HOME=/tmp tests-wordpress sh -c "chmod -c ugo+w /var/www/html/wp-content \
 && chmod -c ugo+w /var/www/html/wp-content/themes \

--- a/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
+++ b/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
@@ -14,7 +14,7 @@ echo -e 'Normalize permissions for wp-config.php \n'
 docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u www-data -e HOME=/tmp tests-wordpress sh -c "chmod -c ugo+w /var/www/html/wp-config.php"
 
 echo -e 'Normalize permissions for wp-content directory \n'
-docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u www-data -e HOME=/tmp tests-wordpress sh -c "chmod -c ugo+w /var/www/html/wp-content \
+docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u $(id -u) -e HOME=/tmp tests-wordpress sh -c "chmod -c ugo+w /var/www/html/wp-content \
 && chmod -c ugo+w /var/www/html/wp-content/themes \
 && chmod -c ugo+w /var/www/html/wp-content/plugins \
 && mkdir -p /var/www/html/wp-content/upgrade \

--- a/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
+++ b/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
@@ -8,7 +8,8 @@ echo -r 'Check Dir/File owners\n'
 docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u www-data -e HOME=/tmp tests-wordpress sh -c "ls -ld /var/www/html/wp-content \
 && ls -ld /var/www/html/wp-config.php \
 && ls -ld /var/www/html/wp-content/themes \
-&& ls -ld /var/www/html/wp-content/plugins"
+&& ls -ld /var/www/html/wp-content/plugins \
+&& ls -ld /var/www/html/.htaccess"
 
 echo -e 'Normalize permissions for wp-config.php \n'
 docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u www-data -e HOME=/tmp tests-wordpress sh -c "chmod -c ugo+w /var/www/html/wp-config.php"

--- a/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
+++ b/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
@@ -4,24 +4,33 @@ ENABLE_HPOS="${ENABLE_HPOS:-0}"
 ENABLE_NEW_PRODUCT_EDITOR="${ENABLE_NEW_PRODUCT_EDITOR:-0}"
 ENABLE_TRACKING="${ENABLE_TRACKING:-0}"
 
-echo -e 'Normalize permissions for /var/www/html & wp-config.php \n'
-docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u www-data -e HOME=/tmp tests-wordpress sh -c "chmod -c ugo+w /var/www/html/wp-config.php"
+if [[ $(uname) == "Darwin" ]]; then
+    # Set variable for macOS
+    user=www-data
+else
+    # Set variable for Linux
+    user=$(id -u)
+fi
 
-echo -e 'Normalize permissions for wp-content directory \n'
-docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u $(id -u) -e HOME=/tmp tests-wordpress sh -c "chmod -c ugo+w /var/www/html/wp-content \
+echo -e 'Normalize permissions for /var/www/html & wp-config.php \n'
+docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u $user -e HOME=/tmp tests-wordpress sh -c "chmod -c ugo+w /var/www/html/wp-config.php"
+
+echo -e 'Normalize permissions for multiple directories \n'
+docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u $user -e HOME=/tmp tests-wordpress sh -c "chmod -c ugo+w /var/www/html/wp-content \
 && chmod -c ugo+w /var/www/html/wp-content/themes \
 && chmod -c ugo+w /var/www/html/wp-content/plugins \
 && mkdir -p /var/www/html/wp-content/upgrade \
 && chmod -c ugo+w /var/www/html \
 && chmod -c ugo+w /var/www/html/wp-content/upgrade"
 
-wp-env run tests-cli "ls \
-&& wp theme install twentynineteen --activate \
-&& wp plugin install https://github.com/WP-API/Basic-Auth/archive/master.zip --activate \
-&& wp plugin install wp-mail-logging --activate \
-&& wp plugin install https://github.com/woocommerce/woocommerce-reset/archive/refs/heads/trunk.zip --activate \
-&& wp rewrite structure '/%postname%/' --hard \
-&& wp user create customer customer@woocommercecoree2etestsuite.com \
+echo -e 'Activate twentynineteen theme \n'
+wp-env run tests-cli "wp theme activate twentynineteen"
+
+echo -e 'Update URL structure \n'
+wp-env run tests-cli "wp rewrite structure '/%postname%/' --hard"
+
+echo -e 'Add Customer user \n'
+wp-env run tests-cli "user create customer customer@woocommercecoree2etestsuite.com \
 	--user_pass=password \
 	--role=subscriber \
 	--first_name='Jane' \
@@ -31,20 +40,19 @@ wp-env run tests-cli "ls \
 echo -e 'Update Blog Name \n'
 wp-env run tests-cli 'wp option update blogname "WooCommerce Core E2E Test Suite"'
 
+wp-env run tests-cli "wp plugin install https://gist.github.com/vedanshujain/564afec8f5e9235a1257994ed39b1449/archive/b031465052fc3e04b17624acbeeb2569ef4d5301.zip --activate"
+
 if [ $ENABLE_HPOS == 1 ]; then
 	echo 'Enable the COT feature'
-	wp-env run test-cli "wp plugin install https://gist.github.com/vedanshujain/564afec8f5e9235a1257994ed39b1449/archive/b031465052fc3e04b17624acbeeb2569ef4d5301.zip --activate"
+	wp-env run tests-cli "wp plugin install https://gist.github.com/vedanshujain/564afec8f5e9235a1257994ed39b1449/archive/b031465052fc3e04b17624acbeeb2569ef4d5301.zip --activate"
 fi
 
 if [ $ENABLE_NEW_PRODUCT_EDITOR == 1 ]; then
 	echo 'Enable the new product editor feature'
-	wp-env run test-cli "wp plugin install https://github.com/woocommerce/woocommerce-experimental-enable-new-product-editor/releases/download/0.1.0/woocommerce-experimental-enable-new-product-editor.zip --activate"
+	wp-env run tests-cli "wp plugin install https://github.com/woocommerce/woocommerce-experimental-enable-new-product-editor/releases/download/0.1.0/woocommerce-experimental-enable-new-product-editor.zip --activate"
 fi
 
 if [ $ENABLE_TRACKING == 1 ]; then
 	echo 'Enable tracking'
-	wp-env run test-cli "wp option update woocommerce_allow_tracking 'yes'"
+	wp-env run tests-cli "wp option update woocommerce_allow_tracking 'yes'"
 fi
-
-echo -e 'Get contents of My Account Page\n'
-curl -L http://localhost:8086/my-account

--- a/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
+++ b/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
@@ -4,6 +4,10 @@ ENABLE_HPOS="${ENABLE_HPOS:-0}"
 ENABLE_NEW_PRODUCT_EDITOR="${ENABLE_NEW_PRODUCT_EDITOR:-0}"
 ENABLE_TRACKING="${ENABLE_TRACKING:-0}"
 
+echo -r 'Check Dir/File owners\n'
+docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u www-data -e HOME=/tmp tests-wordpress sh -c "ls -ld /var/www/html/wp-content \
+&& ls -ld /var/www/html/wp-config.php"
+
 echo -e 'Normalize permissions for wp-content directory \n'
 docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u www-data -e HOME=/tmp tests-wordpress sh -c "chmod -c ugo+w /var/www/html/wp-config.php \
 && chmod -c ugo+w /var/www/html/wp-content \

--- a/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
+++ b/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
@@ -9,17 +9,17 @@ docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u www-data
 && ls -ld /var/www/html/wp-config.php \
 && ls -ld /var/www/html/wp-content/themes \
 && ls -ld /var/www/html/wp-content/plugins \
-&& ls -ld /var/www/html/.htaccess"
+&& ls -ld /var/www/html"
 
-echo -e 'Normalize permissions for wp-config.php \n'
-docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u www-data -e HOME=/tmp tests-wordpress sh -c "chmod -c ugo+w /var/www/html/wp-config.php"
+echo -e 'Normalize permissions for /var/www/html & wp-config.php  \n'
+docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u www-data -e HOME=/tmp tests-wordpress sh -c "chmod -c ugo+w /var/www/html/wp-config.php && chmod -c ugo+w /var/www/html"
 
 echo -e 'Normalize permissions for wp-content directory \n'
-docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u $(id -u) -e HOME=/tmp tests-wordpress sh -c "chmod -c ugo+w /var/www/html/wp-content \
+docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u www-data -e HOME=/tmp tests-wordpress sh -c "chmod -c ugo+w /var/www/html/wp-content \
 && chmod -c ugo+w /var/www/html/wp-content/themes \
 && chmod -c ugo+w /var/www/html/wp-content/plugins \
 && mkdir -p /var/www/html/wp-content/upgrade \
-&& chmod -c ugo+w /var/www/html/.htaccess \
+&& chmod -c ugo+w /var/www/html \
 && chmod -c ugo+w /var/www/html/wp-content/upgrade"
 
 docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u www-data -e HOME=/tmp tests-cli sh -c "ls \

--- a/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
+++ b/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
@@ -10,7 +10,8 @@ docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u $(id -u)
 && chmod -c ugo+w /var/www/html/wp-content/plugins \
 && mkdir -p /var/www/html/wp-content/upgrade \
 && chmod -c ugo+w /var/www/html \
-&& chmod -c ugo+w /var/www/html/wp-content/upgrade"
+&& chmod -c ugo+w /var/www/html/wp-content/upgrade \
+&& chmod -c ugo+w /var/www/html/wp-content/uploads"
 
 echo -e 'Activate twentynineteen theme \n'
 wp-env run tests-cli "wp theme activate twentynineteen"

--- a/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
+++ b/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
@@ -4,17 +4,18 @@ ENABLE_HPOS="${ENABLE_HPOS:-0}"
 ENABLE_NEW_PRODUCT_EDITOR="${ENABLE_NEW_PRODUCT_EDITOR:-0}"
 ENABLE_TRACKING="${ENABLE_TRACKING:-0}"
 
-echo -r 'Check Dir/File owners\n'
-docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u www-data -e HOME=/tmp tests-wordpress sh -c "ls -ld /var/www/html/wp-content \
-&& ls -ld /var/www/html/wp-config.php \
-&& ls -ld /var/www/html/wp-content/themes \
-&& ls -ld /var/www/html/wp-content/plugins \
-&& ls -ld /var/www/html"
-
-echo -e 'Normalize permissions for /var/www/html & wp-config.php  \n'
+echo -e 'Normalize permissions for /var/www/html & wp-config.php \n'
 docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u www-data -e HOME=/tmp tests-wordpress sh -c "chmod -c ugo+w /var/www/html/wp-config.php"
 
-docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u $(id -u) -e HOME=/tmp tests-cli sh -c "ls \
+echo -e 'Normalize permissions for wp-content directory \n'
+docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u $(id -u) -e HOME=/tmp tests-wordpress sh -c "chmod -c ugo+w /var/www/html/wp-content \
+&& chmod -c ugo+w /var/www/html/wp-content/themes \
+&& chmod -c ugo+w /var/www/html/wp-content/plugins \
+&& mkdir -p /var/www/html/wp-content/upgrade \
+&& chmod -c ugo+w /var/www/html \
+&& chmod -c ugo+w /var/www/html/wp-content/upgrade"
+
+wp-env run tests-cli "ls \
 && wp theme install twentynineteen --activate \
 && wp plugin install https://github.com/WP-API/Basic-Auth/archive/master.zip --activate \
 && wp plugin install wp-mail-logging --activate \
@@ -28,21 +29,21 @@ docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u $(id -u)
 	--user_registered='2022-01-01 12:23:45'"
 
 echo -e 'Update Blog Name \n'
-docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u $(id -u) -e HOME=/tmp tests-cli sh -c 'wp option update blogname "WooCommerce Core E2E Test Suite"'
+wp-env run tests-cli 'wp option update blogname "WooCommerce Core E2E Test Suite"'
 
 if [ $ENABLE_HPOS == 1 ]; then
 	echo 'Enable the COT feature'
-	docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u www-data -e HOME=/tmp tests-cli sh -c "wp plugin install https://gist.github.com/vedanshujain/564afec8f5e9235a1257994ed39b1449/archive/b031465052fc3e04b17624acbeeb2569ef4d5301.zip --activate"
+	wp-env run test-cli "wp plugin install https://gist.github.com/vedanshujain/564afec8f5e9235a1257994ed39b1449/archive/b031465052fc3e04b17624acbeeb2569ef4d5301.zip --activate"
 fi
 
 if [ $ENABLE_NEW_PRODUCT_EDITOR == 1 ]; then
 	echo 'Enable the new product editor feature'
-	docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u www-data -e HOME=/tmp tests-cli sh -c "wp plugin install https://github.com/woocommerce/woocommerce-experimental-enable-new-product-editor/releases/download/0.1.0/woocommerce-experimental-enable-new-product-editor.zip --activate"
+	wp-env run test-cli "wp plugin install https://github.com/woocommerce/woocommerce-experimental-enable-new-product-editor/releases/download/0.1.0/woocommerce-experimental-enable-new-product-editor.zip --activate"
 fi
 
 if [ $ENABLE_TRACKING == 1 ]; then
 	echo 'Enable tracking'
-	docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u $(id -u) -e HOME=/tmp tests-cli sh -c "wp option update woocommerce_allow_tracking 'yes'"
+	wp-env run test-cli "wp option update woocommerce_allow_tracking 'yes'"
 fi
 
 echo -e 'Get contents of My Account Page\n'

--- a/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
+++ b/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
@@ -14,7 +14,7 @@ echo -e 'Normalize permissions for wp-config.php \n'
 docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u www-data -e HOME=/tmp tests-wordpress sh -c "chmod -c ugo+w /var/www/html/wp-config.php"
 
 echo -e 'Normalize permissions for wp-content directory \n'
-docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u $(id -u) -e HOME=/tmp tests-wordpress sh -c " && chmod -c ugo+w /var/www/html/wp-content \
+docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u $(id -u) -e HOME=/tmp tests-wordpress sh -c "chmod -c ugo+w /var/www/html/wp-content \
 && chmod -c ugo+w /var/www/html/wp-content/themes \
 && chmod -c ugo+w /var/www/html/wp-content/plugins \
 && mkdir -p /var/www/html/wp-content/upgrade \

--- a/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
+++ b/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
@@ -19,6 +19,7 @@ docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u $(id -u)
 && chmod -c ugo+w /var/www/html/wp-content/themes \
 && chmod -c ugo+w /var/www/html/wp-content/plugins \
 && mkdir -p /var/www/html/wp-content/upgrade \
+&& chmod -c ugo+w /var/www/html/.htaccess \
 && chmod -c ugo+w /var/www/html/wp-content/upgrade"
 
 docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u www-data -e HOME=/tmp tests-cli sh -c "ls \

--- a/plugins/woocommerce/tests/e2e-pw/bin/update-wp-env.php
+++ b/plugins/woocommerce/tests/e2e-pw/bin/update-wp-env.php
@@ -49,12 +49,25 @@ if ( ! class_exists( UPDATE_WP_JSON::class ) ) {
 		public function set_wc_version(){
 			if ( $this->wc_version ) {
 				echo "Set WC Version to $this->wc_version \n";
-				$this->wp_json["plugins"] = [ "https://github.com/woocommerce/woocommerce/releases/download/$this->wc_version/woocommerce.zip" ];
+				$this->wp_json["env"]["tests"]["plugins"] = array_values(
+					array_filter( $this->wp_json["env"]["tests"]["plugins"], function( $string ) {
+						return $string !== ".";
+					} )
+				);
+
+				var_dump( $filtered );
+				array_push( $this->wp_json["env"]["tests"]["plugins"], "https://github.com/woocommerce/woocommerce/releases/download/$this->wc_version/woocommerce.zip" );
 			}
 		}
 
 		public function revert_wc_version(){
-			$this->wp_json["plugins"] = [ "." ];
+			$this->wp_json["env"]["tests"]["plugins"] = array_filter( $this->wp_json["env"]["tests"]["plugins"], function( $string ) {
+				return strpos( $string, "woocommerce.zip" ) === false;
+			} );
+
+			if ( ! in_array( ".", $this->wp_json["env"]["tests"]["plugins"] ) ) {
+				array_unshift( $this->wp_json["env"]["tests"]["plugins"], "." );
+			}
 		}
 
 		public function set_php_version(){

--- a/plugins/woocommerce/tests/e2e-pw/bin/update-wp-env.php
+++ b/plugins/woocommerce/tests/e2e-pw/bin/update-wp-env.php
@@ -55,7 +55,6 @@ if ( ! class_exists( UPDATE_WP_JSON::class ) ) {
 					} )
 				);
 
-				var_dump( $filtered );
 				array_push( $this->wp_json["env"]["tests"]["plugins"], "https://github.com/woocommerce/woocommerce/releases/download/$this->wc_version/woocommerce.zip" );
 			}
 		}

--- a/plugins/woocommerce/tests/e2e-pw/bin/update-wp-env.php
+++ b/plugins/woocommerce/tests/e2e-pw/bin/update-wp-env.php
@@ -84,14 +84,14 @@ if ( ! class_exists( UPDATE_WP_JSON::class ) ) {
 			$this->set_wp_version();
 			$this->set_wc_version();
 			$this->set_php_version();
-			file_put_contents( $this->wp_env_path, json_encode( $this->wp_json, JSON_PRETTY_PRINT ) );
+			file_put_contents( $this->wp_env_path, json_encode( $this->wp_json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
 		}
 
 		public function revert(){
 			$this->revert_wp_version();
 			$this->revert_wc_version();
 			$this->revert_php_version();
-			file_put_contents( $this->wp_env_path, json_encode( $this->wp_json, JSON_PRETTY_PRINT ) );
+			file_put_contents( $this->wp_env_path, json_encode( $this->wp_json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
 
 			echo "Reverted .wp-env.json \n";
 		}

--- a/plugins/woocommerce/tests/performance/bin/init-sample-products.sh
+++ b/plugins/woocommerce/tests/performance/bin/init-sample-products.sh
@@ -4,7 +4,7 @@ ENABLE_HPOS="${ENABLE_HPOS:-0}"
 
 echo "Initializing WooCommerce E2E"
 
-echo -e 'Normalize permissions for wp-content directory \n'
+echo -e 'Normalize permissions for multiple directories \n'
 docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u $(id -u) -e HOME=/tmp tests-wordpress sh -c "chmod -c ugo+w /var/www/html/wp-content \
 && chmod -c ugo+w /var/www/html/wp-content/themes \
 && chmod -c ugo+w /var/www/html/wp-content/plugins \

--- a/plugins/woocommerce/tests/performance/bin/init-sample-products.sh
+++ b/plugins/woocommerce/tests/performance/bin/init-sample-products.sh
@@ -10,7 +10,8 @@ docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u $(id -u)
 && chmod -c ugo+w /var/www/html/wp-content/plugins \
 && mkdir -p /var/www/html/wp-content/upgrade \
 && chmod -c ugo+w /var/www/html \
-&& chmod -c ugo+w /var/www/html/wp-content/upgrade"
+&& chmod -c ugo+w /var/www/html/wp-content/upgrade \
+&& chmod -c ugo+w /var/www/html/wp-content/uploads"
 
 wp-env run tests-cli "wp plugin activate woocommerce"
 

--- a/plugins/woocommerce/tests/performance/bin/init-sample-products.sh
+++ b/plugins/woocommerce/tests/performance/bin/init-sample-products.sh
@@ -16,14 +16,8 @@ wp-env run tests-cli "wp plugin activate woocommerce"
 
 wp-env run tests-cli "wp user create customer customer@woocommercecoree2etestsuite.com --user_pass=password --role=subscriber --path=/var/www/html"
 
-# we cannot create API keys for the API, so we using basic auth, this plugin allows that.
-wp-env run tests-cli "wp plugin install https://github.com/WP-API/Basic-Auth/archive/master.zip --activate"
-
 # update permalinks to `pretty` to make it easier for testing APIs with k6
 wp-env run tests-cli "wp option update permalink_structure /%postname%/"
-
-# install the WP Mail Logging plugin to test emails
-wp-env run tests-cli "wp plugin install wp-mail-logging --activate"
 
 # Installing and activating the WordPress Importer plugin to import sample products"
 wp-env run tests-cli "wp plugin install wordpress-importer --activate"

--- a/plugins/woocommerce/tests/performance/bin/init-sample-products.sh
+++ b/plugins/woocommerce/tests/performance/bin/init-sample-products.sh
@@ -4,6 +4,14 @@ ENABLE_HPOS="${ENABLE_HPOS:-0}"
 
 echo "Initializing WooCommerce E2E"
 
+echo -e 'Normalize permissions for wp-content directory \n'
+docker-compose -f $(wp-env install-path)/docker-compose.yml run --rm -u $(id -u) -e HOME=/tmp tests-wordpress sh -c "chmod -c ugo+w /var/www/html/wp-content \
+&& chmod -c ugo+w /var/www/html/wp-content/themes \
+&& chmod -c ugo+w /var/www/html/wp-content/plugins \
+&& mkdir -p /var/www/html/wp-content/upgrade \
+&& chmod -c ugo+w /var/www/html \
+&& chmod -c ugo+w /var/www/html/wp-content/upgrade"
+
 wp-env run tests-cli "wp plugin activate woocommerce"
 
 wp-env run tests-cli "wp user create customer customer@woocommercecoree2etestsuite.com --user_pass=password --role=subscriber --path=/var/www/html"

--- a/plugins/woocommerce/tests/performance/bin/init-sample-products.sh
+++ b/plugins/woocommerce/tests/performance/bin/init-sample-products.sh
@@ -18,7 +18,7 @@ wp-env run tests-cli "wp plugin activate woocommerce"
 wp-env run tests-cli "wp user create customer customer@woocommercecoree2etestsuite.com --user_pass=password --role=subscriber --path=/var/www/html"
 
 # update permalinks to `pretty` to make it easier for testing APIs with k6
-wp-env run tests-cli "wp option update permalink_structure /%postname%/"
+wp-env run tests-cli "wp rewrite structure '/%postname%/' --hard"
 
 # Installing and activating the WordPress Importer plugin to import sample products"
 wp-env run tests-cli "wp plugin install wordpress-importer --activate"


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This is based on https://github.com/woocommerce/woocommerce/pull/37799 and ensures that e2e, API & performance tests can still run and pass when using `wp-env` version v5.

The most important change in this PR is to update the permissions for few directories using `docker-compose` directly. This is to get around permission issues that would occur when installing plugins and updating the URL structure.

I also moved required plugins into `.wp-env.json` because it should've been done long ago. Thanks @ObliviousHarmony for the nudge.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout this branch 
2. Navigate to the plugin directory with `cd plugins/woocommerce`
3. Build the container with specific version by running `UPDATE_WP_JSON_FILE=1 WP_VERSION=6.1.1 WC_TEST_VERSION=7.4.1 PHP_VERSION=8.2 pnpm run env:test`
4. Confirm that the `.wp-env.json` file is updated accordingly.
5. Destroy the environment and run step 3 with of the version var removed.
6. Confirm that the `.wp-env.json` file is updated accordingly.
7. Run E2E/API tests with `pnpm run test:e2e-pw` / `pnpm run test:api-pw`
8. Destroy the environment and revert the `.wp-env.json` changes by running `pnpm run env:destroy`
9. Confirm that all the changes to `.wp-env.json` have been reverted.
<!-- End testing instructions -->