### PR TITLE
Use snackbar to show variations generated message, instead of browser alert

### DIFF
--- a/plugins/woocommerce/changelog/update-generated-variations-snackbar
+++ b/plugins/woocommerce/changelog/update-generated-variations-snackbar
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Use snackbar instead of alert when showing generated variations message.

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
@@ -1114,7 +1114,10 @@ jQuery( function ( $ ) {
 										count
 								  );
 
-						window.alert( message );
+						window.wp.data.dispatch( 'core/notices' ).createSuccessNotice(
+							message,
+							{ icon: '🎉' }
+						);
 
 						wc_meta_boxes_product_variations_ajax.show_hide_variation_empty_state();
 


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

#### Before

<img width="1129" alt="Screenshot 2023-05-03 at 18 11 08" src="https://user-images.githubusercontent.com/2098816/236061473-302d1370-2a0b-4031-a16d-e5d73f913366.png">

#### After

<img width="1129" alt="Screenshot 2023-05-03 at 18 09 49" src="https://user-images.githubusercontent.com/2098816/236061230-e5096f63-b0a5-46cc-9ac2-6910ad5c1f60.png">

Closes #38095 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to `Products` > `Add New`
2. Change product type to `Variable`
3. Add attributes marked as `Used for variations`
4. Click `Generate variations` on `Variations` tab
5. Verify snackbar notice is shown and dismisses automatically after a short delay

<!-- End testing instructions -->