### PR TITLE
Code Freeze CLI: Add version bump

### DIFF
--- a/tools/monorepo-utils/src/code-freeze/commands/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/index.ts
@@ -9,11 +9,13 @@ import { Command } from '@commander-js/extra-typings';
 import { verifyDayCommand } from './verify-day';
 import { milestoneCommand } from './milestone';
 import { branchCommand } from './branch';
+import { versionBumpCommand } from './version-bump';
 
 const program = new Command( 'code-freeze' )
 	.description( 'Code freeze utilities' )
 	.addCommand( verifyDayCommand )
 	.addCommand( milestoneCommand )
-	.addCommand( branchCommand );
+	.addCommand( branchCommand )
+	.addCommand( versionBumpCommand );
 
 export default program;

--- a/tools/monorepo-utils/src/code-freeze/commands/version-bump/bump.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/version-bump/bump.ts
@@ -1,9 +1,41 @@
 /**
  * External dependencies
  */
-import { join } from 'path';
-import { readFile, writeFile } from 'fs/promises';
+import { prerelease } from 'semver';
 
-export const bumpFiles = async ( tmpRepoPath ) => {
-	const filePath = join( tmpRepoPath, `plugins/woocommerce/woocommerce.php` );
+/**
+ * Internal dependencies
+ */
+import { stripPrereleaseParameters } from './lib/validate';
+import {
+	updatePluginFile,
+	updateReadmeChangelog,
+	updateJSON,
+	updateClassPluginFile,
+	updateReadmeStableTag,
+} from './lib/update';
+
+export const bumpFiles = async ( tmpRepoPath, version ) => {
+	let nextVersion = version;
+
+	const prereleaseParameters = prerelease( nextVersion );
+	const isDevVersionBump =
+		prereleaseParameters && prereleaseParameters[ 0 ] === 'dev';
+
+	await updatePluginFile( tmpRepoPath, nextVersion );
+
+	// Any updated files besides the plugin file get a version stripped of prerelease parameters.
+	nextVersion = stripPrereleaseParameters( nextVersion );
+
+	if ( isDevVersionBump ) {
+		// Bumping the dev version means updating the readme's changelog.
+		await updateReadmeChangelog( tmpRepoPath, nextVersion );
+	} else {
+		// Only update stable tag on real releases.
+		await updateReadmeStableTag( tmpRepoPath, nextVersion );
+	}
+
+	await updateJSON( 'composer', tmpRepoPath, nextVersion );
+	await updateJSON( 'package', tmpRepoPath, nextVersion );
+	await updateClassPluginFile( tmpRepoPath, nextVersion );
 };

--- a/tools/monorepo-utils/src/code-freeze/commands/version-bump/bump.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/version-bump/bump.ts
@@ -1,0 +1,9 @@
+/**
+ * External dependencies
+ */
+import { join } from 'path';
+import { readFile, writeFile } from 'fs/promises';
+
+export const bumpFiles = async ( tmpRepoPath ) => {
+	const filePath = join( tmpRepoPath, `plugins/woocommerce/woocommerce.php` );
+};

--- a/tools/monorepo-utils/src/code-freeze/commands/version-bump/bump.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/version-bump/bump.ts
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { prerelease } from 'semver';
-
-/**
  * Internal dependencies
  */
 import { stripPrereleaseParameters } from './lib/validate';
@@ -12,28 +7,18 @@ import {
 	updateReadmeChangelog,
 	updateJSON,
 	updateClassPluginFile,
-	updateReadmeStableTag,
 } from './lib/update';
 
 export const bumpFiles = async ( tmpRepoPath, version ) => {
 	let nextVersion = version;
-
-	const prereleaseParameters = prerelease( nextVersion );
-	const isDevVersionBump =
-		prereleaseParameters && prereleaseParameters[ 0 ] === 'dev';
 
 	await updatePluginFile( tmpRepoPath, nextVersion );
 
 	// Any updated files besides the plugin file get a version stripped of prerelease parameters.
 	nextVersion = stripPrereleaseParameters( nextVersion );
 
-	if ( isDevVersionBump ) {
-		// Bumping the dev version means updating the readme's changelog.
-		await updateReadmeChangelog( tmpRepoPath, nextVersion );
-	} else {
-		// Only update stable tag on real releases.
-		await updateReadmeStableTag( tmpRepoPath, nextVersion );
-	}
+	// Bumping the dev version means updating the readme's changelog.
+	await updateReadmeChangelog( tmpRepoPath, nextVersion );
 
 	await updateJSON( 'composer', tmpRepoPath, nextVersion );
 	await updateJSON( 'package', tmpRepoPath, nextVersion );

--- a/tools/monorepo-utils/src/code-freeze/commands/version-bump/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/version-bump/index.ts
@@ -75,14 +75,18 @@ export const versionBumpCommand = new Command( 'version-bump' )
 
 		try {
 			Logger.startTask( 'Creating a pull request' );
-			await octokitWithAuth.request( 'POST /repos/{owner}/{repo}/pulls', {
-				owner,
-				repo: name,
-				title: 'Amazing new feature',
-				body: 'Please pull these awesome changes in!',
-				head: branch,
-				base,
-			} );
+			const pr = await octokitWithAuth.request(
+				'POST /repos/{owner}/{repo}/pulls',
+				{
+					owner,
+					repo: name,
+					title: 'Amazing new feature',
+					body: 'Please pull these awesome changes in!',
+					head: branch,
+					base,
+				}
+			);
+			Logger.notice( `Pull request created: ${ pr.data.html_url }` );
 			Logger.endTask();
 		} catch ( e ) {
 			throw e;

--- a/tools/monorepo-utils/src/code-freeze/commands/version-bump/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/version-bump/index.ts
@@ -1,0 +1,97 @@
+/**
+ * External dependencies
+ */
+import { Command } from '@commander-js/extra-typings';
+import { join } from 'path';
+import simpleGit from 'simple-git';
+import { readFile, writeFile } from 'fs/promises';
+
+/**
+ * Internal dependencies
+ */
+import { Logger } from '../../../core/logger';
+import { cloneRepo } from '../../../core/git';
+import { octokitWithAuth } from '../../../core/github/api';
+
+const errFn = ( err ) => {
+	if ( err.git ) {
+		return err.git;
+	} // the unsuccessful mergeSummary
+	throw err; // some other error, so throw
+};
+
+export const versionBumpCommand = new Command( 'version-bump' )
+	.description( 'Bump versions ahead of new development cycle' )
+	.option(
+		'-o --owner <owner>',
+		'Repository owner. Default: woocommerce',
+		'woocommerce'
+	)
+	.option(
+		'-n --name <name>',
+		'Repository name. Default: woocommerce',
+		'woocommerce'
+	)
+	.action( async ( { owner, name } ) => {
+		const source = `github.com/${ owner }/${ name }`;
+		const remote = `https://${ owner }:${ process.env.GITHUB_TOKEN }@${ source }`;
+
+		Logger.startTask(
+			`Making a temporary clone of '${ owner }/${ name }'`
+		);
+		const tmpRepoPath = await cloneRepo( remote );
+		Logger.endTask();
+
+		Logger.notice(
+			`Temporary clone of '${ owner }/${ name }' created at ${ tmpRepoPath }`
+		);
+
+		const git = simpleGit( {
+			baseDir: tmpRepoPath,
+			config: [ 'core.hooksPath=/dev/null' ],
+		} );
+		const branch = 'prep/trunk-for-next-dev-cycle-XX.XX';
+		const base = 'trunk';
+		await git.checkoutBranch( branch, base );
+
+		const filePath = join(
+			tmpRepoPath,
+			`plugins/woocommerce/woocommerce.php`
+		);
+
+		try {
+			const pluginFileContents = await readFile( filePath, 'utf8' );
+
+			const updatedPluginFileContents = pluginFileContents.replace(
+				/Version: \d+\.\d+\.\d+.*\n/m,
+				`Version: XX.XX\n`
+			);
+			await writeFile( filePath, updatedPluginFileContents );
+		} catch ( e ) {
+			Logger.error( 'Unable to update plugin file.' );
+		}
+
+		console.log( 'Adding and committing changes' );
+		await git.add( filePath ).catch( errFn );
+		console.log( 'Committing changes' );
+		await git.commit( 'Prep trunk for XX.XX cycle' ).catch( errFn );
+		console.log( 'authenticating' );
+		await git.env( 'GITHUB_TOKEN', process.env.GITHUB_TOKEN );
+		console.log( 'Pushing changes' );
+		await git
+			.push( 'origin', 'prep/trunk-for-next-dev-cycle-XX.XX' )
+			.catch( errFn );
+
+		const pr = await octokitWithAuth.request(
+			'POST /repos/{owner}/{repo}/pulls',
+			{
+				owner,
+				repo: name,
+				title: 'Amazing new feature',
+				body: 'Please pull these awesome changes in!',
+				head: branch,
+				base,
+			}
+		);
+		console.log( pr );
+	} );

--- a/tools/monorepo-utils/src/code-freeze/commands/version-bump/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/version-bump/index.ts
@@ -11,6 +11,7 @@ import { Logger } from '../../../core/logger';
 import { cloneRepo } from '../../../core/git';
 import { octokitWithAuth } from '../../../core/github/api';
 import { getEnvVar } from '../../../core/environment';
+import { getMajorMinor } from '../../../core/version';
 import { bumpFiles } from './bump';
 import { validateArgs } from './lib/validate';
 
@@ -54,7 +55,8 @@ export const versionBumpCommand = new Command( 'version-bump' )
 			baseDir: tmpRepoPath,
 			config: [ 'core.hooksPath=/dev/null' ],
 		} );
-		const branch = 'prep/trunk-for-next-dev-cycle-XX.XX';
+		const majorMinor = getMajorMinor( version );
+		const branch = `prep/trunk-for-next-dev-cycle-${ majorMinor }`;
 		const base = 'trunk';
 		await git.checkoutBranch( branch, base ).catch( errFn );
 
@@ -64,13 +66,13 @@ export const versionBumpCommand = new Command( 'version-bump' )
 
 		Logger.startTask( 'Adding and committing changes' );
 		await git.add( '.' ).catch( errFn );
-		await git.commit( 'Prep trunk for XX.XX cycle' ).catch( errFn );
+		await git
+			.commit( `Prep trunk for ${ majorMinor } cycle` )
+			.catch( errFn );
 		Logger.endTask();
 
 		Logger.startTask( 'Pushing to Github' );
-		await git
-			.push( 'origin', 'prep/trunk-for-next-dev-cycle-XX.XX' )
-			.catch( errFn );
+		await git.push( 'origin', branch ).catch( errFn );
 		Logger.endTask();
 
 		try {

--- a/tools/monorepo-utils/src/code-freeze/commands/version-bump/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/version-bump/index.ts
@@ -8,7 +8,7 @@ import simpleGit from 'simple-git';
  * Internal dependencies
  */
 import { Logger } from '../../../core/logger';
-import { cloneRepo } from '../../../core/git';
+import { sparseCheckoutRepo } from '../../../core/git';
 import { octokitWithAuth } from '../../../core/github/api';
 import { getEnvVar } from '../../../core/environment';
 import { getMajorMinor } from '../../../core/version';
@@ -49,7 +49,9 @@ export const versionBumpCommand = new Command( 'version-bump' )
 		const source = `github.com/${ owner }/${ name }`;
 		const token = getEnvVar( 'GITHUB_TOKEN' );
 		const remote = `https://${ owner }:${ token }@${ source }`;
-		const tmpRepoPath = await cloneRepo( remote );
+		const tmpRepoPath = await sparseCheckoutRepo( remote, 'woocommerce', [
+			'plugins/woocommerce',
+		] );
 		Logger.endTask();
 
 		Logger.notice(

--- a/tools/monorepo-utils/src/code-freeze/commands/version-bump/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/version-bump/index.ts
@@ -54,7 +54,7 @@ export const versionBumpCommand = new Command( 'version-bump' )
 			'woocommerce',
 			[
 				'plugins/woocommerce/includes/class-woocommerce.php',
-				// All that's truely needed is the line above, but including these here for completeness.
+				// All that's needed is the line above, but including these here for completeness.
 				'plugins/woocommerce/composer.json',
 				'plugins/woocommerce/package.json',
 				'plugins/woocommerce/readme.txt',

--- a/tools/monorepo-utils/src/code-freeze/commands/version-bump/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/version-bump/index.ts
@@ -47,7 +47,7 @@ export const versionBumpCommand = new Command( 'version-bump' )
 			`Making a temporary clone of '${ owner }/${ name }'`
 		);
 		const source = `github.com/${ owner }/${ name }`;
-		const token = getEnvVar( 'GITHUB_TOKEN' );
+		const token = getEnvVar( 'GITHUB_TOKEN', true );
 		const remote = `https://${ owner }:${ token }@${ source }`;
 		const tmpRepoPath = await sparseCheckoutRepoShallow(
 			remote,

--- a/tools/monorepo-utils/src/code-freeze/commands/version-bump/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/version-bump/index.ts
@@ -8,7 +8,7 @@ import simpleGit from 'simple-git';
  * Internal dependencies
  */
 import { Logger } from '../../../core/logger';
-import { cloneRepo } from '../../../core/git';
+import { sparseCheckoutRepo } from '../../../core/git';
 import { octokitWithAuth } from '../../../core/github/api';
 import { getEnvVar } from '../../../core/environment';
 import { getMajorMinor } from '../../../core/version';
@@ -49,7 +49,14 @@ export const versionBumpCommand = new Command( 'version-bump' )
 		const source = `github.com/${ owner }/${ name }`;
 		const token = getEnvVar( 'GITHUB_TOKEN' );
 		const remote = `https://${ owner }:${ token }@${ source }`;
-		const tmpRepoPath = await cloneRepo( remote );
+		const tmpRepoPath = await sparseCheckoutRepo( remote, 'woocommerce', [
+			'plugins/woocommerce/includes/class-woocommerce.php',
+			// All that's truely needed is the line above, but including these here for completeness.
+			'plugins/woocommerce/composer.json',
+			'plugins/woocommerce/package.json',
+			'plugins/woocommerce/readme.txt',
+			'plugins/woocommerce/woocommerce.php',
+		] );
 		Logger.endTask();
 
 		Logger.notice(

--- a/tools/monorepo-utils/src/code-freeze/commands/version-bump/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/version-bump/index.ts
@@ -8,7 +8,7 @@ import simpleGit from 'simple-git';
  * Internal dependencies
  */
 import { Logger } from '../../../core/logger';
-import { sparseCheckoutRepo } from '../../../core/git';
+import { sparseCheckoutRepoShallow } from '../../../core/git';
 import { octokitWithAuth } from '../../../core/github/api';
 import { getEnvVar } from '../../../core/environment';
 import { getMajorMinor } from '../../../core/version';
@@ -49,14 +49,18 @@ export const versionBumpCommand = new Command( 'version-bump' )
 		const source = `github.com/${ owner }/${ name }`;
 		const token = getEnvVar( 'GITHUB_TOKEN' );
 		const remote = `https://${ owner }:${ token }@${ source }`;
-		const tmpRepoPath = await sparseCheckoutRepo( remote, 'woocommerce', [
-			'plugins/woocommerce/includes/class-woocommerce.php',
-			// All that's truely needed is the line above, but including these here for completeness.
-			'plugins/woocommerce/composer.json',
-			'plugins/woocommerce/package.json',
-			'plugins/woocommerce/readme.txt',
-			'plugins/woocommerce/woocommerce.php',
-		] );
+		const tmpRepoPath = await sparseCheckoutRepoShallow(
+			remote,
+			'woocommerce',
+			[
+				'plugins/woocommerce/includes/class-woocommerce.php',
+				// All that's truely needed is the line above, but including these here for completeness.
+				'plugins/woocommerce/composer.json',
+				'plugins/woocommerce/package.json',
+				'plugins/woocommerce/readme.txt',
+				'plugins/woocommerce/woocommerce.php',
+			]
+		);
 		Logger.endTask();
 
 		Logger.notice(

--- a/tools/monorepo-utils/src/code-freeze/commands/version-bump/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/version-bump/index.ts
@@ -50,7 +50,11 @@ export const versionBumpCommand = new Command( 'version-bump' )
 		const token = getEnvVar( 'GITHUB_TOKEN' );
 		const remote = `https://${ owner }:${ token }@${ source }`;
 		const tmpRepoPath = await sparseCheckoutRepo( remote, 'woocommerce', [
-			'plugins/woocommerce',
+			'plugins/woocommerce/composer.json',
+			'plugins/woocommerce/includes/class-woocommerce.php',
+			'plugins/woocommerce/package.json',
+			'plugins/woocommerce/readme.txt',
+			'plugins/woocommerce/woocommerce.php',
 		] );
 		Logger.endTask();
 
@@ -83,7 +87,7 @@ export const versionBumpCommand = new Command( 'version-bump' )
 		await git.push( 'origin', branch ).catch( ( e ) => {
 			Logger.warn( e );
 			Logger.error(
-				`\nBranch ${ branch } already exists. Run \`git push origin --delete ${ branch }\` and rerun this command.`
+				`\nBranch ${ branch } already exists. Run \`git push <remote> --delete ${ branch }\` and rerun this command.`
 			);
 		} );
 		Logger.endTask();

--- a/tools/monorepo-utils/src/code-freeze/commands/version-bump/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/version-bump/index.ts
@@ -14,6 +14,7 @@ import { getEnvVar } from '../../../core/environment';
 import { getMajorMinor } from '../../../core/version';
 import { bumpFiles } from './bump';
 import { validateArgs } from './lib/validate';
+import { Options } from './types';
 
 const genericErrorFunction = ( err ) => {
 	if ( err.git ) {
@@ -40,7 +41,8 @@ export const versionBumpCommand = new Command( 'version-bump' )
 		'Base branch to create the PR against. Default: trunk',
 		'trunk'
 	)
-	.action( async ( { owner, name, version, base } ) => {
+	.action( async ( options: Options ) => {
+		const { owner, name, version, base } = options;
 		Logger.startTask(
 			`Making a temporary clone of '${ owner }/${ name }'`
 		);

--- a/tools/monorepo-utils/src/code-freeze/commands/version-bump/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/version-bump/index.ts
@@ -8,7 +8,7 @@ import simpleGit from 'simple-git';
  * Internal dependencies
  */
 import { Logger } from '../../../core/logger';
-import { sparseCheckoutRepo } from '../../../core/git';
+import { cloneRepo } from '../../../core/git';
 import { octokitWithAuth } from '../../../core/github/api';
 import { getEnvVar } from '../../../core/environment';
 import { getMajorMinor } from '../../../core/version';
@@ -49,13 +49,7 @@ export const versionBumpCommand = new Command( 'version-bump' )
 		const source = `github.com/${ owner }/${ name }`;
 		const token = getEnvVar( 'GITHUB_TOKEN' );
 		const remote = `https://${ owner }:${ token }@${ source }`;
-		const tmpRepoPath = await sparseCheckoutRepo( remote, 'woocommerce', [
-			'plugins/woocommerce/composer.json',
-			'plugins/woocommerce/includes/class-woocommerce.php',
-			'plugins/woocommerce/package.json',
-			'plugins/woocommerce/readme.txt',
-			'plugins/woocommerce/woocommerce.php',
-		] );
+		const tmpRepoPath = await cloneRepo( remote );
 		Logger.endTask();
 
 		Logger.notice(

--- a/tools/monorepo-utils/src/code-freeze/commands/version-bump/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/version-bump/index.ts
@@ -85,22 +85,19 @@ export const versionBumpCommand = new Command( 'version-bump' )
 
 		await git.checkoutBranch( branch, base ).catch( genericErrorFunction );
 
-		Logger.startTask( `Bumping versions in ${ owner }/${ name }` );
+		Logger.notice( `Bumping versions in ${ owner }/${ name }` );
 		bumpFiles( tmpRepoPath, version );
-		Logger.endTask();
 
-		Logger.startTask( 'Adding and committing changes' );
+		Logger.notice( 'Adding and committing changes' );
 		await git.add( '.' ).catch( genericErrorFunction );
 		await git
 			.commit( `Prep trunk for ${ majorMinor } cycle` )
 			.catch( genericErrorFunction );
-		Logger.endTask();
 
-		Logger.startTask( 'Pushing to Github' );
+		Logger.notice( 'Pushing to Github' );
 		await git.push( 'origin', branch ).catch( ( e ) => {
 			Logger.error( e );
 		} );
-		Logger.endTask();
 
 		try {
 			Logger.startTask( 'Creating a pull request' );

--- a/tools/monorepo-utils/src/code-freeze/commands/version-bump/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/version-bump/index.ts
@@ -75,6 +75,14 @@ export const versionBumpCommand = new Command( 'version-bump' )
 		} );
 		const majorMinor = getMajorMinor( version );
 		const branch = `prep/trunk-for-next-dev-cycle-${ majorMinor }`;
+		const exists = await git.raw( 'ls-remote', 'origin', branch );
+
+		if ( exists.trim().length > 0 ) {
+			Logger.error(
+				`Branch ${ branch } already exists. Run \`git push <remote> --delete ${ branch }\` and rerun this command.`
+			);
+		}
+
 		await git.checkoutBranch( branch, base ).catch( genericErrorFunction );
 
 		Logger.startTask( `Bumping versions in ${ owner }/${ name }` );
@@ -90,10 +98,7 @@ export const versionBumpCommand = new Command( 'version-bump' )
 
 		Logger.startTask( 'Pushing to Github' );
 		await git.push( 'origin', branch ).catch( ( e ) => {
-			Logger.warn( e );
-			Logger.error(
-				`\nBranch ${ branch } already exists. Run \`git push <remote> --delete ${ branch }\` and rerun this command.`
-			);
+			Logger.error( e );
 		} );
 		Logger.endTask();
 

--- a/tools/monorepo-utils/src/code-freeze/commands/version-bump/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/version-bump/index.ts
@@ -35,7 +35,12 @@ export const versionBumpCommand = new Command( 'version-bump' )
 		'Repository name. Default: woocommerce',
 		'woocommerce'
 	)
-	.action( async ( { owner, name, version } ) => {
+	.option(
+		'-b --base <base>',
+		'Base branch to create the PR against. Default: trunk',
+		'trunk'
+	)
+	.action( async ( { owner, name, version, base } ) => {
 		Logger.startTask(
 			`Making a temporary clone of '${ owner }/${ name }'`
 		);
@@ -57,7 +62,6 @@ export const versionBumpCommand = new Command( 'version-bump' )
 		} );
 		const majorMinor = getMajorMinor( version );
 		const branch = `prep/trunk-for-next-dev-cycle-${ majorMinor }`;
-		const base = 'trunk';
 		await git.checkoutBranch( branch, base ).catch( errFn );
 
 		Logger.startTask( `Bumping versions in ${ owner }/${ name }` );
@@ -82,8 +86,8 @@ export const versionBumpCommand = new Command( 'version-bump' )
 				{
 					owner,
 					repo: name,
-					title: 'Amazing new feature',
-					body: 'Please pull these awesome changes in!',
+					title: `Prep trunk for ${ majorMinor } cycle`,
+					body: `This PR updates the versions in trunk to ${ version } for next development cycle.`,
 					head: branch,
 					base,
 				}

--- a/tools/monorepo-utils/src/code-freeze/commands/version-bump/lib/update.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/version-bump/lib/update.ts
@@ -1,0 +1,145 @@
+/**
+ * External dependencies
+ */
+import { readFile, writeFile, stat } from 'fs/promises';
+import { join } from 'path';
+
+/**
+ * Internal dependencies
+ */
+import { Logger } from '../../../../core/logger';
+
+/**
+ * Update plugin readme stable tag.
+ *
+ * @param  tmpRepoPath cloned repo path
+ * @param  nextVersion version to bump to
+ */
+export const updateReadmeStableTag = async (
+	tmpRepoPath: string,
+	nextVersion: string
+): Promise< void > => {
+	const filePath = join( tmpRepoPath, `plugins/woocommerce/readme.txt` );
+	try {
+		const readmeContents = await readFile( filePath, 'utf8' );
+
+		const updatedReadmeContents = readmeContents.replace(
+			/Stable tag: \d+\.\d+\.\d+\n/m,
+			`Stable tag: ${ nextVersion }\n`
+		);
+
+		await writeFile( filePath, updatedReadmeContents );
+	} catch ( e ) {
+		Logger.error( 'Unable to update readme stable tag' );
+	}
+};
+
+/**
+ * Update plugin readme changelog.
+ *
+ * @param  tmpRepoPath cloned repo path
+ * @param  nextVersion version to bump to
+ */
+export const updateReadmeChangelog = async (
+	tmpRepoPath: string,
+	nextVersion: string
+): Promise< void > => {
+	const filePath = join( tmpRepoPath, `plugins/woocommerce/readme.txt` );
+	try {
+		const readmeContents = await readFile( filePath, 'utf8' );
+
+		const updatedReadmeContents = readmeContents.replace(
+			/= \d+\.\d+\.\d+ \d\d\d\d-XX-XX =\n/m,
+			`= ${ nextVersion } ${ new Date().getFullYear() }-XX-XX =\n`
+		);
+
+		await writeFile( filePath, updatedReadmeContents );
+	} catch ( e ) {
+		Logger.error( 'Unable to update readme changelog' );
+	}
+};
+
+/**
+ * Update plugin class file.
+ *
+ * @param  tmpRepoPath cloned repo path
+ * @param  nextVersion version to bump to
+ */
+export const updateClassPluginFile = async (
+	tmpRepoPath: string,
+	nextVersion: string
+): Promise< void > => {
+	const filePath = join(
+		tmpRepoPath,
+		`plugins/woocommerce/includes/class-woocommerce.php`
+	);
+
+	try {
+		await stat( filePath );
+	} catch ( e ) {
+		// Class file does not exist, return early.
+		return;
+	}
+
+	try {
+		const classPluginFileContents = await readFile( filePath, 'utf8' );
+
+		const updatedClassPluginFileContents = classPluginFileContents.replace(
+			/public \$version = '\d+\.\d+\.\d+';\n/m,
+			`public $version = '${ nextVersion }';\n`
+		);
+
+		await writeFile( filePath, updatedClassPluginFileContents );
+	} catch ( e ) {
+		Logger.error( 'Unable to update plugin file.' );
+	}
+};
+
+/**
+ * Update plugin JSON files.
+ *
+ * @param {string} type        plugin to update
+ * @param {string} tmpRepoPath cloned repo path
+ * @param {string} nextVersion version to bump to
+ */
+export const updateJSON = async (
+	type: 'package' | 'composer',
+	tmpRepoPath: string,
+	nextVersion: string
+): Promise< void > => {
+	const filePath = join( tmpRepoPath, `plugins/woocommerce/${ type }.json` );
+	try {
+		const composerJson = JSON.parse( await readFile( filePath, 'utf8' ) );
+		composerJson.version = nextVersion;
+		await writeFile(
+			filePath,
+			JSON.stringify( composerJson, null, '\t' ) + '\n'
+		);
+	} catch ( e ) {
+		Logger.error( 'Unable to update composer.json' );
+	}
+};
+
+/**
+ * Update plugin main file.
+ *
+ * @param  tmpRepoPath cloned repo path
+ * @param  nextVersion version to bump to
+ */
+export const updatePluginFile = async (
+	tmpRepoPath: string,
+	nextVersion: string
+): Promise< void > => {
+	const filePath = join( tmpRepoPath, `plugins/woocommerce/woocommerce.php` );
+	try {
+		const pluginFileContents = await readFile( filePath, 'utf8' );
+
+		const updatedPluginFileContents = pluginFileContents.replace(
+			/Version: \d+\.\d+\.\d+.*\n/m,
+			`Version: ${ nextVersion }\n`
+		);
+		await writeFile( filePath, updatedPluginFileContents );
+	} catch ( e ) {
+		Logger.error( 'Unable to update plugin file.' );
+	}
+};

--- a/tools/monorepo-utils/src/code-freeze/commands/version-bump/lib/update.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/version-bump/lib/update.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { readFile, writeFile, stat } from 'fs/promises';
+import { dirent } from 'fs';
 import { join } from 'path';
 
 /**
@@ -49,12 +50,16 @@ export const updateClassPluginFile = async (
 		`plugins/woocommerce/includes/class-woocommerce.php`
 	);
 
-	try {
-		await stat( filePath );
-	} catch ( e ) {
-		Logger.warn( e );
-		Logger.error( 'Unable to update plugin file.' );
+	if ( ! ( await dirent.isFile( filePath + 'adsfd' ) ) ) {
+		Logger.error( 'class-woocommerce.php does not exist.' );
 	}
+
+	// try {
+	// 	await stat( filePath );
+	// } catch ( e ) {
+	// 	Logger.warn( e );
+	// 	Logger.error( 'Unable to update plugin file.' );
+	// }
 
 	try {
 		const classPluginFileContents = await readFile( filePath, 'utf8' );

--- a/tools/monorepo-utils/src/code-freeze/commands/version-bump/lib/update.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/version-bump/lib/update.ts
@@ -52,8 +52,8 @@ export const updateClassPluginFile = async (
 	try {
 		await stat( filePath );
 	} catch ( e ) {
-		// Class file does not exist, return early.
-		return;
+		Logger.warn( e );
+		Logger.error( 'Unable to update plugin file.' );
 	}
 
 	try {
@@ -66,6 +66,7 @@ export const updateClassPluginFile = async (
 
 		await writeFile( filePath, updatedClassPluginFileContents );
 	} catch ( e ) {
+		Logger.warn( e );
 		Logger.error( 'Unable to update plugin file.' );
 	}
 };

--- a/tools/monorepo-utils/src/code-freeze/commands/version-bump/lib/update.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/version-bump/lib/update.ts
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { readFile, writeFile, stat } from 'fs/promises';
+import { readFile, writeFile } from 'fs/promises';
+import { existsSync } from 'fs';
 import { join } from 'path';
 
 /**
@@ -49,11 +50,8 @@ export const updateClassPluginFile = async (
 		`plugins/woocommerce/includes/class-woocommerce.php`
 	);
 
-	try {
-		await stat( filePath );
-	} catch ( e ) {
-		Logger.warn( e );
-		Logger.error( 'Unable to update plugin file.' );
+	if ( ! existsSync( filePath ) ) {
+		Logger.error( "File 'class-woocommerce.php' does not exist." );
 	}
 
 	try {

--- a/tools/monorepo-utils/src/code-freeze/commands/version-bump/lib/update.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/version-bump/lib/update.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { readFile, writeFile, isFile } from 'fs/promises';
+import { readFile, writeFile, stat } from 'fs/promises';
 import { join } from 'path';
 
 /**
@@ -49,8 +49,11 @@ export const updateClassPluginFile = async (
 		`plugins/woocommerce/includes/class-woocommerce.php`
 	);
 
-	if ( ! isFile( filePath ) ) {
-		Logger.error( "Plugin file 'class-woocommerce.php' does not exist." );
+	try {
+		await stat( filePath );
+	} catch ( e ) {
+		Logger.warn( e );
+		Logger.error( 'Unable to update plugin file.' );
 	}
 
 	try {

--- a/tools/monorepo-utils/src/code-freeze/commands/version-bump/lib/update.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/version-bump/lib/update.ts
@@ -19,7 +19,7 @@ export const updateReadmeChangelog = async (
 	tmpRepoPath: string,
 	nextVersion: string
 ): Promise< void > => {
-	const filePath = join( tmpRepoPath, `plugins/woocommerce/readme.txt` );
+	const filePath = join( tmpRepoPath, 'plugins/woocommerce/readme.txt' );
 	try {
 		const readmeContents = await readFile( filePath, 'utf8' );
 
@@ -30,7 +30,7 @@ export const updateReadmeChangelog = async (
 
 		await writeFile( filePath, updatedReadmeContents );
 	} catch ( e ) {
-		Logger.error( 'Unable to update readme changelog' );
+		Logger.error( e );
 	}
 };
 
@@ -52,8 +52,7 @@ export const updateClassPluginFile = async (
 	try {
 		await stat( filePath );
 	} catch ( e ) {
-		Logger.warn( e );
-		Logger.error( 'Unable to update plugin file.' );
+		Logger.error( e );
 	}
 
 	try {
@@ -66,8 +65,7 @@ export const updateClassPluginFile = async (
 
 		await writeFile( filePath, updatedClassPluginFileContents );
 	} catch ( e ) {
-		Logger.warn( e );
-		Logger.error( 'Unable to update plugin file.' );
+		Logger.error( e );
 	}
 };
 
@@ -92,7 +90,7 @@ export const updateJSON = async (
 			JSON.stringify( composerJson, null, '\t' ) + '\n'
 		);
 	} catch ( e ) {
-		Logger.error( 'Unable to update composer.json' );
+		Logger.error( e );
 	}
 };
 
@@ -116,6 +114,6 @@ export const updatePluginFile = async (
 		);
 		await writeFile( filePath, updatedPluginFileContents );
 	} catch ( e ) {
-		Logger.error( 'Unable to update plugin file.' );
+		Logger.error( e );
 	}
 };

--- a/tools/monorepo-utils/src/code-freeze/commands/version-bump/lib/update.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/version-bump/lib/update.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { readFile, writeFile, stat } from 'fs/promises';
+import { readFile, writeFile, isFile } from 'fs/promises';
 import { join } from 'path';
 
 /**
@@ -49,10 +49,8 @@ export const updateClassPluginFile = async (
 		`plugins/woocommerce/includes/class-woocommerce.php`
 	);
 
-	try {
-		await stat( filePath );
-	} catch ( e ) {
-		Logger.error( e );
+	if ( ! isFile( filePath ) ) {
+		Logger.error( "Plugin file 'class-woocommerce.php' does not exist." );
 	}
 
 	try {

--- a/tools/monorepo-utils/src/code-freeze/commands/version-bump/lib/update.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/version-bump/lib/update.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { readFile, writeFile, stat } from 'fs/promises';
-import { dirent } from 'fs';
 import { join } from 'path';
 
 /**
@@ -50,16 +49,12 @@ export const updateClassPluginFile = async (
 		`plugins/woocommerce/includes/class-woocommerce.php`
 	);
 
-	if ( ! ( await dirent.isFile( filePath + 'adsfd' ) ) ) {
-		Logger.error( 'class-woocommerce.php does not exist.' );
+	try {
+		await stat( filePath );
+	} catch ( e ) {
+		Logger.warn( e );
+		Logger.error( 'Unable to update plugin file.' );
 	}
-
-	// try {
-	// 	await stat( filePath );
-	// } catch ( e ) {
-	// 	Logger.warn( e );
-	// 	Logger.error( 'Unable to update plugin file.' );
-	// }
 
 	try {
 		const classPluginFileContents = await readFile( filePath, 'utf8' );

--- a/tools/monorepo-utils/src/code-freeze/commands/version-bump/lib/update.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/version-bump/lib/update.ts
@@ -10,31 +10,6 @@ import { join } from 'path';
 import { Logger } from '../../../../core/logger';
 
 /**
- * Update plugin readme stable tag.
- *
- * @param  tmpRepoPath cloned repo path
- * @param  nextVersion version to bump to
- */
-export const updateReadmeStableTag = async (
-	tmpRepoPath: string,
-	nextVersion: string
-): Promise< void > => {
-	const filePath = join( tmpRepoPath, `plugins/woocommerce/readme.txt` );
-	try {
-		const readmeContents = await readFile( filePath, 'utf8' );
-
-		const updatedReadmeContents = readmeContents.replace(
-			/Stable tag: \d+\.\d+\.\d+\n/m,
-			`Stable tag: ${ nextVersion }\n`
-		);
-
-		await writeFile( filePath, updatedReadmeContents );
-	} catch ( e ) {
-		Logger.error( 'Unable to update readme stable tag' );
-	}
-};
-
-/**
  * Update plugin readme changelog.
  *
  * @param  tmpRepoPath cloned repo path

--- a/tools/monorepo-utils/src/code-freeze/commands/version-bump/lib/validate.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/version-bump/lib/validate.ts
@@ -1,0 +1,74 @@
+/**
+ * External dependencies
+ */
+import { valid, lt as versionLessThan, parse } from 'semver';
+import { join } from 'path';
+import { readFile } from 'fs/promises';
+
+/**
+ * Internal dependencies
+ */
+import { Logger } from '../../../../core/logger';
+/**
+ * Get a plugin's current version.
+ *
+ * @param  tmpRepoPath cloned repo path
+ */
+export const getCurrentVersion = async (
+	tmpRepoPath: string
+): Promise< string | void > => {
+	const filePath = join( tmpRepoPath, `plugins/woocommerce/composer.json` );
+	try {
+		const composerJSON = JSON.parse( await readFile( filePath, 'utf8' ) );
+		return composerJSON.version;
+	} catch ( e ) {
+		Logger.error( 'Unable to read current version.' );
+	}
+};
+
+/**
+ * When given a prerelease version, return just the version.
+ *
+ * @param {string} prereleaseVersion version with prerelease params
+ * @return {string} version
+ */
+export const stripPrereleaseParameters = (
+	prereleaseVersion: string
+): string => {
+	const parsedVersion = parse( prereleaseVersion );
+	if ( parsedVersion ) {
+		const { major, minor, patch } = parsedVersion;
+		return `${ major }.${ minor }.${ patch }`;
+	}
+	return prereleaseVersion;
+};
+
+/**
+ * Validate inputs.
+ *
+ * @param  plugin          plugin
+ * @param  options         options
+ * @param  options.version version
+ */
+export const validateArgs = async (
+	tmpRepoPath: string,
+	version: string
+): Promise< void > => {
+	const nextVersion = version;
+
+	if ( ! valid( nextVersion ) ) {
+		Logger.error(
+			'Invalid version supplied, please pass in a semantically correct version.'
+		);
+	}
+
+	const currentVersion = await getCurrentVersion( tmpRepoPath );
+
+	if ( ! currentVersion ) {
+		Logger.error( 'Unable to determine current version' );
+	} else if ( versionLessThan( nextVersion, currentVersion ) ) {
+		Logger.error(
+			'The version supplied is less than the current version, please supply a valid version.'
+		);
+	}
+};

--- a/tools/monorepo-utils/src/code-freeze/commands/version-bump/lib/validate.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/version-bump/lib/validate.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { valid, lt as versionLessThan, parse } from 'semver';
+import { valid, lt as versionLessThan, parse, prerelease } from 'semver';
 import { join } from 'path';
 import { readFile } from 'fs/promises';
 
@@ -59,6 +59,16 @@ export const validateArgs = async (
 	if ( ! valid( nextVersion ) ) {
 		Logger.error(
 			'Invalid version supplied, please pass in a semantically correct version.'
+		);
+	}
+
+	const prereleaseParameters = prerelease( nextVersion );
+	const isDevVersionBump =
+		prereleaseParameters && prereleaseParameters[ 0 ] === 'dev';
+
+	if ( ! isDevVersionBump ) {
+		Logger.error(
+			`Version ${ nextVersion } is not a development version bump. This tool is only intended to bump development versions for the preparation of the next development cycle.`
 		);
 	}
 

--- a/tools/monorepo-utils/src/code-freeze/commands/version-bump/lib/validate.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/version-bump/lib/validate.ts
@@ -22,7 +22,7 @@ export const getCurrentVersion = async (
 		const composerJSON = JSON.parse( await readFile( filePath, 'utf8' ) );
 		return composerJSON.version;
 	} catch ( e ) {
-		Logger.error( 'Unable to read current version.' );
+		Logger.error( e );
 	}
 };
 

--- a/tools/monorepo-utils/src/code-freeze/commands/version-bump/types.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/version-bump/types.ts
@@ -1,0 +1,6 @@
+export type Options = {
+	owner?: string;
+	name?: string;
+	version?: string;
+	base?: string;
+};

--- a/tools/monorepo-utils/src/core/git.ts
+++ b/tools/monorepo-utils/src/core/git.ts
@@ -83,7 +83,7 @@ export const cloneRepo = async ( repoPath: string ) => {
 	mkdirSync( folderPath, { recursive: true } );
 
 	const git = simpleGit( { baseDir: folderPath } );
-	await git.clone( repoPath, folderPath );
+	await git.clone( repoPath, folderPath, { '--depth': 1 } );
 
 	// If this is a local clone then the simplest way to maintain remote settings is to copy git config across
 	if ( ! isUrl( repoPath ) ) {

--- a/tools/monorepo-utils/src/core/git.ts
+++ b/tools/monorepo-utils/src/core/git.ts
@@ -107,7 +107,8 @@ export const cloneRepo = async ( repoPath: string ) => {
 export const sparseCheckoutRepo = async (
 	githubRepoUrl: string,
 	path: string,
-	directories: string[]
+	directories: string[],
+	base = 'trunk'
 ) => {
 	const folderPath = join( tmpdir(), path );
 
@@ -123,7 +124,7 @@ export const sparseCheckoutRepo = async (
 	} );
 	await git.raw( 'sparse-checkout', 'init', { '--cone': null } );
 	await git.raw( 'sparse-checkout', 'set', directories.join( ' ' ) );
-	await git.checkout( 'trunk' );
+	await git.checkout( base );
 
 	return folderPath;
 };

--- a/tools/monorepo-utils/src/core/git.ts
+++ b/tools/monorepo-utils/src/core/git.ts
@@ -117,9 +117,13 @@ export const sparseCheckoutRepo = async (
 
 	const git = simpleGit( { baseDir: folderPath } );
 
-	await git.clone( githubRepoUrl, folderPath, { '--depth': 1 } );
+	await git.clone( githubRepoUrl, folderPath, {
+		'--depth': 1,
+		'--no-checkout': null,
+	} );
 	await git.raw( 'sparse-checkout', 'init', { '--cone': null } );
 	await git.raw( 'sparse-checkout', 'set', directories.join( ' ' ) );
+	await git.checkout( 'trunk' );
 
 	return folderPath;
 };

--- a/tools/monorepo-utils/src/core/git.ts
+++ b/tools/monorepo-utils/src/core/git.ts
@@ -117,7 +117,7 @@ export const sparseCheckoutRepo = async (
 
 	const git = simpleGit( { baseDir: folderPath } );
 
-	await git.clone( githubRepoUrl, folderPath );
+	await git.clone( githubRepoUrl, folderPath, { '--depth': 1 } );
 	await git.raw( 'sparse-checkout', 'init', { '--cone': null } );
 	await git.raw( 'sparse-checkout', 'set', directories.join( ' ' ) );
 

--- a/tools/monorepo-utils/src/core/git.ts
+++ b/tools/monorepo-utils/src/core/git.ts
@@ -5,7 +5,7 @@ import { execSync } from 'child_process';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { mkdirSync } from 'fs';
-import { simpleGit } from 'simple-git';
+import { simpleGit, TaskOptions } from 'simple-git';
 import { v4 } from 'uuid';
 import { mkdir, rm } from 'fs/promises';
 import { URL } from 'node:url';
@@ -75,15 +75,19 @@ const isUrl = ( maybeURL: string ) => {
 /**
  * Clone a git repository.
  *
- * @param {string} repoPath - the path (either URL or file path) to the repo to clone.
+ * @param {string}      repoPath - the path (either URL or file path) to the repo to clone.
+ * @param {TaskOptions} options  - options to pass to simple-git.
  * @return {Promise<string>} the path to the cloned repo.
  */
-export const cloneRepo = async ( repoPath: string ) => {
+export const cloneRepo = async (
+	repoPath: string,
+	options: TaskOptions = {}
+) => {
 	const folderPath = join( tmpdir(), 'code-analyzer-tmp', v4() );
 	mkdirSync( folderPath, { recursive: true } );
 
 	const git = simpleGit( { baseDir: folderPath } );
-	await git.clone( repoPath, folderPath, { '--depth': 1 } );
+	await git.clone( repoPath, folderPath, options );
 
 	// If this is a local clone then the simplest way to maintain remote settings is to copy git config across
 	if ( ! isUrl( repoPath ) ) {
@@ -97,18 +101,31 @@ export const cloneRepo = async ( repoPath: string ) => {
 };
 
 /**
+ * Clone a git repository without history.
+ *
+ * @param {string} repoPath - the path (either URL or file path) to the repo to clone.
+ * @return {Promise<string>} the path to the cloned repo.
+ */
+export const cloneRepoShallow = async ( repoPath: string ) => {
+	return await cloneRepo( repoPath, { '--depth': 1 } );
+};
+
+/**
  * Do a minimal sparse checkout of a github repo.
  *
  * @param {string}        githubRepoUrl -     the URL to the repo to checkout.
  * @param {string}        path          - the path to checkout to.
  * @param {Array<string>} directories   - the files or directories to checkout.
+ * @param {string}        base          - the base branch to checkout from. Defaults to trunk.
+ * @param {TaskOptions}   options       - options to pass to simple-git.
  * @return {Promise<string>}  the path to the cloned repo.
  */
 export const sparseCheckoutRepo = async (
 	githubRepoUrl: string,
 	path: string,
 	directories: string[],
-	base = 'trunk'
+	base = 'trunk',
+	options: TaskOptions = {}
 ) => {
 	const folderPath = join( tmpdir(), path );
 
@@ -118,15 +135,35 @@ export const sparseCheckoutRepo = async (
 
 	const git = simpleGit( { baseDir: folderPath } );
 
+	const cloneOptions = { '--no-checkout': null };
 	await git.clone( githubRepoUrl, folderPath, {
-		'--depth': 1,
-		'--no-checkout': null,
+		...cloneOptions,
+		...options,
 	} );
 	await git.raw( 'sparse-checkout', 'init', { '--cone': null } );
 	await git.raw( 'sparse-checkout', 'set', directories.join( ' ' ) );
 	await git.checkout( base );
 
 	return folderPath;
+};
+
+/**
+ * Do a minimal sparse checkout of a github repo without history.
+ *
+ * @param {string}        githubRepoUrl -     the URL to the repo to checkout.
+ * @param {string}        path          - the path to checkout to.
+ * @param {Array<string>} directories   - the files or directories to checkout.
+ * @return {Promise<string>}  the path to the cloned repo.
+ */
+export const sparseCheckoutRepoShallow = async (
+	githubRepoUrl: string,
+	path: string,
+	directories: string[],
+	base = 'trunk'
+) => {
+	return await sparseCheckoutRepo( githubRepoUrl, path, directories, base, {
+		'--depth': 1,
+	} );
 };
 
 /**


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR uses the previous tool `version-bump` to create a Code Freeze version bump command. I have copied the logic over and will delete the previous tool once I update the code freeze github action, which is the only place the command is every used (please correct me if I'm wrong).

This PR also uses `sparseCheckoutRepo` to quickly clone the target repo and make all changes in that repo instead of the local copy. The result is a PR to update versions.

One departure I made from the old version bump tool is only accepting development versions, ie `7.9.0-dev`. This is because the tool is only used in this very specific context and our flows don't require it. This simplification allows us to remove the stable tag update function, which is a sensitive change that should not be included in this tool as I fear it will be updated by accident. There is validation against this.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Prerequisites
1. You must have a `GITHUB_TOKEN` environment variable available in your PATH. This needs to be set to a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) with repo permissions enabled.
2. Fork woocommerce onto your own namespace.

#### Command Testing
1. `pnpm install --filter monorepo-utils`
2. Delete branch `prep/trunk-for-next-dev-cycle-7.9` from your fork, if it exists.
3. Try updating to a non-dev version. You should see an error informing you of your drastic mistake.
```
 pnpm run utils code-freeze version-bump -o <owner> -v 7.9.0
```
4. Update to a valid version. If the command succeeds, check open pull requests. Compare it to [a previous Code Freeze's PR](https://github.com/woocommerce/woocommerce/pull/37777) to make sure the PR correctly changes all the relevant files.
```
 pnpm run utils code-freeze version-bump -o <owner> -v 7.9.0-dev
```
5. This PR refactors `sparseCheckoutRepo`, so `ls` through the resulting folder where the repo is checked out to. Its path is logged in the output. Confirm unnecessary paths are not cloned and `cd` into the repo to `git log`. Confirm only one commit was cloned.
5. Without merging the open PR, run the command again. This time you'll see an error that the branch already exists. Confirm the error message is informative.
```
 pnpm run utils code-freeze version-bump -o <owner> -v 7.9.0-dev
```

<!-- End testing instructions -->