### PR TITLE
Variations - Remove separator between buttons and empty state screen

### DIFF
--- a/plugins/woocommerce/changelog/dev-38122_remove_separator_between_buttons_and_empty_state_screen
+++ b/plugins/woocommerce/changelog/dev-38122_remove_separator_between_buttons_and_empty_state_screen
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Variations - Remove separator between buttons and empty state screen

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1071,26 +1071,37 @@ $default-line-height: 18px;
 		}
 	}
 
-	.add-variation-container {
-		@extend %container-defaults;
-		flex-direction: column;
-		justify-content: center;
-		align-items: center;
-		gap: 24px;
-		position: relative;
-
-		.arrow-image-wrapper {
-			position: absolute;
-			top: 10px;
-			left: 87px;
+	#variable_product_options_inner {
+		> .toolbar:not(.expand-close-hidden) {
+			border-bottom: 1px solid #eee;
 		}
-
-		p {
-			@extend %centered-text;
-		}
-
-		&.hidden {
+		.add-variation-container {
 			display: none;
+		}
+
+		&.no-variations {
+			> .toolbar:not(.expand-close-hidden) {
+				border-bottom: none;
+			}
+			.add-variation-container {
+				display: flex;
+				@extend %container-defaults;
+				flex-direction: column;
+				justify-content: center;
+				align-items: center;
+				gap: 24px;
+				position: relative;
+
+				.arrow-image-wrapper {
+					position: absolute;
+					top: 10px;
+					left: 87px;
+				}
+
+				p {
+					@extend %centered-text;
+				}
+			}
 		}
 	}
 }
@@ -5505,11 +5516,11 @@ img.help_tip {
   * WooCommerce meta boxes
   */
 .wc-metaboxes-wrapper {
-	&:not(#variable_product_options_inner) {
-		> .toolbar:not(.expand-close-hidden) {
+	:not(#variable_product_options_inner) {
+		.toolbar:not(.expand-close-hidden) {
 		  border-bottom: 1px solid #eee;
 		}
-	  }
+	}
 	.toolbar {
 		margin: 0 !important;
 		border-top: 1px solid white;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -5505,13 +5505,15 @@ img.help_tip {
   * WooCommerce meta boxes
   */
 .wc-metaboxes-wrapper {
+	&:not(#variable_product_options_inner) {
+		> .toolbar:not(.expand-close-hidden) {
+		  border-bottom: 1px solid #eee;
+		}
+	  }
 	.toolbar {
 		margin: 0 !important;
 		border-top: 1px solid white;
 		padding: 9px 12px !important;
-		&:not(.expand-close-hidden) {
-			border-bottom: 1px solid #eee;
-		}
 
 		&:first-child {
 			border-top: 0;

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
@@ -1331,10 +1331,14 @@ jQuery( function ( $ ) {
 				'.woocommerce_variations'
 			);
 			if ( parseInt( wrapper.attr( 'data-total' ) ) > 0 ) {
-				$( '.add-variation-container' ).addClass( 'hidden' );
+				$( '#variable_product_options_inner' ).removeClass(
+					'no-variations'
+				);
 				$( '#field_to_edit' ).removeClass( 'hidden' );
 			} else {
-				$( '.add-variation-container' ).removeClass( 'hidden' );
+				$( '#variable_product_options_inner' ).addClass(
+					'no-variations'
+				);
 				$( '#field_to_edit' ).addClass( 'hidden' );
 			}
 		},


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR removes the separator between buttons and the empty state screen.

![screenshot-one local-2023 05 04-14_06_32](https://user-images.githubusercontent.com/1314156/236300634-3ec05ebb-ebe9-4fae-94d6-4b4afce3abd5.png)


Closes #38122.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to Products > Add New > Product data. 
2. Select `Variable product`.
3. Create an attribute (or add a global attribute if you already have one). 
4. Press `Save attributes`.
5. Press `Variations` and verify that the separator between the buttons and the empty state screen is no longer visible.

<!-- End testing instructions -->