### PR TITLE
Do not call login if user is already logged in

### DIFF
--- a/plugins/woocommerce/changelog/fix-34127
+++ b/plugins/woocommerce/changelog/fix-34127
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent login call if the user is already logged in.

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -961,8 +961,12 @@ class WC_Form_Handler {
 					}
 				}
 
-				// Perform the login.
-				$user = wp_signon( apply_filters( 'woocommerce_login_credentials', $creds ), is_ssl() );
+				// Perform the login if the user is not already logged in.
+				if ( is_user_logged_in() ) {
+					$user = wp_get_current_user();
+				} else {
+					$user = wp_signon( apply_filters( 'woocommerce_login_credentials', $creds ), is_ssl() );
+				}
 
 				if ( is_wp_error( $user ) ) {
 					throw new Exception( $user->get_error_message() );

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -961,12 +961,8 @@ class WC_Form_Handler {
 					}
 				}
 
-				// Perform the login if the user is not already logged in.
-				if ( is_user_logged_in() ) {
-					$user = wp_get_current_user();
-				} else {
-					$user = wp_signon( apply_filters( 'woocommerce_login_credentials', $creds ), is_ssl() );
-				}
+				// Peform the login.
+				$user = wp_signon( apply_filters( 'woocommerce_login_credentials', $creds ), is_ssl() );
 
 				if ( is_wp_error( $user ) ) {
 					throw new Exception( $user->get_error_message() );

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -976,7 +976,9 @@ class WC_Form_Handler {
 						$redirect = wc_get_page_permalink( 'myaccount' );
 					}
 
-					wp_redirect( wp_validate_redirect( apply_filters( 'woocommerce_login_redirect', remove_query_arg( 'wc_error', $redirect ), $user ), wc_get_page_permalink( 'myaccount' ) ) ); // phpcs:ignore
+					$redirect = remove_query_arg( array( 'wc_error', 'password-reset' ), $redirect );
+
+					wp_redirect( wp_validate_redirect( apply_filters( 'woocommerce_login_redirect', $redirect, $user ), wc_get_page_permalink( 'myaccount' ) ) ); // phpcs:ignore
 					exit;
 				}
 			} catch ( Exception $e ) {

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -929,10 +929,17 @@ class WC_Form_Handler {
 	 * @throws Exception On login error.
 	 */
 	public static function process_login() {
+
+		static $valid_nonce;
+
 		// The global form-login.php template used `_wpnonce` in template versions < 3.3.0.
 		$nonce_value = wc_get_var( $_REQUEST['woocommerce-login-nonce'], wc_get_var( $_REQUEST['_wpnonce'], '' ) ); // @codingStandardsIgnoreLine.
 
-		if ( isset( $_POST['login'], $_POST['username'], $_POST['password'] ) && wp_verify_nonce( $nonce_value, 'woocommerce-login' ) ) {
+		if ( ! empty( $nonce_value ) ) {
+			$valid_nonce = wp_verify_nonce( $nonce_value, 'woocommerce-login' );
+		}
+
+		if ( isset( $_POST['login'], $_POST['username'], $_POST['password'] ) && $valid_nonce ) {
 
 			try {
 				$creds = array(

--- a/plugins/woocommerce/includes/class-wc-form-handler.php
+++ b/plugins/woocommerce/includes/class-wc-form-handler.php
@@ -930,12 +930,12 @@ class WC_Form_Handler {
 	 */
 	public static function process_login() {
 
-		static $valid_nonce;
+		static $valid_nonce = null;
 
-		// The global form-login.php template used `_wpnonce` in template versions < 3.3.0.
-		$nonce_value = wc_get_var( $_REQUEST['woocommerce-login-nonce'], wc_get_var( $_REQUEST['_wpnonce'], '' ) ); // @codingStandardsIgnoreLine.
+		if ( null === $valid_nonce ) {
+			// The global form-login.php template used `_wpnonce` in template versions < 3.3.0.
+			$nonce_value = wc_get_var( $_REQUEST['woocommerce-login-nonce'], wc_get_var( $_REQUEST['_wpnonce'], '' ) ); // @codingStandardsIgnoreLine.
 
-		if ( ! empty( $nonce_value ) ) {
 			$valid_nonce = wp_verify_nonce( $nonce_value, 'woocommerce-login' );
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Prevent to call to login function if the user is already logged in.

Closes #34127.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. New user is created during checkout.
2. User gets a link in email to set their password.
3. User follows link and sets new password.
4. User is taken to the login page with message “Your password has been reset successfully.”
5. User enters email and password, clicks “Login”. The login operation should be successful at the first try.