### PR TITLE
Update List price Pricing link on the general tab to navigate to the Pricing tab

### DIFF
--- a/packages/js/product-editor/changelog/add-37931
+++ b/packages/js/product-editor/changelog/add-37931
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Update List price Pricing link on the general tab to navigate to the Pricing tab

--- a/packages/js/product-editor/src/blocks/pricing/block.json
+++ b/packages/js/product-editor/src/blocks/pricing/block.json
@@ -15,8 +15,8 @@
 		"label": {
 			"type": "string"
 		},
-		"showPricingSection": {
-			"type": "boolean"
+		"help": {
+			"type": "string"
 		}
 	},
 	"supports": {

--- a/packages/js/product-editor/src/blocks/pricing/edit.tsx
+++ b/packages/js/product-editor/src/blocks/pricing/edit.tsx
@@ -52,9 +52,7 @@ export function Edit( {
 					<Link
 						href={ getNewPath( { tab: 'pricing' } ) }
 						onClick={ () => {
-							recordEvent(
-								'product_pricing_list_price_help_tax_settings_click'
-							);
+							recordEvent( 'product_pricing_help_click' );
 						} }
 					/>
 				),

--- a/packages/js/product-editor/src/blocks/pricing/index.ts
+++ b/packages/js/product-editor/src/blocks/pricing/index.ts
@@ -1,22 +1,27 @@
 /**
+ * External dependencies
+ */
+import { BlockConfiguration } from '@wordpress/blocks';
+
+/**
  * Internal dependencies
  */
-import { initBlock } from '../../utils';
-import metadata from './block.json';
+import { initBlock } from '../../utils/init-blocks';
+import blockConfiguration from './block.json';
 import { Edit } from './edit';
+import { PricingBlockAttributes } from './types';
 
-const { name } = metadata;
+const { name, ...metadata } =
+	blockConfiguration as BlockConfiguration< PricingBlockAttributes >;
 
 export { metadata, name };
 
-export const settings = {
-	example: {},
-	edit: Edit,
-};
+export const settings: Partial< BlockConfiguration< PricingBlockAttributes > > =
+	{
+		example: {},
+		edit: Edit,
+	};
 
-export const init = () =>
-	initBlock( {
-		name,
-		metadata: metadata as never,
-		settings,
-	} );
+export function init() {
+	return initBlock( { name, metadata, settings } );
+}

--- a/packages/js/product-editor/src/blocks/pricing/types.ts
+++ b/packages/js/product-editor/src/blocks/pricing/types.ts
@@ -1,0 +1,10 @@
+/**
+ * External dependencies
+ */
+import { BlockAttributes } from '@wordpress/blocks';
+
+export interface PricingBlockAttributes extends BlockAttributes {
+	name: string;
+	label: string;
+	help?: string;
+}

--- a/plugins/woocommerce/changelog/add-37931
+++ b/plugins/woocommerce/changelog/add-37931
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Update List price Pricing link on the general tab to navigate to the Pricing tab

--- a/plugins/woocommerce/includes/class-wc-post-types.php
+++ b/plugins/woocommerce/includes/class-wc-post-types.php
@@ -405,9 +405,9 @@ class WC_Post_Types {
 														array(
 															'woocommerce/product-pricing-field',
 															array(
-																'name' => 'regular_price',
+																'name'  => 'regular_price',
 																'label' => __( 'List price', 'woocommerce' ),
-																'showPricingSection' => true,
+																'help'  => __( 'Manage more settings in <PricingTab>Pricing.</PricingTab>', 'woocommerce' ),
 															),
 														),
 													),
@@ -421,7 +421,7 @@ class WC_Post_Types {
 														array(
 															'woocommerce/product-pricing-field',
 															array(
-																'name' => 'sale_price',
+																'name'  => 'sale_price',
 																'label' => __( 'Sale price', 'woocommerce' ),
 															),
 														),
@@ -506,9 +506,8 @@ class WC_Post_Types {
 														array(
 															'woocommerce/product-pricing-field',
 															array(
-																'name' => 'regular_price',
+																'name'  => 'regular_price',
 																'label' => __( 'List price', 'woocommerce' ),
-																'showPricingSection' => true,
 															),
 														),
 													),
@@ -522,7 +521,7 @@ class WC_Post_Types {
 														array(
 															'woocommerce/product-pricing-field',
 															array(
-																'name' => 'sale_price',
+																'name'  => 'sale_price',
 																'label' => __( 'Sale price', 'woocommerce' ),
 															),
 														),


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/37931

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Got to `/wp-admin/tools.php?page=woocommerce-admin-test-helper`
2. Under Features tab make sure to enable `product-block-editor`
3. Then visit `/wp-admin/admin.php?page=wc-admin&path=/add-product`
4. Under `General` tab and within `Basic details` section the `List price` field helper text should be `Manage more settings in Pricing`.
5. When click the `Pricing` the `Pricing` tab should be shown and the `List price` field helper text should not be shown.

<!-- End testing instructions -->