### PR TITLE
Fix #36664

### DIFF
--- a/plugins/woocommerce/changelog/pr-37916
+++ b/plugins/woocommerce/changelog/pr-37916
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+add pagination navigation below Settings Tax list table

--- a/plugins/woocommerce/client/legacy/js/admin/settings-views-html-settings-tax.js
+++ b/plugins/woocommerce/client/legacy/js/admin/settings-views-html-settings-tax.js
@@ -19,6 +19,7 @@
 			$tbody             = $( '#rates' ),
 			$save_button       = $( ':input[name="save"]' ),
 			$pagination        = $( '#rates-pagination' ),
+			$bottom_pagination = $( '#rates-bottom-pagination' ),
 			$search_field      = $( '#rates-search .wc-tax-rates-search-field' ),
 			$submit            = $( '.submit .button-primary[type=submit]' ),
 			WCTaxTableModelConstructor = Backbone.Model.extend({
@@ -121,8 +122,8 @@
 					this.listenTo( this.model, 'saved:rates', this.clearUnloadConfirmation );
 					$tbody.on( 'change autocompletechange', ':input', { view: this }, this.updateModelOnChange );
 					$search_field.on( 'keyup search', { view: this }, this.onSearchField );
-					$pagination.on( 'click', 'a', { view: this }, this.onPageChange );
-					$pagination.on( 'change', 'input', { view: this }, this.onPageChange );
+					$pagination.add($bottom_pagination).on( 'click', 'a', { view: this }, this.onPageChange );
+					$pagination.add($bottom_pagination).on( 'change', 'input', { view: this }, this.onPageChange );
 					$( window ).on( 'beforeunload', { view: this }, this.unloadConfirmation );
 					$submit.on( 'click', { view: this }, this.onSubmit );
 					$save_button.prop( 'disabled', true );
@@ -173,7 +174,7 @@
 
 					if ( qty_pages > 1 ) {
 						// We've now displayed our initial page, time to render the pagination box.
-						$pagination.html( paginationTemplate( {
+						$pagination.add($bottom_pagination).html( paginationTemplate( {
 							qty_rates:    qty_rates,
 							current_page: this.page,
 							qty_pages:    qty_pages

--- a/plugins/woocommerce/client/legacy/js/admin/settings-views-html-settings-tax.js
+++ b/plugins/woocommerce/client/legacy/js/admin/settings-views-html-settings-tax.js
@@ -18,8 +18,7 @@
 			$table             = $( '.wc_tax_rates' ),
 			$tbody             = $( '#rates' ),
 			$save_button       = $( ':input[name="save"]' ),
-			$pagination        = $( '#rates-pagination' ),
-			$bottom_pagination = $( '#rates-bottom-pagination' ),
+			$pagination        = $( '#rates-pagination, #rates-bottom-pagination' ),
 			$search_field      = $( '#rates-search .wc-tax-rates-search-field' ),
 			$submit            = $( '.submit .button-primary[type=submit]' ),
 			WCTaxTableModelConstructor = Backbone.Model.extend({
@@ -122,8 +121,8 @@
 					this.listenTo( this.model, 'saved:rates', this.clearUnloadConfirmation );
 					$tbody.on( 'change autocompletechange', ':input', { view: this }, this.updateModelOnChange );
 					$search_field.on( 'keyup search', { view: this }, this.onSearchField );
-					$pagination.add($bottom_pagination).on( 'click', 'a', { view: this }, this.onPageChange );
-					$pagination.add($bottom_pagination).on( 'change', 'input', { view: this }, this.onPageChange );
+					$pagination.on( 'click', 'a', { view: this }, this.onPageChange );
+					$pagination.on( 'change', 'input', { view: this }, this.onPageChange );
 					$( window ).on( 'beforeunload', { view: this }, this.unloadConfirmation );
 					$submit.on( 'click', { view: this }, this.onSubmit );
 					$save_button.prop( 'disabled', true );
@@ -174,7 +173,7 @@
 
 					if ( qty_pages > 1 ) {
 						// We've now displayed our initial page, time to render the pagination box.
-						$pagination.add($bottom_pagination).html( paginationTemplate( {
+						$pagination.html( paginationTemplate( {
 							qty_rates:    qty_rates,
 							current_page: this.page,
 							qty_pages:    qty_pages

--- a/plugins/woocommerce/includes/admin/settings/views/html-settings-tax.php
+++ b/plugins/woocommerce/includes/admin/settings/views/html-settings-tax.php
@@ -57,6 +57,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</tbody>
 </table>
 
+<div id="rates-bottom-pagination"></div>
+
 <script type="text/html" id="tmpl-wc-tax-table-row">
 	<tr class="tips" data-tip="<?php printf( esc_attr__( 'Tax rate ID: %s', 'woocommerce' ), '{{ data.tax_rate_id }}' ); ?>" data-id="{{ data.tax_rate_id }}">
 		<td class="country">


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.


### Changes proposed in this Pull Request:

Added another pagination to the bottom of the tax rates page

Closes #36664.

<!-- Begin testing instructions -->
At the settings page -> Tax tab -> Standard rates -> when there is many rates, pagination will be on the bottom as well as the top.
