### PR TITLE
Fix bulk sale price update

### DIFF
--- a/changelog/fix-37681
+++ b/changelog/fix-37681
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Added numeric check for Regular price in bulk edits.

--- a/changelog/fix-37681
+++ b/changelog/fix-37681
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Added numeric check for Regular price in bulk edits.

--- a/plugins/woocommerce/changelog/fix-37681
+++ b/plugins/woocommerce/changelog/fix-37681
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Added numeric check for Regular price in bulk edits.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php
@@ -985,7 +985,7 @@ class WC_Admin_Post_Types {
 					break;
 				}
 				$regular_price = $product->get_regular_price();
-				if ( $is_percentage ) {
+				if ( $is_percentage && is_numeric( $regular_price ) ) {
 					$percent   = $price / 100;
 					$new_price = max( 0, $regular_price - ( NumberUtil::round( $regular_price * $percent, wc_get_price_decimals() ) ) );
 				} else {


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Added numeric check for Regular price variable in bulk edits. A strict numeric check is not required. It passes the result. 

Closes #37681.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Thank you @lynnjat7 for listing the steps to reproduce the bug in detail. It helped to re-create the bug & fix it. 

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), following points can be followed to test the fixes. 

1. Create a few simple products on the back end.
2. Set a few products with blank Regular prices.
3. When viewing the main Products list under Products, check off products to edit, including the one with the blank price.
4. Click on Bulk Actions > Edit
5. Select to edit the Sale price as "regular price decreased by" and enter some value with % as the discount.
![set-sale-price-via-bulk-edit](https://user-images.githubusercontent.com/11537877/232997886-9e43dd70-2692-4f52-aa2d-c2b3439ba498.png)

6. Blank price product will remain as is. The rest of the products will get updated and Admin will view the success screen. 

![successful-product-update](https://user-images.githubusercontent.com/11537877/232997984-f0189197-9cdb-4f13-9f65-c910a1720678.png)

<!-- End testing instructions -->