### PR TITLE
Hide "Upload a logo" step in Personalize task if theme doesn't support it

### DIFF
--- a/plugins/woocommerce-admin/client/tasks/fills/appearance.js
+++ b/plugins/woocommerce-admin/client/tasks/fills/appearance.js
@@ -25,11 +25,13 @@ import { WooOnboardingTask } from '@woocommerce/onboarding';
 class Appearance extends Component {
 	constructor( props ) {
 		super( props );
-		const { hasHomepage, hasProducts } = props.task.additionalData;
+		const { hasHomepage, hasProducts, supportCustomLogo } =
+			props.task.additionalData;
 
 		this.stepVisibility = {
 			homepage: ! hasHomepage,
 			import: ! hasProducts,
+			logo: supportCustomLogo,
 		};
 
 		this.state = {
@@ -338,7 +340,7 @@ class Appearance extends Component {
 						</Button>
 					</Fragment>
 				),
-				visible: true,
+				visible: this.stepVisibility.logo,
 			},
 			{
 				key: 'notice',

--- a/plugins/woocommerce/changelog/update-hide-logo-step-if-not-support
+++ b/plugins/woocommerce/changelog/update-hide-logo-step-if-not-support
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Hide upload logo step in Personalize task if theme doesn't support it

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Appearance.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Appearance.php
@@ -80,6 +80,7 @@ class Appearance extends Task {
 			'has_products' => Products::has_products(),
 			'stylesheet'   => get_option( 'stylesheet' ),
 			'theme_mods'   => get_theme_mods(),
+			'support_custom_logo' => false !== get_theme_support( 'custom-logo' ),
 		);
 	}
 

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Appearance.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Appearance.php
@@ -76,10 +76,10 @@ class Appearance extends Task {
 	 */
 	public function get_additional_data() {
 		return array(
-			'has_homepage' => self::has_homepage(),
-			'has_products' => Products::has_products(),
-			'stylesheet'   => get_option( 'stylesheet' ),
-			'theme_mods'   => get_theme_mods(),
+			'has_homepage'        => self::has_homepage(),
+			'has_products'        => Products::has_products(),
+			'stylesheet'          => get_option( 'stylesheet' ),
+			'theme_mods'          => get_theme_mods(),
 			'support_custom_logo' => false !== get_theme_support( 'custom-logo' ),
 		);
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/36334.

This PR hides the "Upload a logo" step in Personalize task if a theme doesn't support it by checking [`get_theme_support('custom-logo')`](https://developer.wordpress.org/reference/functions/get_theme_support/) value.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Use `Twenty Twenty-Three` theme
2. Go to `WooCommerce > Home` and click on `Personalize your store` task from Task list
3. Observe that "Upload a logo" step is **not** shown.
4. Use Storefront theme
5. Go to `WooCommerce > Home` and click on `Personalize your store` task from Task list
6. Observe that "Upload a logo" step is shown.

<!-- End testing instructions -->