### PR TITLE
Add "SlotFill Examples" Feature to Beta Tester Plugin

### DIFF
--- a/plugins/woocommerce-beta-tester/changelog/add-example-slotfills
+++ b/plugins/woocommerce-beta-tester/changelog/add-example-slotfills
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add SlotFill Examples feature

--- a/plugins/woocommerce-beta-tester/plugin.php
+++ b/plugins/woocommerce-beta-tester/plugin.php
@@ -16,7 +16,7 @@ add_action( 'wp_loaded', function() {
 } );
 
 add_filter( 'woocommerce_admin_get_feature_config', function( $feature_config ) {
-	$feature_config[ 'beta-tester-slotfill-examples' ] = false;
+	$feature_config['beta-tester-slotfill-examples'] = false;
     $custom_feature_values = get_option( 'wc_admin_helper_feature_values', array() );
     foreach ( $custom_feature_values as $feature => $value ) {
         if ( isset(  $feature_config[$feature] ) ) {

--- a/plugins/woocommerce-beta-tester/plugin.php
+++ b/plugins/woocommerce-beta-tester/plugin.php
@@ -16,6 +16,7 @@ add_action( 'wp_loaded', function() {
 } );
 
 add_filter( 'woocommerce_admin_get_feature_config', function( $feature_config ) {
+	$feature_config[ 'beta-tester-slotfill-examples' ] = false;
     $custom_feature_values = get_option( 'wc_admin_helper_feature_values', array() );
     foreach ( $custom_feature_values as $feature => $value ) {
         if ( isset(  $feature_config[$feature] ) ) {

--- a/plugins/woocommerce-beta-tester/src/example-fills/experimental-woocommerce-wcpay-feature.js
+++ b/plugins/woocommerce-beta-tester/src/example-fills/experimental-woocommerce-wcpay-feature.js
@@ -14,7 +14,7 @@ const MyFill = () => (
 	</Fill>
 );
 
-if ( window.wcAdminFeatures[ 'beta-tester-slotfill-examples' ] ) {
+if ( window.wcAdminFeatures && window.wcAdminFeatures[ 'beta-tester-slotfill-examples' ] ) {
 	registerPlugin(
 		'beta-tester-woocommerce-experiments-placeholder-slotfill-example',
 		{

--- a/plugins/woocommerce-beta-tester/src/example-fills/experimental-woocommerce-wcpay-feature.js
+++ b/plugins/woocommerce-beta-tester/src/example-fills/experimental-woocommerce-wcpay-feature.js
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import { registerPlugin } from '@wordpress/plugins';
+import { Fill } from '@wordpress/components';
+
+const MyFill = () => (
+	<Fill name="experimental_woocommerce_wcpay_feature">
+		<div className="woocommerce-experiments-placeholder-slotfill">
+			<div className="placeholder-slotfill-content">
+				Slotfill goes in here!
+			</div>
+		</div>
+	</Fill>
+);
+
+if ( window.wcAdminFeatures[ 'beta-tester-slotfill-examples' ] ) {
+	registerPlugin(
+		'beta-tester-woocommerce-experiments-placeholder-slotfill-example',
+		{
+			render: MyFill,
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore
+			scope: 'woocommerce-admin',
+		}
+	);
+}

--- a/plugins/woocommerce-beta-tester/src/index.js
+++ b/plugins/woocommerce-beta-tester/src/index.js
@@ -8,6 +8,7 @@ import { render } from '@wordpress/element';
  */
 import { App } from './app';
 import './index.scss';
+import './example-fills/experimental-woocommerce-wcpay-feature';
 
 const appRoot = document.getElementById(
 	'woocommerce-admin-test-helper-app-root'

--- a/plugins/woocommerce-beta-tester/woocommerce-beta-tester.php
+++ b/plugins/woocommerce-beta-tester/woocommerce-beta-tester.php
@@ -87,6 +87,7 @@ function add_extension_register_script() {
 			'version'      => filemtime( $script_path ),
 		);
 	$script_url        = plugins_url( $script_path, __FILE__ );
+
 	$script_asset['dependencies'][] = WC_ADMIN_APP; // Add WCA as a dependency to ensure it loads first.
 
 	wp_register_script(

--- a/plugins/woocommerce-beta-tester/woocommerce-beta-tester.php
+++ b/plugins/woocommerce-beta-tester/woocommerce-beta-tester.php
@@ -87,6 +87,7 @@ function add_extension_register_script() {
 			'version'      => filemtime( $script_path ),
 		);
 	$script_url        = plugins_url( $script_path, __FILE__ );
+	$script_asset['dependencies'][] = WC_ADMIN_APP; // Add WCA as a dependency to ensure it loads first.
 
 	wp_register_script(
 		'woocommerce-admin-test-helper',


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This adds a new feature in Beta Tester to allow [SlotFills](https://developer.wordpress.org/block-editor/reference-guides/slotfills/) extension points in Woo to be easily tested with an example fill.

A basic fill is added for the `experimental_woocommerce_wcpay_feature` slot. It is hoped that more and better examples are added as follow-up tasks in the future.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Build the front-end, e.g. `cd plugins/woocommerce-beta-tester` and run `pnpm start`. 
Additionally a zip of beta tester can be built with `pnpm run build:zip`
3. Navigate to Tools > WCA Test Helper > Features screen
4. See that the `beta-tester-slotfill-examples` feature is listed and disabled by default
5. Toggle the `beta-tester-slotfill-examples` feature **on**
6. Navigate to WooCommerce > Home
7. Hide the main task list using the "3 dots" menu
8. See that the fill `Slotfill goes in here!` is injected per the screenshot
9. Navigate to Tools > WCA Test Helper > Features screen
10. Toggle the `beta-tester-slotfill-examples` feature **off**
11. Navigate to WooCommerce > Home
12. See that no fills are present and the home screen appears as expected

### Screenshots

![image](https://user-images.githubusercontent.com/9312929/236166662-bad72d81-1321-408b-9492-dbc7929fe832.png)
WCA Test Helper Feature tab with `beta-tester-slotfill-examples` toggled on.

![image](https://user-images.githubusercontent.com/9312929/236166277-b6840c07-b063-443e-b0bb-b11aedd74d8a.png)
Example SlotFill on homepage.

<!-- End testing instructions -->