### PR TITLE
Update WC Blocks to 10.0.2

### DIFF
--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-10.0.2
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-10.0.2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update WooCommerce Blocks to 10.0.2

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -21,7 +21,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.5.4",
-		"woocommerce/woocommerce-blocks": "10.0.1"
+		"woocommerce/woocommerce-blocks": "10.0.2"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.3.0",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e761f51237d0594766a7365e0ec97100",
+    "content-hash": "9b9f6dff1c579d1d1e86436b8e1fb6a7",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -628,16 +628,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "10.0.1",
+            "version": "10.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "f36207e9cebe9a7080485a8446dcf86d5f2c0997"
+                "reference": "d7275884591bc05f7e780c8cd7919d50b79b9ffa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/f36207e9cebe9a7080485a8446dcf86d5f2c0997",
-                "reference": "f36207e9cebe9a7080485a8446dcf86d5f2c0997",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/d7275884591bc05f7e780c8cd7919d50b79b9ffa",
+                "reference": "d7275884591bc05f7e780c8cd7919d50b79b9ffa",
                 "shasum": ""
             },
             "require": {
@@ -683,9 +683,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v10.0.1"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v10.0.2"
             },
-            "time": "2023-04-18T12:23:21+00:00"
+            "time": "2023-04-19T08:04:13+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This PR updates the WooCommerce Blocks plugin to 10.0.2. It includes changes from WooCommerce Blocks 10.0.2 and is intended to target WooCommerce 7.7 for release.

Details from all the different releases included in this pull:

## WooCommerce Blocks 10.0.2

* [Release PR](https://github.com/woocommerce/woocommerce-blocks/pull/9093)
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/1002.md)

### Changelog entry

### The following changelog entries are only those that impact existing blocks and functionality surfaced to users:

#### Bug Fixes

- Fix infinite loop with the registration of Single Product Block (and inner blocks) breaking WP Post and Page editors in WP 6.1. ([9090](https://github.com/woocommerce/woocommerce-blocks/pull/9090))