### PR TITLE
Add fixed toolbar to modal editor

### DIFF
--- a/packages/js/product-editor/changelog/update-37899
+++ b/packages/js/product-editor/changelog/update-37899
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update the IframeEditor to use a fixed toolbar

--- a/packages/js/product-editor/src/components/iframe-editor/iframe-editor.scss
+++ b/packages/js/product-editor/src/components/iframe-editor/iframe-editor.scss
@@ -16,14 +16,24 @@
 	&__content {
 		flex-grow: 1;
 		background-color: #2f2f2f;
-		padding: 40px 48px;
+		padding: 90px 48px 40px;
 		height: 100%;
 		justify-content: center;
 		display: flex;
+		position: relative;
 	}
 
 	&__sidebar {
 		flex-shrink: 0;
 		width: 280px;
+	}
+
+	.block-editor-block-contextual-toolbar.is-fixed {
+		position: absolute;
+		left: 0;
+		top: 0;
+		border-bottom: 1px solid $gray-400;
+		border-right: 1px solid $gray-400;
+		box-sizing: border-box;
 	}
 }

--- a/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
@@ -80,6 +80,7 @@ export function IframeEditor( {
 			<BlockEditorProvider
 				settings={ {
 					...( settings || parentEditorSettings ),
+					hasFixedToolbar: true,
 					templateLock: false,
 				} }
 				value={ blocks }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Moves the contextual toolbar to a fixed position under the modal header.

<img width="982" alt="Screen Shot 2023-04-26 at 7 54 42 PM" src="https://user-images.githubusercontent.com/10561050/234933330-f50ec31a-52ca-41df-ba8e-b46f95a27e67.png">


Closes #37899 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Navigate to Tools -> WCA Test Helper -> Features and enable the new product blocks editing experience
2. Navigate to Products -> Add new
3. Click on "Add description" under the description
4. Add some content
5. Note the toolbar is fixed under the modal header

<!-- End testing instructions -->