### PR TITLE
Add REST API Products featured image

### DIFF
--- a/plugins/woocommerce/changelog/add-rest-api-products-featured-image
+++ b/plugins/woocommerce/changelog/add-rest-api-products-featured-image
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add `featured` field to the images array for Product REST API

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -45,9 +45,11 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 	protected function get_images( $product ) {
 		$images         = array();
 		$attachment_ids = array();
+		$featured_id    = null;
 
 		// Add featured image.
 		if ( $product->get_image_id() ) {
+			$featured_id      = $product->get_image_id();
 			$attachment_ids[] = $product->get_image_id();
 		}
 
@@ -68,6 +70,7 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 
 			$images[] = array(
 				'id'                => (int) $attachment_id,
+				'featured'          => (int) $featured_id === (int) $attachment_id,
 				'date_created'      => wc_rest_prepare_date_response( $attachment_post->post_date, false ),
 				'date_created_gmt'  => wc_rest_prepare_date_response( strtotime( $attachment_post->post_date_gmt ) ),
 				'date_modified'     => wc_rest_prepare_date_response( $attachment_post->post_modified, false ),

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -1256,6 +1256,12 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 								'type'        => 'integer',
 								'context'     => array( 'view', 'edit' ),
 							),
+							'featured'          => array(
+								'description' => __( 'Featured image.', 'woocommerce' ),
+								'type'        => 'boolean',
+								'default'     => false,
+								'context'     => array( 'view', 'edit' ),
+							),
 							'date_created'      => array(
 								'description' => __( "The date the image was created, in the site's timezone.", 'woocommerce' ),
 								'type'        => 'date-time',

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -320,7 +320,7 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 			}
 
 			// Handle multiple featured images.
-			if ($featured_image_count > 1) {
+			if ( $featured_image_count > 1 ) {
 				throw new WC_REST_Exception(
 					'woocommerce_rest_product_featured_image_count',
 					__( 'Only one featured image is allowed.', 'woocommerce' ),

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller-tests.php
@@ -263,7 +263,7 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 		$this->assertNotWPError( $gallery_url );
 		$gallery_id = $wpdb->get_col( $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE guid = %s", $gallery_url ) );
 
-		$featured_url = media_sideload_image( 'http://cldup.com/Dr1Bczxq4q.png', $product->get_id(), 'featured', 'src' );
+		$featured_url = media_sideload_image( 'https://cldup.com/Dr1Bczxq4q.png', $product->get_id(), 'featured', 'src' );
 		$this->assertNotWPError( $featured_url );
 		$featured_id = $wpdb->get_col( $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE guid = %s", $featured_url ) );
 

--- a/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller-tests.php
+++ b/plugins/woocommerce/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller-tests.php
@@ -205,7 +205,55 @@ class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that all fields are returned when requested one by one.
+	 * Test that featured field exists under images in product argument.
+	 */
+	public function test_products_args_includes_featured_field() {
+		$request = new WP_REST_Request( 'OPTIONS', '/wc/v3/products' );
+		$request->set_param( '_fields', 'endpoints.1.args.images.items.properties' );
+		$response  = $this->server->dispatch( $request );
+		$image_arg = $response->get_data()['endpoints'][1]['args']['images']['items']['properties'];
+		$this->assertArrayHasKey( 'featured', $image_arg );
+		$this->assertEquals(
+			array(
+				'description' => 'Featured image.',
+				'type'        => 'boolean',
+				'default'     => false,
+				'context'     =>
+				array(
+					0 => 'view',
+					1 => 'edit',
+				),
+			),
+			$image_arg['featured']
+		);
+	}
+
+	/**
+	 * Test that featured field exists under images in product schema.
+	 */
+	public function test_products_schema_includes_featured_field() {
+		$request = new WP_REST_Request( 'OPTIONS', '/wc/v3/products' );
+		$request->set_param( '_fields', 'schema.properties.images.items.properties' );
+		$response     = $this->server->dispatch( $request );
+		$image_schema = $response->get_data()['schema']['properties']['images']['items']['properties'];
+		$this->assertArrayHasKey( 'featured', $image_schema );
+		$this->assertEquals(
+			array(
+				'description' => 'Featured image.',
+				'type'        => 'boolean',
+				'default'     => false,
+				'context'     =>
+				array(
+					0 => 'view',
+					1 => 'edit',
+				),
+			),
+			$image_schema['featured']
+		);
+	}
+
+	/**
+	 * Test that feature field is returned inside images.
 	 */
 	public function test_products_get_images_array_contains_featured() {
 		global $wpdb;


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Proposed Changes in this Pull Request:

This pull request introduces a new `featured` field to the image object within the Product REST API endpoint's schema and arguments.

Although adding a new argument to a REST API can potentially cause backward-incompatible changes, this endpoint works as previously if the newly added argument is not present. With the new `featured` argument, REST API users can now explicitly set which image they want to mark as featured.

Closes #31924

### How to test the changes in this Pull Request:

#### Live Testing

**Prerequisites**
 - Create a new product or use an existing one without images. Take note of the product ID.

**Test `featured` false**
1. Add an image to your product in the WP dashboard, but do not make it featured.
2. Query the 'GET' `wp-json/wc/v3/products/<id>` endpoint.
3. Observe that the images have a `featured` field set to `false`.

**Test `featured` multiple values**
1. Add another image to your product and make it featured.
2. Query the 'GET' `wp-json/wc/v3/products/<id>` endpoint.
3. Observe that the new image has a `featured` field set to `true`.
4. Observe that the newly added featured image is the first in the `images` array.

**Test `featured` all `false` values**
1. Remove all images from the product.
2. Query the 'PUT' `wp-json/wc/v3/products/<id>` endpoint and set two images:

```json
{
  "images": [
    { "src": "https://cldup.com/6L9h56D9Bw.jpg", "featured": false },
    { "src": "https://cldup.com/Dr1Bczxq4q.png", "featured": false }
  ]
}
```
3. Observe that both images have a `featured` field set to `false`.

**Test error when attempting to create multiple featured images**
1. Remove all images from the product.
2. Query the 'PUT' `wp-json/wc/v3/products/<id>` endpoint and set two images:

```json
{
  "images": [
    { "src": "https://cldup.com/6L9h56D9Bw.jpg", "featured": true },
    { "src": "https://cldup.com/Dr1Bczxq4q.png", "featured": true }
  ]
}
```
3. Observe the 400 Bad Request response:

```json
{
  "code": "woocommerce_rest_product_featured_image_count",
  "message": "Only one featured image is allowed.",
  "data": { "status": 400 }
}
```

**Test backward-compatible behaviour**
1. Remove all images from the product.
2. Query the 'PUT' `wp-json/wc/v3/products/<id>` endpoint and set two images:

```json
{
  "images": [
    { "src": "https://cldup.com/6L9h56D9Bw.jpg" },
    { "src": "https://cldup.com/Dr1Bczxq4q.png" }
  ]
}
```
3. Observe that the first image has a `featured` field set to `true`, and the second one is set to `false`.

#### Automated tests

Run tests as usual.

New tests have been added for the Product REST API and Unit tests.
