### PR TITLE
fix/33389: add `refunded_payment` property in the create refund response

### DIFF
--- a/plugins/woocommerce/changelog/fix-33389
+++ b/plugins/woocommerce/changelog/fix-33389
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+add refunded_payment property in the create refund response

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-order-refunds-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-order-refunds-v2-controller.php
@@ -394,7 +394,7 @@ class WC_REST_Order_Refunds_V2_Controller extends WC_REST_Orders_V2_Controller {
 				'refunded_payment' => array(
 					'description' => __( 'If the payment was refunded via the API.', 'woocommerce' ),
 					'type'        => 'boolean',
-					'context'     => array( 'view' ),
+					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'meta_data'        => array(


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #33389

This PR adds the `refunded_payment` property in the create refund response.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create an order using a payment gateway that supports automatic payments.
2. Create REST credentials under `/admin.php?page=wc-settings&tab=advanced&section=keys`
3. Perform a refund using the `/wp-json/wc/v3/orders/<order_id>/refunds` endpoint. Use the body `{ "amount": "<refund_amount>" }`.
4. Observe the JSON response. In the trunk branch, the `refunded_payment` is missing but is present in the fix branch. 

<!-- End testing instructions -->