### PR TITLE
Rewrite the useOptionsHydration hook to not dispatch inside useSelect

### DIFF
--- a/packages/js/data/changelog/fix-dispatch-in-useselect-with-options-hydration
+++ b/packages/js/data/changelog/fix-dispatch-in-useselect-with-options-hydration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Rewrote withOptionsHydration to not use dispatch-within-useselect pattern that is broken after gutenberg 15.5 update

--- a/packages/js/data/src/options/index.ts
+++ b/packages/js/data/src/options/index.ts
@@ -13,7 +13,7 @@ import * as actions from './actions';
 import * as resolvers from './resolvers';
 import reducer, { State } from './reducer';
 import { controls } from './controls';
-import { WPDataSelectors } from '../types';
+import { WPDataActions, WPDataSelectors } from '../types';
 export * from './types';
 export type { State };
 
@@ -30,7 +30,7 @@ export const OPTIONS_STORE_NAME = STORE_NAME;
 declare module '@wordpress/data' {
 	function dispatch(
 		key: typeof STORE_NAME
-	): DispatchFromMap< typeof actions >;
+	): DispatchFromMap< typeof actions & WPDataActions >;
 	function select(
 		key: typeof STORE_NAME
 	): SelectFromMap< typeof selectors > & WPDataSelectors;

--- a/packages/js/data/src/options/test/with-options-hydration.tsx
+++ b/packages/js/data/src/options/test/with-options-hydration.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { render } from '@testing-library/react';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { createElement } from '@wordpress/element';
 
 /**
@@ -16,6 +16,7 @@ import {
 jest.mock( '@wordpress/data', () => ( {
 	...jest.requireActual( '@wordpress/data' ),
 	useSelect: jest.fn(),
+	useDispatch: jest.fn(),
 } ) );
 
 const optionData = {
@@ -40,20 +41,16 @@ describe( 'withOptionsHydration', () => {
 	const receiveOptionsMock = jest.fn();
 	beforeEach( () => {
 		( useSelect as jest.Mock ).mockImplementation( ( callback ) => {
-			callback(
-				() => ( {
-					isResolving: isResolvingMock,
-					hasFinishedResolution: hasFinishedMock,
-				} ),
-				{
-					dispatch: () => ( {
-						startResolution: startResolutionMock,
-						finishResolution: jest.fn(),
-						receiveOptions: receiveOptionsMock,
-					} ),
-				}
-			);
+			return callback( () => ( {
+				isResolving: isResolvingMock,
+				hasFinishedResolution: hasFinishedMock,
+			} ) );
 		} );
+		( useDispatch as jest.Mock ).mockImplementation( () => ( {
+			startResolution: startResolutionMock,
+			finishResolution: jest.fn(),
+			receiveOptions: receiveOptionsMock,
+		} ) );
 	} );
 
 	afterEach( () => {


### PR DESCRIPTION
Follow up to #37641, fixes also the `useOptionsHydration` hook that was originally missed.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Activate Gutenberg 15.5
2. Verify the WooCommerce Admin Home page loads without issues.
3. Verify that skipping the onboarding wizard works without issue, and also with completing the onboarding wizard
4. Verify that homescreen's inbox notes are displayed as usual
5. Verify steps 2 - 5 still apply with Gutenberg plugin disabled