### PR TITLE
Change from using a `figure` to using a `div` around the single product image

### DIFF
--- a/plugins/woocommerce/changelog/tweak-37603
+++ b/plugins/woocommerce/changelog/tweak-37603
@@ -1,0 +1,4 @@
+Significance: major
+Type: enhancement
+
+Change from using a figure to using a div around the single product image to improve accessibility

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -285,7 +285,6 @@
 				}
 			}
 
-			figure.woocommerce-product-gallery__wrapper,
 			div.woocommerce-product-gallery__wrapper {
 				margin: 0;
 			}
@@ -300,7 +299,6 @@
 				margin: 0;
 			}
 
-			figure.woocommerce-product-gallery__wrapper,
 			div.woocommerce-product-gallery__wrapper {
 				margin: 0;
 			}

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -285,6 +285,7 @@
 				}
 			}
 
+			figure.woocommerce-product-gallery__wrapper,
 			div.woocommerce-product-gallery__wrapper {
 				margin: 0;
 			}
@@ -299,6 +300,7 @@
 				margin: 0;
 			}
 
+			figure.woocommerce-product-gallery__wrapper,
 			div.woocommerce-product-gallery__wrapper {
 				margin: 0;
 			}

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -285,7 +285,8 @@
 				}
 			}
 
-			figure.woocommerce-product-gallery__wrapper {
+			figure.woocommerce-product-gallery__wrapper,
+			div.woocommerce-product-gallery__wrapper {
 				margin: 0;
 			}
 
@@ -299,7 +300,8 @@
 				margin: 0;
 			}
 
-			figure.woocommerce-product-gallery__wrapper {
+			figure.woocommerce-product-gallery__wrapper,
+			div.woocommerce-product-gallery__wrapper {
 				margin: 0;
 			}
 

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
@@ -298,6 +298,7 @@ $tt2-gray: #f7f7f7;
 				}
 			}
 
+			figure.woocommerce-product-gallery__wrapper,
 			div.woocommerce-product-gallery__wrapper {
 				margin: 0;
 			}
@@ -312,6 +313,7 @@ $tt2-gray: #f7f7f7;
 				margin: 0;
 			}
 
+			figure.woocommerce-product-gallery__wrapper,
 			div.woocommerce-product-gallery__wrapper {
 				margin: 0;
 			}

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
@@ -298,7 +298,8 @@ $tt2-gray: #f7f7f7;
 				}
 			}
 
-			figure.woocommerce-product-gallery__wrapper {
+			figure.woocommerce-product-gallery__wrapper,
+			div.woocommerce-product-gallery__wrapper {
 				margin: 0;
 			}
 
@@ -312,7 +313,8 @@ $tt2-gray: #f7f7f7;
 				margin: 0;
 			}
 
-			figure.woocommerce-product-gallery__wrapper {
+			figure.woocommerce-product-gallery__wrapper,
+			div.woocommerce-product-gallery__wrapper {
 				margin: 0;
 			}
 

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
@@ -298,7 +298,6 @@ $tt2-gray: #f7f7f7;
 				}
 			}
 
-			figure.woocommerce-product-gallery__wrapper,
 			div.woocommerce-product-gallery__wrapper {
 				margin: 0;
 			}
@@ -313,7 +312,6 @@ $tt2-gray: #f7f7f7;
 				margin: 0;
 			}
 
-			figure.woocommerce-product-gallery__wrapper,
 			div.woocommerce-product-gallery__wrapper {
 				margin: 0;
 			}

--- a/plugins/woocommerce/templates/single-product/product-image.php
+++ b/plugins/woocommerce/templates/single-product/product-image.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 3.5.1
+ * @version 7.8.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/single-product/product-image.php
+++ b/plugins/woocommerce/templates/single-product/product-image.php
@@ -37,7 +37,7 @@ $wrapper_classes   = apply_filters(
 );
 ?>
 <div class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $wrapper_classes ) ) ); ?>" data-columns="<?php echo esc_attr( $columns ); ?>" style="opacity: 0; transition: opacity .25s ease-in-out;">
-	<figure class="woocommerce-product-gallery__wrapper">
+	<div class="woocommerce-product-gallery__wrapper">
 		<?php
 		if ( $post_thumbnail_id ) {
 			$html = wc_get_gallery_image_html( $post_thumbnail_id, true );
@@ -51,5 +51,5 @@ $wrapper_classes   = apply_filters(
 
 		do_action( 'woocommerce_product_thumbnails' );
 		?>
-	</figure>
+	</div>
 </div>


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This PR changes the wrapping container around the single product image from using a `figure` tag to using a `div` tag. This is a change to help with accessibility, particularly for screen readers.

In addition to changing the tag, I've adjusted some CSS we have in place that impacts the Twenty Twenty Three and Twenty Twenty Two themes. This CSS was scoped to the `figure` tag so I've changed that scope to the `div` tag. As an alternative, we could change this to being scoped just based on the class and not the tag itself.

I've tested this change on Storefront v4.2.0 as well as Twenty Twenty Three v1.0. I've tested at various breakpoints and as far as I can tell, no styles were impacted as part of this change.

**Note**: I've marked this as a major change because if any existing themes are styling the `figure` tag directly instead of the class, those styles will no longer be applied. Not sure if that counts as a breaking change though.

Closes #37603

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new product and add an image to that product (or use an existing product with an image)
2. Go to the single product page for that product
3. Ensure the image shows correctly and styling matches expectations
4. Check the image at various breakpoints to ensure it all looks correct

In my testing, I had two windows open where I loaded a product without the changes in this PR and another window with the same product but after the changes made here. This allowed me to compare these two side-by-side to ensure they matched.

### Screenshots

| With `figure` tag using Storefront | With `div` tag using Storefront |
| :-: | :-: |
| <img width="711" alt="with-figure-tag-storefront" src="https://user-images.githubusercontent.com/916738/233147011-826ec376-012c-4d2f-bfad-c55c61ca8e87.png"> |  <img width="764" alt="with-div-tag-storefront" src="https://user-images.githubusercontent.com/916738/233147083-4dbe09d3-f64d-4cea-9e36-68c50a3f7b52.png"> |

| With `figure` tag using Twenty Twenty Three | With `div` tag using Twenty Twenty Three |
| :-: | :-: |
| <img width="888" alt="with-figure-twentytwentythree" src="https://user-images.githubusercontent.com/916738/233147203-7e92c71f-acdc-4646-a705-b51f0b1d0b6b.png"> |  <img width="893" alt="with-div-twentytwentythree" src="https://user-images.githubusercontent.com/916738/233147265-e830cf6b-d1c5-4fe8-acbf-065d88e2cbbb.png"> |