### PR TITLE
Fix summary toolbar positioning and selection on blur

### DIFF
--- a/packages/js/product-editor/changelog/fix-37956
+++ b/packages/js/product-editor/changelog/fix-37956
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix summary toolbar positioning and selection on blur

--- a/packages/js/product-editor/src/blocks/summary/edit.tsx
+++ b/packages/js/product-editor/src/blocks/summary/edit.tsx
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { createElement } from '@wordpress/element';
 import { BlockEditProps } from '@wordpress/blocks';
 import { BaseControl } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import { useEntityProp } from '@wordpress/core-data';
 import uniqueId from 'lodash/uniqueId';
 import classNames from 'classnames';
@@ -14,6 +15,7 @@ import {
 	AlignmentControl,
 	BlockControls,
 	RichText,
+	store as blockEditorStore,
 	useBlockProps,
 } from '@wordpress/block-editor';
 
@@ -38,6 +40,9 @@ export function Edit( {
 		'product',
 		'short_description'
 	);
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore No types for this exist yet.
+	const { clearSelectedBlock } = useDispatch( blockEditorStore );
 
 	function handleAlignmentChange( value: SummaryAttributes[ 'align' ] ) {
 		setAttributes( { align: value } );
@@ -45,6 +50,15 @@ export function Edit( {
 
 	function handleDirectionChange( value: SummaryAttributes[ 'direction' ] ) {
 		setAttributes( { direction: value } );
+	}
+
+	function handleBlur( event: React.FocusEvent< 'p', Element > ) {
+		const isToolbar = event.relatedTarget?.closest(
+			'.block-editor-block-contextual-toolbar'
+		);
+		if ( ! isToolbar ) {
+			clearSelectedBlock();
+		}
 	}
 
 	return (
@@ -84,6 +98,7 @@ export function Edit( {
 					} ) }
 					dir={ direction }
 					allowedFormats={ allowedFormats }
+					onBlur={ handleBlur }
 				/>
 			</BaseControl>
 		</div>

--- a/packages/js/product-editor/src/blocks/summary/edit.tsx
+++ b/packages/js/product-editor/src/blocks/summary/edit.tsx
@@ -7,7 +7,7 @@ import { BlockEditProps } from '@wordpress/blocks';
 import { BaseControl } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { useEntityProp } from '@wordpress/core-data';
-import uniqueId from 'lodash/uniqueId';
+import { useInstanceId } from '@wordpress/compose';
 import classNames from 'classnames';
 import {
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -34,8 +34,9 @@ export function Edit( {
 	const blockProps = useBlockProps( {
 		style: { direction },
 	} );
-	const contentId = uniqueId(
-		'wp-block-woocommerce-product-summary-field__content-'
+	const contentId = useInstanceId(
+		Edit,
+		'wp-block-woocommerce-product-summary-field__content'
 	);
 	const [ summary, setSummary ] = useEntityProp< string >(
 		'postType',
@@ -85,12 +86,12 @@ export function Edit( {
 			</BlockControls>
 
 			<BaseControl
-				id={ contentId }
+				id={ contentId.toString() }
 				label={ label || __( 'Summary', 'woocommerce' ) }
 			>
 				<div { ...blockProps }>
 					<RichText
-						id={ contentId }
+						id={ contentId.toString() }
 						identifier="content"
 						tagName="p"
 						value={ summary }

--- a/packages/js/product-editor/src/blocks/summary/edit.tsx
+++ b/packages/js/product-editor/src/blocks/summary/edit.tsx
@@ -62,7 +62,11 @@ export function Edit( {
 	}
 
 	return (
-		<div { ...blockProps }>
+		<div
+			className={
+				'wp-block wp-block-woocommerce-product-summary-field-wrapper'
+			}
+		>
 			{ /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */ }
 			{ /* @ts-ignore No types for this exist yet. */ }
 			<BlockControls group="block">
@@ -82,24 +86,26 @@ export function Edit( {
 				id={ id }
 				label={ label || __( 'Summary', 'woocommerce' ) }
 			>
-				<RichText
-					id={ id }
-					identifier="content"
-					tagName="p"
-					value={ summary }
-					onChange={ setSummary }
-					placeholder={ __(
-						"Summarize this product in 1-2 short sentences. We'll show it at the top of the page.",
-						'woocommerce'
-					) }
-					data-empty={ Boolean( summary ) }
-					className={ classNames( 'components-summary-control', {
-						[ `has-text-align-${ align }` ]: align,
-					} ) }
-					dir={ direction }
-					allowedFormats={ allowedFormats }
-					onBlur={ handleBlur }
-				/>
+				<div { ...blockProps }>
+					<RichText
+						id={ id }
+						identifier="content"
+						tagName="p"
+						value={ summary }
+						onChange={ setSummary }
+						placeholder={ __(
+							"Summarize this product in 1-2 short sentences. We'll show it at the top of the page.",
+							'woocommerce'
+						) }
+						data-empty={ Boolean( summary ) }
+						className={ classNames( 'components-summary-control', {
+							[ `has-text-align-${ align }` ]: align,
+						} ) }
+						dir={ direction }
+						allowedFormats={ allowedFormats }
+						onBlur={ handleBlur }
+					/>
+				</div>
 			</BaseControl>
 		</div>
 	);

--- a/packages/js/product-editor/src/blocks/summary/edit.tsx
+++ b/packages/js/product-editor/src/blocks/summary/edit.tsx
@@ -34,7 +34,9 @@ export function Edit( {
 	const blockProps = useBlockProps( {
 		style: { direction },
 	} );
-	const id = uniqueId();
+	const contentId = uniqueId(
+		'wp-block-woocommerce-product-summary-field__content-'
+	);
 	const [ summary, setSummary ] = useEntityProp< string >(
 		'postType',
 		'product',
@@ -83,12 +85,12 @@ export function Edit( {
 			</BlockControls>
 
 			<BaseControl
-				id={ id }
+				id={ contentId }
 				label={ label || __( 'Summary', 'woocommerce' ) }
 			>
 				<div { ...blockProps }>
 					<RichText
-						id={ id }
+						id={ contentId }
 						identifier="content"
 						tagName="p"
 						value={ summary }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

* Fixes the toolbar positioning to right above the content editing area
* Deselects the block on blur to remove the toolbar

<img width="341" alt="Screen Shot 2023-05-02 at 4 31 01 PM" src="https://user-images.githubusercontent.com/10561050/235810300-e325b55d-26ae-46d6-b642-d43d63db8d56.png">


Closes #37956  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Navigate to Tools -> WCA Test Helper -> Features and enable the new product blocks editing experience
2. Navigate to Products -> Add new
3. Click on the summary field
4. Note that the toolbar is now directly above the editable area and not above the label "Summary"
5. Type some text and then attempt to use the toolbar, verifying that it works as expected
6. Click anywhere else on the page and verify that the toolbar is no longer visible

<!-- End testing instructions -->