### PR TITLE
[Enhancement]: Allow dropdown options recording for WooCommerce Settings

### DIFF
--- a/plugins/woocommerce/changelog/dev-37989_allow_dropdown_recording_for_wc_settings
+++ b/plugins/woocommerce/changelog/dev-37989_allow_dropdown_recording_for_wc_settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Modify 'WC_Settings_Tracking' to allow dropdown options recording for WooCommerce Settings

--- a/plugins/woocommerce/includes/tracks/events/class-wc-settings-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-settings-tracking.php
@@ -76,7 +76,7 @@ class WC_Settings_Tracking {
 	public function add_option_to_list( $option ) {
 		$this->allowed_options[] = $option['id'];
 
-		if ( isset( $option[ 'options' ] ) ){
+		if ( isset( $option['options'] ) ) {
 			$this->dropdown_menu_options[] = $option['id'];
 		}
 
@@ -112,8 +112,8 @@ class WC_Settings_Tracking {
 
 		if ( in_array( $option_name, $this->dropdown_menu_options, true ) ) {
 			$this->modified_options[ $option_name ] = $new_value;
-		// Check and save toggled options.
 		} elseif ( in_array( $new_value, array( 'yes', 'no' ), true ) && in_array( $old_value, array( 'yes', 'no' ), true ) ) {
+			// Save toggled options.
 			$option_state                             = 'yes' === $new_value ? 'enabled' : 'disabled';
 			$this->toggled_options[ $option_state ][] = $option_name;
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Record events for dropdown menus under WooCommerce Settings.

Closes #37989.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to WooCommerce > Settings.
2. Choose a dropdown menu and change it (e.g.: `General > Selling location(s)` ).
3. Press `Save changes`.
4. Go to WooCommerce > Status > Logs (URL `/wp-admin/admin.php?page=wc-status&tab=logs`) and select the file that starts with `tracks-[date]-[hash]`.
5. Look for the event `wcadmin_settings_change` and verify the option has been recorded. In the case of the example I mentioned, the settings name is `woocommerce_allowed_countries`.
6. Please note that some files are not recording Tracks events yet. This fix targets recording dropdowns for settings that are already being saved.

<!-- End testing instructions -->