### PR TITLE
Fix/37600 Remove `aria-disabled` from `Update Cart` button

### DIFF
--- a/plugins/woocommerce/changelog/fix-37600
+++ b/plugins/woocommerce/changelog/fix-37600
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-The "Update Cart" button does not need an aria-disabled attribute, as it has a disabled attribute, this PR removes it.
+Removed aria-disabled attribute from "Update Cart" button as it already has a disabled attribute.

--- a/plugins/woocommerce/changelog/fix-37600
+++ b/plugins/woocommerce/changelog/fix-37600
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+The "Update Cart" button does not need an aria-disabled attribute, as it has a disabled attribute, this PR removes it.

--- a/plugins/woocommerce/client/legacy/js/frontend/cart.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/cart.js
@@ -127,7 +127,7 @@ jQuery( function( $ ) {
 			}
 
 			$( '.woocommerce-cart-form' ).replaceWith( $new_form );
-			$( '.woocommerce-cart-form' ).find( ':input[name="update_cart"]' ).prop( 'disabled', true ).attr( 'aria-disabled', true );
+			$( '.woocommerce-cart-form' ).find( ':input[name="update_cart"]' ).prop( 'disabled', true );
 
 			if ( $notices.length > 0 ) {
 				show_notice( $notices );
@@ -327,14 +327,14 @@ jQuery( function( $ ) {
 				'.woocommerce-cart-form .cart_item :input',
 				this.input_changed );
 
-			$( '.woocommerce-cart-form :input[name="update_cart"]' ).prop( 'disabled', true ).attr( 'aria-disabled', true );
+			$( '.woocommerce-cart-form :input[name="update_cart"]' ).prop( 'disabled', true );
 		},
 
 		/**
 		 * After an input is changed, enable the update cart button.
 		 */
 		input_changed: function() {
-			$( '.woocommerce-cart-form :input[name="update_cart"]' ).prop( 'disabled', false ).attr( 'aria-disabled', false );
+			$( '.woocommerce-cart-form :input[name="update_cart"]' ).prop( 'disabled', false );
 		},
 
 		/**


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The "Update Cart" button does not need an aria-disabled attribute, as it has a disabled attribute, this PR removes it.

Closes #37600.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add product to the cart.
2. Visit the Cart page
3. Inspect the "Update Cart" button
4. I should not have an `aria-disabled` attribute.

<!-- End testing instructions -->