### PR TITLE
Update empty state for product attributes tab

### DIFF
--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
@@ -412,36 +412,23 @@ const attachProductTagsTracks = () => {
  * Attaches attributes tracks.
  */
 const attachAttributesTracks = () => {
-	function addNewTermEventHandler() {
-		recordEvent( 'product_attributes_add_term', {
-			page: 'product',
-		} );
-	}
-
-	function addNewAttributeTermTracks() {
-		const addNewTermButtons = document.querySelectorAll(
-			'.woocommerce_attribute .add_new_attribute'
-		);
-		addNewTermButtons.forEach( ( button ) => {
-			button.removeEventListener( 'click', addNewTermEventHandler );
-			button.addEventListener( 'click', addNewTermEventHandler );
-		} );
-	}
-	addNewAttributeTermTracks();
-
-	document
-		.querySelector( '.add_custom_attribute' )
-		?.addEventListener( 'click', () => {
-			setTimeout( () => {
-				addNewAttributeTermTracks();
-			}, 1000 );
-		} );
+	attachEventListenerToParentForChildren( '#product_attributes', [
+		{
+			eventName: 'click',
+			childQuery: '.add_new_attribute',
+			callback: () => {
+				recordEvent( 'product_attributes_add_term', {
+					page: 'product',
+				} );
+			},
+		},
+	] );
 };
 
 /**
- * Attaches product attributes tracks.
+ * Attaches Tracks event for when a new custom attribute is added to a product.
  */
-const attachProductAttributesTracks = () => {
+const attachAddCustomAttributeTracks = () => {
 	document
 		.querySelector( '#product_attributes .add_custom_attribute' )
 		?.addEventListener( 'click', () => {
@@ -449,22 +436,29 @@ const attachProductAttributesTracks = () => {
 				action: 'add_new',
 			} );
 		} );
-	document
-		.querySelector( '#product_attributes .add_custom_attribute' )
-		?.addEventListener( 'click', () => {
-			// We verify that we are not adding an existing attribute to not
-			// duplicate the recorded event.
-			const selectElement = document.querySelector(
-				'.attribute_taxonomy'
-			) as HTMLSelectElement;
-			// Get the index of the selected option
-			const selectedIndex = selectElement.selectedIndex;
-			if ( selectElement.options[ selectedIndex ]?.value === '' ) {
-				recordEvent( 'product_attributes_buttons', {
-					action: 'add_new',
-				} );
-			}
+};
+
+/**
+ * Attaches Tracks event for when an existing global attribute is added to a product.
+ */
+const attachAddExistingAttributeTracks = () => {
+	window
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore Need to use jQuery to hook up to the select2:select event since the select2 component is jQuery-based
+		?.jQuery( 'select.wc-attribute-search' )
+		.on( 'select2:select', function () {
+			recordEvent( 'product_attributes_buttons', {
+				action: 'add_existing',
+			} );
 		} );
+};
+
+/**
+ * Attaches product attributes tracks.
+ */
+const attachProductAttributesTracks = () => {
+	attachAddCustomAttributeTracks();
+	attachAddExistingAttributeTracks();
 
 	const attributesSection = '#product_attributes';
 

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
@@ -446,7 +446,7 @@ const attachProductAttributesTracks = () => {
 		.querySelector( '#product_attributes .add_custom_attribute' )
 		?.addEventListener( 'click', () => {
 			recordEvent( 'product_attributes_buttons', {
-				action: 'add_first_attribute',
+				action: 'add_new',
 			} );
 		} );
 	document

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
@@ -430,7 +430,7 @@ const attachAttributesTracks = () => {
 	addNewAttributeTermTracks();
 
 	document
-		.querySelector( '.add_attribute' )
+		.querySelector( '.add_custom_attribute' )
 		?.addEventListener( 'click', () => {
 			setTimeout( () => {
 				addNewAttributeTermTracks();
@@ -450,7 +450,7 @@ const attachProductAttributesTracks = () => {
 			} );
 		} );
 	document
-		.querySelector( '#product_attributes .add_attribute' )
+		.querySelector( '#product_attributes .add_custom_attribute' )
 		?.addEventListener( 'click', () => {
 			// We verify that we are not adding an existing attribute to not
 			// duplicate the recorded event.

--- a/plugins/woocommerce/changelog/update-attribute-empty-state
+++ b/plugins/woocommerce/changelog/update-attribute-empty-state
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update empty state for product attributes tab.

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -532,10 +532,6 @@ jQuery( function ( $ ) {
 
 			selectedAttributes = add_if_not_exists( selectedAttributes, attributeId );
 			disable_in_attribute_search( selectedAttributes );
-
-			window.wcTracks.recordEvent( 'product_attributes_buttons', {
-				action: 'add_existing',
-			} );
 		}
 
 		$( this ).val( null );

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -711,7 +711,9 @@ jQuery( function ( $ ) {
 	$( '.product_attributes' ).on(
 		'click',
 		'button.add_new_attribute',
-		function () {
+		function ( event ) {
+			event.preventDefault();
+
 			$( '.product_attributes' ).block( {
 				message: null,
 				overlayCSS: {
@@ -761,8 +763,6 @@ jQuery( function ( $ ) {
 			} else {
 				$( '.product_attributes' ).unblock();
 			}
-
-			return false;
 		}
 	);
 

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -516,9 +516,6 @@ jQuery( function ( $ ) {
 			const $attributeName = $attribute.find( 'input[name="attribute_names[0]"]' );
 			const $attributeValue = $attribute.find( 'input[name="attribute_values[0]"]' );
 
-			console.log( 'name: ' + $attributeName.val() );
-			console.log( 'value: ' + $attributeValue.val() );
-
 			if ( ! $attributeName.val() && ! $attributeValue.val() ) {
 				$attribute.remove();
 			}

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -395,7 +395,8 @@ jQuery( function ( $ ) {
 		.get();
 
 	// If the product has no attributes, add an empty attribute to be filled out by the user.
-	$( function add_empty_attribute() {
+	$( function add_blank_custom_attribute_if_no_attributes() {
+
 		if ( woocommerce_attribute_items.length === 0  ) {
 			$( 'button.add_custom_attribute' ).trigger( 'click' );
 		}
@@ -507,7 +508,7 @@ jQuery( function ( $ ) {
 		$( 'select.wc-attribute-search' ).data( 'disabled-items', selectedAttributes );
 	}
 
-	function remove_empty_attribute_if_only() {
+	function remove_blank_custom_attribute_if_no_other_attributes() {
 		const $attributes = $( '.product_attributes .woocommerce_attribute' );
 
 		if ( $attributes.length === 1 ) {
@@ -526,7 +527,7 @@ jQuery( function ( $ ) {
 		const attributeId = e?.params?.data?.id;
 
 		if ( attributeId ) {
-			remove_empty_attribute_if_only();
+			remove_blank_custom_attribute_if_no_other_attributes();
 
 			add_attribute( this, attributeId );
 
@@ -708,6 +709,7 @@ jQuery( function ( $ ) {
 		'click',
 		'button.add_new_attribute',
 		function ( event ) {
+			// prevent form submission but allow event propagation
 			event.preventDefault();
 
 			$( '.product_attributes' ).block( {

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -57,12 +57,6 @@ jQuery( function ( $ ) {
 		} );
 	} );
 
-	$( function () {
-		if ( ! woocommerce_admin_meta_boxes.has_local_attributes ) {
-			$( 'button.add_attribute' ).trigger( 'click' );
-		}
-	} );
-
 	// Catalog Visibility.
 	$( '#catalog-visibility' )
 		.find( '.edit-catalog-visibility' )
@@ -399,6 +393,13 @@ jQuery( function ( $ ) {
 	var woocommerce_attribute_items = $( '.product_attributes' )
 		.find( '.woocommerce_attribute' )
 		.get();
+
+	// If the product has no attributes, add an empty attribute to be filled out by the user.
+	$( function add_empty_attribute() {
+		if ( woocommerce_attribute_items.length === 0  ) {
+			$( 'button.add_custom_attribute' ).trigger( 'click' );
+		}
+	} );
 
 	woocommerce_attribute_items.sort( function ( a, b ) {
 		var compA = parseInt( $( a ).attr( 'rel' ), 10 );

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -446,12 +446,6 @@ jQuery( function ( $ ) {
 		selectedAttributes
 	);
 
-	function toggle_add_global_attribute_layout() {
-		$( 'div.add-attribute-container' ).toggle();
-		$( 'div.add-global-attribute-container' ).toggle();
-		$( '#product_attributes > .toolbar-buttons' ).toggle();
-	}
-
 	function add_attribute( element, attribute ) {
 		var size = $( '.product_attributes .woocommerce_attribute' ).length;
 		var $wrapper = $( element ).closest( '#product_attributes' );
@@ -521,12 +515,6 @@ jQuery( function ( $ ) {
 		}
 		$( this ).val( null );
 		$( this ).trigger( 'change' );
-		if (
-			$( 'div.add-attribute-container' ).hasClass( 'hidden' ) &&
-			! $( 'div.add-global-attribute-container' ).hasClass( 'hidden' )
-		) {
-			toggle_add_global_attribute_layout();
-		}
 
 		return false;
 	} );
@@ -557,12 +545,6 @@ jQuery( function ( $ ) {
 	$( 'button.add_custom_attribute' ).on( 'click', function () {
 		add_attribute( this, '' );
 
-		if (
-			$( 'div.add-attribute-container' ).hasClass( 'hidden' ) &&
-			! $( 'div.add-global-attribute-container' ).hasClass( 'hidden' )
-		) {
-			toggle_add_global_attribute_layout();
-		}
 		return false;
 	} );
 
@@ -695,16 +677,6 @@ jQuery( function ( $ ) {
 					action: 'remove_attribute',
 				} );
 
-				if (
-					! $( '.woocommerce_attribute_data' ).is( ':visible' ) &&
-					! $( 'div.add-global-attribute-container' ).hasClass(
-						'hidden'
-					) &&
-					$( '.product_attributes' ).find( 'input, select, textarea' )
-						.length === 0
-				) {
-					toggle_add_global_attribute_layout();
-				}
 				jQuery.maybe_disable_save_button();
 			}
 			return false;

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -507,10 +507,30 @@ jQuery( function ( $ ) {
 		$( 'select.wc-attribute-search' ).data( 'disabled-items', selectedAttributes );
 	}
 
+	function remove_empty_attribute_if_only() {
+		const $attributes = $( '.product_attributes .woocommerce_attribute' );
+
+		if ( $attributes.length === 1 ) {
+			const $attribute = $attributes.first();
+
+			const $attributeName = $attribute.find( 'input[name="attribute_names[0]"]' );
+			const $attributeValue = $attribute.find( 'input[name="attribute_values[0]"]' );
+
+			console.log( 'name: ' + $attributeName.val() );
+			console.log( 'value: ' + $attributeValue.val() );
+
+			if ( ! $attributeName.val() && ! $attributeValue.val() ) {
+				$attribute.remove();
+			}
+		}
+	}
+
 	$( 'select.wc-attribute-search' ).on( 'select2:select', function ( e ) {
 		const attributeId = e?.params?.data?.id;
 
 		if ( attributeId ) {
+			remove_empty_attribute_if_only();
+
 			add_attribute( this, attributeId );
 
 			selectedAttributes = add_if_not_exists( selectedAttributes, attributeId );

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -499,20 +499,28 @@ jQuery( function ( $ ) {
 		}
 	}
 
+	function add_if_not_exists( arr, item ) {
+		return arr.includes( item ) ? attr : [ ...arr, item ];
+	}
+
+	function disable_in_attribute_search( selectedAttributes ) {
+		$( 'select.wc-attribute-search' ).data( 'disabled-items', selectedAttributes );
+	}
+
 	$( 'select.wc-attribute-search' ).on( 'select2:select', function ( e ) {
-		if ( e.params && e.params.data && e.params.data.id ) {
-			add_attribute( this, e.params.data.id );
-			if ( ! selectedAttributes.includes( e.params.data.id ) ) {
-				selectedAttributes.push( e.params.data.id );
-				$( 'select.wc-attribute-search' ).data(
-					'disabled-items',
-					selectedAttributes
-				);
-			}
+		const attributeId = e?.params?.data?.id;
+
+		if ( attributeId ) {
+			add_attribute( this, attributeId );
+
+			selectedAttributes = add_if_not_exists( selectedAttributes, attributeId );
+			disable_in_attribute_search( selectedAttributes );
+
 			window.wcTracks.recordEvent( 'product_attributes_buttons', {
 				action: 'add_existing',
 			} );
 		}
+
 		$( this ).val( null );
 		$( this ).trigger( 'change' );
 

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -520,27 +520,6 @@ jQuery( function ( $ ) {
 	} );
 
 	// Add rows.
-	$( 'button.add_attribute' ).on( 'click', function () {
-		var attribute = $( 'select.attribute_taxonomy' ).val();
-		if (
-			! attribute &&
-			$( 'select.attribute_taxonomy' ).hasClass( 'wc-attribute-search' )
-		) {
-			return;
-		}
-		add_attribute( this, attribute );
-		$( 'select.attribute_taxonomy' ).val( null );
-		$( 'select.attribute_taxonomy' ).trigger( 'change' );
-
-		// We record the event only when an existing attribute is added.
-		if ( attribute !== '' ) {
-			window.wcTracks.recordEvent( 'product_attributes_buttons', {
-				action: 'add_existing',
-			} );
-		}
-
-		return false;
-	} );
 
 	$( 'button.add_custom_attribute' ).on( 'click', function () {
 		add_attribute( this, '' );

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -416,7 +416,6 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					'rounding_precision'                 => wc_get_rounding_precision(),
 					'tax_rounding_mode'                  => wc_get_tax_rounding_mode(),
 					'product_types'                      => array_unique( array_merge( array( 'simple', 'grouped', 'variable', 'external' ), array_keys( wc_get_product_types() ) ) ),
-					'has_local_attributes'               => ! empty( wc_get_attribute_taxonomies() ),
 					'i18n_download_permission_fail'      => __( 'Could not grant access - the user may already have permission for this file or billing email is not set. Ensure the billing email is set, and the order has been saved.', 'woocommerce' ),
 					'i18n_permission_revoke'             => __( 'Are you sure you want to revoke access to this download?', 'woocommerce' ),
 					'i18n_tax_rate_already_exists'       => __( 'You cannot add the same tax rate twice!', 'woocommerce' ),

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
@@ -13,36 +13,11 @@ global $wc_product_attributes;
 // Array of defined attribute taxonomies.
 $attribute_taxonomies = wc_get_attribute_taxonomies();
 // Product attributes - taxonomies and custom, ordered, with visibility and variation attributes set.
-$product_attributes              = $product_object->get_attributes( 'edit' );
-$has_local_attributes            = empty( $attribute_taxonomies );
-$has_global_attributes           = empty( $product_attributes );
-$is_add_global_attribute_visible = ! $has_local_attributes && $has_global_attributes;
-$icon_url                        = WC_ADMIN_IMAGES_FOLDER_URL . '/icons/global-attributes-icon.svg';
+$product_attributes = $product_object->get_attributes( 'edit' );
 ?>
 <div id="product_attributes" class="panel wc-metaboxes-wrapper hidden">
-	<div class="toolbar toolbar-top <?php echo $is_add_global_attribute_visible ? ' expand-close-hidden' : ''; ?>">
-		<div class="add-global-attribute-container<?php echo $is_add_global_attribute_visible ? '' : ' hidden'; ?>">
-			<div class="actions">
-				<button type="button" class="button add_custom_attribute"><?php esc_html_e( 'Add new', 'woocommerce' ); ?></button>
-				<select class="wc-attribute-search" data-placeholder="<?php esc_attr_e( 'Add existing', 'woocommerce' ); ?>" data-minimum-input-length="0">
-				</select>
-			</div>
-			<div class="message">
-				<img src="<?php echo esc_url( $icon_url ); ?>" />
-				<p>
-					<?php
-					esc_html_e(
-						'Add descriptive pieces of information that customers can use to search for this product on your store, such as “Material” or “Brand”.',
-						'woocommerce'
-					);
-					?>
-				</p>
-			</div>
-		</div>
-		<div class="add-attribute-container<?php echo $is_add_global_attribute_visible ? ' hidden' : ' '; ?>">
-			<?php
-			if ( $has_local_attributes && $has_global_attributes ) :
-				?>
+	<div class="toolbar toolbar-top">
+		<div class="add-attribute-container">
 			<div id="message" class="inline notice woocommerce-message">
 				<p>
 					<?php
@@ -53,38 +28,14 @@ $icon_url                        = WC_ADMIN_IMAGES_FOLDER_URL . '/icons/global-a
 					?>
 				</p>
 			</div>
-			<?php endif; ?>
+			<div class="actions">
+				<button type="button" class="button add_custom_attribute"><?php esc_html_e( 'Add new', 'woocommerce' ); ?></button>
+				<select class="wc-attribute-search" data-placeholder="<?php esc_attr_e( 'Add existing', 'woocommerce' ); ?>" data-minimum-input-length="0">
+				</select>
+			</div>
 			<span class="expand-close">
 				<a href="#" class="expand_all"><?php esc_html_e( 'Expand', 'woocommerce' ); ?></a> / <a href="#" class="close_all"><?php esc_html_e( 'Close', 'woocommerce' ); ?></a>
 			</span>
-
-			<?php
-			/**
-			 * Filter for the attribute taxonomy filter dropdown threshold.
-			 *
-			 * @since 7.0.0
-			 * @param number $threshold The threshold for showing the simple dropdown.
-			 */
-			if ( count( $attribute_taxonomies ) <= apply_filters( 'woocommerce_attribute_taxonomy_filter_threshold', 20 ) ) :
-				?>
-			<select name="attribute_taxonomy" class="attribute_taxonomy">
-				<option value=""><?php esc_html_e( 'Custom product attribute', 'woocommerce' ); ?></option>
-				<?php
-				if ( ! $has_local_attributes ) {
-					foreach ( $attribute_taxonomies as $attr_taxonomy ) {
-						$attribute_taxonomy_name = wc_attribute_taxonomy_name( $attr_taxonomy->attribute_name );
-						$label                   = $attr_taxonomy->attribute_label ? $attr_taxonomy->attribute_label : $attr_taxonomy->attribute_name;
-						echo '<option value="' . esc_attr( $attribute_taxonomy_name ) . '">' . esc_html( $label ) . '</option>';
-					}
-				}
-				?>
-			</select>
-			<button type="button" class="button add_attribute"><?php esc_html_e( 'Add', 'woocommerce' ); ?></button>
-			<?php else : ?>
-			<button type="button" class="button add_custom_attribute"><?php esc_html_e( 'Add custom attribute', 'woocommerce' ); ?></button>
-			<select class="wc-attribute-search attribute_taxonomy" id="attribute_taxonomy" name="attribute_taxonomy" data-placeholder="<?php esc_attr_e( 'Add existing attribute', 'woocommerce' ); ?>" data-minimum-input-length="0">
-			</select>
-			<?php endif; ?>
 		</div>
 	</div>
 	<div class="product_attributes wc-metaboxes">
@@ -104,7 +55,7 @@ $icon_url                        = WC_ADMIN_IMAGES_FOLDER_URL . '/icons/global-a
 		}
 		?>
 	</div>
-	<div class="toolbar toolbar-buttons<?php echo $is_add_global_attribute_visible ? ' hidden' : ''; ?>">
+	<div class="toolbar toolbar-buttons">
 		<span class="expand-close">
 			<a href="#" class="expand_all"><?php esc_html_e( 'Expand', 'woocommerce' ); ?></a> / <a href="#" class="close_all"><?php esc_html_e( 'Close', 'woocommerce' ); ?></a>
 		</span>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
@@ -28,14 +28,14 @@ $product_attributes = $product_object->get_attributes( 'edit' );
 					?>
 				</p>
 			</div>
+			<span class="expand-close">
+				<a href="#" class="expand_all"><?php esc_html_e( 'Expand', 'woocommerce' ); ?></a> / <a href="#" class="close_all"><?php esc_html_e( 'Close', 'woocommerce' ); ?></a>
+			</span>
 			<div class="actions">
 				<button type="button" class="button add_custom_attribute"><?php esc_html_e( 'Add new', 'woocommerce' ); ?></button>
 				<select class="wc-attribute-search" data-placeholder="<?php esc_attr_e( 'Add existing', 'woocommerce' ); ?>" data-minimum-input-length="0">
 				</select>
 			</div>
-			<span class="expand-close">
-				<a href="#" class="expand_all"><?php esc_html_e( 'Expand', 'woocommerce' ); ?></a> / <a href="#" class="close_all"><?php esc_html_e( 'Close', 'woocommerce' ); ?></a>
-			</span>
 		</div>
 	</div>
 	<div class="product_attributes wc-metaboxes">

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-attributes.php
@@ -17,25 +17,23 @@ $product_attributes = $product_object->get_attributes( 'edit' );
 ?>
 <div id="product_attributes" class="panel wc-metaboxes-wrapper hidden">
 	<div class="toolbar toolbar-top">
-		<div class="add-attribute-container">
-			<div id="message" class="inline notice woocommerce-message">
-				<p>
-					<?php
-					esc_html_e(
-						'Add descriptive pieces of information that customers can use to search for this product on your store, such as “Material” or “Brand”.',
-						'woocommerce'
-					);
-					?>
-				</p>
-			</div>
-			<span class="expand-close">
-				<a href="#" class="expand_all"><?php esc_html_e( 'Expand', 'woocommerce' ); ?></a> / <a href="#" class="close_all"><?php esc_html_e( 'Close', 'woocommerce' ); ?></a>
-			</span>
-			<div class="actions">
-				<button type="button" class="button add_custom_attribute"><?php esc_html_e( 'Add new', 'woocommerce' ); ?></button>
-				<select class="wc-attribute-search" data-placeholder="<?php esc_attr_e( 'Add existing', 'woocommerce' ); ?>" data-minimum-input-length="0">
-				</select>
-			</div>
+		<div id="message" class="inline notice woocommerce-message">
+			<p>
+				<?php
+				esc_html_e(
+					'Add descriptive pieces of information that customers can use to search for this product on your store, such as “Material” or “Brand”.',
+					'woocommerce'
+				);
+				?>
+			</p>
+		</div>
+		<span class="expand-close">
+			<a href="#" class="expand_all"><?php esc_html_e( 'Expand', 'woocommerce' ); ?></a> / <a href="#" class="close_all"><?php esc_html_e( 'Close', 'woocommerce' ); ?></a>
+		</span>
+		<div class="actions">
+			<button type="button" class="button add_custom_attribute"><?php esc_html_e( 'Add new', 'woocommerce' ); ?></button>
+			<select class="wc-attribute-search" data-placeholder="<?php esc_attr_e( 'Add existing', 'woocommerce' ); ?>" data-minimum-input-length="0">
+			</select>
 		</div>
 	</div>
 	<div class="product_attributes wc-metaboxes">

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-variable-product.spec.js
@@ -292,8 +292,8 @@ test.describe( 'Add New Variable Product Page', () => {
 				if ( i > 0 ) {
 					await test.step( "Click 'Add'.", async () => {
 						await page
-							.locator( '.add-attribute-container' )
-							.getByRole( 'button', { name: 'Add' } )
+							.locator( '#product_attributes .toolbar-top' )
+							.getByRole( 'button', { name: 'Add new' } )
 							.click();
 					} );
 				}
@@ -746,7 +746,7 @@ test.describe( 'Add New Variable Product Page', () => {
 		// add 3 attributes
 		for ( let i = 0; i < 3; i++ ) {
 			if ( i > 0 ) {
-				await page.click( 'button.add_attribute' );
+				await page.click( 'button.add_custom_attribute' );
 			}
 			await page.waitForSelector(
 				`input[name="attribute_names[${ i }]"]`


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR updates the empty state for the product `Attributes` tab so that it always shows an empty local attribute form, which makes it quicker for users to add attributes to a product. This empty local attribute form is shown regardless of whether any global attributes are in the system.

_Also, it is mentioned in the issue acceptance criteria, but bears calling out here as well.. the header buttons are now always the `Add new` and `Add existing` ones, replacing the older `Custom product attribute` dropdown and `Add` button._

The implementation of this change required some updates to the logging of the following Tracks events:

- `wcadmin_product_attributes_buttons` with `action: 'add_new'`
    - Logged when the `Add new` button is clicked
- `wcadmin_product_attributes_buttons` with `action: 'add_existing'`
    - Logged when an existing global attribute is selected from the `Add existing` dropdown
- `wcadmin_product_attributes_add_term`
    - Logged when `Create value` is clicked to create a new value for a global attribute (this is logged regardless of whether a new value is actually created, to keep behavior consistent with how it was prior to this PR)

The e2e tests were updated to reflect the change in CSS classes used in the implementation.

#### Before

Empty state when no global attributes exist:

<img width="788" alt="Screenshot 2023-05-04 at 09 22 57" src="https://user-images.githubusercontent.com/2098816/236217610-cebc3a0e-72fd-4ef7-93e8-260a433b4f6f.png">

Empty state when global attributes exist:

<img width="788" alt="Screenshot 2023-05-04 at 09 21 08" src="https://user-images.githubusercontent.com/2098816/236217149-c1499f1a-1271-4b2b-b1aa-c120115d521f.png">

#### After

<img width="809" alt="Screenshot 2023-05-05 at 15 08 08" src="https://user-images.githubusercontent.com/2098816/236548525-35471f39-db35-45bc-9b82-11bf3e457f7a.png">

Closes #38104.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Common instructions

- To create a new product, go to `Products` > `Add New`
- To edit an existing product, go to `Products` > `All Products`
- To add or remove global attributes, go to `Products` > `Attributes`
- To save attributes, click `Save attributes` button on the `Attributes` tab
- To save a product, click `Publish` (or `Update`, if an existing product)
- To see Tracks events
    - `Tools` > `WCA Test Helper` > `Tools` > `Enable wc-admin Tracking` 
    - Filter by `recordevent` in the browser dev console

#### No global attributes in system

1. Remove all global attributes from the system
2. Create a new product
3. Go to the `Attributes` tab
4. Verify that the empty attribute form is shown
5. Fill out the attribute and save it
6. Save the product and verify the attributes are correct
7. Reload the product and verify the attributes are correct

#### Global attributes in system, adding a new local attribute

1. Add at least one global attribute to the system, and configure terms for it
2. Create a new product
3. Go to the `Attributes` tab
4. Verify that the empty attribute form is shown
5. Fill out the attribute and save it
6. Save the product and verify the attributes are correct
7. Reload the product and verify the attributes are correct

#### Global attributes in system, adding a global attribute

1. Add at least one global attribute to the system, and configure terms for it
2. Create a new product
3. Go to the `Attributes` tab
4. Verify that the empty attribute form is shown
5. Select a global attribute from the `Add existing` dropdown
6. Verify the empty attribute form is removed
7. Verify the same global attribute cannot be selected again from the `Add existing` dropdown
8. Select terms for the global attribute and save it
9. Save the product and verify the attributes are correct
10. Reload the product and verify the attributes are correct

#### Editing an existing product with no attributes

1. Edit one of your existing products no attributes
2. Verify the empty attribute form is automatically shown when the `Attributes` tab is shown

#### Editing an existing product with local attributes

1. Edit one of your existing products with local attributes (either saved from above or before)
2. Verify the empty attribute form is not automatically shown when the `Attributes` tab is shown
3. Verify the attributes are correct

#### Editing an existing product with global attributes

1. Edit one of your existing products with global attributes (either saved from above or before)
2. Verify the empty attribute form is not automatically shown when the `Attributes` tab is shown
3. Verify the attributes are correct

#### Tracks events

1. Clicking on `Add new` should log `wcadmin_product_attributes_buttons` with `action: 'add_new'`
2. Clicking on an existing attribute in `Add existing` should log `wcadmin_product_attributes_buttons` with `action: 'add_existing'`
3. Clicking on `Create value` for a global attribute should log `wcadmin_product_attributes_add_term`

<!-- End testing instructions -->