### PR TITLE
[HPOS] Fix regression in supporting nested date query arguments

### DIFF
--- a/plugins/woocommerce/changelog/fix-37732
+++ b/plugins/woocommerce/changelog/fix-37732
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix regression in supporting nested date query arguments in HPOS.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -270,15 +270,6 @@ class OrdersTableQuery {
 				$this->args['meta_query'] = array( $shortcut_meta_query ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 			}
 		}
-
-		// Date query.
-		if ( isset( $this->args['date_query'] ) && is_array( $this->args['date_query'] ) ) {
-			foreach ( $this->args['date_query'] as $index => $query ) {
-				if ( isset( $query['column'] ) && isset( $mapping[ $query['column'] ] ) ) {
-					$this->args['date_query'][ $index ]['column'] = $mapping[ $query['column'] ];
-				}
-			}
-		}
 	}
 
 	/**
@@ -333,29 +324,15 @@ class OrdersTableQuery {
 			'date_paid'      => 'date_paid_gmt',
 			'date_completed' => 'date_completed_gmt',
 		);
-		$gmt_date_keys          = array_values( $local_to_gmt_date_keys );
-		$local_date_keys        = array_keys( $local_to_gmt_date_keys );
+
+		$gmt_date_keys   = array_values( $local_to_gmt_date_keys );
+		$local_date_keys = array_keys( $local_to_gmt_date_keys );
 
 		$valid_date_keys = array_merge( $gmt_date_keys, $local_date_keys );
 		$date_keys       = array_filter( $valid_date_keys, array( $this, 'arg_isset' ) );
 
 		// Process already passed date queries args.
-		if ( $this->arg_isset( 'date_query' ) && is_array( $this->args['date_query'] ) ) {
-			foreach ( $this->args['date_query'] as $index => $query ) {
-				if ( ! isset( $query['column'] ) || ! in_array( $query['column'], $valid_date_keys, true ) ) {
-					unset( $this->args['date_query'][ $index ] );
-					continue;
-				}
-				// Convert any local dates to GMT.
-				if ( isset( $local_to_gmt_date_keys[ $query['column'] ] ) ) {
-					$this->args['date_query'][ $index ]['column'] = $local_to_gmt_date_keys[ $query['column'] ];
-					$op                                        = isset( $query['after'] ) ? 'after' : 'before';
-					$date_value_local                          = $query[ $op ];
-					$date_value_gmt                            = wc_string_to_timestamp( get_gmt_from_date( wc_string_to_datetime( $date_value_local ) ) );
-					$this->args['date_query'][ $index ][ $op ] = $this->date_to_date_query_arg( $date_value_gmt, 'UTC' );
-				}
-			}
-		}
+		$this->args['date_query'] = $this->map_gmt_and_post_keys_to_hpos_keys( $this->args['date_query'] );
 
 		foreach ( $date_keys as $date_key ) {
 			$date_value = $this->args[ $date_key ];
@@ -428,6 +405,63 @@ class OrdersTableQuery {
 		}
 
 		$this->process_date_query_columns();
+	}
+
+	/**
+	 * Helper function to map posts and gmt based keys to HPOS keys.
+	 *
+	 * @param array $query Date query argument.
+	 *
+	 * @return array|mixed Date query argument with modified keys.
+	 */
+	private function map_gmt_and_post_keys_to_hpos_keys( $query ) {
+		if ( ! is_array( $query ) ) {
+			return $query;
+		}
+
+		$post_to_hpos_mappings = array(
+			'post_date'         => 'date_created',
+			'post_date_gmt'     => 'date_created_gmt',
+			'post_modified'     => 'date_updated',
+			'post_modified_gmt' => 'date_updated_gmt',
+			'_date_completed'   => 'date_completed',
+			'_date_paid'        => 'date_paid',
+			'date_modified'     => 'date_updated',
+			'date_modified_gmt' => 'date_updated_gmt',
+		);
+
+		$local_to_gmt_date_keys = array(
+			'date_created'   => 'date_created_gmt',
+			'date_updated'   => 'date_updated_gmt',
+			'date_paid'      => 'date_paid_gmt',
+			'date_completed' => 'date_completed_gmt',
+		);
+
+		array_walk(
+			$query,
+			function ( &$sub_query ) {
+				$sub_query = $this->map_gmt_and_post_keys_to_hpos_keys( $sub_query );
+			}
+		);
+
+		if ( ! isset( $query['column'] ) ) {
+			return $query;
+		}
+
+		if ( isset( $post_to_hpos_mappings[ $query['column'] ] ) ) {
+			$query['column'] = $post_to_hpos_mappings[ $query['column'] ];
+		}
+
+		// Convert any local dates to GMT.
+		if ( isset( $local_to_gmt_date_keys[ $query['column'] ] ) ) {
+			$query['column']  = $local_to_gmt_date_keys[ $query['column'] ];
+			$op               = isset( $query['after'] ) ? 'after' : 'before';
+			$date_value_local = $query[ $op ];
+			$date_value_gmt   = wc_string_to_timestamp( get_gmt_from_date( wc_string_to_datetime( $date_value_local ) ) );
+			$query[ $op ]     = $this->date_to_date_query_arg( $date_value_gmt, 'UTC' );
+		}
+
+		return $query;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -316,6 +316,11 @@ class OrdersTableQuery {
 	 * @throws \Exception When date args are invalid.
 	 */
 	private function process_date_args(): void {
+		if ( $this->arg_isset( 'date_query' ) ) {
+			// Process already passed date queries args.
+			$this->args['date_query'] = $this->map_gmt_and_post_keys_to_hpos_keys( $this->args['date_query'] );
+		}
+
 		$valid_operators        = array( '>', '>=', '=', '<=', '<', '...' );
 		$date_queries           = array();
 		$local_to_gmt_date_keys = array(
@@ -330,9 +335,6 @@ class OrdersTableQuery {
 
 		$valid_date_keys = array_merge( $gmt_date_keys, $local_date_keys );
 		$date_keys       = array_filter( $valid_date_keys, array( $this, 'arg_isset' ) );
-
-		// Process already passed date queries args.
-		$this->args['date_query'] = $this->map_gmt_and_post_keys_to_hpos_keys( $this->args['date_query'] );
 
 		foreach ( $date_keys as $date_key ) {
 			$date_value = $this->args[ $date_key ];

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
@@ -1,0 +1,136 @@
+<?php
+
+use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
+use Automattic\WooCommerce\RestApi\UnitTests\HPOSToggleTrait;
+use Automattic\WooCommerce\Utilities\OrderUtil;
+
+/**
+ * Class OrdersTableQueryTests.
+ */
+class OrdersTableQueryTests extends WC_Unit_Test_Case {
+	use HPOSToggleTrait;
+
+	/**
+	 * Stores the original COT state.
+	 *
+	 * @var bool
+	 */
+	private $cot_state;
+
+	/**
+	 * Setup - enable COT.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->setup_cot();
+		$this->cot_state = OrderUtil::custom_orders_table_usage_is_enabled();
+		$this->toggle_cot( true );
+	}
+
+	/**
+	 * Restore the original COT state.
+	 */
+	public function tearDown(): void {
+		$this->toggle_cot( $this->cot_state );
+		parent::tearDown();
+	}
+
+	/**
+	 * Helper function to create different orders with different dates for testing.
+	 *
+	 * @return array Array of WC_Order objects.
+	 */
+	private function create_orders_with_different_dates() {
+		$order1 = OrderHelper::create_order();
+		$order2 = OrderHelper::create_order();
+		$order3 = OrderHelper::create_order();
+
+		$order1->set_date_created( '2000-01-01T10:00:00' );
+		$order1->set_date_modified( '2001-02-01T10:00:00' );
+		$order1->set_date_paid( '2002-03-01T10:00:00' );
+		$order1->save();
+
+		$order2->set_date_created( '2000-02-01T10:00:00' );
+		$order2->set_date_modified( '2001-01-01T10:00:00' );
+		$order2->set_date_paid( '2002-03-01T10:00:00' );
+		$order2->save();
+
+		$order3->set_date_created( '2001-01-01T10:00:00' );
+		$order3->set_date_modified( '2001-02-01T10:00:00' );
+		$order3->set_date_paid( '2002-03-01T10:00:00' );
+		$order3->save();
+
+		return array( $order1, $order2, $order3 );
+	}
+
+	/**
+	 * @testDox Nested date queries works as expected.
+	 */
+	public function test_nested_date_queries_single() {
+		$orders = $this->create_orders_with_different_dates();
+
+		$date_query_created_in_2000 = array(
+			array(
+				'relation' => 'AND',
+				array(
+					'column'    => 'date_created',
+					'inclusive' => true,
+					'after'     => '2000-01-01T00:00:00',
+				),
+				array(
+					'column'    => 'date_created',
+					'inclusive' => false,
+					'before'    => '2001-01-01T10:00:00',
+				),
+			),
+		);
+
+		$queried_orders = wc_get_orders(
+			array(
+				'return'     => 'ids',
+				'date_query' => $date_query_created_in_2000,
+			)
+		);
+
+		$this->assertEquals( 2, count( $queried_orders ) );
+		$this->assertContains( $orders[0]->get_id(), $queried_orders );
+		$this->assertContains( $orders[1]->get_id(), $queried_orders );
+	}
+
+	/**
+	 * @testDox Multiple nested date queries works as expected.
+	 */
+	public function test_nested_date_queries_multi() {
+		$orders = $this->create_orders_with_different_dates();
+
+		$date_query_created_in_2000_and_modified_in_2001 = array(
+			array(
+				'relation' => 'AND',
+				array(
+					'column'    => 'date_created',
+					'inclusive' => true,
+					'after'     => '2000-01-01T00:00:00',
+				),
+				array(
+					'column'    => 'post_date',
+					'inclusive' => false,
+					'before'    => '2001-01-01T10:00:00',
+				),
+			),
+			array(
+				'column' => 'date_modified',
+				'before' => '2001-01-02T10:00:00',
+			),
+		);
+
+		$queried_orders = wc_get_orders(
+			array(
+				'return'     => 'ids',
+				'date_query' => $date_query_created_in_2000_and_modified_in_2001,
+			)
+		);
+
+		$this->assertEquals( 1, count( $queried_orders ) );
+		$this->assertContains( $orders[1]->get_id(), $queried_orders );
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In #36910 when fixing a unit test when in the context of HPOS, we, unfortunately, ended up breaking support for nested date queries as described in #37732. This PR fixes the regression, by mapping all the params in post format to HPOS format recursively instead of just doing it for the outermost array.

Closes #37732.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

For this unit tests should be good enough, however, for smoke testing

1. Create two orders, with different date_created. You can also modify date_created of individual order by going to WooCommerce > Order > Order edit page. Let's set the date of two different orders in gap of one day. Let's say for order1, created at date is set to 2023-04-13:01-01 and for order2 it's set to 2023-04-02:01-01.
2. On a shell run a nested query that gets order created in first week of April, and also modified after first week of April (basically, we will get order2 but it will exclude order1 since while both are modified after first week of April, only order2 was created in the first week) like so:

```php
$created_before_7_april = [ 'column' => 'post_date', 'before' => '2023-04-07' ];
$created_after_1_april = [ 'column' => 'post_date', 'after' => '2023-04-01' ];
$between_1_and_7_april = [ 'relation' => 'AND', $created_after_1_april, $created_before_7_april ];

$modifed_after_7_april = [ 'column' => 'post_modified', 'after' => '2023-04-07' ];

$date_query = [ $between_1_and_7_april, $modifed_after_7_april ];

$ids = wc_get_orders( array( 'return' => 'ids', 'limit' => -1, 'date_query' => $date_query ) ); // this should include id for order2
```

<!-- End testing instructions -->