### PR TITLE
Prevent double debouncing of iframe editor callback

### DIFF
--- a/packages/js/product-editor/changelog/fix-38020
+++ b/packages/js/product-editor/changelog/fix-38020
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Prevent double debouncing of iframe editor callback

--- a/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
@@ -4,13 +4,8 @@
 import { BlockInstance } from '@wordpress/blocks';
 import { Popover } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import {
-	createElement,
-	useCallback,
-	useEffect,
-	useState,
-} from '@wordpress/element';
-import { useDebounce, useResizeObserver } from '@wordpress/compose';
+import { createElement, useEffect, useState } from '@wordpress/element';
+import { useResizeObserver } from '@wordpress/compose';
 import {
 	BlockEditorProvider,
 	BlockInspector,
@@ -66,15 +61,6 @@ export function IframeEditor( {
 		updateSettings( productBlockEditorSettings );
 	}, [] );
 
-	const handleChange = useCallback(
-		( updatedBlocks: BlockInstance[] ) => {
-			onChange( updatedBlocks );
-		},
-		[ onChange ]
-	);
-
-	const debouncedOnChange = useDebounce( handleChange, 200 );
-
 	return (
 		<div className="woocommerce-iframe-editor">
 			<BlockEditorProvider
@@ -86,7 +72,7 @@ export function IframeEditor( {
 				value={ blocks }
 				onChange={ ( updatedBlocks: BlockInstance[] ) => {
 					setBlocks( updatedBlocks );
-					debouncedOnChange( updatedBlocks );
+					onChange( updatedBlocks );
 				} }
 				useSubRegistry={ true }
 			>
@@ -104,7 +90,13 @@ export function IframeEditor( {
 					{ /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */ }
 					{ /* @ts-ignore */ }
 					<BlockEditorKeyboardShortcuts.Register />
-					{ onClose && <BackButton onClick={ onClose } /> }
+					{ onClose && (
+						<BackButton
+							onClick={ () => {
+								setTimeout( onClose, 550 );
+							} }
+						/>
+					) }
 					<ResizableEditor
 						enableResizing={ true }
 						// eslint-disable-next-line @typescript-eslint/ban-ts-comment


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #38020 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Navigate to Tools -> WCA Test Helper -> Features and enable the new product blocks editing experience
2. Navigate to Products -> Add new
3. Click on Add description
4. Add some content
5. Wait approximately ~2s
6. Close the modal
7. Make sure the content shows in the preview or click "Edit description" to make sure the content has persisted

<!-- End testing instructions -->