### PR TITLE
Add Sale price validation

### DIFF
--- a/packages/js/product-editor/changelog/add-37985
+++ b/packages/js/product-editor/changelog/add-37985
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add Sale price validation#37985

--- a/packages/js/product-editor/src/blocks/index.ts
+++ b/packages/js/product-editor/src/blocks/index.ts
@@ -9,6 +9,7 @@ export { init as initSku } from './inventory-sku';
 export { init as initName } from './name';
 export { init as initPricing } from './pricing';
 export { init as initRadio } from './radio';
+export { init as initRegularPrice } from './regular-price';
 export { init as initSalePrice } from './sale-price';
 export { init as initScheduleSale } from './schedule-sale';
 export { init as initSection } from './section';

--- a/packages/js/product-editor/src/blocks/index.ts
+++ b/packages/js/product-editor/src/blocks/index.ts
@@ -9,6 +9,7 @@ export { init as initSku } from './inventory-sku';
 export { init as initName } from './name';
 export { init as initPricing } from './pricing';
 export { init as initRadio } from './radio';
+export { init as initSalePrice } from './sale-price';
 export { init as initScheduleSale } from './schedule-sale';
 export { init as initSection } from './section';
 export { init as initShippingDimensions } from './shipping-dimensions';

--- a/packages/js/product-editor/src/blocks/regular-price/block.json
+++ b/packages/js/product-editor/src/blocks/regular-price/block.json
@@ -1,0 +1,29 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "woocommerce/product-regular-price-field",
+	"description": "A product price block with currency display.",
+	"title": "Product regular price",
+	"category": "widgets",
+	"keywords": [ "products", "price" ],
+	"textdomain": "default",
+	"attributes": {
+		"label": {
+			"type": "string",
+			"__experimentalRole": "content"
+		},
+		"help": {
+			"type": "string"
+		}
+	},
+	"supports": {
+		"align": false,
+		"html": false,
+		"multiple": false,
+		"reusable": false,
+		"inserter": false,
+		"lock": false,
+		"__experimentalToolbar": false
+	},
+	"editorStyle": "file:./editor.css"
+}

