### PR TITLE
Fix the child order upshifting when parent order is deleted

### DIFF
--- a/plugins/woocommerce/changelog/fix-order-upshifting
+++ b/plugins/woocommerce/changelog/fix-order-upshifting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix: when order is deleted child orders should be deleted too, not set to parent id 0, unless the post type for the order is hierarchical

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -104,14 +104,6 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	protected $object_type = 'order';
 
 	/**
-	 * Indicates if set_parent_id will throw an error if no order exists with the supplied id.
-	 *
-	 * @since 7.8.0
-	 * @var bool
-	 */
-	private $verify_parent_id = true;
-
-	/**
 	 * Get the order if ID is passed, otherwise the order is new and empty.
 	 * This class should NOT be instantiated, but the wc_get_order function or new WC_Order_Factory
 	 * should be used. It is possible, but the aforementioned are preferred and are the only
@@ -616,36 +608,13 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 *
 	 * @since 3.0.0
 	 * @param int $value Value to set.
-	 * @throws WC_Data_Exception Exception thrown if parent ID does not exist or is invalid (only if $verify_parent_id is true).
+	 * @throws WC_Data_Exception Exception thrown if parent ID does not exist or is invalid.
 	 */
 	public function set_parent_id( $value ) {
-		if ( $this->verify_parent_id && $value && ( $value === $this->get_id() || ! wc_get_order( $value ) ) ) {
+		if ( $value && ( $value === $this->get_id() || ! wc_get_order( $value ) ) ) {
 			$this->error( 'order_invalid_parent_id', __( 'Invalid parent ID', 'woocommerce' ) );
 		}
 		$this->set_prop( 'parent_id', absint( $value ) );
-	}
-
-	/**
-	 * Sets the value of the $verify_parent_id flag.
-	 *
-	 * If the flag is set, set_parent_id will throw an error if no order exists with the supplied id.
-	 *
-	 * @param bool $value The value to set.
-	 * @return void
-	 */
-	public function set_verify_parent_id( bool $value ) {
-		$this->verify_parent_id = $value;
-	}
-
-	/**
-	 * Gets the value of the $verify_parent_id flag.
-	 *
-	 * If the flag is set, set_parent_id will throw an error if no order exists with the supplied id.
-	 *
-	 * @return bool
-	 */
-	public function get_verify_parent_id(): bool {
-		return $this->verify_parent_id;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -104,6 +104,14 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	protected $object_type = 'order';
 
 	/**
+	 * Indicates if set_parent_id will throw an error if no order exists with the supplied id.
+	 *
+	 * @since 7.8.0
+	 * @var bool
+	 */
+	private $verify_parent_id = true;
+
+	/**
 	 * Get the order if ID is passed, otherwise the order is new and empty.
 	 * This class should NOT be instantiated, but the wc_get_order function or new WC_Order_Factory
 	 * should be used. It is possible, but the aforementioned are preferred and are the only
@@ -608,13 +616,36 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 *
 	 * @since 3.0.0
 	 * @param int $value Value to set.
-	 * @throws WC_Data_Exception Exception thrown if parent ID does not exist or is invalid.
+	 * @throws WC_Data_Exception Exception thrown if parent ID does not exist or is invalid (only if $verify_parent_id is true).
 	 */
 	public function set_parent_id( $value ) {
-		if ( $value && ( $value === $this->get_id() || ! wc_get_order( $value ) ) ) {
+		if ( $this->verify_parent_id && $value && ( $value === $this->get_id() || ! wc_get_order( $value ) ) ) {
 			$this->error( 'order_invalid_parent_id', __( 'Invalid parent ID', 'woocommerce' ) );
 		}
 		$this->set_prop( 'parent_id', absint( $value ) );
+	}
+
+	/**
+	 * Sets the value of the $verify_parent_id flag.
+	 *
+	 * If the flag is set, set_parent_id will throw an error if no order exists with the supplied id.
+	 *
+	 * @param bool $value The value to set.
+	 * @return void
+	 */
+	public function set_verify_parent_id( bool $value ) {
+		$this->verify_parent_id = $value;
+	}
+
+	/**
+	 * Gets the value of the $verify_parent_id flag.
+	 *
+	 * If the flag is set, set_parent_id will throw an error if no order exists with the supplied id.
+	 *
+	 * @return bool
+	 */
+	public function get_verify_parent_id(): bool {
+		return $this->verify_parent_id;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1860,16 +1860,14 @@ FROM $order_meta_table
 					$order->get_id()
 				)
 			);
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 			foreach ( $child_order_ids as $child_order_id ) {
-				// We can't use wc_get_order here because we would get a "Invalid parent ID" error
-				// (and we don't need to load the full order from the database anyway).
-				$child_order = new \WC_Order();
-				$child_order->set_verify_parent_id( false );
-				$child_order->set_id( $child_order_id );
-				$child_order->delete( true );
+				$child_order = wc_get_order( $child_order_id );
+				if ( $child_order ) {
+					$child_order->delete( true );
+				}
 			}
-			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		}
 	}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1860,8 +1860,14 @@ FROM $order_meta_table
 					$order->get_id()
 				)
 			);
