### PR TITLE
Await triggerNoteAction before navigating when action is clicked

### DIFF
--- a/plugins/woocommerce-admin/client/layout/store-alerts/index.js
+++ b/plugins/woocommerce-admin/client/layout/store-alerts/index.js
@@ -74,7 +74,14 @@ export class StoreAlerts extends Component {
 					isPrimary={ action.primary }
 					isSecondary={ ! action.primary }
 					href={ action.url || undefined }
-					onClick={ () => triggerNoteAction( alert.id, action.id ) }
+					onClick={ async ( event ) => {
+						const url = event.currentTarget.getAttribute( 'href' );
+						event.preventDefault();
+						await triggerNoteAction( alert.id, action.id );
+						if ( url && url !== '#' ) {
+							window.location.href = url;
+						}
+					} }
 				>
 					{ action.label }
 				</Button>

--- a/plugins/woocommerce-admin/client/layout/store-alerts/index.js
+++ b/plugins/woocommerce-admin/client/layout/store-alerts/index.js
@@ -20,6 +20,7 @@ import { Icon, chevronLeft, chevronRight } from '@wordpress/icons';
 import { NOTES_STORE_NAME, QUERY_DEFAULTS } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { Text } from '@woocommerce/experimental';
+import { navigateTo, parseAdminUrl } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -78,8 +79,12 @@ export class StoreAlerts extends Component {
 						const url = event.currentTarget.getAttribute( 'href' );
 						event.preventDefault();
 						await triggerNoteAction( alert.id, action.id );
-						if ( url && url !== '#' ) {
-							window.location.href = url;
+						if (
+							url &&
+							url !== '#' &&
+							parseAdminUrl( url ).href !== window.location.href
+						) {
+							navigateTo( { url } );
 						}
 					} }
 				>

--- a/plugins/woocommerce/changelog/fix-undismissable-notice
+++ b/plugins/woocommerce/changelog/fix-undismissable-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix race condition that caused some store alerts to be undismissable


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This addresses an issue where certain store alerts can be undismissable based on a race condition.

The issue itself is very hard to reproduce. I was unable to, but we're pretty sure that this was what's causing the issue.

Optional: Check https://github.com/woocommerce/woocommerce/pull/37710 for all the context that led to this solution.

Closes #36913 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. With WCA Test Helper installed, go to Tools > WCA Test Helper.
2. Go to Admin Notes tab.
3. Add one or more alerts of type: update.
4. Go to WooCommerce > Home.
5. Click the 'Test Action' button.
6. Check if the message disappears.
7. Optional: manually set the button's link's href to '#' through dev tools inspector.
8. Click it
9. Check that the alert is dismissed without reloading the page

<!-- End testing instructions -->