### PR TITLE
Fixing more menu width in product block editor header

### DIFF
--- a/packages/js/product-editor/changelog/fix-more-menu-width-38001
+++ b/packages/js/product-editor/changelog/fix-more-menu-width-38001
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixing more menu width.

--- a/packages/js/product-editor/src/components/header/more-menu/more-menu.tsx
+++ b/packages/js/product-editor/src/components/header/more-menu/more-menu.tsx
@@ -16,7 +16,11 @@ import { WooProductMoreMenuItem } from '../woo-more-menu-item';
 export const MoreMenu = () => {
 	return (
 		<>
-			<MoreMenuDropdown>
+			<MoreMenuDropdown
+				popoverProps={ {
+					className: 'woocommerce-product-header__more-menu',
+				} }
+			>
 				{ ( { onClose }: { onClose: () => void } ) => (
 					<>
 						<WooProductMoreMenuItem.Slot

--- a/packages/js/product-editor/src/components/header/style.scss
+++ b/packages/js/product-editor/src/components/header/style.scss
@@ -32,11 +32,6 @@
 		margin-left: auto;
 	}
 
-	.components-popover__content {
-		min-width: auto;
-		width: min-content;
-	}
-
 	.woocommerce-product-header__actions {
 		display: flex;
 
@@ -52,4 +47,12 @@
 			color: #fff;
 		}
 	}
+}
+
+.woocommerce-product-header__more-menu {
+	.components-popover__content {
+		min-width: auto;
+		width: min-content;
+	}
+
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #38001 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Checkout branch and enable `product-block-editor` feature flag.
2. Navigate to Product -> Add new
3. Click "..." more menu in top right of screen in the product header.
4. Verify the width appears correct, and not too wide as it was previously: 
![image](https://user-images.githubusercontent.com/444632/235266741-f76c27c0-8d13-4ab8-8183-37c7cb5c4b09.png)


<!-- End testing instructions -->