### PR TITLE
Fix deprecation - Changed position prop to popoverProps.placement

### DIFF
--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -268,7 +268,6 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 				'woocommerce-date-time-picker-control',
 				className
 			) }
-			position="bottom left"
 			focusOnMount={ false }
 			// @ts-expect-error `onToggle` does exist.
 			onToggle={ callOnBlurIfDropdownIsNotOpening }
@@ -326,6 +325,7 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
 			) }
 			popoverProps={ {
 				className: 'woocommerce-date-time-picker-control__popover',
+				placement: 'bottom left',
 			} }
 			renderContent={ () => {
 				const Picker = isDateOnlyPicker ? DatePicker : WpDateTimePicker;


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Updated position prop after deprecation in WordPress 6.2.

Closes #37784.

### How to test the changes in this Pull Request:

1. Access **Woocommerce > Home** 
2. There should be no deprecation notice.