### PR TITLE
Fix product data field description styling, including checkboxes and radio buttons

### DIFF
--- a/plugins/woocommerce/changelog/fix-checkbox-labels
+++ b/plugins/woocommerce/changelog/fix-checkbox-labels
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix styling of checkbox (and other input) labels on product page tabs.

--- a/plugins/woocommerce/changelog/fix-product-data-field-description-styling.
+++ b/plugins/woocommerce/changelog/fix-product-data-field-description-styling.
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Fix styling of product data field descriptions, including checkboxes and radio buttons.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -5348,11 +5348,19 @@ img.help_tip {
 		}
 	}
 
-	.description {
+	.description,
+	input[type="checkbox"] + .description,
+	input[type="radio"] + .description {
 		padding: 0;
 		margin: 0 0 0 7px;
 		clear: none;
 		display: inline;
+	}
+
+	input:not([type="checkbox"]):not([type="radio"]) + .description {
+		display: block;
+		clear: both;
+		margin-left: 0;
 	}
 
 	.description-block {
@@ -6706,7 +6714,7 @@ table.bar_chart {
 	}
 
 	.woocommerce_options_panel {
-		:not(input) + .description {
+		.description {
 			display: block;
 			clear: both;
 			margin-left: 0;


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR tweaks the fix originally supplied in #37791 to improve the product data field description styling, including checkbox and radio buttons. The previous fix, while addressing checkbox and radio buttons, made the styling of descriptions associated with other types of inputs worse on smaller viewports.

This updated implementation keeps the improvement of the checkbox and radio button label styling, and also improves the styling of descriptions associated with other types of inputs by always showing those descriptions below the corresponding input field, regardless of viewport width. This improves situations where the description is long and would wrap oddly before.

I resisted making changes to the structure of the HTML, since that may lead to unexpected issues for extensions. There is certainly a lot of room for improvement, but any such changes would need to be carefully considered.

#### Before

<img width="793" alt="Screenshot 2023-05-01 at 21 15 34" src="https://user-images.githubusercontent.com/2098816/235559023-31544c79-813f-40e5-98f8-1e502021f52f.png">

<img width="793" alt="Screenshot 2023-05-01 at 21 15 50" src="https://user-images.githubusercontent.com/2098816/235559035-bbf223fb-d91d-40e4-9d0e-3c4588eec407.png">


#### After

<img width="793" alt="Screenshot 2023-05-01 at 21 08 33" src="https://user-images.githubusercontent.com/2098816/235559053-c1fa86d5-9ba3-4987-8707-6afb229d1fdb.png">

<img width="793" alt="Screenshot 2023-05-01 at 21 12 16" src="https://user-images.githubusercontent.com/2098816/235559060-5b95f311-6272-4779-b061-7b0eedf1ac45.png">

(No visual change to _Inventory_ tab)


<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Go to Products > Add New (`/wp-admin/post-new.php?post_type=product`)
2. Enable `Downloadable`
3. Go to the `General` tab
4. Verify the `Schedule` link is below the `Sale price ($)` field
5. Verify the descriptions for `Download limit` and `Download expiry` are below the input field
6. Go to the `Inventory` tab
7. Verify the checkboxes are displayed correctly on both larger and smaller viewports. The checkbox label should always start right next to the checkbox, never fully below it. (This is no change over what was implemented in #37791)

<!-- End testing instructions -->