### PR TITLE
Show comma separated list in ready only mode of select tree control

### DIFF
--- a/packages/js/components/changelog/update-37727
+++ b/packages/js/components/changelog/update-37727
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Show comma separated list in ready only mode of select tree control

--- a/packages/js/components/src/experimental-select-control/combo-box.tsx
+++ b/packages/js/components/src/experimental-select-control/combo-box.tsx
@@ -75,8 +75,8 @@ export const ComboBox = ( {
 					<input
 						{ ...inputProps }
 						ref={ ( node ) => {
+							inputRef.current = node;
 							if ( typeof inputProps.ref === 'function' ) {
-								inputRef.current = node;
 								(
 									inputProps.ref as unknown as (
 										node: HTMLInputElement | null

--- a/packages/js/components/src/experimental-select-control/select-control.scss
+++ b/packages/js/components/src/experimental-select-control/select-control.scss
@@ -12,7 +12,7 @@
 		border-color: var( --wp-admin-theme-color );
 	}
 
-	&.is-read-only {
+	&.is-read-only.is-multiple.has-selected-items {
 		.woocommerce-experimental-select-control__combo-box-wrapper {
 			cursor: default;
 		}

--- a/packages/js/components/src/experimental-select-control/select-control.scss
+++ b/packages/js/components/src/experimental-select-control/select-control.scss
@@ -12,6 +12,18 @@
 		border-color: var( --wp-admin-theme-color );
 	}
 
+	&.is-read-only {
+		.woocommerce-experimental-select-control__combo-box-wrapper {
+			cursor: default;
+		}
+
+		.woocommerce-experimental-select-control__input {
+			opacity: 0;
+			width: 0;
+			height: 0;
+		}
+	}
+
 	&__label {
 		display: inline-block;
 		margin-bottom: $gap-smaller;

--- a/packages/js/components/src/experimental-select-control/select-control.tsx
+++ b/packages/js/components/src/experimental-select-control/select-control.tsx
@@ -15,7 +15,7 @@ import {
 	createElement,
 	Fragment,
 } from '@wordpress/element';
-import { search } from '@wordpress/icons';
+import { chevronDown } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -123,7 +123,7 @@ function SelectControl< ItemType = DefaultItemType >( {
 	className,
 	disabled,
 	inputProps = {},
-	suffix = <SuffixIcon icon={ search } />,
+	suffix = <SuffixIcon icon={ chevronDown } />,
 	showToggleButton = false,
 	__experimentalOpenMenuOnFocus = false,
 }: SelectControlProps< ItemType > ) {
@@ -239,6 +239,7 @@ function SelectControl< ItemType = DefaultItemType >( {
 	const selectedItemTags = multiple ? (
 		<SelectedItems
 			items={ selectedItems }
+			isReadOnly={ ! isOpen }
 			getItemLabel={ getItemLabel }
 			getItemValue={ getItemValue }
 			getSelectedItemProps={ getSelectedItemProps }
@@ -282,7 +283,7 @@ function SelectControl< ItemType = DefaultItemType >( {
 							openMenu();
 						}
 					},
-					onBlur: () => setIsFocused( false ),
+					// onBlur: () => setIsFocused( false ),
 					placeholder,
 					disabled,
 					...inputProps,

--- a/packages/js/components/src/experimental-select-control/select-control.tsx
+++ b/packages/js/components/src/experimental-select-control/select-control.tsx
@@ -283,7 +283,7 @@ function SelectControl< ItemType = DefaultItemType >( {
 							openMenu();
 						}
 					},
-					// onBlur: () => setIsFocused( false ),
+					onBlur: () => setIsFocused( false ),
 					placeholder,
 					disabled,
 					...inputProps,

--- a/packages/js/components/src/experimental-select-control/select-control.tsx
+++ b/packages/js/components/src/experimental-select-control/select-control.tsx
@@ -9,6 +9,7 @@ import {
 	useMultipleSelection,
 	GetInputPropsOptions,
 } from 'downshift';
+import { useInstanceId } from '@wordpress/compose';
 import {
 	useState,
 	useEffect,
@@ -129,6 +130,10 @@ function SelectControl< ItemType = DefaultItemType >( {
 }: SelectControlProps< ItemType > ) {
 	const [ isFocused, setIsFocused ] = useState( false );
 	const [ inputValue, setInputValue ] = useState( '' );
+	const instanceId = useInstanceId(
+		SelectControl,
+		'woocommerce-experimental-select-control'
+	);
 
 	let selectedItems = selected === null ? [] : selected;
 	selectedItems = Array.isArray( selectedItems )
@@ -230,6 +235,12 @@ function SelectControl< ItemType = DefaultItemType >( {
 		},
 	} );
 
+	const isEventOutside = ( event: React.FocusEvent ) => {
+		return ! document
+			.querySelector( '.' + instanceId )
+			?.contains( event.relatedTarget );
+	};
+
 	const onRemoveItem = ( item: ItemType ) => {
 		selectItem( null );
 		removeSelectedItem( item );
@@ -254,6 +265,7 @@ function SelectControl< ItemType = DefaultItemType >( {
 			className={ classnames(
 				'woocommerce-experimental-select-control',
 				className,
+				instanceId,
 				{
 					'is-read-only': isReadOnly,
 					'is-focused': isFocused,
@@ -288,7 +300,11 @@ function SelectControl< ItemType = DefaultItemType >( {
 							openMenu();
 						}
 					},
-					onBlur: () => setIsFocused( false ),
+					onBlur: ( event: React.FocusEvent ) => {
+						if ( isEventOutside( event ) ) {
+							setIsFocused( false );
+						}
+					},
 					placeholder,
 					disabled,
 					...inputProps,

--- a/packages/js/components/src/experimental-select-control/select-control.tsx
+++ b/packages/js/components/src/experimental-select-control/select-control.tsx
@@ -236,10 +236,12 @@ function SelectControl< ItemType = DefaultItemType >( {
 		onRemove( item );
 	};
 
+	const isReadOnly = ! isOpen;
+
 	const selectedItemTags = multiple ? (
 		<SelectedItems
 			items={ selectedItems }
-			isReadOnly={ ! isOpen }
+			isReadOnly={ isReadOnly }
 			getItemLabel={ getItemLabel }
 			getItemValue={ getItemValue }
 			getSelectedItemProps={ getSelectedItemProps }
@@ -253,6 +255,7 @@ function SelectControl< ItemType = DefaultItemType >( {
 				'woocommerce-experimental-select-control',
 				className,
 				{
+					'is-read-only': isReadOnly,
 					'is-focused': isFocused,
 				}
 			) }

--- a/packages/js/components/src/experimental-select-control/select-control.tsx
+++ b/packages/js/components/src/experimental-select-control/select-control.tsx
@@ -257,6 +257,8 @@ function SelectControl< ItemType = DefaultItemType >( {
 				{
 					'is-read-only': isReadOnly,
 					'is-focused': isFocused,
+					'is-multiple': multiple,
+					'has-selected-items': selectedItems.length,
 				}
 			) }
 		>

--- a/packages/js/components/src/experimental-select-control/select-control.tsx
+++ b/packages/js/components/src/experimental-select-control/select-control.tsx
@@ -236,7 +236,7 @@ function SelectControl< ItemType = DefaultItemType >( {
 		onRemove( item );
 	};
 
-	const isReadOnly = ! isOpen;
+	const isReadOnly = ! isOpen && ! isFocused;
 
 	const selectedItemTags = multiple ? (
 		<SelectedItems

--- a/packages/js/components/src/experimental-select-control/selected-items.scss
+++ b/packages/js/components/src/experimental-select-control/selected-items.scss
@@ -1,3 +1,9 @@
+.woocommerce-experimental-select-control__selected-items.is-read-only {
+    font-size: 13px;
+    color: $gray-900;
+    font-family: var(--wp--preset--font-family--system-font);
+}
+
 .woocommerce-experimental-select-control__selected-item {
     margin-right: $gap-smallest;
     margin-top: 2px;

--- a/packages/js/components/src/experimental-select-control/selected-items.tsx
+++ b/packages/js/components/src/experimental-select-control/selected-items.tsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { createElement, Fragment } from '@wordpress/element';
+import classnames from 'classnames';
+import { createElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -10,6 +11,7 @@ import Tag from '../tag';
 import { getItemLabelType, getItemValueType } from './types';
 
 type SelectedItemsProps< ItemType > = {
+	isReadOnly: boolean;
 	items: ItemType[];
 	getItemLabel: getItemLabelType< ItemType >;
 	getItemValue: getItemValueType< ItemType >;
@@ -22,14 +24,34 @@ type SelectedItemsProps< ItemType > = {
 };
 
 export const SelectedItems = < ItemType, >( {
+	isReadOnly,
 	items,
 	getItemLabel,
 	getItemValue,
 	getSelectedItemProps,
 	onRemove,
 }: SelectedItemsProps< ItemType > ) => {
+	const classes = classnames(
+		'woocommerce-experimental-select-control__selected-items',
+		{
+			'is-read-only': isReadOnly,
+		}
+	);
+
+	if ( isReadOnly ) {
+		return (
+			<div className={ classes }>
+				{ items
+					.map( ( item ) => {
+						return getItemLabel( item );
+					} )
+					.join( ', ' ) }
+			</div>
+		);
+	}
+
 	return (
-		<>
+		<div className={ classes }>
 			{ items.map( ( item, index ) => {
 				return (
 					// Disable reason: We prevent the default action to keep the input focused on click.
@@ -56,6 +78,6 @@ export const SelectedItems = < ItemType, >( {
 					</div>
 				);
 			} ) }
-		</>
+		</div>
 	);
 };

--- a/packages/js/components/src/experimental-select-control/selected-items.tsx
+++ b/packages/js/components/src/experimental-select-control/selected-items.tsx
@@ -64,6 +64,9 @@ export const SelectedItems = < ItemType, >( {
 							selectedItem: item,
 							index,
 						} ) }
+						onMouseDown={ ( event ) => {
+							event.preventDefault();
+						} }
 						onClick={ ( event ) => {
 							event.preventDefault();
 						} }

--- a/packages/js/components/src/experimental-select-tree-control/select-tree-menu.tsx
+++ b/packages/js/components/src/experimental-select-tree-control/select-tree-menu.tsx
@@ -22,6 +22,7 @@ import {
 } from '../experimental-tree-control';
 
 type MenuProps = {
+	isEventOutside: ( event: React.FocusEvent ) => boolean;
 	isOpen: boolean;
 	isLoading?: boolean;
 	position?: Popover.Position;
@@ -32,6 +33,7 @@ type MenuProps = {
 } & Omit< TreeControlProps, 'items' >;
 
 export const SelectTreeMenu = ( {
+	isEventOutside,
 	isLoading,
 	isOpen,
 	className,
@@ -103,8 +105,10 @@ export const SelectTreeMenu = ( {
 					) }
 					position={ position }
 					animate={ false }
-					onFocusOutside={ () => {
-						onClose();
+					onFocusOutside={ ( event ) => {
+						if ( isEventOutside( event ) ) {
+							onClose();
+						}
 					} }
 				>
 					{ isOpen && (

--- a/packages/js/components/src/experimental-select-tree-control/select-tree.tsx
+++ b/packages/js/components/src/experimental-select-tree-control/select-tree.tsx
@@ -2,9 +2,9 @@
 /**
  * External dependencies
  */
-import { createElement, useState } from '@wordpress/element';
+import { chevronDown } from '@wordpress/icons';
 import classNames from 'classnames';
-import { search } from '@wordpress/icons';
+import { createElement, useState } from '@wordpress/element';
 import { useInstanceId } from '@wordpress/compose';
 
 /**
@@ -32,7 +32,7 @@ export const SelectTree = function SelectTree( {
 	items,
 	getSelectedItemProps,
 	treeRef: ref,
-	suffix = <SuffixIcon icon={ search } />,
+	suffix = <SuffixIcon icon={ chevronDown } />,
 	placeholder,
 	isLoading,
 	onInputChange,
@@ -126,6 +126,7 @@ export const SelectTree = function SelectTree( {
 					suffix={ suffix }
 				>
 					<SelectedItems
+						isReadOnly={ ! isOpen }
 						items={ ( props.selected as Item[] ) || [] }
 						getItemLabel={ ( item ) => item?.label || '' }
 						getItemValue={ ( item ) => item?.value || '' }

--- a/packages/js/components/src/experimental-select-tree-control/select-tree.tsx
+++ b/packages/js/components/src/experimental-select-tree-control/select-tree.tsx
@@ -40,17 +40,26 @@ export const SelectTree = function SelectTree( {
 	...props
 }: SelectTreeProps ) {
 	const linkedTree = useLinkedTree( items );
+	const selectTreeInstanceId = useInstanceId(
+		SelectTree,
+		'woocommerce-experimental-select-tree-control__dropdown'
+	);
 	const menuInstanceId = useInstanceId(
 		SelectTree,
 		'woocommerce-select-tree-control__menu'
 	);
+	const isEventOutside = ( event: React.FocusEvent ) => {
+		return ! document
+			.querySelector( '.' + selectTreeInstanceId )
+			?.contains( event.relatedTarget );
+	};
 
 	const [ isFocused, setIsFocused ] = useState( false );
 	const [ isOpen, setIsOpen ] = useState( false );
 
 	return (
 		<div
-			className="woocommerce-experimental-select-tree-control__dropdown"
+			className={ `woocommerce-experimental-select-tree-control__dropdown ${ selectTreeInstanceId }` }
 			tabIndex={ -1 }
 		>
 			<div
@@ -93,12 +102,7 @@ export const SelectTree = function SelectTree( {
 						},
 						onBlur: ( event ) => {
 							// if blurring to an element inside the dropdown, don't close it
-							if (
-								isOpen &&
-								! document
-									.querySelector( '.' + menuInstanceId )
-									?.contains( event.relatedTarget )
-							) {
+							if ( isEventOutside( event ) ) {
 								setIsOpen( false );
 							}
 							setIsFocused( false );
@@ -133,7 +137,6 @@ export const SelectTree = function SelectTree( {
 						onRemove={ ( item ) => {
 							if ( ! Array.isArray( item ) && props.onRemove ) {
 								props.onRemove( item );
-								setIsOpen( false );
 							}
 						} }
 						getSelectedItemProps={ () => ( {} ) }
@@ -145,10 +148,13 @@ export const SelectTree = function SelectTree( {
 				id={ `${ props.id }-menu` }
 				className={ menuInstanceId.toString() }
 				ref={ ref }
+				isEventOutside={ isEventOutside }
 				isOpen={ isOpen }
 				items={ linkedTree }
 				shouldShowCreateButton={ shouldShowCreateButton }
-				onClose={ () => setIsOpen( false ) }
+				onClose={ () => {
+					setIsOpen( false );
+				} }
 			/>
 		</div>
 	);

--- a/packages/js/components/src/experimental-select-tree-control/select-tree.tsx
+++ b/packages/js/components/src/experimental-select-tree-control/select-tree.tsx
@@ -69,6 +69,8 @@ export const SelectTree = function SelectTree( {
 					{
 						'is-read-only': isReadOnly,
 						'is-focused': isFocused,
+						'is-multiple': props.multiple,
+						'has-selected-items': props.selected?.length,
 					}
 				) }
 			>

--- a/packages/js/components/src/experimental-select-tree-control/select-tree.tsx
+++ b/packages/js/components/src/experimental-select-tree-control/select-tree.tsx
@@ -56,6 +56,7 @@ export const SelectTree = function SelectTree( {
 
 	const [ isFocused, setIsFocused ] = useState( false );
 	const [ isOpen, setIsOpen ] = useState( false );
+	const isReadOnly = ! isOpen;
 
 	return (
 		<div
@@ -66,6 +67,7 @@ export const SelectTree = function SelectTree( {
 				className={ classNames(
 					'woocommerce-experimental-select-control',
 					{
+						'is-read-only': isReadOnly,
 						'is-focused': isFocused,
 					}
 				) }
@@ -130,7 +132,7 @@ export const SelectTree = function SelectTree( {
 					suffix={ suffix }
 				>
 					<SelectedItems
-						isReadOnly={ ! isOpen }
+						isReadOnly={ isReadOnly }
 						items={ ( props.selected as Item[] ) || [] }
 						getItemLabel={ ( item ) => item?.label || '' }
 						getItemValue={ ( item ) => item?.value || '' }

--- a/packages/js/components/src/experimental-select-tree-control/select-tree.tsx
+++ b/packages/js/components/src/experimental-select-tree-control/select-tree.tsx
@@ -56,7 +56,7 @@ export const SelectTree = function SelectTree( {
 
 	const [ isFocused, setIsFocused ] = useState( false );
 	const [ isOpen, setIsOpen ] = useState( false );
-	const isReadOnly = ! isOpen;
+	const isReadOnly = ! isOpen && ! isFocused;
 
 	return (
 		<div

--- a/packages/js/product-editor/changelog/update-37727
+++ b/packages/js/product-editor/changelog/update-37727
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Fix broken assertion with comma separated list in category select control

--- a/packages/js/product-editor/src/components/details-categories-field/test/category-field.test.tsx
+++ b/packages/js/product-editor/src/components/details-categories-field/test/category-field.test.tsx
@@ -74,7 +74,6 @@ describe( 'CategoryField', () => {
 			</Form>
 		);
 		queryByPlaceholderText( 'Search or create category…' )?.focus();
-		expect( queryAllByText( 'Test' ) ).toHaveLength( 2 );
-		expect( queryAllByText( 'Clothing' ) ).toHaveLength( 2 );
+		expect( queryAllByText( 'Test, Clothing' ) ).toHaveLength( 1 );
 	} );
 } );


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Shows a comma separated list for selected values when a select control is in read-only mode (menu closed).  Note that in order for this behavior to work and to allow the "remove" buttons on the tags to continue to work when the menu is open, we need to keep the menu open when clicking the input or clicking one of the remove buttons.  Otherwise, clicking the "remove" button closes the menu and the list reverts to read only mode before the item can be removed.

cc @jarekmorawski if this is the expectation and @louwie17 since you last touched this component's open/close state in case you have any "gotchas" around opening/closing.


<img width="523" alt="Screen Shot 2023-04-28 at 2 24 45 PM" src="https://user-images.githubusercontent.com/10561050/235257591-edec6918-0434-45b8-a0fe-21900c630caa.png">
<img width="684" alt="Screen Shot 2023-04-28 at 1 58 54 PM" src="https://user-images.githubusercontent.com/10561050/235257595-cba8d3ea-365b-4356-9a04-244101e28565.png">

Closes #37727 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:


1. Navigate to Tools -> WCA Test Helper -> Features and enable the new product blocks editing experience
3. Navigate to Products -> Add new
4. Add some categories to your product
5. Note that the categories are in a comma-separated list when the menu is closed
6. Note that the categories are in "tag" format when the menu is open
7. Click on the "x" next to the category tags
8. Make sure the category is removed and that the menu remains open

<!-- End testing instructions -->