### PR TITLE
Add check for bot author to steps that should be skipped

### DIFF
--- a/.github/workflows/pr-build-and-e2e-tests.yml
+++ b/.github/workflows/pr-build-and-e2e-tests.yml
@@ -85,6 +85,7 @@ jobs:
 
     api-tests-run:
         name: Runs API tests.
+        if: github.event.pull_request.user.login != 'github-actions[bot]'
         runs-on: ubuntu-20.04
         permissions:
             contents: read
@@ -137,6 +138,7 @@ jobs:
 
     k6-tests-run:
         name: Runs k6 Performance tests
+        if: github.event.pull_request.user.login != 'github-actions[bot]'
         runs-on: ubuntu-20.04
         permissions:
             contents: read
@@ -167,6 +169,7 @@ jobs:
         if: |
             always() && 
             ! github.event.pull_request.head.repo.fork &&
+            github.event.pull_request.user.login != 'github-actions[bot]' &&
             (
               contains( needs.*.result, 'success' ) ||
               contains( needs.*.result, 'failure' )
@@ -239,6 +242,7 @@ jobs:
         if: |
             always() && 
             ! github.event.pull_request.head.repo.fork &&
+            github.event.pull_request.user.login != 'github-actions[bot]' &&
             (
               contains( needs.*.result, 'success' ) ||
               contains( needs.*.result, 'failure' )


### PR DESCRIPTION
### Changes proposed in this Pull Request:

There are some steps in this workflow that don't need to be run on bot authored PRs. This will stop these steps from being run on cherry pick PRs for example.

Closes https://github.com/woocommerce/woocommerce/issues/37336

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Fork this repository. While forking, it's helpful to copy all branches so that you get release branches as well. Ensure you have a release/7.5 branch.
2. Enable actions in your fork, and make sure that workflow permissions are set to "Read and write permissions", and "Allow GitHub Actions to create and approve pull requests" is checked (/settings/actions).
3. Make sure that issuses are enabled in your fork (/settings).
4. Create numbered milestone 7.5.0 in milestones (/milestones).
5. (This seems unconventional but I think its ok) -Add required checks on your release/7.5 branch that match required checks of woocommerce trunk branch
6. Apply the changes in this PR to trunk in your fork.
7. Create a new PR in your fork with milestone 7.5.0 Verify that the required checks run as intended, and that you are able to merge the PR without bypassing the checks.
8. Merge the PR. The automation should place it in the 7.5.0 milestone and auto create a cherry pick PR

Verify that in the auto created cherry pick PR that the skip checks are run, you're able to merge the PR without bypassing the checks.

<!-- End testing instructions -->