### PR TITLE
Prevent PHP Error in Customers API Endpoint

### DIFF
--- a/plugins/woocommerce/changelog/fix-37089
+++ b/plugins/woocommerce/changelog/fix-37089
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevents error in Customers API endpoint when date_created value is missing

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-customers-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-customers-v2-controller.php
@@ -55,7 +55,7 @@ class WC_REST_Customers_V2_Controller extends WC_REST_Customers_V1_Controller {
 		// Format date values.
 		foreach ( $format_date as $key ) {
 			// Date created is stored UTC, date modified is stored WP local time.
-			$datetime              = 'date_created' === $key && $data[ $key ] ? get_date_from_gmt( gmdate( 'Y-m-d H:i:s', $data[ $key ]->getTimestamp() ) ) : $data[ $key ];
+			$datetime              = 'date_created' === $key && is_subclass_of( $data[ $key ], 'DateTime' ) ? get_date_from_gmt( gmdate( 'Y-m-d H:i:s', $data[ $key ]->getTimestamp() ) ) : $data[ $key ];
 			$data[ $key ]          = wc_rest_prepare_date_response( $datetime, false );
 			$data[ $key . '_gmt' ] = wc_rest_prepare_date_response( $datetime );
 		}

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-customers-v2-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version2/class-wc-rest-customers-v2-controller.php
@@ -55,7 +55,7 @@ class WC_REST_Customers_V2_Controller extends WC_REST_Customers_V1_Controller {
 		// Format date values.
 		foreach ( $format_date as $key ) {
 			// Date created is stored UTC, date modified is stored WP local time.
-			$datetime              = 'date_created' === $key ? get_date_from_gmt( gmdate( 'Y-m-d H:i:s', $data[ $key ]->getTimestamp() ) ) : $data[ $key ];
+			$datetime              = 'date_created' === $key && $data[ $key ] ? get_date_from_gmt( gmdate( 'Y-m-d H:i:s', $data[ $key ]->getTimestamp() ) ) : $data[ $key ];
 			$data[ $key ]          = wc_rest_prepare_date_response( $datetime, false );
 			$data[ $key . '_gmt' ] = wc_rest_prepare_date_response( $datetime );
 		}


### PR DESCRIPTION
This one-line change prevents PHP errors if the date_created value is falsy when formatting the customer data object for responses from the customers endpoint in API V2.

### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #37089 (Customers Endpoint Errors)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Start with fresh install
2. You'll need to replicate the bad data some of us seem to have in our DBs
3. First, change the structure of the wp_users table in MySQL to allow NULL values in the user_registered column
3. Then, set your user's user_registered value to NULL
4. Follow the instructions on [Getting started with the REST API](/woocommerce/woocommerce/wiki/Getting-started-with-the-REST-API)
5. Before applying the patch, a request to `/wp-json/wc/v2/customers/1` will cause a fatal error.
6. After apply the patch, a request to `/wp-json/wc/v2/customers/1` will result in a NULL value in the `date_created` and `date_created_gmt` fields (same behavior as `date_modified` and `date_modified_gmt`).