### PR TITLE
Fix partial data import with product task imports

### DIFF
--- a/plugins/woocommerce/changelog/fix-38069-fix-product-task-imports
+++ b/plugins/woocommerce/changelog/fix-38069-fix-product-task-imports
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix product task import for cases when user locale is en_US

--- a/plugins/woocommerce/includes/admin/importers/mappings/default.php
+++ b/plugins/woocommerce/includes/admin/importers/mappings/default.php
@@ -32,7 +32,7 @@ function wc_importer_current_locale() {
  * @return array
  */
 function wc_importer_default_english_mappings( $mappings ) {
-	if ( 'en_US' === wc_importer_current_locale() ) {
+	if ( 'en_US' === wc_importer_current_locale() && is_array( $mappings ) && count( $mappings ) > 0 ) {
 		return $mappings;
 	}
 
@@ -92,7 +92,7 @@ add_filter( 'woocommerce_csv_product_import_mapping_default_columns', 'wc_import
  * @return array
  */
 function wc_importer_default_special_english_mappings( $mappings ) {
-	if ( 'en_US' === wc_importer_current_locale() ) {
+	if ( 'en_US' === wc_importer_current_locale() && is_array( $mappings ) && count( $mappings ) > 0 ) {
 		return $mappings;
 	}
 

--- a/plugins/woocommerce/src/Admin/API/OnboardingTasks.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingTasks.php
@@ -355,7 +355,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public static function create_product_from_template( $request ) {
-		$template_name = $request->get_param( 'template_name' );
+		$template_name = basename( $request->get_param( 'template_name' ) );
 		$template_path = __DIR__ . '/Templates/' . $template_name . '_product.csv';
 		$template_path = apply_filters( 'woocommerce_product_template_csv_file_path', $template_path, $template_name );
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/onboarding-tasks.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/onboarding-tasks.php
@@ -136,6 +136,32 @@ class WC_Admin_Tests_API_Onboarding_Tasks extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Test creating a product from a template with 'en_US' locale since this is handled differently.
+	 */
+	public function test_create_product_from_template_locale() {
+		wp_set_current_user( $this->user );
+
+		// Get the current user's locale.
+		$user_locale = get_user_locale();
+		switch_to_locale( 'en_US', $this->user );
+
+		$request = new WP_REST_Request( 'POST', $this->endpoint . '/create_product_from_template' );
+		$request->set_param( 'template_name', 'variable' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$this->assertArrayHasKey( 'id', $data );
+		$product = wc_get_product( $data['id'] );
+		$this->assertEquals( 'auto-draft', $product->get_status() );
+		$this->assertEquals( 'variable', $product->get_type() );
+
+		// Set to initial locale.
+		switch_to_locale( $user_locale, $this->user );
+	}
+
+	/**
 	 * Test that we get an error when template_name does not exist.
 	 */
 	public function test_create_product_from_wrong_template_name() {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #38069.

Fixes import failures when user profile language preference is set to `en_US`.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

#### Prerequisite
1. Go to Users > Profile
2. Set language to `English (United States)`
3. Save profile

#### Testing product type
5. Go to WooCommerce > Home
6. Click on "Add Products" task
7. Click on "Variable product"
8. Observe the product is created as a "variable product" and the product image is shown

#### Testing sample import
5. Go to WooCommerce > Home
6. Click on "Add Products" task
7. Click on "View more product types"
8. Click on "Load Sample Products"
9. Observe 9 sample products are loaded and product image is shown for the newly imported products

<!-- End testing instructions -->