### PR TITLE
Add missing woocommerce_run_on_woocommerce_admin_updated hook for RemoteInboxNotificationsEngine scheduled action

### DIFF
--- a/plugins/woocommerce/changelog/fix-woocommerce_admin_updated-does-not-run
+++ b/plugins/woocommerce/changelog/fix-woocommerce_admin_updated-does-not-run
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add missing woocommerce_run_on_woocommerce_admin_updated hook for the scheduled action registered in RemoteInboxNotificationsEngine

--- a/plugins/woocommerce/changelog/remove-onboarding-hook
+++ b/plugins/woocommerce/changelog/remove-onboarding-hook
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Remove Core onboarding usage of woocommerce_updated hook

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
@@ -40,19 +40,20 @@ class RemoteInboxNotificationsEngine {
 
 		// Hook into WCA updated. This is hooked up here rather than in
 		// on_admin_init because that runs too late to hook into the action.
+		add_action( 'woocommerce_run_on_woocommerce_admin_updated' , array( __CLASS__, 'run_on_woocommerce_admin_updated' ) );
 		add_action(
 			'woocommerce_updated',
 			function() {
 				$next_hook = WC()->queue()->get_next(
 					'woocommerce_run_on_woocommerce_admin_updated',
-					array( __CLASS__, 'run_on_woocommerce_admin_updated' ),
+					array(),
 					'woocommerce-remote-inbox-engine'
 				);
-				if ( null === $next_hook ) {
+				if ( $next_hook === null ) {
 					WC()->queue()->schedule_single(
 						time(),
 						'woocommerce_run_on_woocommerce_admin_updated',
-						array( __CLASS__, 'run_on_woocommerce_admin_updated' ),
+						array(),
 						'woocommerce-remote-inbox-engine'
 					);
 				}

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
@@ -40,7 +40,7 @@ class RemoteInboxNotificationsEngine {
 
 		// Hook into WCA updated. This is hooked up here rather than in
 		// on_admin_init because that runs too late to hook into the action.
-		add_action( 'woocommerce_run_on_woocommerce_admin_updated' , array( __CLASS__, 'run_on_woocommerce_admin_updated' ) );
+		add_action( 'woocommerce_run_on_woocommerce_admin_updated', array( __CLASS__, 'run_on_woocommerce_admin_updated' ) );
 		add_action(
 			'woocommerce_updated',
 			function() {
@@ -49,7 +49,7 @@ class RemoteInboxNotificationsEngine {
 					array(),
 					'woocommerce-remote-inbox-engine'
 				);
-				if ( $next_hook === null ) {
+				if ( null === $next_hook ) {
 					WC()->queue()->schedule_single(
 						time(),
 						'woocommerce_run_on_woocommerce_admin_updated',

--- a/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingProfile.php
+++ b/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingProfile.php
@@ -22,7 +22,6 @@ class OnboardingProfile {
 	 * Add onboarding actions.
 	 */
 	public static function init() {
-		add_action( 'woocommerce_updated', array( __CLASS__, 'maybe_mark_complete' ) );
 		add_action( 'update_option_' . self::DATA_OPTION, array( __CLASS__, 'trigger_complete' ), 10, 2 );
 	}
 
@@ -64,38 +63,5 @@ class OnboardingProfile {
 		// @todo When merging to WooCommerce Core, we should set the `completed` flag to true during the upgrade progress.
 		// https://github.com/woocommerce/woocommerce-admin/pull/2300#discussion_r287237498.
 		return ! $is_completed && ! $is_skipped;
-	}
-
-	/**
-	 * When updating WooCommerce, mark the profiler and task list complete.
-	 *
-	 * @todo The `maybe_enable_setup_wizard()` method should be revamped on onboarding enable in core.
-	 * See https://github.com/woocommerce/woocommerce/blob/1ca791f8f2325fe2ee0947b9c47e6a4627366374/includes/class-wc-install.php#L341
-	 */
-	public static function maybe_mark_complete() {
-		// The install notice still exists so don't complete the profiler.
-		if ( ! class_exists( 'WC_Admin_Notices' ) || \WC_Admin_Notices::has_notice( 'install' ) ) {
-			return;
-		}
-
-		$onboarding_data = get_option( self::DATA_OPTION, array() );
-		// Don't make updates if the profiler is completed or skipped, but task list is potentially incomplete.
-		if (
-			( isset( $onboarding_data['completed'] ) && $onboarding_data['completed'] ) ||
-			( isset( $onboarding_data['skipped'] ) && $onboarding_data['skipped'] )
-		) {
-			return;
-		}
-
-		$onboarding_data['completed'] = true;
-		update_option( self::DATA_OPTION, $onboarding_data );
-
-		if ( ! WCAdminHelper::is_wc_admin_active_for( DAY_IN_SECONDS ) ) {
-			$task_list = TaskLists::get_list( 'setup' );
-			if ( ! $task_list ) {
-				return;
-			}
-			$task_list->hide();
-		}
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Bring https://github.com/woocommerce/woocommerce/pull/36768 back.

I didn't use the [last commit](https://github.com/woocommerce/woocommerce/pull/36768/commits/580b9ba069ccabe3936177fbf221b9d107c913aa) because I noticed that it would trigger `woocommerce_updated` hook on every page loaded while we should only trigger it when woocommerce is updated to a new version.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Use a fresh site
2. Go to `WooCommerce -> Status -> Scheduled` Actions and search for `woocommerce_run_on_woocommerce_admin_updated` then delete it
3. Open wp_options table and search for `woocommerce_version`
4. Update woocommerce_version to a lower number.
5. Go to any WooCommerce Admin page and refresh.
6. Confirm `woocommerce_version` has been updated to the latest number.
7. Go to `WooCommerce -> Status -> Scheduled Actions` and search for `woocommerce_run_on_woocommerce_admin_updated`.
8. Confirm the action executed.


<!-- End testing instructions -->