### PR TITLE
Remove dot in images description

### DIFF
--- a/plugins/woocommerce/changelog/fix-37954_update_image_description
+++ b/plugins/woocommerce/changelog/fix-37954_update_image_description
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Just removing a dot within a description, fixing small typo.
+
+

--- a/plugins/woocommerce/includes/class-wc-post-types.php
+++ b/plugins/woocommerce/includes/class-wc-post-types.php
@@ -437,7 +437,7 @@ class WC_Post_Types {
 										'title'       => __( 'Images', 'woocommerce' ),
 										'description' => sprintf(
 											/* translators: %1$s: Images guide link opening tag. %2$s: Images guide link closing tag.*/
-											__( 'Drag images, upload new ones or select files from your library. For best results, use JPEG files that are 1000 by 1000 pixels or larger. %1$sHow to prepare images?%2$s.', 'woocommerce' ),
+											__( 'Drag images, upload new ones or select files from your library. For best results, use JPEG files that are 1000 by 1000 pixels or larger. %1$sHow to prepare images?%2$s', 'woocommerce' ),
 											'<a href="http://woocommerce.com/#" target="_blank" rel="noreferrer">',
 											'</a>'
 										),


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Very tiny PR removing dot at the end of the images description.

Closes #37954  .

![Screenshot 2023-04-25 at 4 59 40 PM](https://user-images.githubusercontent.com/2240960/234318664-b0cb7bf5-3d40-4589-b5fa-1e3a2c765bb6.png)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the `product-block-editor` feature flag and go to **Products > Add New**
2. Scroll down to the images section and make sure there is no `.` visible at the end of the description after the `how to prepare images?` link.

<!-- End testing instructions -->