### PR TITLE
Add form id attribute

### DIFF
--- a/plugins/woocommerce/templates/single-product/add-to-cart/simple.php
+++ b/plugins/woocommerce/templates/single-product/add-to-cart/simple.php
@@ -29,7 +29,7 @@ if ( $product->is_in_stock() ) : ?>
 
 	<?php do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 
-	<form class="cart" action="<?php echo esc_url( apply_filters( 'woocommerce_add_to_cart_form_action', $product->get_permalink() ) ); ?>" method="post" enctype='multipart/form-data'>
+	<form class="cart" id="wc-add-to-cart-<?php esc_attr_e( $product->get_id() ); ?>" action="<?php echo esc_url( apply_filters( 'woocommerce_add_to_cart_form_action', $product->get_permalink() ) ); ?>" method="post" enctype='multipart/form-data'>
 		<?php do_action( 'woocommerce_before_add_to_cart_button' ); ?>
 
 		<?php


### PR DESCRIPTION
Add id attribute to &lt;form&gt; inside all product add-to-cart templates, for plugins/add-ons which might add <inputs> outside the <form>. Inputs can then use the form="" attribute to be included in the form submission.

Suggested ID could be anything WC decides, obviously. Including Product ID might be too specific.

### Changes proposed in this Pull Request:

ID attribute added to add-to-cart <form> for product pages (simple used as example, variation etc. would also need ID attributes added). Inconsequential change other than that it allows for more 3rd party functionality on the product pages.

### Testing Instructions
Code review should be sufficient before making this change. Adding a unique selector to a Woo &lt;form&gt; should not affect existing installations, but could benefit existing ones.