### PR TITLE
Reduce code duplication in Report Controllers

### DIFF
--- a/plugins/woocommerce/changelog/dev-dry-reports
+++ b/plugins/woocommerce/changelog/dev-dry-reports
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Move Reports-related code to reduce duplicates.

--- a/plugins/woocommerce/src/Admin/API/Reports/AbstractController.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/AbstractController.php
@@ -57,4 +57,67 @@ abstract class AbstractController extends \WC_REST_Reports_Controller {
 
 		return $response;
 	}
+
+	/**
+	 * Get the query params for collections.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$params                        = array();
+		$params['context']             = $this->get_context_param( array( 'default' => 'view' ) );
+		$params['page']                = array(
+			'description'       => __( 'Current page of the collection.', 'woocommerce' ),
+			'type'              => 'integer',
+			'default'           => 1,
+			'sanitize_callback' => 'absint',
+			'validate_callback' => 'rest_validate_request_arg',
+			'minimum'           => 1,
+		);
+		$params['per_page']            = array(
+			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
+			'type'              => 'integer',
+			'default'           => 10,
+			'minimum'           => 1,
+			'maximum'           => 100,
+			'sanitize_callback' => 'absint',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['after']               = array(
+			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce' ),
+			'type'              => 'string',
+			'format'            => 'date-time',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['before']              = array(
+			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce' ),
+			'type'              => 'string',
+			'format'            => 'date-time',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['order']               = array(
+			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce' ),
+			'type'              => 'string',
+			'default'           => 'desc',
+			'enum'              => array( 'asc', 'desc' ),
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['orderby']             = array(
+			'description'       => __( 'Sort collection by object attribute.', 'woocommerce' ),
+			'type'              => 'string',
+			'default'           => 'date',
+			'enum'              => array(
+				'date',
+			),
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['force_cache_refresh'] = array(
+			'description'       => __( 'Force retrieval of fresh data instead of from the cache.', 'woocommerce' ),
+			'type'              => 'boolean',
+			'sanitize_callback' => 'wp_validate_boolean',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+
+		return $params;
+	}
 }

--- a/plugins/woocommerce/src/Admin/API/Reports/AbstractController.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/AbstractController.php
@@ -1,0 +1,60 @@
+<?php
+namespace Automattic\WooCommerce\Admin\API\Reports;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC REST API Reports controller extended
+ * to be shared as a generic base for all Analytics controllers.
+ *
+ * @internal
+ * @extends WC_REST_Reports_Controller
+ */
+abstract class AbstractController extends \WC_REST_Reports_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc-analytics';
+
+
+	/**
+	 * Add pagination headers and links.
+	 *
+	 * @param WP_REST_Request        $request   Request data.
+	 * @param WP_REST_Response|array $response  Response data.
+	 * @param int                    $total     Total results.
+	 * @param int                    $page      Current page.
+	 * @param int                    $max_pages Total amount of pages.
+	 * @return WP_REST_Response
+	 */
+	public function add_pagination_headers( $request, $response, int $total, int $page, int $max_pages ) {
+		$response = rest_ensure_response( $response );
+		$response->header( 'X-WP-Total', $total );
+		$response->header( 'X-WP-TotalPages', $max_pages );
+
+		$base = add_query_arg(
+			$request->get_query_params(),
+			rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) )
+		);
+
+		if ( $page > 1 ) {
+			$prev_page = $page - 1;
+			if ( $prev_page > $max_pages ) {
+				$prev_page = $max_pages;
+			}
+			$prev_link = add_query_arg( 'page', $prev_page, $base );
+			$response->link_header( 'prev', $prev_link );
+		}
+
+		if ( $max_pages > $page ) {
+			$next_page = $page + 1;
+			$next_link = add_query_arg( 'page', $next_page, $base );
+			$response->link_header( 'next', $next_link );
+		}
+
+		return $response;
+	}
+}

--- a/plugins/woocommerce/src/Admin/API/Reports/AbstractController.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/AbstractController.php
@@ -3,6 +3,9 @@ namespace Automattic\WooCommerce\Admin\API\Reports;
 
 defined( 'ABSPATH' ) || exit;
 
+use WP_REST_Request;
+use WP_REST_Response;
+
 /**
  * WC REST API Reports controller extended
  * to be shared as a generic base for all Analytics controllers.
@@ -119,5 +122,23 @@ abstract class AbstractController extends \WC_REST_Reports_Controller {
 		);
 
 		return $params;
+	}
+
+	/**
+	 * Prepare a report object for serialization.
+	 *
+	 * @param array           $report  Report data.
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response
+	 */
+	public function prepare_item_for_response( $report, $request ) {
+		$data = $report;
+
+		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data    = $this->add_additional_fields_to_object( $data, $request );
+		$data    = $this->filter_response_by_context( $data, $context );
+
+		// Wrap the data in a response object.
+		return rest_ensure_response( $data );
 	}
 }

