### PR TITLE
Fix "Marketing & Merchandising" padding on store management panel

### DIFF
--- a/plugins/woocommerce-admin/client/store-management-links/style.scss
+++ b/plugins/woocommerce-admin/client/store-management-links/style.scss
@@ -1,9 +1,3 @@
-// Setting a custom size that is not recognised by the <CardBody> allows us to override the card's default padding sizes.
-// We need to do this to allow item hover backgrounds to stretch the whole card body.
-.woocommerce-store-management-links__card-body.is-size-custom {
-	padding: 24px 0 8px 0;
-}
-
 .woocommerce-store-management-links__card-body {
-	padding-top: 24px;
+	padding: $gap-large 0 $gap-smaller 0;
 }

--- a/plugins/woocommerce-admin/client/store-management-links/style.scss
+++ b/plugins/woocommerce-admin/client/store-management-links/style.scss
@@ -3,3 +3,7 @@
 .woocommerce-store-management-links__card-body.is-size-custom {
 	padding: 24px 0 8px 0;
 }
+
+.woocommerce-store-management-links__card-body {
+	padding-top: 24px;
+}

--- a/plugins/woocommerce-admin/client/store-management-links/style.scss
+++ b/plugins/woocommerce-admin/client/store-management-links/style.scss
@@ -1,3 +1,3 @@
 .woocommerce-store-management-links__card-body {
-	padding: $gap-large 0 $gap-smaller 0;
+	padding-top: $gap;
 }

--- a/plugins/woocommerce/changelog/fix-manage-store-panel-padding
+++ b/plugins/woocommerce/changelog/fix-manage-store-panel-padding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Add a 24px spacing to store management body


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/35583.

This PR adds a 24px spacing between the Manage my store header and the Marketing & Merchandising heading

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to `WooCommerce > Home`
2. Hide setup task list
3. Confirm the heading "Marketing & Merchandising" has padding between the Manage my store header

![Screenshot 2023-05-03 at 16 06 00](https://user-images.githubusercontent.com/4344253/235862513-0a927c9e-0238-4ece-9f2c-88c1249f8248.png)


<!-- End testing instructions -->