### PR TITLE
Update disable drag and drop within images block

### DIFF
--- a/packages/js/components/changelog/update-37955_disable_drag_and_drop_images_block
+++ b/packages/js/components/changelog/update-37955_disable_drag_and_drop_images_block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add allowDragging option to ImageGallery to support disabling drag and drop of images.

--- a/packages/js/components/src/image-gallery/image-gallery-toolbar.tsx
+++ b/packages/js/components/src/image-gallery/image-gallery-toolbar.tsx
@@ -16,6 +16,7 @@ import { MediaUploadComponentType } from './types';
 
 export type ImageGalleryToolbarProps = {
 	childIndex: number;
+	allowDragging?: boolean;
 	moveItem: ( fromIndex: number, toIndex: number ) => void;
 	removeItem: ( removeIndex: number ) => void;
 	replaceItem: (
@@ -29,6 +30,7 @@ export type ImageGalleryToolbarProps = {
 
 export const ImageGalleryToolbar: React.FC< ImageGalleryToolbarProps > = ( {
 	childIndex,
+	allowDragging = true,
 	moveItem,
 	removeItem,
 	replaceItem,
@@ -60,12 +62,14 @@ export const ImageGalleryToolbar: React.FC< ImageGalleryToolbarProps > = ( {
 			>
 				{ ! isCoverItem && (
 					<ToolbarGroup>
-						<ToolbarButton
-							icon={ () => (
-								<SortableHandle itemIndex={ childIndex } />
-							) }
-							label={ __( 'Drag to reorder', 'woocommerce' ) }
-						/>
+						{ allowDragging && (
+							<ToolbarButton
+								icon={ () => (
+									<SortableHandle itemIndex={ childIndex } />
+								) }
+								label={ __( 'Drag to reorder', 'woocommerce' ) }
+							/>
+						) }
 						<ToolbarButton
 							disabled={ childIndex < 2 }
 							onClick={ () => movePrevious() }

--- a/packages/js/components/src/image-gallery/image-gallery-wrapper.tsx
+++ b/packages/js/components/src/image-gallery/image-gallery-wrapper.tsx
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import { createElement } from '@wordpress/element';
+import { DragEventHandler } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { Sortable } from '../sortable';
+import { ImageGalleryChild } from './types';
+
+export type ImageGalleryWrapperProps = {
+	children: JSX.Element[];
+	allowDragging?: boolean;
+	onDragStart?: DragEventHandler< HTMLDivElement >;
+	onDragEnd?: DragEventHandler< HTMLDivElement >;
+	onDragOver?: DragEventHandler< HTMLLIElement >;
+	updateOrderedChildren?: ( items: ImageGalleryChild[] ) => void;
+};
+
+export const ImageGalleryWrapper: React.FC< ImageGalleryWrapperProps > = ( {
+	children,
+	allowDragging = true,
+	onDragStart = () => null,
+	onDragEnd = () => null,
+	onDragOver = () => null,
+	updateOrderedChildren = () => null,
+} ) => {
+	if ( allowDragging ) {
+		return (
+			<Sortable
+				isHorizontal
+				onOrderChange={ ( items ) => {
+					updateOrderedChildren( items );
+				} }
+				onDragStart={ ( event ) => {
+					onDragStart( event );
+				} }
+				onDragEnd={ ( event ) => {
+					onDragEnd( event );
+				} }
+				onDragOver={ onDragOver }
+			>
+				{ children }
+			</Sortable>
+		);
+	}
+	return (
+		<div className="woocommerce-image-gallery__wrapper">{ children }</div>
+	);
+};

--- a/packages/js/components/src/image-gallery/image-gallery.scss
+++ b/packages/js/components/src/image-gallery/image-gallery.scss
@@ -3,7 +3,7 @@
         display: block;
     }
 
-    .woocommerce-sortable {
+    .woocommerce-sortable, &__wrapper {
         display: grid;
         grid-template-columns: inherit;
         grid-gap: $gap;

--- a/packages/js/components/src/image-gallery/image-gallery.tsx
+++ b/packages/js/components/src/image-gallery/image-gallery.tsx
@@ -14,10 +14,11 @@ import { MediaItem, MediaUpload } from '@wordpress/media-utils';
 /**
  * Internal dependencies
  */
-import { Sortable, moveIndex } from '../sortable';
+import { moveIndex } from '../sortable';
 import { ImageGalleryToolbar } from './index';
 import { ImageGalleryChild, MediaUploadComponentType } from './types';
 import { removeItem, replaceItem } from './utils';
+import { ImageGalleryWrapper } from './image-gallery-wrapper';
 
 export type ImageGalleryProps = {
 	children: ImageGalleryChild | ImageGalleryChild[];
@@ -30,6 +31,7 @@ export type ImageGalleryProps = {
 		replaceIndex: number;
 		media: { id: number } & MediaItem;
 	} ) => void;
+	allowDragging?: boolean;
 	onSelectAsCover?: ( itemId: string | null ) => void;
 	onOrderChange?: ( items: ImageGalleryChild[] ) => void;
 	MediaUploadComponent?: MediaUploadComponentType;
@@ -41,6 +43,7 @@ export type ImageGalleryProps = {
 export const ImageGallery: React.FC< ImageGalleryProps > = ( {
 	children,
 	columns = 4,
+	allowDragging = true,
 	onSelectAsCover = () => null,
 	onOrderChange = () => null,
 	onRemove = () => null,
@@ -82,11 +85,9 @@ export const ImageGallery: React.FC< ImageGalleryProps > = ( {
 				gridTemplateColumns: 'min-content '.repeat( columns ),
 			} }
 		>
-			<Sortable
-				isHorizontal
-				onOrderChange={ ( items ) => {
-					updateOrderedChildren( items );
-				} }
+			<ImageGalleryWrapper
+				allowDragging={ allowDragging }
+				updateOrderedChildren={ updateOrderedChildren }
 				onDragStart={ ( event ) => {
 					setIsDragging( true );
 					onDragStart( event );
@@ -137,6 +138,7 @@ export const ImageGallery: React.FC< ImageGalleryProps > = ( {
 						},
 						isToolbarVisible ? (
 							<ImageGalleryToolbar
+								allowDragging={ allowDragging }
 								childIndex={ childIndex }
 								lastChild={
 									childIndex === orderedChildren.length - 1
@@ -190,7 +192,7 @@ export const ImageGallery: React.FC< ImageGalleryProps > = ( {
 						) : null
 					);
 				} ) }
-			</Sortable>
+			</ImageGalleryWrapper>
 		</div>
 	);
 };

--- a/packages/js/product-editor/changelog/update-37955_disable_drag_and_drop_images_block
+++ b/packages/js/product-editor/changelog/update-37955_disable_drag_and_drop_images_block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Disable dragging and dropping of images within Product Images block.

--- a/packages/js/product-editor/src/blocks/images/edit.tsx
+++ b/packages/js/product-editor/src/blocks/images/edit.tsx
@@ -114,6 +114,7 @@ export function Edit() {
 				) }
 			</div>
 			<ImageGallery
+				allowDragging={ false }
 				onDragStart={ ( event ) => {
 					const { id: imageId, dataset } =
 						event.target as HTMLElement;

--- a/packages/js/product-editor/src/blocks/images/edit.tsx
+++ b/packages/js/product-editor/src/blocks/images/edit.tsx
@@ -151,11 +151,12 @@ export function Edit() {
 						images.find( ( img ) => media.id === img.id ) ===
 						undefined
 					) {
-						images[ replaceIndex ] = media as MediaItem;
+						let newImages = [ ...images ];
+						newImages[ replaceIndex ] = media as MediaItem;
 						recordEvent(
 							'product_images_replace_image_button_click'
 						);
-						setImages( images );
+						setImages( newImages );
 					}
 				} }
 				onSelectAsCover={ () =>

--- a/packages/js/product-editor/src/blocks/images/edit.tsx
+++ b/packages/js/product-editor/src/blocks/images/edit.tsx
@@ -151,7 +151,7 @@ export function Edit() {
 						images.find( ( img ) => media.id === img.id ) ===
 						undefined
 					) {
-						let newImages = [ ...images ];
+						const newImages = [ ...images ];
 						newImages[ replaceIndex ] = media as MediaItem;
 						recordEvent(
 							'product_images_replace_image_button_click'


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This adds support to `ImageGallery` component to disable dragging, by the new `allowDragging` prop (defaults to `true`).
As a second change this disables dragging within the product images block.

Closes #37955 

![Screenshot 2023-04-28 at 3 51 51 PM](https://user-images.githubusercontent.com/2240960/235166260-14c25b99-9945-4193-8718-4f90dd410841.png)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Build and load this branch and enable the `new-product-management-experience` feature flag ( the non-block editor )
2. Go to **Products > Add New** and scroll down to images and add some images.
3. Now re-arrange them by dragging the images around, this should still work as expected.
4. Now enable the block based editor, with the `product-block-editor` feature flag
5. Go to **Products > Add New** and scroll down to images and add some images.
6. Try dragging images around, this should **not** be possible, the drag handle should also not be visible within the image toolbar.
7. Click on the arrows within the image toolbar, this should still move images around successfully.

<!-- End testing instructions -->