### PR TITLE
Fix wrong file name in error message in `update-wp-env.php`

### DIFF
--- a/plugins/woocommerce/changelog/fix-update-wp-env-error-message
+++ b/plugins/woocommerce/changelog/fix-update-wp-env-error-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix wrong file name in error message in update-wp-env.php.

--- a/plugins/woocommerce/tests/e2e-pw/bin/update-wp-env.php
+++ b/plugins/woocommerce/tests/e2e-pw/bin/update-wp-env.php
@@ -14,7 +14,7 @@ if ( ! class_exists( UPDATE_WP_JSON::class ) ) {
 			if ( file_exists( $this->wp_env_path ) ) {
 				$this->wp_json = json_decode( file_get_contents( $this->wp_env_path ), true );
 			} else {
-				throw new Exception( ".wp_env.json doesn't exist!" );
+				throw new Exception( ".wp-env.json doesn't exist!" );
 			}
 
 			$env = getenv();


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes the wrong `.wp_env.json` file name to the correct `.wp-env.json` file name in the error message in `update-wp-env.php` file.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. In `plugins/woocommerce` directory, delete the `.wp-env.json` file.
2. Run `update-wp-env` command in the terminal: `pnpm --filter=woocommerce run update-wp-env`.
3. See the error message. It should be `.wp-env.json`, not `.wp_env.json`.

<!-- End testing instructions -->