### PR TITLE
use of page.fill() in variable product e2e tests

### DIFF
--- a/plugins/woocommerce/changelog/tweak-37458
+++ b/plugins/woocommerce/changelog/tweak-37458
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Use locator.fill to fill variation values in the form instead of page.fill

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
@@ -232,7 +232,9 @@ test.describe( 'Add New Variable Product Page', () => {
 		await test.step(
 			`Type "${ variableProductName }" into the "Product name" input field.`,
 			async () => {
-				await page.fill( '#title', variableProductName );
+				await page
+					.getByLabel( 'Product name' )
+					.fill( variableProductName );
 			}
 		);
 
@@ -715,7 +717,7 @@ test.describe( 'Add New Variable Product Page', () => {
 		page,
 	} ) => {
 		await page.goto( productPageURL );
-		await page.fill( '#title', manualVariableProduct );
+		await page.getByLabel( 'Product name' ).fill( manualVariableProduct );
 		await page.selectOption( '#product-type', 'variable' );
 
 		await page
@@ -808,15 +810,22 @@ test.describe( 'Add New Variable Product Page', () => {
 			'#variable_product_options .toolbar-top a.expand_all'
 		);
 		await page.check( 'input.checkbox.variable_manage_stock' );
-		await page.fill( 'input#variable_regular_price_0', variationOnePrice );
+
+		const firstVariationContainerLocator = await page
+			.locator('.woocommerce_variations  .woocommerce_variation')
+			.first();
+
+		await firstVariationContainerLocator
+			.getByPlaceholder( 'Variation price (required)' )
+			.fill( variationOnePrice );
 		await expect(
 			page.locator( 'p.variable_stock_status' )
 		).not.toBeVisible();
-		await page.fill( 'input#variable_stock0', stockAmount );
+		await firstVariationContainerLocator.getByLabel( 'Stock quantity' ).fill( stockAmount );
 		await page.selectOption( '#variable_backorders0', 'notify', {
 			force: true,
 		} );
-		await page.fill( 'input#variable_low_stock_amount0', lowStockAmount );
+		await firstVariationContainerLocator.getByPlaceholder( 'Store-wide threshold (2)' ).fill( lowStockAmount );
 		await page.click( 'button.save-variation-changes' );
 		await page.click(
 			'#variable_product_options .toolbar-top a.expand_all'

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
@@ -811,23 +811,23 @@ test.describe( 'Add New Variable Product Page', () => {
 		);
 		await page.check( 'input.checkbox.variable_manage_stock' );
 
-		const firstVariationContainerLocator = await page
+		const firstVariationContainer = await page
 			.locator( '.woocommerce_variations  .woocommerce_variation' )
 			.first();
 
-		await firstVariationContainerLocator
+		await firstVariationContainer
 			.getByPlaceholder( 'Variation price (required)' )
 			.fill( variationOnePrice );
 		await expect(
 			page.locator( 'p.variable_stock_status' )
 		).not.toBeVisible();
-		await firstVariationContainerLocator
+		await firstVariationContainer
 			.getByLabel( 'Stock quantity' )
 			.fill( stockAmount );
 		await page.selectOption( '#variable_backorders0', 'notify', {
 			force: true,
 		} );
-		await firstVariationContainerLocator
+		await firstVariationContainer
 			.getByPlaceholder( 'Store-wide threshold (2)' )
 			.fill( lowStockAmount );
 		await page.click( 'button.save-variation-changes' );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
@@ -812,7 +812,7 @@ test.describe( 'Add New Variable Product Page', () => {
 		await page.check( 'input.checkbox.variable_manage_stock' );
 
 		const firstVariationContainerLocator = await page
-			.locator('.woocommerce_variations  .woocommerce_variation')
+			.locator( '.woocommerce_variations  .woocommerce_variation' )
 			.first();
 
 		await firstVariationContainerLocator
@@ -821,11 +821,15 @@ test.describe( 'Add New Variable Product Page', () => {
 		await expect(
 			page.locator( 'p.variable_stock_status' )
 		).not.toBeVisible();
-		await firstVariationContainerLocator.getByLabel( 'Stock quantity' ).fill( stockAmount );
+		await firstVariationContainerLocator
+			.getByLabel( 'Stock quantity' )
+			.fill( stockAmount );
 		await page.selectOption( '#variable_backorders0', 'notify', {
 			force: true,
 		} );
-		await firstVariationContainerLocator.getByPlaceholder( 'Store-wide threshold (2)' ).fill( lowStockAmount );
+		await firstVariationContainerLocator
+			.getByPlaceholder( 'Store-wide threshold (2)' )
+			.fill( lowStockAmount );
 		await page.click( 'button.save-variation-changes' );
 		await page.click(
 			'#variable_product_options .toolbar-top a.expand_all'

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
@@ -823,6 +823,7 @@ test.describe( 'Add New Variable Product Page', () => {
 		).not.toBeVisible();
 		await firstVariationContainer
 			.getByLabel( 'Stock quantity' )
+			.last()
 			.fill( stockAmount );
 		await page.selectOption( '#variable_backorders0', 'notify', {
 			force: true,

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
@@ -823,7 +823,7 @@ test.describe( 'Add New Variable Product Page', () => {
 		).not.toBeVisible();
 		await firstVariationContainer
 			.getByLabel( 'Stock quantity' )
-			.second()
+			.nth(1)
 			.fill( stockAmount );
 		await page.selectOption( '#variable_backorders0', 'notify', {
 			force: true,

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
@@ -823,7 +823,7 @@ test.describe( 'Add New Variable Product Page', () => {
 		).not.toBeVisible();
 		await firstVariationContainer
 			.getByLabel( 'Stock quantity' )
-			.first()
+			.second()
 			.fill( stockAmount );
 		await page.selectOption( '#variable_backorders0', 'notify', {
 			force: true,

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
@@ -823,7 +823,7 @@ test.describe( 'Add New Variable Product Page', () => {
 		).not.toBeVisible();
 		await firstVariationContainer
 			.getByLabel( 'Stock quantity' )
-			.last()
+			.first()
 			.fill( stockAmount );
 		await page.selectOption( '#variable_backorders0', 'notify', {
 			force: true,


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
In this pull request, i replace `page.fill` with `locator.fill`

Closes #37458 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

All e2e tests should pass in the edited e2e test file.

<!-- End testing instructions -->