### PR TITLE
Removing auto-draft as wc post type to fix post publish time bug

### DIFF
--- a/plugins/woocommerce/changelog/fix-auto-draft-post-time-38075
+++ b/plugins/woocommerce/changelog/fix-auto-draft-post-time-38075
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Removing auto-draft as wc post type to resolve publish time bug.

--- a/plugins/woocommerce/includes/class-wc-post-types.php
+++ b/plugins/woocommerce/includes/class-wc-post-types.php
@@ -1074,15 +1074,6 @@ class WC_Post_Types {
 					/* translators: %s: number of orders */
 					'label_count'               => _n_noop( 'Failed <span class="count">(%s)</span>', 'Failed <span class="count">(%s)</span>', 'woocommerce' ),
 				),
-				'auto-draft'    => array(
-					'label'                     => _x( 'Auto Draft', 'Order status', 'woocommerce' ),
-					'public'                    => false,
-					'exclude_from_search'       => false,
-					'show_in_admin_all_list'    => true,
-					'show_in_admin_status_list' => true,
-					/* translators: %s: number of orders */
-					'label_count'               => _n_noop( 'Auto draft <span class="count">(%s)</span>', 'Auto draft <span class="count">(%s)</span>', 'woocommerce' ),
-				),
 			)
 		);
 


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The `auto-draft` status was added to the wc post type array as a prerequisite for the product-block editor. At the time it was necessary to use the entity data store for a  pre-publish product, but it looks like that is no longer a requirement. This is likely due to our using the upgraded API through [this apiFetch middleware](https://github.com/woocommerce/woocommerce/blob/66ec8df5882eac5f63abf7fb63690f0749ba2534/packages/js/product-editor/src/utils/product-apifetch-middleware.ts#L17) since then.

Closes #38075 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout this branch on a new site.
2. Add a new post, start editing the post. Either set your client clock forward, or wait a few minutes before publishing the post.
3. Publish the post, notice how the publish time is now correctly the time that you hit publish, and not when you first started the post.

<!-- End testing instructions -->