### PR TITLE
Add ContentPreview component for previewing block content

### DIFF
--- a/packages/js/product-editor/changelog/add-37900
+++ b/packages/js/product-editor/changelog/add-37900
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add ContentPreview component for previewing block content

--- a/packages/js/product-editor/src/blocks/description/edit.tsx
+++ b/packages/js/product-editor/src/blocks/description/edit.tsx
@@ -12,6 +12,7 @@ import { useEntityProp } from '@wordpress/core-data';
  * Internal dependencies
  */
 import { IframeEditor } from '../../components/iframe-editor';
+import { ContentPreview } from '../../components/content-preview';
 
 /**
  * Internal dependencies
@@ -46,6 +47,7 @@ export function Edit() {
 					onClose={ () => setIsModalOpen( false ) }
 				/>
 			) }
+			<ContentPreview content={ description } />
 		</div>
 	);
 }

--- a/packages/js/product-editor/src/blocks/description/edit.tsx
+++ b/packages/js/product-editor/src/blocks/description/edit.tsx
@@ -47,7 +47,9 @@ export function Edit() {
 					onClose={ () => setIsModalOpen( false ) }
 				/>
 			) }
-			<ContentPreview content={ description } />
+			{ !! description.length && (
+				<ContentPreview content={ description } />
+			) }
 		</div>
 	);
 }

--- a/packages/js/product-editor/src/components/content-preview/content-preview.tsx
+++ b/packages/js/product-editor/src/components/content-preview/content-preview.tsx
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import { createElement } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { sanitizeHTML } from '../../utils/sanitize-html';
+
+type ContentPreviewProps = {
+	content: string;
+};
+
+const CONTENT_TAGS = [
+	'a',
+	'b',
+	'em',
+	'i',
+	'strong',
+	'p',
+	'br',
+	'img',
+	'blockquote',
+	'cite',
+	'h1',
+	'h2',
+	'h3',
+	'h4',
+	'h5',
+	'h6',
+	'ul',
+	'li',
+	'ol',
+	'div',
+];
+
+const CONTENT_ATTR = [
+	'target',
+	'href',
+	'rel',
+	'name',
+	'download',
+	'src',
+	'style',
+	'class',
+];
+
+export function ContentPreview( { content }: ContentPreviewProps ) {
+	return (
+		<div
+			className="woocommerce-content-preview"
+			dangerouslySetInnerHTML={ sanitizeHTML( content, {
+				tags: CONTENT_TAGS,
+				attr: CONTENT_ATTR,
+			} ) }
+		/>
+	);
+}

--- a/packages/js/product-editor/src/components/content-preview/index.ts
+++ b/packages/js/product-editor/src/components/content-preview/index.ts
@@ -1,0 +1,1 @@
+export * from './content-preview';

--- a/packages/js/product-editor/src/components/content-preview/style.scss
+++ b/packages/js/product-editor/src/components/content-preview/style.scss
@@ -1,0 +1,26 @@
+.woocommerce-content-preview {
+    border: 1px solid $gray-300;
+    max-height: 144px;
+    overflow: hidden;
+    padding: $gap-large;
+    margin-top: $gap-largest;
+
+    >:first-child {
+        margin-top: 0;
+    }
+
+    > * {
+        max-width: 100%;
+    }
+
+    &:after {
+        content: '';
+        display: block;
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        height: 57px;
+        width: 100%;
+        background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, #FFFFFF 89.5%);
+    }
+}

--- a/packages/js/product-editor/src/style.scss
+++ b/packages/js/product-editor/src/style.scss
@@ -11,6 +11,7 @@
 
 /* Components */
 
+@import 'components/content-preview/style.scss';
 @import 'components/radio-field/style.scss';
 @import 'components/iframe-editor/style.scss';
 @import 'components/details-categories-field/style.scss';

--- a/packages/js/product-editor/src/utils/sanitize-html.ts
+++ b/packages/js/product-editor/src/utils/sanitize-html.ts
@@ -6,8 +6,17 @@ import { sanitize } from 'dompurify';
 const ALLOWED_TAGS = [ 'a', 'b', 'em', 'i', 'strong', 'p', 'br' ];
 const ALLOWED_ATTR = [ 'target', 'href', 'rel', 'name', 'download' ];
 
-export function sanitizeHTML( html: string ) {
+export function sanitizeHTML(
+	html: string,
+	config?: { tags?: string[]; attr?: string[] }
+) {
+	const allowedTags = config?.tags || ALLOWED_TAGS;
+	const allowedAttr = config?.attr || ALLOWED_ATTR;
+
 	return {
-		__html: sanitize( html, { ALLOWED_TAGS, ALLOWED_ATTR } ),
+		__html: sanitize( html, {
+			ALLOWED_TAGS: allowedTags,
+			ALLOWED_ATTR: allowedAttr,
+		} ),
 	};
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a `ContentPreview` component and hooks up the description with a preview area.

Note that the preview area does not show video content currently.  I'm not sure if this absolutely necessary to have and may create loading and/or render issues in the product form.

<img width="712" alt="Screen Shot 2023-04-25 at 2 41 04 PM" src="https://user-images.githubusercontent.com/10561050/234411357-be327151-4288-451d-b8ed-7b830f92132d.png">


Closes #37900 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Navigate to Tools -> WCA Test Helper -> Features and enable the new product blocks editing experience
2. Navigate to Products -> Add new
3. Click on "Add description" under the description
4. Add some content via the blocks editor
5. Close the description editor
6. Note that the content you added is now visible in the preview area.

<!-- End testing instructions -->