### PR TITLE
Add tinymce scripts to product editor pages

### DIFF
--- a/plugins/woocommerce/changelog/add-38118
+++ b/plugins/woocommerce/changelog/add-38118
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add tinymce scripts to product editor pages

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -75,6 +75,7 @@ class Init {
 			sprintf( 'wp.blocks.setCategories( %s );', wp_json_encode( $editor_settings['blockCategories'] ) ),
 			'before'
 		);
+		wp_tinymce_inline_scripts();
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds tinymce scripts so that the classic editor blocks work in the new product editing experience.

<img width="649" alt="Screen Shot 2023-05-08 at 3 52 07 PM" src="https://user-images.githubusercontent.com/10561050/236954394-5253665f-71bd-4cfc-af74-59a191bf9ca4.png">


Closes #38118  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Navigate to Tools -> WCA Test Helper -> Features and enable the new product blocks editing experience
2. Navigate to Products -> Add new
3. Click on the "Add description" button
4. Add a classic editor block
5. Check that the classic editor block works as expected without console errors

<!-- End testing instructions -->