### PR TITLE
dev: added xstate inspector toggling

### DIFF
--- a/plugins/woocommerce-admin/.eslintrc.js
+++ b/plugins/woocommerce-admin/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
-	extends: [ 'plugin:@woocommerce/eslint-plugin/recommended' ],
+	extends: [ 'plugin:@woocommerce/eslint-plugin/recommended', 'plugin:xstate/all' ],
+	plugins: [ 'xstate' ],
 	root: true,
 	overrides: [
 		{

--- a/plugins/woocommerce-admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/index.tsx
@@ -14,13 +14,6 @@ import { UserProfile } from './pages/UserProfile';
 import { BusinessInfo } from './pages/BusinessInfo';
 import { BusinessLocation } from './pages/BusinessLocation';
 
-/** Uncomment below to display xstate inspector during development */
-// import { inspect } from '@xstate/inspect';
-// inspect( {
-// 	// url: 'https://stately.ai/viz?inspect', // (default)
-// 	iframe: false, // open in new window
-// } );
-
 // TODO: Typescript support can be improved, but for now lets write the types ourselves
 // https://stately.ai/blog/introducing-typescript-typegen-for-xstate
 

--- a/plugins/woocommerce-admin/client/index.js
+++ b/plugins/woocommerce-admin/client/index.js
@@ -18,6 +18,7 @@ import { PageLayout, EmbedLayout, PrimaryLayout as NoticeArea } from './layout';
 import { EmbeddedBodyLayout } from './embedded-body-layout';
 import { WcAdminPaymentsGatewaysBannerSlot } from './payments/payments-settings-banner-slotfill';
 import { WcAdminConflictErrorSlot } from './settings/conflict-error-slotfill.js';
+import './xstate.js';
 
 // Modify webpack pubilcPath at runtime based on location of WordPress Plugin.
 // eslint-disable-next-line no-undef,camelcase

--- a/plugins/woocommerce-admin/client/xstate.js
+++ b/plugins/woocommerce-admin/client/xstate.js
@@ -1,0 +1,30 @@
+/**
+ * This script configures the XState development tools in the
+ * development environment. It should not be included in production.
+ *
+ * To enable the XState inspector, open the browser console and type:
+ * localStorage.setItem("xstate_inspect", "true")
+ */
+
+async function enableXStateInspect() {
+	const { inspect } = await import( '@xstate/inspect' );
+	const { Interpreter } = await import( 'xstate' );
+	// configure the XState inspector to open in a new tab
+	inspect( {
+		url: 'https://stately.ai/viz?inspect',
+		iframe: false,
+	} );
+	// configure all XServices to use the inspector
+	Interpreter.defaultOptions.devTools = true;
+	// eslint-disable-next-line no-console
+	console.log(
+		'Devtools: XState inspector enabled for WooCommerce Admin. To disable, type localStorage.setItem("xstate_inspect", "false")'
+	);
+}
+
+if (
+	process.env.NODE_ENV === 'development' &&
+	window.localStorage.getItem( 'xstate_inspect' ) === 'true'
+) {
+	enableXStateInspect();
+}

--- a/plugins/woocommerce-admin/package.json
+++ b/plugins/woocommerce-admin/package.json
@@ -190,6 +190,7 @@
 		"eslint-import-resolver-webpack": "^0.13.2",
 		"eslint-plugin-import": "^2.25.4",
 		"eslint-plugin-react": "^7.29.2",
+		"eslint-plugin-xstate": "^1.1.0",
 		"expose-loader": "^3.1.0",
 		"fork-ts-checker-webpack-plugin": "^6.5.0",
 		"jest": "^27.5.1",

--- a/plugins/woocommerce/changelog/dev-xstate-inspector-toggling
+++ b/plugins/woocommerce/changelog/dev-xstate-inspector-toggling
@@ -1,0 +1,6 @@
+Significance: patch
+Type: dev
+
+Added xstate inspector toggling via localStorage flag and dev node environment
+
+ 

--- a/plugins/woocommerce/changelog/dev-xstate-inspector-toggling
+++ b/plugins/woocommerce/changelog/dev-xstate-inspector-toggling
@@ -1,6 +1,6 @@
 Significance: patch
 Type: dev
 
-Added xstate inspector toggling via localStorage flag and dev node environment
+Added xstate inspector toggling via localStorage flag and dev node environment, and eslint xstate plugin
 
  

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1451,7 +1451,7 @@ importers:
         version: 1.2.3(@storybook/addon-actions@6.4.19)
       '@storybook/react':
         specifier: ^6.4.19
-        version: 6.4.19(@babel/core@7.17.8)(acorn@8.8.1)(eslint@8.32.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)(webpack-cli@3.3.12)
+        version: 6.4.19(@babel/core@7.17.8)(@types/react@17.0.50)(acorn@8.8.1)(eslint@8.32.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)(webpack-cli@3.3.12)
       '@testing-library/dom':
         specifier: ^8.11.3
         version: 8.11.3
@@ -2845,6 +2845,9 @@ importers:
       eslint-plugin-react:
         specifier: ^7.29.2
         version: 7.29.4(eslint@8.32.0)
+      eslint-plugin-xstate:
+        specifier: ^1.1.0
+        version: 1.1.0(eslint@8.32.0)
       expose-loader:
         specifier: ^3.1.0
         version: 3.1.0(webpack@5.70.0)
@@ -3783,7 +3786,7 @@ packages:
       '@wordpress/primitives': 3.8.0
       '@wordpress/react-i18n': 3.8.0
       classnames: 2.3.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       react-popper: 2.2.5(@popperjs/core@2.11.4)(react@17.0.2)
@@ -3902,7 +3905,6 @@ packages:
   /@babel/compat-data@7.16.4:
     resolution: {integrity: sha512-1o/jo7D+kC9ZjHX5v+EHrdjl3PhxMrLSOTGsOdHJ+KL8HCaEK6ehrVL2RS6oHDZp+L7xLirLrPmQtEng769J/Q==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
   /@babel/compat-data@7.17.7:
     resolution: {integrity: sha512-p8pdE6j0a29TNGebNm7NzYZWB3xVZJBZ7XGs42uAKzQo8VQ3F0By/cQCtUEABwIqw5zo6WA4NbmxsfzADzMKnQ==}
@@ -3926,7 +3928,7 @@ packages:
       '@babel/traverse': 7.17.3
       '@babel/types': 7.17.0
       convert-source-map: 1.8.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       gensync: 1.0.0-beta.2
       json5: 2.2.0
       lodash: 4.17.21
@@ -3951,7 +3953,7 @@ packages:
       '@babel/traverse': 7.19.3
       '@babel/types': 7.19.3
       convert-source-map: 1.8.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       gensync: 1.0.0-beta.2
       json5: 2.2.0
       semver: 6.3.0
@@ -3973,7 +3975,7 @@ packages:
       '@babel/traverse': 7.21.3
       '@babel/types': 7.21.3
       convert-source-map: 1.8.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.0
@@ -4085,7 +4087,6 @@ packages:
       '@babel/helper-validator-option': 7.18.6
       browserslist: 4.19.3
       semver: 6.3.0
-    dev: true
 
   /@babel/helper-compilation-targets@7.17.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-UFzlz2jjd8kroj0hmCFV5zr+tQPi1dpC2cRsDV/3IEW8bJfCPrPpmcSN6ZS8RqIq4LXcmpipCQFPddyFA5Yc7w==}
@@ -4150,7 +4151,6 @@ packages:
       browserslist: 4.21.4
       lru-cache: 5.1.1
       semver: 6.3.0
-    dev: true
 
   /@babel/helper-compilation-targets@7.20.7(@babel/core@7.17.8):
     resolution: {integrity: sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==}
@@ -4164,6 +4164,7 @@ packages:
       browserslist: 4.21.4
       lru-cache: 5.1.1
       semver: 6.3.0
+    dev: true
 
   /@babel/helper-compilation-targets@7.20.7(@babel/core@7.21.3):
     resolution: {integrity: sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==}
@@ -4247,7 +4248,6 @@ packages:
       '@babel/helper-split-export-declaration': 7.18.6
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/helper-create-class-features-plugin@7.19.0(@babel/core@7.17.8):
     resolution: {integrity: sha512-NRz8DwF4jT3UfrmUoZjd0Uph9HQnP30t7Ash+weACcyNkiYTywpIjDBgReJMKgr+n86sn2nPVVmJ28Dm053Kqw==}
@@ -4292,7 +4292,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-annotate-as-pure': 7.18.6
       regexpu-core: 5.2.1
-    dev: true
 
   /@babel/helper-create-regexp-features-plugin@7.19.0(@babel/core@7.17.8):
     resolution: {integrity: sha512-htnV+mHX32DF81amCDrwIDr8nrp1PTm+3wfBN9/v8QJOLEioOCOG7qNyq0nHeFiWbT3Eb7gsPwEmV64UCQ1jzw==}
@@ -4303,6 +4302,7 @@ packages:
       '@babel/core': 7.17.8
       '@babel/helper-annotate-as-pure': 7.18.6
       regexpu-core: 5.2.1
+    dev: true
 
   /@babel/helper-create-regexp-features-plugin@7.19.0(@babel/core@7.21.3):
     resolution: {integrity: sha512-htnV+mHX32DF81amCDrwIDr8nrp1PTm+3wfBN9/v8QJOLEioOCOG7qNyq0nHeFiWbT3Eb7gsPwEmV64UCQ1jzw==}
@@ -4324,7 +4324,7 @@ packages:
       '@babel/helper-module-imports': 7.18.6
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/traverse': 7.21.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       lodash.debounce: 4.0.8
       resolve: 1.22.1
       semver: 6.3.0
@@ -4342,7 +4342,7 @@ packages:
       '@babel/helper-module-imports': 7.18.6
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/traverse': 7.21.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       lodash.debounce: 4.0.8
       resolve: 1.22.1
       semver: 6.3.0
@@ -4358,13 +4358,12 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.12.9)
       '@babel/helper-plugin-utils': 7.20.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       lodash.debounce: 4.0.8
       resolve: 1.22.1
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/helper-define-polyfill-provider@0.3.3(@babel/core@7.17.8):
     resolution: {integrity: sha512-z5aQKU4IzbqCC1XH0nAqfsFLMVSo22SBKUc0BxGrLkolTdPTructy0ToNnlO2zA4j9Q/7pjMZf0DSY+DSTYzww==}
@@ -4374,12 +4373,13 @@ packages:
       '@babel/core': 7.17.8
       '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.17.8)
       '@babel/helper-plugin-utils': 7.20.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       lodash.debounce: 4.0.8
       resolve: 1.22.1
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/helper-define-polyfill-provider@0.3.3(@babel/core@7.21.3):
     resolution: {integrity: sha512-z5aQKU4IzbqCC1XH0nAqfsFLMVSo22SBKUc0BxGrLkolTdPTructy0ToNnlO2zA4j9Q/7pjMZf0DSY+DSTYzww==}
@@ -4389,7 +4389,7 @@ packages:
       '@babel/core': 7.21.3
       '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.21.3)
       '@babel/helper-plugin-utils': 7.20.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       lodash.debounce: 4.0.8
       resolve: 1.22.1
       semver: 6.3.0
@@ -4430,7 +4430,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.21.3
-    dev: true
 
   /@babel/helper-module-imports@7.16.7:
     resolution: {integrity: sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==}
@@ -4503,7 +4502,6 @@ packages:
   /@babel/helper-plugin-utils@7.14.5:
     resolution: {integrity: sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
   /@babel/helper-plugin-utils@7.18.9:
     resolution: {integrity: sha512-aBXPT3bmtLryXaoJLyYPXPlSD4p1ld9aYeR+sJNOZjJJGiOpb+fKfh3NkcCu7J54nUJwCERPBExCCpyCOHnu/w==}
@@ -4526,7 +4524,6 @@ packages:
       '@babel/types': 7.21.3
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/helper-remap-async-to-generator@7.16.8:
     resolution: {integrity: sha512-fm0gH7Flb8H51LqJHy3HJ3wnE1+qtYR2A99K06ahwrawLdOFsCEWjZOrYricXJHoPSudNKxrMBUPEIPxiIIvBw==}
@@ -4552,7 +4549,6 @@ packages:
       '@babel/types': 7.21.3
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/helper-remap-async-to-generator@7.18.9(@babel/core@7.17.8):
     resolution: {integrity: sha512-dI7q50YKd8BAv3VEfgg7PS7yD3Rtbi2J1XMXaalXO0W0164hYLnh8zpjRS0mte9MfVp/tltvr/cfdXPvJr1opA==}
@@ -4567,6 +4563,7 @@ packages:
       '@babel/types': 7.21.3
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/helper-remap-async-to-generator@7.18.9(@babel/core@7.21.3):
     resolution: {integrity: sha512-dI7q50YKd8BAv3VEfgg7PS7yD3Rtbi2J1XMXaalXO0W0164hYLnh8zpjRS0mte9MfVp/tltvr/cfdXPvJr1opA==}
@@ -4624,7 +4621,6 @@ packages:
   /@babel/helper-validator-option@7.14.5:
     resolution: {integrity: sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
   /@babel/helper-validator-option@7.16.7:
     resolution: {integrity: sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==}
@@ -4837,7 +4833,6 @@ packages:
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.12.9)
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/plugin-proposal-async-generator-functions@7.16.8(@babel/core@7.12.9):
     resolution: {integrity: sha512-71YHIvMuiuqWJQkebWJtdhQTfd4Q4mF76q2IX37uZPkG9+olBxsX+rH1vkhFto4UeJZ9dPY2s+mDvhDm1u2BGQ==}
@@ -4894,7 +4889,6 @@ packages:
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.12.9)
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/plugin-proposal-async-generator-functions@7.20.7(@babel/core@7.17.8):
     resolution: {integrity: sha512-xMbiLsn/8RK7Wq7VeVytytS2L6qE69bXPB10YCmMdDZbKF4okCqY74pI/jJQ/8U0b/F6NrT2+14b8/P9/3AMGA==}
@@ -4909,6 +4903,7 @@ packages:
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.17.8)
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/plugin-proposal-async-generator-functions@7.20.7(@babel/core@7.21.3):
     resolution: {integrity: sha512-xMbiLsn/8RK7Wq7VeVytytS2L6qE69bXPB10YCmMdDZbKF4okCqY74pI/jJQ/8U0b/F6NrT2+14b8/P9/3AMGA==}
@@ -4935,7 +4930,6 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/plugin-proposal-class-properties@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-IobU0Xme31ewjYOShSIqd/ZGM/r/cuOz2z0MDbNrhF5FW+ZVgi0f2lyeoj9KFPDOAqsYxmLWZte1WOwlvY9aww==}
@@ -4986,7 +4980,6 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.17.8):
     resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
