### PR TITLE
Fix/issue 36668: Shows warning only when the variation price is empty

### DIFF
--- a/plugins/woocommerce/changelog/fix-issue-36668
+++ b/plugins/woocommerce/changelog/fix-issue-36668
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+No warning shown for zero price.

--- a/plugins/woocommerce/includes/admin/wc-admin-functions.php
+++ b/plugins/woocommerce/includes/admin/wc-admin-functions.php
@@ -508,18 +508,20 @@ function wc_render_invalid_variation_notice( $product_object ) {
 
 	// Check if a variation exists without pricing data.
 	// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
-	$invalid_variation_count = $wpdb->get_var(
+	$valid_variation_count = $wpdb->get_var(
 		"
 		SELECT count(post_id) FROM {$wpdb->postmeta}
 		WHERE post_id in (" . implode( ',', array_map( 'absint', $variation_ids ) ) . ")
 		AND ( meta_key='_subscription_sign_up_fee' OR meta_key='_price' )
-		AND meta_value > 0
+		AND meta_value >= 0
 		AND meta_value != ''
 		"
 	);
 	// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 
-	if ( 0 < ( $variation_count - $invalid_variation_count ) ) {
+	$invalid_variation_count = $variation_count - $valid_variation_count;
+
+	if ( 0 < $invalid_variation_count ) {
 		?>
 		<div id="message" class="inline notice notice-warning woocommerce-message woocommerce-notice-invalid-variation">
 			<p>
@@ -527,8 +529,8 @@ function wc_render_invalid_variation_notice( $product_object ) {
 			echo wp_kses_post(
 				sprintf(
 					/* Translators: %d variation count. */
-					_n( '%d variation does not have a price.', '%d variations do not have prices.', ( $variation_count - $invalid_variation_count ), 'woocommerce' ),
-					( $variation_count - $invalid_variation_count )
+					_n( '%d variation does not have a price.', '%d variations do not have prices.', $invalid_variation_count, 'woocommerce' ),
+					$invalid_variation_count
 				) . '&nbsp;' .
 				__( 'Variations (and their attributes) that do not have prices will not be shown in your store.', 'woocommerce' )
 			);


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR is to fix issue for a warning that being displayed when user put `0` price for product variation.
To fix that, I changed the condition in sql to be like this : 
```
SELECT count(post_id) FROM {$wpdb->postmeta}
WHERE post_id in (" . implode( ',', array_map( 'absint', $variation_ids ) ) . ")
AND ( meta_key='_subscription_sign_up_fee' OR meta_key='_price' )
AND meta_value >= 0
AND meta_value != ''
```
By doing this, it allows the user to set the price with 0.
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #36668  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new variable product.
2. Set two new attributes for the product like the screenshot below : 
![image](https://user-images.githubusercontent.com/631098/233018347-2cac99ac-a059-40bd-a662-6062caee4b29.png)

3. Go to "Variations" tab and click "Generate variations".
4. Add the regular price for the first variant with `0` and the other variants with any number but more than 0.
![image](https://user-images.githubusercontent.com/631098/233020018-54e841fc-f0f1-4d82-9f57-3a073981fa56.png)

![image](https://user-images.githubusercontent.com/631098/233020192-ace113b1-a103-41b3-9099-1892142ccace.png)

5. Click "Save Changes" to save the variations.
6. Notice that no Warning being displayed.
7. Now, empty the regular price for the first variant and click "Save Changes".
![image](https://user-images.githubusercontent.com/631098/233020444-8af2534b-2749-4759-b430-24fc46e5293b.png)

8. Notice that the warning being displayed : 
![image](https://user-images.githubusercontent.com/631098/233019704-2a46de50-01da-44be-8633-7b08a9136784.png)


<!-- End testing instructions -->