### PR TITLE
Adding basic ordering to tab slot fill

### DIFF
--- a/packages/js/product-editor/changelog/fix-tabs-reordering-38002
+++ b/packages/js/product-editor/changelog/fix-tabs-reordering-38002
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Adding basic ordering to product tabs slot-fill.

--- a/packages/js/product-editor/src/blocks/tab/block.json
+++ b/packages/js/product-editor/src/blocks/tab/block.json
@@ -13,6 +13,9 @@
 		},
 		"title": {
 			"type": "string"
+		},
+		"order": {
+			"type": "number"
 		}
 	},
 	"supports": {

--- a/packages/js/product-editor/src/blocks/tab/edit.tsx
+++ b/packages/js/product-editor/src/blocks/tab/edit.tsx
@@ -21,7 +21,7 @@ export function Edit( {
 	};
 } ) {
 	const blockProps = useBlockProps();
-	const { id, title } = attributes;
+	const { id, title, order } = attributes;
 	const isSelected = context?.selectedTab === id;
 
 	const classes = classnames( 'wp-block-woocommerce-product-tab__content', {
@@ -30,7 +30,7 @@ export function Edit( {
 
 	return (
 		<div { ...blockProps }>
-			<TabButton id={ id } selected={ isSelected }>
+			<TabButton id={ id } selected={ isSelected } order={ order }>
 				{ title }
 			</TabButton>
 			<div

--- a/packages/js/product-editor/src/blocks/tab/tab-button.tsx
+++ b/packages/js/product-editor/src/blocks/tab/tab-button.tsx
@@ -3,7 +3,7 @@
  */
 import { Button, Fill } from '@wordpress/components';
 import classnames from 'classnames';
-import { createElement } from '@wordpress/element';
+import { createElement, Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -11,16 +11,27 @@ import { createElement } from '@wordpress/element';
 import { TABS_SLOT_NAME } from '../../components/tabs/constants';
 import { TabsFillProps } from '../../components/tabs';
 
+export const DEFAULT_TAB_ORDER = 100;
+
+const OrderedWrapper = ( {
+	children,
+}: {
+	order: number;
+	children: JSX.Element | JSX.Element[];
+} ) => <>{ children }</>;
+
 export function TabButton( {
 	children,
 	className,
 	id,
+	order = DEFAULT_TAB_ORDER,
 	selected = false,
 }: {
 	children: string | JSX.Element;
 	className?: string;
 	id: string;
 	selected?: boolean;
+	order?: number;
 } ) {
 	const classes = classnames(
 		'wp-block-woocommerce-product-tab__button',
@@ -33,16 +44,18 @@ export function TabButton( {
 			{ ( fillProps: TabsFillProps ) => {
 				const { onClick } = fillProps;
 				return (
-					<Button
-						key={ id }
-						className={ classes }
-						onClick={ () => onClick( id ) }
-						id={ `woocommerce-product-tab__${ id }` }
-						aria-controls={ `woocommerce-product-tab__${ id }-content` }
-						aria-selected={ selected }
-					>
-						{ children }
-					</Button>
+					<OrderedWrapper order={ order }>
+						<Button
+							key={ id }
+							className={ classes }
+							onClick={ () => onClick( id ) }
+							id={ `woocommerce-product-tab__${ id }` }
+							aria-controls={ `woocommerce-product-tab__${ id }-content` }
+							aria-selected={ selected }
+						>
+							{ children }
+						</Button>
+					</OrderedWrapper>
 				);
 			} }
 		</Fill>

--- a/packages/js/product-editor/src/components/tabs/tabs.tsx
+++ b/packages/js/product-editor/src/components/tabs/tabs.tsx
@@ -46,8 +46,7 @@ export function Tabs( { onChange = () => {} }: TabsProps ) {
 			if ( fills[ i ][ 0 ].props.disabled ) {
 				continue;
 			}
-			// Remove the `.$` prefix on keys.  E.g., .$key => key
-			const tabId = fills[ i ][ 0 ].key?.toString().slice( 2 ) || null;
+			const tabId = fills[ i ][ 0 ].props?.children?.key || null;
 			setSelected( tabId );
 			return;
 		}

--- a/packages/js/product-editor/src/components/tabs/tabs.tsx
+++ b/packages/js/product-editor/src/components/tabs/tabs.tsx
@@ -6,6 +6,7 @@ import {
 	Fragment,
 	useEffect,
 	useState,
+	Children,
 } from '@wordpress/element';
 import { ReactElement } from 'react';
 import { NavigableMenu, Slot } from '@wordpress/components';
@@ -17,6 +18,7 @@ import { navigateTo, getNewPath, getQuery } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
+import { sortFillsByOrder } from '../../utils';
 import { TABS_SLOT_NAME } from './constants';
 
 type TabsProps = {
@@ -30,13 +32,6 @@ export type TabsFillProps = {
 export function Tabs( { onChange = () => {} }: TabsProps ) {
 	const [ selected, setSelected ] = useState< string | null >( null );
 	const query = getQuery() as Record< string, string >;
-
-	function onClick( tabId: string ) {
-		window.document.documentElement.scrollTop = 0;
-		navigateTo( {
-			url: getNewPath( { tab: tabId } ),
-		} );
-	}
 
 	useEffect( () => {
 		onChange( selected );
@@ -81,14 +76,21 @@ export function Tabs( { onChange = () => {} }: TabsProps ) {
 			<Slot
 				fillProps={
 					{
-						onClick,
+						onClick: ( tabId ) =>
+							navigateTo( {
+								url: getNewPath( { tab: tabId } ),
+							} ),
 					} as TabsFillProps
 				}
 				name={ TABS_SLOT_NAME }
 			>
 				{ ( fills ) => {
+					if ( ! sortFillsByOrder ) {
+						return null;
+					}
+
 					maybeSetSelected( fills );
-					return <>{ fills }</>;
+					return sortFillsByOrder( fills );
 				} }
 			</Slot>
 		</NavigableMenu>

--- a/packages/js/product-editor/src/components/tabs/tabs.tsx
+++ b/packages/js/product-editor/src/components/tabs/tabs.tsx
@@ -1,13 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	createElement,
-	Fragment,
-	useEffect,
-	useState,
-	Children,
-} from '@wordpress/element';
+import { createElement, useEffect, useState } from '@wordpress/element';
 import { ReactElement } from 'react';
 import { NavigableMenu, Slot } from '@wordpress/components';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/packages/js/product-editor/src/utils/sort-fills-by-order.tsx
+++ b/packages/js/product-editor/src/utils/sort-fills-by-order.tsx
@@ -11,7 +11,7 @@ import { createElement } from '@wordpress/element';
  * @param {Array} fills - slot's `Fill`s.
  * @return {Node} Node.
  */
-export const sortFillsByOrder: Slot.Props[ 'children' ] = ( fills ) => {
+export const sortFillsByOrder: Slot.Props[ 'children' ] = ( fills = [] ) => {
 	// Copy fills array here because its type is readonly array that doesn't have .sort method in Typescript definition.
 	const sortedFills = [ ...fills ].sort( ( a, b ) => {
 		return a[ 0 ].props.order - b[ 0 ].props.order;

--- a/packages/js/product-editor/src/utils/sort-fills-by-order.tsx
+++ b/packages/js/product-editor/src/utils/sort-fills-by-order.tsx
@@ -11,7 +11,7 @@ import { createElement } from '@wordpress/element';
  * @param {Array} fills - slot's `Fill`s.
  * @return {Node} Node.
  */
-export const sortFillsByOrder: Slot.Props[ 'children' ] = ( fills = [] ) => {
+export const sortFillsByOrder: Slot.Props[ 'children' ] = ( fills ) => {
 	// Copy fills array here because its type is readonly array that doesn't have .sort method in Typescript definition.
 	const sortedFills = [ ...fills ].sort( ( a, b ) => {
 		return a[ 0 ].props.order - b[ 0 ].props.order;

--- a/plugins/woocommerce/changelog/fix-tabs-reordering-38002
+++ b/plugins/woocommerce/changelog/fix-tabs-reordering-38002
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Adding order attributes to product tabs template.

--- a/plugins/woocommerce/includes/class-wc-post-types.php
+++ b/plugins/woocommerce/includes/class-wc-post-types.php
@@ -371,6 +371,7 @@ class WC_Post_Types {
 							array(
 								'id'    => 'general',
 								'title' => __( 'General', 'woocommerce' ),
+								'order' => 10,
 							),
 							array(
 								array(
@@ -491,6 +492,7 @@ class WC_Post_Types {
 							array(
 								'id'    => 'pricing',
 								'title' => __( 'Pricing', 'woocommerce' ),
+								'order' => 20,
 							),
 							array(
 								array(
@@ -614,6 +616,7 @@ class WC_Post_Types {
 							array(
 								'id'    => 'inventory',
 								'title' => __( 'Inventory', 'woocommerce' ),
+								'order' => 30,
 							),
 							array(
 								array(
@@ -763,6 +766,7 @@ class WC_Post_Types {
 							array(
 								'id'    => 'shipping',
 								'title' => __( 'Shipping', 'woocommerce' ),
+								'order' => 40,
 							),
 							array(
 								array(


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adding order attribute to tab blocks, and preventing reordering while rendering.

Closes #38002 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout branch and enable `product-block-editor` feature flag (can do with WCA Test Helper plugin)
2. Navigate to Products -> Add new to see product editor.
3. Refresh the page and observe the header tabs as the page loads, and ensure that they don't reorder as they were originally (see [issue for video](https://github.com/woocommerce/woocommerce/issues/38002))

<!-- End testing instructions -->