### PR TITLE
Fix tasklist completion message when no tasks are completed

### DIFF
--- a/plugins/woocommerce-admin/client/task-lists/progress-title/default-progress-title.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/progress-title/default-progress-title.tsx
@@ -55,7 +55,7 @@ export const DefaultProgressTitle: React.FC< DefaultProgressTitleProps > = ( {
 				  )
 				: __( 'Welcome to your store', 'woocommerce' );
 		}
-		if ( completedCount > 0 && completedCount < 4 ) {
+		if ( completedCount <= 3 ) {
 			return __( "Let's get you started", 'woocommerce' ) + '   🚀';
 		}
 		if ( completedCount > 3 && completedCount < 6 ) {

--- a/plugins/woocommerce-admin/client/task-lists/progress-title/test/default-progress-title.test.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/progress-title/test/default-progress-title.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { DefaultProgressTitle } from '../default-progress-title';
+
+jest.mock( '@wordpress/data', () => ( {
+	...jest.requireActual( '@wordpress/data' ),
+	useSelect: jest.fn(),
+} ) );
+
+describe( 'default-progress-title', () => {
+	( useSelect as jest.Mock ).mockImplementation( ( fn ) =>
+		fn( () => ( {
+			getTaskList: () => ( {
+				tasks: [],
+			} ),
+			hasFinishedResolution: () => true,
+		} ) )
+	);
+
+	it( 'should render "Welcome to your store" when no tasks are completed and visited', () => {
+		render( <DefaultProgressTitle taskListId="1" /> );
+		expect(
+			screen.getByText( 'Welcome to your store' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should render "Welcome to your store" when all tasks are completed', () => {
+		( useSelect as jest.Mock ).mockImplementation( ( fn ) =>
+			fn( () => ( {
+				getTaskList: () => ( {
+					tasks: [
+						{ isVisited: true, isComplete: true },
+						{ isVisited: true, isComplete: true },
+					],
+				} ),
+				hasFinishedResolution: () => true,
+			} ) )
+		);
+		render( <DefaultProgressTitle taskListId="1" /> );
+		expect(
+			screen.getByText( 'Welcome to your store' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should render "Let\'s get you started" when has task visited and task completed count <= 3', () => {
+		( useSelect as jest.Mock ).mockImplementation( ( fn ) =>
+			fn( () => ( {
+				getTaskList: () => ( {
+					tasks: [ { isVisited: true, isComplete: false } ],
+				} ),
+				hasFinishedResolution: () => true,
+			} ) )
+		);
+		render( <DefaultProgressTitle taskListId="1" /> );
+		expect(
+			screen.getByText( "Let's get you started", { exact: false } )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should render "You are on the right track" when has task visited and task completed count > 3', () => {
+		( useSelect as jest.Mock ).mockImplementation( ( fn ) =>
+			fn( () => ( {
+				getTaskList: () => ( {
+					tasks: [
+						{ isVisited: true, isComplete: true },
+						{ isVisited: true, isComplete: true },
+						{ isVisited: true, isComplete: true },
+						{ isVisited: true, isComplete: true },
+						{ isVisited: true, isComplete: false },
+					],
+				} ),
+				hasFinishedResolution: () => true,
+			} ) )
+		);
+		render( <DefaultProgressTitle taskListId="1" /> );
+		expect(
+			screen.getByText( 'You are on the right track', { exact: false } )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should render "You are almost there" when has task visited and task completed count > 5', () => {
+		( useSelect as jest.Mock ).mockImplementation( ( fn ) =>
+			fn( () => ( {
+				getTaskList: () => ( {
+					tasks: [
+						{ isVisited: true, isComplete: true },
+						{ isVisited: true, isComplete: true },
+						{ isVisited: true, isComplete: true },
+						{ isVisited: true, isComplete: true },
+						{ isVisited: true, isComplete: true },
+						{ isVisited: true, isComplete: true },
+						{ isVisited: true, isComplete: false },
+					],
+				} ),
+				hasFinishedResolution: () => true,
+			} ) )
+		);
+		render( <DefaultProgressTitle taskListId="1" /> );
+		expect(
+			screen.getByText( 'You are almost there', { exact: false } )
+		).toBeInTheDocument();
+	} );
+} );

--- a/plugins/woocommerce/changelog/fix-tasklist-completion-message
+++ b/plugins/woocommerce/changelog/fix-tasklist-completion-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix task list progress title when no tasks are completed


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/37554.

When one of the tasks is visited and no tasks are completed, the message should say Let's get you started.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Start a fresh site
2. Skip the onboarding wizard so no tasks complete
3. Go to `WooCommerce > Home`
4. See the message above the task list
5. The message should display "Welcome to your store"
6. Click on `Add products` task
7. Go back to WooCommerce > Home
8. The message should display "Let's get you started 🚀"

<!-- End testing instructions -->