### PR TITLE
Dev/37219 add hook to remove order items

### DIFF
--- a/plugins/woocommerce/changelog/dev-37219_add_hook_to_remove_order_items
+++ b/plugins/woocommerce/changelog/dev-37219_add_hook_to_remove_order_items
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Add action hooks to WC_Abstract_Order::remove_order_items

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -817,6 +817,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		 * @param  WC_Order  $this  The current order object.
 		 * @param  string $type Order item type. Default null.
 		 *
+		 * @since 7.8.0
 		 */
 		do_action( 'woocommerce_remove_order_items', $this, $type );
 		if ( ! empty( $type ) ) {
@@ -837,6 +838,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		 * @param  WC_Order  $this  The current order object.
 		 * @param  string $type Order item type. Default null.
 		 *
+		 * @since 7.8.0
 		 */
 		do_action( 'woocommerce_removed_order_items', $this, $type );
 	}

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -810,6 +810,14 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param string $type Order item type. Default null.
 	 */
 	public function remove_order_items( $type = null ) {
+
+		/**
+		 * Trigger action before removing all order line items. Allows you to track order items.
+		 *
+		 * @param  WC_Order  $this  The current order object.
+		 * @param  string $type Order item type. Default null.
+		 *
+		 */
 		do_action( 'woocommerce_remove_order_items', $this, $type );
 		if ( ! empty( $type ) ) {
 			$this->data_store->delete_items( $this, $type );
@@ -823,6 +831,13 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			$this->data_store->delete_items( $this );
 			$this->items = array();
 		}
+		/**
+		 * Trigger action after removing all order line items.
+		 *
+		 * @param  WC_Order  $this  The current order object.
+		 * @param  string $type Order item type. Default null.
+		 *
+		 */
 		do_action( 'woocommerce_removed_order_items', $this, $type );
 	}
 

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -810,6 +810,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @param string $type Order item type. Default null.
 	 */
 	public function remove_order_items( $type = null ) {
+		do_action( 'woocommerce_remove_order_items', $this, $type );
 		if ( ! empty( $type ) ) {
 			$this->data_store->delete_items( $this, $type );
 
@@ -822,6 +823,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			$this->data_store->delete_items( $this );
 			$this->items = array();
 		}
+		do_action( 'woocommerce_removed_order_items', $this, $type );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Added action hooks to the WC_Abstract_Order::remove_order_items() to facilitate the tracking of the removal of products from an order for failed payments & order reuse.

Closes #37219

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a test plugin at wp-content/plugins/test-37822/test-37822.php.
2. It should contain the following code:

```
<?php
/**
* Plugin Name: 37822 Test code
* Description: Can be used to test PR https://github.com/woocommerce/woocommerce/pull/37822
* Version: 1.0.0
**/

defined( 'ABSPATH' ) || exit;

add_action( 'woocommerce_remove_order_items', 'before_order_cleared', 10, 2);
function before_order_cleared($order, $type) {
    // save information about failed order
    $logger = wc_get_logger();
    $context = array( 'source' => 'testplugin' );
    $types = array( 'line_item', 'tax', 'shipping', 'fee', 'coupon' );
    $log = 'The order ' . $order->get_id() . ' is going to be cleared for retry payment. It has ' . count( $order->get_items( $types ) ) . ' line items including products, coupons, taxes, and shipping';
    $logger->info( $log, $context );
}

add_action( 'woocommerce_removed_order_items', 'after_order_cleared', 10, 2);
function after_order_cleared($order, $type) {
    // log order cleared action
    $logger = wc_get_logger();
    $context = array( 'source' => 'testplugin' );
    $log = 'The order ' . $order->get_id() . ' was successfully cleared for retry payment.' ;
    $logger->info( $log, $context );
}
```
3. [Install](https://woocommerce.com/document/stripe/#installation) the Stripe payment gateway and [set it up](https://woocommerce.com/document/stripe/#setup-and-configuration) in [test mode](https://woocommerce.com/document/stripe/#test-mode). 
4. Check out with [a card that produces a decline](https://stripe.com/docs/testing#declined-payments) **twice**, the code above will log information into the WooCommerce Logs  
5. You can go to `WooCommerce > Status > Logs` to see the details logged.
![Screenshot 2023-05-19 at 12 08 05](https://github.com/woocommerce/woocommerce/assets/2207451/429b6429-1448-4e5d-8b1a-711d2eb21442)

