### PR TITLE
Add e2e test for Merchant > Posts > Can create a new post

### DIFF
--- a/plugins/woocommerce/changelog/e2e-pw-add-merchant-create-post
+++ b/plugins/woocommerce/changelog/e2e-pw-add-merchant-create-post
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add e2e test for Merchant > Posts > Can create a new post

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-post.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-post.spec.js
@@ -7,13 +7,16 @@ test.describe( 'Can create a new post', () => {
 	test.use( { storageState: process.env.ADMINSTATE } );
 
 	test.afterAll( async ( { baseURL } ) => {
-		const base64auth = btoa( `${ admin.username }:${ admin.password }` );
+		const base64auth = Buffer.from(
+			`${ admin.username }:${ admin.password }`
+		).toString( 'base64' );
 		const wpApi = await request.newContext( {
 			baseURL: `${ baseURL }/wp-json/wp/v2/`,
 			extraHTTPHeaders: {
 				Authorization: `Basic ${ base64auth }`,
 			},
 		} );
+
 		let response = await wpApi.get( `posts` );
 		const allPosts = await response.json();
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-post.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-post.spec.js
@@ -1,0 +1,59 @@
+const { test, expect, request } = require( '@playwright/test' );
+const { admin } = require( '../../test-data/data' );
+
+const postTitle = `Post-${ new Date().getTime().toString() }`;
+
+test.describe( 'Can create a new post', () => {
+	test.use( { storageState: process.env.ADMINSTATE } );
+
+	test.afterAll( async ( { baseURL } ) => {
+		const base64auth = btoa( `${ admin.username }:${ admin.password }` );
+		const wpApi = await request.newContext( {
+			baseURL: `${ baseURL }/wp-json/wp/v2/`,
+			extraHTTPHeaders: {
+				Authorization: `Basic ${ base64auth }`,
+			},
+		} );
+		let response = await wpApi.get( `posts` );
+		const allPosts = await response.json();
+
+		await allPosts.forEach( async ( post ) => {
+			if ( post.title.rendered === postTitle ) {
+				response = await wpApi.delete( `posts/${ post.id }` );
+				expect( response.ok() ).toBeTruthy();
+			}
+		} );
+	} );
+
+	test( 'can create new post', async ( { page } ) => {
+		await page.goto( 'wp-admin/post-new.php', {
+			waitUntil: 'networkidle',
+		} );
+
+		await page
+			.getByRole( 'textbox', { name: 'Add Title' } )
+			.fill( postTitle );
+
+		await page.getByRole( 'button', { name: 'Add default block' } ).click();
+
+		await page
+			.getByRole( 'document', {
+				name:
+					'Empty block; start writing or type forward slash to choose a block',
+			} )
+			.fill( 'Test Post' );
+
+		await page
+			.getByRole( 'button', { name: 'Publish', exact: true } )
+			.click();
+
+		await page
+			.getByRole( 'region', { name: 'Editor publish' } )
+			.getByRole( 'button', { name: 'Publish', exact: true } )
+			.click();
+
+		expect(
+			await page.getByText( `${ postTitle } is now live.` )
+		).toBeTruthy();
+	} );
+} );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-post.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-post.spec.js
@@ -19,16 +19,28 @@ test.describe( 'Can create a new post', () => {
 
 		await allPosts.forEach( async ( post ) => {
 			if ( post.title.rendered === postTitle ) {
-				response = await wpApi.delete( `posts/${ post.id }` );
+				response = await wpApi.delete( `posts/${ post.id }`, {
+					data: {
+						force: true,
+					},
+				} );
 				expect( response.ok() ).toBeTruthy();
 			}
 		} );
 	} );
 
 	test( 'can create new post', async ( { page } ) => {
-		await page.goto( 'wp-admin/post-new.php', {
-			waitUntil: 'networkidle',
-		} );
+		await page.goto( 'wp-admin/post-new.php' );
+
+		const welcomeModalVisible = await page
+			.getByRole( 'heading', {
+				name: 'Welcome to the block editor',
+			} )
+			.isVisible();
+
+		if ( welcomeModalVisible ) {
+			await page.getByRole( 'button', { name: 'Close dialog' } ).click();
+		}
 
 		await page
 			.getByRole( 'textbox', { name: 'Add Title' } )
@@ -52,8 +64,8 @@ test.describe( 'Can create a new post', () => {
 			.getByRole( 'button', { name: 'Publish', exact: true } )
 			.click();
 
-		expect(
-			await page.getByText( `${ postTitle } is now live.` )
-		).toBeTruthy();
+		await expect(
+			page.getByText( `${ postTitle } is now live.` )
+		).toBeVisible();
 	} );
 } );


### PR DESCRIPTION
Create e2e test for Critical Flow: Merchant > Posts > Can create a new post

### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [ ] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 


### Changes proposed in this Pull Request:

This PR adds e2e-pw test for Critical flow: `Merchant > Post > Can create post`.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Make sure you meet the [Pre-requisites](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/tests/e2e-pw#pre-requisites)
2. Run `pnpm test:e2e-pw ./tests/e2e-pw/tests/e2e-pw/tests/merchant/create-post.spec.js`
3. A new post [_Title: Post-#EPOCHTIME_] should be created first, and then deleted via API
4. You should find this as a Trashed post.
