### PR TITLE
Ensure the remove icon shows properly on smaller screens when using the Twenty Twenty One theme

### DIFF
--- a/plugins/woocommerce/changelog/fix-32023
+++ b/plugins/woocommerce/changelog/fix-32023
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure the remove icon shows properly on smaller screens when using the Twenty Twenty One theme

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-one.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-one.scss
@@ -2345,6 +2345,10 @@ a.reset_variations {
 
 				&:first-child {
 					border-top: 1px solid;
+
+					td.product-remove:first-child {
+						border-top: inherit;
+					}
 				}
 
 				&:last-child {
@@ -2384,6 +2388,8 @@ a.reset_variations {
 
 				.product-remove {
 					float: right;
+					position: relative;
+					z-index: 1;
 				}
 
 				.product-thumbnail {


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

As reported in #32023, when using the Twenty Twenty One theme on smaller screens (less than 768px), when multiple products are in the cart, the remove icon does not properly show on every other item (so the 1st, 3rd, 5th, etc).

The issue here is we apply a custom CSS filter to each `td` element that gives us the alternating background colors. This ends up overlapping with the remove icon and in essence, hides it. This PR fixes this by adding a `z-index` and `position` argument to the close icon.

Closes #32023

### Screenshots

| Before fix | After fix |
| :-: | :-: |
| <img width="437" alt="before-fix" src="https://user-images.githubusercontent.com/916738/233192814-63caa71c-0bef-4829-b900-09bcb313c755.png">  | <img width="438" alt="after-fix" src="https://user-images.githubusercontent.com/916738/233192629-dd682eab-b985-4adc-8e01-2e5a7cb578bb.png"> |

### How to test the changes in this Pull Request:

1. Install and activate the Twenty Twenty One theme
2. Create two or more products in your store
3. As a customer, add at least two of these products into your cart
4. Go to the cart page on a small-screen device
5. Ensure the remove icon shows properly for each product and that clicking on the icon works as expected
