### PR TITLE
Change product-category-metabox scripts/styles enqueue logic

### DIFF
--- a/plugins/woocommerce/changelog/update-change-product-category-metabox-enqueue
+++ b/plugins/woocommerce/changelog/update-change-product-category-metabox-enqueue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Change product-category-metabox JS/style enqueue logic

--- a/plugins/woocommerce/src/Admin/Features/AsyncProductEditorCategoryField/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/AsyncProductEditorCategoryField/Init.php
@@ -46,9 +46,10 @@ class Init {
 	 * Enqueue scripts needed for the product form block editor.
 	 */
 	public function enqueue_scripts() {
-		if ( ! PageController::is_admin_or_embed_page() ) {
+		if ( ! PageController::is_embed_page() ) {
 			return;
 		}
+
 		WCAdminAssets::register_script( 'wp-admin-scripts', 'product-category-metabox', true );
 		wp_localize_script(
 			'wc-admin-product-category-metabox',
@@ -66,7 +67,7 @@ class Init {
 	 * Enqueue styles needed for the rich text editor.
 	 */
 	public function enqueue_styles() {
-		if ( ! PageController::is_admin_or_embed_page() ) {
+		if ( ! PageController::is_embed_page() ) {
 			return;
 		}
 		$version = Constants::get_constant( 'WC_VERSION' );


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR changes the product-category-metabox enqueue logic to fix hot reloading.

I noticed that  `product-category-metabox` scripts are loaded on all admin/embed pages. If I understand correctly, I think we only need to load them on product pages. 

Currently, react-refresh is not working because react-refresh only [allows one copy of both the HMR runtime and the plugin's runtime](https://github.com/pmmmwh/react-refresh-webpack-plugin/blob/main/docs/TROUBLESHOOTING.md#component-not-updating-with-bundle-splitting-techniques) and HMR is not [working with multiple entries](https://github.com/webpack/webpack-dev-server/issues/2792).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Follow the test instructions in https://github.com/woocommerce/woocommerce/pull/36869

<!-- End testing instructions -->