### PR TITLE
Update stable tag to 7.6.1

### DIFF
--- a/plugins/woocommerce/changelog/dev-update-stable-7.6.1
+++ b/plugins/woocommerce/changelog/dev-update-stable-7.6.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update stable tag to 7.6.1

--- a/plugins/woocommerce/readme.txt
+++ b/plugins/woocommerce/readme.txt
@@ -4,7 +4,7 @@ Tags: online store, ecommerce, shop, shopping cart, sell online, storefront, che
 Requires at least: 6.0
 Tested up to: 6.2
 Requires PHP: 7.3
-Stable tag: 7.6.0
+Stable tag: 7.6.1
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 


### PR DESCRIPTION
This PR updates the stable tag based on the latest release: 7.6.1.