### PR TITLE
Update: make "Used for variations" checkbox unchecked by default when adding new attribute to product type variable

### DIFF
--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -602,7 +602,7 @@ class WC_AJAX {
 		$attribute->set_name( sanitize_text_field( wp_unslash( $_POST['taxonomy'] ) ) );
 		/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
 		$attribute->set_visible( apply_filters( 'woocommerce_attribute_default_visibility', 1 ) );
-		$attribute->set_variation( apply_filters( 'woocommerce_attribute_default_is_variation', 1 ) );
+		$attribute->set_variation( apply_filters( 'woocommerce_attribute_default_is_variation', 0 ) );
 		/* phpcs: enable */
 
 		if ( $attribute->is_taxonomy() ) {


### PR DESCRIPTION
When you are editing a variable product in the admin dashboard and want to add an attribute, the "Used for variations" option is checked by default. 
`![image](https://user-images.githubusercontent.com/65178363/235246382-3bfc140e-bb21-4f6b-9b79-61e38227fd41.png)
'
This has been added in recent versions. We are forced to always to remove it using the filter:

`add_filter('woocommerce_attribute_default_is_variation', '__return_false');`

It is not a bug, but I think it is better to be unchecked by default as in old version.


### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
<!-- Mark completed items with an [x] -->