@@ -4999,6 +4992,7 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.21.3):
     resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
@@ -5132,7 +5126,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.12.9)
-    dev: true
 
   /@babel/plugin-proposal-dynamic-import@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-I8SW9Ho3/8DRSdmDdH3gORdyUuYnk1m4cMxUAdu5oy4n3OfN8flDEH+d60iG7dUfi0KkYwSvoalHzzdRzpWHTg==}
@@ -5199,6 +5192,16 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.21.3)
 
+  /@babel/plugin-proposal-export-default-from@7.16.7(@babel/core@7.12.9):
+    resolution: {integrity: sha512-+cENpW1rgIjExn+o5c8Jw/4BuH4eGKKYvkMB8/0ZxFQ9mC0t4z09VsPIwNg6waF69QYC81zxGeAsREGuqQoKeg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.12.9
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/plugin-syntax-export-default-from': 7.16.7(@babel/core@7.12.9)
+
   /@babel/plugin-proposal-export-default-from@7.16.7(@babel/core@7.17.8):
     resolution: {integrity: sha512-+cENpW1rgIjExn+o5c8Jw/4BuH4eGKKYvkMB8/0ZxFQ9mC0t4z09VsPIwNg6waF69QYC81zxGeAsREGuqQoKeg==}
     engines: {node: '>=6.9.0'}
@@ -5208,6 +5211,7 @@ packages:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-export-default-from': 7.16.7(@babel/core@7.17.8)
+    dev: true
 
   /@babel/plugin-proposal-export-default-from@7.16.7(@babel/core@7.21.3):
     resolution: {integrity: sha512-+cENpW1rgIjExn+o5c8Jw/4BuH4eGKKYvkMB8/0ZxFQ9mC0t4z09VsPIwNg6waF69QYC81zxGeAsREGuqQoKeg==}
@@ -5228,7 +5232,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.12.9)
-    dev: true
 
   /@babel/plugin-proposal-export-namespace-from@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-ZxdtqDXLRGBL64ocZcs7ovt71L3jhC1RGSyR996svrCi3PYqHNkb3SwPJCs8RIzD86s+WPpt2S73+EHCGO+NUA==}
@@ -5304,7 +5307,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.12.9)
-    dev: true
 
   /@babel/plugin-proposal-json-strings@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-lNZ3EEggsGY78JavgbHsK9u5P3pQaW7k4axlgFLYkMd7UBsiNahCITShLjNQschPyjtO6dADrL24757IdhBrsQ==}
@@ -5380,7 +5382,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.12.9)
-    dev: true
 
   /@babel/plugin-proposal-logical-assignment-operators@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-K3XzyZJGQCr00+EtYtrDjmwX7o7PLK6U9bi1nCwkQioRFVUv6dJoxbQjtWVtP+bCPy82bONBKG8NPyQ4+i6yjg==}
@@ -5456,7 +5457,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.12.9)
-    dev: true
 
   /@babel/plugin-proposal-nullish-coalescing-operator@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-aUOrYU3EVtjf62jQrCj63pYZ7k6vns2h/DQvHPWGmsJRYzWXZ6/AsfgpiRy6XiuIDADhJzP2Q9MwSMKauBQ+UQ==}
@@ -5499,7 +5499,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.12.9)
-    dev: true
 
   /@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.17.8):
     resolution: {integrity: sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==}
@@ -5510,6 +5509,7 @@ packages:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.17.8)
+    dev: true
 
   /@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.21.3):
     resolution: {integrity: sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==}
@@ -5530,7 +5530,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.12.9)
-    dev: true
 
   /@babel/plugin-proposal-numeric-separator@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-vQgPMknOIgiuVqbokToyXbkY/OmmjAzr/0lhSIbG/KmnzXPGwW/AdhdKpi+O4X/VkWiWjnkKOBiqJrTaC98VKw==}
@@ -5620,7 +5619,6 @@ packages:
       '@babel/helper-plugin-utils': 7.14.5
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.12.9)
       '@babel/plugin-transform-parameters': 7.16.3(@babel/core@7.12.9)
-    dev: true
 
   /@babel/plugin-proposal-object-rest-spread@7.17.3(@babel/core@7.12.9):
     resolution: {integrity: sha512-yuL5iQA/TbZn+RGAfxQXfi7CNLmKi1f8zInn4IgobuCWcAb7i+zj4TYzQ9l8cEzVyJ89PDGuqxK1xZpUDISesw==}
@@ -5676,7 +5674,6 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.12.9)
       '@babel/plugin-transform-parameters': 7.21.3(@babel/core@7.12.9)
-    dev: true
 
   /@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.17.8):
     resolution: {integrity: sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==}
@@ -5690,6 +5687,7 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.17.8)
       '@babel/plugin-transform-parameters': 7.21.3(@babel/core@7.17.8)
+    dev: true
 
   /@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.21.3):
     resolution: {integrity: sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==}
@@ -5713,7 +5711,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.12.9)
-    dev: true
 
   /@babel/plugin-proposal-optional-catch-binding@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-eMOH/L4OvWSZAE1VkHbr1vckLG1WUcHGJSLqqQwl2GaUqG6QjddvrOaTUMNYiv77H5IKPMZ9U9P7EaHwvAShfA==}
@@ -5757,7 +5754,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.12.9)
-    dev: true
 
   /@babel/plugin-proposal-optional-catch-binding@7.18.6(@babel/core@7.17.8):
     resolution: {integrity: sha512-Q40HEhs9DJQyaZfUjjn6vE8Cv4GmMHCYuMGIWUnlxH6400VGxOuwWsPt4FxXxJkC/5eOzgn0z21M9gMT4MOhbw==}
@@ -5768,6 +5764,7 @@ packages:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.17.8)
+    dev: true
 
   /@babel/plugin-proposal-optional-catch-binding@7.18.6(@babel/core@7.21.3):
     resolution: {integrity: sha512-Q40HEhs9DJQyaZfUjjn6vE8Cv4GmMHCYuMGIWUnlxH6400VGxOuwWsPt4FxXxJkC/5eOzgn0z21M9gMT4MOhbw==}
@@ -5789,7 +5786,6 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-skip-transparent-expression-wrappers': 7.18.9
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.12.9)
-    dev: true
 
   /@babel/plugin-proposal-optional-chaining@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-eC3xy+ZrUcBtP7x+sq62Q/HYd674pPTb/77XZMb5wbDPGWIdUbSr4Agr052+zaUPSb+gGRnjxXfKFvx5iMJ+DA==}
@@ -5836,7 +5832,6 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-skip-transparent-expression-wrappers': 7.18.9
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.12.9)
-    dev: true
 
   /@babel/plugin-proposal-optional-chaining@7.18.9(@babel/core@7.17.8):
     resolution: {integrity: sha512-v5nwt4IqBXihxGsW2QmCWMDS3B3bzGIk/EQVZz2ei7f3NJl8NzAJVvUmpDW5q1CRNY+Beb/k58UAH1Km1N411w==}
@@ -5848,6 +5843,7 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-skip-transparent-expression-wrappers': 7.18.9
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.17.8)
+    dev: true
 
   /@babel/plugin-proposal-optional-chaining@7.18.9(@babel/core@7.21.3):
     resolution: {integrity: sha512-v5nwt4IqBXihxGsW2QmCWMDS3B3bzGIk/EQVZz2ei7f3NJl8NzAJVvUmpDW5q1CRNY+Beb/k58UAH1Km1N411w==}
@@ -5871,7 +5867,6 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/plugin-proposal-private-methods@7.16.11(@babel/core@7.12.9):
     resolution: {integrity: sha512-F/2uAkPlXDr8+BHpZvo19w3hLFKge+k75XUprE6jaqKxjGkSYcK+4c+bup5PdW/7W/Rpjwql7FTVEDW+fRAQsw==}
@@ -6048,7 +6043,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-create-regexp-features-plugin': 7.19.0(@babel/core@7.12.9)
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-proposal-unicode-property-regex@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-QRK0YI/40VLhNVGIjRNAAQkEHws0cswSdFFjpFyt943YmJIU1da9uW63Iu6NFV6CxTZW5eTDCrwZUstBWgp/Rg==}
@@ -6092,7 +6086,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-create-regexp-features-plugin': 7.19.0(@babel/core@7.12.9)
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-proposal-unicode-property-regex@7.18.6(@babel/core@7.17.8):
     resolution: {integrity: sha512-2BShG/d5yoZyXZfVePH91urL5wTG6ASZU9M4o03lKK8u8UW1y08OMttBSOADTcJrnPMpvDXRG3G8fyLh4ovs8w==}
@@ -6130,6 +6123,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.20.2
+    dev: true
 
   /@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.21.3):
     resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
@@ -6180,6 +6174,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.20.2
+    dev: true
 
   /@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.21.3):
     resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
@@ -6245,7 +6240,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.17.8):
     resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
@@ -6254,6 +6248,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.20.2
+    dev: true
 
   /@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.21.3):
     resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
@@ -6261,6 +6256,15 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.3
+      '@babel/helper-plugin-utils': 7.20.2
+
+  /@babel/plugin-syntax-export-default-from@7.16.7(@babel/core@7.12.9):
+    resolution: {integrity: sha512-4C3E4NsrLOgftKaTYTULhHsuQrGv3FHrBzOMDiS7UYKIpgGBkAdawg4h+EI8zPeK9M0fiIIh72hIwsI24K7MbA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-syntax-export-default-from@7.16.7(@babel/core@7.17.8):
@@ -6271,6 +6275,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.20.2
+    dev: true
 
   /@babel/plugin-syntax-export-default-from@7.16.7(@babel/core@7.21.3):
     resolution: {integrity: sha512-4C3E4NsrLOgftKaTYTULhHsuQrGv3FHrBzOMDiS7UYKIpgGBkAdawg4h+EI8zPeK9M0fiIIh72hIwsI24K7MbA==}
@@ -6288,7 +6293,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.17.8):
     resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==}
@@ -6305,6 +6309,15 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.3
+      '@babel/helper-plugin-utils': 7.20.2
+
+  /@babel/plugin-syntax-flow@7.16.7(@babel/core@7.12.9):
+    resolution: {integrity: sha512-UDo3YGQO0jH6ytzVwgSLv9i/CzMcUjbKenL67dTrAZPPv6GFAtDhe6jqnvmoKzC/7htNTohhos+onPtDMqJwaQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-syntax-flow@7.16.7(@babel/core@7.17.8):
@@ -6444,6 +6457,15 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
+  /@babel/plugin-syntax-jsx@7.18.6(@babel/core@7.12.9):
+    resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.12.9
+      '@babel/helper-plugin-utils': 7.20.2
+
   /@babel/plugin-syntax-jsx@7.18.6(@babel/core@7.17.8):
     resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
     engines: {node: '>=6.9.0'}
@@ -6551,6 +6573,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.19.0
+    dev: true
 
   /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.21.3):
     resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
@@ -6575,6 +6598,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.20.2
+    dev: true
 
   /@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.21.3):
     resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
@@ -6683,13 +6707,13 @@ packages:
       '@babel/core': 7.21.3
       '@babel/helper-plugin-utils': 7.20.2
 
-  /@babel/plugin-syntax-typescript@7.18.6(@babel/core@7.17.8):
+  /@babel/plugin-syntax-typescript@7.18.6(@babel/core@7.12.9):
     resolution: {integrity: sha512-mAWAuq4rvOepWCBid55JuRNvpTNf2UGVgoz4JV0fXEKolsVZDzsa4NqCef758WZJj/GDu0gVGItjKFiClTAmZA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.17.8
+      '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-syntax-typescript@7.18.6(@babel/core@7.21.3):
@@ -6709,7 +6733,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-arrow-functions@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-9ffkFFMbvzTvv+7dTp/66xvZAWASuPD5Tl9LK3Z9vhOmANo6j94rik+5YMBt4CwHVMWLWpMsriIc2zsa3WW3xQ==}
@@ -6749,7 +6772,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-arrow-functions@7.18.6(@babel/core@7.17.8):
     resolution: {integrity: sha512-9S9X9RUefzrsHZmKMbDXxweEH+YlE8JJEuat9FdvW9Qh1cw7W64jELCtWNkPBPX5En45uy28KGvA/AySqUh8CQ==}
@@ -6759,6 +6781,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.20.2
+    dev: true
 
   /@babel/plugin-transform-arrow-functions@7.18.6(@babel/core@7.21.3):
     resolution: {integrity: sha512-9S9X9RUefzrsHZmKMbDXxweEH+YlE8JJEuat9FdvW9Qh1cw7W64jELCtWNkPBPX5En45uy28KGvA/AySqUh8CQ==}
@@ -6781,7 +6804,6 @@ packages:
       '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.12.9)
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/plugin-transform-async-to-generator@7.16.8(@babel/core@7.12.9):
     resolution: {integrity: sha512-MtmUmTJQHCnyJVrScNzNlofQJ3dLFuobYn3mwOTKHnSCMtbNsqvF71GQmJfFjdrXSsAA7iysFmYWw4bXZ20hOg==}
@@ -6837,7 +6859,6 @@ packages:
       '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.12.9)
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/plugin-transform-async-to-generator@7.18.6(@babel/core@7.17.8):
     resolution: {integrity: sha512-ARE5wZLKnTgPW7/1ftQmSi1CmkqqHo2DNmtztFhvgtOWSDfq0Cq9/9L+KnZNYSNrydBekhW3rwShduf59RoXag==}
@@ -6851,6 +6872,7 @@ packages:
       '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.17.8)
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/plugin-transform-async-to-generator@7.18.6(@babel/core@7.21.3):
     resolution: {integrity: sha512-ARE5wZLKnTgPW7/1ftQmSi1CmkqqHo2DNmtztFhvgtOWSDfq0Cq9/9L+KnZNYSNrydBekhW3rwShduf59RoXag==}
@@ -6873,7 +6895,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-block-scoped-functions@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-JUuzlzmF40Z9cXyytcbZEZKckgrQzChbQJw/5PuEHYeqzCsvebDx0K0jWnIIVcmmDOAVctCgnYs0pMcrYj2zJg==}
@@ -6913,7 +6934,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-block-scoped-functions@7.18.6(@babel/core@7.17.8):
     resolution: {integrity: sha512-ExUcOqpPWnliRcPqves5HJcJOvHvIIWfuS4sroBUenPuMdmW+SMHDakmtS7qOo13sVppmUijqeTv7qqGsvURpQ==}
