### PR TITLE
Update WooCommerce support policy to L-1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,80 +1,80 @@
 name: Run CI
-on: 
-  push:
-    branches:
-      - trunk
-      - 'release/**'
-  workflow_dispatch:
+on:
+    push:
+        branches:
+            - trunk
+            - 'release/**'
+    workflow_dispatch:
 
 defaults:
-  run:
-    shell: bash
-concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+    run:
+        shell: bash
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
 
 permissions: {}
 
 jobs:
-  test:
-    name: PHP ${{ matrix.php }} WP ${{ matrix.wp }}
-    timeout-minutes: 30
-    runs-on: ubuntu-20.04
-    permissions:
-      contents: read
-    continue-on-error: ${{ matrix.wp == 'nightly' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        php: [ '7.4', '8.0' ]
-        wp: [ 'latest' ]
-        include:
-          - wp: nightly
-            php: '7.4'
-          - wp: '6.0'
-            php: 7.4
-    services:
-      database:
-        image: mysql:5.6
-        env:
-          MYSQL_ROOT_PASSWORD: root
-        ports:
-          - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
-    steps:
-      - uses: actions/checkout@v3
+    test:
+        name: PHP ${{ matrix.php }} WP ${{ matrix.wp }}
+        timeout-minutes: 30
+        runs-on: ubuntu-20.04
+        permissions:
+            contents: read
+        continue-on-error: ${{ matrix.wp == 'nightly' }}
+        strategy:
+            fail-fast: false
+            matrix:
+                php: ['7.4', '8.0']
+                wp: ['latest']
+                include:
+                    - wp: nightly
+                      php: '7.4'
+                    - wp: '6.1'
+                      php: 7.4
+        services:
+            database:
+                image: mysql:5.6
+                env:
+                    MYSQL_ROOT_PASSWORD: root
+                ports:
+                    - 3306:3306
+                options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
+        steps:
+            - uses: actions/checkout@v3
 
-      - name: Setup WooCommerce Monorepo
-        uses: ./.github/actions/setup-woocommerce-monorepo
-        with:
-          build-filters: woocommerce
+            - name: Setup WooCommerce Monorepo
+              uses: ./.github/actions/setup-woocommerce-monorepo
+              with:
+                  build-filters: woocommerce
 
-      - name: Tool versions
-        run: |
-          php --version
-          composer --version
+            - name: Tool versions
+              run: |
+                  php --version
+                  composer --version
 
-      - name: Build Admin feature config
-        working-directory: plugins/woocommerce
-        run: pnpm run build:feature-config
+            - name: Build Admin feature config
+              working-directory: plugins/woocommerce
+              run: pnpm run build:feature-config
 
-      - name: Add PHP8 Compatibility.
-        run: |
-          if [ "$(php -r "echo version_compare(PHP_VERSION,'8.0','>=');")" ]; then
-             cd plugins/woocommerce
-             curl -L https://github.com/woocommerce/phpunit/archive/add-compatibility-with-php8-to-phpunit-7.zip -o /tmp/phpunit-7.5-fork.zip
-             unzip -d /tmp/phpunit-7.5-fork /tmp/phpunit-7.5-fork.zip
-             composer bin phpunit config --unset platform
-             composer bin phpunit config repositories.0 '{"type": "path", "url": "/tmp/phpunit-7.5-fork/phpunit-add-compatibility-with-php8-to-phpunit-7", "options": {"symlink": false}}'
-             composer bin phpunit require --dev -W phpunit/phpunit:@dev --ignore-platform-reqs
-             rm -rf ./vendor/phpunit/
-             composer dump-autoload
-           fi
+            - name: Add PHP8 Compatibility.
+              run: |
+                  if [ "$(php -r "echo version_compare(PHP_VERSION,'8.0','>=');")" ]; then
+                     cd plugins/woocommerce
+                     curl -L https://github.com/woocommerce/phpunit/archive/add-compatibility-with-php8-to-phpunit-7.zip -o /tmp/phpunit-7.5-fork.zip
+                     unzip -d /tmp/phpunit-7.5-fork /tmp/phpunit-7.5-fork.zip
+                     composer bin phpunit config --unset platform
+                     composer bin phpunit config repositories.0 '{"type": "path", "url": "/tmp/phpunit-7.5-fork/phpunit-add-compatibility-with-php8-to-phpunit-7", "options": {"symlink": false}}'
+                     composer bin phpunit require --dev -W phpunit/phpunit:@dev --ignore-platform-reqs
+                     rm -rf ./vendor/phpunit/
+                     composer dump-autoload
+                   fi
 
-      - name: Init DB and WP
-        working-directory: plugins/woocommerce
-        run: ./tests/bin/install.sh woo_test root root 127.0.0.1 ${{ matrix.wp }}
+            - name: Init DB and WP
+              working-directory: plugins/woocommerce
+              run: ./tests/bin/install.sh woo_test root root 127.0.0.1 ${{ matrix.wp }}
 
-      - name: Run tests
-        working-directory: plugins/woocommerce
-        run: pnpm run test --color
+            - name: Run tests
+              working-directory: plugins/woocommerce
+              run: pnpm run test --color

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -13,54 +13,54 @@ concurrency:
 permissions: {}
 
 jobs:
-  test:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.user.login != 'github-actions[bot]' }}
-    name: PHP ${{ matrix.php }} WP ${{ matrix.wp }} ${{ matrix.hpos && 'HPOS' || '' }}
-    timeout-minutes: 30
-    runs-on: ubuntu-20.04
-    permissions:
-      contents: read
-    continue-on-error: ${{ matrix.wp == 'nightly' }}
-    env:
-      HPOS: ${{ matrix.hpos }}
-    strategy:
-      fail-fast: false
-      matrix:
-        php: [ '7.4', '8.0' ]
-        wp: [ "latest" ]
-        include:
-          - wp: nightly
-            php: '7.4'
-          - wp: '6.0'
-            php: 7.4
-          - wp: 'latest'
-            php: '7.4'
-            hpos: true
-    services:
-      database:
-        image: mysql:5.6
+    test:
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.user.login != 'github-actions[bot]' }}
+        name: PHP ${{ matrix.php }} WP ${{ matrix.wp }} ${{ matrix.hpos && 'HPOS' || '' }}
+        timeout-minutes: 30
+        runs-on: ubuntu-20.04
+        permissions:
+            contents: read
+        continue-on-error: ${{ matrix.wp == 'nightly' }}
         env:
