### PR TITLE
Enhancement: Add order note to display held stock inventory. #29132

### DIFF
--- a/plugins/woocommerce/changelog/enhancement-add-held-stock-note
+++ b/plugins/woocommerce/changelog/enhancement-add-held-stock-note
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add order note to display held stock inventory to provide more visibility to merchants.

--- a/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
+++ b/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
@@ -130,7 +130,7 @@ final class ReserveStock {
 
 		// Add order note after successfully holding the stock.
 		if ( ! empty( $rows ) ) {
-			$order->add_order_note( sprintf( __( 'Products stock held for %s minutes:', 'woocommerce' ), $minutes ) . ' ' . implode( ', ', $order_notes ) );
+			$order->add_order_note( sprintf( __( 'Stock is held for %s minutes for payment:', 'woocommerce' ), $minutes ) . ' ' . implode( ', ', $order_notes ) );
 		}
 	}
 

--- a/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
+++ b/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
@@ -130,6 +130,7 @@ final class ReserveStock {
 
 		// Add order note after successfully holding the stock.
 		if ( ! empty( $held_stock_notes ) ) {
+			// translators: %s is a time in minutes
 			$order->add_order_note( sprintf( __( 'Stock is held for %s minutes for payment:', 'woocommerce' ), $minutes ) . ' ' . implode( ', ', $order_notes ) );
 		}
 	}

--- a/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
+++ b/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
@@ -131,7 +131,7 @@ final class ReserveStock {
 		// Add order note after successfully holding the stock.
 		if ( ! empty( $held_stock_notes ) ) {
 			// translators: %s is a time in minutes
-			$order->add_order_note( sprintf( __( 'Stock is held for %s minutes for payment:', 'woocommerce' ), $minutes ) . ' ' . implode( ', ', $order_notes ) );
+			$order->add_order_note( sprintf( __( 'Stock is held for %s minutes for payment:', 'woocommerce' ), $minutes ) . ' ' . implode( ', ', $held_stock_notes ) );
 		}
 	}
 

--- a/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
+++ b/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
@@ -73,7 +73,6 @@ final class ReserveStock {
 		}
 
 		$held_stock_notes   = array();
