### PR TITLE
Add editor styles to product editor and iframe editor

### DIFF
--- a/packages/js/product-editor/changelog/fix-38021
+++ b/packages/js/product-editor/changelog/fix-38021
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Add editor styles to product editor and iframe editor

--- a/packages/js/product-editor/src/blocks/section/editor.scss
+++ b/packages/js/product-editor/src/blocks/section/editor.scss
@@ -6,7 +6,7 @@
 		padding-top: 64px;
 	}
 
-    &__title {
+    .wp-block-woocommerce-product-section__title {
         margin-top: 0;
         margin-bottom: 0;
         font-size: 24px;

--- a/packages/js/product-editor/src/components/block-editor/block-editor.tsx
+++ b/packages/js/product-editor/src/components/block-editor/block-editor.tsx
@@ -105,7 +105,6 @@ export function BlockEditor( {
 					settings={ settings }
 				>
 					<EditorStyles styles={ settings?.styles } />
-					{/* <EditorStyles styles={ styles } /> */}
 					<div className="editor-styles-wrapper">
 						{ /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */ }
 						{ /* @ts-ignore No types for this exist yet. */ }

--- a/packages/js/product-editor/src/components/block-editor/block-editor.tsx
+++ b/packages/js/product-editor/src/components/block-editor/block-editor.tsx
@@ -20,6 +20,9 @@ import {
 	EditorBlockListSettings,
 	WritingFlow,
 	ObserveTyping,
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore No types for this exist yet.
+	__unstableEditorStyles as EditorStyles,
 } from '@wordpress/block-editor';
 // It doesn't seem to notice the External dependency block whn @ts-ignore is added.
 // eslint-disable-next-line @woocommerce/dependency-group
@@ -101,6 +104,8 @@ export function BlockEditor( {
 					onChange={ onChange }
 					settings={ settings }
 				>
+					<EditorStyles styles={ settings?.styles } />
+					{/* <EditorStyles styles={ styles } /> */}
 					<div className="editor-styles-wrapper">
 						{ /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */ }
 						{ /* @ts-ignore No types for this exist yet. */ }

--- a/packages/js/product-editor/src/components/iframe-editor/editor-canvas.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/editor-canvas.tsx
@@ -3,22 +3,29 @@
  */
 import { createElement, Fragment } from '@wordpress/element';
 import {
+	EditorSettings,
+	EditorBlockListSettings,
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore No types for this exist yet.
 	__unstableIframe as Iframe,
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore No types for this exist yet.
 	__unstableUseMouseMoveTypingReset as useMouseMoveTypingReset,
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore No types for this exist yet.
+	__unstableEditorStyles as EditorStyles,
 } from '@wordpress/block-editor';
 
 type EditorCanvasProps = {
-	enableResizing: boolean;
 	children: React.ReactNode;
+	enableResizing: boolean;
+	settings: Partial< EditorSettings & EditorBlockListSettings > | undefined;
 };
 
 export function EditorCanvas( {
-	enableResizing,
 	children,
+	enableResizing,
+	settings,
 	...props
 }: EditorCanvasProps ) {
 	const mouseMoveTypingRef = useMouseMoveTypingReset();
@@ -26,6 +33,7 @@ export function EditorCanvas( {
 		<Iframe
 			head={
 				<>
+					<EditorStyles styles={ settings?.styles } />
 					<style>
 						{
 							// Forming a "block formatting context" to prevent margin collapsing.

--- a/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
@@ -19,6 +19,9 @@ import {
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore
 	store as blockEditorStore,
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore No types for this exist yet.
+__unstableEditorStyles as EditorStyles,
 } from '@wordpress/block-editor';
 
 /**
@@ -39,7 +42,7 @@ export function IframeEditor( {
 	initialBlocks = [],
 	onChange,
 	onClose,
-	settings,
+	settings: __settings,
 }: IframeEditorProps ) {
 	const [ resizeObserver, sizes ] = useResizeObserver();
 	const [ blocks, setBlocks ] = useState< BlockInstance[] >( initialBlocks );
@@ -61,11 +64,13 @@ export function IframeEditor( {
 		updateSettings( productBlockEditorSettings );
 	}, [] );
 
+	const settings = __settings || parentEditorSettings;
+
 	return (
 		<div className="woocommerce-iframe-editor">
 			<BlockEditorProvider
 				settings={ {
-					...( settings || parentEditorSettings ),
+					...settings,
 					hasFixedToolbar: true,
 					templateLock: false,
 				} }
@@ -103,7 +108,7 @@ export function IframeEditor( {
 						// @ts-ignore This accepts numbers or strings.
 						height={ sizes.height ?? '100%' }
 					>
-						<EditorCanvas enableResizing={ true }>
+						<EditorCanvas enableResizing={ true } settings={ settings }>
 							{ resizeObserver }
 							<BlockList className="edit-site-block-editor__block-list wp-site-blocks" />
 						</EditorCanvas>

--- a/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
@@ -19,9 +19,6 @@ import {
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore
 	store as blockEditorStore,
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore No types for this exist yet.
-__unstableEditorStyles as EditorStyles,
 } from '@wordpress/block-editor';
 
 /**
@@ -108,7 +105,10 @@ export function IframeEditor( {
 						// @ts-ignore This accepts numbers or strings.
 						height={ sizes.height ?? '100%' }
 					>
-						<EditorCanvas enableResizing={ true } settings={ settings }>
+						<EditorCanvas
+							enableResizing={ true }
+							settings={ settings }
+						>
 							{ resizeObserver }
 							<BlockList className="edit-site-block-editor__block-list wp-site-blocks" />
 						</EditorCanvas>


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes an issue where certain editor styles (such as buttons) were not being applied to the editor and iframe editor.


#### Before
<img width="474" alt="Screen Shot 2023-05-08 at 9 50 14 AM" src="https://user-images.githubusercontent.com/10561050/236883040-bcf08355-2008-46ef-bf44-11c8a89f975b.png">



#### After

<img width="574" alt="Screen Shot 2023-05-08 at 9 49 08 AM" src="https://user-images.githubusercontent.com/10561050/236882806-a6429f7c-fe7d-4a9d-a035-8b96e29addad.png">

Closes #38021.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Navigate to Tools -> WCA Test Helper -> Features and enable the new product blocks editing experience
2. Navigate to Products -> Add new
3. Click on the "Add description" button
4. Add a button block
5. Note that the button styles appear using your site default styles in the modal/iframe editor
6. Close the modal
7. Note that the preview also shows the same styles

<!-- End testing instructions -->