### PR TITLE
Fix/ Decrease product total_sales when an order is reversed #23796

### DIFF
--- a/plugins/woocommerce/changelog/fix-issue-23796
+++ b/plugins/woocommerce/changelog/fix-issue-23796
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Decrease product total sales when an order is reversed

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -879,6 +879,10 @@ function wc_update_total_sales_counts( $order_id ) {
 	$recorded_sales  = $order->get_data_store()->get_recorded_sales( $order );
 	$reflected_order = in_array( $order->get_status(), array( 'cancelled', 'refunded' ) );
 
+	if ( ! $reflected_order && 'before_delete_post' === current_action() ) {
+		$reflected_order = true;
+	}
+
 	if ( $recorded_sales && ! $reflected_order ) {
 		return;
 	}
@@ -915,6 +919,7 @@ add_action( 'woocommerce_order_status_on-hold', 'wc_update_total_sales_counts' )
 add_action( 'woocommerce_order_status_completed_to_cancelled', 'wc_update_total_sales_counts' );
 add_action( 'woocommerce_order_status_processing_to_cancelled', 'wc_update_total_sales_counts' );
 add_action( 'woocommerce_order_status_on-hold_to_cancelled', 'wc_update_total_sales_counts' );
+add_action( 'before_delete_post', 'wc_update_total_sales_counts' );
 
 /**
  * Update used coupon amount for each coupon within an order.

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -877,7 +877,7 @@ function wc_update_total_sales_counts( $order_id ) {
 	}
 
 	$recorded_sales  = $order->get_data_store()->get_recorded_sales( $order );
-	$reflected_order = in_array( $order->get_status(), array( 'cancelled', 'refunded' ) );
+	$reflected_order = in_array( $order->get_status(), array( 'cancelled', 'trash' ) );
 
 	if ( ! $reflected_order && 'before_delete_post' === current_action() ) {
 		$reflected_order = true;
@@ -919,6 +919,10 @@ add_action( 'woocommerce_order_status_on-hold', 'wc_update_total_sales_counts' )
 add_action( 'woocommerce_order_status_completed_to_cancelled', 'wc_update_total_sales_counts' );
 add_action( 'woocommerce_order_status_processing_to_cancelled', 'wc_update_total_sales_counts' );
 add_action( 'woocommerce_order_status_on-hold_to_cancelled', 'wc_update_total_sales_counts' );
+add_action( 'trashed_post', 'wc_update_total_sales_counts' );
+add_action( 'untrashed_post', 'wc_update_total_sales_counts' );
+add_action( 'woocommerce_trash_order', 'wc_update_total_sales_counts' );
+add_action( 'woocommerce_untrash_order', 'wc_update_total_sales_counts' );
 add_action( 'before_delete_post', 'wc_update_total_sales_counts' );
 
 /**

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -883,7 +883,7 @@ function wc_update_total_sales_counts( $order_id ) {
 		$reflected_order = true;
 	}
 
-	if ( $recorded_sales && ! $reflected_order ) {
+	if ( $recorded_sales xor $reflected_order ) {
 		return;
 	}
 

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -877,7 +877,7 @@ function wc_update_total_sales_counts( $order_id ) {
 	}
 
 	$recorded_sales  = $order->get_data_store()->get_recorded_sales( $order );
-	$reflected_order = in_array( $order->get_status(), array( 'cancelled', 'trash' ) );
+	$reflected_order = in_array( $order->get_status(), array( 'cancelled', 'trash' ), true );
 
 	if ( ! $reflected_order && 'before_delete_post' === current_action() ) {
 		$reflected_order = true;

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -913,11 +913,8 @@ add_action( 'woocommerce_order_status_completed', 'wc_update_total_sales_counts'
 add_action( 'woocommerce_order_status_processing', 'wc_update_total_sales_counts' );
 add_action( 'woocommerce_order_status_on-hold', 'wc_update_total_sales_counts' );
 add_action( 'woocommerce_order_status_completed_to_cancelled', 'wc_update_total_sales_counts' );
-add_action( 'woocommerce_order_status_completed_to_refunded', 'wc_update_total_sales_counts' );
 add_action( 'woocommerce_order_status_processing_to_cancelled', 'wc_update_total_sales_counts' );
-add_action( 'woocommerce_order_status_processing_to_refunded', 'wc_update_total_sales_counts' );
 add_action( 'woocommerce_order_status_on-hold_to_cancelled', 'wc_update_total_sales_counts' );
-add_action( 'woocommerce_order_status_on-hold_to_refunded', 'wc_update_total_sales_counts' );
 
 /**
  * Update used coupon amount for each coupon within an order.

--- a/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
@@ -97,6 +97,15 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 		$order->update_status( 'processing' );
 		$this->assertEquals( 1, $product->get_total_sales() );
 
+		// Test order trash / un-trash.
+		if ( $order->delete( false ) ) {
+			$this->assertEquals( 0, $product->get_total_sales() );
+
+			wp_untrash_post( $order->get_id() );
+			$this->assertEquals( 1, $product->get_total_sales() );
+		}
+
+		// Test force delete.
 		if ( $order->delete( true ) ) {
 			$this->assertEquals( 0, $product->get_total_sales() );
 		}

--- a/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
@@ -64,9 +64,9 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 	 */
 	public function test_wc_update_total_sales_counts() {
 
-		$product = WC_Helper_Product::create_simple_product();
+		$product_id = WC_Helper_Product::create_simple_product()->get_id();
 
-		WC()->cart->add_to_cart( $product->get_id() );
+		WC()->cart->add_to_cart( $product_id );
 
 		$order_id = WC_Checkout::instance()->create_order(
 			array(
@@ -75,40 +75,39 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 			)
 		);
 
-		$this->assertEquals( 0, $product->get_total_sales() );
+		$this->assertEquals( 0, wc_get_product( $product_id )->get_total_sales() );
 
 		$order = new WC_Order( $order_id );
 
 		$order->update_status( 'processing' );
-		$this->assertEquals( 1, $product->get_total_sales() );
+		$this->assertEquals( 1, wc_get_product( $product_id )->get_total_sales() );
 
 		$order->update_status( 'cancelled' );
-		$this->assertEquals( 0, $product->get_total_sales() );
+		$this->assertEquals( 0, wc_get_product( $product_id )->get_total_sales() );
 
 		$order->update_status( 'processing' );
-		$this->assertEquals( 1, $product->get_total_sales() );
+		$this->assertEquals( 1, wc_get_product( $product_id )->get_total_sales() );
 
 		$order->update_status( 'completed' );
-		$this->assertEquals( 1, $product->get_total_sales() );
+		$this->assertEquals( 1, wc_get_product( $product_id )->get_total_sales() );
 
 		$order->update_status( 'refunded' );
-		$this->assertEquals( 1, $product->get_total_sales() );
+		$this->assertEquals( 1, wc_get_product( $product_id )->get_total_sales() );
 
 		$order->update_status( 'processing' );
-		$this->assertEquals( 1, $product->get_total_sales() );
+		$this->assertEquals( 1, wc_get_product( $product_id )->get_total_sales() );
 
-		// Test order trash / un-trash.
-		if ( $order->delete( false ) ) {
-			$this->assertEquals( 0, $product->get_total_sales() );
+		// Test trashing the order.
+		$order->delete( false );
+		$this->assertEquals( 0, wc_get_product( $product_id )->get_total_sales() );
 
-			$order->untrash();
-			$this->assertEquals( 1, $product->get_total_sales() );
-		}
+		// To successfully untrash, we need to grab a new instance of the order.
+		wc_get_order( $order_id )->untrash();
+		$this->assertEquals( 1, wc_get_product( $product_id )->get_total_sales() );
 
-		// Test force delete.
-		if ( $order->delete( true ) ) {
-			$this->assertEquals( 0, $product->get_total_sales() );
-		}
+		// Test full deletion of the order (again, we need to grab a new instance of the order).
+		wc_get_order( $order_id )->delete( true );
+		$this->assertEquals( 0, wc_get_product( $product_id )->get_total_sales() );
 	}
 
 }