--- a/packages/js/product-editor/src/blocks/regular-price/edit.tsx
+++ b/packages/js/product-editor/src/blocks/regular-price/edit.tsx
@@ -1,0 +1,126 @@
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+import { Link } from '@woocommerce/components';
+import { CurrencyContext } from '@woocommerce/currency';
+import { getNewPath } from '@woocommerce/navigation';
+import { recordEvent } from '@woocommerce/tracks';
+import { useBlockProps } from '@wordpress/block-editor';
+import { BlockEditProps } from '@wordpress/blocks';
+import { useInstanceId } from '@wordpress/compose';
+import { useEntityProp } from '@wordpress/core-data';
+import {
+	createElement,
+	useContext,
+	createInterpolateElement,
+} from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import {
+	BaseControl,
+	// @ts-expect-error `__experimentalInputControl` does exist.
+	__experimentalInputControl as InputControl,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { useCurrencyInputProps } from '../../hooks/use-currency-input-props';
+import { formatCurrencyDisplayValue } from '../../utils';
+import { SalePriceBlockAttributes } from './types';
+import { useValidation } from '../../hooks/use-validation';
+
+export function Edit( {
+	attributes,
+}: BlockEditProps< SalePriceBlockAttributes > ) {
+	const blockProps = useBlockProps();
+	const { label, help } = attributes;
+	const [ regularPrice, setRegularPrice ] = useEntityProp< string >(
+		'postType',
+		'product',
+		'regular_price'
+	);
+	const [ salePrice ] = useEntityProp< string >(
+		'postType',
+		'product',
+		'sale_price'
+	);
+	const context = useContext( CurrencyContext );
+	const { getCurrencyConfig, formatAmount } = context;
+	const currencyConfig = getCurrencyConfig();
+	const inputProps = useCurrencyInputProps( {
+		value: regularPrice,
+		setValue: setRegularPrice,
+	} );
+
+	const interpolatedHelp = help
+		? createInterpolateElement( help, {
+				PricingTab: (
+					<Link
+						href={ getNewPath( { tab: 'pricing' } ) }
+						onClick={ () => {
+							recordEvent( 'product_pricing_help_click' );
+						} }
+					/>
+				),
+		  } )
+		: null;
+
+	const regularPriceId = useInstanceId(
+		BaseControl,
+		'wp-block-woocommerce-product-regular-price-field'
+	) as string;
+
+	const regularPriceValidationError = useValidation(
+		'product/regular_price',
+		function nameValidator() {
+			const listPrice = Number.parseFloat( regularPrice );
+			if ( listPrice ) {
+				if ( listPrice < 0 ) {
+					return __(
+						'List price must be greater than or equals to zero.',
+						'woocommerce'
+					);
+				}
+				if (
+					salePrice &&
+					listPrice <= Number.parseFloat( salePrice )
+				) {
+					return __(
+						'List price must be greater than the sale price.',
+						'woocommerce'
+					);
+				}
+			}
+		}
+	);
+
+	return (
+		<div { ...blockProps }>
+			<BaseControl
+				id={ regularPriceId }
+				help={
+					regularPriceValidationError
+						? regularPriceValidationError
+						: interpolatedHelp
+				}
+				className={ classNames( {
+					'has-error': regularPriceValidationError,
+				} ) }
+			>
+				<InputControl
+					{ ...inputProps }
+					id={ regularPriceId }
+					name={ 'regular_price' }
+					label={ label }
+					value={ formatCurrencyDisplayValue(
+						String( regularPrice ),
+						currencyConfig,
+						formatAmount
+					) }
+					onChange={ setRegularPrice }
+				/>
+			</BaseControl>
+		</div>
+	);
+}

--- a/packages/js/product-editor/src/blocks/regular-price/edit.tsx
+++ b/packages/js/product-editor/src/blocks/regular-price/edit.tsx
@@ -73,7 +73,7 @@ export function Edit( {
 
 	const regularPriceValidationError = useValidation(
 		'product/regular_price',
-		function nameValidator() {
+		function regularPriceValidator() {
 			const listPrice = Number.parseFloat( regularPrice );
 			if ( listPrice ) {
 				if ( listPrice < 0 ) {

--- a/packages/js/product-editor/src/blocks/regular-price/editor.scss
+++ b/packages/js/product-editor/src/blocks/regular-price/editor.scss
@@ -1,0 +1,11 @@
+.wp-block-woocommerce-product-regular-price-field {
+	.components-currency-control {
+		.components-input-control__prefix {
+			color: $gray-700;
+		}
+
+		.components-input-control__input {
+			text-align: right;
+		}
+	}
+}

--- a/packages/js/product-editor/src/blocks/regular-price/index.ts
+++ b/packages/js/product-editor/src/blocks/regular-price/index.ts
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { BlockConfiguration } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { initBlock } from '../../utils/init-blocks';
+import blockConfiguration from './block.json';
+import { Edit } from './edit';
+import { SalePriceBlockAttributes } from './types';
+
+const { name, ...metadata } =
+	blockConfiguration as BlockConfiguration< SalePriceBlockAttributes >;
+
+export { metadata, name };
+
+export const settings: Partial<
+	BlockConfiguration< SalePriceBlockAttributes >
+> = {
+	example: {},
+	edit: Edit,
+};
+
+export function init() {
+	return initBlock( { name, metadata, settings } );
+}

--- a/packages/js/product-editor/src/blocks/regular-price/types.ts
+++ b/packages/js/product-editor/src/blocks/regular-price/types.ts
@@ -1,0 +1,9 @@
+/**
+ * External dependencies
+ */
+import { BlockAttributes } from '@wordpress/blocks';
+
+export interface SalePriceBlockAttributes extends BlockAttributes {
+	label: string;
+	help?: string;
+}

--- a/packages/js/product-editor/src/blocks/sale-price/block.json
+++ b/packages/js/product-editor/src/blocks/sale-price/block.json
@@ -1,0 +1,29 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "woocommerce/product-sale-price-field",
+	"description": "A product price block with currency display.",
+	"title": "Product sale price",
+	"category": "widgets",
+	"keywords": [ "products", "price" ],
+	"textdomain": "default",
+	"attributes": {
+		"label": {
+			"type": "string",
+			"__experimentalRole": "content"
+		},
+		"help": {
+			"type": "string"
+		}
+	},
+	"supports": {
+		"align": false,
+		"html": false,
+		"multiple": false,
+		"reusable": false,
+		"inserter": false,
+		"lock": false,
+		"__experimentalToolbar": false
+	},
+	"editorStyle": "file:./editor.css"
+}

--- a/packages/js/product-editor/src/blocks/sale-price/edit.tsx
+++ b/packages/js/product-editor/src/blocks/sale-price/edit.tsx
@@ -53,7 +53,7 @@ export function Edit( {
 
 	const salePriceValidationError = useValidation(
 		'product/sale_price',
-		function nameValidator() {
+		function salePriceValidator() {
 			if ( salePrice ) {
 				if ( Number.parseFloat( salePrice ) < 0 ) {
 					return __(

--- a/packages/js/product-editor/src/blocks/sale-price/edit.tsx
+++ b/packages/js/product-editor/src/blocks/sale-price/edit.tsx
@@ -1,0 +1,104 @@
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+import { CurrencyContext } from '@woocommerce/currency';
+import { useBlockProps } from '@wordpress/block-editor';
+import { BlockEditProps } from '@wordpress/blocks';
+import { useInstanceId } from '@wordpress/compose';
+import { useEntityProp } from '@wordpress/core-data';
+import { createElement, useContext } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import {
+	BaseControl,
+	// @ts-expect-error `__experimentalInputControl` does exist.
+	__experimentalInputControl as InputControl,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { useCurrencyInputProps } from '../../hooks/use-currency-input-props';
+import { formatCurrencyDisplayValue } from '../../utils';
+import { SalePriceBlockAttributes } from './types';
+import { useValidation } from '../../hooks/use-validation';
+
+export function Edit( {
+	attributes,
+}: BlockEditProps< SalePriceBlockAttributes > ) {
+	const blockProps = useBlockProps();
+	const { label, help } = attributes;
+	const [ regularPrice ] = useEntityProp< string >(
+		'postType',
+		'product',
+		'regular_price'
+	);
+	const [ salePrice, setSalePrice ] = useEntityProp< string >(
+		'postType',
+		'product',
+		'sale_price'
+	);
+	const context = useContext( CurrencyContext );
+	const { getCurrencyConfig, formatAmount } = context;
+	const currencyConfig = getCurrencyConfig();
+	const inputProps = useCurrencyInputProps( {
+		value: salePrice,
+		setValue: setSalePrice,
+	} );
+
+	const salePriceId = useInstanceId(
+		BaseControl,
+		'wp-block-woocommerce-product-sale-price-field'
+	) as string;
+
+	const salePriceValidationError = useValidation(
+		'product/sale_price',
+		function nameValidator() {
+			if ( salePrice ) {
+				if ( Number.parseFloat( salePrice ) < 0 ) {
+					return __(
+						'Sale price must be greater than or equals to zero.',
+						'woocommerce'
+					);
+				}
+				const listPrice = Number.parseFloat( regularPrice );
+				if (
+					! listPrice ||
+					listPrice <= Number.parseFloat( salePrice )
+				) {
+					return __(
+						'Sale price must be lower than the list price.',
+						'woocommerce'
+					);
+				}
+			}
+		}
+	);
+
+	return (
+		<div { ...blockProps }>
+			<BaseControl
+				id={ salePriceId }
+				help={
+					salePriceValidationError ? salePriceValidationError : help
+				}
+				className={ classNames( {
+					'has-error': salePriceValidationError,
+				} ) }
+			>
+				<InputControl
+					{ ...inputProps }
+					id={ salePriceId }
+					name={ 'sale_price' }
+					onChange={ setSalePrice }
+					label={ label }
+					value={ formatCurrencyDisplayValue(
+						String( salePrice ),
+						currencyConfig,
+						formatAmount
+					) }
+				/>
+			</BaseControl>
+		</div>
+	);
+}

--- a/packages/js/product-editor/src/blocks/sale-price/editor.scss
+++ b/packages/js/product-editor/src/blocks/sale-price/editor.scss
@@ -1,0 +1,11 @@
+.wp-block-woocommerce-product-sale-price-field {
+	.components-currency-control {
+		.components-input-control__prefix {
+			color: $gray-700;
+		}
+
+		.components-input-control__input {
+			text-align: right;
+		}
+	}
+}

--- a/packages/js/product-editor/src/blocks/sale-price/index.ts
+++ b/packages/js/product-editor/src/blocks/sale-price/index.ts
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { BlockConfiguration } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { initBlock } from '../../utils/init-blocks';
+import blockConfiguration from './block.json';
+import { Edit } from './edit';
+import { SalePriceBlockAttributes } from './types';
+
+const { name, ...metadata } =
+	blockConfiguration as BlockConfiguration< SalePriceBlockAttributes >;
+
+export { metadata, name };
+
+export const settings: Partial<
+	BlockConfiguration< SalePriceBlockAttributes >
+> = {
+	example: {},
+	edit: Edit,
+};
+
+export function init() {
+	return initBlock( { name, metadata, settings } );
+}

--- a/packages/js/product-editor/src/blocks/sale-price/types.ts
+++ b/packages/js/product-editor/src/blocks/sale-price/types.ts
@@ -1,0 +1,9 @@
+/**
+ * External dependencies
+ */
+import { BlockAttributes } from '@wordpress/blocks';
+
+export interface SalePriceBlockAttributes extends BlockAttributes {
+	label: string;
+	help?: string;
+}

--- a/packages/js/product-editor/src/blocks/style.scss
+++ b/packages/js/product-editor/src/blocks/style.scss
@@ -5,6 +5,7 @@
 @import 'inventory-sku/editor.scss';
 @import 'name/editor.scss';
 @import 'pricing/editor.scss';
+@import 'regular-price/editor.scss';
 @import 'sale-price/editor.scss';
 @import 'schedule-sale/editor.scss';
 @import 'section/editor.scss';

--- a/packages/js/product-editor/src/blocks/style.scss
+++ b/packages/js/product-editor/src/blocks/style.scss
@@ -5,6 +5,7 @@
 @import 'inventory-sku/editor.scss';
 @import 'name/editor.scss';
 @import 'pricing/editor.scss';
+@import 'sale-price/editor.scss';
 @import 'schedule-sale/editor.scss';
 @import 'section/editor.scss';
 @import 'shipping-dimensions/editor.scss';

--- a/plugins/woocommerce/changelog/add-37985
+++ b/plugins/woocommerce/changelog/add-37985
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add Sale price validation#37985

--- a/plugins/woocommerce/includes/class-wc-post-types.php
+++ b/plugins/woocommerce/includes/class-wc-post-types.php
@@ -403,7 +403,7 @@ class WC_Post_Types {
 													),
 													array(
 														array(
-															'woocommerce/product-pricing-field',
+															'woocommerce/product-regular-price-field',
 															array(
 																'name'  => 'regular_price',
 																'label' => __( 'List price', 'woocommerce' ),
@@ -518,7 +518,7 @@ class WC_Post_Types {
 													),
 													array(
 														array(
-															'woocommerce/product-pricing-field',
+															'woocommerce/product-regular-price-field',
 															array(
 																'name'  => 'regular_price',
 																'label' => __( 'List price', 'woocommerce' ),

--- a/plugins/woocommerce/includes/class-wc-post-types.php
+++ b/plugins/woocommerce/includes/class-wc-post-types.php
@@ -419,9 +419,8 @@ class WC_Post_Types {
 													),
 													array(
 														array(
-															'woocommerce/product-pricing-field',
+															'woocommerce/product-sale-price-field',
 															array(
-																'name'  => 'sale_price',
 																'label' => __( 'Sale price', 'woocommerce' ),
 															),
 														),
@@ -534,9 +533,8 @@ class WC_Post_Types {
 													),
 													array(
 														array(
-															'woocommerce/product-pricing-field',
+															'woocommerce/product-sale-price-field',
 															array(
-																'name'  => 'sale_price',
 																'label' => __( 'Sale price', 'woocommerce' ),
 															),
 														),

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
@@ -31,6 +31,7 @@ class BlockRegistry {
 		'woocommerce/product-name-field',
 		'woocommerce/product-pricing-field',
 		'woocommerce/product-radio-field',
+		'woocommerce/product-sale-price-field',
 		'woocommerce/product-schedule-sale-fields',
 		'woocommerce/product-section',
 		'woocommerce/product-shipping-dimensions-fields',

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
@@ -31,6 +31,7 @@ class BlockRegistry {
 		'woocommerce/product-name-field',
 		'woocommerce/product-pricing-field',
 		'woocommerce/product-radio-field',
+		'woocommerce/product-regular-price-field',
 		'woocommerce/product-sale-price-field',
 		'woocommerce/product-schedule-sale-fields',
 		'woocommerce/product-section',


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #37985

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Got to `/wp-admin/tools.php?page=woocommerce-admin-test-helper`
2. Under Features tab make sure to enable `product-block-editor`
3. Then visit `/wp-admin/admin.php?page=wc-admin&path=/add-product`
4. Under `General` tab and within `Basic details` section the product list price and sale price should validate according the AC described in #37985

<!-- End testing instructions -->