### PR TITLE
Send Slack summary of release test results

### DIFF
--- a/.github/actions/tests/run-api-tests/action.yml
+++ b/.github/actions/tests/run-api-tests/action.yml
@@ -9,6 +9,11 @@ inputs:
     tests:
         description: Specific tests to run, separated by single whitespace. See https://playwright.dev/docs/test-cli
 
+outputs:
+    result:
+        description: Whether the test passed or failed.
+        value: ${{ steps.run-api-tests.conclusion }}
+
 runs:
     using: composite
     steps:

--- a/.github/actions/tests/run-e2e-tests/action.yml
+++ b/.github/actions/tests/run-e2e-tests/action.yml
@@ -12,6 +12,11 @@ inputs:
         description: The Playwright configuration file to use.
         default: playwright.config.js
 
+outputs:
+    result:
+        description: Whether the test passed or failed.
+        value: ${{ steps.run-e2e-tests.conclusion }}
+
 runs:
     using: composite
     steps:

--- a/.github/actions/tests/slack-summary-on-release/slack-blocks/action.yml
+++ b/.github/actions/tests/slack-summary-on-release/slack-blocks/action.yml
@@ -1,0 +1,59 @@
+name: Compose a Slack block for release tests
+description: Create a Slack block that shows the API and E2E test results from one of the release tests, and upload it as an artifact.
+permissions: {}
+
+inputs:
+    test-name:
+        required: true
+    api-result:
+        required: true
+        type: choice
+        default: skipped
+        options:
+            - success
+            - failure
+            - cancelled
+            - skipped
+    e2e-result:
+        required: true
+        type: choice
+        default: skipped
+        options:
+            - success
+            - failure
+            - cancelled
+            - skipped
+    env-slug:
+        required: true
+    release-version:
+        required: true
+
+runs:
+    using: composite
+    steps:
+        - name: Create context block as a JSON object
+          id: generate-json
+          uses: actions/github-script@v6
+          with:
+              script: |
+                  const script = require('./.github/actions/tests/slack-summary-on-release/slack-blocks/scripts/create-result-block');
+                  return script();
+          env:
+              API_RESULT: ${{ inputs.api-result }}
+              E2E_RESULT: ${{ inputs.e2e-result }}
+              ENV_SLUG: ${{ inputs.env-slug }}
+              TEST_NAME: ${{ inputs.test-name }}
+              RELEASE_VERSION: ${{ inputs.release-version }}
+
+        - name: Write JSON file
+          working-directory: /tmp
+          shell: bash
+          env:
+              CONTEXT_JSON: ${{ toJSON(steps.generate-json.outputs.result) }}
+          run: echo ${{ env.CONTEXT_JSON }} > "${{ inputs.test-name }}.json"
+
+        - name: Upload JSON file as artifact
+          uses: actions/upload-artifact@v3
+          with:
+              name: ${{ env.SLACK_BLOCKS_ARTIFACT }}
+              path: /tmp/${{ inputs.test-name }}.json

--- a/.github/actions/tests/slack-summary-on-release/slack-blocks/scripts/create-result-block/index.js
+++ b/.github/actions/tests/slack-summary-on-release/slack-blocks/scripts/create-result-block/index.js
@@ -1,0 +1,31 @@
+module.exports = () => {
+	const { API_RESULT, E2E_RESULT, ENV_SLUG, TEST_NAME, RELEASE_VERSION } =
+		process.env;
+	const { setElementText } = require( './utils' );
+
+	const apiLinkText = setElementText( {
+		testType: 'API',
+		result: API_RESULT,
+		envSlug: ENV_SLUG,
+		releaseVersion: RELEASE_VERSION,
+	} );
+	const e2eLinkText = setElementText( {
+		testType: 'E2E',
+		result: E2E_RESULT,
+		envSlug: ENV_SLUG,
+		releaseVersion: RELEASE_VERSION,
+	} );
+	const elementText = `*${ TEST_NAME }*\n    ${ apiLinkText }    ${ e2eLinkText }`;
+
+	const contextBlock = {
+		type: 'context',
+		elements: [
+			{
+				type: 'mrkdwn',
+				text: elementText,
+			},
+		],
+	};
+
+	return contextBlock;
+};

