### PR TITLE
Add WC Tracker unique payment method

### DIFF
--- a/plugins/woocommerce/changelog/add-tracker_unique_payment_method
+++ b/plugins/woocommerce/changelog/add-tracker_unique_payment_method
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+In the WC Tracker, group payment methods and origins ignoring unique ids within their names.

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -531,7 +531,8 @@ class WC_Tracker {
 
 		$orders_by_gateway_currency = array();
 		foreach ( $orders_by_gateway as $orders_details ) {
-			$gateway  = 'gateway_' . $orders_details->gateway;
+            $key = str_replace( array( "payment method", "gateway" ), "",  strtolower( $orders_details->gateway ) );
+
 			$currency = $orders_details->currency;
 			$count    = $gateway . '_' . $currency . '_count';
 			$total    = $gateway . '_' . $currency . '_total';

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -656,16 +656,9 @@ class WC_Tracker {
 
 
 		$orders_by_origin = array();
-		foreach ( $orders_origin as $origin ) {
-			$key = strtolower( $origin->origin );
 
-			// If the origin name has a unique id, discard it, especially if the count is 1.
-			if ( 1 === (int) $origin->count ) {
-				$pos = strcspn( $key, '0123456789' );
-				if ( $pos ) {
-					$key = substr( $key, 0, $pos );
-				}
-			}
+		foreach ( $orders_and_origins as $origin ) {
+			$key = strtolower( $origin->group_key );
 
 			if ( array_key_exists( $key, $orders_by_origin ) ) {
 				$orders_by_origin[ $key ] = $orders_by_origin[ $key ] + (int) $origin->count;

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -587,7 +587,7 @@ class WC_Tracker {
 			$key = strtolower( $origin->origin );
 
 			// If the origin name has a unique id, discard it, especially if the count is 1.
-			if ( 1 === $origin->count ) {
+			if ( 1 === (int) $origin->count ) {
 				$pos = strcspn( $key, '0123456789' );
 				if ( $pos ) {
 					$key = substr( $key, 0, $pos );

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -631,6 +631,18 @@ class WC_Tracker {
 			"
 		);
 
+		$orders_and_origins = self::group_objects_by_key(
+			// Convert into an associative array with the origin as key
+			array_reduce( $orders_origin,
+				function( $result, $item ) {
+					$key = $item->origin;
+
+					$result[ $key ] = $item;
+					return $result;
+				}, array()
+			), 'origin' );
+
+
 		$orders_by_origin = array();
 		foreach ( $orders_origin as $origin ) {
 			$key = strtolower( $origin->origin );

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -579,6 +579,19 @@ class WC_Tracker {
 		);
 
 		$orders_by_gateway_currency = array();
+
+		$orders_by_gateway = self::group_objects_by_key(
+			// Convert into an associative array with a combination of currency and gateway as key
+			array_reduce( $orders_and_gateway_details,
+				function( $result, $item ) {
+					$key = $item->currency . '==' . $item->gateway;
+
+					$result[ $key ] = $item;
+					return $result;
+				}, array()
+			), 'gateway' );
+
+
 		foreach ( $orders_by_gateway as $orders_details ) {
 			$key = str_replace( array( 'payment method', 'gateway' ), '', strtolower( $orders_details->gateway ) );
 

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -499,42 +499,51 @@ class WC_Tracker {
 	}
 
 	/**
-	 * Group an associative array of objects by removing unique id from the key
+	 * Group an associative array of objects which have unique ids in the key.
+	 * A 'group_key' property is introduced in the object.
 	 *
-	 * @return array
+	 * @param array  $objects     The array of objects that need to be grouped.
+	 * @param string $default_key The property that will be the default group_key.
+	 * @return array Contains the objects with a group_key property.
 	 */
 	private static function group_objects_by_key( $objects, $default_key ) {
 		$keys = array_keys( $objects );
 
-		// sort keys by length and then by characters within the same length keys
-  		usort( $keys, function( $a, $b ) {
-			if ( strlen( $a ) == strlen( $b ) ) {
-				return strcmp( $a, $b );
+		// Sort keys by length and then by characters within the same length keys.
+		usort(
+			$keys,
+			function( $a, $b ) {
+				if ( strlen( $a ) === strlen( $b ) ) {
+					return strcmp( $a, $b );
+				}
+				return ( strlen( $a ) < strlen( $b ) ) ? -1 : 1;
 			}
-			return ( strlen( $a ) < strlen( $b ) ) ? -1 : 1;
-		} );
+		);
 
-		// Look for common tokens in every pair of adjacent keys
+		// Look for common tokens in every pair of adjacent keys.
 		$prev = '';
 		foreach ( $keys as $key ) {
 			if ( $prev ) {
 				$comm_tokens = array();
 
-				// Tokenize the current and previous gateway names
+				// Tokenize the current and previous gateway names.
 				$curr_tokens = preg_split( '/[ :,\-_]/ ', $key );
 				$prev_tokens = preg_split( '/[ :,\-_]/ ', $prev );
 
+				$len_curr = count( $curr_tokens );
+				$len_prev = count( $prev_tokens );
+
 				// Gather the common tokens.
 				// Let us allow for the unique reference id to be anywhere in the name but for the first token.
-				for( $i = 0; $i < count( $curr_tokens ) && $i < count( $prev_tokens ); $i++ ) {
-					if ($curr_tokens[ $i ] === $prev_tokens[ $i ] ) {
+				for ( $i = 0; $i < $len_curr && $i < $len_prev; $i++ ) {
+					if ( $curr_tokens[ $i ] === $prev_tokens[ $i ] ) {
 						$comm_tokens[] = $curr_tokens[ $i ];
 					}
 				}
 
 				// If only one token is different, that could be the unique id.
 				if ( count( $curr_tokens ) - count( $comm_tokens ) <= 1 && count( $comm_tokens ) > 0 ) {
-					$objects[ $key ]->group_key = implode( ' ', $comm_tokens );
+					$objects[ $key ]->group_key  = implode( ' ', $comm_tokens );
 					$objects[ $prev ]->group_key = implode( ' ', $comm_tokens );
 				} else {
 					$objects[ $key ]->group_key = $objects[ $key ]->$default_key;
@@ -581,23 +590,28 @@ class WC_Tracker {
 		$orders_by_gateway_currency = array();
 
 		$orders_by_gateway = self::group_objects_by_key(
-			// Convert into an associative array with a combination of currency and gateway as key
-			array_reduce( $orders_and_gateway_details,
+			// Convert into an associative array with a combination of currency and gateway as key.
+			array_reduce(
+				$orders_and_gateway_details,
 				function( $result, $item ) {
+					// Introduce currency as a prefix for the key.
 					$key = $item->currency . '==' . $item->gateway;
 
 					$result[ $key ] = $item;
 					return $result;
-				}, array()
-			), 'gateway' );
-
+				},
+				array()
+			),
+			'gateway'
+		);
 
 		foreach ( $orders_by_gateway as $orders_details ) {
 			$gkey = $orders_details->group_key;
-			// Remove currency as prefix of key for backward compatibility
+
+			// Remove currency as prefix of key for backward compatibility.
 			if ( str_contains( $gkey, '==' ) ) {
-				$tokens = preg_split('/==/', $gkey);
-				$key = $tokens[1];
+				$tokens = preg_split( '/==/', $gkey );
+				$key    = $tokens[1];
 			} else {
 				$key = $gkey;
 			}
@@ -644,16 +658,19 @@ class WC_Tracker {
 		);
 
 		$orders_and_origins = self::group_objects_by_key(
-			// Convert into an associative array with the origin as key
-			array_reduce( $orders_origin,
+			// Convert into an associative array with the origin as key.
+			array_reduce(
+				$orders_origin,
 				function( $result, $item ) {
 					$key = $item->origin;
 
 					$result[ $key ] = $item;
 					return $result;
-				}, array()
-			), 'origin' );
-
+				},
+				array()
+			),
+			'origin'
+		);
 
 		$orders_by_origin = array();
 

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -533,6 +533,13 @@ class WC_Tracker {
 		foreach ( $orders_by_gateway as $orders_details ) {
             $key = str_replace( array( "payment method", "gateway" ), "",  strtolower( $orders_details->gateway ) );
 
+            // If a payment method has a unique id( like last 4 digits of a credit card), we don't want it to be a unique payment method
+            // If the count is very less( less than 6 ), it is highly likely that it is a payment method with a unique id 
+            // In addition, if it has a digit, then truncate the payment method name( the key ) to just before the first digit
+            if ( $orders_details->counts <= 5 && $pos = strcspn( $key , '0123456789' ) ) {
+                  $key = substr( $key, 0, $pos );
+            }
+
 			$currency = $orders_details->currency;
 			$count    = $gateway . '_' . $currency . '_count';
 			$total    = $gateway . '_' . $currency . '_total';

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -540,13 +540,18 @@ class WC_Tracker {
                   $key = substr( $key, 0, $pos );
             }
 
-			$currency = $orders_details->currency;
-			$count    = $gateway . '_' . $currency . '_count';
-			$total    = $gateway . '_' . $currency . '_total';
+		$key       = 'gateway_' . $key . '_' . $orders_details->currency;
+		$count_key = $key . '_count';
+		$total_key = $key . '_total';
 
-			$orders_by_gateway_currency[ $count ] = $orders_details->counts;
-			$orders_by_gateway_currency[ $total ] = $orders_details->totals;
-		}
+		if ( array_key_exists( $count_key, $orders_by_gateway_currency ) || array_key_exists( $total_key, $orders_by_gateway_currency ) ) {
+			$orders_by_gateway_currency[ $count_key ] = $orders_by_gateway_currency[ $count_key ] + $orders_details->counts;
+			$orders_by_gateway_currency[ $total_key ] = $orders_by_gateway_currency[ $total_key ] + $orders_details->totals;
+            } else {
+                $orders_by_gateway_currency[ $count_key ] = $orders_details->counts;
+                $orders_by_gateway_currency[ $total_key ] = $orders_details->totals;
+            }
+        }
 
 		return $orders_by_gateway_currency;
 	}

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -628,7 +628,8 @@ class WC_Tracker {
 				$key = $gkey;
 			}
 
-			$key = str_replace( array( 'payment method', 'gateway' ), '', strtolower( $key ) );
+			$key = str_replace( array( 'payment method', 'payment gateway', 'gateway' ), '', strtolower( $key ) );
+			$key = trim( preg_replace( '/[: ,#*\-_]+/', ' ', $key ) );
 
 			// Add currency as postfix of gateway for backward compatibility.
 			$key       = 'gateway_' . $key . '_' . $orders_details->currency;

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -535,16 +535,19 @@ class WC_Tracker {
 				$len_curr = count( $curr_tokens );
 				$len_prev = count( $prev_tokens );
 
+				$index_unique = -1;
 				// Gather the common tokens.
-				// Let us allow for the unique reference id to be anywhere in the name but for the first token.
+				// Let us allow for the unique reference id to be anywhere in the name.
 				for ( $i = 0; $i < $len_curr && $i < $len_prev; $i++ ) {
 					if ( $curr_tokens[ $i ] === $prev_tokens[ $i ] ) {
 						$comm_tokens[] = $curr_tokens[ $i ];
+					} elseif ( preg_match( '/\d/', $curr_tokens[ $i ] ) && preg_match( '/\d/', $prev_tokens[ $i ] ) ) {
+						$index_unique = $i;
 					}
 				}
 
-				// If only one token is different, that could be the unique id.
-				if ( count( $curr_tokens ) - count( $comm_tokens ) <= 1 && count( $comm_tokens ) > 0 ) {
+				// If only one token is different, and those tokens contain digits, then that could be the unique id.
+				if ( count( $curr_tokens ) - count( $comm_tokens ) <= 1 && count( $comm_tokens ) > 0 && $index_unique > -1 ) {
 					$objects[ $key ]->group_key  = implode( ' ', $comm_tokens );
 					$objects[ $prev ]->group_key = implode( ' ', $comm_tokens );
 				} else {

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -529,8 +529,8 @@ class WC_Tracker {
 				$comm_tokens = array();
 
 				// Tokenize the current and previous gateway names.
-				$curr_tokens = preg_split( '/[ :,\-_]/ ', $key );
-				$prev_tokens = preg_split( '/[ :,\-_]/ ', $prev );
+				$curr_tokens = preg_split( '/[ :,\-_]+/', $key );
+				$prev_tokens = preg_split( '/[ :,\-_]+/', $prev );
 
 				$len_curr = count( $curr_tokens );
 				$len_prev = count( $prev_tokens );


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The WC Tracker client code groups orders(counts and total volume) by gateway(payment method) and also by origin.
But at times, these gateway(payment method) names or the origin names contain some unique id like `Visa **** 1635` defeating the purpose of the grouping. This PR attempts to remove such unique ids formed using digits as a first step in consolidating the order details.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create some orders that have the `_payment_method` meta set to a value with a unique id. If this cannot be done by placing an order, then change the value in existing orders in the database.
<img width="662" alt="Screenshot 2023-04-24 at 4 46 16 PM" src="https://user-images.githubusercontent.com/6427897/234000265-637d018d-1ba1-4677-ab53-55a90c0b9ec2.png">

2. Trigger a Tracker snapshot - Call `send_tracking_data()`. Check the values in the snapshot created. Alternately, call `get_tracking_data()` and look at the results.


3. On trunk, the same payment method with different reference ids will be listed as different items in the meta. On this branch, they should be combined into one with the unique ids stripped off.
<img width="512" alt="Screenshot 2023-04-24 at 4 48 14 PM" src="https://user-images.githubusercontent.com/6427897/234000788-9985dffc-42e8-4027-941c-c4de3dc2cae8.png">

4. Do a similar process for `created_via`. 


<img width="249" alt="Screenshot 2023-04-24 at 4 52 36 PM" src="https://user-images.githubusercontent.com/6427897/234001732-c86a3e50-a2dd-454f-b448-a758846c3672.png">




<!-- End testing instructions -->



