### PR TITLE
Add the product description block and callbacks for the IframeEditor

### DIFF
--- a/packages/js/product-editor/changelog/add-37771
+++ b/packages/js/product-editor/changelog/add-37771
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add the product description block

--- a/packages/js/product-editor/src/blocks/description/block.json
+++ b/packages/js/product-editor/src/blocks/description/block.json
@@ -1,0 +1,26 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "woocommerce/product-description",
+	"title": "Product description",
+	"category": "woocommerce",
+	"description": "The product description.",
+	"keywords": [ "products", "description" ],
+	"textdomain": "default",
+	"attributes": {
+		"__contentEditable": {
+			"type": "string",
+			"__experimentalRole": "content"
+		}
+	},
+	"supports": {
+		"align": false,
+		"html": false,
+		"multiple": true,
+		"reusable": false,
+		"inserter": false,
+		"lock": false,
+		"__experimentalToolbar": false
+	},
+	"editorStyle": "file:./editor.css"
+}

--- a/packages/js/product-editor/src/blocks/description/block.json
+++ b/packages/js/product-editor/src/blocks/description/block.json
@@ -21,6 +21,5 @@
 		"inserter": false,
 		"lock": false,
 		"__experimentalToolbar": false
-	},
-	"editorStyle": "file:./editor.css"
+	}
 }

--- a/packages/js/product-editor/src/blocks/description/block.json
+++ b/packages/js/product-editor/src/blocks/description/block.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
-	"name": "woocommerce/product-description",
+	"name": "woocommerce/product-description-field",
 	"title": "Product description",
 	"category": "woocommerce",
 	"description": "The product description.",

--- a/packages/js/product-editor/src/blocks/description/edit.tsx
+++ b/packages/js/product-editor/src/blocks/description/edit.tsx
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { createElement, useState } from '@wordpress/element';
+import { serialize } from '@wordpress/blocks';
+import { Button } from '@wordpress/components';
+import { useBlockProps } from '@wordpress/block-editor';
+import { useEntityProp } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { IframeEditor } from '../../components/iframe-editor';
+
+/**
+ * Internal dependencies
+ */
+
+export function Edit() {
+	const blockProps = useBlockProps();
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
+	const [ , setDescription ] = useEntityProp< string >(
+		'postType',
+		'product',
+		'description'
+	);
+
+	return (
+		<div { ...blockProps }>
+			<Button
+				variant="secondary"
+				onClick={ () => setIsModalOpen( true ) }
+			>
+				{ __( 'Add description', 'woocommerce' ) }
+			</Button>
+			{ isModalOpen && (
+				<IframeEditor
+					onChange={ ( blocks ) => {
+						const html = serialize( blocks );
+						setDescription( html );
+					} }
+					onClose={ () => setIsModalOpen( false ) }
+				/>
+			) }
+		</div>
+	);
+}

--- a/packages/js/product-editor/src/blocks/description/edit.tsx
+++ b/packages/js/product-editor/src/blocks/description/edit.tsx
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { createElement, useState } from '@wordpress/element';
-import { serialize } from '@wordpress/blocks';
+import { parse, serialize } from '@wordpress/blocks';
 import { Button } from '@wordpress/components';
 import { useBlockProps } from '@wordpress/block-editor';
 import { useEntityProp } from '@wordpress/core-data';
