### PR TITLE
cart : min_quantity : apply filter

### DIFF
--- a/plugins/woocommerce/templates/cart/cart.php
+++ b/plugins/woocommerce/templates/cart/cart.php
@@ -106,7 +106,7 @@ do_action( 'woocommerce_before_cart' ); ?>
 							$min_quantity = 1;
 							$max_quantity = 1;
 						} else {
-							$min_quantity = 0;
+							$min_quantity = apply_filters( 'woocommerce_quantity_input_min', 0, $_product );
 							$max_quantity = $_product->get_max_purchase_quantity();
 						}
 


### PR DESCRIPTION
apply_filter woocommerce_quantity_input_min
to have the same minimum quantity value in all pages (product and cart).

Because if we had change the min value possible for a product by the use of woocommerce_quantity_input_min, it's work in product single page, but not in the cart, this fix make it work also in the cart page. 

Thank you,
Florent