### PR TITLE
Re-assign existing webhooks during user deletion

### DIFF
--- a/plugins/woocommerce/changelog/fix-37806
+++ b/plugins/woocommerce/changelog/fix-37806
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-When deleting an administrator user, and the "Attribute all content to" option is chosen, any existing webhooks linked to the user being deleted are re-assigned to the other user.
+When deleting an administrator user, any existing webhook(s) owned to the user being deleted are re-assigned to the nominated user if the "Attribute all content to" option is chosen, or re-assigned to user id zero. This helps avoid `woocommerce_rest_cannot_view` webhook payload errors.

--- a/plugins/woocommerce/changelog/fix-37806
+++ b/plugins/woocommerce/changelog/fix-37806
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+When deleting an administrator user, and the "Attribute all content to" option is chosen, any existing webhooks linked to the user being deleted are re-assigned to the other user.

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -18,6 +18,7 @@ use Automattic\WooCommerce\Internal\ProductAttributesLookup\LookupDataStore;
 use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Register as ProductDownloadDirectories;
 use Automattic\WooCommerce\Internal\RestockRefundedItemsAdjuster;
 use Automattic\WooCommerce\Internal\Settings\OptionSanitizer;
+use Automattic\WooCommerce\Internal\Utilities\WebhookUtil;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
 
 /**
@@ -239,6 +240,7 @@ final class WooCommerce {
 		$container->get( OptionSanitizer::class );
 		$container->get( BatchProcessingController::class );
 		$container->get( FeaturesController::class );
+		$container->get( WebhookUtil::class );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/data-stores/class-wc-webhook-data-store.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-webhook-data-store.php
@@ -282,6 +282,7 @@ class WC_Webhook_Data_Store implements WC_Webhook_Data_Store_Interface {
 		$exclude         = '';
 		$date_created    = '';
 		$date_modified   = '';
+		$user_id         = '';
 
 		if ( ! empty( $args['include'] ) ) {
 			$args['include'] = implode( ',', wp_parse_id_list( $args['include'] ) );
@@ -291,6 +292,10 @@ class WC_Webhook_Data_Store implements WC_Webhook_Data_Store_Interface {
 		if ( ! empty( $args['exclude'] ) ) {
 			$args['exclude'] = implode( ',', wp_parse_id_list( $args['exclude'] ) );
 			$exclude         = 'AND webhook_id NOT IN (' . $args['exclude'] . ')';
+		}
+
+		if ( ! empty( $args['user_id'] ) ) {
+			$user_id = $wpdb->prepare( 'AND `user_id` = %d', absint( $args['user_id'] ) );
 		}
 
 		if ( ! empty( $args['after'] ) || ! empty( $args['before'] ) ) {
@@ -326,6 +331,7 @@ class WC_Webhook_Data_Store implements WC_Webhook_Data_Store_Interface {
 				{$exclude}
 				{$date_created}
 				{$date_modified}
+				{$user_id}
 				{$order}
 				{$limit}
 				{$offset}"
@@ -349,6 +355,7 @@ class WC_Webhook_Data_Store implements WC_Webhook_Data_Store_Interface {
 				{$exclude}
 				{$date_created}
 				{$date_modified}
+				{$user_id}
 				{$order}
 				{$limit}
 				{$offset}"

--- a/plugins/woocommerce/includes/wc-webhook-functions.php
+++ b/plugins/woocommerce/includes/wc-webhook-functions.php
@@ -202,36 +202,3 @@ function wc_get_webhook_rest_api_versions() {
 		'wp_api_v3',
 	);
 }
-
-
-/**
- * Whenever a user is deleted, re-assign their webhooks to the new user.
- *
- * If re-assignment isn't selected during deletion, assign the webhooks to user_id 0,
- * so that an admin can edit and re-save them in order to get them to be assigned to a valid user.
- *
- * @param int      $old_user_id ID of the deleted user.
- * @param int|null $new_user_id ID of the user to reassign existing data to, or null if no re-assignment is requested.
- *
- * @return void
- * @since 7.8.0
- */
-function wc_reassign_webhooks_to_new_user_id( $old_user_id, $new_user_id ) {
-	if ( is_null( $old_user_id ) ) {
-		$old_user_id = 0;
-	}
-
-	$data_store  = WC_Data_Store::load( 'webhook' );
-	$webhook_ids = $data_store->search_webhooks(
-		array(
-			'user_id' => $old_user_id,
-		)
-	);
-	foreach ( $webhook_ids as $webhook_id ) {
-		$webhook = new WC_Webhook( $webhook_id );
-		$webhook->set_user_id( $new_user_id );
-		$webhook->save();
-	}
-
-}
-add_action( 'deleted_user', 'wc_reassign_webhooks_to_new_user_id', 10, 2 );

