### PR TITLE
Fix Playwright E2E tests documentation as some steps to set up the local environment and run E2E tests were not accurate

### DIFF
--- a/plugins/woocommerce/changelog/fix-e2e-test-docs
+++ b/plugins/woocommerce/changelog/fix-e2e-test-docs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Small documentation change
+
+

--- a/plugins/woocommerce/tests/e2e-pw/README.md
+++ b/plugins/woocommerce/tests/e2e-pw/README.md
@@ -34,24 +34,27 @@ End-to-end tests are powered by Playwright. The test site is spinned up using `w
 
 **Running tests for the first time:**
 
--   `nvm use`
--   `pnpm install`
--   `pnpm run build --filter=woocommerce`
--   `pnpm env:start`
+-   `nvm use` (uses the default node version you have set in NVM)
+-   `pnpm install` (installs dependencies)
+-   `pnpm run build --filter=woocommerce` (builds WooCommerce locally)
+-   `cd plugins/woocommerce` (heads to the WooCommerce plugin folder)
+-   `npx playwright install` (makes sure to use the latest Playwright version)
+-   `pnpm env:start` (starts the local environment)
+-   `pnpm test:e2e-pw` (runs tests in headless mode)
 
 To run the test again, re-create the environment to start with a fresh state:
 
--   `pnpm restart`
--   `pnpm test:e2e-pw`
+-   `pnpm env:restart` (restarts the local environment)
+-   `pnpm test:e2e-pw` (runs tests in headless mode)
 
-Other ways of running tests:
+Other ways of running tests (make sure you are in the `plugins/woocommerce` folder):
 
--   `pnpm env:test` (headless)
--   `cd plugin/woocommerce && USE_WP_ENV=1 pnpm playwright test --config=tests/e2e-pw/playwright.config.js --headed` (headed)
--   `cd plugins/woocommerce && USE_WP_ENV=1 pnpm playwright test --config=tests/e2e-pw/playwright.config.js --debug` (debug)
--   `cd plugins/woocommerce && USE_WP_ENV=1 pnpm playwright test --config=tests/e2e-pw/playwright.config.js ./tests/e2e-pw/tests/activate-and-setup/basic-setup.spec.js` (running a single test)
+-   `pnpm test:e2e-pw` (usual, headless run)
+-   `pnpm test:e2e-pw --headed` (headed -- displaying browser window and test interactions)
+-   `pnpm test:e2e-pw --debug` (runs tests in debug mode)
+-   `pnpm test:e2e-pw ./tests/e2e-pw/tests/activate-and-setup/basic-setup.spec.js` (runs a single test)
 
-To see all options, run `cd plugins/woocommerce && pnpm playwright test --help`
+To see all options, make sure you are in the `plugins/woocommerce` folder and run `pnpm playwright test --help`
 
 ### About the environment
 

--- a/plugins/woocommerce/tests/e2e-pw/README.md
+++ b/plugins/woocommerce/tests/e2e-pw/README.md
@@ -37,8 +37,8 @@ End-to-end tests are powered by Playwright. The test site is spinned up using `w
 -   `nvm use` (uses the default node version you have set in NVM)
 -   `pnpm install` (installs dependencies)
 -   `pnpm run build --filter=woocommerce` (builds WooCommerce locally)
--   `cd plugins/woocommerce` (heads to the WooCommerce plugin folder)
--   `npx playwright install` (makes sure to use the latest Playwright version)
+-   `cd plugins/woocommerce` (changes into the WooCommerce plugin folder)
+-   `npx playwright install` (installs the latest Playwright version)
 -   `pnpm env:start` (starts the local environment)
 -   `pnpm test:e2e-pw` (runs tests in headless mode)
 


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The Playwright E2E tests documentation was not accurate as it exposed obsolete yet working commands for running tests but also it was missing some important steps in the process that were causing confusion to new contributors. This PR aims to solve this by providing some light an accuracy in the steps to be performed to run E2E tests.

Closes [#36867](https://github.com/woocommerce/woocommerce/issues/36867).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Review the changes and check they make sense.
2. Run the steps for `running tests for the first time:
-   `nvm use` (uses the default node version you have set in NVM)
-   `pnpm install` (installs dependencies)
-   `pnpm run build --filter=woocommerce` (builds WooCommerce locally)
-   `cd plugins/woocommerce` (heads to the WooCommerce plugin folder)
-   `npx playwright install` (makes sure to use the latest Playwright version)
-   `pnpm env:start` (starts the local environment)
-   `pnpm test:e2e-pw` (runs tests in headless mode)
3. Check the flow worked and you could run tests successfully in headless mode.
4. Try to run the tests again by restarting the environment:
-   `pnpm env:restart` (restarts the local environment)
-   `pnpm test:e2e-pw` (runs tests in headless mode)
5. Check that the `other ways of running tests` work:
-   `pnpm test:e2e-pw` (usual, headless run)
-   `pnpm test:e2e-pw --headed` (headed -- displaying browser window and test interactions)
-   `pnpm test:e2e-pw --debug` (runs tests in debug mode)
-   `pnpm test:e2e-pw ./tests/e2e-pw/tests/activate-and-setup/basic-setup.spec.js` (runs a single test)
