### PR TITLE
Compute if any order is pending, when deciding to process next migration batch

### DIFF
--- a/plugins/woocommerce/changelog/fix-34804-2
+++ b/plugins/woocommerce/changelog/fix-34804-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Compute if any order is pending, when deciding to process next migration batch

--- a/plugins/woocommerce/tests/php/src/Internal/BatchProcessing/BatchProcessingControllerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/BatchProcessing/BatchProcessingControllerTests.php
@@ -145,7 +145,7 @@ class BatchProcessingControllerTests extends WC_Unit_Test_Case {
 	public function test_process_single_update_unfinished() {
 		$test_process_mock = $this->getMockBuilder( get_class( $this->test_process ) )->getMock();
 		$test_process_mock->method( 'get_total_pending_count' )->willReturn( 10 );
-		$test_process_mock->expects( $this->once() )->method( 'get_next_batch_to_process' )->willReturn( array( 'dummy_id' ) );
+		$test_process_mock->expects( $this->exactly( 2 ) )->method( 'get_next_batch_to_process' )->willReturn( array( 'dummy_id' ) );
 
 		add_filter(
 			'woocommerce_get_batch_processor',
@@ -166,8 +166,14 @@ class BatchProcessingControllerTests extends WC_Unit_Test_Case {
 	public function test_process_single_update_finished() {
 		$test_process_mock = $this->getMockBuilder( get_class( $this->test_process ) )->getMock();
 		$test_process_mock->method( 'get_total_pending_count' )->willReturn( 0 );
-		$test_process_mock->expects( $this->once() )->method( 'get_next_batch_to_process' )->willReturn( array( 'dummy_id' ) );
-
+		$test_process_mock
+			->expects( $this->exactly( 2 ) )
+			->method( 'get_next_batch_to_process' )
+			->willReturnCallback(
+				function ( $batch_size ) {
+					return 1 === $batch_size ? array() : array( 'dummy_id' );
+				}
+			);
 		add_filter(
 			'woocommerce_get_batch_processor',
 			function() use ( $test_process_mock ) {


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We change the behavior of how we decide whether to continue or stop the migration. Earlier, when deciding, we were counting all pending orders which was slow especially on large sites, and will continue to get slower as the migration processes. However, now we will only fetch if there is any order that needs migrating to decide whether to go ahead with the migration or not, which should be much faster then calculating the total count.

Closes #34804

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Note that this is a performance change, so there is no functionality that was broken on an earlier version of WC.

#### Test that migration works as expected for post to HPOS tables:

1. With Post tables as authoritative and sync set to off (and some orders present). Drop the HPOS tables if needed by going to WooCommerce > Status > Tools > Delete the custom orders tables
2. Run the following sync command: `wp wc cot sync --batch-size=10`. Note that batch size should be set to something so that atleast 2 different batches are processed, so if you have only 3 orders in your test site, set it to 1, but if you have 1200 orders, the default size of 500 is good enough.
3. Make sure that sync completes as expected.

#### Test the migration with batch processor via action scheduler

1. With Post tables as authoritative and sync set to off (and some orders present). Drop the HPOS tables if needed by going to WooCommerce > Status > Tools > Delete the custom orders tables.
2. Enable the sync from HPOS feature page.
3. Wait a while and make sure that sync completes.

#### Test the migration from HPOS to post tables.
1. With HPOS as authoritative and sync set to off, generate some orders via WC Smooth generator.
2. Run the following sync command: `wp wc cot sync --batch-size=10`. Note that batch size should be set to something so that atleast 2 different batches are processed, so if you have only 3 orders in your test site, set it to 1, but if you have 1200 orders, the default size of 500 is good enough.
3. Make sure that sync completes as expected.

#### Test the migration from HPOS to post tables via action scheduler
1. With HPOS as authoritative and sync set to off, generate some orders via WC Smooth generator.
2. Enable sync from HPOS feature page.
3. Wait a while and make sure that sync completes.

<!-- End testing instructions -->