### PR TITLE
Add tests to tracks events fired through JS

### DIFF
--- a/packages/js/internal-js-tests/jest-preset.js
+++ b/packages/js/internal-js-tests/jest-preset.js
@@ -10,6 +10,10 @@ module.exports = {
 			__dirname,
 			'build/mocks/woocommerce-settings'
 		),
+		'@woocommerce/tracks': path.resolve(
+			__dirname,
+			'build/mocks/woocommerce-tracks'
+		),
 		'~/(.*)': path.resolve(
 			__dirname,
 			'../../../plugins/woocommerce-admin/client/$1'

--- a/packages/js/internal-js-tests/src/mocks/woocommerce-tracks.js
+++ b/packages/js/internal-js-tests/src/mocks/woocommerce-tracks.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = {
+	recordEvent: jest.fn(),
+	recordPageView: jest.fn(),
+};

--- a/plugins/woocommerce-admin/client/analytics/components/report-filters/test/index.js
+++ b/plugins/woocommerce-admin/client/analytics/components/report-filters/test/index.js
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+import { recordEvent } from '@woocommerce/tracks';
+
+import userEvent from '@testing-library/user-event';
+
+/**
+ * Internal dependencies
+ */
+import ReportFilters from '..';
+
+jest.mock( '@woocommerce/tracks', () => ( { recordEvent: jest.fn() } ) );
+
+describe( 'ReportFilters', () => {
+	test( 'should fire analytics_filter when filter is changed ', async () => {
+		const { getByText } = render(
+			<ReportFilters
+				report="test-report"
+				query={ {
+					page: 'page',
+					path: 'path',
+				} }
+				filters={ [
+					{
+						filters: [
+							{
+								label: 'All products',
+								value: 'all',
+							},
+							{
+								label: 'Some products',
+								value: 'some',
+							},
+						],
+						label: 'Show',
+						param: 'filter',
+						showFilters: () => true,
+						staticParams: [],
+					},
+				] }
+			/>
+		);
+		userEvent.click( getByText( 'All products' ) );
+		userEvent.click( getByText( 'Some products' ) );
+		expect( recordEvent ).toHaveBeenCalledWith( 'analytics_filter', {
+			filter: 'some',
+			report: 'test-report',
+		} );
+	} );
+} );

--- a/plugins/woocommerce-admin/client/analytics/components/report-filters/test/index.js
+++ b/plugins/woocommerce-admin/client/analytics/components/report-filters/test/index.js
@@ -11,8 +11,6 @@ import userEvent from '@testing-library/user-event';
  */
 import ReportFilters from '..';
 
-jest.mock( '@woocommerce/tracks', () => ( { recordEvent: jest.fn() } ) );
-
 describe( 'ReportFilters', () => {
 	test( 'should record analytics_filter Tracks event when filter is changed', async () => {
 		const { getByText } = render(

--- a/plugins/woocommerce-admin/client/analytics/components/report-filters/test/index.js
+++ b/plugins/woocommerce-admin/client/analytics/components/report-filters/test/index.js
@@ -14,7 +14,7 @@ import ReportFilters from '..';
 jest.mock( '@woocommerce/tracks', () => ( { recordEvent: jest.fn() } ) );
 
 describe( 'ReportFilters', () => {
-	test( 'should fire analytics_filter when filter is changed ', async () => {
+	test( 'should record analytics_filter Tracks event when filter is changed', async () => {
 		const { getByText } = render(
 			<ReportFilters
 				report="test-report"

--- a/plugins/woocommerce-admin/client/homescreen/activity-panel/orders/test/index.js
+++ b/plugins/woocommerce-admin/client/homescreen/activity-panel/orders/test/index.js
@@ -22,17 +22,6 @@ jest.mock( '@wordpress/data', () => {
 	};
 } );
 
-jest.mock( '@woocommerce/tracks', () => {
-	// Require the original module to not be mocked...
-	const originalModule = jest.requireActual( '@woocommerce/tracks' );
-
-	return {
-		__esModule: true, // Use it when dealing with esModules
-		...originalModule,
-		recordEvent: jest.fn(),
-	};
-} );
-
 describe( 'OrdersPanel', () => {
 	it( 'should render an empty order card', () => {
 		useSelect.mockReturnValue( {

--- a/plugins/woocommerce-admin/client/homescreen/activity-panel/orders/test/index.js
+++ b/plugins/woocommerce-admin/client/homescreen/activity-panel/orders/test/index.js
@@ -45,7 +45,7 @@ describe( 'OrdersPanel', () => {
 			screen.queryByText( 'You’ve fulfilled all your orders' )
 		).toBeInTheDocument();
 	} );
-	it( 'should call activity_panel_orders_orders_begin_fulfillment when order is clicked', () => {
+	it( 'should record activity_panel_orders_orders_begin_fulfillment Tracks event when order is clicked', () => {
 		useSelect.mockReturnValue( {
 			orders: [
 				{

--- a/plugins/woocommerce-admin/client/homescreen/activity-panel/stock/test/index.js
+++ b/plugins/woocommerce-admin/client/homescreen/activity-panel/stock/test/index.js
@@ -74,7 +74,7 @@ describe( 'StockPanel', () => {
 			expect( invalidateResolution ).toHaveBeenCalled();
 		} );
 	} );
-	it( 'should fire tracks event activity_panel_stock_update_stock when Update stock is clicked', async () => {
+	it( 'should record activity_panel_stock_update_stock Tracks event when Update stock is clicked', async () => {
 		const createNotice = jest.fn();
 		const invalidateResolution = jest.fn();
 		const updateProductStock = jest.fn().mockResolvedValue( true );
@@ -99,7 +99,7 @@ describe( 'StockPanel', () => {
 			/>
 		);
 		userEvent.click( getByRole( 'button', { name: 'Update stock' } ) );
-		expect( recordEvent ).toHaveBeenLastCalledWith(
+		expect( recordEvent ).toHaveBeenCalledWith(
 			'activity_panel_stock_update_stock',
 			{}
 		);

--- a/plugins/woocommerce-admin/client/homescreen/activity-panel/stock/test/index.js
+++ b/plugins/woocommerce-admin/client/homescreen/activity-panel/stock/test/index.js
@@ -4,11 +4,23 @@
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createElement } from '@wordpress/element';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
  */
 import { StockPanel } from '../';
+
+jest.mock( '@woocommerce/tracks', () => {
+	// Require the original module to not be mocked...
+	const originalModule = jest.requireActual( '@woocommerce/tracks' );
+
+	return {
+		__esModule: true, // Use it when dealing with esModules
+		...originalModule,
+		recordEvent: jest.fn(),
+	};
+} );
 
 describe( 'StockPanel', () => {
 	it( 'should the correct number of placeholders', () => {
@@ -61,5 +73,35 @@ describe( 'StockPanel', () => {
 		await waitFor( () => {
 			expect( invalidateResolution ).toHaveBeenCalled();
 		} );
+	} );
+	it( 'should fire tracks event activity_panel_stock_update_stock when Update stock is clicked', async () => {
+		const createNotice = jest.fn();
+		const invalidateResolution = jest.fn();
+		const updateProductStock = jest.fn().mockResolvedValue( true );
+
+		const { getByRole } = render(
+			<StockPanel
+				lowStockProductsCount={ 1 }
+				isError={ false }
+				isRequesting={ false }
+				products={ [
+					{
+						id: 1,
+						name: 'Test Product',
+						low_stock_amount: 5,
+						stock_quantity: 1,
+						type: 'simple',
+					},
+				] }
+				invalidateResolution={ invalidateResolution }
+				updateProductStock={ updateProductStock }
+				createNotice={ createNotice }
+			/>
+		);
+		userEvent.click( getByRole( 'button', { name: 'Update stock' } ) );
+		expect( recordEvent ).toHaveBeenLastCalledWith(
+			'activity_panel_stock_update_stock',
+			{}
+		);
 	} );
 } );

--- a/plugins/woocommerce-admin/client/homescreen/activity-panel/stock/test/index.js
+++ b/plugins/woocommerce-admin/client/homescreen/activity-panel/stock/test/index.js
@@ -11,17 +11,6 @@ import { recordEvent } from '@woocommerce/tracks';
  */
 import { StockPanel } from '../';
 
-jest.mock( '@woocommerce/tracks', () => {
-	// Require the original module to not be mocked...
-	const originalModule = jest.requireActual( '@woocommerce/tracks' );
-
-	return {
-		__esModule: true, // Use it when dealing with esModules
-		...originalModule,
-		recordEvent: jest.fn(),
-	};
-} );
-
 describe( 'StockPanel', () => {
 	it( 'should the correct number of placeholders', () => {
 		const { container } = render(

--- a/plugins/woocommerce-admin/client/homescreen/activity-panel/test/index.js
+++ b/plugins/woocommerce-admin/client/homescreen/activity-panel/test/index.js
@@ -56,10 +56,6 @@ jest.mock( '../orders/utils', () => {
 	};
 } );
 
-jest.mock( '@woocommerce/tracks', () => ( {
-	recordEvent: jest.fn(),
-} ) );
-
 describe( 'ActivityPanel', () => {
 	it( 'should render a panel with two rows', () => {
 		render( <ActivityPanel /> );

--- a/plugins/woocommerce-admin/client/homescreen/activity-panel/test/index.js
+++ b/plugins/woocommerce-admin/client/homescreen/activity-panel/test/index.js
@@ -2,7 +2,9 @@
  * External dependencies
  */
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { useSelect } from '@wordpress/data';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -54,6 +56,10 @@ jest.mock( '../orders/utils', () => {
 	};
 } );
 
+jest.mock( '@woocommerce/tracks', () => ( {
+	recordEvent: jest.fn(),
+} ) );
+
 describe( 'ActivityPanel', () => {
 	it( 'should render a panel with two rows', () => {
 		render( <ActivityPanel /> );
@@ -83,5 +89,16 @@ describe( 'ActivityPanel', () => {
 		render( <ActivityPanel /> );
 		expect( screen.queryByText( 'custom-panel-1' ) ).toBeNull();
 		expect( screen.queryByText( 'custom-panel-2' ) ).toBeNull();
+	} );
+
+	it( 'should call recordEvent with the correct tab when a panel is opened', () => {
+		useSelect.mockReturnValue( {
+			isTaskListHidden: false,
+		} );
+		const { getByText } = render( <ActivityPanel /> );
+		userEvent.click( getByText( 'custom-panel-2' ) );
+		expect( recordEvent ).toHaveBeenCalledWith( 'activity_panel_open', {
+			tab: 'custom-panel-2',
+		} );
 	} );
 } );

--- a/plugins/woocommerce-admin/client/homescreen/activity-panel/test/index.js
+++ b/plugins/woocommerce-admin/client/homescreen/activity-panel/test/index.js
@@ -91,7 +91,7 @@ describe( 'ActivityPanel', () => {
 		expect( screen.queryByText( 'custom-panel-2' ) ).toBeNull();
 	} );
 
-	it( 'should call recordEvent with the correct tab when a panel is opened', () => {
+	it( 'should record activity_panel_open Tracks event when panel is opened', () => {
 		useSelect.mockReturnValue( {
 			isTaskListHidden: false,
 		} );

--- a/plugins/woocommerce-admin/client/inbox-panel/test/index.js
+++ b/plugins/woocommerce-admin/client/inbox-panel/test/index.js
@@ -34,7 +34,9 @@ jest.mock( '@woocommerce/experimental', () => {
 	return {
 		__esModule: true, // Use it when dealing with esModules
 		...originalModule,
-		InboxNoteCard: jest.fn(),
+		InboxNoteCard: jest.fn().mockImplementation( ( { note } ) => {
+			return <div>{ note.id }</div>;
+		} ),
 	};
 } );
 
@@ -149,9 +151,6 @@ describe( 'inbox_panel_view_event', () => {
 			notesHaveResolved: true,
 			isBatchUpdating: false,
 		} ) );
-		InboxNoteCard.mockImplementation( ( { note } ) => {
-			return <div>{ note.id }</div>;
-		} );
 		render( <InboxPanel /> );
 
 		expect( recordEvent ).toHaveBeenCalledWith( 'inbox_panel_view', {
@@ -174,14 +173,13 @@ describe( 'inbox_note_view event', () => {
 			return <div>{ note.id }</div>;
 		} );
 		render( <InboxPanel /> );
-		notes.forEach( ( note ) => {
-			expect( recordEvent ).toHaveBeenCalledWith( 'inbox_note_view', {
-				note_content: note.content,
-				note_name: note.name,
-				note_title: note.title,
-				note_type: note.type,
-				screen: '',
-			} );
+
+		expect( recordEvent ).toHaveBeenCalledWith( 'inbox_note_view', {
+			note_content: notes[ 0 ].content,
+			note_name: notes[ 0 ].name,
+			note_title: notes[ 0 ].title,
+			note_type: notes[ 0 ].type,
+			screen: '',
 		} );
 	} );
 } );
@@ -203,13 +201,11 @@ describe( 'inbox_action_click event', () => {
 		} );
 		const { getAllByText } = render( <InboxPanel /> );
 		const buttons = getAllByText( 'Trigger action' );
-		buttons.forEach( ( button ) => userEvent.click( button ) );
-		notes.forEach( ( note ) => {
-			expect( recordEvent ).toHaveBeenCalledWith( 'inbox_action_click', {
-				note_name: note.name,
-				note_title: note.title,
-				note_content_inner_link: 'innerLink',
-			} );
+		userEvent.click( buttons[ 0 ] );
+		expect( recordEvent ).toHaveBeenCalledWith( 'inbox_action_click', {
+			note_name: notes[ 0 ].name,
+			note_title: notes[ 0 ].title,
+			note_content_inner_link: 'innerLink',
 		} );
 	} );
 } );

--- a/plugins/woocommerce-admin/client/inbox-panel/test/index.js
+++ b/plugins/woocommerce-admin/client/inbox-panel/test/index.js
@@ -25,8 +25,6 @@ jest.mock( '@wordpress/data', () => {
 	};
 } );
 
-jest.mock( '@woocommerce/tracks', () => ( { recordEvent: jest.fn() } ) );
-
 jest.mock( '@woocommerce/experimental', () => {
 	// Require the original module to not be mocked...
 	const originalModule = jest.requireActual( '@woocommerce/experimental' );

--- a/plugins/woocommerce-admin/client/layout/test/index.js
+++ b/plugins/woocommerce-admin/client/layout/test/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { render } from '@testing-library/react';
-import * as tracks from '@woocommerce/tracks';
+import { recordPageView } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -73,10 +73,9 @@ describe( 'updateLinkHref', () => {
 
 describe( 'Layout', () => {
 	it( 'should call recordPageView with correct parameters', () => {
-		jest.spyOn( tracks, 'recordPageView' );
 		window.history.pushState( {}, 'Page Title', '/url?search' );
 		render( <EmbedLayout /> );
-		expect( tracks.recordPageView ).toHaveBeenCalledWith( '/url?search', {
+		expect( recordPageView ).toHaveBeenCalledWith( '/url?search', {
 			has_navigation: true,
 			is_embedded: true,
 		} );

--- a/plugins/woocommerce-admin/client/layout/test/index.js
+++ b/plugins/woocommerce-admin/client/layout/test/index.js
@@ -1,7 +1,14 @@
 /**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+import * as tracks from '@woocommerce/tracks';
+
+/**
  * Internal dependencies
  */
 import { updateLinkHref } from '../controller';
+import { EmbedLayout } from '../index';
 
 describe( 'updateLinkHref', () => {
 	const timeExcludedScreens = [ 'stock', 'settings', 'customers' ];
@@ -61,5 +68,17 @@ describe( 'updateLinkHref', () => {
 		updateLinkHref( item, nextQuery, timeExcludedScreens );
 
 		expect( item.href ).toBe( WP_ADMIN_URL );
+	} );
+} );
+
+describe( 'Layout', () => {
+	it( 'should call recordPageView with correct parameters', () => {
+		jest.spyOn( tracks, 'recordPageView' );
+		window.history.pushState( {}, 'Page Title', '/url?search' );
+		render( <EmbedLayout /> );
+		expect( tracks.recordPageView ).toHaveBeenCalledWith( '/url?search', {
+			has_navigation: true,
+			is_embedded: true,
+		} );
 	} );
 } );

--- a/plugins/woocommerce/changelog/dev-add-tracks-tests
+++ b/plugins/woocommerce/changelog/dev-add-tracks-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Add tracks tests
+
+

--- a/plugins/woocommerce/changelog/dev-add-tracks-tests
+++ b/plugins/woocommerce/changelog/dev-add-tracks-tests
@@ -1,5 +1,3 @@
 Significance: patch
 Type: dev
-Comment: Add tracks tests
-
-
+Comment: Add jest tests to certain critical tracks events on React components


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:


<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Add tests to tracks events fired through JS.

Out of the list in issue #37856 , I didn't write tests for `wcadmin_ces_feedback` and `wcadmin_ces_view`, since there are no tests for the component and it seems like a big effort to create them. We should discuss whether it's worth the effort to tackle them, maybe in a separate issue.

Closes #37856.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

No manual tests needed. Just run the unit tests through `pnpm --filter='*admin' test:client` and review the code.

<!-- End testing instructions -->