### PR TITLE
Analytics: Fix update_registered_customer when invalid user_registered value

### DIFF
--- a/plugins/woocommerce/changelog/2023-04-20-20-32-58-372082
+++ b/plugins/woocommerce/changelog/2023-04-20-20-32-58-372082
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Handle updating customer when user_registered is 0000-00-00 00:00:00.

--- a/plugins/woocommerce/src/Admin/API/Reports/Customers/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Customers/DataStore.php
@@ -747,7 +747,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			'state'            => $customer->get_billing_state( 'edit' ),
 			'postcode'         => $customer->get_billing_postcode( 'edit' ),
 			'country'          => $customer->get_billing_country( 'edit' ),
-			'date_registered'  => $customer->get_date_created( 'edit' )->date( TimeInterval::$sql_datetime_format ),
+			'date_registered'  => $customer->get_date_created( 'edit' ) ? $customer->get_date_created( 'edit' )->date( TimeInterval::$sql_datetime_format ) : null,
 			'date_last_active' => $last_active ? gmdate( 'Y-m-d H:i:s', $last_active ) : null,
 		);
 		$format      = array(


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR prevents a fatal from occurring in the following scenario:

- Customer user record with the `user_registered` column set to `0000-00-00 00:00:00`

This could happen due to "bad" data in an import file or some manipulation of the database directly. Whatever the cause, we should gracefully handle it instead of throwing a Fatal error.

This Fatal can occur anytime the `update_registered_customer` function is called, including during checkout.

Closes #35752.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

_Note: You may not be able to set `wp_users.user_registered` to `0000-00-00 00:00:00` with MySql. With MariaDB you can (I tested with MariaDB 10.11.2)._

1. Go to `Users` > `Add New`.
2. Set the user role to `Customer`, and save the user by clicking `Add New User`.
3. Directly edit the database record for the new customer by setting `wp_users.user_registered` to `0000-00-00 00:00:00` for that customer.
4. Go to `Users` > `All Users`.
5. Select the customer, to bring up the `Edit User` screen.
6. Make no changes.
7. Click `Update User`.
8. Verify no Fatal is thrown.

<!-- End testing instructions -->