### PR TITLE
Skip the `review-testing-instructions` workflow on PR's from community contributors

### DIFF
--- a/.github/workflows/review-testing-instructions.yml
+++ b/.github/workflows/review-testing-instructions.yml
@@ -11,7 +11,14 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      - name: Check if user is a community contributor
+        id: is-community-contributor
+        run: node .github/workflows/scripts/is-community-contributor.js
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Get the username of requested reviewers
+        if: steps.is-community-contributor.outputs.is-community == 'no'
         id: get_reviewer_username
         run: |
           # Retrieves the username of all reviewers and stores them in a comma-separated list

--- a/.github/workflows/review-testing-instructions.yml
+++ b/.github/workflows/review-testing-instructions.yml
@@ -11,6 +11,17 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
+
+      - name: Install Octokit
+        run: npm --prefix .github/workflows/scripts install @octokit/action
+
+      - name: Install Actions Core
+        run: npm --prefix .github/workflows/scripts install @actions/core
+
       - name: Check if user is a community contributor
         id: is-community-contributor
         run: node .github/workflows/scripts/is-community-contributor.js

--- a/plugins/woocommerce/changelog/update-check-external-testing-instructions
+++ b/plugins/woocommerce/changelog/update-check-external-testing-instructions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add the ability to skip the `review-testing-instructions` workflow when the PR is from an external contributor.


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds the ability to skip the `review-testing-instructions` workflow when the PR is from an external contributor.
This would help unblock community PR's during the Contributor Day. See the issue reported here for context: p1681843624632139-slack-C03CPM3UXDJ

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Not sure if this PR could be tested, since the only way to test its changes is to have an external PR wanting to merge to `trunk` and the author requesting a review. 

Maybe it's enough to verify that the `Remind reviewers to also review the testing instructions.` workflow in this PR passes.