### PR TITLE
Prevent height flickering when selecting a variation in TT3

### DIFF
--- a/plugins/woocommerce/changelog/fix-tt3-variation-select-height-flicker
+++ b/plugins/woocommerce/changelog/fix-tt3-variation-select-height-flicker
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevented an issue with height flickering when selecting a variation

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -332,6 +332,11 @@
 
 		.single_variation_wrap {
 			margin-top: var(--wp--style--block-gap);
+
+			// Prevent height flickering when selecting a variation.
+			.single_variation .woocommerce-variation-description > :first-child {
+				margin-top: 0;
+			}
 		}
 
 		ol.flex-control-thumbs {


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

This PR aims to fix an issue regarding height-flickering when selecting a variation in TT3. The reason behind this weird behavior is that when the core script tries to toggle the visibility of a single's variation data, it adds the `overflow:hidden` rule to the variation wrapper, resulting in a strange height flicker. 

In this PR, we remove the _margin-top_ of the first element in the description container to prevent the overflow setting from messing with the container height. 

Although it may not be the perfect solution, it is the simplest option with minimal risk involved. For example, in Storefront, this is fixed by introducing a global behavior for all `p` tags. See https://github.com/woocommerce/storefront/blob/trunk/assets/css/base/_base.scss#L129-L131


### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

**Before:**
![Before](https://cdn-std.droplr.net/files/acc_1208648/Z1R3MK)

**After:**
![After](https://cdn-std.droplr.net/files/acc_1208648/GUrYjB)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Use a store with TT3
2. Navigate to a variable product single page and ensure that at least one variation includes a description
3. Select this variation and notice the height flicker
4. Apply this patch and ensure that the flickering is fixed

<!-- End testing instructions -->