### PR TITLE
Implement admin-side order edit lock

### DIFF
--- a/plugins/woocommerce/changelog/fix-37108
+++ b/plugins/woocommerce/changelog/fix-37108
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add admin-side order edit lock for HPOS.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -2885,6 +2885,14 @@ ul.wc_coupon_list_block {
 	}
 }
 
+.woocommerce_page_wc-orders .wp-list-table .locked-indicator-icon {
+	margin-left: -2px;
+
+	&:before {
+		vertical-align: top;
+	}
+}
+
 .order-status {
 	display: inline-flex;
 	line-height: 2.5em;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -2800,6 +2800,10 @@ ul.wc_coupon_list_block {
 			padding: 1em 1em 1em 1em !important;
 			vertical-align: middle;
 
+			.locked-indicator {
+				margin-left: 0;
+			}
+
 			input {
 				vertical-align: text-top;
 				margin: 1px 0;

--- a/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
+++ b/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
@@ -665,4 +665,47 @@
 			);
 		}
 	} );
+
+	$( function() {
+		/**
+		 * Handles heartbeat integration of order locking when HPOS is enabled.
+		 */
+		var wc_order_lock = {
+			init: function() {
+				// Orders list table.
+				this.$list_table = $( '.woocommerce_page_wc-orders table.wc-orders-list-table' );
+				if ( 0 !== this.$list_table.length ) {
+					$( document ).on( 'heartbeat-send', this.send_orders_in_list );
+					$( document ).on( 'heartbeat-tick', this.check_orders_in_list );
+				}
+			},
+
+			send_orders_in_list: function( e, data ) {
+				data['wc-check-locked-orders'] = wc_order_lock.$list_table.find( 'tr input[name="order"]' ).map(
+					function() { return this.value; }
+				).get();
+			},
+
+			check_orders_in_list: function( e, data ) {
+				var locked_orders = data['wc-check-locked-orders'] || {};
+
+				wc_order_lock.$list_table.find( 'tr' ).each( function( i, tr ) {
+					var $tr      = $( tr );
+					var order_id = $tr.find( 'input[name="order"]' ).val();
+
+					if ( locked_orders[ order_id ] ) {
+						if ( ! $tr.hasClass( 'wp-locked' ) ) {
+							$tr.find( '.check-column checkbox' ).prop( 'checked', false );
+							$tr.addClass( 'wp-locked' );
+						}
+					} else {
+						$tr.removeClass( 'wp-locked' ).find( '.locked-info span' ).empty();
+					}
+				} );
+			}
+		};
+
+		wc_order_lock.init();
+	} );
+
 } )( jQuery, woocommerce_admin );