-          MYSQL_ROOT_PASSWORD: root
-        ports:
-          - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
-    steps:
-      - uses: actions/checkout@v3
+            HPOS: ${{ matrix.hpos }}
+        strategy:
+            fail-fast: false
+            matrix:
+                php: ['7.4', '8.0']
+                wp: ['latest']
+                include:
+                    - wp: nightly
+                      php: '7.4'
+                    - wp: '6.1'
+                      php: 7.4
+                    - wp: 'latest'
+                      php: '7.4'
+                      hpos: true
+        services:
+            database:
+                image: mysql:5.6
+                env:
+                    MYSQL_ROOT_PASSWORD: root
+                ports:
+                    - 3306:3306
+                options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
+        steps:
+            - uses: actions/checkout@v3
 
-      - name: Setup WooCommerce Monorepo
-        uses: ./.github/actions/setup-woocommerce-monorepo
-        with:
-            php-version: ${{ matrix.php }}
+            - name: Setup WooCommerce Monorepo
+              uses: ./.github/actions/setup-woocommerce-monorepo
+              with:
+                  php-version: ${{ matrix.php }}
 
-      - name: Tool versions
-        run: |
-            php --version
-            composer --version
+            - name: Tool versions
+              run: |
+                  php --version
+                  composer --version
 
-      - name: Init DB and WP
-        working-directory: plugins/woocommerce
-        run: ./tests/bin/install.sh woo_test root root 127.0.0.1 ${{ matrix.wp }}
+            - name: Init DB and WP
+              working-directory: plugins/woocommerce
+              run: ./tests/bin/install.sh woo_test root root 127.0.0.1 ${{ matrix.wp }}
 
-      - name: Run tests
-        working-directory: plugins/woocommerce
-        run: pnpm run test --filter=woocommerce --color
+            - name: Run tests
+              working-directory: plugins/woocommerce
+              run: pnpm run test --filter=woocommerce --color

--- a/plugins/woocommerce/changelog/update-woo-L1-support-policy
+++ b/plugins/woocommerce/changelog/update-woo-L1-support-policy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update Woo to L-1 support policy for 7.8

--- a/plugins/woocommerce/readme.txt
+++ b/plugins/woocommerce/readme.txt
@@ -1,7 +1,7 @@
 === WooCommerce ===
 Contributors: automattic, mikejolley, jameskoster, claudiosanches, rodrigosprimo, peterfabian1000, vedjain, jamosova, obliviousharmony, konamiman, sadowski, wpmuguru, royho, barryhughes-1
 Tags: online store, ecommerce, shop, shopping cart, sell online, storefront, checkout, payments, woo, woo commerce, e-commerce, store
-Requires at least: 6.0
+Requires at least: 6.1
 Tested up to: 6.2
 Requires PHP: 7.3
 Stable tag: 7.6.0

--- a/plugins/woocommerce/woocommerce.php
+++ b/plugins/woocommerce/woocommerce.php
@@ -8,7 +8,7 @@
  * Author URI: https://woocommerce.com
  * Text Domain: woocommerce
  * Domain Path: /i18n/languages/
- * Requires at least: 6.0
+ * Requires at least: 6.1
  * Requires PHP: 7.3
  *
  * @package WooCommerce


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

WooCommerce will begin an L-1 support policy starting with the 7.8 release.
See details in https://developer.woocommerce.com/2023/02/23/revisiting-wordpress-core-support-policy-for-woocommerce/

This PR updates the main file and readme to reflect this change as well as updating the testing matrices.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Review changes and make sure they make sense according to the developer blog post. 
2. See https://github.com/woocommerce/woocommerce/pull/37970/files?w=1 for changes not including whitespace changes.

<!-- End testing instructions -->