### PR TITLE
Fix activity panel not showing unread when closed

### DIFF
--- a/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
+++ b/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
@@ -153,6 +153,7 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 	const {
 		hasUnreadNotes,
 		hasAbbreviatedNotifications,
+		hasUnread,
 		isCompletedTask,
 		thingsToDoNextCount,
 		requestingTaskListOptions,
@@ -175,6 +176,8 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 
 		const thingsToDoCount = getThingsToDoNextCount( extendedTaskList );
 
+		const orderStatuses = getOrderStatuses( select );
+
 		return {
 			hasUnreadNotes: isNotesPanelVisible( select ),
 			hasAbbreviatedNotifications: isAbbreviatedPanelVisible(
@@ -182,6 +185,12 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 				isSetupTaskListHidden,
 				thingsToDoCount
 			),
+			unread:
+				getUnreadOrders( select, orderStatuses ) > 0 ||
+				getUnapprovedReviews( select ) ||
+				getLowStockProducts( select ) ||
+				thingsToDoCount > 0 ||
+				hasExtendedNotifications,
 			thingsToDoNextCount: thingsToDoCount,
 			requestingTaskListOptions:
 				! hasFinishedResolution( 'getTaskLists' ),
@@ -271,7 +280,7 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 			name: 'activity',
 			title: __( 'Activity', 'woocommerce' ),
 			icon: <IconFlag />,
-			unread: hasUnreadNotes || hasAbbreviatedNotifications,
+			unread: hasUnread,
 			visible:
 				( isEmbedded || ! isHomescreen() ) &&
 				! isPerformingSetupTask() &&

--- a/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
+++ b/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
@@ -28,7 +28,7 @@ import {
  */
 import './style.scss';
 import { IconFlag } from './icon-flag';
-import { isNotesPanelVisible } from './unread-indicators';
+import { hasUnreadNotes as hasUnreadNotesFn } from './unread-indicators';
 import { Tabs } from './tabs';
 import { SetupProgress } from './setup-progress';
 import { DisplayOptions } from './display-options';
@@ -121,25 +121,22 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 		).length;
 	}
 
-	function isAbbreviatedPanelVisible(
+	function hasAbbreviatedNotificationsFn(
 		select,
 		setupTaskListHidden,
 		thingsToDoNextCount
 	) {
 		const orderStatuses = getOrderStatuses( select );
 
-		const isOrdersCardVisible =
-			setupTaskListHidden && isPanelOpen
-				? getUnreadOrders( select, orderStatuses ) > 0
-				: false;
-		const isReviewsCardVisible =
-			setupTaskListHidden && isPanelOpen
-				? getUnapprovedReviews( select )
-				: false;
-		const isLowStockCardVisible =
-			setupTaskListHidden && isPanelOpen
-				? getLowStockProducts( select )
-				: false;
+		const isOrdersCardVisible = setupTaskListHidden
+			? getUnreadOrders( select, orderStatuses ) > 0
+			: false;
+		const isReviewsCardVisible = setupTaskListHidden
+			? getUnapprovedReviews( select )
+			: false;
+		const isLowStockCardVisible = setupTaskListHidden
+			? getLowStockProducts( select )
+			: false;
 
 		return (
 			thingsToDoNextCount > 0 ||
@@ -153,7 +150,6 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 	const {
 		hasUnreadNotes,
 		hasAbbreviatedNotifications,
-		hasUnread,
 		isCompletedTask,
 		thingsToDoNextCount,
 		requestingTaskListOptions,
@@ -176,21 +172,13 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 
 		const thingsToDoCount = getThingsToDoNextCount( extendedTaskList );
 
-		const orderStatuses = getOrderStatuses( select );
-
 		return {
-			hasUnreadNotes: isNotesPanelVisible( select ),
-			hasAbbreviatedNotifications: isAbbreviatedPanelVisible(
+			hasUnreadNotes: hasUnreadNotesFn( select ),
+			hasAbbreviatedNotifications: hasAbbreviatedNotificationsFn(
 				select,
 				isSetupTaskListHidden,
 				thingsToDoCount
 			),
-			hasUnread:
-				getUnreadOrders( select, orderStatuses ) > 0 ||
-				getUnapprovedReviews( select ) ||
-				getLowStockProducts( select ) ||
-				thingsToDoCount > 0 ||
-				hasExtendedNotifications,
 			thingsToDoNextCount: thingsToDoCount,
 			requestingTaskListOptions:
 				! hasFinishedResolution( 'getTaskLists' ),
@@ -280,7 +268,7 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 			name: 'activity',
 			title: __( 'Activity', 'woocommerce' ),
 			icon: <IconFlag />,
-			unread: hasUnread,
+			unread: hasUnreadNotes || hasAbbreviatedNotifications,
 			visible:
 				( isEmbedded || ! isHomescreen() ) &&
 				! isPerformingSetupTask() &&

--- a/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
+++ b/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
@@ -28,7 +28,7 @@ import {
  */
 import './style.scss';
 import { IconFlag } from './icon-flag';
-import { hasUnreadNotes as hasUnreadNotesFn } from './unread-indicators';
+import { hasUnreadNotes as checkIfHasUnreadNotes } from './unread-indicators';
 import { Tabs } from './tabs';
 import { SetupProgress } from './setup-progress';
 import { DisplayOptions } from './display-options';
@@ -121,7 +121,7 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 		).length;
 	}
 
-	function hasAbbreviatedNotificationsFn(
+	function checkIfHasAbbreviatedNotifications(
 		select,
 		setupTaskListHidden,
 		thingsToDoNextCount
@@ -173,8 +173,8 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 		const thingsToDoCount = getThingsToDoNextCount( extendedTaskList );
 
 		return {
-			hasUnreadNotes: hasUnreadNotesFn( select ),
-			hasAbbreviatedNotifications: hasAbbreviatedNotificationsFn(
+			hasUnreadNotes: checkIfHasUnreadNotes( select ),
+			hasAbbreviatedNotifications: checkIfHasAbbreviatedNotifications(
 				select,
 				isSetupTaskListHidden,
 				thingsToDoCount

--- a/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
+++ b/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
@@ -185,7 +185,7 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 				isSetupTaskListHidden,
 				thingsToDoCount
 			),
-			unread:
+			hasUnread:
 				getUnreadOrders( select, orderStatuses ) > 0 ||
 				getUnapprovedReviews( select ) ||
 				getLowStockProducts( select ) ||

--- a/plugins/woocommerce-admin/client/activity-panel/unread-indicators.js
+++ b/plugins/woocommerce-admin/client/activity-panel/unread-indicators.js
@@ -22,7 +22,7 @@ const UNREAD_NOTES_QUERY = {
 	order: 'desc',
 };
 
-export function isNotesPanelVisible( select ) {
+export function hasUnreadNotes( select ) {
 	const { getNotes, getNotesError, isResolving } = select( NOTES_STORE_NAME );
 
 	const { getCurrentUser } = select( USER_STORE_NAME );

--- a/plugins/woocommerce/changelog/fix-activity-icon
+++ b/plugins/woocommerce/changelog/fix-activity-icon
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix activity panel not showing unread when closed


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fix activity panel not showing unread when closed.

I refactored some code and removed the `&& isPanelOpen` clause from `hasAbbreviatedNotificationsFn`. Please review if that's actually needed for some reason, as it's passed to `InboxPanel` as a prop.

Closes #38139 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. In a fresh site with WooCommerce, hide both setup tasklist and “Things to do next” tasklist
2. Create a new order with Processing status
3. Go to a URL where "Activity" button appears (e.g. Product > Add) and toggle “Activity”, the red badge should appear with panel both open and closed.

<!-- End testing instructions -->