### PR TITLE
Update WooCommerce blocks package to 10.0.4

### DIFF
--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-10.0.4
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-10.0.4
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Woo Blocks 10.0.4

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -21,7 +21,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.5.4",
-		"woocommerce/woocommerce-blocks": "10.0.2"
+		"woocommerce/woocommerce-blocks": "10.0.4"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.3.0",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9b9f6dff1c579d1d1e86436b8e1fb6a7",
+    "content-hash": "e2c19d28d8b778a3b73522796391eb88",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -628,16 +628,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "10.0.2",
+            "version": "10.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "d7275884591bc05f7e780c8cd7919d50b79b9ffa"
+                "reference": "1717e5f237b308982870da919bdd52618955c365"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/d7275884591bc05f7e780c8cd7919d50b79b9ffa",
-                "reference": "d7275884591bc05f7e780c8cd7919d50b79b9ffa",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/1717e5f237b308982870da919bdd52618955c365",
+                "reference": "1717e5f237b308982870da919bdd52618955c365",
                 "shasum": ""
             },
             "require": {
@@ -683,9 +683,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v10.0.2"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v10.0.4"
             },
-            "time": "2023-04-19T08:04:13+00:00"
+            "time": "2023-05-05T09:32:30+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 10.0.4. 
## Blocks 10.0.4

* [Release PR](https://github.com/woocommerce/woocommerce-blocks/pull/9357)
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/1004.md)



### Changelog entry

#### Bug Fixes

- Fix "Edit Mini Cart template part" URL for the Mini Cart block. ([9348](https://github.com/woocommerce/woocommerce-blocks/pull/9348))
- Fix duplicate taxonomy templates being created on every save. ([9330](https://github.com/woocommerce/woocommerce-blocks/pull/9330))