@@ -6923,6 +6943,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.20.2
+    dev: true
 
   /@babel/plugin-transform-block-scoped-functions@7.18.6(@babel/core@7.21.3):
     resolution: {integrity: sha512-ExUcOqpPWnliRcPqves5HJcJOvHvIIWfuS4sroBUenPuMdmW+SMHDakmtS7qOo13sVppmUijqeTv7qqGsvURpQ==}
@@ -6941,7 +6962,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-block-scoping@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-ObZev2nxVAYA4bhyusELdo9hb3H+A56bxH3FZMbEImZFiEDYVHXQSJ1hQKFlDnlt8G9bBrCZ5ZpURZUrV4G5qQ==}
@@ -6981,7 +7001,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-block-scoping@7.21.0(@babel/core@7.17.8):
     resolution: {integrity: sha512-Mdrbunoh9SxwFZapeHVrwFmri16+oYotcZysSzhNIVDwIAb1UV+kvnxULSYq9J3/q5MDG+4X6w8QVgD1zhBXNQ==}
@@ -6991,6 +7010,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.20.2
+    dev: true
 
   /@babel/plugin-transform-block-scoping@7.21.0(@babel/core@7.21.3):
     resolution: {integrity: sha512-Mdrbunoh9SxwFZapeHVrwFmri16+oYotcZysSzhNIVDwIAb1UV+kvnxULSYq9J3/q5MDG+4X6w8QVgD1zhBXNQ==}
@@ -7017,7 +7037,6 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/plugin-transform-classes@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-WY7og38SFAGYRe64BrjKf8OrE6ulEHtr5jEYaZMwox9KebgqPi67Zqz8K53EKk1fFEJgm96r32rkKZ3qA2nCWQ==}
@@ -7094,7 +7113,6 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/plugin-transform-classes@7.21.0(@babel/core@7.17.8):
     resolution: {integrity: sha512-RZhbYTCEUAe6ntPehC4hlslPWosNHDox+vAs4On/mCLRLfoDVHf6hVEd7kuxr1RnHwJmxFfUM3cZiZRmPxJPXQ==}
@@ -7114,6 +7132,7 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/plugin-transform-classes@7.21.0(@babel/core@7.21.3):
     resolution: {integrity: sha512-RZhbYTCEUAe6ntPehC4hlslPWosNHDox+vAs4On/mCLRLfoDVHf6hVEd7kuxr1RnHwJmxFfUM3cZiZRmPxJPXQ==}
@@ -7142,7 +7161,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-computed-properties@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-gN72G9bcmenVILj//sv1zLNaPyYcOzUho2lIJBMh/iakJ9ygCo/hEF9cpGb61SCMEDxbbyBoVQxrt+bWKu5KGw==}
@@ -7182,7 +7200,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-computed-properties@7.18.9(@babel/core@7.17.8):
     resolution: {integrity: sha512-+i0ZU1bCDymKakLxn5srGHrsAPRELC2WIbzwjLhHW9SIE1cPYkLCL0NlnXMZaM1vhfgA2+M7hySk42VBvrkBRw==}
@@ -7192,6 +7209,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.20.2
+    dev: true
 
   /@babel/plugin-transform-computed-properties@7.18.9(@babel/core@7.21.3):
     resolution: {integrity: sha512-+i0ZU1bCDymKakLxn5srGHrsAPRELC2WIbzwjLhHW9SIE1cPYkLCL0NlnXMZaM1vhfgA2+M7hySk42VBvrkBRw==}
@@ -7210,7 +7228,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-destructuring@7.17.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-XVh0r5yq9sLR4vZ6eVZe8FKfIcSgaTBxVBRSYokRj2qksf6QerYnTxz9/GTuKTH/n/HwLP7t6gtlybHetJ/6hQ==}
@@ -7250,7 +7267,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-destructuring@7.21.3(@babel/core@7.17.8):
     resolution: {integrity: sha512-bp6hwMFzuiE4HqYEyoGJ/V2LeIWn+hLVKc4pnj++E5XQptwhtcGmSayM029d/j2X1bPKGTlsyPwAubuU22KhMA==}
@@ -7260,6 +7276,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.20.2
+    dev: true
 
   /@babel/plugin-transform-destructuring@7.21.3(@babel/core@7.21.3):
     resolution: {integrity: sha512-bp6hwMFzuiE4HqYEyoGJ/V2LeIWn+hLVKc4pnj++E5XQptwhtcGmSayM029d/j2X1bPKGTlsyPwAubuU22KhMA==}
@@ -7279,7 +7296,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-create-regexp-features-plugin': 7.19.0(@babel/core@7.12.9)
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-dotall-regex@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-Lyttaao2SjZF6Pf4vk1dVKv8YypMpomAbygW+mU5cYP3S5cWTfCJjG8xV6CFdzGFlfWK81IjL9viiTvpb6G7gQ==}
@@ -7323,7 +7339,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-create-regexp-features-plugin': 7.19.0(@babel/core@7.12.9)
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-dotall-regex@7.18.6(@babel/core@7.17.8):
     resolution: {integrity: sha512-6S3jpun1eEbAxq7TdjLotAsl4WpQI9DxfkycRcKrjhQYzU87qpXdknpBg/e+TdcMehqGnLFi7tnFUBR02Vq6wg==}
@@ -7354,7 +7369,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-duplicate-keys@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-03DvpbRfvWIXyK0/6QiR1KMTWeT6OcQ7tbhjrXyFS02kjuX/mu5Bvnh5SDSWHxyawit2g5aWhKwI86EE7GUnTw==}
@@ -7424,7 +7438,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.18.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-exponentiation-operator@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-8UYLSlyLgRixQvlYH3J2ekXFHDFLQutdy7FfFAMm3CPZ6q9wHCwnUyiXpQCe3gVVnQlHc5nsuiEVziteRNTXEA==}
@@ -7468,7 +7481,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.18.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-exponentiation-operator@7.18.6(@babel/core@7.17.8):
     resolution: {integrity: sha512-wzEtc0+2c88FVR34aQmiz56dxEkxr2g8DQb/KfaFa1JYXOFVsbhvAonFN6PwVWj++fKmku8NP80plJ5Et4wqHw==}
@@ -7479,6 +7491,7 @@ packages:
       '@babel/core': 7.17.8
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.18.9
       '@babel/helper-plugin-utils': 7.20.2
+    dev: true
 
   /@babel/plugin-transform-exponentiation-operator@7.18.6(@babel/core@7.21.3):
     resolution: {integrity: sha512-wzEtc0+2c88FVR34aQmiz56dxEkxr2g8DQb/KfaFa1JYXOFVsbhvAonFN6PwVWj++fKmku8NP80plJ5Et4wqHw==}
@@ -7489,6 +7502,16 @@ packages:
       '@babel/core': 7.21.3
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.18.9
       '@babel/helper-plugin-utils': 7.20.2
+
+  /@babel/plugin-transform-flow-strip-types@7.16.7(@babel/core@7.12.9):
+    resolution: {integrity: sha512-mzmCq3cNsDpZZu9FADYYyfZJIOrSONmHcop2XEKPdBNMa4PDC4eEvcOvzZaCNcjKu72v0XQlA5y1g58aLRXdYg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.12.9
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/plugin-syntax-flow': 7.16.7(@babel/core@7.12.9)
 
   /@babel/plugin-transform-flow-strip-types@7.16.7(@babel/core@7.17.8):
     resolution: {integrity: sha512-mzmCq3cNsDpZZu9FADYYyfZJIOrSONmHcop2XEKPdBNMa4PDC4eEvcOvzZaCNcjKu72v0XQlA5y1g58aLRXdYg==}
@@ -7518,7 +7541,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-for-of@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-/QZm9W92Ptpw7sjI9Nx1mbcsWz33+l8kuMIQnDwgQBG5s3fAfQvkRjQ7NqXhtNcKOnPkdICmUHyCaWW06HCsqg==}
@@ -7558,7 +7580,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-for-of@7.18.8(@babel/core@7.17.8):
     resolution: {integrity: sha512-yEfTRnjuskWYo0k1mHUqrVWaZwrdq8AYbfrpqULOJOaucGSp4mNMVps+YtA8byoevxS/urwU75vyhQIxcCgiBQ==}
@@ -7568,6 +7589,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.20.2
+    dev: true
 
   /@babel/plugin-transform-for-of@7.18.8(@babel/core@7.21.3):
     resolution: {integrity: sha512-yEfTRnjuskWYo0k1mHUqrVWaZwrdq8AYbfrpqULOJOaucGSp4mNMVps+YtA8byoevxS/urwU75vyhQIxcCgiBQ==}
@@ -7587,7 +7609,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-function-name': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-function-name@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-SU/C68YVwTRxqWj5kgsbKINakGag0KTgq9f2iZEXdStoAbOzLHEBRYzImmA6yFo8YZhJVflvXmIHUO7GWHmxxA==}
@@ -7635,7 +7656,6 @@ packages:
       '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.12.9)
       '@babel/helper-function-name': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-function-name@7.18.9(@babel/core@7.17.8):
     resolution: {integrity: sha512-WvIBoRPaJQ5yVHzcnJFor7oS5Ls0PYixlTYE63lCj2RtdQEl15M68FXQlxnG6wdraJIXRdR7KI+hQ7q/9QjrCQ==}
@@ -7647,6 +7667,7 @@ packages:
       '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.17.8)
       '@babel/helper-function-name': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
+    dev: true
 
   /@babel/plugin-transform-function-name@7.18.9(@babel/core@7.21.3):
     resolution: {integrity: sha512-WvIBoRPaJQ5yVHzcnJFor7oS5Ls0PYixlTYE63lCj2RtdQEl15M68FXQlxnG6wdraJIXRdR7KI+hQ7q/9QjrCQ==}
@@ -7667,7 +7688,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-literals@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-6tH8RTpTWI0s2sV6uq3e/C9wPo4PTqqZps4uF0kzQ9/xPLFQtipynvmT1g/dOfEJ+0EQsHhkQ/zyRId8J2b8zQ==}
@@ -7707,7 +7727,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-literals@7.18.9(@babel/core@7.17.8):
     resolution: {integrity: sha512-IFQDSRoTPnrAIrI5zoZv73IFeZu2dhu6irxQjY9rNjTT53VmKg9fenjvoiOWOkJ6mm4jKVPtdMzBY98Fp4Z4cg==}
@@ -7717,6 +7736,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.20.2
+    dev: true
 
   /@babel/plugin-transform-literals@7.18.9(@babel/core@7.21.3):
     resolution: {integrity: sha512-IFQDSRoTPnrAIrI5zoZv73IFeZu2dhu6irxQjY9rNjTT53VmKg9fenjvoiOWOkJ6mm4jKVPtdMzBY98Fp4Z4cg==}
@@ -7735,7 +7755,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-member-expression-literals@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-mBruRMbktKQwbxaJof32LT9KLy2f3gH+27a5XSuXo6h7R3vqltl0PgZ80C8ZMKw98Bf8bqt6BEVi3svOh2PzMw==}
@@ -7775,7 +7794,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-member-expression-literals@7.18.6(@babel/core@7.17.8):
     resolution: {integrity: sha512-qSF1ihLGO3q+/g48k85tUjD033C29TNTVB2paCwZPVmOsjn9pClvYYrM2VeJpBY2bcNkuny0YUyTNRyRxJ54KA==}
@@ -7785,6 +7803,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.20.2
+    dev: true
 
   /@babel/plugin-transform-member-expression-literals@7.18.6(@babel/core@7.21.3):
     resolution: {integrity: sha512-qSF1ihLGO3q+/g48k85tUjD033C29TNTVB2paCwZPVmOsjn9pClvYYrM2VeJpBY2bcNkuny0YUyTNRyRxJ54KA==}
@@ -7807,7 +7826,6 @@ packages:
       babel-plugin-dynamic-import-node: 2.3.3
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/plugin-transform-modules-amd@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-KaaEtgBL7FKYwjJ/teH63oAmE3lP34N3kshz8mm4VMAw7U3PxjVwwUmxEFksbgsNUaO3wId9R2AVQYSEGRa2+g==}
@@ -7902,7 +7920,6 @@ packages:
       babel-plugin-dynamic-import-node: 2.3.3
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/plugin-transform-modules-commonjs@7.17.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-ITPmR2V7MqioMJyrxUo2onHNC3e+MvfFiFIR0RP21d3PtlVb6sfzoxNKiphSZUOM9hEIdzCcZe83ieX3yoqjUA==}
@@ -7960,7 +7977,6 @@ packages:
       '@babel/helper-simple-access': 7.20.2
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/plugin-transform-modules-commonjs@7.21.2(@babel/core@7.17.8):
     resolution: {integrity: sha512-Cln+Yy04Gxua7iPdj6nOV96smLGjpElir5YwzF0LBPKoPlLDNJePNlrGGaybAJkd0zKRnOVXOgizSqPYMNYkzA==}
@@ -7974,6 +7990,7 @@ packages:
       '@babel/helper-simple-access': 7.20.2
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/plugin-transform-modules-commonjs@7.21.2(@babel/core@7.21.3):
     resolution: {integrity: sha512-Cln+Yy04Gxua7iPdj6nOV96smLGjpElir5YwzF0LBPKoPlLDNJePNlrGGaybAJkd0zKRnOVXOgizSqPYMNYkzA==}
@@ -8002,7 +8019,6 @@ packages:
       babel-plugin-dynamic-import-node: 2.3.3
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/plugin-transform-modules-systemjs@7.17.8(@babel/core@7.12.9):
     resolution: {integrity: sha512-39reIkMTUVagzgA5x88zDYXPCMT6lcaRKs1+S9K6NKBPErbgO/w/kP8GlNQTC87b412ZTlmNgr3k2JrWgHH+Bw==}
@@ -8107,7 +8123,6 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/plugin-transform-modules-umd@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-EMh7uolsC8O4xhudF2F6wedbSHm1HHZ0C6aJ7K67zcDNidMzVcxWdGr+htW9n21klm+bOn+Rx4CBsAntZd3rEQ==}
@@ -8194,7 +8209,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-create-regexp-features-plugin': 7.19.0(@babel/core@7.12.9)
-    dev: true
 
   /@babel/plugin-transform-named-capturing-groups-regex@7.16.8(@babel/core@7.12.9):
     resolution: {integrity: sha512-j3Jw+n5PvpmhRR+mrgIh04puSANCk/T/UA3m3P1MjJkhlK906+ApHhDIqBQDdOgL/r1UYpz4GNclTXxyZrYGSw==}
