### PR TITLE
Fix modal resizing when selecting different shipping methods

### DIFF
--- a/plugins/woocommerce/changelog/fix-38077-disable-modal-resizing
+++ b/plugins/woocommerce/changelog/fix-38077-disable-modal-resizing
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix modal resizing when selecting different shipping methods

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -7033,6 +7033,7 @@ table.bar_chart {
 
 	article {
 		padding: 1.5em;
+		transition: height .3s;
 
 		p {
 			margin: 1.5em 0;

--- a/plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js
@@ -405,6 +405,7 @@
 					$( this ).parent().find( '.wc-shipping-zone-method-description' ).remove();
 					$( this ).after( '<div class="wc-shipping-zone-method-description">' + description + '</div>' );
 					$( this ).closest( 'article' ).height( $( this ).parent().height() );
+					$( this ).closest( 'article' ).width( $( this ).parent().width() );
 				},
 				onTogglePostcodes: function( event ) {
 					event.preventDefault();


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #38077 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to WooCommerce > Settings and select the Shipping tab
2. Click Add shipping method and select Local pickup
3. Modal width should be the same

<!-- End testing instructions -->