### PR TITLE
Update WooCommerce Blocks package to 9.8.5

### DIFF
--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-9.8.5
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-9.8.5
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update WooCommerce Blocks to 9.8.5

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -21,7 +21,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.5.4",
-		"woocommerce/woocommerce-blocks": "9.8.4"
+		"woocommerce/woocommerce-blocks": "9.8.5"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.3.0",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6267272b0deee3fb00d6f72b07b199c4",
+    "content-hash": "5bbb612a8efe14541aee6e83e2d3e986",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -628,16 +628,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "9.8.4",
+            "version": "9.8.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "bdb2e6ab2288f980a7fa75fa46dc846fd0c6b31f"
+                "reference": "95587377e1085f6cc09b6d09973bc568eb91be6f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/bdb2e6ab2288f980a7fa75fa46dc846fd0c6b31f",
-                "reference": "bdb2e6ab2288f980a7fa75fa46dc846fd0c6b31f",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/95587377e1085f6cc09b6d09973bc568eb91be6f",
+                "reference": "95587377e1085f6cc09b6d09973bc568eb91be6f",
                 "shasum": ""
             },
             "require": {
@@ -683,9 +683,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v9.8.4"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v9.8.5"
             },
-            "time": "2023-03-29T12:01:19+00:00"
+            "time": "2023-04-21T08:13:59+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 9.8.5. It is intended to target WooCommerce 7.6 for release.

Details from all the different releases included in this pull:

##  WC Blocks 9.8.5

* [Release PR](https://github.com/woocommerce/woocommerce-blocks/pull/9146)
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/985.md)

### Changelog entry

**The following changelog entries are only those that impact existing blocks and functionality surfaced to users:**

#### Bug Fixes

- Fix image editor in Featured Product/Category blocks on WP 6.2. ([9142](https://github.com/woocommerce/woocommerce-blocks/pull/9142))