### PR TITLE
Remove core onboarding usage of woocommerce_updated hook

### DIFF
--- a/plugins/woocommerce/changelog/remove-onboarding-hook
+++ b/plugins/woocommerce/changelog/remove-onboarding-hook
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Remove Core onboarding usage of woocommerce_updated hook

--- a/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingProfile.php
+++ b/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingProfile.php
@@ -22,7 +22,6 @@ class OnboardingProfile {
 	 * Add onboarding actions.
 	 */
 	public static function init() {
-		add_action( 'woocommerce_updated', array( __CLASS__, 'maybe_mark_complete' ) );
 		add_action( 'update_option_' . self::DATA_OPTION, array( __CLASS__, 'trigger_complete' ), 10, 2 );
 	}
 
@@ -64,38 +63,5 @@ class OnboardingProfile {
 		// @todo When merging to WooCommerce Core, we should set the `completed` flag to true during the upgrade progress.
 		// https://github.com/woocommerce/woocommerce-admin/pull/2300#discussion_r287237498.
 		return ! $is_completed && ! $is_skipped;
-	}
-
-	/**
-	 * When updating WooCommerce, mark the profiler and task list complete.
-	 *
-	 * @todo The `maybe_enable_setup_wizard()` method should be revamped on onboarding enable in core.
-	 * See https://github.com/woocommerce/woocommerce/blob/1ca791f8f2325fe2ee0947b9c47e6a4627366374/includes/class-wc-install.php#L341
-	 */
-	public static function maybe_mark_complete() {
-		// The install notice still exists so don't complete the profiler.
-		if ( ! class_exists( 'WC_Admin_Notices' ) || \WC_Admin_Notices::has_notice( 'install' ) ) {
-			return;
-		}
-
-		$onboarding_data = get_option( self::DATA_OPTION, array() );
-		// Don't make updates if the profiler is completed or skipped, but task list is potentially incomplete.
-		if (
-			( isset( $onboarding_data['completed'] ) && $onboarding_data['completed'] ) ||
-			( isset( $onboarding_data['skipped'] ) && $onboarding_data['skipped'] )
-		) {
-			return;
-		}
-
-		$onboarding_data['completed'] = true;
-		update_option( self::DATA_OPTION, $onboarding_data );
-
-		if ( ! WCAdminHelper::is_wc_admin_active_for( DAY_IN_SECONDS ) ) {
-			$task_list = TaskLists::get_list( 'setup' );
-			if ( ! $task_list ) {
-				return;
-			}
-			$task_list->hide();
-		}
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #37424.

> Remnants of an https://github.com/woocommerce/woocommerce-admin/pull/3590 is no longer useful and is causing onboarding wizard to be marked as completed and hides tasklist unintentionally.

This PR removes the old hook and relevant codes.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Use a fresh site
2. Open `wp_options` table and search for `woocommerce_version`
3. Update `woocommerce_version` to a lower number.
4. Go to any WooCommerce Admin page and refresh.
5. Confirm `woocommerce_version` has been updated to the latest number.
6. OBW shouldn't get automatically completed
7. Tasklist shouldn't be hidden


<!-- End testing instructions -->