### PR TITLE
Update wp org listing description

### DIFF
--- a/plugins/woocommerce/changelog/try-update-wporg-listing-desc
+++ b/plugins/woocommerce/changelog/try-update-wporg-listing-desc
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Update plugin listing description

--- a/plugins/woocommerce/readme.txt
+++ b/plugins/woocommerce/readme.txt
@@ -8,7 +8,7 @@ Stable tag: 7.6.1
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
-WooCommerce is the world’s most popular open-source eCommerce solution.
+WooCommerce has helped millions of merchants build successful businesses for the long term. Get everything you need to launch an online store in days and keep it growing for years. From your first sale to millions in revenue, Woo is with you.
 
 == Description ==
 

--- a/plugins/woocommerce/readme.txt
+++ b/plugins/woocommerce/readme.txt
@@ -8,7 +8,7 @@ Stable tag: 7.6.1
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
-WooCommerce has helped millions of merchants build successful businesses for the long term. Get everything you need to launch an online store in days and keep it growing for years. From your first sale to millions in revenue, Woo is with you.
+Everything you need to launch an online store in days and keep it growing for years. From your first sale to millions in revenue, Woo is with you.
 
 == Description ==
 


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This change should update the wp org description that shows up when you search for plugins in the context of wp.org plugin directory or via WP Admin Install Plugins screen:
 
![Screenshot 2023-05-02 at 15 07 53](https://user-images.githubusercontent.com/2207451/235675436-74680549-2c40-4e0f-9d49-e69dbfe7a84d.png)

It can be accompanied by a similar update directly in the SVN repo to expedite the change.

Internal ref: p6riRB-8Aw-p2

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

I don't think there is any way to test this change locally, unless you want to create a new wporg plugin and test it out through the listing of the new plugin.

And since we're testing in production, this is how it looks live:

<img width="1723" alt="Screenshot 2023-05-03 at 22 50 42" src="https://user-images.githubusercontent.com/2207451/236046743-bbd7baad-dbbe-49df-b4a1-724894558a43.png">


<!-- End testing instructions -->