### PR TITLE
Fixed null in the part that gets the element of the custom post of th…

### DIFF
--- a/plugins/woocommerce/src/Admin/Features/Navigation/CoreMenu.php
+++ b/plugins/woocommerce/src/Admin/Features/Navigation/CoreMenu.php
@@ -224,6 +224,7 @@ class CoreMenu {
 			);
 		}
 
+		if(isset($coupon_items['default']))$coupon_items['default'] = array();
 		return array_merge(
 			array(
 				$home_item,

--- a/plugins/woocommerce/src/Admin/Features/Navigation/CoreMenu.php
+++ b/plugins/woocommerce/src/Admin/Features/Navigation/CoreMenu.php
@@ -224,7 +224,7 @@ class CoreMenu {
 			);
 		}
 
-		if(isset($coupon_items['default']))$coupon_items['default'] = array();
+		if(　isset(　$coupon_items['default']　)　)　$coupon_items['default'] = array();
 		return array_merge(
 			array(
 				$home_item,


### PR DESCRIPTION
…e coupon

I received a consultation from a person who had the same phenomenon as the following forum. After looking at the code, I think this fix will fix it.

https://wordpress.org/support/topic/warning-since-latest-update/

### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1.
2.
3.

<!-- End testing instructions -->