### PR TITLE
Add block inspector to modal iframe editor

### DIFF
--- a/packages/js/product-editor/changelog/add-37911
+++ b/packages/js/product-editor/changelog/add-37911
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add block inspector to modal iframe editor

--- a/packages/js/product-editor/src/components/iframe-editor/iframe-editor.scss
+++ b/packages/js/product-editor/src/components/iframe-editor/iframe-editor.scss
@@ -1,16 +1,29 @@
 .woocommerce-iframe-editor {
-    align-items: center;
-    background-color: #2f2f2f;
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-    width: 100%;
-    overflow: hidden;
-    padding: 40px 48px;
-    z-index: 1000;
+	align-items: flex-start;
+	display: flex;
+	flex-direction: row;
+	flex-grow: 1;
+	height: 100%;
+	width: 100%;
+	overflow: hidden;
+	z-index: 1000;
 
-    iframe {
-        width: 100%;
-        height: 100%;
-    }
+	iframe {
+		width: 100%;
+		height: 100%;
+	}
+
+	&__content {
+		flex-grow: 1;
+		background-color: #2f2f2f;
+		padding: 40px 48px;
+		height: 100%;
+		justify-content: center;
+		display: flex;
+	}
+
+	&__sidebar {
+		flex-shrink: 0;
+		width: 280px;
+	}
 }

--- a/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
@@ -13,6 +13,7 @@ import {
 import { useDebounce, useResizeObserver } from '@wordpress/compose';
 import {
 	BlockEditorProvider,
+	BlockInspector,
 	BlockList,
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore
@@ -75,46 +76,51 @@ export function IframeEditor( {
 	const debouncedOnChange = useDebounce( handleChange, 200 );
 
 	return (
-		<BlockEditorProvider
-			settings={ {
-				...( settings || parentEditorSettings ),
-				templateLock: false,
-			} }
-			value={ blocks }
-			onChange={ ( updatedBlocks: BlockInstance[] ) => {
-				setBlocks( updatedBlocks );
-				debouncedOnChange( updatedBlocks );
-			} }
-			useSubRegistry={ true }
-		>
-			<BlockTools
-				className={ 'woocommerce-iframe-editor' }
-				onClick={ (
-					event: React.MouseEvent< HTMLDivElement, MouseEvent >
-				) => {
-					// Clear selected block when clicking on the gray background.
-					if ( event.target === event.currentTarget ) {
-						clearSelectedBlock();
-					}
+		<div className="woocommerce-iframe-editor">
+			<BlockEditorProvider
+				settings={ {
+					...( settings || parentEditorSettings ),
+					templateLock: false,
 				} }
+				value={ blocks }
+				onChange={ ( updatedBlocks: BlockInstance[] ) => {
+					setBlocks( updatedBlocks );
+					debouncedOnChange( updatedBlocks );
+				} }
+				useSubRegistry={ true }
 			>
-				{ /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */ }
-				{ /* @ts-ignore */ }
-				<BlockEditorKeyboardShortcuts.Register />
-				{ onClose && <BackButton onClick={ onClose } /> }
-				<ResizableEditor
-					enableResizing={ true }
-					// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-					// @ts-ignore This accepts numbers or strings.
-					height={ sizes.height ?? '100%' }
+				<BlockTools
+					className={ 'woocommerce-iframe-editor__content' }
+					onClick={ (
+						event: React.MouseEvent< HTMLDivElement, MouseEvent >
+					) => {
+						// Clear selected block when clicking on the gray background.
+						if ( event.target === event.currentTarget ) {
+							clearSelectedBlock();
+						}
+					} }
 				>
-					<EditorCanvas enableResizing={ true }>
-						{ resizeObserver }
-						<BlockList className="edit-site-block-editor__block-list wp-site-blocks" />
-					</EditorCanvas>
-					<Popover.Slot />
-				</ResizableEditor>
-			</BlockTools>
-		</BlockEditorProvider>
+					{ /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */ }
+					{ /* @ts-ignore */ }
+					<BlockEditorKeyboardShortcuts.Register />
+					{ onClose && <BackButton onClick={ onClose } /> }
+					<ResizableEditor
+						enableResizing={ true }
+						// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+						// @ts-ignore This accepts numbers or strings.
+						height={ sizes.height ?? '100%' }
+					>
+						<EditorCanvas enableResizing={ true }>
+							{ resizeObserver }
+							<BlockList className="edit-site-block-editor__block-list wp-site-blocks" />
+						</EditorCanvas>
+						<Popover.Slot />
+					</ResizableEditor>
+				</BlockTools>
+				<div className="woocommerce-iframe-editor__sidebar">
+					<BlockInspector />
+				</div>
+			</BlockEditorProvider>
+		</div>
 	);
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds the sidebar inspector and styling for the modal editor.

<img width="958" alt="Screen Shot 2023-04-26 at 10 34 55 AM" src="https://user-images.githubusercontent.com/10561050/234658322-9294d60a-169f-4341-8608-e4704e131b69.png">


Closes #37911 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Navigate to Tools -> WCA Test Helper -> Features and enable the new product blocks editing experience
2. Navigate to Products -> Add new
3. Click on "Add description" under the description
4. Add some content via the blocks editor
5. Note that the sidebar includes the inspector for a given block when selecting a block

<!-- End testing instructions -->