### PR TITLE
Manual cherry-pick of 37890 into the `release/7.7`

### DIFF
--- a/plugins/woocommerce/changelog/fix-stock-status-not-hidden
+++ b/plugins/woocommerce/changelog/fix-stock-status-not-hidden
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Hide stock status field if stock management is enabled.

--- a/plugins/woocommerce/changelog/fix-stock-status-not-hidden
+++ b/plugins/woocommerce/changelog/fix-stock-status-not-hidden
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Hide stock status field if stock management is enabled.

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -330,19 +330,30 @@ jQuery( function ( $ ) {
 	);
 
 	// Stock options.
+	function show_or_hide_stock_management_fields(
+		isStockManagementEnabled,
+		productType
+	) {
+		const $stockManagementFields = $( '.stock_fields' );
+		const $stockStatusField = $( '.stock_status_field' );
+
+		$stockManagementFields.toggle( isStockManagementEnabled );
+		$stockStatusField.toggle(
+			! isStockManagementEnabled &&
+				// do not show stock status field if it should be hidden for the product type
+				! $stockStatusField.is( '.hide_if_' + productType )
+		);
+	}
+
 	$( 'input#_manage_stock' )
 		.on( 'change', function () {
-			if ( $( this ).is( ':checked' ) ) {
-				$( 'div.stock_fields' ).show();
-				$( 'p.stock_status_field' ).hide();
-			} else {
-				var product_type = $( 'select#product-type' ).val();
+			const isStockManagementEnabled = $( this ).is( ':checked' );
+			const productType = $( 'select#product-type' ).val();
 
-				$( 'div.stock_fields' ).hide();
-				$(
-					'p.stock_status_field:not( .hide_if_' + product_type + ' )'
-				).show();
-			}
+			show_or_hide_stock_management_fields(
+				isStockManagementEnabled,
+				productType
+			);
 
 			$( 'input.variable_manage_stock' ).trigger( 'change' );
 		} )
@@ -1093,6 +1104,7 @@ jQuery( function ( $ ) {
 	$( '#wp-content-media-buttons' )
 		.append( '<span class="woocommerce-help-tip" tabindex="-1"></span>' )
 		.find( '.woocommerce-help-tip' )
+		.attr( 'tabindex', '0' )
 		.attr( 'for', 'content' )
 		.attr(
 			'aria-label',
@@ -1111,6 +1123,7 @@ jQuery( function ( $ ) {
 	$( '#postexcerpt > .postbox-header > .hndle' )
 		.append( '<span class="woocommerce-help-tip"></span>' )
 		.find( '.woocommerce-help-tip' )
+		.attr( 'tabindex', '0' )
 		.attr(
 			'aria-label',
 			woocommerce_admin_meta_boxes.i18n_product_short_description_tip

--- a/plugins/woocommerce/readme.txt
+++ b/plugins/woocommerce/readme.txt
@@ -201,6 +201,7 @@ WooCommerce comes with some sample data you can use to see how products look; im
 * Fix - Updates an e2e variable name to be more descriptive [#37448](https://github.com/woocommerce/woocommerce/pull/37448)
 * Fix - update select all to checkbox in menu editor [#37562](https://github.com/woocommerce/woocommerce/pull/37562)
 * Fix - Use first meta value for HPOS migration when there are duplicates for flat column. [#37676](https://github.com/woocommerce/woocommerce/pull/37676)
+* Fix - Hide stock status field if stock management is enabled. [#37890](https://github.com/woocommerce/woocommerce/pull/37890)
 * Add - Add a category for product editor blocks [#37347](https://github.com/woocommerce/woocommerce/pull/37347)
 * Add - Add country query param to payment gateway data sources [#37443](https://github.com/woocommerce/woocommerce/pull/37443)
 * Add - Add image configuration to the product block template [#37340](https://github.com/woocommerce/woocommerce/pull/37340)


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/woocommerce/woocommerce/pull/37890 into the `release/7.7` branch.

There was [a conflict](https://github.com/woocommerce/woocommerce/actions/runs/4780637816) with the changes made previously in https://github.com/woocommerce/woocommerce/pull/37808.

@mattsherman @Sidsector9, could you please verify my manual conflict resolution was done correctly? 