### PR TITLE
Remove strange block editor highlighting within product block editor

### DIFF
--- a/packages/js/product-editor/changelog/fix-37928_block_editor_highlighting
+++ b/packages/js/product-editor/changelog/fix-37928_block_editor_highlighting
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update styling of block editor to remove highlighting of selected blocks.

--- a/packages/js/product-editor/src/blocks/tab/editor.scss
+++ b/packages/js/product-editor/src/blocks/tab/editor.scss
@@ -1,10 +1,16 @@
 .wp-block-woocommerce-product-tab__content {
     &:not(.is-selected) {
-        display: none;
-    }
+		display: none;
+	}
+}
+
+.woocommerce-product-tabs {
+	.wp-block-woocommerce-product-tab__button:focus:not( :disabled ) {
+		box-shadow: none;
+	}
 }
 
 // Remove the Gutenberg selected outline.
 .wp-block-woocommerce-product-tab:after {
-    display: none;
+	display: none;
 }

--- a/packages/js/product-editor/src/components/block-editor/style.scss
+++ b/packages/js/product-editor/src/components/block-editor/style.scss
@@ -94,6 +94,10 @@
 		color: $gray-900;
 		font-weight: 500;
 	}
+
+	.block-editor-block-list__layout .block-editor-block-list__block:not( [contenteditable] ):focus:after {
+		display: none; // use important or increase specificity.
+	}
 }
 
 .woocommerce-layout:has( .woocommerce-product-block-editor ) {


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This removes the highlighting when selecting block content or the highlight within tab buttons.

Closes #37928

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Load this branch and enable the `product-block-editor` feature flag
2. Go to **Products > Add New** click on the content of individual blocks, like the description or labels of fields, there should be no blue outline around the entire block.
3. Now switch tabs, the tab button should only show a blue border at the bottom not around the entire button.
4. Play around with the summary field and the edit description field, these should still work and act the same (not missing any specific highlighting).

<!-- End testing instructions -->