@@ -8235,7 +8249,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-create-regexp-features-plugin': 7.19.0(@babel/core@7.12.9)
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-named-capturing-groups-regex@7.19.1(@babel/core@7.17.8):
     resolution: {integrity: sha512-oWk9l9WItWBQYS4FgXD4Uyy5kq898lvkXpXQxoJEY1RnvPk4R/Dvu2ebXU9q8lP+rlMwUQTFf2Ok6d78ODa0kw==}
@@ -8246,6 +8259,7 @@ packages:
       '@babel/core': 7.17.8
       '@babel/helper-create-regexp-features-plugin': 7.19.0(@babel/core@7.17.8)
       '@babel/helper-plugin-utils': 7.20.2
+    dev: true
 
   /@babel/plugin-transform-named-capturing-groups-regex@7.19.1(@babel/core@7.21.3):
     resolution: {integrity: sha512-oWk9l9WItWBQYS4FgXD4Uyy5kq898lvkXpXQxoJEY1RnvPk4R/Dvu2ebXU9q8lP+rlMwUQTFf2Ok6d78ODa0kw==}
@@ -8265,7 +8279,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-new-target@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-xiLDzWNMfKoGOpc6t3U+etCE2yRnn3SM09BXqWPIZOBpL2gvVrBWUKnsJx0K/ADi5F5YC5f8APFfWrz25TdlGg==}
@@ -8337,7 +8350,6 @@ packages:
       '@babel/helper-replace-supers': 7.20.7
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/plugin-transform-object-super@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-14J1feiQVWaGvRxj2WjyMuXS2jsBkgB3MdSN5HuC2G5nRspa5RK9COcs82Pwy5BuGcjb+fYaUj94mYcOj7rCvw==}
@@ -8389,7 +8401,6 @@ packages:
       '@babel/helper-replace-supers': 7.20.7
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/plugin-transform-object-super@7.18.6(@babel/core@7.17.8):
     resolution: {integrity: sha512-uvGz6zk+pZoS1aTZrOvrbj6Pp/kK2mp45t2B+bTDre2UgsZZ8EZLSJtUg7m/no0zOJUWgFONpB7Zv9W2tSaFlA==}
@@ -8402,6 +8413,7 @@ packages:
       '@babel/helper-replace-supers': 7.20.7
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/plugin-transform-object-super@7.18.6(@babel/core@7.21.3):
     resolution: {integrity: sha512-uvGz6zk+pZoS1aTZrOvrbj6Pp/kK2mp45t2B+bTDre2UgsZZ8EZLSJtUg7m/no0zOJUWgFONpB7Zv9W2tSaFlA==}
@@ -8423,7 +8435,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-parameters@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-AT3MufQ7zZEhU2hwOA11axBnExW0Lszu4RL/tAlUJBuNoRak+wehQW8h6KcXOcgjY42fHtDxswuMhMjFEuv/aw==}
@@ -8463,7 +8474,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-parameters@7.21.3(@babel/core@7.17.8):
     resolution: {integrity: sha512-Wxc+TvppQG9xWFYatvCGPvZ6+SIUxQ2ZdiBP+PHYMIjnPXD+uThCshaz4NZOnODAtBjjcVQQ/3OKs9LW28purQ==}
@@ -8473,6 +8483,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.20.2
+    dev: true
 
   /@babel/plugin-transform-parameters@7.21.3(@babel/core@7.21.3):
     resolution: {integrity: sha512-Wxc+TvppQG9xWFYatvCGPvZ6+SIUxQ2ZdiBP+PHYMIjnPXD+uThCshaz4NZOnODAtBjjcVQQ/3OKs9LW28purQ==}
@@ -8491,7 +8502,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-property-literals@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-z4FGr9NMGdoIl1RqavCqGG+ZuYjfZ/hkCIeuH6Do7tXmSm0ls11nYVSJqFEUOSJbDab5wC6lRE/w6YjVcr6Hqw==}
@@ -8531,7 +8541,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-property-literals@7.18.6(@babel/core@7.17.8):
     resolution: {integrity: sha512-cYcs6qlgafTud3PAzrrRNbQtfpQ8+y/+M5tKmksS9+M1ckbH6kzY8MrexEM9mcA6JDsukE19iIRvAyYl463sMg==}
@@ -8541,6 +8550,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.20.2
+    dev: true
 
   /@babel/plugin-transform-property-literals@7.18.6(@babel/core@7.21.3):
     resolution: {integrity: sha512-cYcs6qlgafTud3PAzrrRNbQtfpQ8+y/+M5tKmksS9+M1ckbH6kzY8MrexEM9mcA6JDsukE19iIRvAyYl463sMg==}
@@ -8561,6 +8571,15 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
+  /@babel/plugin-transform-react-display-name@7.16.7(@babel/core@7.12.9):
+    resolution: {integrity: sha512-qgIg8BcZgd0G/Cz916D5+9kqX0c7nPZyXaP8R2tLNN5tkyIZdG5fEwBrxwplzSnjC1jvQmyMNVwUCZPcbGY7Pg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.12.9
+      '@babel/helper-plugin-utils': 7.20.2
+
   /@babel/plugin-transform-react-display-name@7.16.7(@babel/core@7.17.8):
     resolution: {integrity: sha512-qgIg8BcZgd0G/Cz916D5+9kqX0c7nPZyXaP8R2tLNN5tkyIZdG5fEwBrxwplzSnjC1jvQmyMNVwUCZPcbGY7Pg==}
     engines: {node: '>=6.9.0'}
@@ -8569,6 +8588,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.20.2
+    dev: true
 
   /@babel/plugin-transform-react-display-name@7.16.7(@babel/core@7.21.3):
     resolution: {integrity: sha512-qgIg8BcZgd0G/Cz916D5+9kqX0c7nPZyXaP8R2tLNN5tkyIZdG5fEwBrxwplzSnjC1jvQmyMNVwUCZPcbGY7Pg==}
@@ -8599,13 +8619,13 @@ packages:
       '@babel/plugin-transform-react-jsx': 7.19.0(@babel/core@7.21.3)
     dev: true
 
-  /@babel/plugin-transform-react-jsx-self@7.18.6(@babel/core@7.17.8):
+  /@babel/plugin-transform-react-jsx-self@7.18.6(@babel/core@7.12.9):
     resolution: {integrity: sha512-A0LQGx4+4Jv7u/tWzoJF7alZwnBDQd6cGLh9P+Ttk4dpiL+J5p7NSNv/9tlEFFJDq3kjxOavWmbm6t0Gk+A3Ig==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.17.8
+      '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-react-jsx-self@7.18.6(@babel/core@7.21.3):
@@ -8617,13 +8637,13 @@ packages:
       '@babel/core': 7.21.3
       '@babel/helper-plugin-utils': 7.20.2
 
-  /@babel/plugin-transform-react-jsx-source@7.18.6(@babel/core@7.17.8):
+  /@babel/plugin-transform-react-jsx-source@7.18.6(@babel/core@7.12.9):
     resolution: {integrity: sha512-utZmlASneDfdaMh0m/WausbjUjEdGrQJz0vFK93d7wD3xf5wBtX219+q6IlCNZeguIcxS2f/CvLZrlLSvSHQXw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.17.8
+      '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-react-jsx-source@7.18.6(@babel/core@7.21.3):
@@ -8672,10 +8692,23 @@ packages:
       '@babel/core': 7.21.3
       '@babel/helper-annotate-as-pure': 7.16.7
       '@babel/helper-module-imports': 7.16.7
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-jsx': 7.16.7(@babel/core@7.21.3)
-      '@babel/types': 7.17.0
+      '@babel/types': 7.21.3
     dev: true
+
+  /@babel/plugin-transform-react-jsx@7.19.0(@babel/core@7.12.9):
+    resolution: {integrity: sha512-UVEvX3tXie3Szm3emi1+G63jyw1w5IcMY0FSKM+CRnKRI5Mr1YbCNgsSTwoTwKphQEG9P+QqmuRFneJPZuHNhg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.12.9
+      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.12.9)
+      '@babel/types': 7.21.3
 
   /@babel/plugin-transform-react-jsx@7.19.0(@babel/core@7.17.8):
     resolution: {integrity: sha512-UVEvX3tXie3Szm3emi1+G63jyw1w5IcMY0FSKM+CRnKRI5Mr1YbCNgsSTwoTwKphQEG9P+QqmuRFneJPZuHNhg==}
@@ -8689,6 +8722,7 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.17.8)
       '@babel/types': 7.21.3
+    dev: true
 
   /@babel/plugin-transform-react-jsx@7.19.0(@babel/core@7.21.3):
     resolution: {integrity: sha512-UVEvX3tXie3Szm3emi1+G63jyw1w5IcMY0FSKM+CRnKRI5Mr1YbCNgsSTwoTwKphQEG9P+QqmuRFneJPZuHNhg==}
@@ -8733,7 +8767,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       regenerator-transform: 0.14.5
-    dev: true
 
   /@babel/plugin-transform-regenerator@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-mF7jOgGYCkSJagJ6XCujSQg+6xC1M77/03K2oBmVJWoFGNUtnVJO4WHKJk3dnPC8HCcj4xBQP1Egm8DWh3Pb3Q==}
@@ -8805,7 +8838,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-reserved-words@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-KQzzDnZ9hWQBjwi5lpY5v9shmm6IVG0U9pB18zvMu2i4H90xpT4gmqwPYsn8rObiadYe2M0gmgsiOIF5A/2rtg==}
@@ -8900,18 +8932,18 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-runtime@7.19.1(@babel/core@7.17.8):
+  /@babel/plugin-transform-runtime@7.19.1(@babel/core@7.12.9):
     resolution: {integrity: sha512-2nJjTUFIzBMP/f/miLxEK9vxwW/KUXsdvN4sR//TmuDhe6yU2h57WmIOE12Gng3MDP/xpjUV/ToZRdcf8Yj4fA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.17.8
+      '@babel/core': 7.12.9
       '@babel/helper-module-imports': 7.18.6
       '@babel/helper-plugin-utils': 7.20.2
-      babel-plugin-polyfill-corejs2: 0.3.3(@babel/core@7.17.8)
-      babel-plugin-polyfill-corejs3: 0.6.0(@babel/core@7.17.8)
-      babel-plugin-polyfill-regenerator: 0.4.1(@babel/core@7.17.8)
+      babel-plugin-polyfill-corejs2: 0.3.3(@babel/core@7.12.9)
+      babel-plugin-polyfill-corejs3: 0.6.0(@babel/core@7.12.9)
+      babel-plugin-polyfill-regenerator: 0.4.1(@babel/core@7.12.9)
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
@@ -8940,7 +8972,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-shorthand-properties@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-hah2+FEnoRoATdIb05IOXf+4GzXYTq75TVhIn1PewihbpyrNWUt2JbudKQOETWw6QpLe+AIUpJ5MVLYTQbeeUg==}
@@ -8980,7 +9011,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-shorthand-properties@7.18.6(@babel/core@7.17.8):
     resolution: {integrity: sha512-eCLXXJqv8okzg86ywZJbRn19YJHU4XUa55oz2wbHhaQVn/MM+XhukiT7SYqp/7o00dg52Rj51Ny+Ecw4oyoygw==}
@@ -8990,6 +9020,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.20.2
+    dev: true
 
   /@babel/plugin-transform-shorthand-properties@7.18.6(@babel/core@7.21.3):
     resolution: {integrity: sha512-eCLXXJqv8okzg86ywZJbRn19YJHU4XUa55oz2wbHhaQVn/MM+XhukiT7SYqp/7o00dg52Rj51Ny+Ecw4oyoygw==}
@@ -9009,7 +9040,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-skip-transparent-expression-wrappers': 7.18.9
-    dev: true
 
   /@babel/plugin-transform-spread@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-+pjJpgAngb53L0iaA5gU/1MLXJIfXcYepLgXB3esVRf4fqmj8f2cxM3/FKaHsZms08hFQJkFccEWuIpm429TXg==}
@@ -9053,7 +9083,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-skip-transparent-expression-wrappers': 7.18.9
-    dev: true
 
   /@babel/plugin-transform-spread@7.19.0(@babel/core@7.17.8):
     resolution: {integrity: sha512-RsuMk7j6n+r752EtzyScnWkQyuJdli6LdO5Klv8Yx0OfPVTcQkIUfS8clx5e9yHXzlnhOZF3CbQ8C2uP5j074w==}
@@ -9064,6 +9093,7 @@ packages:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-skip-transparent-expression-wrappers': 7.18.9
+    dev: true
 
   /@babel/plugin-transform-spread@7.19.0(@babel/core@7.21.3):
     resolution: {integrity: sha512-RsuMk7j6n+r752EtzyScnWkQyuJdli6LdO5Klv8Yx0OfPVTcQkIUfS8clx5e9yHXzlnhOZF3CbQ8C2uP5j074w==}
@@ -9083,7 +9113,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-sticky-regex@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-NJa0Bd/87QV5NZZzTuZG5BPJjLYadeSZ9fO6oOUoL4iQx+9EEuw/eEM92SrsT19Yc2jgB1u1hsjqDtH02c3Drw==}
@@ -9123,7 +9152,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-sticky-regex@7.18.6(@babel/core@7.17.8):
     resolution: {integrity: sha512-kfiDrDQ+PBsQDO85yj1icueWMfGfJFKN1KCkndygtu/C9+XUfydLC8Iv5UYJqRwy4zk8EcplRxEOeLyjq1gm6Q==}
@@ -9133,6 +9161,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.20.2
+    dev: true
 
   /@babel/plugin-transform-sticky-regex@7.18.6(@babel/core@7.21.3):
     resolution: {integrity: sha512-kfiDrDQ+PBsQDO85yj1icueWMfGfJFKN1KCkndygtu/C9+XUfydLC8Iv5UYJqRwy4zk8EcplRxEOeLyjq1gm6Q==}
@@ -9151,7 +9180,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-template-literals@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-VwbkDDUeenlIjmfNeDX/V0aWrQH2QiVyJtwymVQSzItFDTpxfyJh3EVaQiS0rIN/CqbLGr0VcGmuwyTdZtdIsA==}
@@ -9191,7 +9219,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-template-literals@7.18.9(@babel/core@7.17.8):
     resolution: {integrity: sha512-S8cOWfT82gTezpYOiVaGHrCbhlHgKhQt8XH5ES46P2XWmX92yisoZywf5km75wv5sYcXDUCLMmMxOLCtthDgMA==}
@@ -9201,6 +9228,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.20.2
+    dev: true
 
   /@babel/plugin-transform-template-literals@7.18.9(@babel/core@7.21.3):
     resolution: {integrity: sha512-S8cOWfT82gTezpYOiVaGHrCbhlHgKhQt8XH5ES46P2XWmX92yisoZywf5km75wv5sYcXDUCLMmMxOLCtthDgMA==}
