### PR TITLE
Fix broken link to WSL setup instructions

### DIFF
--- a/plugins/woocommerce/changelog/e2e-update-wsl-setup-instructions
+++ b/plugins/woocommerce/changelog/e2e-update-wsl-setup-instructions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update the WSL setup instructions in the readme.

--- a/plugins/woocommerce/tests/e2e-pw/README.md
+++ b/plugins/woocommerce/tests/e2e-pw/README.md
@@ -26,7 +26,7 @@ This is the documentation for the new e2e testing setup based on Playwright and 
 
 Note, that if you are on Mac and you install docker through other methods such as homebrew, for example, your steps to set it up might be different. The commands listed in steps below may also vary.
 
-If you are using Windows, we recommend using [Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/wsl/) for running E2E tests. Follow the [WSL Setup Instructions](../tests/e2e/WSL_SETUP_INSTRUCTIONS.md) first before proceeding with the steps below.
+If you are using Windows, we recommend using [Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/wsl/) for running E2E tests. Follow the [WSL Setup Instructions](./WSL_SETUP_INSTRUCTIONS.md) first before proceeding with the steps below.
 
 ### Introduction
 

--- a/plugins/woocommerce/tests/e2e-pw/WSL_SETUP_INSTRUCTIONS.md
+++ b/plugins/woocommerce/tests/e2e-pw/WSL_SETUP_INSTRUCTIONS.md
@@ -5,22 +5,26 @@ You can set up a local development environment on Windows with [Windows Subsyste
 ## Pre-requisites
 
 You should have the following already set up on your Windows computer:
-- **Docker Desktop for Windows** - https://docs.docker.com/docker-for-windows/install/
-- **WSL 2** - https://docs.microsoft.com/en-us/windows/wsl/install
-- **Set the default Linux distribution** - https://docs.microsoft.com/en-us/windows/wsl/basic-commands#set-default-linux-distribution
+
+-   **Docker Desktop for Windows** - https://docs.docker.com/docker-for-windows/install/
+-   **WSL 2** - https://docs.microsoft.com/en-us/windows/wsl/install
+-   **Set the default Linux distribution** - https://docs.microsoft.com/en-us/windows/wsl/basic-commands#set-default-linux-distribution
 
 ## Setup Steps
 
 Update and upgrade packages.
+
 ```bash
 sudo apt update -y && sudo apt upgrade -y
 ```
 
 In order for Composer commands to work later on, you have to install the following:
-- PHP
-- Composer
-- `php-xml`
-- `php-mbstring`
+
+-   PHP
+-   Composer
+-   `php-xml`
+-   `php-mbstring`
+
 ```bash
 sudo apt install php-cli unzip -y
 
@@ -44,15 +48,17 @@ sudo apt install php-mbstring -y
 ```
 
 For Playwright to run in headless mode you'll need to install additional packages:
+
 ```bash
 sudo apt install -y ca-certificates fonts-liberation gconf-service libappindicator1 libasound2 libatk-bridge2.0-0 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libnss3 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 lsb-release wget xdg-utils
 ```
 
 Add your username to the `docker` group to avoid having to type `sudo` when you run Docker commands.
+
 ```bash
 sudo usermod -aG docker ${YOUR_USERNAME}
 
 su - ${YOUR_USERNAME}
 ```
 
-At this point, you're now ready to proceed with the steps in [Prep work for running tests](./README.md#prep-work-for-running-tests).
+At this point, you're now ready to proceed with the steps in [WooCommerce Playwright End to End Tests](./README.md).

--- a/plugins/woocommerce/tests/e2e-pw/WSL_SETUP_INSTRUCTIONS.md
+++ b/plugins/woocommerce/tests/e2e-pw/WSL_SETUP_INSTRUCTIONS.md
@@ -1,0 +1,97 @@
+# Setup Instructions for Windows Subsystem for Linux (WSL)
+
+You can set up a local development environment on Windows with [Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/wsl/).
+
+## Pre-requisites
+
+You should have the following already set up on your Windows computer:
+
+-   **Docker Desktop for Windows:** Follow the setup instructions from the official [Docker documentation](https://docs.docker.com/docker-for-windows/install/)
+-   **WSL 2:** Follow the setup instructions from the official [WSL documentation](https://docs.microsoft.com/en-us/windows/wsl/install)
+-   **Set default Linux distribution:** To avoid having to specify the Linux distribution every time you use the `wsl` command, set it as the defaul distro by following the instructions from the official [WSL documentation](https://docs.microsoft.com/en-us/windows/wsl/basic-commands#set-default-linux-distribution)
+
+## Setup Steps
+
+
+
+1. Update and upgrade packages.
+
+    ```bash
+    sudo apt update -y && sudo apt upgrade -y
+    ```
+
+1. Install PHP.
+
+    ```bash
+    sudo apt install -y php
+    ```
+
+    To verify that PHP was installed correctly, run:
+
+    ```bash
+    php -v
+    ```
+
+    You should see the result to be something like:
+
+    ```
+    PHP 8.1.2-1ubuntu2.11 (cli) (built: Feb 22 2023 22:56:18) (NTS)
+    Copyright (c) The PHP Group
+    Zend Engine v4.1.2, Copyright (c) Zend Technologies
+        with Zend OPcache v8.1.2-1ubuntu2.11, Copyright (c), by Zend Technologies
+    ```
+
+1. Install Composer.
+
+    ```bash
+    cd ~
+    curl -sS https://getcomposer.org/installer -o composer-setup.php
+    HASH=`curl -sS https://composer.github.io/installer.sig`
+    echo $HASH # should print the correct hash
+    ```
+
+
+
+1. 
+-   PHP
+-   Composer
+-   `php-xml`
+-   `php-mbstring`
+
+```bash
+sudo apt install php-cli unzip -y
+
+cd ~
+
+curl -sS https://getcomposer.org/installer -o composer-setup.php
+
+HASH=`curl -sS https://composer.github.io/installer.sig`
+
+echo $HASH
+
+php -r "if (hash_file('SHA384', 'composer-setup.php') === '$HASH') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+
+sudo php composer-setup.php --install-dir=/usr/local/bin --filename=composer
+
+composer --version --no-interaction # Verify that Composer installation was successful
+
+sudo apt install php-xml -y
+
+sudo apt install php-mbstring -y
+```
+
+For Puppeteer to run in headless mode you'll need to install additional packages:
+
+```bash
+sudo apt install -y ca-certificates fonts-liberation gconf-service libappindicator1 libasound2 libatk-bridge2.0-0 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libnss3 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 lsb-release wget xdg-utils
+```
+
+Add your username to the `docker` group to avoid having to type `sudo` when you run Docker commands.
+
+```bash
+sudo usermod -aG docker ${YOUR_USERNAME}
+
+su - ${YOUR_USERNAME}
+```
+
+At this point, you're now ready to proceed with the steps in [Prep work for running tests](./README.md#prep-work-for-running-tests).

--- a/plugins/woocommerce/tests/e2e-pw/WSL_SETUP_INSTRUCTIONS.md
+++ b/plugins/woocommerce/tests/e2e-pw/WSL_SETUP_INSTRUCTIONS.md
@@ -1,63 +1,26 @@
 # Setup Instructions for Windows Subsystem for Linux (WSL)
 
-You can set up a local development environment on Windows with [Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/wsl/).
+You can set up a local development environment on Windows with [Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/wsl/). The following instructions are for Ubuntu 20.04 and Ubuntu 22.04.
 
 ## Pre-requisites
 
 You should have the following already set up on your Windows computer:
-
--   **Docker Desktop for Windows:** Follow the setup instructions from the official [Docker documentation](https://docs.docker.com/docker-for-windows/install/)
--   **WSL 2:** Follow the setup instructions from the official [WSL documentation](https://docs.microsoft.com/en-us/windows/wsl/install)
--   **Set default Linux distribution:** To avoid having to specify the Linux distribution every time you use the `wsl` command, set it as the defaul distro by following the instructions from the official [WSL documentation](https://docs.microsoft.com/en-us/windows/wsl/basic-commands#set-default-linux-distribution)
+- **Docker Desktop for Windows** - https://docs.docker.com/docker-for-windows/install/
+- **WSL 2** - https://docs.microsoft.com/en-us/windows/wsl/install
+- **Set the default Linux distribution** - https://docs.microsoft.com/en-us/windows/wsl/basic-commands#set-default-linux-distribution
 
 ## Setup Steps
 
+Update and upgrade packages.
+```bash
+sudo apt update -y && sudo apt upgrade -y
+```
 
-
-1. Update and upgrade packages.
-
-    ```bash
-    sudo apt update -y && sudo apt upgrade -y
-    ```
-
-1. Install PHP.
-
-    ```bash
-    sudo apt install -y php
-    ```
-
-    To verify that PHP was installed correctly, run:
-
-    ```bash
-    php -v
-    ```
-
-    You should see the result to be something like:
-
-    ```
-    PHP 8.1.2-1ubuntu2.11 (cli) (built: Feb 22 2023 22:56:18) (NTS)
-    Copyright (c) The PHP Group
-    Zend Engine v4.1.2, Copyright (c) Zend Technologies
-        with Zend OPcache v8.1.2-1ubuntu2.11, Copyright (c), by Zend Technologies
-    ```
-
-1. Install Composer.
-
-    ```bash
-    cd ~
-    curl -sS https://getcomposer.org/installer -o composer-setup.php
-    HASH=`curl -sS https://composer.github.io/installer.sig`
-    echo $HASH # should print the correct hash
-    ```
-
-
-
-1. 
--   PHP
--   Composer
--   `php-xml`
--   `php-mbstring`
-
+In order for Composer commands to work later on, you have to install the following:
+- PHP
+- Composer
+- `php-xml`
+- `php-mbstring`
 ```bash
 sudo apt install php-cli unzip -y
 
@@ -80,14 +43,12 @@ sudo apt install php-xml -y
 sudo apt install php-mbstring -y
 ```
 
-For Puppeteer to run in headless mode you'll need to install additional packages:
-
+For Playwright to run in headless mode you'll need to install additional packages:
 ```bash
 sudo apt install -y ca-certificates fonts-liberation gconf-service libappindicator1 libasound2 libatk-bridge2.0-0 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libnss3 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 lsb-release wget xdg-utils
 ```
 
 Add your username to the `docker` group to avoid having to type `sudo` when you run Docker commands.
-
 ```bash
 sudo usermod -aG docker ${YOUR_USERNAME}
 


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR updates the link to the WSL setup instructions inside the `e2e-pw` folder.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Go to https://github.com/woocommerce/woocommerce/blob/e2e/fix-wsl-setup-link/plugins/woocommerce/tests/e2e-pw/README.md.
2. Click on the link to the WSL setup instructions. You should be taken to the "Setup Instructions for Windows Subsystem for Linux (WSL)" page.
   <img width="797" alt="LUAs1nTjBN" src="https://user-images.githubusercontent.com/4509348/233024027-8c9dcbc5-60de-485f-a581-f1a06a97fbf8.png">
1. Now that you're in the WSL Setup Instructions readme page, verify that all the info and links are correct, no typos, and that there's no mention of "Puppeteer" within the document.

<!-- End testing instructions -->