### PR TITLE
Correcting spacing for image gallery block

### DIFF
--- a/packages/js/product-editor/changelog/fix-image-section-spacing
+++ b/packages/js/product-editor/changelog/fix-image-section-spacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixing spacing when no images added on image gallery block.

--- a/packages/js/product-editor/src/blocks/images/editor.scss
+++ b/packages/js/product-editor/src/blocks/images/editor.scss
@@ -1,7 +1,4 @@
 .wp-block-woocommerce-product-images-field {
-	.woocommerce-image-gallery {
-		margin-top: $gap-largest;
-	}
     .woocommerce-media-uploader {
         text-align: left;
     }
@@ -12,6 +9,12 @@
         margin-top: 0;
         padding: 0;
     }
+
+	&.has-images {
+		.woocommerce-image-gallery {
+			margin-top: $gap-largest;
+		}
+	}
 
     &:not(.has-images) {
         .woocommerce-sortable {


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Previously, when no images were yet added there was too much spacing between the "Choose images" button and the section divider below. This spacing should have only been present when images were added, which I've fixed in this PR.

Before:
![image](https://user-images.githubusercontent.com/444632/236578550-b2fe47cc-16c5-41da-8932-a36af810396f.png)


After:
![image](https://user-images.githubusercontent.com/444632/236578571-110b5a42-5480-45d3-afce-3875de959215.png)


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout branch and enable `product-block-editor` feature flag.
2. Navigate to Products -> Add new to see product block editor.
3. Scroll to the images section and verify that the spacing is correct (see **After** image above)
4. Add an image, and ensure that the spacing is still  correct.

<!-- End testing instructions -->