### PR TITLE
Drop WP 5.9 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,6 @@ jobs:
             php: '7.4'
           - wp: '6.0'
             php: 7.4
-          - wp: '5.9'
-            php: 7.4
     services:
       database:
         image: mysql:5.6

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -33,8 +33,6 @@ jobs:
             php: '7.4'
           - wp: '6.0'
             php: 7.4
-          - wp: '5.9'
-            php: 7.4
           - wp: 'latest'
             php: '7.4'
             hpos: true


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

p1681843895773319-slack-C03CPM3UXDJ

Drop 5.9 from the matrix since the minimum supported version of WP is [6.0](https://github.com/woocommerce/woocommerce/blob/7.6.0/plugins/woocommerce/woocommerce.php#L11).

https://github.com/woocommerce/woocommerce/blob/b47a45d8f6ed1f62d5ddb05ab795deba53d2c465/plugins/woocommerce/woocommerce.php#L11

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Confirm PHP unit test CI doesn't run in WP 5.9.

<!-- End testing instructions -->