-		$held_stock_counter = 0;
 
 		try {
 			$items = array_filter(
@@ -117,9 +116,8 @@ final class ReserveStock {
 
 				$rows[ $managed_by_id ] = isset( $rows[ $managed_by_id ] ) ? $rows[ $managed_by_id ] + $item_quantity : $item_quantity;
 
-				if ( $held_stock_counter < 5 ) {
 					$held_stock_notes[] = $product->get_formatted_name() . ' x ' . $rows[ $managed_by_id ];
-					$held_stock_counter++;
+				if ( count( $held_stock_notes ) < 5 ) {
 				}
 			}
 
@@ -138,9 +136,9 @@ final class ReserveStock {
 
 			$note_suffix   = '';
 			// Add suffix if there are more than 5 items.
-			if ( count( $items ) > $held_stock_counter ) {
-				$remaining_count = count( $items ) - $held_stock_counter;
 
+			$remaining_count = count( $rows ) - count( $held_stock_notes );
+			if ( $remaining_count > 0 ) {
 				// translators: %d is the remaining order items count.
 				$note_suffix     = '<br>- ' . sprintf( __( '... and %d more items.', 'woocommerce' ), $remaining_count );
 			}

--- a/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
+++ b/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
@@ -72,7 +72,7 @@ final class ReserveStock {
 			return;
 		}
 
-		$order_notes = array();
+		$held_stock_notes = array();
 
 		try {
 			$items = array_filter(
@@ -115,7 +115,7 @@ final class ReserveStock {
 				$item_quantity = apply_filters( 'woocommerce_order_item_quantity', $item->get_quantity(), $order, $item );
 
 				$rows[ $managed_by_id ] = isset( $rows[ $managed_by_id ] ) ? $rows[ $managed_by_id ] + $item_quantity : $item_quantity;
-				$order_notes[]          = $product->get_formatted_name() . ' : ' . $rows[ $managed_by_id ];
+				$held_stock_notes[]     = $product->get_formatted_name() . ' : ' . $rows[ $managed_by_id ];
 			}
 
 			if ( ! empty( $rows ) ) {
@@ -129,7 +129,7 @@ final class ReserveStock {
 		}
 
 		// Add order note after successfully holding the stock.
-		if ( ! empty( $rows ) ) {
+		if ( ! empty( $held_stock_notes ) ) {
 			$order->add_order_note( sprintf( __( 'Stock is held for %s minutes for payment:', 'woocommerce' ), $minutes ) . ' ' . implode( ', ', $order_notes ) );
 		}
 	}

--- a/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
+++ b/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
@@ -72,6 +72,8 @@ final class ReserveStock {
 			return;
 		}
 
+		$order_notes = array();
+
 		try {
 			$items = array_filter(
 				$order->get_items(),
@@ -113,6 +115,7 @@ final class ReserveStock {
 				$item_quantity = apply_filters( 'woocommerce_order_item_quantity', $item->get_quantity(), $order, $item );
 
 				$rows[ $managed_by_id ] = isset( $rows[ $managed_by_id ] ) ? $rows[ $managed_by_id ] + $item_quantity : $item_quantity;
+				$order_notes[]          = $product->get_formatted_name() . ' : ' . $rows[ $managed_by_id ];
 			}
 
 			if ( ! empty( $rows ) ) {
@@ -123,6 +126,11 @@ final class ReserveStock {
 		} catch ( ReserveStockException $e ) {
 			$this->release_stock_for_order( $order );
 			throw $e;
+		}
+
+		// Add order note after successfully holding the stock.
+		if ( ! empty( $rows ) ) {
+			$order->add_order_note( sprintf( __( 'Products stock held for %s minutes:', 'woocommerce' ), $minutes ) . ' ' . implode( ', ', $order_notes ) );
 		}
 	}
 

--- a/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
+++ b/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
@@ -115,7 +115,7 @@ final class ReserveStock {
 				$item_quantity = apply_filters( 'woocommerce_order_item_quantity', $item->get_quantity(), $order, $item );
 
 				$rows[ $managed_by_id ] = isset( $rows[ $managed_by_id ] ) ? $rows[ $managed_by_id ] + $item_quantity : $item_quantity;
-				$held_stock_notes[]     = $product->get_formatted_name() . ' : ' . $rows[ $managed_by_id ];
+				$held_stock_notes[]     = $product->get_formatted_name() . ' x ' . $rows[ $managed_by_id ];
 			}
 
 			if ( ! empty( $rows ) ) {
@@ -131,7 +131,7 @@ final class ReserveStock {
 		// Add order note after successfully holding the stock.
 		if ( ! empty( $held_stock_notes ) ) {
 			// translators: %s is a time in minutes
-			$order->add_order_note( sprintf( __( 'Stock is held for %s minutes for payment:', 'woocommerce' ), $minutes ) . ' ' . implode( ', ', $held_stock_notes ) );
+			$order->add_order_note( sprintf( __( 'Stock is held for %s minutes for payment:', 'woocommerce' ), $minutes ) . '<br>- ' . implode( '<br>- ', $held_stock_notes ) );
 		}
 	}
 

--- a/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
+++ b/plugins/woocommerce/src/Checkout/Helpers/ReserveStock.php
@@ -72,7 +72,7 @@ final class ReserveStock {
 			return;
 		}
 
-		$held_stock_notes   = array();
+		$held_stock_notes = array();
 
 		try {
 			$items = array_filter(
@@ -116,8 +116,9 @@ final class ReserveStock {
 
 				$rows[ $managed_by_id ] = isset( $rows[ $managed_by_id ] ) ? $rows[ $managed_by_id ] + $item_quantity : $item_quantity;
 
-					$held_stock_notes[] = $product->get_formatted_name() . ' x ' . $rows[ $managed_by_id ];
 				if ( count( $held_stock_notes ) < 5 ) {
+					// translators: %1$s is a product's formatted name, %2$d: is the quantity of said product to which the stock hold applied.
+					$held_stock_notes[] = sprintf( _x( '- %1$s &times; %2$d', 'held stock note', 'woocommerce' ), $product->get_formatted_name(), $rows[ $managed_by_id ] );
 				}
 			}
 
@@ -133,18 +134,23 @@ final class ReserveStock {
 
 		// Add order note after successfully holding the stock.
 		if ( ! empty( $held_stock_notes ) ) {
-
-			$note_suffix   = '';
-			// Add suffix if there are more than 5 items.
-
 			$remaining_count = count( $rows ) - count( $held_stock_notes );
 			if ( $remaining_count > 0 ) {
-				// translators: %d is the remaining order items count.
-				$note_suffix     = '<br>- ' . sprintf( __( '... and %d more items.', 'woocommerce' ), $remaining_count );
+				$held_stock_notes[] = sprintf(
+					// translators: %d is the remaining order items count.
+					_nx( '- ...and %d more item.', '- ... and %d more items.', $remaining_count, 'held stock note', 'woocommerce' ),
+					$remaining_count
+				);
 			}
 
-			// translators: %s is a time in minutes
-			$order->add_order_note( sprintf( __( 'Stock hold of %s minutes applied to:', 'woocommerce' ), $minutes ) . '<br>- ' . implode( '<br>- ', $held_stock_notes ) . $note_suffix );
+			$order->add_order_note(
+				sprintf(
+					// translators: %1$s is a time in minutes, %2$s is a list of products and quantities.
+					_x( 'Stock hold of %1$s minutes applied to: %2$s', 'held stock note', 'woocommerce' ),
+					$minutes,
+					'<br>' . implode( '<br>', $held_stock_notes )
+				)
+			);
 		}
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #29132 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new order without completing the payment process or with "Direct bank transfer" payment method.
2. Check the order notes.
3.  <img width="303" alt="image" src="https://user-images.githubusercontent.com/19236737/233079743-dde7eb44-60fc-477f-a0e8-64dfe16cb6b1.png">



<!-- End testing instructions -->