### PR TITLE
Add pattern for thousand and decimal separator in Woo settings

### DIFF
--- a/changelog/pr-34373
+++ b/changelog/pr-34373
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Incorporate pattern for thousand and decimal separator to restrict input to only special characters as valid values.

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-general.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-general.php
@@ -260,7 +260,7 @@ class WC_Settings_General extends WC_Settings_Page {
 					'type'     => 'text',
 					'desc_tip' => true,
 					'custom_attributes' => array(
-						'pattern'  => '[,.]{1}',
+						'pattern'  => '^[^a-zA-Z0-9]*([ ]|[^a-zA-Z0-9])[^a-zA-Z0-9]*$',
 					),
 				),
 
@@ -273,7 +273,7 @@ class WC_Settings_General extends WC_Settings_Page {
 					'type'     => 'text',
 					'desc_tip' => true,
 					'custom_attributes' => array(
-						'pattern'  => '[,.]{1}',
+						'pattern'  => '^[^a-zA-Z0-9]*([ ]|[^a-zA-Z0-9])[^a-zA-Z0-9]*$',
 					),
 				),
 

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-general.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-general.php
@@ -259,6 +259,9 @@ class WC_Settings_General extends WC_Settings_Page {
 					'default'  => ',',
 					'type'     => 'text',
 					'desc_tip' => true,
+					'custom_attributes' => array(
+						'pattern'  => '[,.]{1}',
+					),
 				),
 
 				array(
@@ -269,6 +272,9 @@ class WC_Settings_General extends WC_Settings_Page {
 					'default'  => '.',
 					'type'     => 'text',
 					'desc_tip' => true,
+					'custom_attributes' => array(
+						'pattern'  => '[,.]{1}',
+					),
 				),
 
 				array(

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-general.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-general.php
@@ -260,7 +260,7 @@ class WC_Settings_General extends WC_Settings_Page {
 					'type'     => 'text',
 					'desc_tip' => true,
 					'custom_attributes' => array(
-						'pattern'  => '^[^a-zA-Z0-9]*([ ]|[^a-zA-Z0-9])[^a-zA-Z0-9]*$',
+						'pattern'  => '[^a-zA-Z\d]{1}',
 					),
 				),
 
@@ -273,7 +273,7 @@ class WC_Settings_General extends WC_Settings_Page {
 					'type'     => 'text',
 					'desc_tip' => true,
 					'custom_attributes' => array(
-						'pattern'  => '^[^a-zA-Z0-9]*([ ]|[^a-zA-Z0-9])[^a-zA-Z0-9]*$',
+						'pattern'  => '[^a-zA-Z\d]{1}',
 					),
 				),
 


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.


### Changes proposed in this Pull Request:

fix: Incorporate pattern for thousand and decimal separator to restrict input to only comma and period as valid values.

This fix is related to:  https://github.com/woocommerce/woocommerce/issues/34373

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. In the new site go to WooCommerce > Settings > General
2. Try to change Thousand separator or Decimal separator to something else then comma (,) or period (.)
3. You should get validation message saying **Please match the format requested.**

<!-- End testing instructions -->
