### PR TITLE
Added a button to download SSR to a file.

### DIFF
--- a/plugins/woocommerce/changelog/try-download-ssr
+++ b/plugins/woocommerce/changelog/try-download-ssr
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Added a button to download SSR to a file.

--- a/plugins/woocommerce/client/legacy/js/admin/system-status.js
+++ b/plugins/woocommerce/client/legacy/js/admin/system-status.js
@@ -14,7 +14,8 @@ jQuery( function ( $ ) {
 				.on( 'click', 'a.debug-report', this.generateReport )
 				.on( 'click', '#copy-for-support', this.copyReport )
 				.on( 'aftercopy', '#copy-for-support', this.copySuccess )
-				.on( 'aftercopyfailure', '#copy-for-support', this.copyFail );
+				.on( 'aftercopyfailure', '#copy-for-support', this.copyFail )
+				.on( 'click', '#download-for-support', this.downloadReport );
 		},
 
 		/**
@@ -112,6 +113,17 @@ jQuery( function ( $ ) {
 		copyFail: function() {
 			$( '.copy-error' ).removeClass( 'hidden' );
 			$( '#debug-report' ).find( 'textarea' ).trigger( 'focus' ).trigger( 'select' );
+		},
+
+		downloadReport: function() {
+			var ssr_text = new Blob( [ $( '#debug-report' ).find( 'textarea' ).val() ], { type: 'text/plain' } );
+			var a = document.createElement( 'a' );
+			a.download = 'SystemStatusReport.txt';
+			a.href = window.URL.createObjectURL( ssr_text );
+			a.textContent = 'Download ready';
+			a.style='display:none';
+			a.click();
+			a.remove();
 		}
 	};
 

--- a/plugins/woocommerce/client/legacy/js/admin/system-status.js
+++ b/plugins/woocommerce/client/legacy/js/admin/system-status.js
@@ -117,8 +117,12 @@ jQuery( function ( $ ) {
 
 		downloadReport: function() {
 			var ssr_text = new Blob( [ $( '#debug-report' ).find( 'textarea' ).val() ], { type: 'text/plain' } );
+
+			var domain = window.location.hostname;
+			var datetime = new Date().toISOString().slice( 0, 19 ).replace( /:/g, '-' );
+
 			var a = document.createElement( 'a' );
-			a.download = 'SystemStatusReport.txt';
+			a.download = 'SystemStatusReport_' + domain + '_' + datetime + '.txt';
 			a.href = window.URL.createObjectURL( ssr_text );
 			a.textContent = 'Download ready';
 			a.style='display:none';

--- a/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
@@ -38,7 +38,10 @@ $untested_plugins   = $plugin_updates->get_untested_plugins( WC()->version, Cons
 	<div id="debug-report">
 		<textarea readonly="readonly"></textarea>
 		<p class="submit">
-			<button id="copy-for-support" class="button-primary" href="#" data-tip="<?php esc_attr_e( 'Copied!', 'woocommerce' ); ?>">
+			<button id="download-for-support" class="button-primary" href="#">
+				<?php esc_html_e( 'Download for support', 'woocommerce' ); ?>
+			</button>
+			<button id="copy-for-support" class="button" href="#" data-tip="<?php esc_attr_e( 'Copied!', 'woocommerce' ); ?>">
 				<?php esc_html_e( 'Copy for support', 'woocommerce' ); ?>
 			</button>
 		</p>


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Since WC Happiness Engineer folks started using Zendesk Messaging instead of the previous tool, the character limit no longer allows copy & pasting SSR to chats. However, there's a possibility to upload a file, so I've added a button to WC > Status to allow downloading SSR. 

There are other paths we could take to make this work, like generating the file on the server and sending it back to the client, but since we already have the infrastructure for copying that creates the required content in the text area, it seems the easiest way here is to actually just use JS to grab that text and send it over to user as a file.

This was tested on Chrome, Firefox, Edge and Safari. Safari prompts the user whether they want to allow downloading from this site, which seems like not a huge issue in this context. 

![Screenshot 2023-05-04 at 11 15 11](https://user-images.githubusercontent.com/2207451/236161868-735a05fb-8c44-4e06-b6d4-c44eb52203f6.png)


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install WP and WC from this branch. Any settings are fine.
2. Go to WC > Status
3. Click on Get System report (primary button)
4. You should see a new button: `Download for support` and also the good old button `Copy for support`, now no longer as the primary action.
5. Test both buttons. Both download and copy should work as expected: Download should download a file, and copy should copy the SSR content to the clipboard.

![Screenshot 2023-05-04 at 11 08 41](https://user-images.githubusercontent.com/2207451/236161561-908cce3f-6111-4a6f-8561-808bd36fbdb8.png)

Tested this in Chrome, Safari, Firefox and Edge and it seemed to work fine.

<!-- End testing instructions -->