### PR TITLE
Remove AUTO-DRAFT in product name field on create new product page

### DIFF
--- a/packages/js/product-editor/changelog/add-37930
+++ b/packages/js/product-editor/changelog/add-37930
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Remove AUTO-DRAFT in product name field on create new product page #37930

--- a/packages/js/product-editor/src/blocks/name/edit.tsx
+++ b/packages/js/product-editor/src/blocks/name/edit.tsx
@@ -7,7 +7,6 @@ import {
 	Fragment,
 	createInterpolateElement,
 	useState,
-	useEffect,
 } from '@wordpress/element';
 
 import { useBlockProps } from '@wordpress/block-editor';

--- a/packages/js/product-editor/src/blocks/name/edit.tsx
+++ b/packages/js/product-editor/src/blocks/name/edit.tsx
@@ -7,6 +7,7 @@ import {
 	Fragment,
 	createInterpolateElement,
 	useState,
+	useEffect,
 } from '@wordpress/element';
 
 import { useBlockProps } from '@wordpress/block-editor';
@@ -159,7 +160,7 @@ export function Edit() {
 							'woocommerce'
 						) }
 						onChange={ setName }
-						value={ name || '' }
+						value={ name && name !== AUTO_DRAFT_NAME ? name : '' }
 						onBlur={ setSkuIfEmpty }
 					/>
 				</BaseControl>


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #37930

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Got to `/wp-admin/tools.php?page=woocommerce-admin-test-helper`
2. Under Features tab make sure to enable `product-block-editor`
3. Then visit `/wp-admin/admin.php?page=wc-admin&path=/add-product`
4. Under `General` tab and within `Basic details` section the product name should not longer be `AUTO-DRAFT` when creating the product.

<!-- End testing instructions -->