### PR TITLE
Fix/36785 Clear floats after Product Summary in 2023 theme

### DIFF
--- a/plugins/woocommerce/changelog/fix-36785
+++ b/plugins/woocommerce/changelog/fix-36785
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Clear floats in Twenty Twenty Three theme on Related products and Upsells.

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -361,8 +361,12 @@
 
 		.related.products {
 			margin-top: 7rem;
+			clear: both;
 		}
 
+		.upsells.products {
+			clear: both;
+		}
 	}
 
 	// Reviews tab.


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Clear floats in Twenty Twenty Three theme on Related products and Upsells.

Closes #36785.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add a new product or edit an existing one.
2. Make sure to remove everything that is shown as a tab under the product description. Like, disabling the review, etc.
3. Make sure you have related products or upsells enable and visible on the product page at FE.
4. In `trunk`, see the related product/upsells section is not "cleared", i.e. it is touching the bottom of the Add to Cart button section.

![image](https://user-images.githubusercontent.com/25176325/233318763-0ed44cf2-13bd-4969-804a-165d4055ed81.png)

5. In this PR's fix branch, it clears the float and visible right after the product images (left) and the add to cart button (right).

![image](https://user-images.githubusercontent.com/25176325/233318584-b429346f-ebdd-4ff5-8150-81f8d0434b95.png)

<!-- End testing instructions -->