### PR TITLE
Fix tracks identifier mismatch

### DIFF
--- a/plugins/woocommerce/changelog/fix-38093-tracks-id-mismatch
+++ b/plugins/woocommerce/changelog/fix-38093-tracks-id-mismatch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix tracks user ID mismatch between PHP and JS when Jetpack is active and connected

--- a/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
@@ -67,7 +67,7 @@ class WC_Site_Tracking {
 		$user           = wp_get_current_user();
 		$server_details = WC_Tracks::get_server_details();
 		$blog_details   = WC_Tracks::get_blog_details( $user->ID );
-		$tracks_identity = WC_Tracks_Client::get_identity( $user->ID);
+		$tracks_identity = WC_Tracks_Client::get_identity( $user->ID );
 
 		$client_tracking_properties = array_merge( $server_details, $blog_details );
 		/**
@@ -84,8 +84,8 @@ class WC_Site_Tracking {
 			window.wcTracks.isEnabled = <?php echo self::is_tracking_enabled() ? 'true' : 'false'; ?>;
 			window._tkq = window._tkq || [];
 
-			<?php if ( $tracks_identity['_ut'] !== 'anon' ) { ?>
-			window._tkq.push( [ 'identifyUser', '<?= $tracks_identity['_ui'] ?>' ] );
+			<?php if ( 'anon' !== $tracks_identity['_ut'] ) { ?>
+			window._tkq.push( [ 'identifyUser', '<?php echo $tracks_identity['_ui']; ?>' ] );
 			<?php } ?>
 			window.wcTracks.validateEvent = function( eventName, props = {} ) {
 				let isValid = true;

--- a/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
@@ -81,7 +81,6 @@ class WC_Site_Tracking {
 		<!-- WooCommerce Tracks -->
 		<script type="text/javascript">
 			window.wcTracks = window.wcTracks || {};
-			window.wcTracks.isInitialized = false;
 			window.wcTracks.isEnabled = <?php echo self::is_tracking_enabled() ? 'true' : 'false'; ?>;
 			window._tkq = window._tkq || [];
 

--- a/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
@@ -67,6 +67,7 @@ class WC_Site_Tracking {
 		$user           = wp_get_current_user();
 		$server_details = WC_Tracks::get_server_details();
 		$blog_details   = WC_Tracks::get_blog_details( $user->ID );
+		$tracks_identity = WC_Tracks_Client::get_identity( $user->ID);
 
 		$client_tracking_properties = array_merge( $server_details, $blog_details );
 		/**
@@ -80,7 +81,13 @@ class WC_Site_Tracking {
 		<!-- WooCommerce Tracks -->
 		<script type="text/javascript">
 			window.wcTracks = window.wcTracks || {};
+			window.wcTracks.isInitialized = false;
 			window.wcTracks.isEnabled = <?php echo self::is_tracking_enabled() ? 'true' : 'false'; ?>;
+			window._tkq = window._tkq || [];
+
+			<?php if ( $tracks_identity['_ut'] !== 'anon' ) { ?>
+			window._tkq.push( [ 'identifyUser', '<?= $tracks_identity['_ui'] ?>' ] );
+			<?php } ?>
 			window.wcTracks.validateEvent = function( eventName, props = {} ) {
 				let isValid = true;
 				if ( ! <?php echo esc_js( WC_Tracks_Event::EVENT_NAME_REGEX ); ?>.test( eventName ) ) {
@@ -124,7 +131,6 @@ class WC_Site_Tracking {
 				if ( ! window.wcTracks.validateEvent( eventName, eventProperties ) ) {
 					return;
 				}
-				window._tkq = window._tkq || [];
 				window._tkq.push( [ 'recordEvent', eventName, eventProperties ] );
 			}
 		</script>

--- a/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
@@ -64,9 +64,9 @@ class WC_Site_Tracking {
 	 * Adds the tracking function to the admin footer.
 	 */
 	public static function add_tracking_function() {
-		$user           = wp_get_current_user();
-		$server_details = WC_Tracks::get_server_details();
-		$blog_details   = WC_Tracks::get_blog_details( $user->ID );
+		$user            = wp_get_current_user();
+		$server_details  = WC_Tracks::get_server_details();
+		$blog_details    = WC_Tracks::get_blog_details( $user->ID );
 		$tracks_identity = WC_Tracks_Client::get_identity( $user->ID );
 
 		$client_tracking_properties = array_merge( $server_details, $blog_details );

--- a/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
@@ -85,7 +85,7 @@ class WC_Site_Tracking {
 			window._tkq = window._tkq || [];
 
 			<?php if ( 'anon' !== $tracks_identity['_ut'] ) { ?>
-			window._tkq.push( [ 'identifyUser', '<?php echo $tracks_identity['_ui']; ?>' ] );
+			window._tkq.push( [ 'identifyUser', '<?php echo esc_js( $tracks_identity['_ui'] ); ?>' ] );
 			<?php } ?>
 			window.wcTracks.validateEvent = function( eventName, props = {} ) {
 				let isValid = true;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #38093. This PR fixes the mismatch by introducing Jetpack's identifier to `wcTracks` when it's available via `identifyUser`.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. In a fresh JN site with this branch, go to Jetpack
2. Click on "Set up Jetpack" and connect to your account
3. Open the developer console and open the `Network` tab
4. Filter for `t.gif`
5. Go to WooCommerce > Home and scroll down to trigger some tracks
6. Click on any of them and open its payload tab
7. Look for `_ui` param and observe its value is integer, i.e: `189375723`
8. Look for `_ut` param and observe its value is `wpcom:user_id`

<!-- End testing instructions -->