### PR TITLE
Make all fields in the tax location form mandatory

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/fills/steps/location.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/steps/location.tsx
@@ -16,7 +16,7 @@ import {
 	getStoreAddressValidator,
 } from '../../../dashboard/components/settings/general/store-address';
 
-type FormValues = {
+export type FormValues = {
 	addressLine1: string;
 	addressLine2: string;
 	countryState: string;
@@ -50,6 +50,12 @@ type StoreLocationProps = {
 	settings?: {
 		[ key: string ]: string;
 	};
+	validate?: ( values: FormValues ) => { [ key: string ]: string };
+};
+
+export const defaultValidate = ( values: FormValues ) => {
+	const validator = getStoreAddressValidator();
+	return validator( values );
 };
 
 const StoreLocation = ( {
@@ -60,6 +66,7 @@ const StoreLocation = ( {
 	updateAndPersistSettingsForGroup,
 	settings,
 	buttonText = __( 'Continue', 'woocommerce' ),
+	validate = defaultValidate,
 }: StoreLocationProps ) => {
 	const { hasFinishedResolution } = useSelect( ( select ) => {
 		const countryStore = select( COUNTRIES_STORE_NAME );
@@ -105,11 +112,6 @@ const StoreLocation = ( {
 			countryState: settings?.woocommerce_default_country || '',
 			postCode: settings?.woocommerce_store_postcode || '',
 		};
-	};
-
-	const validate = ( values: FormValues ) => {
-		const validator = getStoreAddressValidator();
-		return validator( values );
 	};
 
 	if ( isSettingsRequesting || ! hasFinishedResolution ) {

--- a/plugins/woocommerce-admin/client/tasks/fills/tax/components/store-location.tsx
+++ b/plugins/woocommerce-admin/client/tasks/fills/tax/components/store-location.tsx
@@ -5,13 +5,35 @@ import { SETTINGS_STORE_NAME } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { useEffect } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { getCountryCode } from '~/dashboard/utils';
 import { hasCompleteAddress } from '../utils';
-import { default as StoreLocationForm } from '~/tasks/fills/steps/location';
+import {
+	default as StoreLocationForm,
+	FormValues,
+	defaultValidate,
+} from '~/tasks/fills/steps/location';
+
+const validateLocationForm = ( values: FormValues ) => {
+	const errors = defaultValidate( values );
+
+	if ( ! values.addressLine1.trim().length ) {
+		errors.addressLine1 = __( 'Please enter an address', 'woocommerce' );
+	}
+
+	if ( ! values.postCode.trim().length ) {
+		errors.postCode = __( 'Please enter a post code', 'woocommerce' );
+	}
+
+	if ( ! values.city.trim().length ) {
+		errors.city = __( 'Please enter a city', 'woocommerce' );
+	}
+	return errors;
+};
 
 export const StoreLocation: React.FC< {
 	nextStep: () => void;
@@ -44,7 +66,12 @@ export const StoreLocation: React.FC< {
 
 	return (
 		<StoreLocationForm
+			validate={ validateLocationForm }
 			onComplete={ ( values: { [ key: string ]: string } ) => {
+				if ( ! hasCompleteAddress( generalSettings || {} ) ) {
+					return;
+				}
+
 				const country = getCountryCode( values.countryState );
 				recordEvent( 'tasklist_tax_set_location', {
 					country,

--- a/plugins/woocommerce/changelog/update-tax-location-form
+++ b/plugins/woocommerce/changelog/update-tax-location-form
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Make all fields in the tax location form mandatory


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/36925.

The automated tax screen is only visible when all store details (address, zip code, city) are filled in. However, these fields are not mandatory in the first step.

Thus, when a user connects the Jetpack/WCS without filling in all fields, the user is redirected to the first step without any error message.

This PR makes all fields mandatory to fix the issue.

p1677138140476049/1676907287.360079-slack-C01SFMVEYAK

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install and activate WooCommerce in a brand new site
2. Go to the WooCommerce onboarding wizard.
3. Choose US as store country on the store details step
4. Click on the Continue button without filling out other fields
5. Go to `WooCommerce > Home` and click on `Add tax rates` task from Task list
6. Click on the Continue button
7. Observe that it displays form validation error messages

![Screenshot 2023-05-05 at 18 42 22](https://user-images.githubusercontent.com/4344253/236437562-1c552a44-2305-4f44-b64d-57f81d0d2908.png)

8. Fill out all fields
9. Click on the Continue button
10. Should go to next step



<!-- End testing instructions -->