### PR TITLE
Add troubleshooting for PHP install

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -23,26 +23,26 @@ Here are some examples of the ways you can use Turborepo / pnpm commands:
 ```bash
 # Lint and build all plugins, packages, and tools. Note the use of `-r` for lint,
 # turbo does not run the lint at this time.
-pnpm run -r lint && pnpm run build 
+pnpm run -r lint && pnpm run build
 
 # Build WooCommerce Core and all of its dependencies
-pnpm run --filter='woocommerce' build 
+pnpm run --filter='woocommerce' build
 
 # Lint the @woocommerce/components package - note the different argument order, turbo scripts
 # are not running lints at this point in time.
-pnpm run -r --filter='@woocommerce/components' lint 
+pnpm run -r --filter='@woocommerce/components' lint
 
 # Test all of the @woocommerce scoped packages
-pnpm run --filter='@woocommerce/*' test 
+pnpm run --filter='@woocommerce/*' test
 
 # Build all of the JavaScript packages
-pnpm run --filter='./packages/js/*' build 
+pnpm run --filter='./packages/js/*' build
 
 # Build everything except WooCommerce Core
-pnpm run --filter='!woocommerce' build 
+pnpm run --filter='!woocommerce' build
 
 # Build everything that has changed since the last commit
-pnpm run --filter='[HEAD^1]' build 
+pnpm run --filter='[HEAD^1]' build
 ```
 
 ### Cache busting Turbo
@@ -90,3 +90,25 @@ pnpm -- wp-env destroy
 Each of the [plugins in our repository](plugins) support using this tool to spin up a development environment. Note that rather than having a single top-level environment, each plugin has its own. This is done in order to prevent conflicts between them.
 
 Please check out [the official documentation](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/) if you would like to learn more about this tool.
+
+## Troubleshooting
+
+### Installing PHP in Unix (e.g. Ubuntu)
+
+Many unix systems such as Ubuntu will have PHP already installed. Sometimes without the extra packages you need to run Wordpress and this will cause you to run into troubles.
+
+Use your package manager to add the extra PHP packages you'll need.
+e.g. in Ubuntu you can run:
+
+```
+sudo apt update
+sudo apt install php-bcmath \
+                 php-curl \
+                 php-imagick \
+                 php-intl \
+                 php-json \
+                 php-mbstring \
+                 php-mysql \
+                 php-xml \
+                 php-zip
+```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -95,7 +95,7 @@ Please check out [the official documentation](https://developer.wordpress.org/bl
 
 ### Installing PHP in Unix (e.g. Ubuntu)
 
-Many unix systems such as Ubuntu will have PHP already installed. Sometimes without the extra packages you need to run Wordpress and this will cause you to run into troubles.
+Many unix systems such as Ubuntu will have PHP already installed. Sometimes without the extra packages you need to run WordPress and this will cause you to run into troubles.
 
 Use your package manager to add the extra PHP packages you'll need.
 e.g. in Ubuntu you can run:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To get up and running within the WooCommerce Monorepo, you will need to make sur
 
 -   [NVM](https://github.com/nvm-sh/nvm#installing-and-updating): While you can always install Node through other means, we recommend using NVM to ensure you're aligned with the version used by our development teams. Our repository contains [an `.nvmrc` file](.nvmrc) which helps ensure you are using the correct version of Node.
 -   [PNPM](https://pnpm.io/installation): Our repository utilizes PNPM to manage project dependencies and run various scripts involved in building and testing projects.
--   [PHP 7.2+](https://www.php.net/manual/en/install.php): WooCommerce Core currently features a minimum PHP version of 7.2. It is also needed to run Composer and various project build scripts.
+-   [PHP 7.2+](https://www.php.net/manual/en/install.php): WooCommerce Core currently features a minimum PHP version of 7.2. It is also needed to run Composer and various project build scripts. See [troubleshooting](DEVELOPMENT.md#troubleshooting) for troubleshooting problems installing PHP.
 -   [Composer](https://getcomposer.org/doc/00-intro.md): We use Composer to manage all of the dependencies for PHP packages and plugins.
 
 Once you've installed all of the prerequisites, you can run the following commands to get everything working.


### PR DESCRIPTION

### Changes proposed in this Pull Request:

As @jonathansadowski mentioned in #36436 in many Linux distributions they come with PHP preinstalled in some way, but often not with all the extra PHP packages required.

I thought it made sense to add a basic troubleshooting section to DEVELOPMENT.md and we can add these kind of gotcha's there.

The extensive set of PHP packages needed for Wordpress was taken from https://ubuntu.com/tutorials/install-and-configure-wordpress#2-install-dependencies

Closes #36436

No testing required here.