### PR TITLE
Restoring standard tabbing behavior in product block editor

### DIFF
--- a/packages/js/product-editor/changelog/fix-tabbed-navigation-37932
+++ b/packages/js/product-editor/changelog/fix-tabbed-navigation-37932
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Removing WritingFlow component which was suppressing tabbing behavior in form.

--- a/packages/js/product-editor/src/components/block-editor/block-editor.tsx
+++ b/packages/js/product-editor/src/components/block-editor/block-editor.tsx
@@ -18,7 +18,6 @@ import {
 	BlockTools,
 	EditorSettings,
 	EditorBlockListSettings,
-	WritingFlow,
 	ObserveTyping,
 } from '@wordpress/block-editor';
 // It doesn't seem to notice the External dependency block whn @ts-ignore is added.
@@ -106,11 +105,9 @@ export function BlockEditor( {
 						{ /* @ts-ignore No types for this exist yet. */ }
 						<BlockEditorKeyboardShortcuts.Register />
 						<BlockTools>
-							<WritingFlow>
-								<ObserveTyping>
-									<BlockList className="woocommerce-product-block-editor__block-list" />
-								</ObserveTyping>
-							</WritingFlow>
+							<ObserveTyping>
+								<BlockList className="woocommerce-product-block-editor__block-list" />
+							</ObserveTyping>
 						</BlockTools>
 					</div>
 				</BlockEditorProvider>


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Previous to this PR tabbing behavior was not working in the product editor form ([see issue video](https://github.com/woocommerce/woocommerce/issues/37932)). After some exploration I realized that the `WritingFlow` component was responsible. It's used for selection across blocks which I don't believe is needed for our implementation, so it's been removed.

Closes #37932 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout branch and enable the `product-block-editor` feature flag via the WCA Test Helper plugin.
2. Navigate to Products -> Add new on the sidebar.
3. Use the `tab` key to navigate through the form fields in the editor. I should focus the fields as normal.

<!-- End testing instructions -->