### PR TITLE
Add default styles for product meta in the TT3 order details table

### DIFF
--- a/plugins/woocommerce/changelog/fix-tt3-order-details-item-meta-styling
+++ b/plugins/woocommerce/changelog/fix-tt3-order-details-item-meta-styling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add default styles for product meta in the TT3 order details table

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -1019,6 +1019,15 @@ ul.wc-tabs {
 		thead th {
 			text-transform: uppercase;
 		}
+
+		.wc-item-meta {
+			list-style-type: none;
+			padding-inline-start: 2rem;
+
+			li > p {
+				margin-block-start: 0.3rem;
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR aims to add default styles for product meta in TT3's order details tables. 

*Before*:
![Before](https://cdn-std.droplr.net/files/acc_1208648/4U07L4)
*After*:
![After](https://cdn-std.droplr.net/files/acc_1208648/DIr7pk)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure that we have a store running with TT3 theme.
2. Add a variable product to the cart and proceed with the order.
3. Notice the styling of the meta list being excessively default with the bullets. 
4. Apply this patch and refresh the thank-you page.
5. Notice the item meta styling is fixed.

<!-- End testing instructions -->