### PR TITLE
Rewrite withNavigationHydration to work with Gutenberg 15.5+

### DIFF
--- a/packages/js/data/changelog/fix-with-navigation-hydration
+++ b/packages/js/data/changelog/fix-with-navigation-hydration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Rewrite withNavigationHydration to work Gutenberg 15.5+

--- a/packages/js/data/src/navigation/with-navigation-hydration.tsx
+++ b/packages/js/data/src/navigation/with-navigation-hydration.tsx
@@ -3,7 +3,7 @@
  */
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { createElement, useEffect, useRef } from '@wordpress/element';
+import { createElement, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/packages/js/data/src/navigation/with-navigation-hydration.tsx
+++ b/packages/js/data/src/navigation/with-navigation-hydration.tsx
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import { createHigherOrderComponent } from '@wordpress/compose';
-import { useSelect } from '@wordpress/data';
-import { createElement, useRef } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { createElement, useEffect, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -20,28 +20,29 @@ import { MenuItem } from './types';
 export const withNavigationHydration = ( data: { menuItems: MenuItem[] } ) =>
 	createHigherOrderComponent< Record< string, unknown > >(
 		( OriginalComponent ) => ( props ) => {
-			const dataRef = useRef( data );
-
-			// @ts-expect-error // @ts-expect-error registry is not defined in the wp.data typings
-			useSelect( ( select, registry ) => {
-				if ( ! dataRef.current ) {
+			const shouldHydrate = useSelect( ( select ) => {
+				if ( ! data ) {
 					return;
 				}
 
 				const { isResolving, hasFinishedResolution } =
 					select( STORE_NAME );
-				const { startResolution, finishResolution, setMenuItems } =
-					registry.dispatch( STORE_NAME );
-
-				if (
+				return (
 					! isResolving( 'getMenuItems' ) &&
 					! hasFinishedResolution( 'getMenuItems' )
-				) {
-					startResolution( 'getMenuItems', [] );
-					setMenuItems( dataRef.current.menuItems );
-					finishResolution( 'getMenuItems', [] );
-				}
+				);
 			} );
+			const { startResolution, finishResolution, setMenuItems } =
+				useDispatch( STORE_NAME );
+
+			useEffect( () => {
+				if ( ! shouldHydrate ) {
+					return;
+				}
+				startResolution( 'getMenuItems', [] );
+				setMenuItems( data.menuItems );
+				finishResolution( 'getMenuItems', [] );
+			}, [ shouldHydrate ] );
 
 			return <OriginalComponent { ...props } />;
 		},


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/Automattic/wp-calypso/issues/76054

This PR updates `withNavigationHydration` to work with Gutenberg 15.5+ 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Checkout `trunk`
2. Install and activate the latest Gutenberg.
3. Undo changes from this [PR](https://github.com/woocommerce/woocommerce/pull/36456/files) to enable the new navigation option.
 4. Go to WooCommerce -> Settings -> Features
 5. Enable Navigation
 6. Navigate to a wc admin page
 7. Confirm the navigation is broken.
 8. Checkout this branch and rebuild the assets
 9. Refresh and confirm the navigation works as expected. 

<!-- End testing instructions -->