### PR TITLE
Fix/37785 cash on delivery not showing

### DIFF
--- a/plugins/woocommerce/changelog/fix-37785_cash_on_delivery_not_showing
+++ b/plugins/woocommerce/changelog/fix-37785_cash_on_delivery_not_showing
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Sync up date_column_name default for orders table, between stats and table data.

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/DataStore.php
@@ -23,7 +23,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 * Dynamically sets the date column name based on configuration
 	 */
 	public function __construct() {
-		$this->date_column_name = get_option( 'woocommerce_date_type', 'date_created' );
+		$this->date_column_name = get_option( 'woocommerce_date_type', 'date_paid' );
 		parent::__construct();
 	}
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-orders.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/reports-orders.php
@@ -414,6 +414,7 @@ class WC_Admin_Tests_API_Reports_Orders extends WC_REST_Unit_Test_Case {
 	 * See: https://github.com/woocommerce/woocommerce-admin/issues/5803#issuecomment-738403405.
 	 */
 	public function test_order_price_formatting_with_different_base_currency() {
+		update_option( 'woocommerce_date_type', 'date_created' );
 		wp_set_current_user( $this->user );
 		WC_Helper_Reports::reset_stats_dbs();
 


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Updates the default of the `date_column_name` value in the Orders data store to match that of the Orders Stats data store. This fixes a discrepancy between the stats and table when the default is not set.

I updated the Orders data to default to `order_paid` because we are showing a spotlight that mentions this.

Closes #37785  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Load this branch and set up a new Woo site
2. Make sure the Date Type under Analytics settings is not set ( it should be on a brand new store ).
3. Enable the `Cash On Delivery` payment method, and do a test COD order
4. Allow Scheduled actions to run to import the order in Analytics
5. Check the Analytics > Orders area for today's date, the table should be empty and the stats should display `0`
6. Set a date type to `Date created` and go back to Analytics orders, you should see the order now and the stats should match.

<!-- End testing instructions -->