### PR TITLE
 Fix misaligned loading sample product's progress message

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/fills/components/load-sample-product-confirm-modal.scss
+++ b/plugins/woocommerce-admin/client/tasks/fills/components/load-sample-product-confirm-modal.scss
@@ -1,3 +1,17 @@
+.woocommerce-products-load-sample-product-confirm-modal-overlay {
+	@media (min-width: 783px ) {
+		& {
+			left: 35px;
+		}
+	}
+
+	@include break-large {
+		& {
+			left: 160px;
+		}
+	}
+}
+
 .woocommerce-products-load-sample-product-confirm-modal {
 	.components-truncate.components-text.woocommerce-confirmation-modal__message {
 		color: $studio-gray-60;

--- a/plugins/woocommerce-admin/client/tasks/fills/components/load-sample-product-confirm-modal.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/components/load-sample-product-confirm-modal.tsx
@@ -22,6 +22,7 @@ export const LoadSampleProductConfirmModal: React.VFC< Props > = ( {
 	return (
 		<Modal
 			className="woocommerce-products-load-sample-product-confirm-modal"
+			overlayClassName="woocommerce-products-load-sample-product-confirm-modal-overlay"
 			title={ __( 'Load sample products', 'woocommerce' ) }
 			onRequestClose={ onCancel }
 		>

--- a/plugins/woocommerce-admin/client/tasks/fills/components/load-sample-product-modal.scss
+++ b/plugins/woocommerce-admin/client/tasks/fills/components/load-sample-product-modal.scss
@@ -25,7 +25,8 @@
 		display: none;
 	}
 
-	.components-modal__content {
+	.components-modal__content,
+	.components-modal__header + div {
 		display: flex;
 		flex-direction: column;
 		align-items: center;

--- a/plugins/woocommerce/changelog/fix-load-sample-product-modal
+++ b/plugins/woocommerce/changelog/fix-load-sample-product-modal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix loading sample product's progress message is misaligned if Gutenberg plugin is enabled


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #37708.

This PR fixes the misaligned loading sample product's progress message when Gutenberg plugin is enabled.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install the latest Gutenberg
2. Skip the Setup Wizard.
3. In the Task List (WooCommerce > Home), click the "Add Products" task.
4. Click "View more product types".
5. Click "Load Sample Products".
6. Click the "Import sample products" button.
7. Confirm the progress message looks like below.

![Screenshot 2023-05-04 at 11 07 28](https://user-images.githubusercontent.com/4344253/236104765-ba919e44-f532-49cd-99ec-4d0ab7ced86a.png)


<!-- End testing instructions -->