### PR TITLE
Add product type options to product tracking

### DIFF
--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
@@ -26,6 +26,37 @@ const getProductType = () => {
 		?.value;
 };
 
+type ProductTypeOption = {
+	id: string | null;
+	isEnabled: boolean;
+};
+
+function getProductTypeOptions() {
+	const productTypeOptionsCheckboxes = Array.from(
+		document.querySelectorAll(
+			'input[type="checkbox"][data-product-type-option-id]'
+		)
+	) as HTMLInputElement[];
+	const productTypeOptions = productTypeOptionsCheckboxes.map(
+		( checkbox ) => {
+			return {
+				id: checkbox.getAttribute( 'data-product-type-option-id' ),
+				isEnabled: checkbox.checked,
+			};
+		}
+	);
+	return productTypeOptions;
+}
+
+function getProductTypeOptionsString(
+	productTypeOptions: ProductTypeOption[]
+) {
+	return productTypeOptions
+		.filter( ( productTypeOption ) => productTypeOption.isEnabled )
+		.map( ( productTypeOption ) => productTypeOption.id )
+		.join( ', ' );
+}
+
 const getProductData = () => {
 	const isBlockEditor =
 		document.querySelectorAll( '.block-editor' ).length > 0;
@@ -55,10 +86,15 @@ const getProductData = () => {
 		 )?.value;
 	}
 
