### PR TITLE
Try: replace URL-encoded newlines with normal escaped newlines [WIP]

### DIFF
--- a/tools/monorepo/check-changelogger-use.php
+++ b/tools/monorepo/check-changelogger-use.php
@@ -216,7 +216,7 @@ foreach ( $touched_projects as $slug => $files ) {
 		} elseif ( getenv( 'CI' ) ) {
 			printf( "---\n" ); // Bracket message containing newlines for better visibility in GH's logs.
 			printf(
-				"::error::Project %s is being changed, but no change file in %s is touched!%%0A%%0AUse `pnpm --filter=./%s run changelog add` to add a change file.\n",
+				"::error::Project %s is being changed, but no change file in %s is touched!\n\nUse `pnpm --filter=./%s run changelog add` to add a change file.\n",
 				$slug,
 				"$slug/{$changelogger_projects[ $slug ]['changes-dir']}/",
 				$slug


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The `tools/monorepo/check-changelogger-use.php` file mixes regualr `\n` escaped linefeeds with URL encoding `%0A` to print newlines in the error message. This PR replaces the URL-espaced linefeeds, which after an internal discussion might just be old code clones, with a proper `\n`. 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Observe that that's no difference between [this old check](https://github.com/woocommerce/woocommerce/actions/runs/4894287717/jobs/8738328256) that uses the URL-encoded linebreaks and [the check on this PR](https://github.com/woocommerce/woocommerce/actions/runs/4918114811/jobs/8784395058). 
2. This PR contains a commit that triggers the error. Once approved I'd remove that commit and ask for re-approval. 

<!-- End testing instructions -->