### PR TITLE
Fix `wc-experimental` strings are not translated 

### DIFF
--- a/plugins/woocommerce/changelog/fix-wc-experimental-i18n
+++ b/plugins/woocommerce/changelog/fix-wc-experimental-i18n
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix wc-experimental not translated issue

--- a/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php
@@ -278,6 +278,7 @@ class WCAdminAssets {
 			'wc-date',
 			'wc-components',
 			'wc-customer-effort-score',
+			'wc-experimental',
 			WC_ADMIN_APP,
 		);
 


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/37416.

Add `wc-experimental` to `$translated_scripts` to load i18n locale data for wc-experimental.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Set the WP administration language to `Italian`.
2. Go to `/wp-admin/update-core.php` and make sure the translations are all up to date
3. Go to `WooCommerce > Home`
4. Scroll down and confirm the inbox note "Dismiss" button is translated to `Ignora`. 

![Screenshot 2023-05-04 at 13 33 37](https://user-images.githubusercontent.com/4344253/236119730-45c45b0b-d671-48c0-93a0-59e275ce7836.png)


<!-- End testing instructions -->