--- a/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
+++ b/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
@@ -672,12 +672,56 @@
 		 */
 		var wc_order_lock = {
 			init: function() {
+				// Order screen.
+				this.$lock_dialog = $( '.woocommerce_page_wc-orders #post-lock-dialog.order-lock-dialog' );
+				if ( 0 !== this.$lock_dialog.length && 'undefined' !== typeof woocommerce_admin_meta_boxes ) {
+					$( document ).on( 'heartbeat-send', this.refresh_order_lock );
+					$( document ).on( 'heartbeat-tick', this.check_order_lock );
+				}
+
 				// Orders list table.
 				this.$list_table = $( '.woocommerce_page_wc-orders table.wc-orders-list-table' );
 				if ( 0 !== this.$list_table.length ) {
 					$( document ).on( 'heartbeat-send', this.send_orders_in_list );
 					$( document ).on( 'heartbeat-tick', this.check_orders_in_list );
 				}
+			},
+
+			refresh_order_lock: function( e, data ) {
+				data['wc-refresh-order-lock'] = woocommerce_admin_meta_boxes.post_id;
+			},
+
+			check_order_lock: function( e, data ) {
+				var lock_data = data['wc-refresh-order-lock'];
+
+				if ( ! lock_data || ! lock_data.error ) {
+					// No lock request in heartbeat or lock refreshed ok.
+					return;
+				}
+
+				if ( wc_order_lock.$lock_dialog.is( ':visible' ) ) {
+					return;
+				}
+
+				if ( lock_data.error.user_avatar_src ) {
+					wc_order_lock.$lock_dialog.find( '.post-locked-avatar' ).empty().append(
+						$(
+							'<img />',
+							{
+								'class': 'avatar avatar-64 photo',
+								width: 64,
+								height: 64,
+								alt: '',
+								src: lock_data.error.user_avatar_src,
+								srcset: lock_data.error.user_avatar_src_2x ? lock_data.error.user_avatar_src_2x + ' 2x' : undefined
+							}
+						)
+					);
+				}
+
+				wc_order_lock.$lock_dialog.find( '.currently-editing' ).text( lock_data.error.message );
+				wc_order_lock.$lock_dialog.show();
+				wc_order_lock.$lock_dialog.find( '.wp-tab-first' ).trigger( 'focus' );
 			},
 
 			send_orders_in_list: function( e, data ) {

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -199,6 +199,7 @@ class WC_AJAX {
 
 		// WP's heartbeat.
 		$ajax_heartbeat_callbacks = array(
+			'order_refresh_lock',
 			'check_locked_orders',
 		);
 		foreach ( $ajax_heartbeat_callbacks as $ajax_callback ) {
@@ -3336,6 +3337,17 @@ class WC_AJAX {
 	 */
 	private static function order_delete_meta() : void {
 		wc_get_container()->get( CustomMetaBox::class )->delete_meta_ajax();
+	}
+
+	/**
+	 * Hooked to 'heartbeat_received' on the edit order page to refresh the lock on an order being edited by the current user.
+	 *
+	 * @param array $response The heartbeat response to be sent.
+	 * @param array $data     Data sent through the heartbeat.
+	 * @return array Response to be sent.
+	 */
+	private static function order_refresh_lock( $response, $data ) : array {
+		return wc_get_container()->get( Automattic\WooCommerce\Internal\Admin\Orders\EditLock::class )->refresh_lock_ajax( $response, $data );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -196,6 +196,21 @@ class WC_AJAX {
 				}
 			);
 		}
+
+		// WP's heartbeat.
+		$ajax_heartbeat_callbacks = array(
+			'check_locked_orders',
+		);
+		foreach ( $ajax_heartbeat_callbacks as $ajax_callback ) {
+			add_filter(
+				'heartbeat_received',
+				function( $response, $data ) use ( $ajax_callback ) {
+					return call_user_func_array( array( __CLASS__, $ajax_callback ), func_get_args() );
+				},
+				10,
+				2
+			);
+		}
 	}
 
 	/**
@@ -3322,6 +3337,20 @@ class WC_AJAX {
 	private static function order_delete_meta() : void {
 		wc_get_container()->get( CustomMetaBox::class )->delete_meta_ajax();
 	}
+
+	/**
+	 * Hooked to 'heartbeat_received' on the orders screen to refresh the locked status of orders in the list table.
+	 *
+	 * @since 7.8.0
+	 *
+	 * @param array $response The heartbeat response to be sent.
+	 * @param array $data     Data sent through the heartbeat.
+	 * @return array Response to be sent.
+	 */
+	private static function check_locked_orders( $response, $data ) : array {
+		return wc_get_container()->get( Automattic\WooCommerce\Internal\Admin\Orders\EditLock::class )->check_locked_orders_ajax( $response, $data );
+	}
+
 }
 
 WC_AJAX::init();

--- a/plugins/woocommerce/src/Internal/Admin/EditLock.php
+++ b/plugins/woocommerce/src/Internal/Admin/EditLock.php
@@ -1,0 +1,199 @@
+<?php
+namespace Automattic\WooCommerce\Internal\Admin\Orders;
+
+/**
+ * This class takes care of the edit lock logic when HPOS is enabled.
+ * For better interoperability with WordPress, edit locks are stored in the same format as posts. That is, as a metadata
+ * in the order object (key: '_edit_lock') in the format "timestamp:user_id".
+ *
+ * @since 7.8.0
+ */
+class EditLock {
+
+	/**
+	 * Obtains lock information for a given order. If the lock has expired or it's assigned to an invalid user,
+	 * the order is no longer considered locked.
+	 *
+	 * @param \WC_Order $order Order to check.
+	 * @return bool|array
+	 */
+	public function get_lock( \WC_Order $order ) {
+		$lock = $order->get_meta( '_edit_lock', true, 'edit' );
+		if ( ! $lock ) {
+			return false;
+		}
+
+		$lock = explode( ':', $lock );
+		if ( 2 !== count( $lock ) ) {
+			return false;
+		}
+
+		$time    = absint( $lock[0] );
+		$user_id = isset( $lock[1] ) ? absint( $lock[1] ) : 0;
+
+		if ( ! $time || ! get_user_by( 'id', $user_id ) ) {
+			return false;
+		}
+
+		/** This filter is documented in WP's wp-admin/includes/ajax-actions.php */
+		$time_window = apply_filters( 'wp_check_post_lock_window', 150 ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingSinceComment
+		if ( time() >= ( $time + $time_window ) ) {
+			return false;
+		}
+
+		return compact( 'time', 'user_id' );
+	}
+
+	/**
+	 * Checks whether the order is being edited (i.e. locked) by another user.
+	 *
+	 * @param \WC_Order $order Order to check.
+	 * @return bool TRUE if order is locked and currently being edited by another user. FALSE otherwise.
+	 */
+	public function is_locked_by_another_user( \WC_Order $order ) : bool {
+		$lock = $this->get_lock( $order );
+		return $lock && ( get_current_user_id() !== $lock['user_id'] );
+	}
+
+	/**
+	 * Assigns an order's edit lock to the current user.
+	 *
+	 * @param \WC_Order $order The order to apply the lock to.
+	 * @return array|bool FALSE if no user is logged-in, an array in the same format as {@see get_lock()} otherwise.
+	 */
+	public function lock( \WC_Order $order ) {
+		$user_id = get_current_user_id();
+
+		if ( ! $user_id ) {
+			return false;
+		}
+
+		$order->update_meta_data( '_edit_lock', time() . ':' . $user_id );
+		$order->save_meta_data();
+
+		return $order->get_meta( '_edit_lock', true, 'edit' );
+	}
+
+	/**
+	 * Hooked to 'heartbeat_received' on the edit order page to refresh the lock on an order being edited by the current user.
+	 *
+	 * @param array $response The heartbeat response to be sent.
+	 * @param array $data     Data sent through the heartbeat.
+	 * @return array Response to be sent.
+	 */
+	public function refresh_lock_ajax( $response, $data ) {
+		$order_id = absint( $data['wc-refresh-order-lock'] ?? 0 );
+		if ( ! $order_id ) {
+			return $response;
+		}
+
+		$order = wc_get_order( $order_id );
+		if ( ! current_user_can( get_post_type_object( $order->get_type() )->cap->edit_post, $order->get_id() ) && ! current_user_can( 'manage_woocommerce' ) ) {
+			return $response;
+		}
+
+		$response['wc-refresh-order-lock'] = array();
+
+		if ( ! $this->is_locked_by_another_user( $order ) ) {
+			$response['wc-refresh-order-lock']['lock'] = $this->lock( $order );
+		} else {
+			$current_lock = $this->get_lock( $order );
+			$user         = get_user_by( 'id', $current_lock['user_id'] );
+
+			$response['wc-refresh-order-lock']['error'] = array(
+				// translators: %s is a user's name.
+				'message'            => sprintf( __( '%s has taken over and is currently editing.', 'woocommerce' ), $user->display_name ),
+				'user_name'          => $user->display_name,
+				'user_avatar_src'    => get_option( 'show_avatars' ) ? get_avatar_url( $user->ID, array( 'size' => 64 ) ) : '',
+				'user_avatar_src_2x' => get_option( 'show_avatars' ) ? get_avatar_url( $user->ID, array( 'size' => 128 ) ) : '',
+			);
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Hooked to 'heartbeat_received' on the orders screen to refresh the locked status of orders in the list table.
+	 *
+	 * @param array $response The heartbeat response to be sent.
+	 * @param array $data     Data sent through the heartbeat.
+	 * @return array Response to be sent.
+	 */
+	public function check_locked_orders_ajax( $response, $data ) {
+		if ( empty( $data['wc-check-locked-orders'] ) || ! is_array( $data['wc-check-locked-orders'] ) ) {
+			return $response;
+		}
+
+		$response['wc-check-locked-orders'] = array();
+
+		$order_ids = array_unique( array_map( 'absint', $data['wc-check-locked-orders'] ) );
+		foreach ( $order_ids as $order_id ) {
+			$order = wc_get_order( $order_id );
+			if ( ! $order ) {
+				continue;
+			}
+
+			if ( ! $this->is_locked_by_another_user( $order ) || ( ! current_user_can( get_post_type_object( $order->get_type() )->cap->edit_post, $order->get_id() ) && ! current_user_can( 'manage_woocommerce' ) ) ) {
+				continue;
+			}
+
+			$response['wc-check-locked-orders'][ $order_id ] = true;
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Outputs HTML for the lock dialog based on the status of the lock on the order (if any).
+	 * Depending on who owns the lock, this could be a message with the chance to take over or a message indicating that
+	 * someone else has taken over the order.
+	 *
+	 * @param \WC_Order $order Order object.
+	 * @return void
+	 */
+	public function render_dialog( $order ) {
+		$locked = $this->is_locked_by_another_user( $order );
+		$lock   = $this->get_lock( $order );
+		$user   = get_user_by( 'id', $lock['user_id'] );
+
+		$edit_url = wc_get_container()->get( \Automattic\WooCommerce\Internal\Admin\Orders\PageController::class )->get_edit_url( $order->get_id() );
+
+		$sendback_url = wp_get_referer();
+		if ( ! $sendback_url ) {
+			$sendback_url = wc_get_container()->get( \Automattic\WooCommerce\Internal\Admin\Orders\PageController::class )->get_base_page_url( $order->get_type() );
+		}
+
+		$sendback_text = __( 'Go back', 'woocommerce' );
+		?>
+		<div id="post-lock-dialog" class="notification-dialog-wrap <?php echo $locked ? '' : 'hidden'; ?> order-lock-dialog">
+			<div class="notification-dialog-background"></div>
+			<div class="notification-dialog">
+			<?php if ( $locked ) : ?>
+			<div class="post-locked-message">
+				<div class="post-locked-avatar"><?php echo get_avatar( $user->ID, 64 ); ?></div>
+				<p class="currently-editing wp-tab-first" tabindex="0">
+				<?php
+				// translators: %s is a user's name.
+				echo esc_html( sprintf( __( '%s is currently editing this order. Do you want to take over?', 'woocommerce' ), esc_html( $user->display_name ) ) );
+				?>
+				</p>
+				<p>
+					<a class="button" href="<?php echo esc_url( $sendback_url ); ?>"><?php echo esc_html( $sendback_text ); ?></a>
+					<a class="button button-primary wp-tab-last" href="<?php echo esc_url( add_query_arg( 'claim-lock', '1', wp_nonce_url( $edit_url, 'claim-lock-' . $order->get_id() ) ) ); ?>"><?php esc_html_e( 'Take over', 'woocommerce' ); ?></a>
+				</p>
+			</div>
+			<?php else : ?>
+			<div class="post-taken-over">
+				<div class="post-locked-avatar"></div>
+				<p class="wp-tab-first" tabindex="0">
+				<span class="currently-editing"></span><br />
+				</p>
+				<p><a class="button button-primary wp-tab-last" href="<?php echo esc_url( $sendback_url ); ?>"><?php echo esc_html( $sendback_text ); ?></a></p>
+			</div>
+			<?php endif; ?>
+			</div>
+		</div>
+		<?php
+	}
+
+}

--- a/plugins/woocommerce/src/Internal/Admin/Orders/EditLock.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/EditLock.php
@@ -10,6 +10,8 @@ namespace Automattic\WooCommerce\Internal\Admin\Orders;
  */
 class EditLock {
 
+	const META_KEY_NAME = '_edit_lock';
+
 	/**
 	 * Obtains lock information for a given order. If the lock has expired or it's assigned to an invalid user,
 	 * the order is no longer considered locked.
@@ -18,7 +20,7 @@ class EditLock {
 	 * @return bool|array
 	 */
 	public function get_lock( \WC_Order $order ) {
-		$lock = $order->get_meta( '_edit_lock', true, 'edit' );
+		$lock = $order->get_meta( self::META_KEY_NAME, true, 'edit' );
 		if ( ! $lock ) {
 			return false;
 		}
@@ -56,6 +58,16 @@ class EditLock {
 	}
 
 	/**
+	 * Checks whether the order is being edited by any user.
+	 *
+	 * @param \WC_Order $order Order to check.
+	 * @return boolean TRUE if order is locked and currently being edited by a user. FALSE otherwise.
+	 */
+	public function is_locked( \WC_Order $order ) : bool {
+		return (bool) $this->get_lock( $order );
+	}
+
+	/**
 	 * Assigns an order's edit lock to the current user.
 	 *
 	 * @param \WC_Order $order The order to apply the lock to.
@@ -68,10 +80,10 @@ class EditLock {
 			return false;
 		}
 
-		$order->update_meta_data( '_edit_lock', time() . ':' . $user_id );
+		$order->update_meta_data( self::META_KEY_NAME, time() . ':' . $user_id );
 		$order->save_meta_data();
 
-		return $order->get_meta( '_edit_lock', true, 'edit' );
+		return $order->get_meta( self::META_KEY_NAME, true, 'edit' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -841,7 +841,11 @@ class ListTable extends WP_List_Table {
 	 * @return string
 	 */
 	public function column_cb( $item ) {
-		return sprintf( '<input type="checkbox" name="%1$s[]" value="%2$s" />', esc_attr( $this->_args['singular'] ), esc_attr( $item->get_id() ) );
+		ob_start();
+		?>
+		<input id="cb-select-<?php echo esc_attr( $item->get_id() ); ?>" type="checkbox" name="<?php echo esc_attr( $this->_args['singular'] ); ?>" value="<?php echo esc_attr( $item->get_id() ); ?>" />
+		<?php
+		return ob_get_clean();
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -868,6 +868,16 @@ class ListTable extends WP_List_Table {
 		ob_start();
 		?>
 		<input id="cb-select-<?php echo esc_attr( $item->get_id() ); ?>" type="checkbox" name="<?php echo esc_attr( $this->_args['singular'] ); ?>" value="<?php echo esc_attr( $item->get_id() ); ?>" />
+
+		<div class="locked-indicator">
+			<span class="locked-indicator-icon" aria-hidden="true"></span>
+			<span class="screen-reader-text">
+				<?php
+				// translators: %s is an order ID.
+				echo esc_html( sprintf( __( 'Order %s is locked.', 'woocommerce' ), $item->get_id() ) );
+				?>
+			</span>
+		</div>
 		<?php
 		return ob_get_clean();
 	}

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -1113,7 +1113,7 @@ class ListTable extends WP_List_Table {
 
 			$action = 'delete';
 		} else {
-			$ids = isset( $_REQUEST['order'] ) ? array_reverse( array_map( 'absint', $_REQUEST['order'] ) ) : array();
+			$ids = isset( $_REQUEST['order'] ) ? array_reverse( array_map( 'absint', (array) $_REQUEST['order'] ) ) : array();
 		}
 
 		/**

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -115,20 +115,35 @@ class ListTable extends WP_List_Table {
 	 *
 	 * @since 7.8.0
 	 *
-	 * @param \WC_Order $order The current order
+	 * @param \WC_Order $order The current order.
 	 */
 	public function single_row( $order ) {
-		// CSS classes.
+		/**
+		 * Filters the list of CSS class names for a given order row in the orders list table.
+		 *
+		 * @since 7.8.0
+		 *
+		 * @param string[]  $classes An array of CSS class names.
+		 * @param \WC_Order $order   The order object.
+		 */
 		$css_classes = apply_filters(
 			'woocommerce_' . $this->order_type . '_list_table_order_css_classes',
 			array(
 				'order-' . $order->get_id(),
 				'type-' . $order->get_type(),
 				'status-' . $order->get_status(),
-			)
+			),
+			$order
 		);
 		$css_classes = array_unique( array_map( 'trim', $css_classes ) );
-		echo '<tr id="order-' . $order->get_id() . '" class="' . esc_attr( implode( ' ', $css_classes ) ) . '">';
+
+		// Is locked?
+		$edit_lock = wc_get_container()->get( EditLock::class );
+		if ( $edit_lock->is_locked_by_another_user( $order ) ) {
+			$css_classes[] = 'wp-locked';
+		}
+
+		echo '<tr id="order-' . esc_attr( $order->get_id() ) . '" class="' . esc_attr( implode( ' ', $css_classes ) ) . '">';
 		$this->single_row_columns( $order );
 		echo '</tr>';
 	}
@@ -308,6 +323,14 @@ class ListTable extends WP_List_Table {
 	 * @return string[] Array of CSS classes for the table tag.
 	 */
 	protected function get_table_classes() {
+		/**
+		 * Filters the list of CSS class names for the orders list table.
+		 *
+		 * @since 7.8.0
+		 *
+		 * @param string[] $classes    An array of CSS class names.
+		 * @param string   $order_type The order type.
+		 */
 		$css_classes = apply_filters(
 			'woocommerce_' . $this->order_type . '_list_table_css_classes',
 			array_merge(
@@ -316,7 +339,8 @@ class ListTable extends WP_List_Table {
 					'wc-orders-list-table',
 					'wc-orders-list-table-' . $this->order_type,
 				)
-			)
+			),
+			$this->order_type
 		);
 
 		return array_unique( array_map( 'trim', $css_classes ) );

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -4,6 +4,7 @@ namespace Automattic\WooCommerce\Internal\Admin\Orders;
 
 use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
 use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
+use Automattic\WooCommerce\Utilities\OrderUtil;
 use WC_Order;
 use WP_List_Table;
 use WP_Screen;
@@ -107,6 +108,29 @@ class ListTable extends WP_List_Table {
 		set_screen_options();
 
 		add_action( 'manage_' . wc_get_page_screen_id( $this->order_type ) . '_custom_column', array( $this, 'render_column' ), 10, 2 );
+	}
+
+	/**
+	 * Generates content for a single row of the table.
+	 *
+	 * @since 7.8.0
+	 *
+	 * @param \WC_Order $order The current order
+	 */
+	public function single_row( $order ) {
+		// CSS classes.
+		$css_classes = apply_filters(
+			'woocommerce_' . $this->order_type . '_list_table_order_css_classes',
+			array(
+				'order-' . $order->get_id(),
+				'type-' . $order->get_type(),
+				'status-' . $order->get_status(),
+			)
+		);
+		$css_classes = array_unique( array_map( 'trim', $css_classes ) );
+		echo '<tr id="order-' . $order->get_id() . '" class="' . esc_attr( implode( ' ', $css_classes ) ) . '">';
+		$this->single_row_columns( $order );
+		echo '</tr>';
 	}
 
 	/**
@@ -274,6 +298,28 @@ class ListTable extends WP_List_Table {
 		}
 
 		return $actions;
+	}
+
+	/**
+	 * Gets a list of CSS classes for the WP_List_Table table tag.
+	 *
+	 * @since 7.8.0
+	 *
+	 * @return string[] Array of CSS classes for the table tag.
+	 */
+	protected function get_table_classes() {
+		$css_classes = apply_filters(
+			'woocommerce_' . $this->order_type . '_list_table_css_classes',
+			array_merge(
+				parent::get_table_classes(),
+				array(
+					'wc-orders-list-table',
+					'wc-orders-list-table-' . $this->order_type,
+				)
+			)
+		);
+
+		return array_unique( array_map( 'trim', $css_classes ) );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
@@ -92,6 +92,40 @@ class PageController {
 	}
 
 	/**
+	 * Claims the lock for the order being edited/created (unless it belongs to someone else).
+	 * Also handles the 'claim-lock' action which allows taking over the order forcefully.
+	 *
+	 * @return void
+	 */
+	private function handle_edit_lock() {
+		if ( ! $this->order ) {
+			return;
+		}
+
+		$edit_lock = wc_get_container()->get( EditLock::class );
+
+		$locked = $edit_lock->is_locked_by_another_user( $this->order );
+
+		// Take over order?
+		if ( ! empty( $_GET['claim-lock'] ) && wp_verify_nonce( $_GET['_wpnonce'] ?? '', 'claim-lock-' . $this->order->get_id() ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+			$edit_lock->lock( $this->order );
+			wp_safe_redirect( $this->get_edit_url( $this->order->get_id() ) );
+			exit;
+		}
+
+		if ( ! $locked ) {
+			$edit_lock->lock( $this->order );
+		}
+
+		add_action(
+			'admin_footer',
+			function() use ( $edit_lock ) {
+				$edit_lock->render_dialog( $this->order );
+			}
+		);
+	}
+
+	/**
 	 * Sets up the page controller, including registering the menu item.
 	 *
 	 * @return void
@@ -266,6 +300,7 @@ class PageController {
 		global $theorder;
 		$this->order = wc_get_order( absint( isset( $_GET['id'] ) ? $_GET['id'] : 0 ) );
 		$this->verify_edit_permission();
+		$this->handle_edit_lock();
 		$theorder = $this->order;
 	}
 
@@ -288,6 +323,7 @@ class PageController {
 		$this->order->set_object_read( false );
 		$this->order->set_status( 'auto-draft' );
 		$this->order->save();
+		$this->handle_edit_lock();
 
 		// Schedule auto-draft cleanup. We re-use the WP event here on purpose.
 		if ( ! wp_next_scheduled( 'wp_scheduled_auto_draft_delete' ) ) {

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -62,7 +62,6 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 		'_shipping_phone',
 		'_completed_date',
 		'_paid_date',
-		'_edit_lock',
 		'_edit_last',
 		'_cart_discount',
 		'_cart_discount_tax',

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/OrderAdminServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/OrderAdminServiceProvider.php
@@ -7,6 +7,7 @@ namespace Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders;
 
 use Automattic\WooCommerce\Internal\Admin\Orders\COTRedirectionController;
 use Automattic\WooCommerce\Internal\Admin\Orders\Edit;
+use Automattic\WooCommerce\Internal\Admin\Orders\EditLock;
 use Automattic\WooCommerce\Internal\Admin\Orders\ListTable;
 use Automattic\WooCommerce\Internal\Admin\Orders\PageController;
 use Automattic\WooCommerce\Internal\DependencyManagement\AbstractServiceProvider;
@@ -26,6 +27,7 @@ class OrderAdminServiceProvider extends AbstractServiceProvider {
 		PageController::class,
 		Edit::class,
 		ListTable::class,
+		EditLock::class,
 	);
 
 	/**
@@ -38,5 +40,6 @@ class OrderAdminServiceProvider extends AbstractServiceProvider {
 		$this->share( PageController::class );
 		$this->share( Edit::class )->addArgument( PageController::class );
 		$this->share( ListTable::class )->addArgument( PageController::class );
+		$this->share( EditLock::class );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/EditLockTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/EditLockTest.php
@@ -1,0 +1,159 @@
+<?php
+
+use Automattic\WooCommerce\Internal\Admin\Orders\EditLock;
+use Automattic\WooCommerce\RestApi\UnitTests\HPOSToggleTrait;
+
+/**
+ * Tests related to order edit locking in admin.
+ */
+class EditLockTest extends WC_Unit_Test_Case {
+	use HPOSToggleTrait;
+
+	/**
+	 * @var EditLock
+	 */
+	private $sut;
+
+	/**
+	 * Test order.
+	 *
+	 * @var \WC_Order
+	 */
+	private $order;
+
+	/**
+	 * Test user ID.
+	 *
+	 * @var int
+	 */
+	private $user1;
+
+	/**
+	 * Test user ID.
+	 *
+	 * @var int
+	 */
+	private $user2;
+
+	/**
+	 * Setup - enables HPOS and creates test users and order.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->setup_cot();
+		$this->toggle_cot( true );
+
+		$order = new \WC_Order();
+
+		$this->sut   = new EditLock();
+		$this->order = new \WC_Order();
+		$this->order->save();
+		$this->user1 = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		$this->user2 = $this->factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	/**
+	 * Restore HPOS state.
+	 */
+	public function tearDown(): void {
+		$this->clean_up_cot_setup();
+		parent::tearDown();
+	}
+
+	/**
+	 * @testDox Basic locking works as expected.
+	 */
+	public function test_basic_locking() {
+		wp_set_current_user( $this->user1 );
+		$this->sut->lock( $this->order );
+
+		// Confirm order is locked and user1 owns the lock.
+		$this->assertTrue( $this->sut->is_locked( $this->order ) );
+		$this->assertFalse( $this->sut->is_locked_by_another_user( $this->order ) );
+
+		// user2 can't edit.
+		wp_set_current_user( $this->user2 );
+		$this->assertTrue( $this->sut->is_locked_by_another_user( $this->order ) );
+
+		// If the user no longer exists, the order shouldn't be considered locked.
+		wp_delete_user( $this->user1 );
+		$this->assertFalse( $this->sut->is_locked( $this->order ) );
+	}
+
+	/**
+	 * @testDox Order locking respects the post lock window.
+	 */
+	public function test_lock_time_window() {
+		$now           = time();
+		$five_mins_ago = $now - ( 5 * MINUTE_IN_SECONDS );
+
+		// Simulate a lock set "now".
+		$this->simulate_lock_with_time( $this->order, $now, $this->user1 );
+		$this->assertTrue( $this->sut->is_locked( $this->order ) );
+
+		// Simulate a lock set 5 mins ago.
+		$this->simulate_lock_with_time( $this->order, $five_mins_ago, $this->user1 );
+
+		// Change the lock window to 6 mins. Order should be considered locked.
+		add_filter(
+			'wp_check_post_lock_window',
+			function() {
+				return 6 * MINUTE_IN_SECONDS;
+			}
+		);
+		$this->assertTrue( $this->sut->is_locked( $this->order ) );
+
+		// With the default post window (2.5 mins), order should no longer be considered locked.
+		remove_all_filters( 'wp_check_post_lock_window' );
+		$this->assertFalse( $this->sut->is_locked( $this->order ) );
+	}
+
+	/**
+	 * @testDox Heartbeat AJAX requests correctly renew edit locks and/or inform of takeovers.
+	 */
+	public function test_edit_lock_ajax() {
+		$request_data = array(
+			'wc-refresh-order-lock' => $this->order->get_id(),
+		);
+
+		// user1 owns the lock first.
+		wp_set_current_user( $this->user1 );
+		$this->sut->lock( $this->order );
+
+		// Simulate a heartbeat, which for user 1 should result in a renewed lock.
+		$response = apply_filters( 'heartbeat_received', array(), $request_data, 'woocommerce_page_wc-orders' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment,WooCommerce.Commenting.CommentHooks.HookCommentWrongStyle
+		$this->assertArrayHasKey( 'wc-refresh-order-lock', $response );
+		$this->assertArrayHasKey( 'lock', $response['wc-refresh-order-lock'] );
+
+		// Refresh order.
+		$this->order = wc_get_order( $this->order->get_id() );
+
+		// user2 takes over.
+		wp_set_current_user( $this->user2 );
+		$this->sut->lock( $this->order );
+
+		// user1 now gets the "taken over" message when the heartbeat attempts to renew the lock.
+		wp_set_current_user( $this->user1 );
+		$response = apply_filters( 'heartbeat_received', array(), $request_data, 'woocommerce_page_wc-orders' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment,WooCommerce.Commenting.CommentHooks.HookCommentWrongStyle
+		$this->assertArrayHasKey( 'wc-refresh-order-lock', $response );
+		$this->assertArrayHasKey( 'error', $response['wc-refresh-order-lock'] );
+
+		$user2 = get_user_by( 'id', $this->user2 );
+		$this->assertEquals( $response['wc-refresh-order-lock']['error']['user_name'], $user2->display_name );
+	}
+
+	/**
+	 * Simulates locking an order at a specific time.
+	 *
+	 * @param \WC_Order $order   Order object.
+	 * @param int       $timestamp Timestamp for the lock.
+	 * @param int       $user_id   User owning the lock.
+	 * @return void
+	 */
+	private function simulate_lock_with_time( \WC_Order $order, int $timestamp, int $user_id ): void {
+		$this->order->update_meta_data( EditLock::META_KEY_NAME, $timestamp . ':' . $user_id );
+		$this->order->save_meta_data();
+	}
+
+
+}


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR adds support to HPOS for order edit locking in the admin (similar to what posts and custom post types get by default). Specifically, the following is implemented:

- The lock is stored in order meta for interoperability with WP's implementation.
- Orders that are being edited by a user other than the current one will appear with a lock icon next to them in the list table. This lock icon/status is updated live via heartbeat with no page refresh necessary.
- When opening an order that is being edited by another user, a warning will be displayed, with the ability to take over the order:
- When someone has taken over an order you're editing, you'll get a warning about it automatically via heartbeat (no page refresh involved):

Closes #37108.


### For discussion ❓ 

Currently, the lock is stored as order meta, similar to how WP uses post meta for the same, but I wonder if it'd be best to add a new column to one of our orders table instead.
That could make some parts of the code a bit more reliable since we wouldn't depend on the order object having up-to-date metadata or re-reading metadata and we certainly wouldn't be risking altering an order's data by saving metadata to store the lock.

Given all of this logic lives in `EditLock` right now, changing it wouldn't be too hard, but unless there's a reason to do it, I didn't want to implement it in this first pass.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:
<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

#### Prerequisites
0. Because of the CSS/JS changes involved, you'll need to fully build the legacy assets in the repo.
1. Enable HPOS:
    - Make sure that "Enable the high performance order storage feature." is checked off on the WooCommerce > Settings > Advanced > Features screen.
    - Make sure that "Use the WooCommerce orders tables" is selected on the WooCommerce > Settings > Advanced > Custom data stores screen.
2. Wait for the sync to complete (if necessary) and create a few test orders with whatever user/items/statuses you like.
3. Make sure you have at least another user with permissions to edit orders. For example, a user with administrator or "shop manager" roles.
4. You'll need to log in both as your regular admin/shop manager user and also the user from step 3. To do so, you can either use a different browser or open an incognito window.
   In what follows, we'll assume users are **userA** and **userB** and are simultaneously logged-in.

#### Test order locking & release
1. As both **userA** and **userB** go to WC > Orders.
2. As **userA** open any order in the orders list.
3. As **userB**, manually refresh the orders list screen. Confirm that the order you just opened as **userA** appears with a lock next to it, similar to this screenshot:
   <img width="450" alt="Screenshot 2023-05-10 at 20 10 39" src="https://github.com/woocommerce/woocommerce/assets/184724/7b51bdaf-16f8-4659-aac2-12808dcb0de1">
4. As **userA** "close" the order you just opened by navigating to a different screen on your admin.
5. As **userB**, wait around ~2.5 mins (lock time window) and manually refresh the page. The lock icon should no longer be visible.

#### Test live update of order locks in orders list table
1. As both **userA** and **userB** go to WC > Orders.
2. As **userA** open various different orders from the list.
3. As **userB** confirm that no order has a lock icon next to it yet.
4. As **userB** wait a little while (no manual refresh necessary) until WP has processed a "heartbeat" event (could be a few mins).
5. As **userB** confirm that the orders opened in step 2 now have a lock icon next to them.
6. As **userA** close some of the orders you've opened.
7. As **userB** wait a few more mins and confirm that the lock icons in the screen appear/disappear accordingly.

Very boring GIF of this workflow:
![Untitled](https://github.com/woocommerce/woocommerce/assets/184724/408be6ea-eac9-4bab-a53b-5e0bb435ceb5)

#### Test lock warning, take-over and take-over warning
1. As both **userA** and **userB** go to WC > Orders.
2. As **userA** open any order not currently being edited. Alternatively, wait a few mins until all order locks are released and choose any order.
3. As **userB** open the order from step 2. You should see a modal warning with some details on who's currently editing the order (userA) and a button to take over:
   <img width="450" alt="Screenshot 2023-05-09 at 16 22 18" src="https://github.com/woocommerce/woocommerce/assets/184724/087e96fe-fb00-43d5-bf4a-e8537b577bfb">
4. Continuing as **userB**, click "Take over" to take over the order.
5. As **userA** wait a few moments (until a heartbeat event is processed by WP) and confirm that a warning appears indicating that **userB** has taken over the order you were editing:
   <img width="450" alt="Screenshot 2023-05-10 at 20 11 42" src="https://github.com/woocommerce/woocommerce/assets/184724/270399eb-a8b9-4e07-9118-96fe6cff0cb6">


<!-- End testing instructions -->