+
 			foreach ( $child_order_ids as $child_order_id ) {
-				$this->delete_order_data_from_custom_order_tables( $child_order_id );
+				// We can't use wc_get_order here because we would get a "Invalid parent ID" error
+				// (and we don't need to load the full order from the database anyway).
+				$child_order = new \WC_Order();
+				$child_order->set_verify_parent_id( false );
+				$child_order->set_id( $child_order_id );
+				$child_order->delete( true );
 			}
 			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -119,6 +119,13 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 	private $error_logger;
 
 	/**
+	 * The instance of the LegacyProxy object to use.
+	 *
+	 * @var LegacyProxy
+	 */
+	private $legacy_proxy;
+
+	/**
 	 * Initialize the object.
 	 *
 	 * @internal
@@ -131,6 +138,7 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 	final public function init( OrdersTableDataStoreMeta $data_store_meta, DatabaseUtil $database_util, LegacyProxy $legacy_proxy ) {
 		$this->data_store_meta    = $data_store_meta;
 		$this->database_util      = $database_util;
+		$this->legacy_proxy       = $legacy_proxy;
 		$this->error_logger       = $legacy_proxy->call_function( 'wc_get_logger' );
 		$this->internal_meta_keys = $this->get_internal_meta_keys();
 	}
@@ -1785,7 +1793,7 @@ FROM $order_meta_table
 			 */
 			do_action( 'woocommerce_before_delete_order', $order_id, $order );
 
-			$this->upshift_child_orders( $order );
+			$this->upshift_or_delete_child_orders( $order );
 			$this->delete_order_data_from_custom_order_tables( $order_id );
 			$this->delete_items( $order );
 
@@ -1823,23 +1831,40 @@ FROM $order_meta_table
 	}
 
 	/**
-	 * Helper method to set child orders to the parent order's parent.
+	 * Set the parent id of child orders to the parent order's parent if the post type
+	 * for the order is hierarchical, just delete the child orders otherwise.
 	 *
 	 * @param \WC_Abstract_Order $order Order object.
 	 *
 	 * @return void
 	 */
-	private function upshift_child_orders( $order ) {
+	private function upshift_or_delete_child_orders( $order ) {
 		global $wpdb;
-		$order_table  = self::get_orders_table_name();
-		$order_parent = $order->get_parent_id();
-		$wpdb->update(
-			$order_table,
-			array( 'parent_order_id' => $order_parent ),
-			array( 'parent_order_id' => $order->get_id() ),
-			array( '%d' ),
-			array( '%d' )
-		);
+
+		$order_table     = self::get_orders_table_name();
+		$order_parent_id = $order->get_parent_id();
+
+		if ( $this->legacy_proxy->call_function( 'is_post_type_hierarchical', $order->get_type() ) ) {
+			$wpdb->update(
+				$order_table,
+				array( 'parent_order_id' => $order_parent_id ),
+				array( 'parent_order_id' => $order->get_id() ),
+				array( '%d' ),
+				array( '%d' )
+			);
+		} else {
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$child_order_ids = $wpdb->get_col(
+				$wpdb->prepare(
+					"SELECT id FROM $order_table WHERE parent_order_id=%d",
+					$order->get_id()
+				)
+			);
+			foreach ( $child_order_ids as $child_order_id ) {
+				$this->delete_order_data_from_custom_order_tables( $child_order_id );
+			}
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		}
 	}
 
 	/**


### PR DESCRIPTION
- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

#36218 implemented child order upshifting (setting their parent order id to 0) when the parent order is deleted, but this needs to
happen only when the post type of the parent order is hierarchical, otherwise child orders need to just be deleted. This pull request fixes that.

### How to test the changes in this Pull Request:

Running the unit tests should be enough, but you can also create an order with refunds, delete the order, and checking that the refund records have disappeared as well from the database.