### PR TITLE
Reference taxanomy in woocommerce_layered_nav_default_query_type filter

### DIFF
--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -868,7 +868,7 @@ class WC_Query {
 
 						$query_type                                    = ! empty( $_GET[ 'query_type_' . $attribute ] ) && in_array( $_GET[ 'query_type_' . $attribute ], array( 'and', 'or' ), true ) ? wc_clean( wp_unslash( $_GET[ 'query_type_' . $attribute ] ) ) : '';
 						self::$chosen_attributes[ $taxonomy ]['terms'] = array_map( 'sanitize_title', $filter_terms ); // Ensures correct encoding.
-						self::$chosen_attributes[ $taxonomy ]['query_type'] = $query_type ? $query_type : apply_filters( 'woocommerce_layered_nav_default_query_type', 'and' );
+						self::$chosen_attributes[ $taxonomy ]['query_type'] = $query_type ? $query_type : apply_filters( 'woocommerce_layered_nav_default_query_type', 'and', $taxonomy );
 					}
 				}
 			}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Filter `woocommerce_layered_nav_default_query_type` didn't differentiate between taxonomies what makes not possible change query_type for specific attribute only.