### PR TITLE
Added filter allowing for the admin order screen product link to be changed

### DIFF
--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item.php
@@ -11,6 +11,16 @@ defined( 'ABSPATH' ) || exit;
 
 $product      = $item->get_product();
 $product_link = $product ? admin_url( 'post.php?post=' . $item->get_product_id() . '&action=edit' ) : '';
+
+/**
+ * Filter the product link which appears on the order admin page.
+ *
+ * @since  7.8.0
+ * @param  string        $product_link Link to view the product.
+ * @param  int           $item_id Order item ID.
+ * @param  WC_Order_Item $item Order Item.
+ * @return string
+ */
 $product_link = apply_filters( 'woocommerce_admin_order_item_product_link_meta_box', $product_link, $product, $item_id, $item );
 $thumbnail    = $product ? apply_filters( 'woocommerce_admin_order_item_thumbnail', $product->get_image( 'thumbnail', array( 'title' => '' ), false ), $item_id, $item ) : '';
 $row_class    = apply_filters( 'woocommerce_admin_html_order_item_class', ! empty( $class ) ? $class : '', $item, $order );

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item.php
@@ -10,7 +10,8 @@
 defined( 'ABSPATH' ) || exit;
 
 $product      = $item->get_product();
-$product_link = $product ? apply_filters( 'woocommerce_admin_order_item_product_link', admin_url( 'post.php?post=' . $item->get_product_id() . '&action=edit' ), $item_id, $item ) : '';
+$product_link = $product ? admin_url( 'post.php?post=' . $item->get_product_id() . '&action=edit' ) : '';
+$product_link = apply_filters( 'woocommerce_admin_order_item_product_link_meta_box', $product_link, $product, $item_id, $item );
 $thumbnail    = $product ? apply_filters( 'woocommerce_admin_order_item_thumbnail', $product->get_image( 'thumbnail', array( 'title' => '' ), false ), $item_id, $item ) : '';
 $row_class    = apply_filters( 'woocommerce_admin_html_order_item_class', ! empty( $class ) ? $class : '', $item, $order );
 ?>

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item.php
@@ -10,7 +10,7 @@
 defined( 'ABSPATH' ) || exit;
 
 $product      = $item->get_product();
-$product_link = $product ? admin_url( 'post.php?post=' . $item->get_product_id() . '&action=edit' ) : '';
+$product_link = $product ? apply_filters( 'woocommerce_admin_order_item_product_link', admin_url( 'post.php?post=' . $item->get_product_id() . '&action=edit' ), $item_id, $item ) : '';
 $thumbnail    = $product ? apply_filters( 'woocommerce_admin_order_item_thumbnail', $product->get_image( 'thumbnail', array( 'title' => '' ), false ), $item_id, $item ) : '';
 $row_class    = apply_filters( 'woocommerce_admin_html_order_item_class', ! empty( $class ) ? $class : '', $item, $order );
 ?>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This adds a filter allowing for the admin order product link to be modified.  

This is helpful in instances where a developer is using a custom post_type in the cart/order as `set_product_id()` on `WC_Order_Item_Product` checks if the post type is a product and fails if its not. It's possible to add a filter to `woocommerce_order_item_product` to return an object which isn't `WC_Product` but the issue is that the product link on the admin order screen calls `$item->get_product_id()` instead of `$item->get_product()->get_id()`. This is a workaround and adds additional flexibility for other scenarios.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add a filter to `woocommerce_admin_order_item_product_link` returning a random string.
2. Check an existing order and you'll notice that the product items will now link to that random string.

<!-- End testing instructions -->