### PR TITLE
Remove drag and drop handle in product blocks editor

### DIFF
--- a/packages/js/product-editor/changelog/update-38117
+++ b/packages/js/product-editor/changelog/update-38117
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Remove drag and drop handle in product blocks editor

--- a/packages/js/product-editor/src/blocks/attributes/editor.scss
+++ b/packages/js/product-editor/src/blocks/attributes/editor.scss
@@ -1,21 +1,18 @@
-.wp-block-woocommerce-product-images-field {
-	.woocommerce-image-gallery {
-		margin-top: $gap-largest;
+.wp-block-woocommerce-product-attributes-field {
+	.woocommerce-sortable {
+		padding: 0;
 	}
-    .woocommerce-media-uploader {
-        text-align: left;
-    }
-    .woocommerce-media-uploader__label {
+
+	.woocommerce-list-item {
+		background: none;
+		border: none;
+		border-bottom: 1px solid $gray-200;
+		padding-left: 0;
+        grid-template-columns: 26% auto 90px;
+	}
+
+    .woocommerce-sortable__handle {
         display: none;
     }
-    .woocommerce-sortable {
-        margin-top: 0;
-        padding: 0;
-    }
 
-    &:not(.has-images) {
-        .woocommerce-sortable {
-            display: none;
-        }
-    }
 }

--- a/packages/js/product-editor/src/blocks/style.scss
+++ b/packages/js/product-editor/src/blocks/style.scss
@@ -1,3 +1,4 @@
+@import 'attributes/editor.scss';
 @import 'category/editor.scss';
 @import 'checkbox/editor.scss';
 @import 'images/editor.scss';

--- a/packages/js/product-editor/src/components/attribute-control/attribute-field.scss
+++ b/packages/js/product-editor/src/components/attribute-control/attribute-field.scss
@@ -19,17 +19,3 @@
 	}
 
 }
-
-.wp-block-woocommerce-product-attributes-field {
-
-	.woocommerce-sortable {
-		padding: 0;
-	}
-
-	.woocommerce-list-item {
-		background: none;
-		border: none;
-		border-bottom: 1px solid $gray-200;
-		padding-left: 0;
-	}
-}


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Removes the attribute drag handles since dragging breaks the blocks inside the blocks editor.

This PR simply hides them through CSS to avoid removing them from the component itself where they can still be used in the previous iteration of the editor.


<img width="710" alt="Screen Shot 2023-05-04 at 6 27 46 PM" src="https://user-images.githubusercontent.com/10561050/236361038-713e6c31-7635-4baf-be54-b5ad1c4e205e.png">

Closes #38117  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Navigate to Tools -> WCA Test Helper -> Features and enable the new product blocks editing experience
2. Navigate to Products -> Add new
3. Add some attributes
4. Make sure the drag handle has been removed and there's no way to drag the attributes

<!-- End testing instructions -->