### PR TITLE
Reduce padding within notices for smaller screens in the Twenty Twenty One theme

### DIFF
--- a/plugins/woocommerce/changelog/fix-36027
+++ b/plugins/woocommerce/changelog/fix-36027
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+For the Twenty Twenty One theme, reduce padding within notices on smaller screens

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-one.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-one.scss
@@ -3056,10 +3056,10 @@ a.reset_variations {
 	.woocommerce-info {
 		padding: 1rem 1.5rem;
 
-		.button {
+		a.button {
 			margin-left: 10px;
 			min-width: 100px;
-			padding: 10px 15px !important;
+			padding: calc(0.70 * var(--button--padding-vertical)) calc(0.50 * var(--button--padding-horizontal));
 		}
 	}
 }

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-one.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-one.scss
@@ -3050,6 +3050,20 @@ a.reset_variations {
 	}
 }
 
+@media only screen and (max-width: 768px) {
+	.woocommerce-message,
+	.woocommerce-error li,
+	.woocommerce-info {
+		padding: 1rem 1.5rem;
+
+		.button {
+			margin-left: 10px;
+			min-width: 100px;
+			padding: 10px 15px !important;
+		}
+	}
+}
+
 .woocommerce-info {
 	border-top-color: var( --wc-blue );
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

When using the Twenty Twenty One theme, on smaller screens, notices can display weird due to lack of space. This PR attempts to fix that by adding some CSS tweaks for smaller breakpoints only that reduce the amount of padding within these notices as well as setting a minimum width on the button within the notice to avoid line-breaks in the middle of a word.

This is a fairly minor change and could definitely do more here to make these even more small-screen friendly but this should display much better across all small screens now.

Closes #36027

### Screenshots

| Message Notice - before | Message Notice - after |
| :-: | :-: |
| <img width="470" alt="message-before" src="https://user-images.githubusercontent.com/916738/233204900-e2092c0b-568a-4edf-a586-ef813477bf55.png"> | <img width="481" alt="message-after" src="https://user-images.githubusercontent.com/916738/233204936-caa28a0f-6a0d-42a5-abda-4e647f7d1b35.png"> |

| Error Notice - before | Error Notice - after |
| :-: | :-: |
| <img width="439" alt="error-before" src="https://user-images.githubusercontent.com/916738/233205096-be297854-0508-4c56-8107-168d7419dfba.png"> | <img width="427" alt="error-after" src="https://user-images.githubusercontent.com/916738/233205122-7e0171d8-8dac-4860-9e47-5ec6ab3f4fce.png"> |

| Info Notice - before | Info Notice - after |
| :-: | :-: |
| <img width="419" alt="info-before" src="https://user-images.githubusercontent.com/916738/233205231-dbfcd261-6198-4e3b-a88a-56a3424cf2de.png"> | <img width="414" alt="info-after" src="https://user-images.githubusercontent.com/916738/233205266-a7f31983-3a2a-43e0-9636-7dcee62fd1a4.png"> |

### How to test the changes in this Pull Request:

1. Install and activate the Twenty Twenty One theme
2. Add some products if your store doesn't have any
3. Disable the ajax add to cart functionality within the Woo settings (WooCommerce > Settings > Products)
4. On a small-screen device, go to the main store page and click the add to cart button for a product
5. Make note of the notice that is shown. Text should all display properly and spacing should be accurate
6. Go to the cart screen and enter in an invalid coupon
7. Make note of the error message that is shown and ensure it displays correctly