@@ -9219,7 +9247,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-typeof-symbol@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-p2rOixCKRJzpg9JB4gjnG4gjWkWa89ZoYUnl9snJ1cWIcTH/hvxZqfO+WjG6T8DRBpctEol5jw1O5rA8gkCokQ==}
@@ -9306,16 +9333,16 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/plugin-transform-typescript@7.19.3(@babel/core@7.17.8):
+  /@babel/plugin-transform-typescript@7.19.3(@babel/core@7.12.9):
     resolution: {integrity: sha512-z6fnuK9ve9u/0X0rRvI9MY0xg+DOUaABDYOe+/SQTxtlptaBB/V9JIUxJn6xp3lMBeb9qe8xSFmHU35oZDXD+w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.17.8
-      '@babel/helper-create-class-features-plugin': 7.19.0(@babel/core@7.17.8)
+      '@babel/core': 7.12.9
+      '@babel/helper-create-class-features-plugin': 7.19.0(@babel/core@7.12.9)
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-typescript': 7.18.6(@babel/core@7.17.8)
+      '@babel/plugin-syntax-typescript': 7.18.6(@babel/core@7.12.9)
     transitivePeerDependencies:
       - supports-color
 
@@ -9340,7 +9367,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-unicode-escapes@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-TAV5IGahIz3yZ9/Hfv35TV2xEm+kaBDaZQCn2S/hG9/CZ0DktxJv9eKfPc7yYCvOYR4JGx1h8C+jcSOvgaaI/Q==}
@@ -9410,7 +9436,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-create-regexp-features-plugin': 7.19.0(@babel/core@7.12.9)
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-unicode-regex@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-oC5tYYKw56HO75KZVLQ+R/Nl3Hro9kf8iG0hXoaHP7tjAyCpvqBiSNe6vGrZni1Z6MggmUOC6A7VP7AVmw225Q==}
@@ -9454,7 +9479,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-create-regexp-features-plugin': 7.19.0(@babel/core@7.12.9)
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-unicode-regex@7.18.6(@babel/core@7.17.8):
     resolution: {integrity: sha512-gE7A6Lt7YLnNOL3Pb9BNeZvi+d8l7tcRrG4+pwJjK9hD2xX4mEvjlQW60G9EEmfXVYRPv9VRQcyegIVHCql/AA==}
@@ -9465,6 +9489,7 @@ packages:
       '@babel/core': 7.17.8
       '@babel/helper-create-regexp-features-plugin': 7.19.0(@babel/core@7.17.8)
       '@babel/helper-plugin-utils': 7.20.2
+    dev: true
 
   /@babel/plugin-transform-unicode-regex@7.18.6(@babel/core@7.21.3):
     resolution: {integrity: sha512-gE7A6Lt7YLnNOL3Pb9BNeZvi+d8l7tcRrG4+pwJjK9hD2xX4mEvjlQW60G9EEmfXVYRPv9VRQcyegIVHCql/AA==}
@@ -9558,7 +9583,6 @@ packages:
       semver: 5.7.1
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/preset-env@7.16.11(@babel/core@7.12.9):
     resolution: {integrity: sha512-qcmWG8R7ZW6WBRPZK//y+E3Cli151B20W1Rv7ln27vuPaXU/8TKms6jFdiJtF7UDTxcrb7mZd88tAeK9LjdT8g==}
@@ -10106,7 +10130,6 @@ packages:
       '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.12.9)
       '@babel/types': 7.21.3
       esutils: 2.0.3
-    dev: true
 
   /@babel/preset-modules@0.1.5(@babel/core@7.17.8):
     resolution: {integrity: sha512-A57th6YRG7oR3cq/yt/Y84MvGgE0eJG2F1JLhKuyG+jFxEgrd/HAMJatiFtmOiZurz+0DkrvbheCLaV5f2JfjA==}
@@ -10311,7 +10334,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/parser': 7.21.3
       '@babel/types': 7.21.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -10328,7 +10351,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/parser': 7.21.3
       '@babel/types': 7.21.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -10345,7 +10368,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/parser': 7.21.3
       '@babel/types': 7.21.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -10356,7 +10379,6 @@ packages:
     dependencies:
       '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
-    dev: true
 
   /@babel/types@7.17.0:
     resolution: {integrity: sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==}
@@ -10791,7 +10813,7 @@ packages:
     engines: {node: ^10.12.0 || >=12.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       espree: 7.3.1
       globals: 13.19.0
       ignore: 4.0.6
@@ -10808,7 +10830,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       espree: 9.4.1
       globals: 13.19.0
       ignore: 5.2.0
@@ -10918,7 +10940,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -10928,7 +10950,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -11927,7 +11949,7 @@ packages:
   /@kwsites/file-exists@1.1.1:
     resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -12302,7 +12324,7 @@ packages:
       '@oclif/color': 1.0.1
       '@oclif/core': 1.16.1
       chalk: 4.1.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       fs-extra: 9.1.0
       http-call: 5.3.0
       load-json-file: 5.3.0
@@ -12320,7 +12342,7 @@ packages:
     dependencies:
       '@oclif/core': 1.16.1
       chalk: 4.1.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       fs-extra: 9.1.0
       http-call: 5.3.0
       lodash: 4.17.21
@@ -12954,7 +12976,7 @@ packages:
     transitivePeerDependencies:
       - encoding
 
-  /@react-native-community/cli-plugin-metro@9.1.1(@babel/core@7.17.8):
+  /@react-native-community/cli-plugin-metro@9.1.1(@babel/core@7.12.9):
     resolution: {integrity: sha512-8CBwEZrbYIeQw69Exg/oW20pV9C6mbYlDz0pxZJ0AYmC20Q+wFFs6sUh5zm28ZUh1L0LxNGmhle/YvMPqA+fMQ==}
     dependencies:
       '@react-native-community/cli-server-api': 9.1.0
@@ -12963,7 +12985,7 @@ packages:
       metro: 0.72.2
       metro-config: 0.72.2
       metro-core: 0.72.2
-      metro-react-native-babel-transformer: 0.72.1(@babel/core@7.17.8)
+      metro-react-native-babel-transformer: 0.72.1(@babel/core@7.12.9)
       metro-resolver: 0.72.2
       metro-runtime: 0.72.2
       readline: 1.3.0
@@ -13012,7 +13034,7 @@ packages:
     dependencies:
       joi: 17.6.0
 
-  /@react-native-community/cli@9.1.1(@babel/core@7.17.8):
+  /@react-native-community/cli@9.1.1(@babel/core@7.12.9):
     resolution: {integrity: sha512-LjXcYahjFzM7TlsGzQLH9bCx3yvBsHEj/5Ytdnk0stdDET329JdXWEh6JiSRjVWPVAoDAV5pRAFmEOEGDNIiAw==}
     engines: {node: '>=14'}
     hasBin: true
@@ -13022,7 +13044,7 @@ packages:
       '@react-native-community/cli-debugger-ui': 9.0.0
       '@react-native-community/cli-doctor': 9.1.1
       '@react-native-community/cli-hermes': 9.1.0
-      '@react-native-community/cli-plugin-metro': 9.1.1(@babel/core@7.17.8)
+      '@react-native-community/cli-plugin-metro': 9.1.1(@babel/core@7.12.9)
       '@react-native-community/cli-server-api': 9.1.0
       '@react-native-community/cli-tools': 9.1.0
       '@react-native-community/cli-types': 9.1.0
@@ -14608,81 +14630,6 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/core-server@6.4.19(acorn@8.8.1)(eslint@8.32.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)(webpack-cli@3.3.12):
-    resolution: {integrity: sha512-bKsUB9f7hl5ya2JXxpIrErmbDQjoH39FVbzYZWjMo4t/b7+Xyi6vYadwyWcqlpUQmis09ZaSMv8L/Tw0TuwLAA==}
-    peerDependencies:
-      '@storybook/builder-webpack5': 6.4.19
-      '@storybook/manager-webpack5': 6.4.19
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      '@storybook/builder-webpack5':
-        optional: true
-      '@storybook/manager-webpack5':
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      '@discoveryjs/json-ext': 0.5.7
-      '@storybook/builder-webpack4': 6.4.19(@types/react@17.0.50)(acorn@8.8.1)(eslint@8.32.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)(webpack-cli@3.3.12)
-      '@storybook/core-client': 6.4.19(@types/react@17.0.50)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)(webpack@4.46.0)
-      '@storybook/core-common': 6.4.19(eslint@8.32.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)(webpack-cli@3.3.12)
-      '@storybook/core-events': 6.4.19
-      '@storybook/csf': 0.0.2--canary.87bc651.0
-      '@storybook/csf-tools': 6.4.19
-      '@storybook/manager-webpack4': 6.4.19(@types/react@17.0.50)(acorn@8.8.1)(eslint@8.32.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)(webpack-cli@3.3.12)
-      '@storybook/node-logger': 6.4.19
-      '@storybook/semver': 7.3.2
-      '@storybook/store': 6.4.19(react-dom@17.0.2)(react@17.0.2)
-      '@types/node': 14.14.33
-      '@types/node-fetch': 2.6.1
-      '@types/pretty-hrtime': 1.0.1
-      '@types/webpack': 4.41.32
-      better-opn: 2.1.1
-      boxen: 5.1.2
-      chalk: 4.1.2
-      cli-table3: 0.6.1
-      commander: 6.2.1
-      compression: 1.7.4
-      core-js: 3.29.1
-      cpy: 8.1.2
-      detect-port: 1.3.0
-      express: 4.18.1
-      file-system-cache: 1.0.5
-      fs-extra: 9.1.0
-      globby: 11.1.0
-      ip: 1.1.5
-      lodash: 4.17.21
-      node-fetch: 2.6.7
-      pretty-hrtime: 1.0.3
-      prompts: 2.4.2
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-      regenerator-runtime: 0.13.11
-      serve-favicon: 2.5.0
-      slash: 3.0.0
-      telejson: 5.3.3
-      ts-dedent: 2.2.0
-      typescript: 4.9.5
-      util-deprecate: 1.0.2
-      watchpack: 2.4.0
-      webpack: 4.46.0(webpack-cli@3.3.12)
-      ws: 8.13.0
-    transitivePeerDependencies:
-      - '@types/react'
-      - acorn
-      - bluebird
-      - bufferutil
-      - encoding
-      - eslint
-      - supports-color
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-command
-    dev: true
-
   /@storybook/core@6.4.19(@storybook/builder-webpack5@6.4.19)(@storybook/manager-webpack5@6.4.19)(acorn@7.4.1)(eslint@8.32.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)(webpack@5.70.0):
     resolution: {integrity: sha512-55LOQ/h/kf1jMhjN85t/pIEdIwWEG9yV7bdwv3niVvmoypCxyyjn9/QNK0RKYAeDSUtdm6FVoJ6k5CpxWz2d8w==}
     peerDependencies:
@@ -14806,41 +14753,6 @@ packages:
     dependencies:
       '@storybook/core-client': 6.4.19(@types/react@17.0.50)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)(webpack@4.46.0)
       '@storybook/core-server': 6.4.19(@types/react@17.0.50)(acorn@8.8.1)(eslint@8.32.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)(webpack-cli@3.3.12)
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-      typescript: 4.9.5
-      webpack: 4.46.0(webpack-cli@3.3.12)
-    transitivePeerDependencies:
-      - '@storybook/manager-webpack5'
-      - '@types/react'
-      - acorn
-      - bluebird
-      - bufferutil
-      - encoding
-      - eslint
-      - supports-color
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-command
-    dev: true
-
-  /@storybook/core@6.4.19(acorn@8.8.1)(eslint@8.32.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)(webpack-cli@3.3.12)(webpack@4.46.0):
-    resolution: {integrity: sha512-55LOQ/h/kf1jMhjN85t/pIEdIwWEG9yV7bdwv3niVvmoypCxyyjn9/QNK0RKYAeDSUtdm6FVoJ6k5CpxWz2d8w==}
-    peerDependencies:
-      '@storybook/builder-webpack5': 6.4.19
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-      typescript: '*'
-      webpack: '*'
-    peerDependenciesMeta:
-      '@storybook/builder-webpack5':
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      '@storybook/core-client': 6.4.19(@types/react@17.0.50)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)(webpack@4.46.0)
-      '@storybook/core-server': 6.4.19(acorn@8.8.1)(eslint@8.32.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)(webpack-cli@3.3.12)
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       typescript: 4.9.5
@@ -15120,7 +15032,7 @@ packages:
       typescript: '>= 3.x'
       webpack: '>= 4'
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       endent: 2.1.0
       find-cache-dir: 3.3.2
       flat-cache: 3.0.4
@@ -15154,71 +15066,6 @@ packages:
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.1(react-refresh@0.11.0)(webpack@4.46.0)
       '@storybook/addons': 6.4.19(react-dom@17.0.2)(react@17.0.2)
       '@storybook/core': 6.4.19(@types/react@17.0.50)(acorn@8.8.1)(eslint@8.32.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)(webpack-cli@3.3.12)(webpack@4.46.0)
