### PR TITLE
Rewrite the withCurrentUserHydration hook to not dispatch inside useSelect

### DIFF
--- a/packages/js/data/changelog/fix-with-current-user-hydration
+++ b/packages/js/data/changelog/fix-with-current-user-hydration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Rewrite withCurrentUserHydration to work with Gutenberg 15.5+

--- a/packages/js/data/src/user/with-current-user-hydration.tsx
+++ b/packages/js/data/src/user/with-current-user-hydration.tsx
@@ -3,7 +3,7 @@
  */
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { createElement, useEffect, useRef } from '@wordpress/element';
+import { createElement } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/packages/js/data/src/user/with-current-user-hydration.tsx
+++ b/packages/js/data/src/user/with-current-user-hydration.tsx
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import { createHigherOrderComponent } from '@wordpress/compose';
-import { useSelect } from '@wordpress/data';
-import { createElement, useRef } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { createElement, useEffect, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -19,32 +19,34 @@ import { WCUser } from './types';
 export const withCurrentUserHydration = ( currentUser: WCUser ) =>
 	createHigherOrderComponent< Record< string, unknown > >(
 		( OriginalComponent ) => ( props ) => {
-			const userRef = useRef( currentUser );
-
 			// Use currentUser to hydrate calls to @wordpress/core-data's getCurrentUser().
-			// @ts-expect-error // @ts-expect-error registry is not defined in the wp.data typings
-			useSelect( ( select, registry ) => {
-				if ( ! userRef.current ) {
+
+			const shouldHydrate = useSelect( ( select ) => {
+				if ( ! currentUser ) {
 					return;
 				}
-
+				// @ts-expect-error registry is not defined in the wp.data typings
 				const { isResolving, hasFinishedResolution } =
 					select( STORE_NAME );
-				const {
-					startResolution,
-					finishResolution,
-					receiveCurrentUser,
-				} = registry.dispatch( STORE_NAME );
-
-				if (
+				return (
 					! isResolving( 'getCurrentUser' ) &&
 					! hasFinishedResolution( 'getCurrentUser' )
-				) {
-					startResolution( 'getCurrentUser', [] );
-					receiveCurrentUser( userRef.current );
-					finishResolution( 'getCurrentUser', [] );
-				}
+				);
 			} );
+
+			const {
+				// @ts-expect-error registry is not defined in the wp.data typings
+				startResolution,
+				// @ts-expect-error registry is not defined in the wp.data typings
+				finishResolution,
+				receiveCurrentUser,
+			} = useDispatch( STORE_NAME );
+
+			if ( shouldHydrate ) {
+				startResolution( 'getCurrentUser', [] );
+				receiveCurrentUser( currentUser );
+				finishResolution( 'getCurrentUser', [] );
+			}
 
 			return <OriginalComponent { ...props } />;
 		},

--- a/packages/js/data/src/user/with-current-user-hydration.tsx
+++ b/packages/js/data/src/user/with-current-user-hydration.tsx
@@ -25,7 +25,7 @@ export const withCurrentUserHydration = ( currentUser: WCUser ) =>
 				if ( ! currentUser ) {
 					return;
 				}
-				// @ts-expect-error registry is not defined in the wp.data typings
+				// @ts-expect-error both functions are not defined in the wp.data typings
 				const { isResolving, hasFinishedResolution } =
 					select( STORE_NAME );
 				return (
@@ -35,9 +35,9 @@ export const withCurrentUserHydration = ( currentUser: WCUser ) =>
 			} );
 
 			const {
-				// @ts-expect-error registry is not defined in the wp.data typings
+				// @ts-expect-error startResolution is not defined in the wp.data typings
 				startResolution,
-				// @ts-expect-error registry is not defined in the wp.data typings
+				// @ts-expect-error finishResolution is not defined in the wp.data typings
 				finishResolution,
 				receiveCurrentUser,
 			} = useDispatch( STORE_NAME );


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Follow up to https://github.com/woocommerce/woocommerce/pull/37641

Fixes `withCurrentUserHydration` hook to not dispatch inside useSelect

<!-- End testing instructions -->