--- a/plugins/woocommerce/includes/wc-webhook-functions.php
+++ b/plugins/woocommerce/includes/wc-webhook-functions.php
@@ -207,16 +207,18 @@ function wc_get_webhook_rest_api_versions() {
 /**
  * Whenever a user is deleted, re-assign their webhooks to the new user.
  *
+ * If re-assignment isn't selected during deletion, assign the webhooks to user_id 0,
+ * so that an admin can edit and re-save them in order to get them to be assigned to a valid user.
+ *
  * @param int      $old_user_id ID of the deleted user.
- * @param int|null $new_user_id ID of the user to reassign existing data to.
+ * @param int|null $new_user_id ID of the user to reassign existing data to, or null if no re-assignment is requested.
  *
  * @return void
  * @since 7.8.0
  */
 function wc_reassign_webhooks_to_new_user_id( $old_user_id, $new_user_id ) {
 	if ( is_null( $old_user_id ) ) {
-		// There is no user id to re-assign existing content to.
-		return;
+		$old_user_id = 0;
 	}
 
 	$data_store  = WC_Data_Store::load( 'webhook' );

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/UtilsClassesServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/UtilsClassesServiceProvider.php
@@ -32,7 +32,7 @@ class UtilsClassesServiceProvider extends AbstractServiceProvider {
 		OrderUtil::class,
 		PluginUtil::class,
 		COTMigrationUtil::class,
-		WebhookUtil::class
+		WebhookUtil::class,
 	);
 
 	/**

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/UtilsClassesServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/UtilsClassesServiceProvider.php
@@ -11,6 +11,7 @@ use Automattic\WooCommerce\Internal\DependencyManagement\AbstractServiceProvider
 use Automattic\WooCommerce\Internal\Utilities\COTMigrationUtil;
 use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
 use Automattic\WooCommerce\Internal\Utilities\HtmlSanitizer;
+use Automattic\WooCommerce\Internal\Utilities\WebhookUtil;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
 use Automattic\WooCommerce\Utilities\PluginUtil;
 use Automattic\WooCommerce\Utilities\OrderUtil;
@@ -31,6 +32,7 @@ class UtilsClassesServiceProvider extends AbstractServiceProvider {
 		OrderUtil::class,
 		PluginUtil::class,
 		COTMigrationUtil::class,
+		WebhookUtil::class
 	);
 
 	/**
@@ -44,5 +46,6 @@ class UtilsClassesServiceProvider extends AbstractServiceProvider {
 			->addArgument( LegacyProxy::class );
 		$this->share( COTMigrationUtil::class )
 			->addArguments( array( CustomOrdersTableController::class, DataSynchronizer::class ) );
+		$this->share( WebhookUtil::class );
 	}
 }

--- a/plugins/woocommerce/src/Internal/Utilities/WebhookUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/WebhookUtil.php
@@ -72,8 +72,8 @@ class WebhookUtil {
 			$text = sprintf(
 				/* translators: 1 = user id, 2 = user login, 3 = webhooks count */
 				_nx(
-					'User #%1$s %2$s has created %3$d webhook.',
-					'User #%1$s %2$s has created %3$d webhooks.',
+					'User #%1$s %2$s has created %3$d WooCommerce webhook.',
+					'User #%1$s %2$s has created %3$d WooCommerce webhooks.',
 					$webhooks_count,
 					'user webhook count',
 					'woocommerce'
@@ -105,18 +105,18 @@ class WebhookUtil {
 		// phpcs:enable WooCommerce.Commenting.CommentHooks, WordPress.DB.PreparedSQL.NotPrepared
 
 		if ( $users_have_content ) {
-			$text = __( 'If the "Delete all content" option is selected, the affected webhooks will <b>not</b> be deleted and will be attributed to user id 0.<br/>', 'woocommerce' );
+			$text = __( 'If the "Delete all content" option is selected, the affected WooCommerce webhooks will <b>not</b> be deleted and will be attributed to user id 0.<br/>', 'woocommerce' );
 		} else {
-			$text = __( 'The affected webhooks will <b>not</b> be deleted and will be attributed to user id 0.<br/>', 'woocommerce' );
+			$text = __( 'The affected WooCommerce webhooks will <b>not</b> be deleted and will be attributed to user id 0.<br/>', 'woocommerce' );
 		}
 
 		$text .= sprintf(
 			/* translators: 1 = url of the WooCommerce webhooks settings page */
-			__( 'After that they can be reassigned to the logged in user by going to the <a href="%1$s">webhooks settings page</a> and re-saving them.', 'woocommerce' ),
+			__( 'After that they can be reassigned to the logged-in user by going to the <a href="%1$s">WooCommerce webhooks settings page</a> and re-saving them.', 'woocommerce' ),
 			$webhooks_settings_url
 		);
 
-		echo '<p>' . esc_html( $text ) . '</p>';
+		echo '<p>' . wp_kses_post( $text ) . '</p>';
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Utilities/WebhookUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/WebhookUtil.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * WebhookUtil class file.
+ */
+
+namespace Automattic\WooCommerce\Internal\Utilities;
+
+use Automattic\WooCommerce\Internal\Traits\AccessiblePrivateMethods;
+
+/**
+ * Class with utility methods for dealing with webhooks.
+ */
+class WebhookUtil {
+
+	use AccessiblePrivateMethods;
+
+	/**
+	 * Creates a new instance of the class.
+	 */
+	public function __construct() {
+		self::add_action( 'deleted_user', array( $this, 'reassign_webhooks_to_new_user_id' ), 10, 2 );
+	}
+
+	/**
+	 * Whenever a user is deleted, re-assign their webhooks to the new user.
+	 *
+	 * If re-assignment isn't selected during deletion, assign the webhooks to user_id 0,
+	 * so that an admin can edit and re-save them in order to get them to be assigned to a valid user.
+	 *
+	 * @param int      $old_user_id ID of the deleted user.
+	 * @param int|null $new_user_id ID of the user to reassign existing data to, or null if no re-assignment is requested.
+	 *
+	 * @return void
+	 * @since 7.8.0
+	 */
+	private function reassign_webhooks_to_new_user_id( int $old_user_id, ?int $new_user_id ): void {
+		$data_store  = \WC_Data_Store::load( 'webhook' );
+		$webhook_ids = $data_store->search_webhooks(
+			array(
+				'user_id' => $old_user_id ?? 0,
+			)
+		);
+
+		foreach ( $webhook_ids as $webhook_id ) {
+			$webhook = new \WC_Webhook( $webhook_id );
+			$webhook->set_user_id( $new_user_id );
+			$webhook->save();
+		}
+	}
+}

--- a/plugins/woocommerce/src/Internal/Utilities/WebhookUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/WebhookUtil.php
@@ -19,6 +19,7 @@ class WebhookUtil {
 	 */
 	public function __construct() {
 		self::add_action( 'deleted_user', array( $this, 'reassign_webhooks_to_new_user_id' ), 10, 2 );
+		self::add_action( 'delete_user_form', array( $this, 'maybe_render_user_with_webhooks_warning' ), 10, 2 );
 	}
 
 	/**
@@ -34,17 +35,102 @@ class WebhookUtil {
 	 * @since 7.8.0
 	 */
 	private function reassign_webhooks_to_new_user_id( int $old_user_id, ?int $new_user_id ): void {
-		$data_store  = \WC_Data_Store::load( 'webhook' );
-		$webhook_ids = $data_store->search_webhooks(
-			array(
-				'user_id' => $old_user_id ?? 0,
-			)
-		);
+		$webhook_ids = $this->get_webhook_ids_for_user( $old_user_id );
 
 		foreach ( $webhook_ids as $webhook_id ) {
 			$webhook = new \WC_Webhook( $webhook_id );
-			$webhook->set_user_id( $new_user_id );
+			$webhook->set_user_id( $new_user_id ?? 0 );
 			$webhook->save();
 		}
+	}
+
+	/**
+	 * When users are about to be deleted show an informative text if they have webhooks assigned.
+	 *
+	 * @param \WP_User $current_user The current logged in user.
+	 * @param array    $userids Array with the ids of the users that are about to be deleted.
+	 * @return void
+	 * @since 7.8.0
+	 */
+	private function maybe_render_user_with_webhooks_warning( \WP_User $current_user, array $userids ): void {
+		global $wpdb;
+
+		$at_least_one_user_with_webhooks = false;
+
+		foreach ( $userids as $user_id ) {
+			$webhook_ids = $this->get_webhook_ids_for_user( $user_id );
+			if ( empty( $webhook_ids ) ) {
+				continue;
+			}
+
+			$at_least_one_user_with_webhooks = true;
+
+			$user_data      = get_userdata( $user_id );
+			$user_login     = false === $user_data ? '' : $user_data->user_login;
+			$webhooks_count = count( $webhook_ids );
+
+			$text = sprintf(
+				/* translators: 1 = user id, 2 = user login, 3 = webhooks count */
+				_nx(
+					'User #%1$s %2$s has created %3$d webhook.',
+					'User #%1$s %2$s has created %3$d webhooks.',
+					$webhooks_count,
+					'user webhook count',
+					'woocommerce'
+				),
+				$user_id,
+				$user_login,
+				$webhooks_count
+			);
+
+			echo '<p>' . esc_html( $text ) . '</p>';
+		}
+
+		if ( ! $at_least_one_user_with_webhooks ) {
+			return;
+		}
+
+		$webhooks_settings_url = esc_url_raw( admin_url( 'admin.php?page=wc-settings&tab=advanced&section=webhooks' ) );
+
+		// This block of code is copied from WordPress' users.php.
+		// phpcs:disable WooCommerce.Commenting.CommentHooks, WordPress.DB.PreparedSQL.NotPrepared
+		$users_have_content = (bool) apply_filters( 'users_have_additional_content', false, $userids );
+		if ( ! $users_have_content ) {
+			if ( $wpdb->get_var( "SELECT ID FROM {$wpdb->posts} WHERE post_author IN( " . implode( ',', $userids ) . ' ) LIMIT 1' ) ) {
+				$users_have_content = true;
+			} elseif ( $wpdb->get_var( "SELECT link_id FROM {$wpdb->links} WHERE link_owner IN( " . implode( ',', $userids ) . ' ) LIMIT 1' ) ) {
+				$users_have_content = true;
+			}
+		}
+		// phpcs:enable WooCommerce.Commenting.CommentHooks, WordPress.DB.PreparedSQL.NotPrepared
+
+		if ( $users_have_content ) {
+			$text = __( 'If the "Delete all content" option is selected, the affected webhooks will <b>not</b> be deleted and will be attributed to user id 0.<br/>', 'woocommerce' );
+		} else {
+			$text = __( 'The affected webhooks will <b>not</b> be deleted and will be attributed to user id 0.<br/>', 'woocommerce' );
+		}
+
+		$text .= sprintf(
+			/* translators: 1 = url of the WooCommerce webhooks settings page */
+			__( 'After that they can be reassigned to the logged in user by going to the <a href="%1$s">webhooks settings page</a> and re-saving them.', 'woocommerce' ),
+			$webhooks_settings_url
+		);
+
+		echo '<p>' . esc_html( $text ) . '</p>';
+	}
+
+	/**
+	 * Get the ids of the webhooks assigned to a given user.
+	 *
+	 * @param int $user_id User id.
+	 * @return int[] Array of webhook ids.
+	 */
+	private function get_webhook_ids_for_user( int $user_id ): array {
+		$data_store = \WC_Data_Store::load( 'webhook' );
+		return $data_store->search_webhooks(
+			array(
+				'user_id' => $user_id,
+			)
+		);
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-webhook-tests.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-webhook-tests.php
@@ -34,4 +34,49 @@ class WC_Webhook_Test extends WC_Unit_Test_Case {
 		$this->assertFalse( $call_is_valid_function->call( $webhook, $product->get_id() ) );
 	}
 
+	/**
+	 * @testDox Check that a deleted administrator user (with content re-assigned to another user)
+	 * does not cause webhook payloads to fail.
+	 */
+	public function test_payload_for_deleted_user_id() {
+		$admin_user_id_1 = wp_insert_user(
+			array(
+				'user_login' => 'test_admin',
+				'user_pass'  => 'password',
+				'role'       => 'administrator',
+			)
+		);
+
+		$webhook = new WC_Webhook();
+		$webhook->set_topic( 'order.created' );
+		$webhook->set_user_id( $admin_user_id_1 );
+		$webhook->save();
+
+		$order = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
+
+		$payload = $webhook->build_payload( $order->get_id() );
+		$this->assertArrayNotHasKey( 'code', $payload );
+		$this->assertArrayHasKey( 'id', $payload );
+		$this->assertSame( $order->get_id(), $payload['id'] );
+
+		// Create a second admin user and delete the first one, reassigning existing content to the second user.
+		$admin_user_id_2 = wp_insert_user(
+			array(
+				'user_login' => 'test_admin2',
+				'user_pass'  => 'password',
+				'role'       => 'administrator',
+			)
+		);
+		wp_delete_user( $admin_user_id_1, $admin_user_id_2 );
+
+		// Re-load the webhook from the database.
+		$webhook = new WC_Webhook( $webhook->get_id() );
+		// Confirm user_id has been updated to the second admin user.
+		$this->assertSame( $admin_user_id_2, $webhook->get_user_id() );
+
+		$this->assertArrayNotHasKey( 'code', $payload );
+		$this->assertArrayHasKey( 'id', $payload );
+		$this->assertSame( $order->get_id(), $payload['id'] );
+	}
+
 }

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-webhook-data-store-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-webhook-data-store-test.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Tests relating to the WC_Webhook_Data_Store class.
+ */
+class WC_Webhook_Data_Store_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * Verify that the search_webhooks() method returns the correct results when searching by user ID.
+	 */
+	public function test_search_webhooks_by_user_id() {
+
+		$store = new WC_Webhook_Data_Store();
+
+		$this->assertEmpty(
+			$store->search_webhooks(
+				array(
+					'user_id' => 1,
+				)
+			)
+		);
+
+		$webhook1 = new WC_Webhook();
+		$webhook1->set_user_id( 1 );
+		$webhook1->save();
+
+		$webhook2 = new WC_Webhook();
+		$webhook2->set_user_id( 2 );
+		$webhook2->save();
+
+		$this->assertSame(
+			array( $webhook1->get_id() ),
+			$store->search_webhooks(
+				array(
+					'user_id' => 1,
+				)
+			)
+		);
+		$this->assertSame(
+			array( $webhook2->get_id() ),
+			$store->search_webhooks(
+				array(
+					'user_id' => 2,
+				)
+			)
+		);
+	}
+
+}


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

1. When deleting an administrator user, and the **Attribute all content to** option is chosen on the WordPress delete user screen, any existing webhook(s) owned by the user being deleted are re-assigned to the other user.
This helps prevent `woocommerce_rest_cannot_view` webhook payload errors that occur after an administrator with existing webhooks is deleted.
2. When deleting an administrator user without the **Attribute all content to** option being chosen on the WordPress delete user screen, any existing webhook(s) owned by the user being deleted are re-assigned to `user_id` zero.
This avoids webhooks from being left in the database with an invalid (non existent) `user_id`.
An admin can edit and re-save each of these webhooks in order to get them to be assigned to a valid user. This is because re-saving a webhook that has user_id=0 causes the webhook ownership to be updated to the currently logged in user.
3. The "Delete users" WordPress page will display a text explaining that the users that are about to be deleted have webhooks assigned, if that's the case.
4. Adds the ability to search for webhooks matching a `user_id` using `WC_Webhook_Data_Store::search_webhooks()` by specifying a `user_id` argument.

Closes #37806.

### How to test the changes in this Pull Request:

For the original issue: follow the **Steps to reproduce** in #37806, however in the last step (step 12), the webhook payload will be a valid order payload rather than a `woocommerce_rest_cannot_view` error.

For the new behavior of the user deletion:

1. Create two administrator users (Users - Add New, select "Administrator" in "Role").
2. Login and create a new webhook (WooCommerce - Settings - Advanced - Webhooks) with each of the newly created users.
3. Go to the users page, check the box for the two newly created users, select "Delete" in the "Bulk actions" dropdown, then click "Apply".

You'll now see a message that warns  about existing webhooks right before the "Confirm Deletion" button:

![image](https://user-images.githubusercontent.com/937723/235643750-4309a3ac-fcd4-4302-8294-a7c5be09fa2d.png)

4. Choose the "Delete all content" radio button and click "Confirm Deletion".
5. Verify that the webhooks still exist and have user id 0 assigned. The easiest way is to directly query the database: `wp db query "select name,user_id from wp_wc_webhooks"`
6. Verify that editing and saving one of the webhooks with user id 0 will indeed set the user id of that webhook to the id of the user currently logged in.

If a user doesn't have any content assigned there will be no choice as to what to do with the user content. The webhooks warning will still appear but with a slightly different wording:

![image](https://user-images.githubusercontent.com/937723/235644734-c1bcac26-539d-47c9-8bb9-2ef4f97efb2d.png)

Testing this isn't straightforwards since a post is created automatically for an user the first time it logs in. You can try creating yet another administrator user, *not* logging in with that user, taking note of its user id (search for `user_id` in the query string of the user edit url in the users page) and manually modifying one of the entries in the `wp_wc_webhooks` table to have that value for `user_id`.