--- a/.github/actions/tests/slack-summary-on-release/slack-blocks/scripts/create-result-block/utils/index.js
+++ b/.github/actions/tests/slack-summary-on-release/slack-blocks/scripts/create-result-block/utils/index.js
@@ -1,0 +1,5 @@
+const { setElementText } = require( './set-element-text' );
+
+module.exports = {
+	setElementText,
+};

--- a/.github/actions/tests/slack-summary-on-release/slack-blocks/scripts/create-result-block/utils/select-emoji.js
+++ b/.github/actions/tests/slack-summary-on-release/slack-blocks/scripts/create-result-block/utils/select-emoji.js
@@ -1,0 +1,26 @@
+const emojis = {
+	PASSED: ':workflow-passed:',
+	FAILED: ':workflow-failed:',
+	SKIPPED: ':workflow-skipped:',
+	CANCELLED: ':workflow-cancelled:',
+	UNKNOWN: ':grey_question:',
+};
+
+const selectEmoji = ( result ) => {
+	switch ( result ) {
+		case 'success':
+			return emojis.PASSED;
+		case 'failure':
+			return emojis.FAILED;
+		case 'skipped':
+			return emojis.SKIPPED;
+		case 'cancelled':
+			return emojis.CANCELLED;
+		default:
+			return emojis.UNKNOWN;
+	}
+};
+
+module.exports = {
+	selectEmoji,
+};

--- a/.github/actions/tests/slack-summary-on-release/slack-blocks/scripts/create-result-block/utils/set-element-text.js
+++ b/.github/actions/tests/slack-summary-on-release/slack-blocks/scripts/create-result-block/utils/set-element-text.js
@@ -1,0 +1,12 @@
+const setElementText = ( { testType, result, envSlug, releaseVersion } ) => {
+	const { selectEmoji } = require( './select-emoji' );
+	const allureReportURL = `https://woocommerce.github.io/woocommerce-test-reports/release/${ releaseVersion }/${ envSlug }/${ testType.toLowerCase() }`;
+	const emoji = selectEmoji( result );
+	const textValue = `<${ allureReportURL }|${ testType.toUpperCase() } ${ emoji }>`;
+
+	return textValue;
+};
+
+module.exports = {
+	setElementText,
+};

--- a/.github/actions/tests/slack-summary-on-release/slack-payload/action.yml
+++ b/.github/actions/tests/slack-summary-on-release/slack-payload/action.yml
@@ -1,0 +1,27 @@
+name: Combine all Slack blocks
+description: Combine all Slack blocks to construct the payload for the Slack GitHub action
+permissions: {}
+
+inputs:
+    release-version:
+        required: true
+    blocks-dir:
+        require: true
+
+outputs:
+    payload:
+        value: ${{ steps.payload.outputs.result }}
+
+runs:
+    using: composite
+    steps:
+        - name: Construct payload from all blocks
+          id: payload
+          uses: actions/github-script@v6
+          env:
+              RELEASE_VERSION: ${{ inputs.release-version }}
+              BLOCKS_DIR: ${{ inputs.blocks-dir }}
+          with:
+              script: |
+                  const script = require('./.github/actions/tests/slack-summary-on-release/slack-payload/scripts/construct-payload');
+                  return script();

--- a/.github/actions/tests/slack-summary-on-release/slack-payload/scripts/construct-payload/index.js
+++ b/.github/actions/tests/slack-summary-on-release/slack-payload/scripts/construct-payload/index.js
@@ -1,0 +1,36 @@
+module.exports = () => {
+	const { RELEASE_VERSION, BLOCKS_DIR } = process.env;
+	const {
+		filterContextBlocks,
+		readContextBlocksFromJsonFiles,
+	} = require( './utils' );
+
+	const headerText = `Test summary for ${ RELEASE_VERSION }`;
+	const headerBlock = {
+		type: 'header',
+		text: {
+			type: 'plain_text',
+			text: headerText,
+			emoji: true,
+		},
+	};
+
+	const blocks_all = readContextBlocksFromJsonFiles( BLOCKS_DIR );
+	const blocks_wcUpdate = filterContextBlocks( blocks_all, 'WC Update' );
+	const blocks_wpVersions = filterContextBlocks( blocks_all, 'WP Latest' );
+	const blocks_phpVersions = filterContextBlocks( blocks_all, 'PHP' );
+	const blocks_plugins = filterContextBlocks( blocks_all, 'With' );
+
+	const blocksPayload = [ headerBlock ]
+		.concat( blocks_wcUpdate )
+		.concat( blocks_wpVersions )
+		.concat( blocks_phpVersions )
+		.concat( blocks_plugins );
+
+	const payload = {
+		text: headerText,
+		blocks: blocksPayload,
+	};
+
+	return payload;
+};