-      '@storybook/core-common': 6.4.19(eslint@8.32.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)(webpack-cli@3.3.12)
-      '@storybook/csf': 0.0.2--canary.87bc651.0
-      '@storybook/node-logger': 6.4.19
-      '@storybook/react-docgen-typescript-plugin': 1.0.2-canary.253f8c1.0(typescript@4.9.5)(webpack@4.46.0)
-      '@storybook/semver': 7.3.2
-      '@storybook/store': 6.4.19(react-dom@17.0.2)(react@17.0.2)
-      '@types/webpack-env': 1.16.3
-      babel-plugin-add-react-displayname: 0.0.5
-      babel-plugin-named-asset-import: 0.3.8(@babel/core@7.17.8)
-      babel-plugin-react-docgen: 4.2.1
-      core-js: 3.29.1
-      global: 4.4.0
-      lodash: 4.17.21
-      prop-types: 15.8.1
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-      react-refresh: 0.11.0
-      read-pkg-up: 7.0.1
-      regenerator-runtime: 0.13.11
-      ts-dedent: 2.2.0
-      typescript: 4.9.5
-      webpack: 4.46.0(webpack-cli@3.3.12)
-    transitivePeerDependencies:
-      - '@storybook/builder-webpack5'
-      - '@storybook/manager-webpack5'
-      - '@types/react'
-      - '@types/webpack'
-      - acorn
-      - bluebird
-      - bufferutil
-      - encoding
-      - eslint
-      - sockjs-client
-      - supports-color
-      - type-fest
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-command
-      - webpack-dev-server
-      - webpack-hot-middleware
-      - webpack-plugin-serve
-    dev: true
-
-  /@storybook/react@6.4.19(@babel/core@7.17.8)(acorn@8.8.1)(eslint@8.32.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)(webpack-cli@3.3.12):
-    resolution: {integrity: sha512-5b3i8jkVrjQGmcxxxXwCduHPIh+cluWkfeweKeQOe+lW4BR8fuUICo3AMLrYPAtB/UcaJyYkIYmTvF2mkfepFA==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-    peerDependencies:
-      '@babel/core': ^7.11.5
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      '@babel/core': 7.17.8
-      '@babel/preset-flow': 7.16.7(@babel/core@7.17.8)
-      '@babel/preset-react': 7.16.7(@babel/core@7.17.8)
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.1(react-refresh@0.11.0)(webpack@4.46.0)
-      '@storybook/addons': 6.4.19(react-dom@17.0.2)(react@17.0.2)
-      '@storybook/core': 6.4.19(acorn@8.8.1)(eslint@8.32.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)(webpack-cli@3.3.12)(webpack@4.46.0)
       '@storybook/core-common': 6.4.19(eslint@8.32.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)(webpack-cli@3.3.12)
       '@storybook/csf': 0.0.2--canary.87bc651.0
       '@storybook/node-logger': 6.4.19
@@ -16538,7 +16385,7 @@ packages:
       '@typescript-eslint/experimental-utils': 4.33.0(eslint@7.32.0)(typescript@4.9.5)
       '@typescript-eslint/parser': 4.33.0(eslint@8.32.0)(typescript@4.9.5)
       '@typescript-eslint/scope-manager': 4.33.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       eslint: 7.32.0
       functional-red-black-tree: 1.0.1
       ignore: 5.2.0
@@ -16565,7 +16412,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.54.0
       '@typescript-eslint/type-utils': 5.54.0(eslint@8.32.0)(typescript@4.9.5)
       '@typescript-eslint/utils': 5.54.0(eslint@8.32.0)(typescript@4.9.5)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       eslint: 8.32.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.0
@@ -16653,7 +16500,7 @@ packages:
       '@typescript-eslint/scope-manager': 4.33.0
       '@typescript-eslint/types': 4.33.0
       '@typescript-eslint/typescript-estree': 4.33.0(typescript@4.9.5)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       eslint: 8.32.0
       typescript: 4.9.5
     transitivePeerDependencies:
@@ -16673,7 +16520,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.54.0
       '@typescript-eslint/types': 5.54.0
       '@typescript-eslint/typescript-estree': 5.54.0(typescript@4.9.5)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       eslint: 8.32.0
       typescript: 4.9.5
     transitivePeerDependencies:
@@ -16714,7 +16561,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.54.0(typescript@4.9.5)
       '@typescript-eslint/utils': 5.54.0(eslint@8.32.0)(typescript@4.9.5)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       eslint: 8.32.0
       tsutils: 3.21.0(typescript@4.9.5)
       typescript: 4.9.5
@@ -16744,7 +16591,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       eslint-visitor-keys: 1.3.0
       glob: 7.2.3
       is-glob: 4.0.3
@@ -16767,7 +16614,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 4.33.0
       '@typescript-eslint/visitor-keys': 4.33.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.8
@@ -16788,7 +16635,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.43.0
       '@typescript-eslint/visitor-keys': 5.43.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.8
@@ -16809,7 +16656,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.54.0
       '@typescript-eslint/visitor-keys': 5.54.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.8
@@ -20395,7 +20242,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -20403,7 +20250,7 @@ packages:
     resolution: {integrity: sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==}
     engines: {node: '>= 8.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       depd: 1.1.2
       humanize-ms: 1.2.1
     transitivePeerDependencies:
@@ -21595,7 +21442,6 @@ packages:
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /babel-plugin-polyfill-corejs2@0.3.3(@babel/core@7.17.8):
     resolution: {integrity: sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==}
@@ -21608,6 +21454,7 @@ packages:
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /babel-plugin-polyfill-corejs2@0.3.3(@babel/core@7.21.3):
     resolution: {integrity: sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==}
@@ -21715,7 +21562,6 @@ packages:
       core-js-compat: 3.25.5
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /babel-plugin-polyfill-corejs3@0.6.0(@babel/core@7.17.8):
     resolution: {integrity: sha512-+eHqR6OPcBhJOGgsIar7xoAB1GcSwVUA3XjAd7HJNzOXT4wv6/H7KIdA/Nc60cvUlDbKApmqNvD1B1bzOt4nyA==}
@@ -21727,6 +21573,7 @@ packages:
       core-js-compat: 3.25.5
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /babel-plugin-polyfill-corejs3@0.6.0(@babel/core@7.21.3):
     resolution: {integrity: sha512-+eHqR6OPcBhJOGgsIar7xoAB1GcSwVUA3XjAd7HJNzOXT4wv6/H7KIdA/Nc60cvUlDbKApmqNvD1B1bzOt4nyA==}
@@ -21781,7 +21628,6 @@ packages:
       '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.12.9)
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /babel-plugin-polyfill-regenerator@0.4.1(@babel/core@7.17.8):
     resolution: {integrity: sha512-NtQGmyQDXjQqQ+IzRkBVwEOz9lQ4zxAQZgoAYEtU9dJjnl1Oc98qnN7jcp+bE7O7aYzVpavXE3/VKXNzUbh7aw==}
@@ -21792,6 +21638,7 @@ packages:
       '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.17.8)
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /babel-plugin-polyfill-regenerator@0.4.1(@babel/core@7.21.3):
     resolution: {integrity: sha512-NtQGmyQDXjQqQ+IzRkBVwEOz9lQ4zxAQZgoAYEtU9dJjnl1Oc98qnN7jcp+bE7O7aYzVpavXE3/VKXNzUbh7aw==}
@@ -21938,38 +21785,38 @@ packages:
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.21.3)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.21.3)
 
-  /babel-preset-fbjs@3.4.0(@babel/core@7.17.8):
+  /babel-preset-fbjs@3.4.0(@babel/core@7.12.9):
     resolution: {integrity: sha512-9ywCsCvo1ojrw0b+XYk7aFvTH6D9064t0RIL1rtMf3nsa02Xw41MS7sZw216Im35xj/UY0PDBQsa1brUDDF1Ow==}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.17.8
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.17.8)
-      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.17.8)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.17.8)
-      '@babel/plugin-syntax-flow': 7.16.7(@babel/core@7.17.8)
-      '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.17.8)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.17.8)
-      '@babel/plugin-transform-arrow-functions': 7.18.6(@babel/core@7.17.8)
-      '@babel/plugin-transform-block-scoped-functions': 7.18.6(@babel/core@7.17.8)
-      '@babel/plugin-transform-block-scoping': 7.21.0(@babel/core@7.17.8)
-      '@babel/plugin-transform-classes': 7.21.0(@babel/core@7.17.8)
-      '@babel/plugin-transform-computed-properties': 7.18.9(@babel/core@7.17.8)
-      '@babel/plugin-transform-destructuring': 7.21.3(@babel/core@7.17.8)
-      '@babel/plugin-transform-flow-strip-types': 7.16.7(@babel/core@7.17.8)
-      '@babel/plugin-transform-for-of': 7.18.8(@babel/core@7.17.8)
-      '@babel/plugin-transform-function-name': 7.18.9(@babel/core@7.17.8)
-      '@babel/plugin-transform-literals': 7.18.9(@babel/core@7.17.8)
-      '@babel/plugin-transform-member-expression-literals': 7.18.6(@babel/core@7.17.8)
-      '@babel/plugin-transform-modules-commonjs': 7.21.2(@babel/core@7.17.8)
-      '@babel/plugin-transform-object-super': 7.18.6(@babel/core@7.17.8)
-      '@babel/plugin-transform-parameters': 7.21.3(@babel/core@7.17.8)
-      '@babel/plugin-transform-property-literals': 7.18.6(@babel/core@7.17.8)
-      '@babel/plugin-transform-react-display-name': 7.16.7(@babel/core@7.17.8)
-      '@babel/plugin-transform-react-jsx': 7.19.0(@babel/core@7.17.8)
-      '@babel/plugin-transform-shorthand-properties': 7.18.6(@babel/core@7.17.8)
-      '@babel/plugin-transform-spread': 7.19.0(@babel/core@7.17.8)
-      '@babel/plugin-transform-template-literals': 7.18.9(@babel/core@7.17.8)
+      '@babel/core': 7.12.9
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.12.9)
+      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.12.9)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.12.9)
+      '@babel/plugin-syntax-flow': 7.16.7(@babel/core@7.12.9)
+      '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.12.9)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.12.9)
+      '@babel/plugin-transform-arrow-functions': 7.18.6(@babel/core@7.12.9)
+      '@babel/plugin-transform-block-scoped-functions': 7.18.6(@babel/core@7.12.9)
+      '@babel/plugin-transform-block-scoping': 7.21.0(@babel/core@7.12.9)
+      '@babel/plugin-transform-classes': 7.21.0(@babel/core@7.12.9)
+      '@babel/plugin-transform-computed-properties': 7.18.9(@babel/core@7.12.9)
+      '@babel/plugin-transform-destructuring': 7.21.3(@babel/core@7.12.9)
+      '@babel/plugin-transform-flow-strip-types': 7.16.7(@babel/core@7.12.9)
+      '@babel/plugin-transform-for-of': 7.18.8(@babel/core@7.12.9)
+      '@babel/plugin-transform-function-name': 7.18.9(@babel/core@7.12.9)
+      '@babel/plugin-transform-literals': 7.18.9(@babel/core@7.12.9)
+      '@babel/plugin-transform-member-expression-literals': 7.18.6(@babel/core@7.12.9)
+      '@babel/plugin-transform-modules-commonjs': 7.21.2(@babel/core@7.12.9)
+      '@babel/plugin-transform-object-super': 7.18.6(@babel/core@7.12.9)
+      '@babel/plugin-transform-parameters': 7.21.3(@babel/core@7.12.9)
+      '@babel/plugin-transform-property-literals': 7.18.6(@babel/core@7.12.9)
+      '@babel/plugin-transform-react-display-name': 7.16.7(@babel/core@7.12.9)
+      '@babel/plugin-transform-react-jsx': 7.19.0(@babel/core@7.12.9)
+      '@babel/plugin-transform-shorthand-properties': 7.18.6(@babel/core@7.12.9)
+      '@babel/plugin-transform-spread': 7.19.0(@babel/core@7.12.9)
+      '@babel/plugin-transform-template-literals': 7.18.9(@babel/core@7.12.9)
       babel-plugin-syntax-trailing-function-commas: 7.0.0-beta.0
     transitivePeerDependencies:
       - supports-color