+	const productTypeOptions = getProductTypeOptions();
+	const productTypeOptionsString =
+		getProductTypeOptionsString( productTypeOptions );
+
 	const productData = {
 		product_id: ( document.querySelector( '#post_ID' ) as HTMLInputElement )
 			?.value,
 		product_type: getProductType(),
+		product_type_options: productTypeOptionsString,
 		is_downloadable: (
 			document.querySelector( '#_downloadable' ) as HTMLInputElement
 		 )?.checked

--- a/plugins/woocommerce/changelog/add-tracks-product-type-options
+++ b/plugins/woocommerce/changelog/add-tracks-product-type-options
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Add product type options tracking to product publish and update events.

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-panel.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-panel.php
@@ -34,7 +34,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			?>
 			<label for="<?php echo esc_attr( $option['id'] ); ?>" class="<?php echo esc_attr( $option['wrapper_class'] ); ?> tips" data-tip="<?php echo esc_attr( $option['description'] ); ?>">
 				<?php echo esc_html( $option['label'] ); ?>:
-				<input type="checkbox" name="<?php echo esc_attr( $option['id'] ); ?>" id="<?php echo esc_attr( $option['id'] ); ?>" <?php echo checked( $selected_value, true, false ); ?> />
+				<input type="checkbox" name="<?php echo esc_attr( $option['id'] ); ?>" id="<?php echo esc_attr( $option['id'] ); ?>" data-product-type-option-id="<?php echo esc_attr( $option['id'] ); ?>" <?php echo checked( $selected_value, true, false ); ?> />
 			</label>
 		<?php endforeach; ?>
 	</span>

--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -151,6 +151,27 @@ class WC_Products_Tracking {
 					var tagsText = '';
 					var currentStockValue = $( '#_stock' ).val();
 
+					function getProductTypeOptions() {
+						const productTypeOptionsCheckboxes = $( 'input[type=\"checkbox\"][data-product-type-option-id]' );
+						const productTypeOptions = productTypeOptionsCheckboxes.map( function() {
+							return {
+								id: $( this ).data( 'product-type-option-id' ),
+								isEnabled: $( this ).is( ':checked' ),
+							};
+						} ).get();
+						return productTypeOptions;
+					}
+
+					function getProductTypeOptionsString( productTypeOptions ) {
+						return productTypeOptions
+							.filter( productTypeOption => productTypeOption.isEnabled )
+							.map( productTypeOption => productTypeOption.id )
+							.join( ', ' );
+					}
+
+					const productTypeOptions = getProductTypeOptions();
+					const productTypeOptionsString = getProductTypeOptionsString( productTypeOptions );
+
 					if ( ! isBlockEditor ) {
 						tagsText          = $( '[name=\"tax_input[product_tag]\"]' ).val();
 						if ( $( '#content' ).is( ':visible' ) ) {
@@ -174,26 +195,27 @@ class WC_Products_Tracking {
 					} ).length;
 
 					var properties = {
-						attributes:				numberOfAttributes,
-						categories:				$( '[name=\"tax_input[product_cat][]\"]:checked' ).length,
-						cross_sells:			$( '#crosssell_ids option' ).length ? 'Yes' : 'No',
-						description:			description_value.trim() !== '' ? 'Yes' : 'No',
-						enable_reviews:			$( '#comment_status' ).is( ':checked' ) ? 'Yes' : 'No',
-						is_virtual:				$( '#_virtual' ).is( ':checked' ) ? 'Yes' : 'No',
-						is_block_editor:		isBlockEditor,
-						is_downloadable:		$( '#_downloadable' ).is( ':checked' ) ? 'Yes' : 'No',
-						manage_stock:			$( '#_manage_stock' ).is( ':checked' ) ? 'Yes' : 'No',
-						menu_order:				parseInt( $( '#menu_order' ).val(), 10 ) !== 0 ? 'Yes' : 'No',
-						product_gallery:		$( '#product_images_container .product_images > li' ).length,
-						product_image:			$( '#_thumbnail_id' ).val() > 0 ? 'Yes' : 'No',
-						product_type:			$( '#product-type' ).val(),
-						purchase_note:			$( '#_purchase_note' ).val().length ? 'yes' : 'no',
-						sale_price:				$( '#_sale_price' ).val() ? 'yes' : 'no',
-						short_description:		$( '#excerpt' ).val().length ? 'yes' : 'no',
-						stock_quantity_update:	( initialStockValue != currentStockValue ) ? 'Yes' : 'No',
-						tags:					tagsText.length > 0 ? tagsText.split( ',' ).length : 0,
-						upsells:				$( '#upsell_ids option' ).length ? 'Yes' : 'No',
-						weight:					$( '#_weight' ).val() ? 'Yes' : 'No',
+						attributes:				     numberOfAttributes,
+						categories:				     $( '[name=\"tax_input[product_cat][]\"]:checked' ).length,
+						cross_sells:			     $( '#crosssell_ids option' ).length ? 'Yes' : 'No',
+						description:			     description_value.trim() !== '' ? 'Yes' : 'No',
+						enable_reviews:			     $( '#comment_status' ).is( ':checked' ) ? 'Yes' : 'No',
+						is_virtual:				     $( '#_virtual' ).is( ':checked' ) ? 'Yes' : 'No',
+						is_block_editor:		     isBlockEditor,
+						is_downloadable:		     $( '#_downloadable' ).is( ':checked' ) ? 'Yes' : 'No',
+						manage_stock:			     $( '#_manage_stock' ).is( ':checked' ) ? 'Yes' : 'No',
+						menu_order:				     parseInt( $( '#menu_order' ).val(), 10 ) !== 0 ? 'Yes' : 'No',
+						product_gallery:		     $( '#product_images_container .product_images > li' ).length,
+						product_image:			     $( '#_thumbnail_id' ).val() > 0 ? 'Yes' : 'No',
+						product_type:			     $( '#product-type' ).val(),
+						product_type_options_string: productTypeOptionsString,
+						purchase_note:			     $( '#_purchase_note' ).val().length ? 'yes' : 'no',
+						sale_price:				     $( '#_sale_price' ).val() ? 'yes' : 'no',
+						short_description:		     $( '#excerpt' ).val().length ? 'yes' : 'no',
+						stock_quantity_update:	     ( initialStockValue != currentStockValue ) ? 'Yes' : 'No',
+						tags:					     tagsText.length > 0 ? tagsText.split( ',' ).length : 0,
+						upsells:				     $( '#upsell_ids option' ).length ? 'Yes' : 'No',
+						weight:					     $( '#_weight' ).val() ? 'Yes' : 'No',
 					};
 					window.wcTracks.recordEvent( 'product_update', properties );
 				} );

--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -224,11 +224,19 @@ class WC_Products_Tracking {
 		);
 	}
 
