### PR TITLE
Rewrite the withPluginsHydration hook to not dispatch inside useSelect

### DIFF
--- a/packages/js/data/changelog/fix-use-plugins-hydration-hook
+++ b/packages/js/data/changelog/fix-use-plugins-hydration-hook
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Rewrite usePluginsHydration hook to not dispatch inside useSelect

--- a/packages/js/data/src/plugins/index.ts
+++ b/packages/js/data/src/plugins/index.ts
@@ -12,7 +12,7 @@ import * as selectors from './selectors';
 import * as actions from './actions';
 import * as resolvers from './resolvers';
 import reducer, { State } from './reducer';
-import { WPDataSelectors } from '../types';
+import { WPDataActions, WPDataSelectors } from '../types';
 export * from './types';
 export type { State };
 
@@ -29,7 +29,7 @@ declare module '@wordpress/data' {
 	// TODO: convert action.js to TS
 	function dispatch(
 		key: typeof STORE_NAME
-	): DispatchFromMap< typeof actions >;
+	): DispatchFromMap< typeof actions & WPDataActions >;
 	function select(
 		key: typeof STORE_NAME
 	): SelectFromMap< typeof selectors > & WPDataSelectors;

--- a/packages/js/data/src/plugins/with-plugins-hydration.tsx
+++ b/packages/js/data/src/plugins/with-plugins-hydration.tsx
@@ -3,8 +3,8 @@
  */
 import { createHigherOrderComponent } from '@wordpress/compose';
 
-import { useSelect } from '@wordpress/data';
-import { createElement, useRef } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { createElement, useEffect } from '@wordpress/element';
 import { SelectFromMap } from '@automattic/data-stores';
 
 /**
@@ -12,7 +12,6 @@ import { SelectFromMap } from '@automattic/data-stores';
  */
 import { STORE_NAME } from './constants';
 import { WPDataActions } from '../';
-import * as actions from './actions';
 import * as selectors from './selectors';
 import { WPDataSelectors } from '../types';
 
@@ -24,62 +23,52 @@ type PluginHydrationData = {
 export const withPluginsHydration = ( data: PluginHydrationData ) =>
 	createHigherOrderComponent< Record< string, unknown > >(
 		( OriginalComponent ) => ( props ) => {
-			const dataRef = useRef( data );
-
-			useSelect(
-				// @ts-expect-error registry is not defined in the wp.data typings
+			const shouldHydrate = useSelect(
 				(
 					select: (
 						key: typeof STORE_NAME
-					) => SelectFromMap< typeof selectors > & WPDataSelectors,
-					registry: {
-						dispatch: (
-							store: string
-						) => typeof actions & WPDataActions;
-					}
+					) => SelectFromMap< typeof selectors > & WPDataSelectors
 				) => {
-					if ( ! dataRef.current ) {
+					if ( ! data ) {
 						return;
 					}
 
 					const { isResolving, hasFinishedResolution } =
 						select( STORE_NAME );
-					const {
-						startResolution,
-						finishResolution,
-						updateActivePlugins,
-						updateInstalledPlugins,
-						updateIsJetpackConnected,
-					} = registry.dispatch( STORE_NAME );
-
-					if (
+					return (
 						! isResolving( 'getActivePlugins', [] ) &&
 						! hasFinishedResolution( 'getActivePlugins', [] )
-					) {
-						startResolution( 'getActivePlugins', [] );
-						startResolution( 'getInstalledPlugins', [] );
-						startResolution( 'isJetpackConnected', [] );
-						updateActivePlugins(
-							dataRef.current.activePlugins,
-							true
-						);
-						updateInstalledPlugins(
-							dataRef.current.installedPlugins,
-							true
-						);
-						updateIsJetpackConnected(
-							dataRef.current.jetpackStatus &&
-								dataRef.current.jetpackStatus.isActive
-								? true
-								: false
-						);
-						finishResolution( 'getActivePlugins', [] );
-						finishResolution( 'getInstalledPlugins', [] );
-						finishResolution( 'isJetpackConnected', [] );
-					}
+					);
 				},
 				[]
 			);
+
+			const {
+				startResolution,
+				finishResolution,
+				updateActivePlugins,
+				updateInstalledPlugins,
+				updateIsJetpackConnected,
+			} = useDispatch( STORE_NAME );
+
+			useEffect( () => {
+				if ( ! shouldHydrate ) {
+					return;
+				}
+				startResolution( 'getActivePlugins', [] );
+				startResolution( 'getInstalledPlugins', [] );
+				startResolution( 'isJetpackConnected', [] );
+				updateActivePlugins( data.activePlugins, true );
+				updateInstalledPlugins( data.installedPlugins, true );
+				updateIsJetpackConnected(
+					data.jetpackStatus && data.jetpackStatus.isActive
+						? true
+						: false
+				);
+				finishResolution( 'getActivePlugins', [] );
+				finishResolution( 'getInstalledPlugins', [] );
+				finishResolution( 'isJetpackConnected', [] );
+			}, [ shouldHydrate ] );
 
 			return <OriginalComponent { ...props } />;
 		},

--- a/packages/js/data/src/plugins/with-plugins-hydration.tsx
+++ b/packages/js/data/src/plugins/with-plugins-hydration.tsx
@@ -11,7 +11,6 @@ import { SelectFromMap } from '@automattic/data-stores';
  * Internal dependencies
  */
 import { STORE_NAME } from './constants';
-import { WPDataActions } from '../';
 import * as selectors from './selectors';
 import { WPDataSelectors } from '../types';
 


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Follow up to https://github.com/woocommerce/woocommerce/pull/37641

Fixes `withPluginsHydration` hook to not dispatch inside useSelect

<!-- End testing instructions -->