### PR TITLE
Monorepo Tools: use cloneRepoShallow

### DIFF
--- a/tools/code-analyzer/src/commands/analyzer/analyzer-major-minor.ts
+++ b/tools/code-analyzer/src/commands/analyzer/analyzer-major-minor.ts
@@ -4,7 +4,7 @@
 import { join } from 'path';
 import { readFile } from 'fs/promises';
 import simpleGit from 'simple-git';
-import { cloneRepo } from '@woocommerce/monorepo-utils/src/core/git';
+import { cloneRepoShallow } from '@woocommerce/monorepo-utils/src/core/git';
 import { Logger } from '@woocommerce/monorepo-utils/src/core/logger';
 import { Command } from '@commander-js/extra-typings';
 
@@ -62,7 +62,7 @@ const program = new Command()
 		const { source } = options;
 
 		Logger.startTask( `Making a temporary clone of '${ branch }'` );
-		const tmpRepoPath = await cloneRepo( source );
+		const tmpRepoPath = await cloneRepoShallow( source );
 		Logger.endTask();
 
 		const version = await getPluginData(

--- a/tools/code-analyzer/src/lib/scan-changes.ts
+++ b/tools/code-analyzer/src/lib/scan-changes.ts
@@ -4,7 +4,7 @@
 import { Logger } from '@woocommerce/monorepo-utils/src/core/logger';
 import { join } from 'path';
 import {
-	cloneRepo,
+	cloneRepoShallow,
 	generateDiff,
 } from '@woocommerce/monorepo-utils/src/core/git';
 import { readFile } from 'fs/promises';
@@ -33,7 +33,7 @@ const generateVersionDiff = async (
 	const tmpRepoPath =
 		typeof clonedPath !== 'undefined'
 			? clonedPath
-			: await cloneRepo( source );
+			: await cloneRepoShallow( source );
 
 	Logger.endTask();
 
@@ -148,7 +148,7 @@ export const scanForChanges = async (
 	const tmpRepoPath =
 		typeof clonedPath !== 'undefined'
 			? clonedPath
-			: await cloneRepo( source );
+			: await cloneRepoShallow( source );
 
 	Logger.endTask();
 

--- a/tools/release-posts/commands/release-post/release-post-release.ts
+++ b/tools/release-posts/commands/release-post/release-post-release.ts
@@ -7,7 +7,7 @@ import { writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import {
-	cloneRepo,
+	cloneRepoShallow,
 	getCommitHash,
 } from '@woocommerce/monorepo-utils/src/core/git';
 import { Logger } from '@woocommerce/monorepo-utils/src/core/logger';
@@ -105,7 +105,7 @@ const program = new Command()
 		Logger.startTask( `Making temporary clone of ${ SOURCE_REPO }...` );
 		const currentParsed = semver.parse( currentVersion );
 		const previousParsed = semver.parse( previousVersion );
-		const tmpRepoPath = await cloneRepo( SOURCE_REPO );
+		const tmpRepoPath = await cloneRepoShallow( SOURCE_REPO );
 		Logger.endTask();
 		let currentBranch;
 		let previousBranch;


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In https://github.com/woocommerce/woocommerce/pull/38036 `cloneRepoShallow` and `sparseCheckoutRepoShallow` were introduced to reduce the amount of time required to clone repos by ignoring git history. Passing in the `--depth=1` flag causes only the latest commit to be cloned instead of all the commits.

This PR updates Code Analyzer and Release Posts tools to use `cloneRepoShallow`.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Review the source
https://github.com/woocommerce/woocommerce/blob/05452979df5bff29aa25c8c6336c27f4a819c665/tools/monorepo-utils/src/core/git.ts#L109-L111
2. Give release posts a test run:
```
cd tools/release-posts
pnpm run release-post rc 7.7.0-rc.1 --outputOnly
```
3. And now Code Analyzer
```
pnpm run analyzer -- lint "release/6.8" "6.8.0" -b release/6.7
```

<!-- End testing instructions -->