### PR TITLE
Re-enable purchase unit tests and falling back to simply not display any prices when data is not available

### DIFF
--- a/plugins/woocommerce/changelog/p
+++ b/plugins/woocommerce/changelog/p
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Fallback to simply not display any prices rather than empty prices and re-enable Purchase unit tests

--- a/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingProducts.php
+++ b/plugins/woocommerce/src/Internal/Admin/Onboarding/OnboardingProducts.php
@@ -128,9 +128,6 @@ class OnboardingProducts {
 				$product_data[ $key ]['description']  = $products[ $product_type['product'] ]->excerpt;
 				$product_data[ $key ]['more_url']     = $products[ $product_type['product'] ]->link;
 				$product_data[ $key ]['slug']         = strtolower( preg_replace( '~[^\pL\d]+~u', '-', $products[ $product_type['product'] ]->slug ) );
-			} elseif ( isset( $product_type['product'] ) ) {
-				/* translators: site currency symbol (used to show that the product costs money) */
-				$product_data[ $key ]['label'] .= sprintf( __( ' — %s', 'woocommerce' ), html_entity_decode( get_woocommerce_currency_symbol() ) );
 			}
 		}
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/tasks/purchase.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/onboarding-tasks/tasks/purchase.php
@@ -82,7 +82,6 @@ class WC_Admin_Tests_OnboardingTasks_Task_Purchase extends WC_Unit_Test_Case {
 	 * Test is_complete function of Purchase task.
 	 */
 	public function test_is_not_complete_if_remaining_paid_products() {
-		$this->markTestSkipped( 'Skipped temporarily due to change in endpoint behavior.' );
 		update_option( OnboardingProfile::DATA_OPTION, array( 'product_types' => array( 'memberships' ) ) );
 		$this->assertEquals( false, $this->task->is_complete() );
 	}
@@ -161,7 +160,6 @@ class WC_Admin_Tests_OnboardingTasks_Task_Purchase extends WC_Unit_Test_Case {
 	 * Test the task title if 2 paid items exist.
 	 */
 	public function test_get_title_if_multiple_paid_themes() {
-		$this->markTestSkipped( 'Skipped temporarily due to change in endpoint behavior.' );
 		update_option(
 			OnboardingProfile::DATA_OPTION,
 			array(
@@ -176,7 +174,6 @@ class WC_Admin_Tests_OnboardingTasks_Task_Purchase extends WC_Unit_Test_Case {
 	 * Test the task title if multiple additional paid items exist.
 	 */
 	public function test_get_title_if_multiple_paid_products() {
-		$this->markTestSkipped( 'Skipped temporarily due to change in endpoint behavior.' );
 		update_option(
 			OnboardingProfile::DATA_OPTION,
 			array(


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/37081.

- Re-enable unit tests that were marked as skipped in https://github.com/woocommerce/woocommerce/pull/36741
- Falling back to simply not display any prices rather than empty prices when price data is not available

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. CI should pass
2. Run `wp option set --format=json _transient_wc_onboarding_product_data '{\"en_US\":{\"body\":\"\"}}'` 
3. Go to `Onboarding wizard > Product Types` tab (/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=product-types)
4. Observe that it only shows the product type names, not containing price symbols.

Before:
![Screenshot 2023-05-08 at 20 37 44](https://user-images.githubusercontent.com/4344253/236825750-8ed74693-f210-4d2d-a832-344c060fd5ea.png)


After:

![Screenshot 2023-05-08 at 20 37 06](https://user-images.githubusercontent.com/4344253/236825670-41d78921-8b6c-43a7-b947-3e13e52c3434.png)


<!-- End testing instructions -->