### PR TITLE
Fix "Add store details" task fails to mark as completed for selecting Nigeria based address

### DIFF
--- a/plugins/woocommerce/changelog/fix-37451-store-details-complete
+++ b/plugins/woocommerce/changelog/fix-37451-store-details-complete
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix "Add store details" task fails to mark as completed for selecting Nigeria based address

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/StoreDetails.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/StoreDetails.php
@@ -69,11 +69,11 @@ class StoreDetails extends Task {
 	 * @return bool
 	 */
 	public function is_complete() {
-		$country = WC()->countries->get_base_country();
+		$country        = WC()->countries->get_base_country();
 		$country_locale = WC()->countries->get_country_locale();
-		$locale = $country_locale[$country] ?? array();
+		$locale         = $country_locale[ $country ] ?? array();
 
-		$hide_postcode  = $locale['postcode']['hidden'] ?? false;
+		$hide_postcode = $locale['postcode']['hidden'] ?? false;
 		// If postcode is hidden, just check that the store address and city are set.
 		if ( $hide_postcode ) {
 			return get_option( 'woocommerce_store_address', '' ) !== '' && get_option( 'woocommerce_store_city', '' ) !== '';

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/StoreDetails.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/StoreDetails.php
@@ -74,7 +74,6 @@ class StoreDetails extends Task {
 		$locale = $country_locale[$country] ?? array();
 
 		$hide_postcode  = $locale['postcode']['hidden'] ?? false;
-
 		// If postcode is hidden, just check that the store address and city are set.
 		if ( $hide_postcode ) {
 			return get_option( 'woocommerce_store_address', '' ) !== '' && get_option( 'woocommerce_store_city', '' ) !== '';

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/StoreDetails.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/StoreDetails.php
@@ -69,6 +69,17 @@ class StoreDetails extends Task {
 	 * @return bool
 	 */
 	public function is_complete() {
+		$country = WC()->countries->get_base_country();
+		$country_locale = WC()->countries->get_country_locale();
+		$locale = $country_locale[$country] ?? array();
+
+		$hide_postcode  = $locale['postcode']['hidden'] ?? false;
+
+		// If postcode is hidden, just check that the store address and city are set.
+		if ( $hide_postcode ) {
+			return get_option( 'woocommerce_store_address', '' ) !== '' && get_option( 'woocommerce_store_city', '' ) !== '';
+		}
+
 		// Mark as completed if the store address, city and postcode are set. We don't need to check the country because it's set by default.
 		return get_option( 'woocommerce_store_address', '' ) !== '' && get_option( 'woocommerce_store_city', '' ) !== '' &&
 		get_option( 'woocommerce_store_postcode', '' ) !== '';


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #37451.

This PR updates the store details task completion logic only to check the post code field when it's not hidden.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install and activate WooCommerce in a brand new site
2. Go to the WooCommerce onboarding wizard.
- You can do this by installing and activating WooCommerce in a brand new site.
- Or, via the **WooCommerce ▸ Settings screen**, locate the Help pulldown and re-run the wizard that way:

![WooCommerce ▸ Settings screen > OBW](https://user-images.githubusercontent.com/3594411/207470607-dfd82ba7-de97-43c2-b691-d76c0eabc2d1.png)

3. Select a Nigeria-based address and fill out all store details fields 
4. Finish OBW.
5. Go to `WooCommerce > Home`
6. Observe that "Add store details" task is marked as completed.
7. Go to `WooCommmerce > Settings` and Change store country to `United State`
8. Go back to `WooCommerce > Home`
9. Observe that "Add store details" task is **not** marked as completed.
10. Click on  "Add store details" task and fill out the post code field 
11. Go back to `WooCommerce > Home`
12. Observe that "Add store details" task is marked as completed.


<!-- End testing instructions -->