### PR TITLE
Fix comment list styling in TT2

### DIFF
--- a/plugins/woocommerce/changelog/fix-tt2-comment-list
+++ b/plugins/woocommerce/changelog/fix-tt2-comment-list
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Fix comment list styling in TT2

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
@@ -376,6 +376,10 @@ $tt2-gray: #f7f7f7;
 			list-style: none;
 			padding-left: 0;
 
+			li.review {
+				margin-bottom: var(--wp--style--block-gap);
+			}
+
 			img.avatar {
 				float: left;
 			}
@@ -385,7 +389,7 @@ $tt2-gray: #f7f7f7;
 			}
 
 			.comment-text {
-				display: inline-block;
+				display: flow-root;
 				padding-left: var(--wp--style--block-gap);
 
 				.star-rating {


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR aims to fix the layout of the comment list in the TT2 theme. It is mainly inspired by [how TT3 handles](https://github.com/woocommerce/woocommerce/blob/7.6.0/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss#L370-L396) the comment list. 

Before:
![Before](https://cdn-std.droplr.net/files/acc_1208648/wk6OxR)
After:
![After](https://cdn-std.droplr.net/files/acc_1208648/Eji5UL)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Write a review for a product on a site using the TT2 theme. Ensure that the comment is long enough.
2. Approve the comment and notice it is falling below the avatar. 
3. Apply this patch and ensure that it is showing correctly.

<!-- End testing instructions -->