### PR TITLE
Fix shipping tour layout context error

### DIFF
--- a/plugins/woocommerce-admin/client/embedded-body-layout/embedded-body-layout.tsx
+++ b/plugins/woocommerce-admin/client/embedded-body-layout/embedded-body-layout.tsx
@@ -5,6 +5,11 @@ import { applyFilters } from '@wordpress/hooks';
 import { useEffect } from '@wordpress/element';
 import { triggerExitPageCesSurvey } from '@woocommerce/customer-effort-score';
 import QueryString, { parse } from 'qs';
+import {
+	LayoutContextProvider,
+	getLayoutContextValue,
+} from '@woocommerce/admin-layout';
+import { memoize } from 'lodash';
 
 /**
  * Internal dependencies
@@ -59,13 +64,15 @@ export const EmbeddedBodyLayout = () => {
 	) as React.ElementType< EmbeddedBodyProps >[];
 
 	return (
-		<div
-			className="woocommerce-embedded-layout__primary"
-			id="woocommerce-embedded-layout__primary"
-		>
-			{ componentList.map( ( Comp, index ) => {
-				return <Comp key={ index } { ...queryParams } />;
-			} ) }
-		</div>
+		<LayoutContextProvider value={ getLayoutContextValue( [ 'page' ] ) }>
+			<div
+				className="woocommerce-embedded-layout__primary"
+				id="woocommerce-embedded-layout__primary"
+			>
+				{ componentList.map( ( Comp, index ) => {
+					return <Comp key={ index } { ...queryParams } />;
+				} ) }
+			</div>
+		</LayoutContextProvider>
 	);
 };

--- a/plugins/woocommerce-admin/client/embedded-body-layout/embedded-body-layout.tsx
+++ b/plugins/woocommerce-admin/client/embedded-body-layout/embedded-body-layout.tsx
@@ -9,7 +9,6 @@ import {
 	LayoutContextProvider,
 	getLayoutContextValue,
 } from '@woocommerce/admin-layout';
-import { memoize } from 'lodash';
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce-admin/client/guided-tours/shipping-tour.tsx
+++ b/plugins/woocommerce-admin/client/guided-tours/shipping-tour.tsx
@@ -292,7 +292,7 @@ export const ShippingTour: React.FC< {
 				createNotice(
 					'error',
 					__(
-						'There was a problem marking the shipping tour as reviewed.',
+						'There was a problem marking the shipping tour as completed.',
 						'woocommerce'
 					)
 				);

--- a/plugins/woocommerce-admin/client/guided-tours/shipping-tour.tsx
+++ b/plugins/woocommerce-admin/client/guided-tours/shipping-tour.tsx
@@ -205,6 +205,7 @@ export const ShippingTour: React.FC< {
 	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
 	const { show: showTour } = useShowShippingTour();
 	const [ step, setStepNumber ] = useState( 0 );
+	const { createNotice } = useDispatch( 'core/notices' );
 
 	const tourConfig: TourKitTypes.WooConfig = {
 		placement: 'auto',
@@ -282,10 +283,24 @@ export const ShippingTour: React.FC< {
 				},
 			},
 		],
-		closeHandler: ( steps, stepIndex, source ) => {
-			updateOptions( {
+		closeHandler: async ( steps, stepIndex, source ) => {
+			const update = await updateOptions( {
 				[ REVIEWED_DEFAULTS_OPTION ]: 'yes',
 			} );
+
+			if ( ! update.success ) {
+				createNotice(
+					'error',
+					__(
+						'There was a problem marking the shipping tour as reviewed.',
+						'woocommerce'
+					)
+				);
+				recordEvent(
+					'walkthrough_settings_shipping_updated_option_error'
+				);
+			}
+
 			if ( source === 'close-btn' ) {
 				recordEvent( 'walkthrough_settings_shipping_dismissed', {
 					step_name: steps[ stepIndex ].meta.name,

--- a/plugins/woocommerce/changelog/fix-shipping-tour
+++ b/plugins/woocommerce/changelog/fix-shipping-tour
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix shipping tour layout context error


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/38112.

When I was investigating https://github.com/woocommerce/woocommerce/issues/38112, I found the shipping tour broken in the trunk branch. I think it's caused by https://github.com/woocommerce/woocommerce/pull/37720 refactoring. `LayoutContextProvider` doesn't exist in embedded-body-layout.

![Screenshot 2023-05-09 at 13 56 12](https://user-images.githubusercontent.com/4344253/237006723-93c6d9a5-b41b-4328-9559-76b9867fefab.png)


This PR adds `LayoutContextProvider` to fix the issue.

Besides, I updated the shipping tour to handle the option update error.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install and activate WooCommerce in a brand new site
2. Go to Onboarding Wizard  (/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard)
3. Select `United States` as your store country
4. Complete OBW
5. Select the `Review shipping options` in the `Things to do next task list` if it isn't shown as completed yet.
6. If it does show as completed you could delete the `woocommerce_admin_reviewed_default_shipping_zones` option.
7. Review shipping options will re-redirect you to the shipping settings and a tooltip tour should show.
8. Walk through the tooltip and finish it.
9. Click `Shipping options` in the top
10. Then hit back using your browser, notice how the tooltip **doesn't** shows up again.


<!-- End testing instructions -->