--- a/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
@@ -91,6 +91,12 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 		$order->update_status( 'completed' );
 		$this->assertEquals( 1, $product->get_total_sales() );
 
+		$order->update_status( 'refunded' );
+		$this->assertEquals( 1, $product->get_total_sales() );
+
+		$order->update_status( 'processing' );
+		$this->assertEquals( 1, $product->get_total_sales() );
+
 		if ( $order->delete( true ) ) {
 			$this->assertEquals( 0, $product->get_total_sales() );
 		}

--- a/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-order-functions-test.php
@@ -101,7 +101,7 @@ class WC_Order_Functions_Test extends \WC_Unit_Test_Case {
 		if ( $order->delete( false ) ) {
 			$this->assertEquals( 0, $product->get_total_sales() );
 
-			wp_untrash_post( $order->get_id() );
+			$order->untrash();
 			$this->assertEquals( 1, $product->get_total_sales() );
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #23796 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new order. Select a product as the line item, quantity one.
2. Check the `total_sales` product meta (either via the product editor, or directly using a database tool of your choosing), which may look something like:

<div align="center"><img width="400" alt="image" src="https://user-images.githubusercontent.com/19236737/233107048-c7b5c982-ac85-4b66-a1dd-7efea8cdfe32.png"></div>

3. Cancel the order, and the meta value should change to be one less (because, if the order was cancelled, the sale effectively did not take place).

<div align="center"><img width="400" alt="image" src="https://user-images.githubusercontent.com/19236737/233107304-5032ee0f-338b-42bc-a8b5-3f9c3967d1c3.png"></div>

4. Restore to a completed status, and note that the meta value should have been adjusted upwards by one unit.
5. Now mark the order as refunded. This time, the meta value should not change (refunds can happen for various reasons, and does not mean the sale did not take place).
6. Trash the order. This is akin to stating the order was a mistake/should not have taken place so, in this case, we should see the total sales value being decremented by one.
7. Restore the order. Total sales should increment by one.



<!-- End testing instructions -->