### PR TITLE
Summary field remove 'inline image' and 'keyboard input' options

### DIFF
--- a/packages/js/product-editor/changelog/add-37986
+++ b/packages/js/product-editor/changelog/add-37986
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Summary field remove 'inline image' and 'keyboard input' options#37986

--- a/packages/js/product-editor/src/blocks/summary/block.json
+++ b/packages/js/product-editor/src/blocks/summary/block.json
@@ -11,6 +11,21 @@
 		"align": {
 			"type": "string"
 		},
+		"allowedFormats": {
+			"type": "array",
+			"default": [
+				"core/bold",
+				"core/code",
+				"core/italic",
+				"core/link",
+				"core/strikethrough",
+				"core/underline",
+				"core/text-color",
+				"core/subscript",
+				"core/superscript",
+				"core/unknown"
+			]
+		},
 		"direction": {
 			"type": "string",
 			"enum": [ "ltr", "rtl" ]

--- a/packages/js/product-editor/src/blocks/summary/edit.tsx
+++ b/packages/js/product-editor/src/blocks/summary/edit.tsx
@@ -28,7 +28,7 @@ export function Edit( {
 	attributes,
 	setAttributes,
 }: BlockEditProps< SummaryAttributes > ) {
-	const { align, direction, label } = attributes;
+	const { align, allowedFormats, direction, label } = attributes;
 	const blockProps = useBlockProps( {
 		style: { direction },
 	} );
@@ -83,6 +83,7 @@ export function Edit( {
 						[ `has-text-align-${ align }` ]: align,
 					} ) }
 					dir={ direction }
+					allowedFormats={ allowedFormats }
 				/>
 			</BaseControl>
 		</div>

--- a/packages/js/product-editor/src/blocks/summary/types.ts
+++ b/packages/js/product-editor/src/blocks/summary/types.ts
@@ -1,5 +1,6 @@
 export type SummaryAttributes = {
 	align: 'left' | 'center' | 'right' | 'justify';
+	allowedFormats?: string[];
 	direction: 'ltr' | 'rtl';
 	label: string;
 };


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #37986

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Got to `/wp-admin/tools.php?page=woocommerce-admin-test-helper`
2. Under Features tab make sure to enable `product-block-editor`
3. Then visit `/wp-admin/admin.php?page=wc-admin&path=/add-product`
4. Under `General` tab and within `Basic details` section the product summary toolbar more menu items should not contains `Inline image` and `Keyboard input` items

<img width="516" alt="image" src="https://user-images.githubusercontent.com/13334210/234669090-67b3e047-7ff3-444e-a396-086c6dc15814.png">

<!-- End testing instructions -->