### PR TITLE
Make more information available to `checkout_place_order` callbacks

### DIFF
--- a/plugins/woocommerce/changelog/26827-checkout-place-order-events
+++ b/plugins/woocommerce/changelog/26827-checkout-place-order-events
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Makes more information available to handlers for the `checkout_place_order` (and related) events.

--- a/plugins/woocommerce/client/legacy/js/frontend/checkout.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/checkout.js
@@ -477,7 +477,7 @@ jQuery( function( $ ) {
 
 			// Trigger a handler to let gateways manipulate the checkout if needed
 			// eslint-disable-next-line max-len
-			if ( $form.triggerHandler( 'checkout_place_order', [wc_checkout_form] ) !== false && $form.triggerHandler( 'checkout_place_order_' + wc_checkout_form.get_payment_method(), [wc_checkout_form] ) !== false ) {
+			if ( $form.triggerHandler( 'checkout_place_order', [ wc_checkout_form ] ) !== false && $form.triggerHandler( 'checkout_place_order_' + wc_checkout_form.get_payment_method(), [ wc_checkout_form ] ) !== false ) {
 
 				$form.addClass( 'processing' );
 
@@ -525,7 +525,7 @@ jQuery( function( $ ) {
 						wc_checkout_form.detachUnloadEventsOnSubmit();
 
 						try {
-							if ( 'success' === result.result && $form.triggerHandler( 'checkout_place_order_success', [result, wc_checkout_form] ) !== false ) {
+							if ( 'success' === result.result && $form.triggerHandler( 'checkout_place_order_success', [ result, wc_checkout_form ] ) !== false ) {
 								if ( -1 === result.redirect.indexOf( 'https://' ) || -1 === result.redirect.indexOf( 'http://' ) ) {
 									window.location = result.redirect;
 								} else {

--- a/plugins/woocommerce/client/legacy/js/frontend/checkout.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/checkout.js
@@ -477,7 +477,7 @@ jQuery( function( $ ) {
 
 			// Trigger a handler to let gateways manipulate the checkout if needed
 			// eslint-disable-next-line max-len
-			if ( $form.triggerHandler( 'checkout_place_order' ) !== false && $form.triggerHandler( 'checkout_place_order_' + wc_checkout_form.get_payment_method() ) !== false ) {
+			if ( $form.triggerHandler( 'checkout_place_order', [wc_checkout_form] ) !== false && $form.triggerHandler( 'checkout_place_order_' + wc_checkout_form.get_payment_method(), [wc_checkout_form] ) !== false ) {
 
 				$form.addClass( 'processing' );
 
@@ -525,7 +525,7 @@ jQuery( function( $ ) {
 						wc_checkout_form.detachUnloadEventsOnSubmit();
 
 						try {
-							if ( 'success' === result.result && $form.triggerHandler( 'checkout_place_order_success', result ) !== false ) {
+							if ( 'success' === result.result && $form.triggerHandler( 'checkout_place_order_success', [result, wc_checkout_form] ) !== false ) {
 								if ( -1 === result.redirect.indexOf( 'https://' ) || -1 === result.redirect.indexOf( 'http://' ) ) {
 									window.location = result.redirect;
 								} else {


### PR DESCRIPTION
🛠️ Makes more information available to Javascript event handlers during the checkout process. This makes it easier for extension (payment gateway) developers to manipulate the checkout experience. In isolation, though, nothing should change and everything should work as before.

ℹ️ This is a replay of https://github.com/woocommerce/woocommerce/pull/26827 and preserves the original commits. This was needed to successfully rebase and add a changelog, etc, since the original contributor branch was protected in some way.

Closes https://github.com/woocommerce/woocommerce/pull/26827.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout this branch, and be sure to rebuild the frontend assets using the `pnpm run --filter='woocommerce/client/legacy' build` command (the mono-repo must be setup [as described here](https://github.com/woocommerce/woocommerce/blob/7.6.1/DEVELOPMENT.md) for this). Otherwise, you may be able to use a live branch if available.
2. Please also add the following snippet to a suitable location. I would recommend `wp-content/mu-plugins/test-38147.php` (and remember to remove it once testing is complete):

```php
<?php

add_action( 'wp_footer', function () {
	echo <<<'JS'
		<script>	
			jQuery( ( $ ) => {
				const $form = $( 'form.checkout.woocommerce-checkout' );
				
				$form.on( 'checkout_place_order_success', ( result ) => {
					console.log( `[38147] checkout_place_order_success callback fired! (${result})` );
				});
				
				$form.on( 'checkout_place_order', () => {
					console.log( '[38147] checkout_place_order callback fired!' );
				});
			} );
		</script>
JS;

} );
```

3. Now navigate to your storefront and add one or more products to the cart.
4. Proceed to checkout, fill in all the required fields.
5. Open your browser console:
    - Enable **persist logs** (Firefox) or **preserve log** (Chrome-esque browsers).
    - Clear all existing log entries.
6. Check out!
    - You should be able to check out successfully.
    - Once you land on the order confirmation page, you should see debug output as follows (try entering `[38147]` in the console filter field to locate these more easily):

```
[38147] checkout_place_order callback fired! 
[38147] checkout_place_order_success callback fired! ([object Object])
```


<!-- End testing instructions -->