### PR TITLE
In E2E Readme, add instruction to run Playwright UI mode

### DIFF
--- a/plugins/woocommerce/changelog/e2e-readme-playwright-ui-mode
+++ b/plugins/woocommerce/changelog/e2e-readme-playwright-ui-mode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add instruction to run Playwright UI mode in E2E readme.

--- a/plugins/woocommerce/tests/e2e-pw/README.md
+++ b/plugins/woocommerce/tests/e2e-pw/README.md
@@ -53,6 +53,7 @@ Other ways of running tests (make sure you are in the `plugins/woocommerce` fold
 -   `pnpm test:e2e-pw --headed` (headed -- displaying browser window and test interactions)
 -   `pnpm test:e2e-pw --debug` (runs tests in debug mode)
 -   `pnpm test:e2e-pw ./tests/e2e-pw/tests/activate-and-setup/basic-setup.spec.js` (runs a single test)
+-   `pnpm test:e2e-pw --ui` (open tests in [Playwright UI mode](https://playwright.dev/docs/test-ui-mode))
 
 To see all options, make sure you are in the `plugins/woocommerce` folder and run `pnpm playwright test --help`
 
@@ -60,7 +61,7 @@ To see all options, make sure you are in the `plugins/woocommerce` folder and ru
 
 The default values are:
 
--   Latest stable WordPress version 
+-   Latest stable WordPress version
 -   PHP 7.4
 -   MariaDB
 -   URL: `http://localhost:8086/`
@@ -69,12 +70,13 @@ The default values are:
 If you want to customize the port or admin credentials, check the [Test Variables](#test-variables) section.
 
 If you would like to customize the `PHP`, `WordPress` or `WooCommerce` versions installed in the environment, you can define `UPDATE_WP_JSON_FILE=1` along with any or all of the following env vars when building the environment.
-- `WP_VERSION`
-  - Acceptable versions are `nightly`, `trunk`, and any version listed on [WordPress Releases] page.
-- `WC_VERSION`
-  - Acceptable versions can be found on the [WooCommerce Releases](https://github.com/woocommerce/woocommerce/releases) page
-- `PHP`
-  - Any PHP version you see it. Please note that WooCommerce requires a minimum of PHP 7.2.
+
+-   `WP_VERSION`
+    -   Acceptable versions are `nightly`, `trunk`, and any version listed on [WordPress Releases] page.
+-   `WC_VERSION`
+    -   Acceptable versions can be found on the [WooCommerce Releases](https://github.com/woocommerce/woocommerce/releases) page
+-   `PHP`
+    -   Any PHP version you see it. Please note that WooCommerce requires a minimum of PHP 7.2.
 
 **Example**
 
@@ -83,7 +85,6 @@ The command below will create and environment with WordPress version 6.2, WooCom
 `UPDATE_WP_JSON_FILE=1 WP_VERSION=6.2 WC_TEST_VERSION=7.5.1 PHP_VERSION=8.2 pnpm run env:test`
 
 If you'd like to run with the default configuration, simply remove the `UPDATE_WP_JSON_FILE`.
-
 
 For more information how to configure the test environment for `wp-env`, please checkout the [documentation](https://github.com/WordPress/gutenberg/tree/trunk/packages/env) documentation.
 


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #38196.

This PR adds a line in the E2E readme to say that our E2E tests can be run in Playwright UI mode by running `pnpm test:e2e-pw --ui`

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Just make sure that this [addition](https://github.com/woocommerce/woocommerce/pull/38197/files#diff-7278e11f22f3f5e1233ee9eb52d3f04c038d89729ec989fd7ef38120cbe1374eR56):
    - has no grammatical mistakes
    - has no formatting mistakes
    - provides the correct link to the Playwright UI mode documentation

Note: All the other changes in the readme file were just spacing corrections.

<!-- End testing instructions -->