### PR TITLE
Code Freeze CLI: Use version bump command in Code Freeze action

### DIFF
--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -29,6 +29,7 @@ jobs:
         permissions:
             contents: write
             issues: write
+            pull-requests: write
         outputs:
             freeze: ${{ steps.check-freeze.outputs.freeze }}
             nextReleaseBranch: ${{ steps.branch.outputs.nextReleaseBranch }}
@@ -63,64 +64,17 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: pnpm run utils code-freeze branch -o ${{ github.repository_owner }}
 
-    prep-trunk:
-        name: Preps trunk for next development cycle
-        runs-on: ubuntu-20.04
-        permissions:
-            contents: write
-            pull-requests: write
-        needs: code-freeze-prep
-        if: needs.code-freeze-prep.outputs.freeze == 'true'
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v3
-              with:
-                  fetch-depth: 100
-
-            - name: fetch-trunk
-              run: git fetch origin trunk
-
-            - name: checkout-trunk
-              run: git checkout trunk
-
-            - name: Setup WooCommerce Monorepo
-              uses: ./.github/actions/setup-woocommerce-monorepo
-
-            - name: Create branch
-              run: git checkout -b prep/trunk-for-next-dev-cycle-${{ needs.code-freeze-prep.outputs.nextDevelopmentVersion }}
-
-            - name: Bump versions
-              working-directory: ./tools/version-bump
-              run: pnpm run version bump woocommerce -v ${{ needs.code-freeze-prep.outputs.nextDevelopmentVersion }}.0-dev
-
-            - name: Checkout pnpm-lock.yaml to prevent issues
-              run: git checkout pnpm-lock.yaml
-
-            - name: Commit changes
-              run: git commit -am "Prep trunk for ${{ needs.code-freeze-prep.outputs.nextDevelopmentVersion }} cycle"
-
-            - name: Push branch up
-              run: git push --no-verify origin prep/trunk-for-next-dev-cycle-${{ needs.code-freeze-prep.outputs.nextDevelopmentVersion }}
-
-            - name: Create the PR
-              uses: actions/github-script@v6
-              with:
-                  script: |
-                      const body = "This PR updates the versions in trunk to ${{ needs.code-freeze-prep.outputs.nextDevelopmentVersion }} for next development cycle."
-
-                      const pr = await github.rest.pulls.create({
-                        owner: context.repo.owner,
-                        repo: context.repo.repo,
-                        title: "Prep trunk for ${{ needs.code-freeze-prep.outputs.nextDevelopmentVersion }} cycle",
-                        head: "prep/trunk-for-next-dev-cycle-${{ needs.code-freeze-prep.outputs.nextDevelopmentVersion }}",
-                        base: "trunk",
-                        body: body
-                      })
+            - name: Prepare trunk for next development cycle
+              id: prep-trunk
+              if: steps.check-freeze.outputs.freeze == 'true'
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: pnpm run utils code-freeze version-bump -o ${{ github.repository_owner }} -v ${{ steps.milestone.outputs.nextDevelopmentVersion }}.0-dev
 
     notify-slack:
         name: 'Sends code freeze notification to Slack'
         runs-on: ubuntu-20.04
-        needs: prep-trunk
+        needs: code-freeze-prep
         if: ${{ inputs.skipSlackPing != true }}
         steps:
             - name: Slack


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR depends on https://github.com/woocommerce/woocommerce/pull/38036 and replaces the Code Freeze action logic for preparing trunk with the CLI version.

Fixes https://github.com/woocommerce/woocommerce/issues/37903

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Prerequisites
1. You must have a `GITHUB_TOKEN` environment variable available in your PATH. This needs to be set to a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) with repo permissions enabled.
2. Fork woocommerce onto your own namespace. Push this branch to your fork

#### Test the action
1. Get `trunk` up to date on fork as well be working with the code freeze for 7.8
3. Make a 7.7.0 tagged release on fork
4. Delete `release/7.8` branch on fork if it already exists
5. Delete `prep/trunk-for-next-dev-cycle-7.9` on your fork if it already exists
6. Delete `update/7.8-changelog` on your fork if it already exists
7. Delete `delete/7.8-changelog` on your fork if it already exists
8. Delete 7.9.0 milestone if it already exists
9. Run the `Release: Code freeze` action from branch `update/code-freeze-prep-trunk`. You'll want to add a time override so the action runs because its not code freeze day. `2023-04-17T15:00:00.000` works well.
10. Make sure the action passes.
11. Check the resulting PR entitled "Prep trunk for 7.9 cycle". Compare it to [a previously created PR](https://github.com/woocommerce/woocommerce/pull/37777) and check that all the right files have been updated with correct values.


<!-- End testing instructions -->