+	/**
+	 * Get the IDs of the possible product type options.
+	 *
+	 * @return array
+	 */
 	private static function get_possible_product_type_options_ids() {
 		$product_type_options_ids = array_merge(
 			array_values(
 				array_map(
-					function ( $product_type_option ) { return $product_type_option['id']; },
+					function ( $product_type_option ) {
+						return $product_type_option['id'];
+					},
+					/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
 					apply_filters( 'product_type_options', array() )
 				)
 			),
@@ -238,10 +246,17 @@ class WC_Products_Tracking {
 		return $product_type_options_ids;
 	}
 
+	/**
+	 * Get the product type options for a product.
+	 *
+	 * @param int $post_id The ID of the product.
+	 *
+	 * @return array
+	 */
 	private static function get_product_type_options( $post_id ) {
 		$possible_product_type_options_ids = self::get_possible_product_type_options_ids();
-		$post_meta = get_post_meta( $post_id );
-		$product_type_options = array();
+		$post_meta                         = get_post_meta( $post_id );
+		$product_type_options              = array();
 
 		foreach ( $possible_product_type_options_ids as $product_type_option_id ) {
 			$product_type_options[ $product_type_option_id ] = isset( $post_meta[ $product_type_option_id ] ) ? $post_meta[ $product_type_option_id ][0] : 'no';
@@ -250,8 +265,25 @@ class WC_Products_Tracking {
 		return $product_type_options;
 	}
 
+	/**
+	 * Get a comma-separated string of the product type options that are enabled.
+	 *
+	 * @param array $product_type_options The product type options.
+	 *
+	 * @return string
+	 */
 	private static function get_product_type_options_string( $product_type_options ) {
-		return implode( ', ', array_keys( array_filter( $product_type_options, function ( $is_enabled ) { return $is_enabled === 'yes'; } ) ) );
+		return implode(
+			', ',
+			array_keys(
+				array_filter(
+					$product_type_options,
+					function ( $is_enabled ) {
+						return 'yes' === $is_enabled;
+					}
+				)
+			)
+		);
 	}
 
 	/**
@@ -274,7 +306,7 @@ class WC_Products_Tracking {
 
 		$product = wc_get_product( $post_id );
 
-		$product_type_options = self::get_product_type_options( $post_id );
+		$product_type_options        = self::get_product_type_options( $post_id );
 		$product_type_options_string = self::get_product_type_options_string( $product_type_options );
 
 		$properties = array(


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds a `product_type_options` property to the following Tracks events:

- `wcadmin_product_add_publish`
- `wcadmin_product_update`
- Some other `wcadmin_product_` events (not all `wcadmin_product_` events include product data):
    - `wcadmin_product_publish_widget_edit`
    - `wcadmin_product_publish_widget_save`
    - `wcadmin_product_copy`
    - `wcadmin_product_delete`
    - `wcadmin_product_view_click`
    - `wcadmin_product_view_product_dismiss`

The built in product type options are:

- `Virtual`: `_virtual`
- `Downloadable`: `_downloadable`

Extensions can add product type options. Some examples...

The [WooCommerce Gift Cards](https://woocommerce.com/products/gift-cards/) extension adds:

- `Gift Card`: `_gift_card` (also hides and selects `_virtual`)

The [WooCommerce One Page Checkout](https://woocommerce.com/products/woocommerce-one-page-checkout/) extension adds:
- `One Page Checkout`: `_wcopc`

**Implementation note:** You will notice duplication of logic in `class-wc-products-tracking.php` and `product-tracking/shared.ts`. These two separate, yet extremely similar, implementations for getting product date for client-side product screen Tracks events is a pre-existing bit of tech debt (why it ever came to be, we may never know 😄). I considered cleaning it up as part of this PR, but felt it would increase the scope of this PR too much, and risk regression with the tracking/analysis of `wcadmin_product_update`. I opted to create a follow-up issue (https://github.com/woocommerce/woocommerce/issues/38033) instead that we should tackle in the near future to make future updates to product-screen Tracks handling easier and more consistent.

Closes #35393.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Notes:
- Install WooCommerce Beta Tester so that the WCA Test Helper is available
- `wcadmin_product_add_publish` can be viewed in `WooCommerce` > `Status` > `Logs`
    - Pick the latest `tracks-` log
- `wcadmin_product_update` can be viewed in the network tab of the browser developer tools
    - Filter by `t.gif`
- Other events mentioned above can be viewed in the console tab of the browser developer tools
    - Use `Tools` > `WCA Test Helper` > `Tools` > `Enable wc-admin Tracking` to enable debugging of Tracks
    - Filter by `recordevent`
- You can also verify Tracks events by using Tracks Live View if you have access

Steps:
1. Go to `Product` > `Add New`
2. Fill out product, including settings some product type options, like `Virtual`, `Downloadable`, `Gift Card` (from the _WooCommerce Gift Cards_ extension, see above)
3. Click `Publish`.
4. Verify the `wcadmin_product_add_publish` Tracks event is logged properly, including the `product_type_options` property. (view log as described above)
5. Click `Update`.
6. Verify the `wcadmin_product_update` Tracks event is logged properly, including the `product_type_options` property. (view network tab, as described above)
7. Click `Edit` link next to `Status: Published` in the `Publish` widget box (the same place you find the `Publish`/`Update` button).
8. Verify the `wcadmin_product_publish_widget_edit` Tracks event is logged properly, including the `product_type_options` property. (view console tab, as described above)

<!-- End testing instructions -->