### PR TITLE
Delete changelog from cherry picked commit from 37890

### DIFF
--- a/plugins/woocommerce/changelog/fix-stock-status-not-hidden
+++ b/plugins/woocommerce/changelog/fix-stock-status-not-hidden
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Hide stock status field if stock management is enabled.


### PR DESCRIPTION
https://github.com/woocommerce/woocommerce/pull/37890 was manually cherry picked in https://github.com/woocommerce/woocommerce/pull/37945 to the `release/7.7` branch. This removes the changelog entry on trunk.