### PR TITLE
Fix N/A displayed on re-enabling toggles for "Stats overview" panel after refreshing "Woocommerce > Home" page.

### DIFF
--- a/packages/js/data/changelog/fix-display-stats-na
+++ b/packages/js/data/changelog/fix-display-stats-na
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fix
+Comment: Handle request with empty stats in performance-indicators report

--- a/packages/js/data/src/reports/resolvers.ts
+++ b/packages/js/data/src/reports/resolvers.ts
@@ -51,6 +51,15 @@ export function* getReportItems(
 		path: addQueryArgs( `${ NAMESPACE }/reports/${ endpoint }`, query ),
 	};
 
+	if ( endpoint === 'performance-indicators' && ! query.stats ) {
+		yield setReportItems( endpoint, query, {
+			data: [],
+			totalResults: 0,
+			totalPages: 0,
+		} );
+		return;
+	}
+
 	try {
 		const response: {
 			headers: Map< string, string >;

--- a/packages/js/data/src/reports/types.ts
+++ b/packages/js/data/src/reports/types.ts
@@ -325,9 +325,9 @@ export type ReportItemObject = {
 		| TaxesReport
 		| StockReport
 		| DownloadReport
-		| OrderReport[]
+		| OrderReport
 		| CategoriesReport
-		| PerformanceIndicatorReport;
+		| PerformanceIndicatorReport[];
 	totalResults: number;
 	totalPages: number;
 };

--- a/packages/js/data/src/reports/types.ts
+++ b/packages/js/data/src/reports/types.ts
@@ -13,7 +13,7 @@ export type ReportItemsEndpoint =
 	| 'coupons'
 	| 'stock'
 	| 'downloads'
-	| 'performance_indicator';
+	| 'performance-indicators';
 
 export type ReportStatEndpoint =
 	| 'products'
@@ -24,7 +24,9 @@ export type ReportStatEndpoint =
 	| 'coupons'
 	| 'customers';
 
-export type ReportQueryParams = ReturnType< typeof getReportTableQuery >;
+export type ReportQueryParams = ReturnType< typeof getReportTableQuery > & {
+	stats?: string;
+};
 export type ReportStatQueryParams = ReturnType< typeof getRequestQuery >;
 
 export type CustomerReport = {
@@ -323,7 +325,7 @@ export type ReportItemObject = {
 		| TaxesReport
 		| StockReport
 		| DownloadReport
-		| OrderReport
+		| OrderReport[]
 		| CategoriesReport
 		| PerformanceIndicatorReport;
 	totalResults: number;

--- a/plugins/woocommerce-admin/client/homescreen/stats-overview/stats-list.js
+++ b/plugins/woocommerce-admin/client/homescreen/stats-overview/stats-list.js
@@ -88,8 +88,5 @@ export const StatsList = ( {
 };
 
 export default withSelect( ( select, { stats, query } ) => {
-	if ( stats.length === 0 ) {
-		return;
-	}
 	return getIndicatorData( select, stats, query );
 } )( StatsList );

--- a/plugins/woocommerce/changelog/fix-display-stats-na
+++ b/plugins/woocommerce/changelog/fix-display-stats-na
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Remove if statement that caused stats not to be loaded on certain scenarios
+
+


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fix N/A displayed on re-enabling toggles for "Stats overview" panel after refreshing "Woocommerce > Home" page.

Closes #35899 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Navigate to WooCommerce > Home
2. Click on the ellipsis menu for the 'Stats Overview' panel and disable all the toggles
3. Refresh the page
4. Re enable the toggles
5. Observe that the issue described in https://github.com/woocommerce/woocommerce/issues/35899 does not happen anymore
6. Run some smoke tests on all the three tabs, Today, Week to Date, and Month to Date

<!-- End testing instructions -->