@@ -20,7 +20,7 @@ import { IframeEditor } from '../../components/iframe-editor';
 export function Edit() {
 	const blockProps = useBlockProps();
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
-	const [ , setDescription ] = useEntityProp< string >(
+	const [ description, setDescription ] = useEntityProp< string >(
 		'postType',
 		'product',
 		'description'
@@ -36,6 +36,7 @@ export function Edit() {
 			</Button>
 			{ isModalOpen && (
 				<IframeEditor
+					initialBlocks={ parse( description ) }
 					onChange={ ( blocks ) => {
 						const html = serialize( blocks );
 						setDescription( html );

--- a/packages/js/product-editor/src/blocks/description/edit.tsx
+++ b/packages/js/product-editor/src/blocks/description/edit.tsx
@@ -32,7 +32,9 @@ export function Edit() {
 				variant="secondary"
 				onClick={ () => setIsModalOpen( true ) }
 			>
-				{ __( 'Add description', 'woocommerce' ) }
+				{ description.length
+					? __( 'Edit description', 'woocommerce' )
+					: __( 'Add description', 'woocommerce' ) }
 			</Button>
 			{ isModalOpen && (
 				<IframeEditor

--- a/packages/js/product-editor/src/blocks/description/index.ts
+++ b/packages/js/product-editor/src/blocks/description/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Internal dependencies
+ */
+import initBlock from '../../utils/init-block';
+import metadata from './block.json';
+import { Edit } from './edit';
+
+const { name } = metadata;
+
+export { metadata, name };
+
+export const settings = {
+	example: {},
+	edit: Edit,
+};
+
+export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/js/product-editor/src/blocks/index.ts
+++ b/packages/js/product-editor/src/blocks/index.ts
@@ -2,6 +2,7 @@ export { init as initCategory } from './category';
 export { init as initCheckbox } from './checkbox';
 export { init as initCollapsible } from './collapsible';
 export { init as initConditional } from './conditional';
+export { init as initDescription } from './description';
 export { init as initImages } from './images';
 export { init as initLowStockQty } from './inventory-email';
 export { init as initSku } from './inventory-sku';

--- a/packages/js/product-editor/src/components/iframe-editor/back-button.scss
+++ b/packages/js/product-editor/src/components/iframe-editor/back-button.scss
@@ -1,0 +1,6 @@
+.woocommerce-iframe-editor__back-button {
+    align-self: flex-start;
+    margin-top: $gap;
+    margin-bottom: $gap;
+    color: white;
+}

--- a/packages/js/product-editor/src/components/iframe-editor/back-button.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/back-button.tsx
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { arrowLeft } from '@wordpress/icons';
+import { Button } from '@wordpress/components';
+import { createElement } from '@wordpress/element';
+
+type BackButtonProps = {
+	onClick: () => void;
+};
+
+export function BackButton( { onClick }: BackButtonProps ) {
+	return (
+		<Button
+			className="woocommerce-iframe-editor__back-button"
+			icon={ arrowLeft }
+			onClick={ onClick }
+		>
+			{ __( 'Back', 'woocommerce' ) }
+		</Button>
+	);
+}

--- a/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
@@ -27,18 +27,20 @@ import { EditorCanvas } from './editor-canvas';
 import { ResizableEditor } from './resizable-editor';
 
 type IframeEditorProps = {
+	initialBlocks?: BlockInstance[];
 	onChange: ( blocks: BlockInstance[] ) => void;
 	onClose?: () => void;
 	settings?: Partial< EditorSettings & EditorBlockListSettings > | undefined;
 };
 
 export function IframeEditor( {
+	initialBlocks = [],
 	onChange,
 	onClose,
 	settings,
 }: IframeEditorProps ) {
 	const [ resizeObserver, sizes ] = useResizeObserver();
-	const [ blocks, setBlocks ] = useState< BlockInstance[] >( [] );
+	const [ blocks, setBlocks ] = useState< BlockInstance[] >( initialBlocks );
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore This action exists in the block editor store.
 	const { clearSelectedBlock, updateSettings } =

--- a/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
@@ -22,14 +22,21 @@ import {
 /**
  * Internal dependencies
  */
+import { BackButton } from './back-button';
 import { EditorCanvas } from './editor-canvas';
 import { ResizableEditor } from './resizable-editor';
 
 type IframeEditorProps = {
+	onChange: ( blocks: BlockInstance[] ) => void;
+	onClose?: () => void;
 	settings?: Partial< EditorSettings & EditorBlockListSettings > | undefined;
 };
 
-export function IframeEditor( { settings }: IframeEditorProps ) {
+export function IframeEditor( {
+	onChange,
+	onClose,
+	settings,
+}: IframeEditorProps ) {
 	const [ resizeObserver, sizes ] = useResizeObserver();
 	const [ blocks, setBlocks ] = useState< BlockInstance[] >( [] );
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -57,7 +64,10 @@ export function IframeEditor( { settings }: IframeEditorProps ) {
 				templateLock: false,
 			} }
 			value={ blocks }
-			onChange={ setBlocks }
+			onChange={ ( updatedBlocks: BlockInstance[] ) => {
+				setBlocks( updatedBlocks );
+				onChange( updatedBlocks );
+			} }
 			useSubRegistry={ true }
 		>
 			<BlockTools
@@ -74,6 +84,7 @@ export function IframeEditor( { settings }: IframeEditorProps ) {
 				{ /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */ }
 				{ /* @ts-ignore */ }
 				<BlockEditorKeyboardShortcuts.Register />
+				{ onClose && <BackButton onClick={ onClose } /> }
 				<ResizableEditor
 					enableResizing={ true }
 					// eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
@@ -3,9 +3,13 @@
  */
 import { BlockInstance } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { createElement, useEffect, useState } from '@wordpress/element';
-import { debounce } from 'lodash';
-import { useResizeObserver } from '@wordpress/compose';
+import {
+	createElement,
+	useCallback,
+	useEffect,
+	useState,
+} from '@wordpress/element';
+import { useDebounce, useResizeObserver } from '@wordpress/compose';
 import {
 	BlockEditorProvider,
 	BlockList,
@@ -60,9 +64,14 @@ export function IframeEditor( {
 		updateSettings( productBlockEditorSettings );
 	}, [] );
 
-	const debouncedOnChange = debounce( ( updatedBlocks ) => {
-		onChange( updatedBlocks );
-	}, 200 );
+	const handleChange = useCallback(
+		( updatedBlocks: BlockInstance[] ) => {
+			onChange( updatedBlocks );
+		},
+		[ onChange ]
+	);
+
+	const debouncedOnChange = useDebounce( handleChange, 200 );
 
 	return (
 		<BlockEditorProvider

--- a/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
@@ -4,6 +4,7 @@
 import { BlockInstance } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { createElement, useEffect, useState } from '@wordpress/element';
+import { debounce } from 'lodash';
 import { useResizeObserver } from '@wordpress/compose';
 import {
 	BlockEditorProvider,
@@ -59,6 +60,10 @@ export function IframeEditor( {
 		updateSettings( productBlockEditorSettings );
 	}, [] );
 
+	const debouncedOnChange = debounce( ( updatedBlocks ) => {
+		onChange( updatedBlocks );
+	}, 200 );
+
 	return (
 		<BlockEditorProvider
 			settings={ {
@@ -68,7 +73,7 @@ export function IframeEditor( {
 			value={ blocks }
 			onChange={ ( updatedBlocks: BlockInstance[] ) => {
 				setBlocks( updatedBlocks );
-				onChange( updatedBlocks );
+				debouncedOnChange( updatedBlocks );
 			} }
 			useSubRegistry={ true }
 		>

--- a/packages/js/product-editor/src/components/iframe-editor/style.scss
+++ b/packages/js/product-editor/src/components/iframe-editor/style.scss
@@ -1,2 +1,3 @@
 @import './iframe-editor.scss';
 @import './resize-handle.scss';
+@import './back-button.scss';

--- a/plugins/woocommerce/changelog/add-37771
+++ b/plugins/woocommerce/changelog/add-37771
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add description block to product editor template

--- a/plugins/woocommerce/includes/class-wc-post-types.php
+++ b/plugins/woocommerce/includes/class-wc-post-types.php
@@ -442,7 +442,7 @@ class WC_Post_Types {
 									),
 									array(
 										array(
-											'woocommerce/product-description',
+											'woocommerce/product-description-field',
 										),
 									),
 								),

--- a/plugins/woocommerce/includes/class-wc-post-types.php
+++ b/plugins/woocommerce/includes/class-wc-post-types.php
@@ -434,6 +434,21 @@ class WC_Post_Types {
 								array(
 									'woocommerce/product-section',
 									array(
+										'title'       => __( 'Description', 'woocommerce' ),
+										'description' => __( 'What makes this product unique? What are its most important features? Enrich the product page by adding rich content using blocks.', 'woocommerce' ),
+										'icon'        => array(
+											'src' => '<svg width="14" height="17" viewBox="0 0 14 17" fill="none" xmlns="http://www.w3.org/2000/svg"><line x1="9.91663" y1="16.5" x2="9.91663" y2="1.38889" stroke="#1E1E1E" stroke-width="1.5"/><line x1="5.47217" y1="16.5" x2="5.47217" y2="1.38889" stroke="#1E1E1E" stroke-width="1.5"/><line x1="13.3334" y1="1.25" x2="4.44448" y2="1.25" stroke="#1E1E1E" stroke-width="1.5"/><path d="M4.13889 5.38889V9.46C2.21109 9.10713 0.75 7.41864 0.75 5.38889C0.75 3.35914 2.21109 1.67065 4.13889 1.31778V5.38889Z" fill="#1E1E1E" stroke="#1E1E1E" stroke-width="1.5"/></svg>',
+										),
+									),
+									array(
+										array(
+											'woocommerce/product-description',
+										),
+									),
+								),
+								array(
+									'woocommerce/product-section',
+									array(
 										'title'       => __( 'Images', 'woocommerce' ),
 										'description' => sprintf(
 											/* translators: %1$s: Images guide link opening tag. %2$s: Images guide link closing tag.*/

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
@@ -24,7 +24,7 @@ class BlockRegistry {
 		'woocommerce/product-category-field',
 		'woocommerce/product-checkbox-field',
 		'woocommerce/product-collapsible',
-		'woocommerce/product-description',
+		'woocommerce/product-description-field',
 		'woocommerce/product-images-field',
 		'woocommerce/product-inventory-email-field',
 		'woocommerce/product-sku-field',

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
@@ -24,6 +24,7 @@ class BlockRegistry {
 		'woocommerce/product-category-field',
 		'woocommerce/product-checkbox-field',
 		'woocommerce/product-collapsible',
+		'woocommerce/product-description',
 		'woocommerce/product-images-field',
 		'woocommerce/product-inventory-email-field',
 		'woocommerce/product-sku-field',


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds the product description block and callbacks to the IframeEditor component to allow it to be used in this block.

A follow-up will address the preview for the description content.

<img width="824" alt="Screen Shot 2023-04-19 at 9 55 42 AM" src="https://user-images.githubusercontent.com/10561050/233149219-aa9d88bd-5319-4c53-991d-3621d3ccf105.png">
<img width="737" alt="Screen Shot 2023-04-19 at 9 55 29 AM" src="https://user-images.githubusercontent.com/10561050/233149222-2161a5de-eed2-4e9a-bce4-a11f1ce8d325.png">

Closes #37852 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Navigate to Tools -> WCA Test Helper -> Features and enable the new product blocks editing experience
2. Navigate to Products -> Add new
3. Click on "Add description" under the description
4. Add some content via the blocks editor
5. Click "Back"
6. Make sure the description button now reads "Edit description"
7. Save the product
8. Refresh the page
9. Click "Edit description"
10. Make sure the description has persisted

<!-- End testing instructions -->