--- a/.github/actions/tests/slack-summary-on-release/slack-payload/scripts/construct-payload/utils/get-context-blocks.js
+++ b/.github/actions/tests/slack-summary-on-release/slack-payload/scripts/construct-payload/utils/get-context-blocks.js
@@ -1,0 +1,42 @@
+const fs = require( 'fs' );
+const path = require( 'path' );
+
+const readContextBlocksFromJsonFiles = ( blocksDir ) => {
+	const jsonsDir = path.resolve( blocksDir );
+	const jsons = fs.readdirSync( jsonsDir );
+
+	let contextBlocks = [];
+
+	for ( const json of jsons ) {
+		const jsonPath = path.resolve( jsonsDir, json );
+		const contextBlock = require( jsonPath );
+
+		contextBlocks.push( contextBlock );
+	}
+
+	return contextBlocks;
+};
+
+const filterContextBlocks = ( blocks, testName ) => {
+	const divider = {
+		type: 'divider',
+	};
+
+	let filteredBlocks = [];
+
+	const matchingBlocks = blocks.filter( ( { elements } ) =>
+		elements[ 0 ].text.includes( testName )
+	);
+
+	matchingBlocks.forEach( ( block ) => {
+		filteredBlocks.push( block );
+		filteredBlocks.push( divider );
+	} );
+
+	return filteredBlocks;
+};
+
+module.exports = {
+	filterContextBlocks,
+	readContextBlocksFromJsonFiles,
+};

--- a/.github/actions/tests/slack-summary-on-release/slack-payload/scripts/construct-payload/utils/index.js
+++ b/.github/actions/tests/slack-summary-on-release/slack-payload/scripts/construct-payload/utils/index.js
@@ -1,0 +1,6 @@
+const {
+	filterContextBlocks,
+	readContextBlocksFromJsonFiles,
+} = require( './get-context-blocks' );
+
+module.exports = { filterContextBlocks, readContextBlocksFromJsonFiles };

--- a/.github/workflows/smoke-test-release.yml
+++ b/.github/workflows/smoke-test-release.yml
@@ -14,7 +14,7 @@ permissions: {}
 env:
     E2E_WP_LATEST_ARTIFACT: E2E test on release smoke test site with WP Latest (run ${{ github.run_number }})
     E2E_UPDATE_WC_ARTIFACT: WooCommerce version update test on release smoke test site (run ${{ github.run_number }})
-
+    SLACK_BLOCKS_ARTIFACT: slack-blocks
 jobs:
     get-tag:
         name: Get WooCommerce release tag
@@ -122,12 +122,26 @@ jobs:
                     -f test_type="e2e" \
                     --repo woocommerce/woocommerce-test-reports
 
+            - name: Create Slack block
+              if: |
+                  success() || (
+                    failure() && steps.run-e2e-composite-action.outputs.result == 'failure'
+                  )
+              uses: ./.github/actions/tests/slack-summary-on-release/slack-blocks
+              with:
+                  test-name: WC Update test
+                  e2e-result: ${{ steps.run-e2e-composite-action.outputs.result }}
+                  env-slug: wp-latest
+                  release-version: ${{ needs.get-tag.outputs.tag }}
+
     api-wp-latest:
         name: API on WP Latest
         runs-on: ubuntu-20.04
         needs: [get-tag, e2e-update-wc]
         permissions:
             contents: read
+        outputs:
+            result: ${{ steps.run-api-composite-action.outputs.result }}
         env:
             ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/api-test-report/allure-report
             ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/api-test-report/allure-results
@@ -177,6 +191,18 @@ jobs:
                     -f env_description="${{ env.ENV_DESCRIPTION }}" \
                     -f test_type="api" \
                     --repo woocommerce/woocommerce-test-reports
+
+            - name: Create Slack block
+              if: |
+                  success() || (
+                    failure() && steps.run-api-composite-action.outputs.result == 'failure'
+                  )
+              uses: ./.github/actions/tests/slack-summary-on-release/slack-blocks
+              with:
+                  test-name: WP Latest
+                  api-result: ${{ steps.run-api-composite-action.outputs.result }}
+                  env-slug: wp-latest
+                  release-version: ${{ needs.get-tag.outputs.tag }}
 
     e2e-wp-latest:
         name: E2E on WP Latest
