### PR TITLE
CLI Code Freeze: Prevent Slack Notification on the wrong day

### DIFF
--- a/.github/workflows/release-code-freeze.yml
+++ b/.github/workflows/release-code-freeze.yml
@@ -75,7 +75,7 @@ jobs:
         name: 'Sends code freeze notification to Slack'
         runs-on: ubuntu-20.04
         needs: code-freeze-prep
-        if: ${{ inputs.skipSlackPing != true }}
+        if: ${{ needs.code-freeze-prep.outputs.freeze == 'true' && inputs.skipSlackPing != true }}
         steps:
             - name: Slack
               uses: archive/github-actions-slack@v2.0.0


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Slack notification happened despite it not being code freeze day. This PR adds a better conditional such to the Notify Slack job.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to the `Release: Code Freeze` [action](https://github.com/woocommerce/woocommerce/actions/workflows/release-code-freeze.yml) and manually run this action using this branch. Since its not code freeze day, the Notify Slack job will be skipped.
2. Confirm it does work on code freeze day by looking over this [example from my fork](https://github.com/psealock/woocommerce/actions/runs/4921092872). I used the time override to get it to work on a non code freeze day.

<!-- End testing instructions -->