@@ -22885,7 +22732,7 @@ packages:
     resolution: {integrity: sha512-FwZ/wxjqe+5RgzF2SRsPSWsVB9+McAVRWW0tRkmbh7fBjrf3HFZZbcr8vr61p1K+NBaAPv57DRjxgIyfbHmd7g==}
     engines: {node: '>=7.6.0'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       puppeteer-core: 1.12.2
     transitivePeerDependencies:
       - bufferutil
@@ -23895,7 +23742,6 @@ packages:
     dependencies:
       browserslist: 4.19.3
       semver: 7.0.0
-    dev: true
 
   /core-js-compat@3.21.1:
     resolution: {integrity: sha512-gbgX5AUvMb8gwxC7FLVWYT7Kkgu/y7+h/h1X43yJkNqhlK2fuYyQimqvKGNZFAY6CKii/GFKJ2cp/1/42TN36g==}
@@ -24696,7 +24542,6 @@ packages:
     dependencies:
       ms: 2.1.2
       supports-color: 9.2.2
-    dev: true
 
   /debuglog@1.0.1:
     resolution: {integrity: sha512-syBZ+rnAK3EgMsH2aYEOLUW7mZSY9Gb+0wUMCFsZvcmiz+HigA0LOcq/HoQqVuGG+EKykunc7QG2bzrponfaSw==}
@@ -25907,7 +25752,7 @@ packages:
       eslint: ^5.0.0 || ^6.0.0
     dependencies:
       comment-parser: 0.7.6
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       eslint: 8.32.0
       jsdoctypeparser: 6.1.0
       lodash: 4.17.21
@@ -25926,7 +25771,7 @@ packages:
       eslint: ^6.0.0 || ^7.0.0
     dependencies:
       comment-parser: 0.7.6
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       eslint: 7.32.0
       jsdoctypeparser: 9.0.0
       lodash: 4.17.21
@@ -25945,7 +25790,7 @@ packages:
     dependencies:
       '@es-joy/jsdoccomment': 0.10.8
       comment-parser: 1.2.4
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       eslint: 7.32.0
       esquery: 1.4.0
       jsdoc-type-pratt-parser: 1.2.0
@@ -25965,7 +25810,7 @@ packages:
     dependencies:
       '@es-joy/jsdoccomment': 0.20.1
       comment-parser: 1.3.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       escape-string-regexp: 4.0.0
       eslint: 8.32.0
       esquery: 1.4.0
@@ -25984,7 +25829,7 @@ packages:
     dependencies:
       '@es-joy/jsdoccomment': 0.36.1
       comment-parser: 1.3.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       escape-string-regexp: 4.0.0
       eslint: 8.32.0
       esquery: 1.4.0
@@ -26240,6 +26085,19 @@ packages:
       eslint: 8.32.0
     dev: true
 
+  /eslint-plugin-xstate@1.1.0(eslint@8.32.0):
+    resolution: {integrity: sha512-NKgrV/YwwJvKXDq+cTERgLLTxBr7Uxsz2NZYic3e1sqcs7u56uRZDWDk6q7pYquNqqX2AT5X8Urn6qHs4lv8PQ==}
+    engines: {node: '>=8.0.0'}
+    peerDependencies:
+      eslint: ^7.1.0||^8.17.0
+    dependencies:
+      eslint: 8.32.0
+      lodash.camelcase: 4.3.0
+      lodash.snakecase: 4.1.1
+      lodash.upperfirst: 4.3.1
+      sanctuary: 3.1.0
+    dev: true
+
   /eslint-scope@4.0.3:
     resolution: {integrity: sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==}
     engines: {node: '>=4.0.0'}
@@ -26315,7 +26173,7 @@ packages:
       ajv: 6.12.6
       chalk: 2.4.2
       cross-spawn: 6.0.5
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       doctrine: 3.0.0
       eslint-scope: 4.0.3
       eslint-utils: 1.4.3
@@ -26360,7 +26218,7 @@ packages:
       ajv: 6.12.6
       chalk: 2.4.2
       cross-spawn: 6.0.5
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       doctrine: 3.0.0
       eslint-scope: 5.1.1
       eslint-utils: 1.4.3
@@ -26408,7 +26266,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       doctrine: 3.0.0
       enquirer: 2.3.6
       escape-string-regexp: 4.0.0
@@ -26458,7 +26316,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.1.1
@@ -26908,7 +26766,7 @@ packages:
     engines: {node: '>= 10.17.0'}
     hasBin: true
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -27237,7 +27095,7 @@ packages:
     dependencies:
       chalk: 4.1.2
       commander: 5.1.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -29048,7 +28906,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       content-type: 1.0.4
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       is-retry-allowed: 1.2.0
       is-stream: 2.0.1
       parse-json: 4.0.0
@@ -29087,7 +28945,7 @@ packages:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -29097,7 +28955,7 @@ packages:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -29169,7 +29027,7 @@ packages:
     engines: {node: '>= 6.0.0'}
     dependencies:
       agent-base: 5.1.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -29178,7 +29036,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -29188,7 +29046,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -29222,7 +29080,7 @@ packages:
     dependencies:
       '@tannin/sprintf': 1.2.0
       '@wordpress/compose': 3.25.3(react@17.0.2)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       events: 3.3.0
       hash.js: 1.1.7
       interpolate-components: 1.1.1
@@ -29243,7 +29101,7 @@ packages:
       '@babel/runtime': 7.21.0
       '@tannin/sprintf': 1.2.0
       '@wordpress/compose': 3.25.3(react@17.0.2)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       events: 3.3.0
       hash.js: 1.1.7
       interpolate-components: 1.1.1
@@ -29265,7 +29123,7 @@ packages:
       '@babel/runtime': 7.21.0
       '@tannin/sprintf': 1.2.0
       '@wordpress/compose': 5.4.1(react@17.0.2)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       events: 3.3.0
       hash.js: 1.1.7
       lodash: 4.17.21
@@ -30303,7 +30161,7 @@ packages:
     resolution: {integrity: sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==}
     engines: {node: '>=6'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       istanbul-lib-coverage: 2.0.5
       make-dir: 2.1.0
       rimraf: 2.7.1
@@ -30316,7 +30174,7 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       istanbul-lib-coverage: 3.2.0
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -32667,6 +32525,35 @@ packages:
   /jsc-android@250230.2.1:
     resolution: {integrity: sha512-KmxeBlRjwoqCnBBKGsihFtvsBHyUFlBxJPK4FzeYcIuBfdjv6jFys44JITAgSTbQD+vIdwMEfyZklsuQX0yI1Q==}
 
+  /jscodeshift@0.13.1(@babel/preset-env@7.12.7):
+    resolution: {integrity: sha512-lGyiEbGOvmMRKgWk4vf+lUrCWO/8YR8sUR3FKF1Cq5fovjZDlIcw3Hu5ppLHAnEXshVffvaM0eyuY/AbOeYpnQ==}
+    hasBin: true
+    peerDependencies:
+      '@babel/preset-env': ^7.1.6
+    dependencies:
+      '@babel/core': 7.17.8
+      '@babel/parser': 7.17.8
+      '@babel/plugin-proposal-class-properties': 7.16.7(@babel/core@7.17.8)
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.16.7(@babel/core@7.17.8)
+      '@babel/plugin-proposal-optional-chaining': 7.16.7(@babel/core@7.17.8)
+      '@babel/plugin-transform-modules-commonjs': 7.17.7(@babel/core@7.17.8)
+      '@babel/preset-env': 7.12.7(@babel/core@7.12.9)
+      '@babel/preset-flow': 7.16.7(@babel/core@7.17.8)
+      '@babel/preset-typescript': 7.16.7(@babel/core@7.17.8)
+      '@babel/register': 7.18.9(@babel/core@7.17.8)
+      babel-core: 7.0.0-bridge.0(@babel/core@7.17.8)
+      chalk: 4.1.2
+      flow-parser: 0.121.0
+      graceful-fs: 4.2.9
+      micromatch: 3.1.10(supports-color@6.1.0)
+      neo-async: 2.6.2
+      node-dir: 0.1.17
+      recast: 0.20.5
+      temp: 0.8.4
+      write-file-atomic: 2.4.1
+    transitivePeerDependencies:
+      - supports-color
+
   /jscodeshift@0.13.1(@babel/preset-env@7.20.2):
     resolution: {integrity: sha512-lGyiEbGOvmMRKgWk4vf+lUrCWO/8YR8sUR3FKF1Cq5fovjZDlIcw3Hu5ppLHAnEXshVffvaM0eyuY/AbOeYpnQ==}
     hasBin: true
@@ -32695,6 +32582,7 @@ packages:
       write-file-atomic: 2.4.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /jsdoc-type-pratt-parser@1.1.1:
     resolution: {integrity: sha512-uelRmpghNwPBuZScwgBG/OzodaFk5RbO5xaivBdsAY70icWfShwZ7PCMO0x1zSkOa8T1FzHThmrdoyg/0AwV5g==}
@@ -33377,6 +33265,10 @@ packages:
     resolution: {integrity: sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=}
     dev: true
 
+  /lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+    dev: true
+
   /lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
 
@@ -33448,6 +33340,10 @@ packages:
     resolution: {integrity: sha512-V/rTAABKLFjoecTZjKSv+A1ZomG8hZg8hlgeG6wwQVD9AGv+10zqqSf6mFq2tVA703Zd5R0YhSuSlXA+E/Ei+Q==}
     dev: false
 
+  /lodash.snakecase@4.1.1:
+    resolution: {integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==}
+    dev: true
+
   /lodash.sortby@4.7.0:
     resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
 
@@ -33460,6 +33356,10 @@ packages:
 
   /lodash.uniq@4.5.0:
     resolution: {integrity: sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=}
+
+  /lodash.upperfirst@4.3.1:
+    resolution: {integrity: sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==}
+    dev: true
 
   /lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
@@ -34164,48 +34064,48 @@ packages:
     dependencies:
       uglify-es: 3.3.9
 
-  /metro-react-native-babel-preset@0.72.1(@babel/core@7.17.8):
+  /metro-react-native-babel-preset@0.72.1(@babel/core@7.12.9):
     resolution: {integrity: sha512-DlvMw2tFrCqD9OXBoN11fPM09kHC22FZpnkTmG4Pr4kecV+aDmEGxwakjUcjELrX1JCXz2MLPvqeJkbiP1f5CA==}
     peerDependencies:
       '@babel/core': '*'
     dependencies:
-      '@babel/core': 7.17.8
-      '@babel/plugin-proposal-async-generator-functions': 7.20.7(@babel/core@7.17.8)
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.17.8)
-      '@babel/plugin-proposal-export-default-from': 7.16.7(@babel/core@7.17.8)
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.17.8)
-      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.17.8)
-      '@babel/plugin-proposal-optional-catch-binding': 7.18.6(@babel/core@7.17.8)
-      '@babel/plugin-proposal-optional-chaining': 7.18.9(@babel/core@7.17.8)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.17.8)
-      '@babel/plugin-syntax-export-default-from': 7.16.7(@babel/core@7.17.8)
-      '@babel/plugin-syntax-flow': 7.16.7(@babel/core@7.17.8)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.17.8)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.17.8)
-      '@babel/plugin-transform-arrow-functions': 7.18.6(@babel/core@7.17.8)
-      '@babel/plugin-transform-async-to-generator': 7.18.6(@babel/core@7.17.8)
-      '@babel/plugin-transform-block-scoping': 7.21.0(@babel/core@7.17.8)
-      '@babel/plugin-transform-classes': 7.21.0(@babel/core@7.17.8)
-      '@babel/plugin-transform-computed-properties': 7.18.9(@babel/core@7.17.8)
-      '@babel/plugin-transform-destructuring': 7.21.3(@babel/core@7.17.8)
-      '@babel/plugin-transform-exponentiation-operator': 7.18.6(@babel/core@7.17.8)
-      '@babel/plugin-transform-flow-strip-types': 7.16.7(@babel/core@7.17.8)
-      '@babel/plugin-transform-function-name': 7.18.9(@babel/core@7.17.8)
-      '@babel/plugin-transform-literals': 7.18.9(@babel/core@7.17.8)
-      '@babel/plugin-transform-modules-commonjs': 7.21.2(@babel/core@7.17.8)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.19.1(@babel/core@7.17.8)
-      '@babel/plugin-transform-parameters': 7.21.3(@babel/core@7.17.8)
-      '@babel/plugin-transform-react-display-name': 7.16.7(@babel/core@7.17.8)
-      '@babel/plugin-transform-react-jsx': 7.19.0(@babel/core@7.17.8)
-      '@babel/plugin-transform-react-jsx-self': 7.18.6(@babel/core@7.17.8)
-      '@babel/plugin-transform-react-jsx-source': 7.18.6(@babel/core@7.17.8)
-      '@babel/plugin-transform-runtime': 7.19.1(@babel/core@7.17.8)
-      '@babel/plugin-transform-shorthand-properties': 7.18.6(@babel/core@7.17.8)
-      '@babel/plugin-transform-spread': 7.19.0(@babel/core@7.17.8)
-      '@babel/plugin-transform-sticky-regex': 7.18.6(@babel/core@7.17.8)
-      '@babel/plugin-transform-template-literals': 7.18.9(@babel/core@7.17.8)
-      '@babel/plugin-transform-typescript': 7.19.3(@babel/core@7.17.8)
-      '@babel/plugin-transform-unicode-regex': 7.18.6(@babel/core@7.17.8)
+      '@babel/core': 7.12.9
+      '@babel/plugin-proposal-async-generator-functions': 7.20.7(@babel/core@7.12.9)
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.12.9)
+      '@babel/plugin-proposal-export-default-from': 7.16.7(@babel/core@7.12.9)
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.12.9)
+      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.12.9)
+      '@babel/plugin-proposal-optional-catch-binding': 7.18.6(@babel/core@7.12.9)
+      '@babel/plugin-proposal-optional-chaining': 7.18.9(@babel/core@7.12.9)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.12.9)
+      '@babel/plugin-syntax-export-default-from': 7.16.7(@babel/core@7.12.9)
+      '@babel/plugin-syntax-flow': 7.16.7(@babel/core@7.12.9)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.12.9)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.12.9)
+      '@babel/plugin-transform-arrow-functions': 7.18.6(@babel/core@7.12.9)
+      '@babel/plugin-transform-async-to-generator': 7.18.6(@babel/core@7.12.9)
+      '@babel/plugin-transform-block-scoping': 7.21.0(@babel/core@7.12.9)
+      '@babel/plugin-transform-classes': 7.21.0(@babel/core@7.12.9)
+      '@babel/plugin-transform-computed-properties': 7.18.9(@babel/core@7.12.9)
+      '@babel/plugin-transform-destructuring': 7.21.3(@babel/core@7.12.9)
+      '@babel/plugin-transform-exponentiation-operator': 7.18.6(@babel/core@7.12.9)
+      '@babel/plugin-transform-flow-strip-types': 7.16.7(@babel/core@7.12.9)
+      '@babel/plugin-transform-function-name': 7.18.9(@babel/core@7.12.9)
+      '@babel/plugin-transform-literals': 7.18.9(@babel/core@7.12.9)
+      '@babel/plugin-transform-modules-commonjs': 7.21.2(@babel/core@7.12.9)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.19.1(@babel/core@7.12.9)
+      '@babel/plugin-transform-parameters': 7.21.3(@babel/core@7.12.9)
+      '@babel/plugin-transform-react-display-name': 7.16.7(@babel/core@7.12.9)
+      '@babel/plugin-transform-react-jsx': 7.19.0(@babel/core@7.12.9)
+      '@babel/plugin-transform-react-jsx-self': 7.18.6(@babel/core@7.12.9)
+      '@babel/plugin-transform-react-jsx-source': 7.18.6(@babel/core@7.12.9)
+      '@babel/plugin-transform-runtime': 7.19.1(@babel/core@7.12.9)
+      '@babel/plugin-transform-shorthand-properties': 7.18.6(@babel/core@7.12.9)
+      '@babel/plugin-transform-spread': 7.19.0(@babel/core@7.12.9)
+      '@babel/plugin-transform-sticky-regex': 7.18.6(@babel/core@7.12.9)
+      '@babel/plugin-transform-template-literals': 7.18.9(@babel/core@7.12.9)
+      '@babel/plugin-transform-typescript': 7.19.3(@babel/core@7.12.9)
+      '@babel/plugin-transform-unicode-regex': 7.18.6(@babel/core@7.12.9)
       '@babel/template': 7.20.7
       react-refresh: 0.4.3
     transitivePeerDependencies:
@@ -34258,16 +34158,16 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /metro-react-native-babel-transformer@0.72.1(@babel/core@7.17.8):
+  /metro-react-native-babel-transformer@0.72.1(@babel/core@7.12.9):
     resolution: {integrity: sha512-hMnN0MOgVloAk94YuXN7sLeDaZ51Y6xIcJXxIU1s/KaygAGXk6o7VAdwf2MY/IV1SIct5lkW4Gn71u/9/EvfXA==}
     peerDependencies:
       '@babel/core': '*'
     dependencies:
-      '@babel/core': 7.17.8
-      babel-preset-fbjs: 3.4.0(@babel/core@7.17.8)
+      '@babel/core': 7.12.9
+      babel-preset-fbjs: 3.4.0(@babel/core@7.12.9)
       hermes-parser: 0.8.0
       metro-babel-transformer: 0.72.1
-      metro-react-native-babel-preset: 0.72.1(@babel/core@7.17.8)
+      metro-react-native-babel-preset: 0.72.1(@babel/core@7.12.9)
       metro-source-map: 0.72.1
       nullthrows: 1.1.1
     transitivePeerDependencies:
@@ -34446,7 +34346,7 @@ packages:
   /micromark@2.11.4:
     resolution: {integrity: sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       parse-entities: 2.0.0
     transitivePeerDependencies:
       - supports-color
@@ -35297,7 +35197,7 @@ packages:
       ajv-errors: 1.0.1(ajv@6.12.6)
       chalk: 4.1.2
       cosmiconfig: 7.0.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       globby: 11.1.0
       ignore: 5.2.0
       is-plain-obj: 3.0.0
@@ -35576,7 +35476,7 @@ packages:
       '@oclif/plugin-warn-if-update-available': 2.0.4
       aws-sdk: 2.1215.0
       concurrently: 7.0.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       find-yarn-workspace-root: 2.0.0
       fs-extra: 8.1.0
       github-slugger: 1.4.0
@@ -35910,7 +35810,7 @@ packages:
     resolution: {integrity: sha512-UJKdSzgd3KOnXXAtqN5+/eeHcvTn1hBkesEmElVgvO/NAYcxAvmjzIGmnNd3Tb/gRAvMBdNRFD4qAWdHxY6QXg==}
     engines: {node: '>=12.10.0'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       p-queue: 6.6.2
     transitivePeerDependencies:
       - supports-color
@@ -36255,7 +36155,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.0
       crc32: 0.2.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       seed-random: 2.2.0
     transitivePeerDependencies:
       - supports-color
@@ -37630,7 +37530,7 @@ packages:
     engines: {node: '>=6.4.0'}
     requiresBuild: true
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       extract-zip: 1.7.0
       https-proxy-agent: 2.2.4
       mime: 2.6.0
@@ -37677,7 +37577,7 @@ packages:
     dependencies:
       chromium-bidi: 0.4.4(devtools-protocol@0.0.1094867)
       cross-fetch: 3.1.5
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       devtools-protocol: 0.0.1094867
       extract-zip: 2.0.1
       https-proxy-agent: 5.0.1
@@ -37698,7 +37598,7 @@ packages:
     engines: {node: '>=10.18.1'}
     dependencies:
       '@types/mime-types': 2.1.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       extract-zip: 2.0.1
       https-proxy-agent: 4.0.0
       mime: 2.6.0
@@ -37722,7 +37622,7 @@ packages:
     requiresBuild: true
     dependencies:
       '@types/mime-types': 2.1.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       extract-zip: 1.7.0
       https-proxy-agent: 4.0.0
       mime: 2.6.0
@@ -37749,7 +37649,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       chalk: 2.4.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       execa: 0.10.0
       fs-extra: 6.0.1
       get-stream: 5.2.0
@@ -38260,12 +38160,12 @@ packages:
       moment: 2.29.4
     dev: false
 
-  /react-native-codegen@0.70.4(@babel/preset-env@7.20.2):
+  /react-native-codegen@0.70.4(@babel/preset-env@7.12.7):
     resolution: {integrity: sha512-bPyd5jm840omfx24VRyMP+KPzAefpRDwE18w5ywMWHCWZBSqLn1qI9WgBPnavlIrjTEuzxznWQNcaA26lw8AMQ==}
     dependencies:
       '@babel/parser': 7.21.3
       flow-parser: 0.121.0
-      jscodeshift: 0.13.1(@babel/preset-env@7.20.2)
+      jscodeshift: 0.13.1(@babel/preset-env@7.12.7)
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - '@babel/preset-env'
@@ -38279,10 +38179,10 @@ packages:
     peerDependencies:
       react-native: '*'
     dependencies:
-      react-native: 0.70.0(@babel/core@7.17.8)(@babel/preset-env@7.20.2)(react@17.0.2)
+      react-native: 0.70.0(@babel/core@7.12.9)(@babel/preset-env@7.12.7)(react@18.1.0)
       whatwg-url-without-unicode: 8.0.0-3
 
-  /react-native@0.70.0(@babel/core@7.17.8)(@babel/preset-env@7.20.2)(react@17.0.2):
+  /react-native@0.70.0(@babel/core@7.12.9)(@babel/preset-env@7.12.7)(react@18.1.0):
     resolution: {integrity: sha512-QjXLbrK9f+/B2eCzn6kAvglLV/8nwPuFGaFv7ggPpAzFRyx5bVN1dwQLHL3MrP7iXR/M7Jc6Nnid7tmRSic6vA==}
     engines: {node: '>=14'}
     hasBin: true
@@ -38290,7 +38190,7 @@ packages:
       react: 18.1.0
     dependencies:
       '@jest/create-cache-key-function': 27.5.1
-      '@react-native-community/cli': 9.1.1(@babel/core@7.17.8)
+      '@react-native-community/cli': 9.1.1(@babel/core@7.12.9)
       '@react-native-community/cli-platform-android': 9.1.0
       '@react-native-community/cli-platform-ios': 9.1.0
       '@react-native/assets': 1.0.0
@@ -38303,23 +38203,23 @@ packages:
       invariant: 2.2.4
       jsc-android: 250230.2.1
       memoize-one: 5.2.1
-      metro-react-native-babel-transformer: 0.72.1(@babel/core@7.17.8)
+      metro-react-native-babel-transformer: 0.72.1(@babel/core@7.12.9)
       metro-runtime: 0.72.1
       metro-source-map: 0.72.1
       mkdirp: 0.5.5
       nullthrows: 1.1.1
       pretty-format: 26.6.2
       promise: 8.2.0
-      react: 17.0.2
+      react: 18.1.0
       react-devtools-core: 4.24.0
-      react-native-codegen: 0.70.4(@babel/preset-env@7.20.2)
+      react-native-codegen: 0.70.4(@babel/preset-env@7.12.7)
       react-native-gradle-plugin: 0.70.2
       react-refresh: 0.4.3
-      react-shallow-renderer: 16.15.0(react@17.0.2)
+      react-shallow-renderer: 16.15.0(react@18.1.0)
       regenerator-runtime: 0.13.11
       scheduler: 0.22.0
       stacktrace-parser: 0.1.10
-      use-sync-external-store: 1.2.0(react@17.0.2)
+      use-sync-external-store: 1.2.0(react@18.1.0)
       whatwg-fetch: 3.6.2
       ws: 6.2.2
     transitivePeerDependencies:
@@ -38501,13 +38401,13 @@ packages:
       react: 17.0.2
       react-is: 17.0.2
 
-  /react-shallow-renderer@16.15.0(react@17.0.2):
+  /react-shallow-renderer@16.15.0(react@18.1.0):
     resolution: {integrity: sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==}
     peerDependencies:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0
     dependencies:
       object-assign: 4.1.1
-      react: 17.0.2
+      react: 18.1.0
       react-is: 18.2.0
 
   /react-sizeme@3.0.2:
@@ -38696,6 +38596,12 @@ packages:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
+
+  /react@18.1.0:
+    resolution: {integrity: sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      loose-envify: 1.4.0
 
   /read-cmd-shim@3.0.1:
     resolution: {integrity: sha512-kEmDUoYf/CDy8yZbLTmhB1X9kkjf9Q80PCNsDMb7ufrGd6zZSQA1+UyjrO+pZm5K/S4OXCWJeiIt1JA8kAsa6g==}
@@ -38970,7 +38876,6 @@ packages:
     resolution: {integrity: sha512-eOf6vka5IO151Jfsw2NO9WpGX58W6wWmefK3I1zEGr0lOD0u8rwPaNqQL1aRxUaxLeKO3ArNh3VYg1KbaD+FFw==}
     dependencies:
       '@babel/runtime': 7.21.0
-    dev: true
 
   /regenerator-transform@0.15.0:
     resolution: {integrity: sha512-LsrGtPmbYg19bcPHwdtmXwbW+TqNvtY4riE3P83foeHRroMbH6/2ddFBfab3t7kbzc7v7p4wbkIecHImqt0QNg==}
@@ -39547,6 +39452,62 @@ packages:
   /safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  /sanctuary-def@0.22.0:
+    resolution: {integrity: sha512-lywS27TfuPHzelMh6M1YWBcB//Lom4Gko/tGjKYbDPkPet1B5KplsSdjY+5sF4mwp6+PDUodsk/Y3Uskrc/ebw==}
+    dependencies:
+      sanctuary-either: 2.1.0
+      sanctuary-show: 2.0.0
+      sanctuary-type-classes: 12.1.0
+      sanctuary-type-identifiers: 3.0.0
+    dev: true
+
+  /sanctuary-either@2.1.0:
+    resolution: {integrity: sha512-AsQCma2yGAVS7Dlxme/09NZWQfcXBNylVmkuvarp8uOe9otSwClOgQyyePN2OxO4hTf3Au1Ck4ggm+97Je06kA==}
+    dependencies:
+      sanctuary-show: 2.0.0
+      sanctuary-type-classes: 12.1.0
+    dev: true
+
+  /sanctuary-maybe@2.1.0:
+    resolution: {integrity: sha512-xCmvaEkYaIz5klWUrsgvgORKTL3bVYxATp7HyGBY0ZCu9tHJtSYDTpwnqMkRknHFIU986Kr2M/dJdiFvuc6UCQ==}
+    dependencies:
+      sanctuary-show: 2.0.0
+      sanctuary-type-classes: 12.1.0
+    dev: true
+
+  /sanctuary-pair@2.1.0:
+    resolution: {integrity: sha512-yY1JzzIJ/Ex7rjN8NmQLB7yv6GVzNeaMvxoYSW8w1ReLQI0n2sGOVCnAVipZuCv7wmfd+BavSXp59rklJeYytw==}
+    dependencies:
+      sanctuary-show: 2.0.0
+      sanctuary-type-classes: 12.1.0
+    dev: true
+
+  /sanctuary-show@2.0.0:
+    resolution: {integrity: sha512-REj4ZiioUXnDLj6EpJ9HcYDIEGaEexmB9Fg5o6InZR9f0x5PfnnC21QeU9SZ9E7G8zXSZPNjy8VRUK4safbesw==}
+    dev: true
+
+  /sanctuary-type-classes@12.1.0:
+    resolution: {integrity: sha512-oWP071Q88dEgJwxHLZp8tc7DoS+mWmYhYOuhP85zznPpIxV1ZjJfyRvcR59YCazyFxyFeBif7bJx1giLhDZW0Q==}
+    dependencies:
+      sanctuary-type-identifiers: 3.0.0
+    dev: true
+
+  /sanctuary-type-identifiers@3.0.0:
+    resolution: {integrity: sha512-YFXYcG0Ura1dSPd/1xLYtE2XAWUEsBHhMTZvYBOvwT8MeFQwdUOCMm2DC+r94z6H93FVq0qxDac8/D7QpJj6Mg==}
+    dev: true
+
+  /sanctuary@3.1.0:
+    resolution: {integrity: sha512-yTpWmslb5Q2jXcHYeIfCzJksIpe3pngBaFBDpjdPXONWyVSB3hBVDZZ8EmitohaMZqjLB+JREeEL0YOVtdxILA==}
+    dependencies:
+      sanctuary-def: 0.22.0
+      sanctuary-either: 2.1.0
+      sanctuary-maybe: 2.1.0
+      sanctuary-pair: 2.1.0
+      sanctuary-show: 2.0.0
+      sanctuary-type-classes: 12.1.0
+      sanctuary-type-identifiers: 3.0.0
+    dev: true
+
   /sane@4.1.0:
     resolution: {integrity: sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -39832,7 +39793,6 @@ packages:
   /semver@7.0.0:
     resolution: {integrity: sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==}
     hasBin: true
-    dev: true
 
   /semver@7.3.5:
     resolution: {integrity: sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==}
@@ -40065,7 +40025,7 @@ packages:
     dependencies:
       '@kwsites/file-exists': 1.1.1
       '@kwsites/promise-deferred': 1.1.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -40234,7 +40194,7 @@ packages:
     engines: {node: '>= 10'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       socks: 2.7.0
     transitivePeerDependencies:
       - supports-color
@@ -40245,7 +40205,7 @@ packages:
     engines: {node: '>= 10'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       socks: 2.7.0
     transitivePeerDependencies:
       - supports-color
@@ -40395,7 +40355,7 @@ packages:
   /spdy-transport@3.0.0:
     resolution: {integrity: sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -40408,7 +40368,7 @@ packages:
     resolution: {integrity: sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==}
     engines: {node: '>=6.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
@@ -40995,7 +40955,7 @@ packages:
       balanced-match: 2.0.0
       chalk: 4.1.2
       cosmiconfig: 7.0.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       execall: 2.0.0
       fast-glob: 3.2.7
       fastest-levenshtein: 1.0.12
@@ -41054,7 +41014,7 @@ packages:
       balanced-match: 1.0.2
       chalk: 4.1.2
       cosmiconfig: 7.0.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       execall: 2.0.0
       fast-glob: 3.2.11
       fastest-levenshtein: 1.0.12
@@ -41174,7 +41134,7 @@ packages:
     dependencies:
       component-emitter: 1.3.0
       cookiejar: 2.1.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       fast-safe-stringify: 2.1.1
       form-data: 4.0.0
       formidable: 2.0.1
@@ -41241,7 +41201,6 @@ packages:
   /supports-color@9.2.2:
     resolution: {integrity: sha512-XC6g/Kgux+rJXmwokjm9ECpD6k/smUoS5LKlUCcsYr4IY3rW0XyAympon2RmxGrlnZURMpg5T18gWDP9CsHXFA==}
     engines: {node: '>=12'}
-    dev: true
 
   /supports-hyperlinks@2.2.0:
     resolution: {integrity: sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==}
@@ -42798,6 +42757,14 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
       react: 17.0.2
+    dev: false
+
+  /use-sync-external-store@1.2.0(react@18.1.0):
+    resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.1.0
 
   /use@3.1.1:
     resolution: {integrity: sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==}
@@ -43114,7 +43081,7 @@ packages:
     dependencies:
       chalk: 2.4.2
       commander: 3.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -43846,7 +43813,7 @@ packages:
     resolution: {integrity: sha512-NMp0YsBM40CuI5vWtHpjWOuf96rPfbpGkamlJpVwYvgenIh1ynRzqVnGfsnjofgz13T2qcKkdwJY0Y2X7z+W+w==}
     dependencies:
       '@babel/runtime': 7.21.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       progress-event: 1.0.0
       uuid: 7.0.3
       wp-error: 1.3.0
@@ -44266,7 +44233,7 @@ packages:
       cli-table: 0.3.11
       commander: 7.1.0
       dateformat: 4.6.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       diff: 5.1.0
       error: 10.4.0
       escape-string-regexp: 4.0.0
@@ -44310,7 +44277,7 @@ packages:
     dependencies:
       chalk: 4.1.2
       dargs: 7.0.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       execa: 5.1.1
       github-username: 6.0.0
       lodash: 4.17.21


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a toggle for XState visual inspector.

To enable the XState inspector, open the browser console and type:
 
`localStorage.setItem("xstate_inspect", "true")`

Also added eslint-plugin-xstate for xstate lint rules.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Dev tooling only, no testing needed
<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Run a local build, enter this in your browser console: `localStorage.setItem("xstate_inspect", "true")`
2. Visit a page that has a XState machine on it, such as http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard
3. Should see the inspector show up in a new tab
4. Should also see lint violation warnings in  `./client/core-profiler/index.tsx` , vscode eslint extension recommended as there are maaaaaany warnings in the whole codebase and it is hard to notice any lint violations.

<!-- End testing instructions -->