### PR TITLE
Disable toolbars in all relevant product editor blocks

### DIFF
--- a/packages/js/product-editor/changelog/fix-37897
+++ b/packages/js/product-editor/changelog/fix-37897
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Disable toolbars in all relevant product editor blocks

--- a/packages/js/product-editor/src/blocks/conditional/block.json
+++ b/packages/js/product-editor/src/blocks/conditional/block.json
@@ -22,6 +22,7 @@
 		"multiple": true,
 		"reusable": false,
 		"inserter": false,
-		"lock": false
+		"lock": false,
+		"__experimentalToolbar": false
 	}
 }

--- a/packages/js/product-editor/src/blocks/inventory-email/block.json
+++ b/packages/js/product-editor/src/blocks/inventory-email/block.json
@@ -19,7 +19,8 @@
 		"multiple": false,
 		"reusable": false,
 		"inserter": false,
-		"lock": false
+		"lock": false,
+		"__experimentalToolbar": false
 	},
 	"editorStyle": "file:./editor.css"
 }

--- a/packages/js/product-editor/src/blocks/schedule-sale/block.json
+++ b/packages/js/product-editor/src/blocks/schedule-sale/block.json
@@ -19,7 +19,8 @@
 		"multiple": true,
 		"reusable": false,
 		"inserter": false,
-		"lock": false
+		"lock": false,
+		"__experimentalToolbar": false
 	},
 	"editorStyle": "file:./editor.css"
 }

--- a/packages/js/product-editor/src/blocks/shipping-dimensions/block.json
+++ b/packages/js/product-editor/src/blocks/shipping-dimensions/block.json
@@ -19,7 +19,8 @@
 		"multiple": false,
 		"reusable": false,
 		"inserter": false,
-		"lock": false
+		"lock": false,
+		"__experimentalToolbar": false
 	},
 	"editorStyle": "file:./editor.css"
 }

--- a/packages/js/product-editor/src/blocks/shipping-fee/block.json
+++ b/packages/js/product-editor/src/blocks/shipping-fee/block.json
@@ -19,7 +19,8 @@
 		"multiple": true,
 		"reusable": false,
 		"inserter": false,
-		"lock": false
+		"lock": false,
+		"__experimentalToolbar": false
 	},
 	"editorStyle": "file:./editor.css"
 }

--- a/packages/js/product-editor/src/blocks/track-inventory/block.json
+++ b/packages/js/product-editor/src/blocks/track-inventory/block.json
@@ -19,7 +19,8 @@
 		"multiple": false,
 		"reusable": false,
 		"inserter": false,
-		"lock": false
+		"lock": false,
+		"__experimentalToolbar": false
 	},
 	"editorStyle": "file:./editor.css"
 }

--- a/packages/js/product-editor/src/components/collapsible-block/block.json
+++ b/packages/js/product-editor/src/components/collapsible-block/block.json
@@ -24,6 +24,7 @@
 		"multiple": true,
 		"reusable": false,
 		"inserter": false,
-		"lock": false
+		"lock": false,
+		"__experimentalToolbar": false
 	}
 }

--- a/packages/js/product-editor/src/components/details-name-block/block.json
+++ b/packages/js/product-editor/src/components/details-name-block/block.json
@@ -19,7 +19,8 @@
 		"multiple": false,
 		"reusable": false,
 		"inserter": false,
-		"lock": false
+		"lock": false,
+		"__experimentalToolbar": false
 	},
 	"editorStyle": "file:./editor.css"
 }

--- a/packages/js/product-editor/src/components/images/block.json
+++ b/packages/js/product-editor/src/components/images/block.json
@@ -27,6 +27,7 @@
 		"multiple": false,
 		"reusable": false,
 		"inserter": false,
-		"lock": false
+		"lock": false,
+		"__experimentalToolbar": false
 	}
 }

--- a/packages/js/product-editor/src/components/pricing-block/block.json
+++ b/packages/js/product-editor/src/components/pricing-block/block.json
@@ -25,7 +25,8 @@
 		"multiple": false,
 		"reusable": false,
 		"inserter": false,
-		"lock": false
+		"lock": false,
+		"__experimentalToolbar": false
 	},
 	"editorStyle": "file:./editor.css"
 }

--- a/packages/js/product-editor/src/components/section/block.json
+++ b/packages/js/product-editor/src/components/section/block.json
@@ -25,7 +25,8 @@
 		"multiple": true,
 		"reusable": false,
 		"inserter": false,
-		"lock": false
+		"lock": false,
+		"__experimentalToolbar": false
 	},
 	"editorStyle": "file:./editor.css"
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Removes the errant toolbar border pixel that is shown when focusing blocks.

Note that there is still an issue upstream that needs to be fixed, but this works well for our current use case where we only need contextual toolbars.

#### Before

<img width="336" alt="Screen Shot 2023-04-20 at 12 12 30 PM" src="https://user-images.githubusercontent.com/10561050/233504099-b6ccf08a-bea3-4371-b44c-158ecd7260ba.png">

#### After

<img width="169" alt="Screen Shot 2023-04-20 at 3 55 17 PM" src="https://user-images.githubusercontent.com/10561050/233504079-47903675-5fda-41cd-9a3b-8b1662453d7a.png">


Closes #37897  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Navigate to Tools -> WCA Test Helper -> Features and enable the new product blocks editing experience
2. Navigate to Products -> Add new
3. Select each block or focus its input
4. Make sure that the single pixel above (where the toolbar would normally be) is not shown

<!-- End testing instructions -->