@@ -268,6 +294,19 @@ jobs:
                     -f test_type="e2e" \
                     --repo woocommerce/woocommerce-test-reports
 
+            - name: Create Slack block
+              if: |
+                  success() || (
+                    failure() && steps.run-e2e-composite-action.outputs.result == 'failure'
+                  )
+              uses: ./.github/actions/tests/slack-summary-on-release/slack-blocks
+              with:
+                  test-name: WP Latest
+                  api-result: ${{ needs.api-wp-latest.outputs.result }}
+                  e2e-result: ${{ steps.run-e2e-composite-action.outputs.result }}
+                  env-slug: wp-latest
+                  release-version: ${{ needs.get-tag.outputs.tag }}
+
     get-wp-versions:
         name: Get WP L-1 & L-2 version numbers
         needs: [get-tag]
@@ -328,6 +367,8 @@ jobs:
 
             - name: Setup WooCommerce Monorepo
               uses: ./.github/actions/setup-woocommerce-monorepo
+              with:
+                  build-filters: woocommerce
 
             - name: Launch WP Env
               working-directory: plugins/woocommerce
@@ -360,7 +401,7 @@ jobs:
               uses: ./.github/actions/tests/run-api-tests
               with:
                   report-name: ${{ env.API_WP_LATEST_X_ARTIFACT }}
-                  tests: hello
+                  tests: hello.test.js
               env:
                   ALLURE_RESULTS_DIR: ${{ env.API_ALLURE_RESULTS_DIR }}
                   ALLURE_REPORT_DIR: ${{ env.API_ALLURE_REPORT_DIR }}
@@ -435,6 +476,22 @@ jobs:
                     -f test_type="e2e" \
                     --repo woocommerce/woocommerce-test-reports
 
+            - name: Create Slack block
+              if: |
+                  success() || (
+                    failure() && (
+                      steps.run-api-composite-action.outputs.result == 'failure' ||
+                      steps.run-e2e-composite-action.outputs.result == 'failure' 
+                    ) 
+                  )
+              uses: ./.github/actions/tests/slack-summary-on-release/slack-blocks
+              with:
+                  test-name: ${{ matrix.version.description }} (${{ matrix.version.number }})
+                  api-result: ${{ steps.run-api-composite-action.outputs.result }}
+                  e2e-result: ${{ steps.run-e2e-composite-action.outputs.result }}
+                  env-slug: ${{ matrix.version.env_description }}
+                  release-version: ${{ needs.get-wp-versions.outputs.tag }}
+
     test-php-versions:
         name: Test against PHP ${{ matrix.php_version }}
         runs-on: ubuntu-20.04
@@ -456,6 +513,8 @@ jobs:
 
             - name: Setup WooCommerce Monorepo
               uses: ./.github/actions/setup-woocommerce-monorepo
+              with:
+                  build-filters: woocommerce
 
             - name: Launch WP Env
               working-directory: plugins/woocommerce
@@ -482,7 +541,7 @@ jobs:
               uses: ./.github/actions/tests/run-api-tests
               with:
                   report-name: ${{ env.API_ARTIFACT }}
-                  tests: hello
+                  tests: hello.test.js
               env:
                   ALLURE_RESULTS_DIR: ${{ env.API_ALLURE_RESULTS_DIR }}
                   ALLURE_REPORT_DIR: ${{ env.API_ALLURE_REPORT_DIR }}
@@ -557,6 +616,22 @@ jobs:
                     -f test_type="e2e" \
                     --repo woocommerce/woocommerce-test-reports
 
+            - name: Create Slack block
+              if: |
+                  success() || (
+                    failure() && (
+                      steps.run-api-composite-action.outputs.result == 'failure' ||
+                      steps.run-e2e-composite-action.outputs.result == 'failure' 
+                    )
+                  )
+              uses: ./.github/actions/tests/slack-summary-on-release/slack-blocks
+              with:
+                  test-name: PHP ${{ matrix.php_version }}
+                  api-result: ${{ steps.run-api-composite-action.outputs.result }}
+                  e2e-result: ${{ steps.run-e2e-composite-action.outputs.result }}
+                  env-slug: php-${{ matrix.php_version }}
+                  release-version: ${{ needs.get-tag.outputs.tag }}
+
     test-plugins:
         name: With ${{ matrix.plugin }}
         runs-on: ubuntu-20.04
