### PR TITLE
Fix "Out of stock threshold" when filed value is empty - Fix/issue 36960

### DIFF
--- a/plugins/woocommerce/changelog/fix-issue-36960
+++ b/plugins/woocommerce/changelog/fix-issue-36960
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Above notification threshold when "Out of stock threshold" filed value is empty

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
@@ -1386,7 +1386,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 			return;
 		}
 
-		$stock_is_above_notification_threshold = ( absint( $this->get_stock_quantity() ) > absint( get_option( 'woocommerce_notify_no_stock_amount', 0 ) ) );
+		$stock_is_above_notification_threshold = ( (int) $this->get_stock_quantity() > absint( get_option( 'woocommerce_notify_no_stock_amount', 0 ) ) );
 		$backorders_are_allowed                = ( 'no' !== $this->get_backorders() );
 
 		if ( $stock_is_above_notification_threshold ) {

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
@@ -1386,7 +1386,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 			return;
 		}
 
-		$stock_is_above_notification_threshold = ( $this->get_stock_quantity() > get_option( 'woocommerce_notify_no_stock_amount', 0 ) );
+		$stock_is_above_notification_threshold = ( absint( $this->get_stock_quantity() ) > absint( get_option( 'woocommerce_notify_no_stock_amount', 0 ) ) );
 		$backorders_are_allowed                = ( 'no' !== $this->get_backorders() );
 
 		if ( $stock_is_above_notification_threshold ) {

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-products.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-products.php
@@ -29,7 +29,6 @@ class WC_Settings_Products extends WC_Settings_Page {
 		$this->label = __( 'Products', 'woocommerce' );
 
 		parent::__construct();
-		add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_notify_no_stock_amount', 'absint' );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-products.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-products.php
@@ -29,6 +29,7 @@ class WC_Settings_Products extends WC_Settings_Page {
 		$this->label = __( 'Products', 'woocommerce' );
 
 		parent::__construct();
+		add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_notify_no_stock_amount', 'absint' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Settings/OptionSanitizer.php
+++ b/plugins/woocommerce/src/Internal/Settings/OptionSanitizer.php
@@ -38,6 +38,8 @@ class OptionSanitizer {
 				2
 			);
 		}
+		// Cast "Out of stock threshold" field to absolute integer to prevent storing empty value.
+		self::add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_notify_no_stock_amount', 'absint' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/product/class-wc-tests-product.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/product/class-wc-tests-product.php
@@ -66,7 +66,7 @@ class WC_Tests_Product extends WC_Unit_Test_Case {
 	 *           [3, 4, false, "outofstock"]
 	 *
 	 * @param int    $stock_quantity Current stock quantity for the product.
-	 * @param bool   $notify_no_stock_amount Value for the woocommerce_notify_no_stock_amount option.
+	 * @param int    $notify_no_stock_amount Value for the woocommerce_notify_no_stock_amount option.
 	 * @param bool   $accepts_backorders Whether the product accepts backorders or not.
 	 * @param string $expected_stock_status The expected stock status of the product after being saved.
 	 */

--- a/plugins/woocommerce/tests/legacy/unit-tests/product/product-variable.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/product/product-variable.php
@@ -154,7 +154,7 @@ class WC_Tests_Product_Variable extends WC_Unit_Test_Case {
 	 *           [3, 4, false, "outofstock"]
 	 *
 	 * @param int    $stock_quantity Current stock quantity for the product.
-	 * @param bool   $notify_no_stock_amount Value for the woocommerce_notify_no_stock_amount option.
+	 * @param int    $notify_no_stock_amount Value for the woocommerce_notify_no_stock_amount option.
 	 * @param bool   $accepts_backorders Whether the product accepts backorders or not.
 	 * @param string $expected_stock_status The expected stock status of the product after being saved.
 	 */


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR
- Cast "Out of stock threshold" field to absolute integer on save by using `woocommerce_admin_settings_sanitize_option_woocommerce_notify_no_stock_amount` filter.
- Casts product stock quantity and no stock amount to absolute int before comparing.
- Fix `@param $notify_no_stock_amount` type in tests


Closes #36960  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. In WP Dashboard Go to `WooCommerce Settings -> Products  -> Inventory`.
2. Remove the value of Out of stock threshold
3. Save settings
4. Field should have default value, that is 0.
![image](https://user-images.githubusercontent.com/11904934/233165914-f75d94bd-382b-403a-8c7b-071fcece970e.png)

**NOTE:**
We should consider do same casting on save for "Low stock threshold" field. 
Or in general we should add new case for all `number` type fields and when empty set to default value.
https://github.com/woocommerce/woocommerce/blob/8ac3c299374329c0fd3119b142c96398f6393c8d/plugins/woocommerce/includes/admin/class-wc-admin-settings.php#L832-L870


<!-- End testing instructions -->