### PR TITLE
Track stock quantity for this product should be disabled when Enable stock management within settings is disabled, and enabled otherwise

### DIFF
--- a/packages/js/product-editor/changelog/add-37888
+++ b/packages/js/product-editor/changelog/add-37888
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Track stock quantity for this product should be disabled when Enable stock management within settings is disabled, and enabled otherwise

--- a/packages/js/product-editor/src/blocks/toggle/block.json
+++ b/packages/js/product-editor/src/blocks/toggle/block.json
@@ -14,6 +14,10 @@
 		},
 		"property": {
 			"type": "string"
+		},
+		"disabled": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"supports": {

--- a/packages/js/product-editor/src/blocks/toggle/edit.tsx
+++ b/packages/js/product-editor/src/blocks/toggle/edit.tsx
@@ -16,7 +16,7 @@ export function Edit( {
 	attributes,
 }: BlockEditProps< ToggleBlockAttributes > ) {
 	const blockProps = useBlockProps();
-	const { label, property } = attributes;
+	const { label, property, disabled } = attributes;
 	const [ value, setValue ] = useEntityProp< boolean >(
 		'postType',
 		'product',
@@ -28,6 +28,7 @@ export function Edit( {
 			<ToggleControl
 				label={ label }
 				checked={ value }
+				disabled={ disabled }
 				onChange={ setValue }
 			/>
 		</div>

--- a/packages/js/product-editor/src/blocks/toggle/types.ts
+++ b/packages/js/product-editor/src/blocks/toggle/types.ts
@@ -6,4 +6,5 @@ import { BlockAttributes } from '@wordpress/blocks';
 export interface ToggleBlockAttributes extends BlockAttributes {
 	label: string;
 	property: string;
+	disabled?: boolean;
 }

--- a/plugins/woocommerce/changelog/add-37888
+++ b/plugins/woocommerce/changelog/add-37888
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Track stock quantity for this product should be disabled when Enable stock management within settings is disabled, and enabled otherwise

--- a/plugins/woocommerce/includes/class-wc-post-types.php
+++ b/plugins/woocommerce/includes/class-wc-post-types.php
@@ -625,6 +625,7 @@ class WC_Post_Types {
 											array(
 												'label'    => __( 'Track stock quantity for this product', 'woocommerce' ),
 												'property' => 'manage_stock',
+												'disabled' => 'yes' !== get_option( 'woocommerce_manage_stock' ),
 											),
 										),
 										array(


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #37888

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Got to `/wp-admin/tools.php?page=woocommerce-admin-test-helper`
2. Under Features tab make sure to enable `product-block-editor`
3. If `Manage stock` is active under `/wp-admin/admin.php?page=wc-settings&tab=products&section=inventory` then `Track stock quantity for this product` under `/wp-admin/admin.php?page=wc-admin&path=/add-product&tab=inventory` should be enabled
4. If `Manage stock` is not active under `/wp-admin/admin.php?page=wc-settings&tab=products&section=inventory` then `Track stock quantity for this product` under `/wp-admin/admin.php?page=wc-admin&path=/add-product&tab=inventory` should be disabled

<!-- End testing instructions -->