@@ -594,6 +669,8 @@ jobs:
 
             - name: Setup WooCommerce Monorepo
               uses: ./.github/actions/setup-woocommerce-monorepo
+              with:
+                  build-filters: woocommerce
 
             - name: Launch WP Env
               working-directory: plugins/woocommerce
@@ -656,3 +733,54 @@ jobs:
                     -f env_description="${{ matrix.env_description }}" \
                     -f test_type="e2e" \
                     --repo woocommerce/woocommerce-test-reports
+
+            - name: Create Slack block
+              if: |
+                  success() || (
+                    failure() && steps.run-e2e-composite-action.outputs.result == 'failure' )
+              uses: ./.github/actions/tests/slack-summary-on-release/slack-blocks
+              with:
+                  test-name: With ${{ matrix.plugin }}
+                  e2e-result: ${{ steps.run-e2e-composite-action.outputs.result }}
+                  env-slug: ${{ matrix.env_description }}
+                  release-version: ${{ needs.get-tag.outputs.tag }}
+
+    post-slack-summary:
+        name: Post Slack summary
+        runs-on: ubuntu-20.04
+        permissions:
+            contents: read
+        if: |
+            success() || (
+              failure() && contains( needs.*.result, 'failure' )
+            )
+        needs:
+            - e2e-wp-latest
+            - get-tag
+            - test-php-versions
+            - test-plugins
+            - test-wp-versions
+        steps:
+            - uses: actions/checkout@v3
+
+            - name: Download all slack blocks
+              id: download-slack-blocks
+              uses: actions/download-artifact@v3
+              with:
+                  name: ${{ env.SLACK_BLOCKS_ARTIFACT }}
+                  path: /tmp/slack-payload
+
+            - name: Construct payload from all blocks
+              id: run-payload-action
+              uses: ./.github/actions/tests/slack-summary-on-release/slack-payload
+              with:
+                  release-version: ${{ needs.get-tag.outputs.tag }}
+                  blocks-dir: ${{ steps.download-slack-blocks.outputs.download-path }}
+
+            - name: Send Slack message
+              uses: slackapi/slack-github-action@v1.23.0
+              with:
+                  channel-id: ${{ secrets.RELEASE_TEST_SLACK_CHANNEL }}
+                  payload: ${{ steps.run-payload-action.outputs.payload }}
+              env:
+                  SLACK_BOT_TOKEN: ${{ secrets.E2E_SLACK_TOKEN }}


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Closes woocommerce/woocommerce-quality#342.

This PR will enable the _"Smoke test release"_ workflow to send a summary of test results from our release tests on Slack. The Slack message will look like this:

<img width="204" alt="aRqWq55oRZ" src="https://user-images.githubusercontent.com/4509348/236992242-a55027e4-7f61-4c71-afed-9897f9eab130.png">

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to the [Smoke test release](https://github.com/woocommerce/woocommerce/actions/workflows/smoke-test-release.yml) workflow page.
2. Select this branch ( `test/release-slack-summary-1` ).
3. Enter any of the 7.7 pre-releases, such as `7.7.0-beta.1`, in the _"WooCommerce Release Tag"_ input field.
4. Start the workflow run, and wait for it to finish. It's fine if the E2E tests failed, as it's due to the differences between the 7.7 pre-release you selected and `trunk`.
5. When it's finished, verify that you see the _"Post Slack summary"_ job had passed.

    <img width="206" alt="B5oKdieheZ" src="https://user-images.githubusercontent.com/4509348/236992287-0cb3b0b3-713d-4641-9c10-863fedae73f5.png">

6. Verify that a summary of the results was sent to `#woo-smoke-tests-release`:
   - Verify that the release version was shown correctly.
   - Verify that the API and E2E test results in the Slack summary were consistent with the workflow run.
   - Verify that each "API" and "E2E" link is taking you to the correct API or E2E Allure report
   
    <img width="605" alt="Hsr6x4FbHb" src="https://user-images.githubusercontent.com/4509348/236992328-42c3c7c4-b00e-446f-9a52-5c5aed878684.png">

