### PR TITLE
fix/35860: Adds missing aria-label and tabindex HTML attributes to the Help tip element.

### DIFF
--- a/plugins/woocommerce/changelog/fix-35860
+++ b/plugins/woocommerce/changelog/fix-35860
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+add missing aria-label attributes to help tips

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -1091,7 +1091,7 @@ jQuery( function ( $ ) {
 
 	// Add a descriptive tooltip to the product description editor
 	$( '#wp-content-media-buttons' )
-		.append( '<span class="woocommerce-help-tip" tabindex="-1"></span>' )
+		.append( '<span class="woocommerce-help-tip" tabindex="0"></span>' )
 		.find( '.woocommerce-help-tip' )
 		.attr(
 			'tabindex',

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -1093,6 +1093,10 @@ jQuery( function ( $ ) {
 	$( '#wp-content-media-buttons' )
 		.append( '<span class="woocommerce-help-tip" tabindex="-1"></span>' )
 		.find( '.woocommerce-help-tip' )
+		.attr(
+			'tabindex',
+			'0'
+		)
 		.attr( 'for', 'content' )
 		.attr(
 			'aria-label',
@@ -1111,6 +1115,10 @@ jQuery( function ( $ ) {
 	$( '#postexcerpt > .postbox-header > .hndle' )
 		.append( '<span class="woocommerce-help-tip"></span>' )
 		.find( '.woocommerce-help-tip' )
+		.attr(
+			'tabindex',
+			'0'
+		)
 		.attr(
 			'aria-label',
 			woocommerce_admin_meta_boxes.i18n_product_short_description_tip

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1610,7 +1610,7 @@ function wc_help_tip( $tip, $allow_html = false ) {
 	 *
 	 * @return string
 	 */
-	return apply_filters( 'wc_help_tip', '<span class="woocommerce-help-tip" data-tip="' . $sanitized_tip . '"></span>', $sanitized_tip, $tip, $allow_html );
+	return apply_filters( 'wc_help_tip', '<span class="woocommerce-help-tip" tabindex="0" aria-label="' . $sanitized_tip . '" data-tip="' . $sanitized_tip . '"></span>', $sanitized_tip, $tip, $allow_html );
 }
 
 /**


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Adds missing `aria-label` and `tabindex` HTML attributes to the Help tip element.

Closes #35860

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to `Products > Add New` (/wp-admin/post-new.php?post_type=product)
2. Search for the class `.woocommerce-help-tip` on the product edit page using Inspector tool on the **trunk** branch.
3. Observe that some matched elements don't have `aria-label` and `tabindex` attribute set.
4. Switch to the fix branch and repeat step (1)
5. Observe matched elements have missing attributes from step (2)
6. Enable screen reader such as VoiceOver
7. Confirm you can navigate to help tip elements using the keyboard and the screen reader can read the text.

![Screenshot 2023-04-19 at 15 18 54](https://user-images.githubusercontent.com/4344253/233003683-df283ca9-c5f4-42c4-adfe-88dc30aab90b.png)
![Screenshot 2023-04-19 at 15 23 21](https://user-images.githubusercontent.com/4344253/233003718-921eba8d-148e-45de-8363-86af54571941.png)


<!-- End testing instructions -->