### PR TITLE
Fix spacing between pricing fields

### DIFF
--- a/packages/js/product-editor/changelog/add-38097
+++ b/packages/js/product-editor/changelog/add-38097
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix spacing between pricing fields

--- a/packages/js/product-editor/src/blocks/schedule-sale/editor.scss
+++ b/packages/js/product-editor/src/blocks/schedule-sale/editor.scss
@@ -1,6 +1,9 @@
 .wp-block-woocommerce-product-schedule-sale-fields {
+	margin-bottom: $gap-large;
+
 	.components-toggle-control {
-		margin-bottom: $gap-large;
+		margin-bottom: $gap;
+		padding-bottom: $gap-smaller;
 	}
 
 	.components-toggle-control__label {

--- a/packages/js/product-editor/src/blocks/schedule-sale/editor.scss
+++ b/packages/js/product-editor/src/blocks/schedule-sale/editor.scss
@@ -1,6 +1,18 @@
 .wp-block-woocommerce-product-schedule-sale-fields {
+	.components-toggle-control {
+		margin-bottom: $gap-large;
+	}
+
 	.components-toggle-control__label {
 		display: flex;
 		align-items: center;
+	}
+}
+
+.wp-block-woocommerce-product-section {
+	> .block-editor-inner-blocks > .block-editor-block-list__layout {
+		> .wp-block.wp-block-woocommerce-product-schedule-sale-fields:not( :first-child ) {
+			margin-top: $gap;
+		}
 	}
 }

--- a/packages/js/product-editor/src/components/block-editor/style.scss
+++ b/packages/js/product-editor/src/components/block-editor/style.scss
@@ -75,6 +75,7 @@
 
 	.wp-block-columns {
 		gap: $gap-large;
+		margin-bottom: 0;
 	}
 
 	.wp-block-woocommerce-product-section {


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #38097

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Got to `/wp-admin/tools.php?page=woocommerce-admin-test-helper`
2. Under Features tab make sure to enable `product-block-editor`
3. Then visit `/wp-admin/admin.php?page=wc-admin&path=/add-product`
4. Under `Pricing` tab and within `Pricing` section the spacing between the List price field and the Schedule sale should be as described in AkVNGImLgSqCObTQ3idVn7-fi-305-38548

<!-- End testing instructions -->