### PR TITLE
fix/28214 Backorders have a wrong availability on application/ld+json

### DIFF
--- a/plugins/woocommerce/changelog/fix-28214
+++ b/plugins/woocommerce/changelog/fix-28214
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix stock status is not correct in JSON structure data if product is onbackorder

--- a/plugins/woocommerce/includes/class-wc-structured-data.php
+++ b/plugins/woocommerce/includes/class-wc-structured-data.php
@@ -257,9 +257,25 @@ class WC_Structured_Data {
 				);
 			}
 
+            $stock_status = $product->get_stock_status();
+
+            switch ( $stock_status ) {
+                case "instock":
+                    $stock_status_schema = "InStock";
+                    break;
+                case "outofstock":
+                    $stock_status_schema = "OutOfStock";
+                    break;
+                case "onbackorder":
+                    $stock_status_schema = "BackOrder";
+                    break;
+                default:
+                    $stock_status_schema = "";
+            }
+
 			$markup_offer += array(
 				'priceCurrency' => $currency,
-				'availability'  => 'http://schema.org/' . ( $product->is_in_stock() ? 'InStock' : 'OutOfStock' ),
+				'availability'  => 'http://schema.org/' . $stock_status_schema,
 				'url'           => $permalink,
 				'seller'        => array(
 					'@type' => 'Organization',

--- a/plugins/woocommerce/includes/class-wc-structured-data.php
+++ b/plugins/woocommerce/includes/class-wc-structured-data.php
@@ -257,20 +257,10 @@ class WC_Structured_Data {
 				);
 			}
 
-			$stock_status = $product->get_stock_status();
-
-			switch ( $stock_status ) {
-				case 'instock':
-					$stock_status_schema = 'InStock';
-					break;
-				case 'outofstock':
-                    $stock_status_schema = 'OutOfStock';
-					break;
-				case "onbackorder":
-                    $stock_status_schema = 'BackOrder';
-					break;
-				default:
-                    $stock_status_schema = '';
+			if ( $product->is_in_stock() ) {
+				$stock_status_schema = ( 'onbackorder' === $product->get_stock_status() ) ? 'BackOrder' : 'InStock';
+			} else {
+				$stock_status_schema = 'OutOfStock';
 			}
 
 			$markup_offer += array(

--- a/plugins/woocommerce/includes/class-wc-structured-data.php
+++ b/plugins/woocommerce/includes/class-wc-structured-data.php
@@ -257,21 +257,21 @@ class WC_Structured_Data {
 				);
 			}
 
-            $stock_status = $product->get_stock_status();
+			$stock_status = $product->get_stock_status();
 
-            switch ( $stock_status ) {
-                case "instock":
-                    $stock_status_schema = "InStock";
-                    break;
-                case "outofstock":
-                    $stock_status_schema = "OutOfStock";
-                    break;
-                case "onbackorder":
-                    $stock_status_schema = "BackOrder";
-                    break;
-                default:
-                    $stock_status_schema = "";
-            }
+			switch ( $stock_status ) {
+				case 'instock':
+					$stock_status_schema = 'InStock';
+					break;
+				case 'outofstock':
+                    $stock_status_schema = 'OutOfStock';
+					break;
+				case "onbackorder":
+                    $stock_status_schema = 'BackOrder';
+					break;
+				default:
+                    $stock_status_schema = '';
+			}
 
 			$markup_offer += array(
 				'priceCurrency' => $currency,


### PR DESCRIPTION
Closes #28214.

Testing instruction: 
- Create some products with different stock status, we have 3 status now (instock, outofstock, onbackorder), so 3 products is minimum
- You can set stock status for those products at Inventory tab in product admin page as below

![image](https://user-images.githubusercontent.com/34084070/233119407-d0eccb0b-33d9-4c3c-90c4-cca01b58a3e6.png)

- Visit each product's page and view page source, then find the availability attribute in LD+JSON schema
- Make sure this value is correct with product's stock status:
      onbackorder = BackOrder
      instock = InStock
      outofstock = OutOfStock
<img width="993" alt="image" src="https://user-images.githubusercontent.com/34084070/233122286-d869fbbc-6073-4fda-862c-7966f73dc282.png">

