### PR TITLE
Enable running phpcs-changed locally against a branch

### DIFF
--- a/plugins/woocommerce/bin/lint-branch.sh
+++ b/plugins/woocommerce/bin/lint-branch.sh
@@ -1,7 +1,17 @@
 #!/bin/sh
 
+# Lint branch
+#
+# Runs phpcs-changed, comparing the current branch to its "base" or "parent" branch.
+# The base branch defaults to trunk, but another branch name can be specified as an
+# optional positional argument.
+#
+# Example:
+# ./lint-branch.sh base-branch
+
 baseBranch=${1:-"trunk"}
 
-chg=$(git diff $(git merge-base HEAD $baseBranch) --relative --name-only -- '*.php')
+changedFiles=$(git diff $(git merge-base HEAD $baseBranch) --relative --name-only -- '*.php')
 
-[ -z $chg ] || composer exec phpcs-changed -- -s --git --git-base $baseBranch $chg
+# Only complete this if changed files are detected.
+[ -z $changedFiles ] || composer exec phpcs-changed -- -s --git --git-base $baseBranch $changedFiles

--- a/plugins/woocommerce/bin/lint-branch.sh
+++ b/plugins/woocommerce/bin/lint-branch.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+baseBranch=${1:-"trunk"}
+
+chg=$(git diff $(git merge-base HEAD $baseBranch) --relative --name-only -- '*.php')
+
+[ -z $chg ] || composer exec phpcs-changed -- -s --git --git-base $baseBranch $chg

--- a/plugins/woocommerce/bin/lint-branch.sh
+++ b/plugins/woocommerce/bin/lint-branch.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Lint branch
 #
@@ -14,4 +14,4 @@ baseBranch=${1:-"trunk"}
 changedFiles=$(git diff $(git merge-base HEAD $baseBranch) --relative --name-only -- '*.php')
 
 # Only complete this if changed files are detected.
-[ -z $changedFiles ] || composer exec phpcs-changed -- -s --git --git-base $baseBranch $changedFiles
+[[ -z $changedFiles ]] || composer exec phpcs-changed -- -s --git --git-base $baseBranch $changedFiles

--- a/plugins/woocommerce/changelog/add-lint-branch
+++ b/plugins/woocommerce/changelog/add-lint-branch
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add a composer script to run phpcs-changed against the current branch

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -89,10 +89,10 @@
 			"phpcs -s -p"
 		],
 		"lint": [
-			"chg=$(git diff --relative --name-only -- '*.php'); [ -z $chg ] || phpcs-changed -s --git --git-unstaged $chg"
+			"chg=$(git diff --relative --name-only -- '*.php'); [[ -z $chg ]] || phpcs-changed -s --git --git-unstaged $chg"
 		],
 		"lint-staged": [
-			"chg=$(git diff HEAD --relative --name-only -- '*.php'); [ -z $chg ] || phpcs-changed -s --git $chg"
+			"chg=$(git diff HEAD --relative --name-only -- '*.php'); [[ -z $chg ]] || phpcs-changed -s --git $chg"
 		],
 		"lint-branch": [
 			"sh ./bin/lint-branch.sh"

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -94,6 +94,9 @@
 		"lint-staged": [
 			"chg=$(git diff HEAD --relative --name-only -- '*.php'); [ -z $chg ] || phpcs-changed -s --git $chg"
 		],
+		"lint-branch": [
+			"sh ./bin/lint-branch.sh"
+		],
 		"phpcbf": [
 			"phpcbf -p"
 		],


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Following up on #37465, this adds a way to run phpcs-changed against commits in a branch, rather than against staged or unstaged changes in the working directory. The way that phpcs-changed works, it needs to have another branch ("base" branch) to compare to for determining which lines have changed and thus should be linted. This script assumes the base branch is trunk, but another branch name can optionally be specified when running the command.

This also updates the other lint commands to use double brackets rather than single for testing the contents of the `$chg` variable, to ensure they work correctly when multiple changed files are involved (see discussion in this PR).

### How to test the changes in this Pull Request:

1. Check out this branch so that you have the new linting script available.
2. Check out another, new branch based off of this one. E.g. `git checkout -b test-lint-branch`
3. On this new branch, make a change to a line that has an existing linting error in a file with lots of existing linting errors. [Here's a good candidate.](https://github.com/woocommerce/woocommerce/blob/c4fc54680b79f306234ba43c0c82f186f643cf1b/plugins/woocommerce/templates/cart/cart.php#L80)
4. Commit that change.
5. Now in your terminal, from the repo root, change to `plugins/woocommerce`.
6. Run the new command: `composer run lint-branch`. The linter should identify errors with the line you changed in your commit, but not other lines in the file.
