### PR TITLE
Fix/issue 36360

### DIFF
--- a/plugins/woocommerce/changelog/fix-issue-36360
+++ b/plugins/woocommerce/changelog/fix-issue-36360
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove the default text in "Additional content" being sent for all emails when the field is empty

--- a/plugins/woocommerce/changelog/fix-issue-36360
+++ b/plugins/woocommerce/changelog/fix-issue-36360
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Remove the default text in "Additional content" being sent for all emails when the field is empty
+Remove the default text in "Additional content" being sent for all emails when the field is empty for Admin New Order email

--- a/plugins/woocommerce/includes/emails/class-wc-email-new-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-new-order.php
@@ -176,7 +176,7 @@ if ( ! class_exists( 'WC_Email_New_Order' ) ) :
 		public function get_additional_content() {
 			return apply_filters( 'woocommerce_email_additional_content_' . $this->id, $this->format_string( $this->get_option( 'additional_content' ) ), $this->object, $this );
 		}
-	
+
 		/**
 		 * Initialise settings form fields.
 		 */

--- a/plugins/woocommerce/includes/emails/class-wc-email-new-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-new-order.php
@@ -174,6 +174,11 @@ if ( ! class_exists( 'WC_Email_New_Order' ) ) :
 		 * @return string
 		 */
 		public function get_additional_content() {
+			/**
+			 * This filter is documented in ./class-wc-email.php
+			 *
+			 * @since 7.8.0
+			 */
 			return apply_filters( 'woocommerce_email_additional_content_' . $this->id, $this->format_string( $this->get_option( 'additional_content' ) ), $this->object, $this ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		}
 

--- a/plugins/woocommerce/includes/emails/class-wc-email-new-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-new-order.php
@@ -174,7 +174,7 @@ if ( ! class_exists( 'WC_Email_New_Order' ) ) :
 		 * @return string
 		 */
 		public function get_additional_content() {
-			return apply_filters( 'woocommerce_email_additional_content_' . $this->id, $this->format_string( $this->get_option( 'additional_content' ) ), $this->object, $this );
+			return apply_filters( 'woocommerce_email_additional_content_' . $this->id, $this->format_string( $this->get_option( 'additional_content' ) ), $this->object, $this ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		}
 
 		/**

--- a/plugins/woocommerce/includes/emails/class-wc-email-new-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-new-order.php
@@ -179,7 +179,7 @@ if ( ! class_exists( 'WC_Email_New_Order' ) ) :
 			 *
 			 * @since 7.8.0
 			 */
-			return apply_filters( 'woocommerce_email_additional_content_' . $this->id, $this->format_string( $this->get_option( 'additional_content' ) ), $this->object, $this ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+			return apply_filters( 'woocommerce_email_additional_content_' . $this->id, $this->format_string( $this->get_option( 'additional_content' ) ), $this->object, $this );
 		}
 
 		/**

--- a/plugins/woocommerce/includes/emails/class-wc-email-new-order.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email-new-order.php
@@ -166,6 +166,18 @@ if ( ! class_exists( 'WC_Email_New_Order' ) ) :
 		}
 
 		/**
+		 * Return content from the additional_content field.
+		 *
+		 * Displayed above the footer.
+		 *
+		 * @since 3.7.0
+		 * @return string
+		 */
+		public function get_additional_content() {
+			return apply_filters( 'woocommerce_email_additional_content_' . $this->id, $this->format_string( $this->get_option( 'additional_content' ) ), $this->object, $this );
+		}
+	
+		/**
 		 * Initialise settings form fields.
 		 */
 		public function init_form_fields() {

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -400,6 +400,15 @@ class WC_Email extends WC_Settings_API {
 	 * @return string
 	 */
 	public function get_additional_content() {
+		/**
+		 * Provides an opportunity to inspect and modify additional content for the email.
+		 *
+		 * @since 3.7.0
+		 *
+		 * @param string      $additional_content Additional content to be added to the email.
+		 * @param object|bool $object             The object (ie, product or order) this email relates to, if any.
+		 * @param WC_Email    $email              WC_Email instance managing the email.
+		 */
 		return apply_filters( 'woocommerce_email_additional_content_' . $this->id, $this->format_string( $this->get_option( 'additional_content', $this->get_default_additional_content() ) ), $this->object, $this );
 	}
 

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -400,7 +400,7 @@ class WC_Email extends WC_Settings_API {
 	 * @return string
 	 */
 	public function get_additional_content() {
-		return apply_filters( 'woocommerce_email_additional_content_' . $this->id, $this->format_string( $this->get_option( 'additional_content' ) ), $this->object, $this );
+		return apply_filters( 'woocommerce_email_additional_content_' . $this->id, $this->format_string( $this->get_option( 'additional_content', $this->get_default_additional_content() ) ), $this->object, $this );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -400,7 +400,7 @@ class WC_Email extends WC_Settings_API {
 	 * @return string
 	 */
 	public function get_additional_content() {
-		return apply_filters( 'woocommerce_email_additional_content_' . $this->id, $this->format_string( $this->get_option( 'additional_content', $this->get_default_additional_content() ) ), $this->object, $this );
+		return apply_filters( 'woocommerce_email_additional_content_' . $this->id, $this->format_string( $this->get_option( 'additional_content' ) ), $this->object, $this );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Remove the default text in "Additional content" being sent for all emails when the field is empty for Admin New Order email

Closes #36360 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Go to WooCommerce > Settings > Email
2. Select the "New order" email
3. Remove the text within the "Additional content" field
4. Make an order on the shop
5. Verify the Admin New Order email does **not** contain the default text "Congratulations on the sale."