--- a/plugins/woocommerce/src/Admin/API/Reports/Categories/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Categories/Controller.php
@@ -193,9 +193,9 @@ class Controller extends ReportsController implements ExportableInterface {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params                  = array();
-		$params['context']       = $this->get_context_param( array( 'default' => 'view' ) );
-		$params['page']          = array(
+		$params                        = array();
+		$params['context']             = $this->get_context_param( array( 'default' => 'view' ) );
+		$params['page']                = array(
 			'description'       => __( 'Current page of the collection.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 1,
@@ -203,7 +203,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'validate_callback' => 'rest_validate_request_arg',
 			'minimum'           => 1,
 		);
-		$params['per_page']      = array(
+		$params['per_page']            = array(
 			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 10,
@@ -212,26 +212,26 @@ class Controller extends ReportsController implements ExportableInterface {
 			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['after']         = array(
+		$params['after']               = array(
 			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['before']        = array(
+		$params['before']              = array(
 			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['order']         = array(
+		$params['order']               = array(
 			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'desc',
 			'enum'              => array( 'asc', 'desc' ),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['orderby']       = array(
+		$params['orderby']             = array(
 			'description'       => __( 'Sort collection by object attribute.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'category_id',
@@ -245,7 +245,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['interval']      = array(
+		$params['interval']            = array(
 			'description'       => __( 'Time interval to use for buckets in the returned data.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'week',
@@ -259,7 +259,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['status_is']     = array(
+		$params['status_is']           = array(
 			'description'       => __( 'Limit result set to items that have the specified order status.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_slug_list',
@@ -269,7 +269,7 @@ class Controller extends ReportsController implements ExportableInterface {
 				'type' => 'string',
 			),
 		);
-		$params['status_is_not'] = array(
+		$params['status_is_not']       = array(
 			'description'       => __( 'Limit result set to items that don\'t have the specified order status.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_slug_list',
@@ -279,7 +279,7 @@ class Controller extends ReportsController implements ExportableInterface {
 				'type' => 'string',
 			),
 		);
-		$params['categories']    = array(
+		$params['categories']          = array(
 			'description'       => __( 'Limit result set to all items that have the specified term assigned in the categories taxonomy.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
@@ -288,7 +288,7 @@ class Controller extends ReportsController implements ExportableInterface {
 				'type' => 'integer',
 			),
 		);
-		$params['extended_info'] = array(
+		$params['extended_info']       = array(
 			'description'       => __( 'Add additional piece of info about each category to the report.', 'woocommerce' ),
 			'type'              => 'boolean',
 			'default'           => false,

--- a/plugins/woocommerce/src/Admin/API/Reports/Categories/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Categories/Controller.php
@@ -77,28 +77,13 @@ class Controller extends ReportsController implements ExportableInterface {
 			$out_data[] = $this->prepare_response_for_collection( $item );
 		}
 
-		$response = rest_ensure_response( $out_data );
-		$response->header( 'X-WP-Total', (int) $report_data->total );
-		$response->header( 'X-WP-TotalPages', (int) $report_data->pages );
-
-		$page      = $report_data->page_no;
-		$max_pages = $report_data->pages;
-		$base      = add_query_arg( $request->get_query_params(), rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ) );
-		if ( $page > 1 ) {
-			$prev_page = $page - 1;
-			if ( $prev_page > $max_pages ) {
-				$prev_page = $max_pages;
-			}
-			$prev_link = add_query_arg( 'page', $prev_page, $base );
-			$response->link_header( 'prev', $prev_link );
-		}
-		if ( $max_pages > $page ) {
-			$next_page = $page + 1;
-			$next_link = add_query_arg( 'page', $next_page, $base );
-			$response->link_header( 'next', $next_link );
-		}
-
-		return $response;
+		return $this->add_pagination_headers(
+			$request,
+			$out_data,
+			(int) $report_data->total,
+			(int) $report_data->page_no,
+			(int) $report_data->pages
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/API/Reports/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Controller.php
@@ -25,13 +25,6 @@ class Controller extends \WC_REST_Reports_Controller {
 	protected $namespace = 'wc-analytics';
 
 	/**
-	 * Route base.
-	 *
-	 * @var string
-	 */
-	protected $rest_base = 'reports';
-
-	/**
 	 * Get all reports.
 	 *
 	 * @param WP_REST_Request $request Request data.

--- a/plugins/woocommerce/src/Admin/API/Reports/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Controller.php
@@ -9,15 +9,15 @@ namespace Automattic\WooCommerce\Admin\API\Reports;
 
 defined( 'ABSPATH' ) || exit;
 
-use Automattic\WooCommerce\Admin\API\Reports\AbstractController;
+use Automattic\WooCommerce\Admin\API\Reports\GenericController;
 
 /**
  * REST API Reports controller class.
  *
  * @internal
- * @extends AbstractController
+ * @extends GenericController
  */
-class Controller extends AbstractController {
+class Controller extends GenericController {
 
 	/**
 	 * Get all reports.

--- a/plugins/woocommerce/src/Admin/API/Reports/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Controller.php
@@ -9,20 +9,15 @@ namespace Automattic\WooCommerce\Admin\API\Reports;
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Admin\API\Reports\AbstractController;
+
 /**
  * REST API Reports controller class.
  *
  * @internal
- * @extends WC_REST_Reports_Controller
+ * @extends AbstractController
  */
-class Controller extends \WC_REST_Reports_Controller {
-
-	/**
-	 * Endpoint namespace.
-	 *
-	 * @var string
-	 */
-	protected $namespace = 'wc-analytics';
+class Controller extends AbstractController {
 
 	/**
 	 * Get all reports.

--- a/plugins/woocommerce/src/Admin/API/Reports/Coupons/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Coupons/Controller.php
@@ -11,6 +11,8 @@ defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Admin\API\Reports\AbstractController;
 use Automattic\WooCommerce\Admin\API\Reports\ExportableInterface;
+use WP_REST_Request;
+use WP_REST_Response;
 
 /**
  * REST API Reports coupons controller class.
@@ -78,19 +80,12 @@ class Controller extends AbstractController implements ExportableInterface {
 	/**
 	 * Prepare a report object for serialization.
 	 *
-	 * @param stdClass        $report  Report data.
+	 * @param array           $report  Report data.
 	 * @param WP_REST_Request $request Request object.
 	 * @return WP_REST_Response
 	 */
 	public function prepare_item_for_response( $report, $request ) {
-		$data = $report;
-
-		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
-		$data    = $this->add_additional_fields_to_object( $data, $request );
-		$data    = $this->filter_response_by_context( $data, $context );
-
-		// Wrap the data in a response object.
-		$response = rest_ensure_response( $data );
+		$response = parent::prepare_item_for_response( $report, $request );
 		$response->add_links( $this->prepare_links( $report ) );
 
 		/**

--- a/plugins/woocommerce/src/Admin/API/Reports/Coupons/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Coupons/Controller.php
@@ -67,7 +67,6 @@ class Controller extends AbstractController implements ExportableInterface {
 			$data[] = $this->prepare_response_for_collection( $item );
 		}
 
-
 		return $this->add_pagination_headers(
 			$request,
 			$data,
@@ -196,7 +195,7 @@ class Controller extends AbstractController implements ExportableInterface {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params = parent::get_collection_params();
+		$params                       = parent::get_collection_params();
 		$params['orderby']['default'] = 'coupon_id';
 		$params['orderby']['enum']    = array(
 			'coupon_id',
@@ -204,7 +203,7 @@ class Controller extends AbstractController implements ExportableInterface {
 			'amount',
 			'orders_count',
 		);
-		$params['coupons']       = array(
+		$params['coupons']            = array(
 			'description'       => __( 'Limit result set to coupons assigned specific coupon IDs.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
@@ -213,7 +212,7 @@ class Controller extends AbstractController implements ExportableInterface {
 				'type' => 'integer',
 			),
 		);
-		$params['extended_info'] = array(
+		$params['extended_info']      = array(
 			'description'       => __( 'Add additional piece of info about each coupon to the report.', 'woocommerce' ),
 			'type'              => 'boolean',
 			'default'           => false,

--- a/plugins/woocommerce/src/Admin/API/Reports/Coupons/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Coupons/Controller.php
@@ -9,22 +9,16 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Coupons;
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Admin\API\Reports\AbstractController;
 use Automattic\WooCommerce\Admin\API\Reports\ExportableInterface;
 
 /**
  * REST API Reports coupons controller class.
  *
  * @internal
- * @extends WC_REST_Reports_Controller
+ * @extends AbstractController
  */
-class Controller extends \WC_REST_Reports_Controller implements ExportableInterface {
-
-	/**
-	 * Endpoint namespace.
-	 *
-	 * @var string
-	 */
-	protected $namespace = 'wc-analytics';
+class Controller extends AbstractController implements ExportableInterface {
 
 	/**
 	 * Route base.
@@ -71,28 +65,14 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			$data[] = $this->prepare_response_for_collection( $item );
 		}
 
-		$response = rest_ensure_response( $data );
-		$response->header( 'X-WP-Total', (int) $report_data->total );
-		$response->header( 'X-WP-TotalPages', (int) $report_data->pages );
 
-		$page      = $report_data->page_no;
-		$max_pages = $report_data->pages;
-		$base      = add_query_arg( $request->get_query_params(), rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ) );
-		if ( $page > 1 ) {
-			$prev_page = $page - 1;
-			if ( $prev_page > $max_pages ) {
-				$prev_page = $max_pages;
-			}
-			$prev_link = add_query_arg( 'page', $prev_page, $base );
-			$response->link_header( 'prev', $prev_link );
-		}
-		if ( $max_pages > $page ) {
-			$next_page = $page + 1;
-			$next_link = add_query_arg( 'page', $next_page, $base );
-			$response->link_header( 'next', $next_link );
-		}
-
-		return $response;
+		return $this->add_pagination_headers(
+			$request,
+			$data,
+			(int) $report_data->total,
+			(int) $report_data->page_no,
+			(int) $report_data->pages
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/API/Reports/Coupons/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Coupons/Controller.php
@@ -201,55 +201,13 @@ class Controller extends AbstractController implements ExportableInterface {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params                  = array();
-		$params['context']       = $this->get_context_param( array( 'default' => 'view' ) );
-		$params['page']          = array(
-			'description'       => __( 'Current page of the collection.', 'woocommerce' ),
-			'type'              => 'integer',
-			'default'           => 1,
-			'sanitize_callback' => 'absint',
-			'validate_callback' => 'rest_validate_request_arg',
-			'minimum'           => 1,
-		);
-		$params['per_page']      = array(
-			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
-			'type'              => 'integer',
-			'default'           => 10,
-			'minimum'           => 1,
-			'maximum'           => 100,
-			'sanitize_callback' => 'absint',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['after']         = array(
-			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce' ),
-			'type'              => 'string',
-			'format'            => 'date-time',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['before']        = array(
-			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce' ),
-			'type'              => 'string',
-			'format'            => 'date-time',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['order']         = array(
-			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce' ),
-			'type'              => 'string',
-			'default'           => 'desc',
-			'enum'              => array( 'asc', 'desc' ),
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['orderby']       = array(
-			'description'       => __( 'Sort collection by object attribute.', 'woocommerce' ),
-			'type'              => 'string',
-			'default'           => 'coupon_id',
-			'enum'              => array(
-				'coupon_id',
-				'code',
-				'amount',
-				'orders_count',
-			),
-			'validate_callback' => 'rest_validate_request_arg',
+		$params = parent::get_collection_params();
+		$params['orderby']['default'] = 'coupon_id';
+		$params['orderby']['enum']    = array(
+			'coupon_id',
+			'code',
+			'amount',
+			'orders_count',
 		);
 		$params['coupons']       = array(
 			'description'       => __( 'Limit result set to coupons assigned specific coupon IDs.', 'woocommerce' ),
@@ -265,12 +223,6 @@ class Controller extends AbstractController implements ExportableInterface {
 			'type'              => 'boolean',
 			'default'           => false,
 			'sanitize_callback' => 'wc_string_to_bool',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['force_cache_refresh'] = array(
-			'description'       => __( 'Force retrieval of fresh data instead of from the cache.', 'woocommerce' ),
-			'type'              => 'boolean',
-			'sanitize_callback' => 'wp_validate_boolean',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Coupons/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Coupons/Controller.php
@@ -9,7 +9,7 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Coupons;
 
 defined( 'ABSPATH' ) || exit;
 
-use Automattic\WooCommerce\Admin\API\Reports\AbstractController;
+use Automattic\WooCommerce\Admin\API\Reports\GenericController;
 use Automattic\WooCommerce\Admin\API\Reports\ExportableInterface;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -18,9 +18,9 @@ use WP_REST_Response;
  * REST API Reports coupons controller class.
  *
  * @internal
- * @extends AbstractController
+ * @extends GenericController
  */
-class Controller extends AbstractController implements ExportableInterface {
+class Controller extends GenericController implements ExportableInterface {
 
 	/**
 	 * Route base.

--- a/plugins/woocommerce/src/Admin/API/Reports/Coupons/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Coupons/Stats/Controller.php
@@ -247,55 +247,12 @@ class Controller extends AbstractController {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params              = array();
-		$params['context']   = $this->get_context_param( array( 'default' => 'view' ) );
-		$params['page']      = array(
-			'description'       => __( 'Current page of the collection.', 'woocommerce' ),
-			'type'              => 'integer',
-			'default'           => 1,
-			'sanitize_callback' => 'absint',
-			'validate_callback' => 'rest_validate_request_arg',
-			'minimum'           => 1,
-		);
-		$params['per_page']  = array(
-			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
-			'type'              => 'integer',
-			'default'           => 10,
-			'minimum'           => 1,
-			'maximum'           => 100,
-			'sanitize_callback' => 'absint',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['after']     = array(
-			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce' ),
-			'type'              => 'string',
-			'format'            => 'date-time',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['before']    = array(
-			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce' ),
-			'type'              => 'string',
-			'format'            => 'date-time',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['order']     = array(
-			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce' ),
-			'type'              => 'string',
-			'default'           => 'desc',
-			'enum'              => array( 'asc', 'desc' ),
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['orderby']   = array(
-			'description'       => __( 'Sort collection by object attribute.', 'woocommerce' ),
-			'type'              => 'string',
-			'default'           => 'date',
-			'enum'              => array(
-				'date',
-				'amount',
-				'coupons_count',
-				'orders_count',
-			),
-			'validate_callback' => 'rest_validate_request_arg',
+		$params = parent::get_collection_params();
+		$params['orderby']['enum'] =  array(
+			'date',
+			'amount',
+			'coupons_count',
+			'orders_count',
 		);
 		$params['interval']  = array(
 			'description'       => __( 'Time interval to use for buckets in the returned data.', 'woocommerce' ),
@@ -339,12 +296,6 @@ class Controller extends AbstractController {
 			'items'             => array(
 				'type' => 'string',
 			),
-		);
-		$params['force_cache_refresh'] = array(
-			'description'       => __( 'Force retrieval of fresh data instead of from the cache.', 'woocommerce' ),
-			'type'              => 'boolean',
-			'sanitize_callback' => 'wp_validate_boolean',
-			'validate_callback' => 'rest_validate_request_arg',
 		);
 
 		return $params;

--- a/plugins/woocommerce/src/Admin/API/Reports/Coupons/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Coupons/Stats/Controller.php
@@ -112,12 +112,13 @@ class Controller extends GenericStatsController {
 	}
 
 	/**
-	 * Get the Report's schema, conforming to JSON Schema.
+	 * Get the Report's item properties schema.
+	 * Will be used by `get_item_schema` as `totals` and `subtotals`.
 	 *
 	 * @return array
 	 */
-	public function get_item_schema() {
-		$data_values = array(
+	public function get_item_properties_schema() {
+		return array(
 			'amount'        => array(
 				'description' => __( 'Net discount amount.', 'woocommerce' ),
 				'type'        => 'number',
@@ -141,99 +142,16 @@ class Controller extends GenericStatsController {
 				'indicator'   => true,
 			),
 		);
+	}
 
-		$segments = array(
-			'segments' => array(
-				'description' => __( 'Reports data grouped by segment condition.', 'woocommerce' ),
-				'type'        => 'array',
-				'context'     => array( 'view', 'edit' ),
-				'readonly'    => true,
-				'items'       => array(
-					'type'       => 'object',
-					'properties' => array(
-						'segment_id' => array(
-							'description' => __( 'Segment identificator.', 'woocommerce' ),
-							'type'        => 'integer',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'subtotals'  => array(
-							'description' => __( 'Interval subtotals.', 'woocommerce' ),
-							'type'        => 'object',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-							'properties'  => $data_values,
-						),
-					),
-				),
-			),
-		);
-
-		$totals = array_merge( $data_values, $segments );
-
-		$schema = array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'report_coupons_stats',
-			'type'       => 'object',
-			'properties' => array(
-				'totals'    => array(
-					'description' => __( 'Totals data.', 'woocommerce' ),
-					'type'        => 'object',
-					'context'     => array( 'view', 'edit' ),
-					'readonly'    => true,
-					'properties'  => $totals,
-				),
-				'intervals' => array(
-					'description' => __( 'Reports data grouped by intervals.', 'woocommerce' ),
-					'type'        => 'array',
-					'context'     => array( 'view', 'edit' ),
-					'readonly'    => true,
-					'items'       => array(
-						'type'       => 'object',
-						'properties' => array(
-							'interval'       => array(
-								'description' => __( 'Type of interval.', 'woocommerce' ),
-								'type'        => 'string',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-								'enum'        => array( 'day', 'week', 'month', 'year' ),
-							),
-							'date_start'     => array(
-								'description' => __( "The date the report start, in the site's timezone.", 'woocommerce' ),
-								'type'        => 'date-time',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'date_start_gmt' => array(
-								'description' => __( 'The date the report start, as GMT.', 'woocommerce' ),
-								'type'        => 'date-time',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'date_end'       => array(
-								'description' => __( "The date the report end, in the site's timezone.", 'woocommerce' ),
-								'type'        => 'date-time',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'date_end_gmt'   => array(
-								'description' => __( 'The date the report end, as GMT.', 'woocommerce' ),
-								'type'        => 'date-time',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'subtotals'      => array(
-								'description' => __( 'Interval subtotals.', 'woocommerce' ),
-								'type'        => 'object',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-								'properties'  => $totals,
-							),
-						),
-					),
-				),
-			),
-		);
+	/**
+	 * Get the Report's schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema          = parent::get_item_schema();
+		$schema['title'] = 'report_coupons_stats';
 
 		return $this->add_additional_fields_schema( $schema );
 	}

--- a/plugins/woocommerce/src/Admin/API/Reports/Coupons/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Coupons/Stats/Controller.php
@@ -9,7 +9,7 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Coupons\Stats;
 
 defined( 'ABSPATH' ) || exit;
 
-use Automattic\WooCommerce\Admin\API\Reports\AbstractController;
+use Automattic\WooCommerce\Admin\API\Reports\GenericStatsController;
 use Automattic\WooCommerce\Admin\API\Reports\ParameterException;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -18,9 +18,9 @@ use WP_REST_Response;
  * REST API Reports coupons stats controller class.
  *
  * @internal
- * @extends AbstractController
+ * @extends GenericStatsController
  */
-class Controller extends AbstractController {
+class Controller extends GenericStatsController {
 
 	/**
 	 * Route base.
@@ -250,20 +250,6 @@ class Controller extends AbstractController {
 			'amount',
 			'coupons_count',
 			'orders_count',
-		);
-		$params['interval']        = array(
-			'description'       => __( 'Time interval to use for buckets in the returned data.', 'woocommerce' ),
-			'type'              => 'string',
-			'default'           => 'week',
-			'enum'              => array(
-				'hour',
-				'day',
-				'week',
-				'month',
-				'quarter',
-				'year',
-			),
-			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['coupons']         = array(
 			'description'       => __( 'Limit result set to coupons assigned specific coupon IDs.', 'woocommerce' ),

--- a/plugins/woocommerce/src/Admin/API/Reports/Coupons/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Coupons/Stats/Controller.php
@@ -244,14 +244,14 @@ class Controller extends AbstractController {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params = parent::get_collection_params();
-		$params['orderby']['enum'] =  array(
+		$params                    = parent::get_collection_params();
+		$params['orderby']['enum'] = array(
 			'date',
 			'amount',
 			'coupons_count',
 			'orders_count',
 		);
-		$params['interval']  = array(
+		$params['interval']        = array(
 			'description'       => __( 'Time interval to use for buckets in the returned data.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'week',
@@ -265,7 +265,7 @@ class Controller extends AbstractController {
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['coupons']   = array(
+		$params['coupons']         = array(
 			'description'       => __( 'Limit result set to coupons assigned specific coupon IDs.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
@@ -274,7 +274,7 @@ class Controller extends AbstractController {
 				'type' => 'integer',
 			),
 		);
-		$params['segmentby'] = array(
+		$params['segmentby']       = array(
 			'description'       => __( 'Segment the response by additional constraint.', 'woocommerce' ),
 			'type'              => 'string',
 			'enum'              => array(
@@ -285,7 +285,7 @@ class Controller extends AbstractController {
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['fields']    = array(
+		$params['fields']          = array(
 			'description'       => __( 'Limit stats fields to the specified items.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_slug_list',

--- a/plugins/woocommerce/src/Admin/API/Reports/Coupons/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Coupons/Stats/Controller.php
@@ -117,7 +117,7 @@ class Controller extends GenericStatsController {
 	 *
 	 * @return array
 	 */
-	public function get_item_properties_schema() {
+	protected function get_item_properties_schema() {
 		return array(
 			'amount'        => array(
 				'description' => __( 'Net discount amount.', 'woocommerce' ),

--- a/plugins/woocommerce/src/Admin/API/Reports/Coupons/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Coupons/Stats/Controller.php
@@ -11,6 +11,8 @@ defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Admin\API\Reports\AbstractController;
 use Automattic\WooCommerce\Admin\API\Reports\ParameterException;
+use WP_REST_Request;
+use WP_REST_Response;
 
 /**
  * REST API Reports coupons stats controller class.
@@ -95,12 +97,7 @@ class Controller extends AbstractController {
 	public function prepare_item_for_response( $report, $request ) {
 		$data = get_object_vars( $report );
 
-		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
-		$data    = $this->add_additional_fields_to_object( $data, $request );
-		$data    = $this->filter_response_by_context( $data, $context );
-
-		// Wrap the data in a response object.
-		$response = rest_ensure_response( $data );
+		$response = parent::prepare_item_for_response( $data, $request );
 
 		/**
 		 * Filter a report returned from the API.

--- a/plugins/woocommerce/src/Admin/API/Reports/Coupons/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Coupons/Stats/Controller.php
@@ -9,22 +9,16 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Coupons\Stats;
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Admin\API\Reports\AbstractController;
 use Automattic\WooCommerce\Admin\API\Reports\ParameterException;
 
 /**
  * REST API Reports coupons stats controller class.
  *
  * @internal
- * @extends WC_REST_Reports_Controller
+ * @extends AbstractController
  */
-class Controller extends \WC_REST_Reports_Controller {
-
-	/**
-	 * Endpoint namespace.
-	 *
-	 * @var string
-	 */
-	protected $namespace = 'wc-analytics';
+class Controller extends AbstractController {
 
 	/**
 	 * Route base.
@@ -82,28 +76,13 @@ class Controller extends \WC_REST_Reports_Controller {
 			$out_data['intervals'][] = $this->prepare_response_for_collection( $item );
 		}
 
-		$response = rest_ensure_response( $out_data );
-		$response->header( 'X-WP-Total', (int) $report_data->total );
-		$response->header( 'X-WP-TotalPages', (int) $report_data->pages );
-
-		$page      = $report_data->page_no;
-		$max_pages = $report_data->pages;
-		$base      = add_query_arg( $request->get_query_params(), rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ) );
-		if ( $page > 1 ) {
-			$prev_page = $page - 1;
-			if ( $prev_page > $max_pages ) {
-				$prev_page = $max_pages;
-			}
-			$prev_link = add_query_arg( 'page', $prev_page, $base );
-			$response->link_header( 'prev', $prev_link );
-		}
-		if ( $max_pages > $page ) {
-			$next_page = $page + 1;
-			$next_link = add_query_arg( 'page', $next_page, $base );
-			$response->link_header( 'next', $next_link );
-		}
-
-		return $response;
+		return $this->add_pagination_headers(
+			$request,
+			$out_data,
+			(int) $report_data->total,
+			(int) $report_data->page_no,
+			(int) $report_data->pages
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/API/Reports/Customers/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Customers/Controller.php
@@ -304,7 +304,7 @@ class Controller extends AbstractController implements ExportableInterface {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params = parent::get_collection_params();
+		$params                            = parent::get_collection_params();
 		$params['registered_before']       = array(
 			'description'       => __( 'Limit response to objects registered before (or at) a given ISO8601 compliant datetime.', 'woocommerce' ),
 			'type'              => 'string',
@@ -317,8 +317,8 @@ class Controller extends AbstractController implements ExportableInterface {
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['orderby']['default'] = 'date_registered';
-		$params['orderby']['enum']    = array(
+		$params['orderby']['default']      = 'date_registered';
+		$params['orderby']['enum']         = array(
 			'username',
 			'name',
 			'country',

--- a/plugins/woocommerce/src/Admin/API/Reports/Customers/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Customers/Controller.php
@@ -304,8 +304,7 @@ class Controller extends AbstractController implements ExportableInterface {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params                            = array();
-		$params['context']                 = $this->get_context_param( array( 'default' => 'view' ) );
+		$params = parent::get_collection_params();
 		$params['registered_before']       = array(
 			'description'       => __( 'Limit response to objects registered before (or at) a given ISO8601 compliant datetime.', 'woocommerce' ),
 			'type'              => 'string',
@@ -318,60 +317,19 @@ class Controller extends AbstractController implements ExportableInterface {
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['after']                   = array(
-			'description'       => __( 'Limit response to resources with orders published after a given ISO8601 compliant date.', 'woocommerce' ),
-			'type'              => 'string',
-			'format'            => 'date-time',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['before']                  = array(
-			'description'       => __( 'Limit response to resources with orders published before a given ISO8601 compliant date.', 'woocommerce' ),
-			'type'              => 'string',
-			'format'            => 'date-time',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['page']                    = array(
-			'description'       => __( 'Current page of the collection.', 'woocommerce' ),
-			'type'              => 'integer',
-			'default'           => 1,
-			'sanitize_callback' => 'absint',
-			'validate_callback' => 'rest_validate_request_arg',
-			'minimum'           => 1,
-		);
-		$params['per_page']                = array(
-			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
-			'type'              => 'integer',
-			'default'           => 10,
-			'minimum'           => 1,
-			'maximum'           => 100,
-			'sanitize_callback' => 'absint',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['order']                   = array(
-			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce' ),
-			'type'              => 'string',
-			'default'           => 'desc',
-			'enum'              => array( 'asc', 'desc' ),
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['orderby']                 = array(
-			'description'       => __( 'Sort collection by object attribute.', 'woocommerce' ),
-			'type'              => 'string',
-			'default'           => 'date_registered',
-			'enum'              => array(
-				'username',
-				'name',
-				'country',
-				'city',
-				'state',
-				'postcode',
-				'date_registered',
-				'date_last_active',
-				'orders_count',
-				'total_spend',
-				'avg_order_value',
-			),
-			'validate_callback' => 'rest_validate_request_arg',
+		$params['orderby']['default'] = 'date_registered';
+		$params['orderby']['enum']    = array(
+			'username',
+			'name',
+			'country',
+			'city',
+			'state',
+			'postcode',
+			'date_registered',
+			'date_last_active',
+			'orders_count',
+			'total_spend',
+			'avg_order_value',
 		);
 		$params['match']                   = array(
 			'description'       => __( 'Indicates whether all the conditions should be true for the resulting set, or if any one of them is sufficient. Match affects the following parameters: status_is, status_is_not, product_includes, product_excludes, coupon_includes, coupon_excludes, customer, categories', 'woocommerce' ),
@@ -563,12 +521,6 @@ class Controller extends AbstractController implements ExportableInterface {
 			'items'             => array(
 				'type' => 'integer',
 			),
-		);
-		$params['force_cache_refresh'] = array(
-			'description'       => __( 'Force retrieval of fresh data instead of from the cache.', 'woocommerce' ),
-			'type'              => 'boolean',
-			'sanitize_callback' => 'wp_validate_boolean',
-			'validate_callback' => 'rest_validate_request_arg',
 		);
 
 		return $params;

--- a/plugins/woocommerce/src/Admin/API/Reports/Customers/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Customers/Controller.php
@@ -9,7 +9,7 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Customers;
 
 defined( 'ABSPATH' ) || exit;
 
-use Automattic\WooCommerce\Admin\API\Reports\AbstractController;
+use Automattic\WooCommerce\Admin\API\Reports\GenericController;
 use Automattic\WooCommerce\Admin\API\Reports\ExportableTraits;
 use Automattic\WooCommerce\Admin\API\Reports\ExportableInterface;
 use Automattic\WooCommerce\Admin\API\Reports\TimeInterval;
@@ -18,9 +18,9 @@ use Automattic\WooCommerce\Admin\API\Reports\TimeInterval;
  * REST API Reports customers controller class.
  *
  * @internal
- * @extends AbstractController
+ * @extends GenericController
  */
-class Controller extends AbstractController implements ExportableInterface {
+class Controller extends GenericController implements ExportableInterface {
 	/**
 	 * Exportable traits.
 	 */

--- a/plugins/woocommerce/src/Admin/API/Reports/Customers/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Customers/Controller.php
@@ -9,6 +9,7 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Customers;
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Admin\API\Reports\AbstractController;
 use Automattic\WooCommerce\Admin\API\Reports\ExportableTraits;
 use Automattic\WooCommerce\Admin\API\Reports\ExportableInterface;
 use Automattic\WooCommerce\Admin\API\Reports\TimeInterval;
@@ -17,20 +18,13 @@ use Automattic\WooCommerce\Admin\API\Reports\TimeInterval;
  * REST API Reports customers controller class.
  *
  * @internal
- * @extends WC_REST_Reports_Controller
+ * @extends AbstractController
  */
-class Controller extends \WC_REST_Reports_Controller implements ExportableInterface {
+class Controller extends AbstractController implements ExportableInterface {
 	/**
 	 * Exportable traits.
 	 */
 	use ExportableTraits;
-
-	/**
-	 * Endpoint namespace.
-	 *
-	 * @var string
-	 */
-	protected $namespace = 'wc-analytics';
 
 	/**
 	 * Route base.
@@ -107,28 +101,13 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			$data[] = $this->prepare_response_for_collection( $item );
 		}
 
-		$response = rest_ensure_response( $data );
-		$response->header( 'X-WP-Total', (int) $report_data->total );
-		$response->header( 'X-WP-TotalPages', (int) $report_data->pages );
-
-		$page      = $report_data->page_no;
-		$max_pages = $report_data->pages;
-		$base      = add_query_arg( $request->get_query_params(), rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ) );
-		if ( $page > 1 ) {
-			$prev_page = $page - 1;
-			if ( $prev_page > $max_pages ) {
-				$prev_page = $max_pages;
-			}
-			$prev_link = add_query_arg( 'page', $prev_page, $base );
-			$response->link_header( 'prev', $prev_link );
-		}
-		if ( $max_pages > $page ) {
-			$next_page = $page + 1;
-			$next_link = add_query_arg( 'page', $next_page, $base );
-			$response->link_header( 'next', $next_link );
-		}
-
-		return $response;
+		return $this->add_pagination_headers(
+			$request,
+			$data,
+			(int) $report_data->total,
+			(int) $report_data->page_no,
+			(int) $report_data->pages
+		);
 	}
 
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Customers/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Customers/Stats/Controller.php
@@ -386,7 +386,7 @@ class Controller extends \WC_REST_Reports_Controller {
 				'type' => 'string',
 			),
 		);
-		$params['force_cache_refresh'] = array(
+		$params['force_cache_refresh']     = array(
 			'description'       => __( 'Force retrieval of fresh data instead of from the cache.', 'woocommerce' ),
 			'type'              => 'boolean',
 			'sanitize_callback' => 'wp_validate_boolean',

--- a/plugins/woocommerce/src/Admin/API/Reports/Downloads/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Downloads/Controller.php
@@ -52,29 +52,13 @@ class Controller extends ReportsController implements ExportableInterface {
 			$data[] = $this->prepare_response_for_collection( $item );
 		}
 
-		$response = rest_ensure_response( $data );
-
-		$response->header( 'X-WP-Total', (int) $downloads_data->total );
-		$response->header( 'X-WP-TotalPages', (int) $downloads_data->pages );
-
-		$page      = $downloads_data->page_no;
-		$max_pages = $downloads_data->pages;
-		$base      = add_query_arg( $request->get_query_params(), rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ) );
-		if ( $page > 1 ) {
-			$prev_page = $page - 1;
-			if ( $prev_page > $max_pages ) {
-				$prev_page = $max_pages;
-			}
-			$prev_link = add_query_arg( 'page', $prev_page, $base );
-			$response->link_header( 'prev', $prev_link );
-		}
-		if ( $max_pages > $page ) {
-			$next_page = $page + 1;
-			$next_link = add_query_arg( 'page', $next_page, $base );
-			$response->link_header( 'next', $next_link );
-		}
-
-		return $response;
+		return $this->add_pagination_headers(
+			$request,
+			$data,
+			(int) $downloads_data->total,
+			(int) $downloads_data->page_no,
+			(int) $downloads_data->pages
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/API/Reports/Downloads/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Downloads/Stats/Controller.php
@@ -10,6 +10,8 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Downloads\Stats;
 defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Admin\API\Reports\AbstractController;
+use WP_REST_Request;
+use WP_REST_Response;
 
 /**
  * REST API Reports downloads stats controller class.
@@ -89,19 +91,12 @@ class Controller extends AbstractController {
 	/**
 	 * Prepare a report object for serialization.
 	 *
-	 * @param Array           $report  Report data.
+	 * @param array           $report  Report data.
 	 * @param WP_REST_Request $request Request object.
 	 * @return WP_REST_Response
 	 */
 	public function prepare_item_for_response( $report, $request ) {
-		$data = $report;
-
-		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
-		$data    = $this->add_additional_fields_to_object( $data, $request );
-		$data    = $this->filter_response_by_context( $data, $context );
-
-		// Wrap the data in a response object.
-		$response = rest_ensure_response( $data );
+		$response = parent::prepare_item_for_response( $report, $request );
 
 		/**
 		 * Filter a report returned from the API.

--- a/plugins/woocommerce/src/Admin/API/Reports/Downloads/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Downloads/Stats/Controller.php
@@ -9,7 +9,7 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Downloads\Stats;
 
 defined( 'ABSPATH' ) || exit;
 
-use Automattic\WooCommerce\Admin\API\Reports\AbstractController;
+use Automattic\WooCommerce\Admin\API\Reports\GenericStatsController;
 use WP_REST_Request;
 use WP_REST_Response;
 
@@ -17,9 +17,9 @@ use WP_REST_Response;
  * REST API Reports downloads stats controller class.
  *
  * @internal
- * @extends AbstractController
+ * @extends GenericStatsController
  */
-class Controller extends AbstractController {
+class Controller extends GenericStatsController {
 
 	/**
 	 * Route base.
@@ -204,20 +204,6 @@ class Controller extends AbstractController {
 		$params['orderby']['enum']  = array(
 			'date',
 			'download_count',
-		);
-		$params['interval']         = array(
-			'description'       => __( 'Time interval to use for buckets in the returned data.', 'woocommerce' ),
-			'type'              => 'string',
-			'default'           => 'week',
-			'enum'              => array(
-				'hour',
-				'day',
-				'week',
-				'month',
-				'quarter',
-				'year',
-			),
-			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['match']            = array(
 			'description'       => __( 'Indicates whether all the conditions should be true for the resulting set, or if any one of them is sufficient. Match affects the following parameters: status_is, status_is_not, product_includes, product_excludes, coupon_includes, coupon_excludes, customer, categories', 'woocommerce' ),

--- a/plugins/woocommerce/src/Admin/API/Reports/Downloads/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Downloads/Stats/Controller.php
@@ -9,20 +9,15 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Downloads\Stats;
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Admin\API\Reports\AbstractController;
+
 /**
  * REST API Reports downloads stats controller class.
  *
  * @internal
- * @extends WC_REST_Reports_Controller
+ * @extends AbstractController
  */
-class Controller extends \WC_REST_Reports_Controller {
-
-	/**
-	 * Endpoint namespace.
-	 *
-	 * @var string
-	 */
-	protected $namespace = 'wc-analytics';
+class Controller extends AbstractController {
 
 	/**
 	 * Route base.
@@ -82,28 +77,13 @@ class Controller extends \WC_REST_Reports_Controller {
 			$out_data['intervals'][] = $this->prepare_response_for_collection( $item );
 		}
 
-		$response = rest_ensure_response( $out_data );
-		$response->header( 'X-WP-Total', (int) $report_data->total );
-		$response->header( 'X-WP-TotalPages', (int) $report_data->pages );
-
-		$page      = $report_data->page_no;
-		$max_pages = $report_data->pages;
-		$base      = add_query_arg( $request->get_query_params(), rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ) );
-		if ( $page > 1 ) {
-			$prev_page = $page - 1;
-			if ( $prev_page > $max_pages ) {
-				$prev_page = $max_pages;
-			}
-			$prev_link = add_query_arg( 'page', $prev_page, $base );
-			$response->link_header( 'prev', $prev_link );
-		}
-		if ( $max_pages > $page ) {
-			$next_page = $page + 1;
-			$next_link = add_query_arg( 'page', $next_page, $base );
-			$response->link_header( 'next', $next_link );
-		}
-
-		return $response;
+		return $this->add_pagination_headers(
+			$request,
+			$out_data,
+			(int) $report_data->total,
+			(int) $report_data->page_no,
+			(int) $report_data->pages
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/API/Reports/Downloads/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Downloads/Stats/Controller.php
@@ -117,7 +117,7 @@ class Controller extends GenericStatsController {
 	 *
 	 * @return array
 	 */
-	public function get_item_properties_schema() {
+	protected function get_item_properties_schema() {
 		return array(
 			'download_count' => array(
 				'title'       => __( 'Downloads', 'woocommerce' ),

--- a/plugins/woocommerce/src/Admin/API/Reports/Downloads/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Downloads/Stats/Controller.php
@@ -110,13 +110,15 @@ class Controller extends GenericStatsController {
 		return apply_filters( 'woocommerce_rest_prepare_report_downloads_stats', $response, $report, $request );
 	}
 
+
 	/**
-	 * Get the Report's schema, conforming to JSON Schema.
+	 * Get the Report's item properties schema.
+	 * Will be used by `get_item_schema` as `totals` and `subtotals`.
 	 *
 	 * @return array
 	 */
-	public function get_item_schema() {
-		$totals = array(
+	public function get_item_properties_schema() {
+		return array(
 			'download_count' => array(
 				'title'       => __( 'Downloads', 'woocommerce' ),
 				'description' => __( 'Number of downloads.', 'woocommerce' ),
@@ -126,6 +128,15 @@ class Controller extends GenericStatsController {
 				'indicator'   => true,
 			),
 		);
+	}
+	/**
+	 * Get the Report's schema, conforming to JSON Schema.
+	 * It does not have the segments as in GenericStatsController.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$totals = $this->get_item_properties_schema();
 
 		$schema = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',

--- a/plugins/woocommerce/src/Admin/API/Reports/Downloads/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Downloads/Stats/Controller.php
@@ -200,8 +200,8 @@ class Controller extends AbstractController {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params = parent::get_collection_params();
-		$params['orderby']['enum'] = array(
+		$params                     = parent::get_collection_params();
+		$params['orderby']['enum']  = array(
 			'date',
 			'download_count',
 		);

--- a/plugins/woocommerce/src/Admin/API/Reports/Downloads/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Downloads/Stats/Controller.php
@@ -205,53 +205,10 @@ class Controller extends AbstractController {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params                     = array();
-		$params['context']          = $this->get_context_param( array( 'default' => 'view' ) );
-		$params['page']             = array(
-			'description'       => __( 'Current page of the collection.', 'woocommerce' ),
-			'type'              => 'integer',
-			'default'           => 1,
-			'sanitize_callback' => 'absint',
-			'validate_callback' => 'rest_validate_request_arg',
-			'minimum'           => 1,
-		);
-		$params['per_page']         = array(
-			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
-			'type'              => 'integer',
-			'default'           => 10,
-			'minimum'           => 1,
-			'maximum'           => 100,
-			'sanitize_callback' => 'absint',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['after']            = array(
-			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce' ),
-			'type'              => 'string',
-			'format'            => 'date-time',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['before']           = array(
-			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce' ),
-			'type'              => 'string',
-			'format'            => 'date-time',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['order']            = array(
-			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce' ),
-			'type'              => 'string',
-			'default'           => 'desc',
-			'enum'              => array( 'asc', 'desc' ),
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['orderby']          = array(
-			'description'       => __( 'Sort collection by object attribute.', 'woocommerce' ),
-			'type'              => 'string',
-			'default'           => 'date',
-			'enum'              => array(
-				'date',
-				'download_count',
-			),
-			'validate_callback' => 'rest_validate_request_arg',
+		$params = parent::get_collection_params();
+		$params['orderby']['enum'] = array(
+			'date',
+			'download_count',
 		);
 		$params['interval']         = array(
 			'description'       => __( 'Time interval to use for buckets in the returned data.', 'woocommerce' ),
@@ -357,12 +314,6 @@ class Controller extends AbstractController {
 			'items'             => array(
 				'type' => 'string',
 			),
-		);
-		$params['force_cache_refresh'] = array(
-			'description'       => __( 'Force retrieval of fresh data instead of from the cache.', 'woocommerce' ),
-			'type'              => 'boolean',
-			'sanitize_callback' => 'wp_validate_boolean',
-			'validate_callback' => 'rest_validate_request_arg',
 		);
 
 		return $params;

--- a/plugins/woocommerce/src/Admin/API/Reports/GenericController.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/GenericController.php
@@ -13,7 +13,7 @@ use WP_REST_Response;
  * @internal
  * @extends WC_REST_Reports_Controller
  */
-abstract class AbstractController extends \WC_REST_Reports_Controller {
+abstract class GenericController extends \WC_REST_Reports_Controller {
 
 	/**
 	 * Endpoint namespace.

--- a/plugins/woocommerce/src/Admin/API/Reports/GenericStatsController.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/GenericStatsController.php
@@ -3,15 +3,15 @@ namespace Automattic\WooCommerce\Admin\API\Reports;
 
 defined( 'ABSPATH' ) || exit;
 
-use Automattic\WooCommerce\Admin\API\Reports\AbstractController;
+use Automattic\WooCommerce\Admin\API\Reports\GenericController;
 
 /**
  * Generic base for all Stats controllers.
  *
  * @internal
- * @extends AbstractController
+ * @extends GenericController
  */
-abstract class GenericStatsController extends AbstractController {
+abstract class GenericStatsController extends GenericController {
 
 	/**
 	 * Get the query params for collections.

--- a/plugins/woocommerce/src/Admin/API/Reports/GenericStatsController.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/GenericStatsController.php
@@ -20,8 +20,8 @@ abstract class GenericStatsController extends GenericController {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params                    = parent::get_collection_params();
-		$params['interval']        = array(
+		$params             = parent::get_collection_params();
+		$params['interval'] = array(
 			'description'       => __( 'Time interval to use for buckets in the returned data.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'week',

--- a/plugins/woocommerce/src/Admin/API/Reports/GenericStatsController.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/GenericStatsController.php
@@ -1,0 +1,41 @@
+<?php
+namespace Automattic\WooCommerce\Admin\API\Reports;
+
+defined( 'ABSPATH' ) || exit;
+
+use Automattic\WooCommerce\Admin\API\Reports\AbstractController;
+
+/**
+ * Generic base for all Stats controllers.
+ *
+ * @internal
+ * @extends AbstractController
+ */
+abstract class GenericStatsController extends AbstractController {
+
+	/**
+	 * Get the query params for collections.
+	 * Adds intervals to the generic list.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$params                    = parent::get_collection_params();
+		$params['interval']        = array(
+			'description'       => __( 'Time interval to use for buckets in the returned data.', 'woocommerce' ),
+			'type'              => 'string',
+			'default'           => 'week',
+			'enum'              => array(
+				'hour',
+				'day',
+				'week',
+				'month',
+				'quarter',
+				'year',
+			),
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+
+		return $params;
+	}
+}

--- a/plugins/woocommerce/src/Admin/API/Reports/GenericStatsController.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/GenericStatsController.php
@@ -45,7 +45,7 @@ abstract class GenericStatsController extends GenericController {
 	 *
 	 * @return array
 	 */
-	abstract function get_item_properties_schema();
+	abstract protected function get_item_properties_schema();
 
 	/**
 	 * Get the Report's schema, conforming to JSON Schema.

--- a/plugins/woocommerce/src/Admin/API/Reports/GenericStatsController.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/GenericStatsController.php
@@ -38,4 +38,121 @@ abstract class GenericStatsController extends GenericController {
 
 		return $params;
 	}
+
+	/**
+	 * Get the Report's item properties schema.
+	 * Will be used by `get_item_schema` as `totals` and `subtotals`.
+	 *
+	 * @return array
+	 */
+	abstract function get_item_properties_schema();
+
+	/**
+	 * Get the Report's schema, conforming to JSON Schema.
+	 *
+	 * Please note, it does not call add_additional_fields_schema,
+	 * as you may want to update the `title` first.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$data_values = $this->get_item_properties_schema();
+
+		$segments = array(
+			'segments' => array(
+				'description' => __( 'Reports data grouped by segment condition.', 'woocommerce' ),
+				'type'        => 'array',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+				'items'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'segment_id' => array(
+							'description' => __( 'Segment identificator.', 'woocommerce' ),
+							'type'        => 'integer',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'subtotals'  => array(
+							'description' => __( 'Interval subtotals.', 'woocommerce' ),
+							'type'        => 'object',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+							'properties'  => $data_values,
+						),
+					),
+				),
+			),
+		);
+
+		$totals = array_merge( $data_values, $segments );
+
+		return array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'report_stats',
+			'type'       => 'object',
+			'properties' => array(
+				'totals'    => array(
+					'description' => __( 'Totals data.', 'woocommerce' ),
+					'type'        => 'object',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+					'properties'  => $totals,
+				),
+				'intervals' => array(
+					'description' => __( 'Reports data grouped by intervals.', 'woocommerce' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'interval'       => array(
+								'description' => __( 'Type of interval.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+								'enum'        => array( 'day', 'week', 'month', 'year' ),
+							),
+							'date_start'     => array(
+								'description' => __( "The date the report start, in the site's timezone.", 'woocommerce' ),
+								'type'        => 'string',
+								'format'      => 'date-time',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'date_start_gmt' => array(
+								'description' => __( 'The date the report start, as GMT.', 'woocommerce' ),
+								'type'        => 'string',
+								'format'      => 'date-time',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'date_end'       => array(
+								'description' => __( "The date the report end, in the site's timezone.", 'woocommerce' ),
+								'type'        => 'string',
+								'format'      => 'date-time',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'date_end_gmt'   => array(
+								'description' => __( 'The date the report end, as GMT.', 'woocommerce' ),
+								'type'        => 'string',
+								'format'      => 'date-time',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'subtotals'      => array(
+								'description' => __( 'Interval subtotals.', 'woocommerce' ),
+								'type'        => 'object',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+								'properties'  => $totals,
+							),
+						),
+					),
+				),
+			),
+		);
+	}
 }

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Controller.php
@@ -242,9 +242,9 @@ class Controller extends ReportsController implements ExportableInterface {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params                       = array();
-		$params['context']            = $this->get_context_param( array( 'default' => 'view' ) );
-		$params['page']               = array(
+		$params                        = array();
+		$params['context']             = $this->get_context_param( array( 'default' => 'view' ) );
+		$params['page']                = array(
 			'description'       => __( 'Current page of the collection.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 1,
@@ -252,7 +252,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'validate_callback' => 'rest_validate_request_arg',
 			'minimum'           => 1,
 		);
-		$params['per_page']           = array(
+		$params['per_page']            = array(
 			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 10,
@@ -261,26 +261,26 @@ class Controller extends ReportsController implements ExportableInterface {
 			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['after']              = array(
+		$params['after']               = array(
 			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['before']             = array(
+		$params['before']              = array(
 			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['order']              = array(
+		$params['order']               = array(
 			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'desc',
 			'enum'              => array( 'asc', 'desc' ),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['orderby']            = array(
+		$params['orderby']             = array(
 			'description'       => __( 'Sort collection by object attribute.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'date',
@@ -291,7 +291,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['product_includes']   = array(
+		$params['product_includes']    = array(
 			'description'       => __( 'Limit result set to items that have the specified product(s) assigned.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
@@ -301,7 +301,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['product_excludes']   = array(
+		$params['product_excludes']    = array(
 			'description'       => __( 'Limit result set to items that don\'t have the specified product(s) assigned.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
@@ -311,7 +311,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'validate_callback' => 'rest_validate_request_arg',
 			'sanitize_callback' => 'wp_parse_id_list',
 		);
-		$params['variation_includes'] = array(
+		$params['variation_includes']  = array(
 			'description'       => __( 'Limit result set to items that have the specified variation(s) assigned.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
@@ -321,7 +321,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['variation_excludes'] = array(
+		$params['variation_excludes']  = array(
 			'description'       => __( 'Limit result set to items that don\'t have the specified variation(s) assigned.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
@@ -331,7 +331,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'validate_callback' => 'rest_validate_request_arg',
 			'sanitize_callback' => 'wp_parse_id_list',
 		);
-		$params['coupon_includes']    = array(
+		$params['coupon_includes']     = array(
 			'description'       => __( 'Limit result set to items that have the specified coupon(s) assigned.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
@@ -341,7 +341,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['coupon_excludes']    = array(
+		$params['coupon_excludes']     = array(
 			'description'       => __( 'Limit result set to items that don\'t have the specified coupon(s) assigned.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
@@ -351,7 +351,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'validate_callback' => 'rest_validate_request_arg',
 			'sanitize_callback' => 'wp_parse_id_list',
 		);
-		$params['tax_rate_includes']  = array(
+		$params['tax_rate_includes']   = array(
 			'description'       => __( 'Limit result set to items that have the specified tax rate(s) assigned.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
@@ -361,7 +361,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['tax_rate_excludes']  = array(
+		$params['tax_rate_excludes']   = array(
 			'description'       => __( 'Limit result set to items that don\'t have the specified tax rate(s) assigned.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
@@ -371,7 +371,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'validate_callback' => 'rest_validate_request_arg',
 			'sanitize_callback' => 'wp_parse_id_list',
 		);
-		$params['status_is']          = array(
+		$params['status_is']           = array(
 			'description'       => __( 'Limit result set to items that have the specified order status.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_slug_list',
@@ -381,7 +381,7 @@ class Controller extends ReportsController implements ExportableInterface {
 				'type' => 'string',
 			),
 		);
-		$params['status_is_not']      = array(
+		$params['status_is_not']       = array(
 			'description'       => __( 'Limit result set to items that don\'t have the specified order status.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_slug_list',
@@ -391,7 +391,7 @@ class Controller extends ReportsController implements ExportableInterface {
 				'type' => 'string',
 			),
 		);
-		$params['customer_type']      = array(
+		$params['customer_type']       = array(
 			'description'       => __( 'Limit result set to returning or new customers.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => '',
@@ -402,7 +402,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['refunds']            = array(
+		$params['refunds']             = array(
 			'description'       => __( 'Limit result set to specific types of refunds.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => '',
@@ -415,14 +415,14 @@ class Controller extends ReportsController implements ExportableInterface {
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['extended_info']      = array(
+		$params['extended_info']       = array(
 			'description'       => __( 'Add additional piece of info about each coupon to the report.', 'woocommerce' ),
 			'type'              => 'boolean',
 			'default'           => false,
 			'sanitize_callback' => 'wc_string_to_bool',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['order_includes']     = array(
+		$params['order_includes']      = array(
 			'description'       => __( 'Limit result set to items that have the specified order ids.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
@@ -431,7 +431,7 @@ class Controller extends ReportsController implements ExportableInterface {
 				'type' => 'integer',
 			),
 		);
-		$params['order_excludes']     = array(
+		$params['order_excludes']      = array(
 			'description'       => __( 'Limit result set to items that don\'t have the specified order ids.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
@@ -440,7 +440,7 @@ class Controller extends ReportsController implements ExportableInterface {
 				'type' => 'integer',
 			),
 		);
-		$params['attribute_is']       = array(
+		$params['attribute_is']        = array(
 			'description'       => __( 'Limit result set to orders that include products with the specified attributes.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
@@ -449,7 +449,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'default'           => array(),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['attribute_is_not']   = array(
+		$params['attribute_is_not']    = array(
 			'description'       => __( 'Limit result set to orders that don\'t include products with the specified attributes.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Controller.php
@@ -84,28 +84,13 @@ class Controller extends ReportsController implements ExportableInterface {
 			$data[]                         = $this->prepare_response_for_collection( $item );
 		}
 
-		$response = rest_ensure_response( $data );
-		$response->header( 'X-WP-Total', (int) $report_data->total );
-		$response->header( 'X-WP-TotalPages', (int) $report_data->pages );
-
-		$page      = $report_data->page_no;
-		$max_pages = $report_data->pages;
-		$base      = add_query_arg( $request->get_query_params(), rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ) );
-		if ( $page > 1 ) {
-			$prev_page = $page - 1;
-			if ( $prev_page > $max_pages ) {
-				$prev_page = $max_pages;
-			}
-			$prev_link = add_query_arg( 'page', $prev_page, $base );
-			$response->link_header( 'prev', $prev_link );
-		}
-		if ( $max_pages > $page ) {
-			$next_page = $page + 1;
-			$next_link = add_query_arg( 'page', $next_page, $base );
-			$response->link_header( 'next', $next_link );
-		}
-
-		return $response;
+		return $this->add_pagination_headers(
+			$request,
+			$data,
+			(int) $report_data->total,
+			(int) $report_data->page_no,
+			(int) $report_data->pages
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/Controller.php
@@ -412,7 +412,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'sanitize_callback' => 'wp_parse_id_list',
 
 		);
-		$params['product_excludes']   = array(
+		$params['product_excludes']    = array(
 			'description'       => __( 'Limit result set to items that don\'t have the specified product(s) assigned.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
@@ -421,7 +421,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'default'           => array(),
 			'sanitize_callback' => 'wp_parse_id_list',
 		);
-		$params['variation_includes'] = array(
+		$params['variation_includes']  = array(
 			'description'       => __( 'Limit result set to items that have the specified variation(s) assigned.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
@@ -431,7 +431,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['variation_excludes'] = array(
+		$params['variation_excludes']  = array(
 			'description'       => __( 'Limit result set to items that don\'t have the specified variation(s) assigned.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
@@ -441,7 +441,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 			'sanitize_callback' => 'wp_parse_id_list',
 		);
-		$params['coupon_includes']    = array(
+		$params['coupon_includes']     = array(
 			'description'       => __( 'Limit result set to items that have the specified coupon(s) assigned.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
@@ -450,7 +450,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'default'           => array(),
 			'sanitize_callback' => 'wp_parse_id_list',
 		);
-		$params['coupon_excludes']    = array(
+		$params['coupon_excludes']     = array(
 			'description'       => __( 'Limit result set to items that don\'t have the specified coupon(s) assigned.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
@@ -459,7 +459,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'default'           => array(),
 			'sanitize_callback' => 'wp_parse_id_list',
 		);
-		$params['tax_rate_includes']  = array(
+		$params['tax_rate_includes']   = array(
 			'description'       => __( 'Limit result set to items that have the specified tax rate(s) assigned.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
@@ -469,7 +469,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['tax_rate_excludes']  = array(
+		$params['tax_rate_excludes']   = array(
 			'description'       => __( 'Limit result set to items that don\'t have the specified tax rate(s) assigned.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
@@ -479,7 +479,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 			'sanitize_callback' => 'wp_parse_id_list',
 		);
-		$params['customer']           = array(
+		$params['customer']            = array(
 			'description'       => __( 'Alias for customer_type (deprecated).', 'woocommerce' ),
 			'type'              => 'string',
 			'enum'              => array(
@@ -488,7 +488,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['customer_type']      = array(
+		$params['customer_type']       = array(
 			'description'       => __( 'Limit result set to orders that have the specified customer_type', 'woocommerce' ),
 			'type'              => 'string',
 			'enum'              => array(
@@ -497,7 +497,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['refunds']            = array(
+		$params['refunds']             = array(
 			'description'       => __( 'Limit result set to specific types of refunds.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => '',
@@ -510,7 +510,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['attribute_is']       = array(
+		$params['attribute_is']        = array(
 			'description'       => __( 'Limit result set to orders that include products with the specified attributes.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
@@ -519,7 +519,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'default'           => array(),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['attribute_is_not']   = array(
+		$params['attribute_is_not']    = array(
 			'description'       => __( 'Limit result set to orders that don\'t include products with the specified attributes.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
@@ -528,7 +528,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'default'           => array(),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['segmentby']          = array(
+		$params['segmentby']           = array(
 			'description'       => __( 'Segment the response by additional constraint.', 'woocommerce' ),
 			'type'              => 'string',
 			'enum'              => array(
@@ -540,7 +540,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['fields']             = array(
+		$params['fields']              = array(
 			'description'       => __( 'Limit stats fields to the specified items.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_slug_list',

--- a/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/Controller.php
@@ -94,28 +94,13 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			$out_data['intervals'][] = $this->prepare_response_for_collection( $item );
 		}
 
-		$response = rest_ensure_response( $out_data );
-		$response->header( 'X-WP-Total', (int) $report_data->total );
-		$response->header( 'X-WP-TotalPages', (int) $report_data->pages );
-
-		$page      = $report_data->page_no;
-		$max_pages = $report_data->pages;
-		$base      = add_query_arg( $request->get_query_params(), rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ) );
-		if ( $page > 1 ) {
-			$prev_page = $page - 1;
-			if ( $prev_page > $max_pages ) {
-				$prev_page = $max_pages;
-			}
-			$prev_link = add_query_arg( 'page', $prev_page, $base );
-			$response->link_header( 'prev', $prev_link );
-		}
-		if ( $max_pages > $page ) {
-			$next_page = $page + 1;
-			$next_link = add_query_arg( 'page', $next_page, $base );
-			$response->link_header( 'next', $next_link );
-		}
-
-		return $response;
+		return $this->add_pagination_headers(
+			$request,
+			$out_data,
+			(int) $report_data->total,
+			(int) $report_data->page_no,
+			(int) $report_data->pages
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/API/Reports/PerformanceIndicators/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/PerformanceIndicators/Controller.php
@@ -7,7 +7,7 @@
 
 namespace Automattic\WooCommerce\Admin\API\Reports\PerformanceIndicators;
 
-use Automattic\WooCommerce\Admin\API\Reports\AbstractController;
+use Automattic\WooCommerce\Admin\API\Reports\GenericController;
 use Automattic\WooCommerce\Admin\API\Reports\TimeInterval;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -18,9 +18,9 @@ defined( 'ABSPATH' ) || exit;
  * REST API Reports Performance indicators controller class.
  *
  * @internal
- * @extends AbstractController
+ * @extends GenericController
  */
-class Controller extends AbstractController {
+class Controller extends GenericController {
 
 	/**
 	 * Route base.

--- a/plugins/woocommerce/src/Admin/API/Reports/PerformanceIndicators/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/PerformanceIndicators/Controller.php
@@ -9,6 +9,8 @@ namespace Automattic\WooCommerce\Admin\API\Reports\PerformanceIndicators;
 
 use Automattic\WooCommerce\Admin\API\Reports\AbstractController;
 use Automattic\WooCommerce\Admin\API\Reports\TimeInterval;
+use WP_REST_Request;
+use WP_REST_Response;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -452,19 +454,14 @@ class Controller extends AbstractController {
 	/**
 	 * Prepare a report object for serialization.
 	 *
-	 * @param stdClass        $stat_data    Report data.
+	 * @param array           $stat_data    Report data.
 	 * @param WP_REST_Request $request Request object.
 	 * @return WP_REST_Response
 	 */
 	public function prepare_item_for_response( $stat_data, $request ) {
-		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
-		$data    = $this->add_additional_fields_to_object( $stat_data, $request );
-		$data    = $this->filter_response_by_context( $data, $context );
+		$response = parent::prepare_item_for_response( $stat_data, $request );
 
-		// Wrap the data in a response object.
-		$response = rest_ensure_response( $data );
-
-		$response->add_links( $this->prepare_links( $data ) );
+		$response->add_links( $this->prepare_links( $stat_data ) );
 
 		/**
 		 * Filter a report returned from the API.

--- a/plugins/woocommerce/src/Admin/API/Reports/PerformanceIndicators/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/PerformanceIndicators/Controller.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\WooCommerce\Admin\API\Reports\PerformanceIndicators;
 
+use Automattic\WooCommerce\Admin\API\Reports\AbstractController;
 use Automattic\WooCommerce\Admin\API\Reports\TimeInterval;
 
 defined( 'ABSPATH' ) || exit;
@@ -15,16 +16,9 @@ defined( 'ABSPATH' ) || exit;
  * REST API Reports Performance indicators controller class.
  *
  * @internal
- * @extends WC_REST_Reports_Controller
+ * @extends AbstractController
  */
-class Controller extends \WC_REST_Reports_Controller {
-
-	/**
-	 * Endpoint namespace.
-	 *
-	 * @var string
-	 */
-	protected $namespace = 'wc-analytics';
+class Controller extends AbstractController {
 
 	/**
 	 * Route base.
@@ -294,13 +288,13 @@ class Controller extends \WC_REST_Reports_Controller {
 			$objects[] = $this->prepare_response_for_collection( $prepared );
 		}
 
-		$response = rest_ensure_response( $objects );
-		$response->header( 'X-WP-Total', count( $data ) );
-		$response->header( 'X-WP-TotalPages', 1 );
-
-		$base = add_query_arg( $request->get_query_params(), rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ) );
-
-		return $response;
+		return $this->add_pagination_headers(
+			$request,
+			$objects,
+			(int) count( $data ),
+			1,
+			1
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/Controller.php
@@ -230,7 +230,7 @@ class Controller extends AbstractController implements ExportableInterface {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params = parent::get_collection_params();
+		$params                    = parent::get_collection_params();
 		$params['orderby']['enum'] = array(
 			'date',
 			'net_revenue',
@@ -240,7 +240,7 @@ class Controller extends AbstractController implements ExportableInterface {
 			'variations',
 			'sku',
 		);
-		$params['categories'] = array(
+		$params['categories']      = array(
 			'description'       => __( 'Limit result to items from the specified categories.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
@@ -249,7 +249,7 @@ class Controller extends AbstractController implements ExportableInterface {
 				'type' => 'integer',
 			),
 		);
-		$params['match']      = array(
+		$params['match']           = array(
 			'description'       => __( 'Indicates whether all the conditions should be true for the resulting set, or if any one of them is sufficient. Match affects the following parameters: status_is, status_is_not, product_includes, product_excludes, coupon_includes, coupon_excludes, customer, categories', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'all',
@@ -259,7 +259,7 @@ class Controller extends AbstractController implements ExportableInterface {
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['products']   = array(
+		$params['products']        = array(
 			'description'       => __( 'Limit result to items with specified product ids.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/Controller.php
@@ -9,7 +9,7 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Products;
 
 defined( 'ABSPATH' ) || exit;
 
-use Automattic\WooCommerce\Admin\API\Reports\AbstractController;
+use Automattic\WooCommerce\Admin\API\Reports\GenericController;
 use Automattic\WooCommerce\Admin\API\Reports\ExportableInterface;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -18,9 +18,9 @@ use WP_REST_Response;
  * REST API Reports products controller class.
  *
  * @internal
- * @extends AbstractController
+ * @extends GenericController
  */
-class Controller extends AbstractController implements ExportableInterface {
+class Controller extends GenericController implements ExportableInterface {
 
 	/**
 	 * Route base.

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/Controller.php
@@ -235,58 +235,15 @@ class Controller extends AbstractController implements ExportableInterface {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params               = array();
-		$params['context']    = $this->get_context_param( array( 'default' => 'view' ) );
-		$params['page']       = array(
-			'description'       => __( 'Current page of the collection.', 'woocommerce' ),
-			'type'              => 'integer',
-			'default'           => 1,
-			'sanitize_callback' => 'absint',
-			'validate_callback' => 'rest_validate_request_arg',
-			'minimum'           => 1,
-		);
-		$params['per_page']   = array(
-			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
-			'type'              => 'integer',
-			'default'           => 10,
-			'minimum'           => 1,
-			'maximum'           => 100,
-			'sanitize_callback' => 'absint',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['after']      = array(
-			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce' ),
-			'type'              => 'string',
-			'format'            => 'date-time',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['before']     = array(
-			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce' ),
-			'type'              => 'string',
-			'format'            => 'date-time',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['order']      = array(
-			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce' ),
-			'type'              => 'string',
-			'default'           => 'desc',
-			'enum'              => array( 'asc', 'desc' ),
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['orderby']    = array(
-			'description'       => __( 'Sort collection by object attribute.', 'woocommerce' ),
-			'type'              => 'string',
-			'default'           => 'date',
-			'enum'              => array(
-				'date',
-				'net_revenue',
-				'orders_count',
-				'items_sold',
-				'product_name',
-				'variations',
-				'sku',
-			),
-			'validate_callback' => 'rest_validate_request_arg',
+		$params = parent::get_collection_params();
+		$params['orderby']['enum'] = array(
+			'date',
+			'net_revenue',
+			'orders_count',
+			'items_sold',
+			'product_name',
+			'variations',
+			'sku',
 		);
 		$params['categories'] = array(
 			'description'       => __( 'Limit result to items from the specified categories.', 'woocommerce' ),
@@ -322,12 +279,6 @@ class Controller extends AbstractController implements ExportableInterface {
 			'type'              => 'boolean',
 			'default'           => false,
 			'sanitize_callback' => 'wc_string_to_bool',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['force_cache_refresh'] = array(
-			'description'       => __( 'Force retrieval of fresh data instead of from the cache.', 'woocommerce' ),
-			'type'              => 'boolean',
-			'sanitize_callback' => 'wp_validate_boolean',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/Controller.php
@@ -11,6 +11,8 @@ defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Admin\API\Reports\AbstractController;
 use Automattic\WooCommerce\Admin\API\Reports\ExportableInterface;
+use WP_REST_Request;
+use WP_REST_Response;
 
 /**
  * REST API Reports products controller class.
@@ -88,14 +90,7 @@ class Controller extends AbstractController implements ExportableInterface {
 	 * @return WP_REST_Response
 	 */
 	public function prepare_item_for_response( $report, $request ) {
-		$data = $report;
-
-		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
-		$data    = $this->add_additional_fields_to_object( $data, $request );
-		$data    = $this->filter_response_by_context( $data, $context );
-
-		// Wrap the data in a response object.
-		$response = rest_ensure_response( $data );
+		$response = parent::prepare_item_for_response( $report, $request );
 		$response->add_links( $this->prepare_links( $report ) );
 
 		/**

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/Controller.php
@@ -9,22 +9,16 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Products;
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Admin\API\Reports\AbstractController;
 use Automattic\WooCommerce\Admin\API\Reports\ExportableInterface;
 
 /**
  * REST API Reports products controller class.
  *
  * @internal
- * @extends WC_REST_Reports_Controller
+ * @extends AbstractController
  */
-class Controller extends \WC_REST_Reports_Controller implements ExportableInterface {
-
-	/**
-	 * Endpoint namespace.
-	 *
-	 * @var string
-	 */
-	protected $namespace = 'wc-analytics';
+class Controller extends AbstractController implements ExportableInterface {
 
 	/**
 	 * Route base.
@@ -77,28 +71,13 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			$data[] = $this->prepare_response_for_collection( $item );
 		}
 
-		$response = rest_ensure_response( $data );
-		$response->header( 'X-WP-Total', (int) $products_data->total );
-		$response->header( 'X-WP-TotalPages', (int) $products_data->pages );
-
-		$page      = $products_data->page_no;
-		$max_pages = $products_data->pages;
-		$base      = add_query_arg( $request->get_query_params(), rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ) );
-		if ( $page > 1 ) {
-			$prev_page = $page - 1;
-			if ( $prev_page > $max_pages ) {
-				$prev_page = $max_pages;
-			}
-			$prev_link = add_query_arg( 'page', $prev_page, $base );
-			$response->link_header( 'prev', $prev_link );
-		}
-		if ( $max_pages > $page ) {
-			$next_page = $page + 1;
-			$next_link = add_query_arg( 'page', $next_page, $base );
-			$response->link_header( 'next', $next_link );
-		}
-
-		return $response;
+		return $this->add_pagination_headers(
+			$request,
+			$data,
+			(int) $products_data->total,
+			(int) $products_data->page_no,
+			(int) $products_data->pages
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/Controller.php
@@ -9,7 +9,7 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Products\Stats;
 
 defined( 'ABSPATH' ) || exit;
 
-use Automattic\WooCommerce\Admin\API\Reports\AbstractController;
+use Automattic\WooCommerce\Admin\API\Reports\GenericStatsController;
 use Automattic\WooCommerce\Admin\API\Reports\ParameterException;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -18,9 +18,9 @@ use WP_REST_Response;
  * REST API Reports products stats controller class.
  *
  * @internal
- * @extends AbstractController
+ * @extends GenericStatsController
  */
-class Controller extends AbstractController {
+class Controller extends GenericStatsController {
 
 	/**
 	 * Route base.
@@ -295,20 +295,6 @@ class Controller extends AbstractController {
 			'net_revenue',
 			'orders_count',
 			'items_sold',
-		);
-		$params['interval']        = array(
-			'description'       => __( 'Time interval to use for buckets in the returned data.', 'woocommerce' ),
-			'type'              => 'string',
-			'default'           => 'week',
-			'enum'              => array(
-				'hour',
-				'day',
-				'week',
-				'month',
-				'quarter',
-				'year',
-			),
-			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['categories']      = array(
 			'description'       => __( 'Limit result to items from the specified categories.', 'woocommerce' ),

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/Controller.php
@@ -284,7 +284,7 @@ class Controller extends AbstractController {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params = parent::get_collection_params();
+		$params                    = parent::get_collection_params();
 		$params['orderby']['enum'] = array(
 			'date',
 			'net_revenue',
@@ -296,7 +296,7 @@ class Controller extends AbstractController {
 			'orders_count',
 			'items_sold',
 		);
-		$params['interval']   = array(
+		$params['interval']        = array(
 			'description'       => __( 'Time interval to use for buckets in the returned data.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'week',
@@ -310,7 +310,7 @@ class Controller extends AbstractController {
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['categories'] = array(
+		$params['categories']      = array(
 			'description'       => __( 'Limit result to items from the specified categories.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
@@ -319,7 +319,7 @@ class Controller extends AbstractController {
 				'type' => 'integer',
 			),
 		);
-		$params['products']   = array(
+		$params['products']        = array(
 			'description'       => __( 'Limit result to items with specified product ids.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
@@ -328,7 +328,7 @@ class Controller extends AbstractController {
 				'type' => 'integer',
 			),
 		);
-		$params['variations'] = array(
+		$params['variations']      = array(
 			'description'       => __( 'Limit result to items with specified variation ids.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
@@ -337,7 +337,7 @@ class Controller extends AbstractController {
 				'type' => 'integer',
 			),
 		);
-		$params['segmentby']  = array(
+		$params['segmentby']       = array(
 			'description'       => __( 'Segment the response by additional constraint.', 'woocommerce' ),
 			'type'              => 'string',
 			'enum'              => array(
@@ -347,7 +347,7 @@ class Controller extends AbstractController {
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['fields']     = array(
+		$params['fields']          = array(
 			'description'       => __( 'Limit stats fields to the specified items.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_slug_list',

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/Controller.php
@@ -129,7 +129,7 @@ class Controller extends GenericStatsController {
 	 *
 	 * @return array
 	 */
-	public function get_item_properties_schema() {
+	protected function get_item_properties_schema() {
 		return array(
 			'items_sold'   => array(
 				'title'       => __( 'Products sold', 'woocommerce' ),

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/Controller.php
@@ -124,12 +124,13 @@ class Controller extends GenericStatsController {
 	}
 
 	/**
-	 * Get the Report's schema, conforming to JSON Schema.
+	 * Get the Report's item properties schema.
+	 * Will be used by `get_item_schema` as `totals` and `subtotals`.
 	 *
 	 * @return array
 	 */
-	public function get_item_schema() {
-		$data_values = array(
+	public function get_item_properties_schema() {
+		return array(
 			'items_sold'   => array(
 				'title'       => __( 'Products sold', 'woocommerce' ),
 				'description' => __( 'Number of product items sold.', 'woocommerce' ),
@@ -152,106 +153,27 @@ class Controller extends GenericStatsController {
 				'readonly'    => true,
 			),
 		);
+	}
 
-		$segments = array(
-			'segments' => array(
-				'description' => __( 'Reports data grouped by segment condition.', 'woocommerce' ),
-				'type'        => 'array',
-				'context'     => array( 'view', 'edit' ),
-				'readonly'    => true,
-				'items'       => array(
-					'type'       => 'object',
-					'properties' => array(
-						'segment_id'    => array(
-							'description' => __( 'Segment identificator.', 'woocommerce' ),
-							'type'        => 'integer',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'segment_label' => array(
-							'description' => __( 'Human readable segment label, either product or variation name.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-							'enum'        => array( 'day', 'week', 'month', 'year' ),
-						),
-						'subtotals'     => array(
-							'description' => __( 'Interval subtotals.', 'woocommerce' ),
-							'type'        => 'object',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-							'properties'  => $data_values,
-						),
-					),
-				),
-			),
+	/**
+	 * Get the Report's schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema          = parent::get_item_schema();
+		$schema['title'] = 'report_products_stats';
+
+		$segment_label = array(
+			'description' => __( 'Human readable segment label, either product or variation name.', 'woocommerce' ),
+			'type'        => 'string',
+			'context'     => array( 'view', 'edit' ),
+			'readonly'    => true,
+			'enum'        => array( 'day', 'week', 'month', 'year' ),
 		);
 
-		$totals = array_merge( $data_values, $segments );
-
-		$schema = array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'report_products_stats',
-			'type'       => 'object',
-			'properties' => array(
-				'totals'    => array(
-					'description' => __( 'Totals data.', 'woocommerce' ),
-					'type'        => 'object',
-					'context'     => array( 'view', 'edit' ),
-					'readonly'    => true,
-					'properties'  => $totals,
-				),
-				'intervals' => array(
-					'description' => __( 'Reports data grouped by intervals.', 'woocommerce' ),
-					'type'        => 'array',
-					'context'     => array( 'view', 'edit' ),
-					'readonly'    => true,
-					'items'       => array(
-						'type'       => 'object',
-						'properties' => array(
-							'interval'       => array(
-								'description' => __( 'Type of interval.', 'woocommerce' ),
-								'type'        => 'string',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-								'enum'        => array( 'day', 'week', 'month', 'year' ),
-							),
-							'date_start'     => array(
-								'description' => __( "The date the report start, in the site's timezone.", 'woocommerce' ),
-								'type'        => 'date-time',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'date_start_gmt' => array(
-								'description' => __( 'The date the report start, as GMT.', 'woocommerce' ),
-								'type'        => 'date-time',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'date_end'       => array(
-								'description' => __( "The date the report end, in the site's timezone.", 'woocommerce' ),
-								'type'        => 'date-time',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'date_end_gmt'   => array(
-								'description' => __( 'The date the report end, as GMT.', 'woocommerce' ),
-								'type'        => 'date-time',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'subtotals'      => array(
-								'description' => __( 'Interval subtotals.', 'woocommerce' ),
-								'type'        => 'object',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-								'properties'  => $totals,
-							),
-						),
-					),
-				),
-			),
-		);
+		$schema['properties']['totals']['properties']['segments']['items']['properties']['segment_label'] = $segment_label;
+		$schema['properties']['intervals']['items']['properties']['subtotals']['properties']              = $segment_label;
 
 		return $this->add_additional_fields_schema( $schema );
 	}

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/Controller.php
@@ -9,22 +9,16 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Products\Stats;
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Admin\API\Reports\AbstractController;
 use Automattic\WooCommerce\Admin\API\Reports\ParameterException;
 
 /**
  * REST API Reports products stats controller class.
  *
  * @internal
- * @extends WC_REST_Reports_Controller
+ * @extends AbstractController
  */
-class Controller extends \WC_REST_Reports_Controller {
-
-	/**
-	 * Endpoint namespace.
-	 *
-	 * @var string
-	 */
-	protected $namespace = 'wc-analytics';
+class Controller extends AbstractController {
 
 	/**
 	 * Route base.
@@ -96,28 +90,13 @@ class Controller extends \WC_REST_Reports_Controller {
 			$out_data['intervals'][] = $this->prepare_response_for_collection( $item );
 		}
 
-		$response = rest_ensure_response( $out_data );
-		$response->header( 'X-WP-Total', (int) $report_data->total );
-		$response->header( 'X-WP-TotalPages', (int) $report_data->pages );
-
-		$page      = $report_data->page_no;
-		$max_pages = $report_data->pages;
-		$base      = add_query_arg( $request->get_query_params(), rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ) );
-		if ( $page > 1 ) {
-			$prev_page = $page - 1;
-			if ( $prev_page > $max_pages ) {
-				$prev_page = $max_pages;
-			}
-			$prev_link = add_query_arg( 'page', $prev_page, $base );
-			$response->link_header( 'prev', $prev_link );
-		}
-		if ( $max_pages > $page ) {
-			$next_page = $page + 1;
-			$next_link = add_query_arg( 'page', $next_page, $base );
-			$response->link_header( 'next', $next_link );
-		}
-
-		return $response;
+		return $this->add_pagination_headers(
+			$request,
+			$out_data,
+			(int) $report_data->total,
+			(int) $report_data->page_no,
+			(int) $report_data->pages
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/Controller.php
@@ -289,60 +289,17 @@ class Controller extends AbstractController {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params               = array();
-		$params['context']    = $this->get_context_param( array( 'default' => 'view' ) );
-		$params['page']       = array(
-			'description'       => __( 'Current page of the collection.', 'woocommerce' ),
-			'type'              => 'integer',
-			'default'           => 1,
-			'sanitize_callback' => 'absint',
-			'validate_callback' => 'rest_validate_request_arg',
-			'minimum'           => 1,
-		);
-		$params['per_page']   = array(
-			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
-			'type'              => 'integer',
-			'default'           => 10,
-			'minimum'           => 1,
-			'maximum'           => 100,
-			'sanitize_callback' => 'absint',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['after']      = array(
-			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce' ),
-			'type'              => 'string',
-			'format'            => 'date-time',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['before']     = array(
-			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce' ),
-			'type'              => 'string',
-			'format'            => 'date-time',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['order']      = array(
-			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce' ),
-			'type'              => 'string',
-			'default'           => 'desc',
-			'enum'              => array( 'asc', 'desc' ),
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['orderby']    = array(
-			'description'       => __( 'Sort collection by object attribute.', 'woocommerce' ),
-			'type'              => 'string',
-			'default'           => 'date',
-			'enum'              => array(
-				'date',
-				'net_revenue',
-				'coupons',
-				'refunds',
-				'shipping',
-				'taxes',
-				'net_revenue',
-				'orders_count',
-				'items_sold',
-			),
-			'validate_callback' => 'rest_validate_request_arg',
+		$params = parent::get_collection_params();
+		$params['orderby']['enum'] = array(
+			'date',
+			'net_revenue',
+			'coupons',
+			'refunds',
+			'shipping',
+			'taxes',
+			'net_revenue',
+			'orders_count',
+			'items_sold',
 		);
 		$params['interval']   = array(
 			'description'       => __( 'Time interval to use for buckets in the returned data.', 'woocommerce' ),
@@ -403,12 +360,6 @@ class Controller extends AbstractController {
 			'items'             => array(
 				'type' => 'string',
 			),
-		);
-		$params['force_cache_refresh'] = array(
-			'description'       => __( 'Force retrieval of fresh data instead of from the cache.', 'woocommerce' ),
-			'type'              => 'boolean',
-			'sanitize_callback' => 'wp_validate_boolean',
-			'validate_callback' => 'rest_validate_request_arg',
 		);
 
 		return $params;

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/Controller.php
@@ -11,6 +11,8 @@ defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Admin\API\Reports\AbstractController;
 use Automattic\WooCommerce\Admin\API\Reports\ParameterException;
+use WP_REST_Request;
+use WP_REST_Response;
 
 /**
  * REST API Reports products stats controller class.
@@ -102,19 +104,12 @@ class Controller extends AbstractController {
 	/**
 	 * Prepare a report object for serialization.
 	 *
-	 * @param Array           $report  Report data.
+	 * @param array           $report  Report data.
 	 * @param WP_REST_Request $request Request object.
 	 * @return WP_REST_Response
 	 */
 	public function prepare_item_for_response( $report, $request ) {
-		$data = $report;
-
-		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
-		$data    = $this->add_additional_fields_to_object( $data, $request );
-		$data    = $this->filter_response_by_context( $data, $context );
-
-		// Wrap the data in a response object.
-		$response = rest_ensure_response( $data );
+		$response = parent::prepare_item_for_response( $report, $request );
 
 		/**
 		 * Filter a report returned from the API.

--- a/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Products/Stats/Controller.php
@@ -172,8 +172,8 @@ class Controller extends GenericStatsController {
 			'enum'        => array( 'day', 'week', 'month', 'year' ),
 		);
 
-		$schema['properties']['totals']['properties']['segments']['items']['properties']['segment_label'] = $segment_label;
-		$schema['properties']['intervals']['items']['properties']['subtotals']['properties']              = $segment_label;
+		$schema['properties']['totals']['properties']['segments']['items']['properties']['segment_label']                                        = $segment_label;
+		$schema['properties']['intervals']['items']['properties']['subtotals']['properties']['segments']['items']['properties']['segment_label'] = $segment_label;
 
 		return $this->add_additional_fields_schema( $schema );
 	}

--- a/plugins/woocommerce/src/Admin/API/Reports/Revenue/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Revenue/Stats/Controller.php
@@ -333,61 +333,18 @@ class Controller extends AbstractController implements ExportableInterface {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params              = array();
-		$params['context']   = $this->get_context_param( array( 'default' => 'view' ) );
-		$params['page']      = array(
-			'description'       => __( 'Current page of the collection.', 'woocommerce' ),
-			'type'              => 'integer',
-			'default'           => 1,
-			'sanitize_callback' => 'absint',
-			'validate_callback' => 'rest_validate_request_arg',
-			'minimum'           => 1,
-		);
-		$params['per_page']  = array(
-			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
-			'type'              => 'integer',
-			'default'           => 10,
-			'minimum'           => 1,
-			'maximum'           => 100,
-			'sanitize_callback' => 'absint',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['after']     = array(
-			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce' ),
-			'type'              => 'string',
-			'format'            => 'date-time',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['before']    = array(
-			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce' ),
-			'type'              => 'string',
-			'format'            => 'date-time',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['order']     = array(
-			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce' ),
-			'type'              => 'string',
-			'default'           => 'desc',
-			'enum'              => array( 'asc', 'desc' ),
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['orderby']   = array(
-			'description'       => __( 'Sort collection by object attribute.', 'woocommerce' ),
-			'type'              => 'string',
-			'default'           => 'date',
-			'enum'              => array(
-				'date',
-				'total_sales',
-				'coupons',
-				'refunds',
-				'shipping',
-				'taxes',
-				'net_revenue',
-				'orders_count',
-				'items_sold',
-				'gross_sales',
-			),
-			'validate_callback' => 'rest_validate_request_arg',
+		$params = parent::get_collection_params();
+		$params['orderby']['enum'] = array(
+			'date',
+			'total_sales',
+			'coupons',
+			'refunds',
+			'shipping',
+			'taxes',
+			'net_revenue',
+			'orders_count',
+			'items_sold',
+			'gross_sales',
 		);
 		$params['interval']  = array(
 			'description'       => __( 'Time interval to use for buckets in the returned data.', 'woocommerce' ),
@@ -413,12 +370,6 @@ class Controller extends AbstractController implements ExportableInterface {
 				'coupon',
 				'customer_type', // new vs returning.
 			),
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['force_cache_refresh'] = array(
-			'description'       => __( 'Force retrieval of fresh data instead of from the cache.', 'woocommerce' ),
-			'type'              => 'boolean',
-			'sanitize_callback' => 'wp_validate_boolean',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Revenue/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Revenue/Stats/Controller.php
@@ -133,12 +133,13 @@ class Controller extends GenericStatsController implements ExportableInterface {
 	}
 
 	/**
-	 * Get the Report's schema, conforming to JSON Schema.
+	 * Get the Report's item properties schema.
+	 * Will be used by `get_item_schema` as `totals` and `subtotals`.
 	 *
 	 * @return array
 	 */
-	public function get_item_schema() {
-		$data_values = array(
+	public function get_item_properties_schema() {
+		return array(
 			'total_sales'    => array(
 				'description' => __( 'Total sales.', 'woocommerce' ),
 				'type'        => 'number',
@@ -205,12 +206,6 @@ class Controller extends GenericStatsController implements ExportableInterface {
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
-			'products'       => array(
-				'description' => __( 'Products sold.', 'woocommerce' ),
-				'type'        => 'integer',
-				'context'     => array( 'view', 'edit' ),
-				'readonly'    => true,
-			),
 			'gross_sales'    => array(
 				'description' => __( 'Gross sales.', 'woocommerce' ),
 				'type'        => 'number',
@@ -220,103 +215,23 @@ class Controller extends GenericStatsController implements ExportableInterface {
 				'format'      => 'currency',
 			),
 		);
+	}
 
-		$segments = array(
-			'segments' => array(
-				'description' => __( 'Reports data grouped by segment condition.', 'woocommerce' ),
-				'type'        => 'array',
-				'context'     => array( 'view', 'edit' ),
-				'readonly'    => true,
-				'items'       => array(
-					'type'       => 'object',
-					'properties' => array(
-						'segment_id' => array(
-							'description' => __( 'Segment identificator.', 'woocommerce' ),
-							'type'        => 'integer',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'subtotals'  => array(
-							'description' => __( 'Interval subtotals.', 'woocommerce' ),
-							'type'        => 'object',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-							'properties'  => $data_values,
-						),
-					),
-				),
-			),
-		);
+	/**
+	 * Get the Report's schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema          = parent::get_item_schema();
+		$schema['title'] = 'report_revenue_stats';
 
-		$totals = array_merge( $data_values, $segments );
-
-		// Products is not shown in intervals.
-		unset( $data_values['products'] );
-
-		$intervals = array_merge( $data_values, $segments );
-
-		$schema = array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'report_revenue_stats',
-			'type'       => 'object',
-			'properties' => array(
-				'totals'    => array(
-					'description' => __( 'Totals data.', 'woocommerce' ),
-					'type'        => 'object',
-					'context'     => array( 'view', 'edit' ),
-					'readonly'    => true,
-					'properties'  => $totals,
-				),
-				'intervals' => array(
-					'description' => __( 'Reports data grouped by intervals.', 'woocommerce' ),
-					'type'        => 'array',
-					'context'     => array( 'view', 'edit' ),
-					'readonly'    => true,
-					'items'       => array(
-						'type'       => 'object',
-						'properties' => array(
-							'interval'       => array(
-								'description' => __( 'Type of interval.', 'woocommerce' ),
-								'type'        => 'string',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-								'enum'        => array( 'day', 'week', 'month', 'year' ),
-							),
-							'date_start'     => array(
-								'description' => __( "The date the report start, in the site's timezone.", 'woocommerce' ),
-								'type'        => 'date-time',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'date_start_gmt' => array(
-								'description' => __( 'The date the report start, as GMT.', 'woocommerce' ),
-								'type'        => 'date-time',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'date_end'       => array(
-								'description' => __( "The date the report end, in the site's timezone.", 'woocommerce' ),
-								'type'        => 'date-time',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'date_end_gmt'   => array(
-								'description' => __( 'The date the report end, as GMT.', 'woocommerce' ),
-								'type'        => 'date-time',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'subtotals'      => array(
-								'description' => __( 'Interval subtotals.', 'woocommerce' ),
-								'type'        => 'object',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-								'properties'  => $intervals,
-							),
-						),
-					),
-				),
-			),
+		// Products is not shown in intervals, only in totals.
+		$schema['properties']['totals']['properties']['products'] = array(
+			'description' => __( 'Products sold.', 'woocommerce' ),
+			'type'        => 'integer',
+			'context'     => array( 'view', 'edit' ),
+			'readonly'    => true,
 		);
 
 		return $this->add_additional_fields_schema( $schema );

--- a/plugins/woocommerce/src/Admin/API/Reports/Revenue/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Revenue/Stats/Controller.php
@@ -9,7 +9,7 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Revenue\Stats;
 
 defined( 'ABSPATH' ) || exit;
 
-use Automattic\WooCommerce\Admin\API\Reports\AbstractController;
+use Automattic\WooCommerce\Admin\API\Reports\GenericStatsController;
 use Automattic\WooCommerce\Admin\API\Reports\Revenue\Query as RevenueQuery;
 use Automattic\WooCommerce\Admin\API\Reports\ExportableInterface;
 use Automattic\WooCommerce\Admin\API\Reports\ExportableTraits;
@@ -21,9 +21,9 @@ use WP_REST_Response;
  * REST API Reports revenue stats controller class.
  *
  * @internal
- * @extends AbstractController
+ * @extends GenericStatsController
  */
-class Controller extends AbstractController implements ExportableInterface {
+class Controller extends GenericStatsController implements ExportableInterface {
 	/**
 	 * Exportable traits.
 	 */
@@ -340,20 +340,6 @@ class Controller extends AbstractController implements ExportableInterface {
 			'orders_count',
 			'items_sold',
 			'gross_sales',
-		);
-		$params['interval']        = array(
-			'description'       => __( 'Time interval to use for buckets in the returned data.', 'woocommerce' ),
-			'type'              => 'string',
-			'default'           => 'week',
-			'enum'              => array(
-				'hour',
-				'day',
-				'week',
-				'month',
-				'quarter',
-				'year',
-			),
-			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['segmentby']       = array(
 			'description'       => __( 'Segment the response by additional constraint.', 'woocommerce' ),

--- a/plugins/woocommerce/src/Admin/API/Reports/Revenue/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Revenue/Stats/Controller.php
@@ -14,6 +14,8 @@ use Automattic\WooCommerce\Admin\API\Reports\Revenue\Query as RevenueQuery;
 use Automattic\WooCommerce\Admin\API\Reports\ExportableInterface;
 use Automattic\WooCommerce\Admin\API\Reports\ExportableTraits;
 use Automattic\WooCommerce\Admin\API\Reports\ParameterException;
+use WP_REST_Request;
+use WP_REST_Response;
 
 /**
  * REST API Reports revenue stats controller class.
@@ -111,19 +113,12 @@ class Controller extends AbstractController implements ExportableInterface {
 	/**
 	 * Prepare a report object for serialization.
 	 *
-	 * @param Array           $report  Report data.
+	 * @param array           $report  Report data.
 	 * @param WP_REST_Request $request Request object.
 	 * @return WP_REST_Response
 	 */
 	public function prepare_item_for_response( $report, $request ) {
-		$data = $report;
-
-		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
-		$data    = $this->add_additional_fields_to_object( $data, $request );
-		$data    = $this->filter_response_by_context( $data, $context );
-
-		// Wrap the data in a response object.
-		$response = rest_ensure_response( $data );
+		$response = parent::prepare_item_for_response( $report, $request );
 
 		/**
 		 * Filter a report returned from the API.

--- a/plugins/woocommerce/src/Admin/API/Reports/Revenue/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Revenue/Stats/Controller.php
@@ -328,7 +328,7 @@ class Controller extends AbstractController implements ExportableInterface {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params = parent::get_collection_params();
+		$params                    = parent::get_collection_params();
 		$params['orderby']['enum'] = array(
 			'date',
 			'total_sales',
@@ -341,7 +341,7 @@ class Controller extends AbstractController implements ExportableInterface {
 			'items_sold',
 			'gross_sales',
 		);
-		$params['interval']  = array(
+		$params['interval']        = array(
 			'description'       => __( 'Time interval to use for buckets in the returned data.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'week',
@@ -355,7 +355,7 @@ class Controller extends AbstractController implements ExportableInterface {
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['segmentby'] = array(
+		$params['segmentby']       = array(
 			'description'       => __( 'Segment the response by additional constraint.', 'woocommerce' ),
 			'type'              => 'string',
 			'enum'              => array(

--- a/plugins/woocommerce/src/Admin/API/Reports/Revenue/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Revenue/Stats/Controller.php
@@ -138,7 +138,7 @@ class Controller extends GenericStatsController implements ExportableInterface {
 	 *
 	 * @return array
 	 */
-	public function get_item_properties_schema() {
+	protected function get_item_properties_schema() {
 		return array(
 			'total_sales'    => array(
 				'description' => __( 'Total sales.', 'woocommerce' ),

--- a/plugins/woocommerce/src/Admin/API/Reports/Revenue/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Revenue/Stats/Controller.php
@@ -9,6 +9,7 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Revenue\Stats;
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Admin\API\Reports\AbstractController;
 use Automattic\WooCommerce\Admin\API\Reports\Revenue\Query as RevenueQuery;
 use Automattic\WooCommerce\Admin\API\Reports\ExportableInterface;
 use Automattic\WooCommerce\Admin\API\Reports\ExportableTraits;
@@ -18,20 +19,13 @@ use Automattic\WooCommerce\Admin\API\Reports\ParameterException;
  * REST API Reports revenue stats controller class.
  *
  * @internal
- * @extends WC_REST_Reports_Controller
+ * @extends AbstractController
  */
-class Controller extends \WC_REST_Reports_Controller implements ExportableInterface {
+class Controller extends AbstractController implements ExportableInterface {
 	/**
 	 * Exportable traits.
 	 */
 	use ExportableTraits;
-
-	/**
-	 * Endpoint namespace.
-	 *
-	 * @var string
-	 */
-	protected $namespace = 'wc-analytics';
 
 	/**
 	 * Route base.
@@ -87,28 +81,13 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			$out_data['intervals'][] = $this->prepare_response_for_collection( $item );
 		}
 
-		$response = rest_ensure_response( $out_data );
-		$response->header( 'X-WP-Total', (int) $report_data->total );
-		$response->header( 'X-WP-TotalPages', (int) $report_data->pages );
-
-		$page      = $report_data->page_no;
-		$max_pages = $report_data->pages;
-		$base      = add_query_arg( $request->get_query_params(), rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ) );
-		if ( $page > 1 ) {
-			$prev_page = $page - 1;
-			if ( $prev_page > $max_pages ) {
-				$prev_page = $max_pages;
-			}
-			$prev_link = add_query_arg( 'page', $prev_page, $base );
-			$response->link_header( 'prev', $prev_link );
-		}
-		if ( $max_pages > $page ) {
-			$next_page = $page + 1;
-			$next_link = add_query_arg( 'page', $next_page, $base );
-			$response->link_header( 'next', $next_link );
-		}
-
-		return $response;
+		return $this->add_pagination_headers(
+			$request,
+			$out_data,
+			(int) $report_data->total,
+			(int) $report_data->page_no,
+			(int) $report_data->pages
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/API/Reports/Stock/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Stock/Controller.php
@@ -11,6 +11,8 @@ defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Admin\API\Reports\AbstractController;
 use Automattic\WooCommerce\Admin\API\Reports\ExportableInterface;
+use WP_REST_Request;
+use WP_REST_Response;
 
 /**
  * REST API Reports stock controller class.
@@ -296,12 +298,7 @@ class Controller extends AbstractController implements ExportableInterface {
 			$data['low_stock_amount'] = absint( max( get_option( 'woocommerce_notify_low_stock_amount' ), 1 ) );
 		}
 
-		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
-		$data    = $this->add_additional_fields_to_object( $data, $request );
-		$data    = $this->filter_response_by_context( $data, $context );
-
-		// Wrap the data in a response object.
-		$response = rest_ensure_response( $data );
+		$response = parent::prepare_item_for_response( $data, $request );
 		$response->add_links( $this->prepare_links( $product ) );
 
 		/**

--- a/plugins/woocommerce/src/Admin/API/Reports/Stock/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Stock/Controller.php
@@ -418,25 +418,8 @@ class Controller extends AbstractController implements ExportableInterface {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params                   = array();
-		$params['context']        = $this->get_context_param( array( 'default' => 'view' ) );
-		$params['page']           = array(
-			'description'       => __( 'Current page of the collection.', 'woocommerce' ),
-			'type'              => 'integer',
-			'default'           => 1,
-			'sanitize_callback' => 'absint',
-			'validate_callback' => 'rest_validate_request_arg',
-			'minimum'           => 1,
-		);
-		$params['per_page']       = array(
-			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
-			'type'              => 'integer',
-			'default'           => 10,
-			'minimum'           => 1,
-			'maximum'           => 100,
-			'sanitize_callback' => 'absint',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
+		$params = parent::get_collection_params();
+		unset( $params['after'], $params['before'], $params['force_cache_refresh'] );
 		$params['exclude']        = array(
 			'description'       => __( 'Ensure result set excludes specific IDs.', 'woocommerce' ),
 			'type'              => 'array',
@@ -461,27 +444,16 @@ class Controller extends AbstractController implements ExportableInterface {
 			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['order']          = array(
-			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce' ),
-			'type'              => 'string',
-			'default'           => 'asc',
-			'enum'              => array( 'asc', 'desc' ),
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['orderby']        = array(
-			'description'       => __( 'Sort collection by object attribute.', 'woocommerce' ),
-			'type'              => 'string',
-			'default'           => 'stock_status',
-			'enum'              => array(
-				'stock_status',
-				'stock_quantity',
-				'date',
-				'id',
-				'include',
-				'title',
-				'sku',
-			),
-			'validate_callback' => 'rest_validate_request_arg',
+		$params['order']['default'] = 'asc';
+		$params['orderby']['default'] = 'stock_status';
+		$params['orderby']['enum'] = array(
+			'stock_status',
+			'stock_quantity',
+			'date',
+			'id',
+			'include',
+			'title',
+			'sku',
 		);
 		$params['parent']         = array(
 			'description'       => __( 'Limit result set to those of particular parent IDs.', 'woocommerce' ),

--- a/plugins/woocommerce/src/Admin/API/Reports/Stock/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Stock/Controller.php
@@ -9,7 +9,7 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Stock;
 
 defined( 'ABSPATH' ) || exit;
 
-use Automattic\WooCommerce\Admin\API\Reports\AbstractController;
+use Automattic\WooCommerce\Admin\API\Reports\GenericController;
 use Automattic\WooCommerce\Admin\API\Reports\ExportableInterface;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -18,9 +18,9 @@ use WP_REST_Response;
  * REST API Reports stock controller class.
  *
  * @internal
- * @extends AbstractController
+ * @extends GenericController
  */
-class Controller extends AbstractController implements ExportableInterface {
+class Controller extends GenericController implements ExportableInterface {
 
 	/**
 	 * Route base.

--- a/plugins/woocommerce/src/Admin/API/Reports/Stock/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Stock/Controller.php
@@ -9,22 +9,16 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Stock;
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Admin\API\Reports\AbstractController;
 use Automattic\WooCommerce\Admin\API\Reports\ExportableInterface;
 
 /**
  * REST API Reports stock controller class.
  *
  * @internal
- * @extends WC_REST_Reports_Controller
+ * @extends AbstractController
  */
-class Controller extends \WC_REST_Reports_Controller implements ExportableInterface {
-
-	/**
-	 * Endpoint namespace.
-	 *
-	 * @var string
-	 */
-	protected $namespace = 'wc-analytics';
+class Controller extends AbstractController implements ExportableInterface {
 
 	/**
 	 * Route base.
@@ -136,30 +130,13 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			$objects[] = $this->prepare_response_for_collection( $data );
 		}
 
-		$page      = (int) $query_args['paged'];
-		$max_pages = $query_results['pages'];
-
-		$response = rest_ensure_response( $objects );
-		$response->header( 'X-WP-Total', $query_results['total'] );
-		$response->header( 'X-WP-TotalPages', (int) $max_pages );
-
-		$base = add_query_arg( $request->get_query_params(), rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ) );
-
-		if ( $page > 1 ) {
-			$prev_page = $page - 1;
-			if ( $prev_page > $max_pages ) {
-				$prev_page = $max_pages;
-			}
-			$prev_link = add_query_arg( 'page', $prev_page, $base );
-			$response->link_header( 'prev', $prev_link );
-		}
-		if ( $max_pages > $page ) {
-			$next_page = $page + 1;
-			$next_link = add_query_arg( 'page', $next_page, $base );
-			$response->link_header( 'next', $next_link );
-		}
-
-		return $response;
+		return $this->add_pagination_headers(
+			$request,
+			$objects,
+			(int) $query_results['total'],
+			(int) $query_args['paged'],
+			(int) $query_results['pages']
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/API/Reports/Stock/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Stock/Controller.php
@@ -417,7 +417,7 @@ class Controller extends AbstractController implements ExportableInterface {
 	public function get_collection_params() {
 		$params = parent::get_collection_params();
 		unset( $params['after'], $params['before'], $params['force_cache_refresh'] );
-		$params['exclude']        = array(
+		$params['exclude']            = array(
 			'description'       => __( 'Ensure result set excludes specific IDs.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
@@ -426,7 +426,7 @@ class Controller extends AbstractController implements ExportableInterface {
 			'default'           => array(),
 			'sanitize_callback' => 'wp_parse_id_list',
 		);
-		$params['include']        = array(
+		$params['include']            = array(
 			'description'       => __( 'Limit result set to specific ids.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
@@ -435,15 +435,15 @@ class Controller extends AbstractController implements ExportableInterface {
 			'default'           => array(),
 			'sanitize_callback' => 'wp_parse_id_list',
 		);
-		$params['offset']         = array(
+		$params['offset']             = array(
 			'description'       => __( 'Offset the result set by a specific number of items.', 'woocommerce' ),
 			'type'              => 'integer',
 			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['order']['default'] = 'asc';
+		$params['order']['default']   = 'asc';
 		$params['orderby']['default'] = 'stock_status';
-		$params['orderby']['enum'] = array(
+		$params['orderby']['enum']    = array(
 			'stock_status',
 			'stock_quantity',
 			'date',
@@ -452,7 +452,7 @@ class Controller extends AbstractController implements ExportableInterface {
 			'title',
 			'sku',
 		);
-		$params['parent']         = array(
+		$params['parent']             = array(
 			'description'       => __( 'Limit result set to those of particular parent IDs.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
@@ -461,7 +461,7 @@ class Controller extends AbstractController implements ExportableInterface {
 			'sanitize_callback' => 'wp_parse_id_list',
 			'default'           => array(),
 		);
-		$params['parent_exclude'] = array(
+		$params['parent_exclude']     = array(
 			'description'       => __( 'Limit result set to all items except those of a particular parent ID.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
@@ -470,7 +470,7 @@ class Controller extends AbstractController implements ExportableInterface {
 			'sanitize_callback' => 'wp_parse_id_list',
 			'default'           => array(),
 		);
-		$params['type']           = array(
+		$params['type']               = array(
 			'description' => __( 'Limit result set to items assigned a stock report type.', 'woocommerce' ),
 			'type'        => 'string',
 			'default'     => 'all',

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/Controller.php
@@ -12,6 +12,8 @@ defined( 'ABSPATH' ) || exit;
 use Automattic\WooCommerce\Admin\API\Reports\AbstractController;
 use Automattic\WooCommerce\Admin\API\Reports\ExportableInterface;
 use Automattic\WooCommerce\Admin\API\Reports\ExportableTraits;
+use WP_REST_Request;
+use WP_REST_Response;
 
 /**
  * REST API Reports taxes controller class.
@@ -87,12 +89,7 @@ class Controller extends AbstractController implements ExportableInterface {
 	 * @return WP_REST_Response
 	 */
 	public function prepare_item_for_response( $report, $request ) {
-		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
-		$report  = $this->add_additional_fields_to_object( $report, $request );
-		$report  = $this->filter_response_by_context( $report, $context );
-
-		// Wrap the data in a response object.
-		$response = rest_ensure_response( $report );
+		$response = parent::prepare_item_for_response( $report, $request );
 		$response->add_links( $this->prepare_links( $report ) );
 
 		/**

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/Controller.php
@@ -9,7 +9,7 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Taxes;
 
 defined( 'ABSPATH' ) || exit;
 
-use Automattic\WooCommerce\Admin\API\Reports\AbstractController;
+use Automattic\WooCommerce\Admin\API\Reports\GenericController;
 use Automattic\WooCommerce\Admin\API\Reports\ExportableInterface;
 use Automattic\WooCommerce\Admin\API\Reports\ExportableTraits;
 use WP_REST_Request;
@@ -19,9 +19,9 @@ use WP_REST_Response;
  * REST API Reports taxes controller class.
  *
  * @internal
- * @extends AbstractController
+ * @extends GenericController
  */
-class Controller extends AbstractController implements ExportableInterface {
+class Controller extends GenericController implements ExportableInterface {
 	/**
 	 * Exportable traits.
 	 */

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/Controller.php
@@ -9,6 +9,7 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Taxes;
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Admin\API\Reports\AbstractController;
 use Automattic\WooCommerce\Admin\API\Reports\ExportableInterface;
 use Automattic\WooCommerce\Admin\API\Reports\ExportableTraits;
 
@@ -16,20 +17,13 @@ use Automattic\WooCommerce\Admin\API\Reports\ExportableTraits;
  * REST API Reports taxes controller class.
  *
  * @internal
- * @extends WC_REST_Reports_Controller
+ * @extends AbstractController
  */
-class Controller extends \WC_REST_Reports_Controller implements ExportableInterface {
+class Controller extends AbstractController implements ExportableInterface {
 	/**
 	 * Exportable traits.
 	 */
 	use ExportableTraits;
-
-	/**
-	 * Endpoint namespace.
-	 *
-	 * @var string
-	 */
-	protected $namespace = 'wc-analytics';
 
 	/**
 	 * Route base.
@@ -76,28 +70,13 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			$data[] = $this->prepare_response_for_collection( $item );
 		}
 
-		$response = rest_ensure_response( $data );
-		$response->header( 'X-WP-Total', (int) $report_data->total );
-		$response->header( 'X-WP-TotalPages', (int) $report_data->pages );
-
-		$page      = $report_data->page_no;
-		$max_pages = $report_data->pages;
-		$base      = add_query_arg( $request->get_query_params(), rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ) );
-		if ( $page > 1 ) {
-			$prev_page = $page - 1;
-			if ( $prev_page > $max_pages ) {
-				$prev_page = $max_pages;
-			}
-			$prev_link = add_query_arg( 'page', $prev_page, $base );
-			$response->link_header( 'prev', $prev_link );
-		}
-		if ( $max_pages > $page ) {
-			$next_page = $page + 1;
-			$next_link = add_query_arg( 'page', $next_page, $base );
-			$response->link_header( 'next', $next_link );
-		}
-
-		return $response;
+		return $this->add_pagination_headers(
+			$request,
+			$data,
+			(int) $report_data->total,
+			(int) $report_data->page_no,
+			(int) $report_data->pages
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/Controller.php
@@ -206,59 +206,17 @@ class Controller extends AbstractController implements ExportableInterface {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params             = array();
-		$params['context']  = $this->get_context_param( array( 'default' => 'view' ) );
-		$params['page']     = array(
-			'description'       => __( 'Current page of the collection.', 'woocommerce' ),
-			'type'              => 'integer',
-			'default'           => 1,
-			'sanitize_callback' => 'absint',
-			'validate_callback' => 'rest_validate_request_arg',
-			'minimum'           => 1,
-		);
-		$params['per_page'] = array(
-			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
-			'type'              => 'integer',
-			'default'           => 10,
-			'minimum'           => 1,
-			'maximum'           => 100,
-			'sanitize_callback' => 'absint',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['after']    = array(
-			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce' ),
-			'type'              => 'string',
-			'format'            => 'date-time',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['before']   = array(
-			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce' ),
-			'type'              => 'string',
-			'format'            => 'date-time',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['order']    = array(
-			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce' ),
-			'type'              => 'string',
-			'default'           => 'desc',
-			'enum'              => array( 'asc', 'desc' ),
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['orderby']  = array(
-			'description'       => __( 'Sort collection by object attribute.', 'woocommerce' ),
-			'type'              => 'string',
-			'default'           => 'tax_rate_id',
-			'enum'              => array(
-				'name',
-				'tax_rate_id',
-				'tax_code',
-				'rate',
-				'order_tax',
-				'total_tax',
-				'shipping_tax',
-				'orders_count',
-			),
-			'validate_callback' => 'rest_validate_request_arg',
+		$params = parent::get_collection_params();
+		$params['orderby']['default'] = 'tax_rate_id';
+		$params['orderby']['enum'] = array(
+			'name',
+			'tax_rate_id',
+			'tax_code',
+			'rate',
+			'order_tax',
+			'total_tax',
+			'shipping_tax',
+			'orders_count',
 		);
 		$params['taxes']    = array(
 			'description'       => __( 'Limit result set to items assigned one or more tax rates.', 'woocommerce' ),
@@ -268,12 +226,6 @@ class Controller extends AbstractController implements ExportableInterface {
 			'items'             => array(
 				'type' => 'string',
 			),
-		);
-		$params['force_cache_refresh'] = array(
-			'description'       => __( 'Force retrieval of fresh data instead of from the cache.', 'woocommerce' ),
-			'type'              => 'boolean',
-			'sanitize_callback' => 'wp_validate_boolean',
-			'validate_callback' => 'rest_validate_request_arg',
 		);
 
 		return $params;

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/Controller.php
@@ -203,9 +203,9 @@ class Controller extends AbstractController implements ExportableInterface {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params = parent::get_collection_params();
+		$params                       = parent::get_collection_params();
 		$params['orderby']['default'] = 'tax_rate_id';
-		$params['orderby']['enum'] = array(
+		$params['orderby']['enum']    = array(
 			'name',
 			'tax_rate_id',
 			'tax_code',
@@ -215,7 +215,7 @@ class Controller extends AbstractController implements ExportableInterface {
 			'shipping_tax',
 			'orders_count',
 		);
-		$params['taxes']    = array(
+		$params['taxes']              = array(
 			'description'       => __( 'Limit result set to items assigned one or more tax rates.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/Controller.php
@@ -284,7 +284,6 @@ class Controller extends AbstractController {
 	 */
 	public function get_collection_params() {
 		$params                    = parent::get_collection_params();
-		$params                    = array();
 		$params['orderby']['enum'] = array(
 			'date',
 			'items_sold',

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/Controller.php
@@ -10,6 +10,8 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Taxes\Stats;
 defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Admin\API\Reports\AbstractController;
+use WP_REST_Request;
+use WP_REST_Response;
 
 /**
  * REST API Reports taxes stats controller class.
@@ -120,12 +122,7 @@ class Controller extends AbstractController {
 	public function prepare_item_for_response( $report, $request ) {
 		$data = get_object_vars( $report );
 
-		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
-		$data    = $this->add_additional_fields_to_object( $data, $request );
-		$data    = $this->filter_response_by_context( $data, $context );
-
-		// Wrap the data in a response object.
-		$response = rest_ensure_response( $data );
+		$response = parent::prepare_item_for_response( $data, $request );
 
 		/**
 		 * Filter a report returned from the API.

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/Controller.php
@@ -9,7 +9,7 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Taxes\Stats;
 
 defined( 'ABSPATH' ) || exit;
 
-use Automattic\WooCommerce\Admin\API\Reports\AbstractController;
+use Automattic\WooCommerce\Admin\API\Reports\GenericStatsController;
 use WP_REST_Request;
 use WP_REST_Response;
 
@@ -17,9 +17,9 @@ use WP_REST_Response;
  * REST API Reports taxes stats controller class.
  *
  * @internal
- * @extends AbstractController
+ * @extends GenericStatsController
  */
-class Controller extends AbstractController {
+class Controller extends GenericStatsController {
 
 	/**
 	 * Route base.
@@ -290,20 +290,6 @@ class Controller extends AbstractController {
 			'total_sales',
 			'orders_count',
 			'products_count',
-		);
-		$params['interval']        = array(
-			'description'       => __( 'Time interval to use for buckets in the returned data.', 'woocommerce' ),
-			'type'              => 'string',
-			'default'           => 'week',
-			'enum'              => array(
-				'hour',
-				'day',
-				'week',
-				'month',
-				'quarter',
-				'year',
-			),
-			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['taxes']           = array(
 			'description'       => __( 'Limit result set to all items that have the specified term assigned in the taxes taxonomy.', 'woocommerce' ),

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/Controller.php
@@ -142,7 +142,7 @@ class Controller extends GenericStatsController {
 	 *
 	 * @return array
 	 */
-	public function get_item_properties_schema() {
+	protected function get_item_properties_schema() {
 		return array(
 			'total_tax'    => array(
 				'description' => __( 'Total tax.', 'woocommerce' ),

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/Controller.php
@@ -286,56 +286,14 @@ class Controller extends AbstractController {
 	 * @return array
 	 */
 	public function get_collection_params() {
+		$params = parent::get_collection_params();
 		$params              = array();
-		$params['context']   = $this->get_context_param( array( 'default' => 'view' ) );
-		$params['page']      = array(
-			'description'       => __( 'Current page of the collection.', 'woocommerce' ),
-			'type'              => 'integer',
-			'default'           => 1,
-			'sanitize_callback' => 'absint',
-			'validate_callback' => 'rest_validate_request_arg',
-			'minimum'           => 1,
-		);
-		$params['per_page']  = array(
-			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
-			'type'              => 'integer',
-			'default'           => 10,
-			'minimum'           => 1,
-			'maximum'           => 100,
-			'sanitize_callback' => 'absint',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['after']     = array(
-			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce' ),
-			'type'              => 'string',
-			'format'            => 'date-time',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['before']    = array(
-			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce' ),
-			'type'              => 'string',
-			'format'            => 'date-time',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['order']     = array(
-			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce' ),
-			'type'              => 'string',
-			'default'           => 'desc',
-			'enum'              => array( 'asc', 'desc' ),
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['orderby']   = array(
-			'description'       => __( 'Sort collection by object attribute.', 'woocommerce' ),
-			'type'              => 'string',
-			'default'           => 'date',
-			'enum'              => array(
-				'date',
-				'items_sold',
-				'total_sales',
-				'orders_count',
-				'products_count',
-			),
-			'validate_callback' => 'rest_validate_request_arg',
+		$params['orderby']['enum'] = array(
+			'date',
+			'items_sold',
+			'total_sales',
+			'orders_count',
+			'products_count',
 		);
 		$params['interval']  = array(
 			'description'       => __( 'Time interval to use for buckets in the returned data.', 'woocommerce' ),
@@ -376,12 +334,6 @@ class Controller extends AbstractController {
 			'items'             => array(
 				'type' => 'string',
 			),
-		);
-		$params['force_cache_refresh'] = array(
-			'description'       => __( 'Force retrieval of fresh data instead of from the cache.', 'woocommerce' ),
-			'type'              => 'boolean',
-			'sanitize_callback' => 'wp_validate_boolean',
-			'validate_callback' => 'rest_validate_request_arg',
 		);
 
 		return $params;

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/Controller.php
@@ -283,8 +283,8 @@ class Controller extends AbstractController {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params = parent::get_collection_params();
-		$params              = array();
+		$params                    = parent::get_collection_params();
+		$params                    = array();
 		$params['orderby']['enum'] = array(
 			'date',
 			'items_sold',
@@ -292,7 +292,7 @@ class Controller extends AbstractController {
 			'orders_count',
 			'products_count',
 		);
-		$params['interval']  = array(
+		$params['interval']        = array(
 			'description'       => __( 'Time interval to use for buckets in the returned data.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'week',
@@ -306,7 +306,7 @@ class Controller extends AbstractController {
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['taxes']     = array(
+		$params['taxes']           = array(
 			'description'       => __( 'Limit result set to all items that have the specified term assigned in the taxes taxonomy.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
@@ -315,7 +315,7 @@ class Controller extends AbstractController {
 				'type' => 'integer',
 			),
 		);
-		$params['segmentby'] = array(
+		$params['segmentby']       = array(
 			'description'       => __( 'Segment the response by additional constraint.', 'woocommerce' ),
 			'type'              => 'string',
 			'enum'              => array(
@@ -323,7 +323,7 @@ class Controller extends AbstractController {
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['fields']    = array(
+		$params['fields']          = array(
 			'description'       => __( 'Limit stats fields to the specified items.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_slug_list',

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/Controller.php
@@ -137,12 +137,13 @@ class Controller extends GenericStatsController {
 	}
 
 	/**
-	 * Get the Report's schema, conforming to JSON Schema.
+	 * Get the Report's item properties schema.
+	 * Will be used by `get_item_schema` as `totals` and `subtotals`.
 	 *
 	 * @return array
 	 */
-	public function get_item_schema() {
-		$data_values = array(
+	public function get_item_properties_schema() {
+		return array(
 			'total_tax'    => array(
 				'description' => __( 'Total tax.', 'woocommerce' ),
 				'type'        => 'number',
@@ -180,99 +181,16 @@ class Controller extends GenericStatsController {
 				'readonly'    => true,
 			),
 		);
+	}
 
-		$segments = array(
-			'segments' => array(
-				'description' => __( 'Reports data grouped by segment condition.', 'woocommerce' ),
-				'type'        => 'array',
-				'context'     => array( 'view', 'edit' ),
-				'readonly'    => true,
-				'items'       => array(
-					'type'       => 'object',
-					'properties' => array(
-						'segment_id' => array(
-							'description' => __( 'Segment identificator.', 'woocommerce' ),
-							'type'        => 'integer',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'subtotals'  => array(
-							'description' => __( 'Interval subtotals.', 'woocommerce' ),
-							'type'        => 'object',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-							'properties'  => $data_values,
-						),
-					),
-				),
-			),
-		);
-
-		$totals = array_merge( $data_values, $segments );
-
-		$schema = array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'report_taxes_stats',
-			'type'       => 'object',
-			'properties' => array(
-				'totals'    => array(
-					'description' => __( 'Totals data.', 'woocommerce' ),
-					'type'        => 'object',
-					'context'     => array( 'view', 'edit' ),
-					'readonly'    => true,
-					'properties'  => $totals,
-				),
-				'intervals' => array(
-					'description' => __( 'Reports data grouped by intervals.', 'woocommerce' ),
-					'type'        => 'array',
-					'context'     => array( 'view', 'edit' ),
-					'readonly'    => true,
-					'items'       => array(
-						'type'       => 'object',
-						'properties' => array(
-							'interval'       => array(
-								'description' => __( 'Type of interval.', 'woocommerce' ),
-								'type'        => 'string',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-								'enum'        => array( 'day', 'week', 'month', 'year' ),
-							),
-							'date_start'     => array(
-								'description' => __( "The date the report start, in the site's timezone.", 'woocommerce' ),
-								'type'        => 'date-time',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'date_start_gmt' => array(
-								'description' => __( 'The date the report start, as GMT.', 'woocommerce' ),
-								'type'        => 'date-time',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'date_end'       => array(
-								'description' => __( "The date the report end, in the site's timezone.", 'woocommerce' ),
-								'type'        => 'date-time',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'date_end_gmt'   => array(
-								'description' => __( 'The date the report end, as GMT.', 'woocommerce' ),
-								'type'        => 'date-time',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'subtotals'      => array(
-								'description' => __( 'Interval subtotals.', 'woocommerce' ),
-								'type'        => 'object',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-								'properties'  => $totals,
-							),
-						),
-					),
-				),
-			),
-		);
+	/**
+	 * Get the Report's schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema          = parent::get_item_schema();
+		$schema['title'] = 'report_taxes_stats';
 
 		return $this->add_additional_fields_schema( $schema );
 	}

--- a/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Taxes/Stats/Controller.php
@@ -9,20 +9,15 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Taxes\Stats;
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Admin\API\Reports\AbstractController;
+
 /**
  * REST API Reports taxes stats controller class.
  *
  * @internal
- * @extends WC_REST_Reports_Controller
+ * @extends AbstractController
  */
-class Controller extends \WC_REST_Reports_Controller {
-
-	/**
-	 * Endpoint namespace.
-	 *
-	 * @var string
-	 */
-	protected $namespace = 'wc-analytics';
+class Controller extends AbstractController {
 
 	/**
 	 * Route base.
@@ -106,28 +101,13 @@ class Controller extends \WC_REST_Reports_Controller {
 			$out_data['intervals'][] = $this->prepare_response_for_collection( $item );
 		}
 
-		$response = rest_ensure_response( $out_data );
-		$response->header( 'X-WP-Total', (int) $report_data->total );
-		$response->header( 'X-WP-TotalPages', (int) $report_data->pages );
-
-		$page      = $report_data->page_no;
-		$max_pages = $report_data->pages;
-		$base      = add_query_arg( $request->get_query_params(), rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ) );
-		if ( $page > 1 ) {
-			$prev_page = $page - 1;
-			if ( $prev_page > $max_pages ) {
-				$prev_page = $max_pages;
-			}
-			$prev_link = add_query_arg( 'page', $prev_page, $base );
-			$response->link_header( 'prev', $prev_link );
-		}
-		if ( $max_pages > $page ) {
-			$next_page = $page + 1;
-			$next_link = add_query_arg( 'page', $next_page, $base );
-			$response->link_header( 'next', $next_link );
-		}
-
-		return $response;
+		return $this->add_pagination_headers(
+			$request,
+			$out_data,
+			(int) $report_data->total,
+			(int) $report_data->page_no,
+			(int) $report_data->pages
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/API/Reports/Variations/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Variations/Controller.php
@@ -82,28 +82,13 @@ class Controller extends ReportsController implements ExportableInterface {
 			$data[] = $this->prepare_response_for_collection( $item );
 		}
 
-		$response = rest_ensure_response( $data );
-		$response->header( 'X-WP-Total', (int) $products_data->total );
-		$response->header( 'X-WP-TotalPages', (int) $products_data->pages );
-
-		$page      = $products_data->page_no;
-		$max_pages = $products_data->pages;
-		$base      = add_query_arg( $request->get_query_params(), rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ) );
-		if ( $page > 1 ) {
-			$prev_page = $page - 1;
-			if ( $prev_page > $max_pages ) {
-				$prev_page = $max_pages;
-			}
-			$prev_link = add_query_arg( 'page', $prev_page, $base );
-			$response->link_header( 'prev', $prev_link );
-		}
-		if ( $max_pages > $page ) {
-			$next_page = $page + 1;
-			$next_link = add_query_arg( 'page', $next_page, $base );
-			$response->link_header( 'next', $next_link );
-		}
-
-		return $response;
+		return $this->add_pagination_headers(
+			$request,
+			$data,
+			(int) $products_data->total,
+			(int) $products_data->page_no,
+			(int) $products_data->pages
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/API/Reports/Variations/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Variations/Controller.php
@@ -243,9 +243,9 @@ class Controller extends ReportsController implements ExportableInterface {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params                      = array();
-		$params['context']           = $this->get_context_param( array( 'default' => 'view' ) );
-		$params['page']              = array(
+		$params                        = array();
+		$params['context']             = $this->get_context_param( array( 'default' => 'view' ) );
+		$params['page']                = array(
 			'description'       => __( 'Current page of the collection.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 1,
@@ -253,7 +253,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'validate_callback' => 'rest_validate_request_arg',
 			'minimum'           => 1,
 		);
-		$params['per_page']          = array(
+		$params['per_page']            = array(
 			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 10,
@@ -262,19 +262,19 @@ class Controller extends ReportsController implements ExportableInterface {
 			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['after']             = array(
+		$params['after']               = array(
 			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['before']            = array(
+		$params['before']              = array(
 			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['match']             = array(
+		$params['match']               = array(
 			'description'       => __( 'Indicates whether all the conditions should be true for the resulting set, or if any one of them is sufficient. Match affects the following parameters: status_is, status_is_not, product_includes, product_excludes, coupon_includes, coupon_excludes, customer, categories', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'all',
@@ -284,14 +284,14 @@ class Controller extends ReportsController implements ExportableInterface {
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['order']             = array(
+		$params['order']               = array(
 			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'desc',
 			'enum'              => array( 'asc', 'desc' ),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['orderby']           = array(
+		$params['orderby']             = array(
 			'description'       => __( 'Sort collection by object attribute.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'date',
@@ -304,7 +304,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['product_includes']  = array(
+		$params['product_includes']    = array(
 			'description'       => __( 'Limit result set to items that have the specified parent product(s).', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
@@ -314,7 +314,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['product_excludes']  = array(
+		$params['product_excludes']    = array(
 			'description'       => __( 'Limit result set to items that don\'t have the specified parent product(s).', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
@@ -324,7 +324,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'validate_callback' => 'rest_validate_request_arg',
 			'sanitize_callback' => 'wp_parse_id_list',
 		);
-		$params['variations']        = array(
+		$params['variations']          = array(
 			'description'       => __( 'Limit result to items with specified variation ids.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
@@ -333,14 +333,14 @@ class Controller extends ReportsController implements ExportableInterface {
 				'type' => 'integer',
 			),
 		);
-		$params['extended_info']     = array(
+		$params['extended_info']       = array(
 			'description'       => __( 'Add additional piece of info about each variation to the report.', 'woocommerce' ),
 			'type'              => 'boolean',
 			'default'           => false,
 			'sanitize_callback' => 'wc_string_to_bool',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['attribute_is']      = array(
+		$params['attribute_is']        = array(
 			'description'       => __( 'Limit result set to variations that include the specified attributes.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
@@ -349,7 +349,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'default'           => array(),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['attribute_is_not']  = array(
+		$params['attribute_is_not']    = array(
 			'description'       => __( 'Limit result set to variations that don\'t include the specified attributes.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
@@ -358,7 +358,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'default'           => array(),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['category_includes'] = array(
+		$params['category_includes']   = array(
 			'description'       => __( 'Limit result set to variations in the specified categories.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
@@ -367,7 +367,7 @@ class Controller extends ReportsController implements ExportableInterface {
 				'type' => 'integer',
 			),
 		);
-		$params['category_excludes'] = array(
+		$params['category_excludes']   = array(
 			'description'       => __( 'Limit result set to variations not in the specified categories.', 'woocommerce' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',

--- a/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/Controller.php
@@ -9,22 +9,16 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Variations\Stats;
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Admin\API\Reports\AbstractController;
 use Automattic\WooCommerce\Admin\API\Reports\ParameterException;
 
 /**
  * REST API Reports variations stats controller class.
  *
  * @internal
- * @extends WC_REST_Reports_Controller
+ * @extends AbstractController
  */
-class Controller extends \WC_REST_Reports_Controller {
-
-	/**
-	 * Endpoint namespace.
-	 *
-	 * @var string
-	 */
-	protected $namespace = 'wc-analytics';
+class Controller extends AbstractController {
 
 	/**
 	 * Route base.
@@ -100,28 +94,13 @@ class Controller extends \WC_REST_Reports_Controller {
 			$out_data['intervals'][] = $this->prepare_response_for_collection( $item );
 		}
 
-		$response = rest_ensure_response( $out_data );
-		$response->header( 'X-WP-Total', (int) $report_data->total );
-		$response->header( 'X-WP-TotalPages', (int) $report_data->pages );
-
-		$page      = $report_data->page_no;
-		$max_pages = $report_data->pages;
-		$base      = add_query_arg( $request->get_query_params(), rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ) );
-		if ( $page > 1 ) {
-			$prev_page = $page - 1;
-			if ( $prev_page > $max_pages ) {
-				$prev_page = $max_pages;
-			}
-			$prev_link = add_query_arg( 'page', $prev_page, $base );
-			$response->link_header( 'prev', $prev_link );
-		}
-		if ( $max_pages > $page ) {
-			$next_page = $page + 1;
-			$next_link = add_query_arg( 'page', $next_page, $base );
-			$response->link_header( 'next', $next_link );
-		}
-
-		return $response;
+		return $this->add_pagination_headers(
+			$request,
+			$out_data,
+			(int) $report_data->total,
+			(int) $report_data->page_no,
+			(int) $report_data->pages
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/Controller.php
@@ -11,6 +11,8 @@ defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Admin\API\Reports\AbstractController;
 use Automattic\WooCommerce\Admin\API\Reports\ParameterException;
+use WP_REST_Request;
+use WP_REST_Response;
 
 /**
  * REST API Reports variations stats controller class.
@@ -106,19 +108,12 @@ class Controller extends AbstractController {
 	/**
 	 * Prepare a report object for serialization.
 	 *
-	 * @param Array           $report  Report data.
+	 * @param array           $report  Report data.
 	 * @param WP_REST_Request $request Request object.
 	 * @return WP_REST_Response
 	 */
 	public function prepare_item_for_response( $report, $request ) {
-		$data = $report;
-
-		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
-		$data    = $this->add_additional_fields_to_object( $data, $request );
-		$data    = $this->filter_response_by_context( $data, $context );
-
-		// Wrap the data in a response object.
-		$response = rest_ensure_response( $data );
+		$response = parent::prepare_item_for_response( $report, $request );
 
 		/**
 		 * Filter a report returned from the API.

--- a/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/Controller.php
@@ -176,8 +176,8 @@ class Controller extends GenericStatsController {
 			'enum'        => array( 'day', 'week', 'month', 'year' ),
 		);
 
-		$schema['properties']['totals']['properties']['segments']['items']['properties']['segment_label'] = $segment_label;
-		$schema['properties']['intervals']['items']['properties']['subtotals']['properties']              = $segment_label;
+		$schema['properties']['totals']['properties']['segments']['items']['properties']['segment_label']                                        = $segment_label;
+		$schema['properties']['intervals']['items']['properties']['subtotals']['properties']['segments']['items']['properties']['segment_label'] = $segment_label;
 
 		return $this->add_additional_fields_schema( $schema );
 	}

--- a/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/Controller.php
@@ -133,7 +133,7 @@ class Controller extends GenericStatsController {
 	 *
 	 * @return array
 	 */
-	public function get_item_properties_schema() {
+	protected function get_item_properties_schema() {
 		return array(
 			'items_sold'   => array(
 				'title'       => __( 'Variations Sold', 'woocommerce' ),

--- a/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/Controller.php
@@ -9,7 +9,7 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Variations\Stats;
 
 defined( 'ABSPATH' ) || exit;
 
-use Automattic\WooCommerce\Admin\API\Reports\AbstractController;
+use Automattic\WooCommerce\Admin\API\Reports\GenericStatsController;
 use Automattic\WooCommerce\Admin\API\Reports\ParameterException;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -18,9 +18,9 @@ use WP_REST_Response;
  * REST API Reports variations stats controller class.
  *
  * @internal
- * @extends AbstractController
+ * @extends GenericStatsController
  */
-class Controller extends AbstractController {
+class Controller extends GenericStatsController {
 
 	/**
 	 * Route base.
@@ -308,20 +308,6 @@ class Controller extends AbstractController {
 			'net_revenue',
 			'orders_count',
 			'items_sold',
-		);
-		$params['interval']          = array(
-			'description'       => __( 'Time interval to use for buckets in the returned data.', 'woocommerce' ),
-			'type'              => 'string',
-			'default'           => 'week',
-			'enum'              => array(
-				'hour',
-				'day',
-				'week',
-				'month',
-				'quarter',
-				'year',
-			),
-			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['category_includes'] = array(
 			'description'       => __( 'Limit result to items from the specified categories.', 'woocommerce' ),

--- a/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/Controller.php
@@ -128,12 +128,13 @@ class Controller extends GenericStatsController {
 	}
 
 	/**
-	 * Get the Report's schema, conforming to JSON Schema.
+	 * Get the Report's item properties schema.
+	 * Will be used by `get_item_schema` as `totals` and `subtotals`.
 	 *
 	 * @return array
 	 */
-	public function get_item_schema() {
-		$data_values = array(
+	public function get_item_properties_schema() {
+		return array(
 			'items_sold'   => array(
 				'title'       => __( 'Variations Sold', 'woocommerce' ),
 				'description' => __( 'Number of variation items sold.', 'woocommerce' ),
@@ -156,106 +157,27 @@ class Controller extends GenericStatsController {
 				'readonly'    => true,
 			),
 		);
+	}
 
-		$segments = array(
-			'segments' => array(
-				'description' => __( 'Reports data grouped by segment condition.', 'woocommerce' ),
-				'type'        => 'array',
-				'context'     => array( 'view', 'edit' ),
-				'readonly'    => true,
-				'items'       => array(
-					'type'       => 'object',
-					'properties' => array(
-						'segment_id'    => array(
-							'description' => __( 'Segment identificator.', 'woocommerce' ),
-							'type'        => 'integer',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'segment_label' => array(
-							'description' => __( 'Human readable segment label, either product or variation name.', 'woocommerce' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-							'enum'        => array( 'day', 'week', 'month', 'year' ),
-						),
-						'subtotals'     => array(
-							'description' => __( 'Interval subtotals.', 'woocommerce' ),
-							'type'        => 'object',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-							'properties'  => $data_values,
-						),
-					),
-				),
-			),
+	/**
+	 * Get the Report's schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema          = parent::get_item_schema();
+		$schema['title'] = 'report_variations_stats';
+
+		$segment_label = array(
+			'description' => __( 'Human readable segment label, either product or variation name.', 'woocommerce' ),
+			'type'        => 'string',
+			'context'     => array( 'view', 'edit' ),
+			'readonly'    => true,
+			'enum'        => array( 'day', 'week', 'month', 'year' ),
 		);
 
-		$totals = array_merge( $data_values, $segments );
-
-		$schema = array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'report_variations_stats',
-			'type'       => 'object',
-			'properties' => array(
-				'totals'    => array(
-					'description' => __( 'Totals data.', 'woocommerce' ),
-					'type'        => 'object',
-					'context'     => array( 'view', 'edit' ),
-					'readonly'    => true,
-					'properties'  => $totals,
-				),
-				'intervals' => array(
-					'description' => __( 'Reports data grouped by intervals.', 'woocommerce' ),
-					'type'        => 'array',
-					'context'     => array( 'view', 'edit' ),
-					'readonly'    => true,
-					'items'       => array(
-						'type'       => 'object',
-						'properties' => array(
-							'interval'       => array(
-								'description' => __( 'Type of interval.', 'woocommerce' ),
-								'type'        => 'string',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-								'enum'        => array( 'day', 'week', 'month', 'year' ),
-							),
-							'date_start'     => array(
-								'description' => __( "The date the report start, in the site's timezone.", 'woocommerce' ),
-								'type'        => 'date-time',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'date_start_gmt' => array(
-								'description' => __( 'The date the report start, as GMT.', 'woocommerce' ),
-								'type'        => 'date-time',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'date_end'       => array(
-								'description' => __( "The date the report end, in the site's timezone.", 'woocommerce' ),
-								'type'        => 'date-time',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'date_end_gmt'   => array(
-								'description' => __( 'The date the report end, as GMT.', 'woocommerce' ),
-								'type'        => 'date-time',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'subtotals'      => array(
-								'description' => __( 'Interval subtotals.', 'woocommerce' ),
-								'type'        => 'object',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-								'properties'  => $totals,
-							),
-						),
-					),
-				),
-			),
-		);
+		$schema['properties']['totals']['properties']['segments']['items']['properties']['segment_label'] = $segment_label;
+		$schema['properties']['intervals']['items']['properties']['subtotals']['properties']              = $segment_label;
 
 		return $this->add_additional_fields_schema( $schema );
 	}

--- a/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/Controller.php
@@ -292,37 +292,7 @@ class Controller extends AbstractController {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params                      = array();
-		$params['context']           = $this->get_context_param( array( 'default' => 'view' ) );
-		$params['page']              = array(
-			'description'       => __( 'Current page of the collection.', 'woocommerce' ),
-			'type'              => 'integer',
-			'default'           => 1,
-			'sanitize_callback' => 'absint',
-			'validate_callback' => 'rest_validate_request_arg',
-			'minimum'           => 1,
-		);
-		$params['per_page']          = array(
-			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
-			'type'              => 'integer',
-			'default'           => 10,
-			'minimum'           => 1,
-			'maximum'           => 100,
-			'sanitize_callback' => 'absint',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['after']             = array(
-			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce' ),
-			'type'              => 'string',
-			'format'            => 'date-time',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['before']            = array(
-			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce' ),
-			'type'              => 'string',
-			'format'            => 'date-time',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
+		$params = parent::get_collection_params();
 		$params['match']             = array(
 			'description'       => __( 'Indicates whether all the conditions should be true for the resulting set, or if any one of them is sufficient. Match affects the following parameters: status_is, status_is_not, product_includes, product_excludes, coupon_includes, coupon_excludes, customer, categories', 'woocommerce' ),
 			'type'              => 'string',
@@ -333,29 +303,16 @@ class Controller extends AbstractController {
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['order']             = array(
-			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce' ),
-			'type'              => 'string',
-			'default'           => 'desc',
-			'enum'              => array( 'asc', 'desc' ),
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['orderby']           = array(
-			'description'       => __( 'Sort collection by object attribute.', 'woocommerce' ),
-			'type'              => 'string',
-			'default'           => 'date',
-			'enum'              => array(
-				'date',
-				'net_revenue',
-				'coupons',
-				'refunds',
-				'shipping',
-				'taxes',
-				'net_revenue',
-				'orders_count',
-				'items_sold',
-			),
-			'validate_callback' => 'rest_validate_request_arg',
+		$params['orderby']['enum'] = array(
+			'date',
+			'net_revenue',
+			'coupons',
+			'refunds',
+			'shipping',
+			'taxes',
+			'net_revenue',
+			'orders_count',
+			'items_sold',
 		);
 		$params['interval']          = array(
 			'description'       => __( 'Time interval to use for buckets in the returned data.', 'woocommerce' ),
@@ -453,12 +410,6 @@ class Controller extends AbstractController {
 				'type' => 'array',
 			),
 			'default'           => array(),
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-		$params['force_cache_refresh'] = array(
-			'description'       => __( 'Force retrieval of fresh data instead of from the cache.', 'woocommerce' ),
-			'type'              => 'boolean',
-			'sanitize_callback' => 'wp_validate_boolean',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 

--- a/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Variations/Stats/Controller.php
@@ -287,7 +287,7 @@ class Controller extends AbstractController {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params = parent::get_collection_params();
+		$params                      = parent::get_collection_params();
 		$params['match']             = array(
 			'description'       => __( 'Indicates whether all the conditions should be true for the resulting set, or if any one of them is sufficient. Match affects the following parameters: status_is, status_is_not, product_includes, product_excludes, coupon_includes, coupon_excludes, customer, categories', 'woocommerce' ),
 			'type'              => 'string',
@@ -298,7 +298,7 @@ class Controller extends AbstractController {
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['orderby']['enum'] = array(
+		$params['orderby']['enum']   = array(
 			'date',
 			'net_revenue',
 			'coupons',


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This code does not change any functionality. Just move code around to make the maintenance more manageable and highlight inconsistencies.

- [Remove `$rest_base` from `…\API\Reports\Controller`](https://github.com/woocommerce/woocommerce/commit/c924b21c844e52add22f293a38d63fd75f4d7f8f) 
   as it is defined in its parent `WC_REST_Controller`
- [Move `X-WP-Total` headers logic to a shared class,](https://github.com/woocommerce/woocommerce/commit/7a2a80bf8118b14935688dbb9c85a8d064915fab) 
- [Move common `get_collection_params` bits to the shared class](https://github.com/woocommerce/woocommerce/commit/9126db1abb3472df00eeb8d2489ed43afbf0b5d3) 
- [Move common `prepare_item_for_response` bits to the shared class](https://github.com/woocommerce/woocommerce/commit/9f921b8e404f8ff9dc323ecc674a4e1602fe0050) 
- [Move `interval` collection param to a shared parent class](https://github.com/woocommerce/woocommerce/pull/38048/commits/58bc88e0fcad82844182bd5f4fc12183fbc8f721)
- [Move common stats item schema bits to a shared class](https://github.com/woocommerce/woocommerce/pull/38048/commits/b0b80445aba7e476fac2229f722ed786ba6a49b2)

`Reports/Controller` differs in terms of `prepare_item_for_response` & `get_collection_params`, so its children will still contain redundant code.

We could consider improving it as well.

### How to test the changes in this Pull Request:

As mentioned above, this code does not change any functionality, so we could read the code to check if it is actually easier to maintain and check for regression issues.

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

0. Read the code to check if it's shorter and easier to comprehend.
1. Run all automated tests
2. Smoke tests Analytics reports

<!-- End testing instructions -->