### PR TITLE
dev: added types for resolveSelect where applicable

### DIFF
--- a/packages/js/data/changelog/dev-add-resolve-select-types
+++ b/packages/js/data/changelog/dev-add-resolve-select-types
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Added types for resolveSelect where applicable.

--- a/packages/js/data/src/countries/index.ts
+++ b/packages/js/data/src/countries/index.ts
@@ -14,6 +14,7 @@ import * as actions from './actions';
 import * as resolvers from './resolvers';
 import reducer, { State } from './reducer';
 import { WPDataSelectors } from '../types';
+import { PromiseifySelectors } from '../types/promiseify-selectors';
 export * from './types';
 export type { State };
 
@@ -35,4 +36,7 @@ declare module '@wordpress/data' {
 	function select(
 		key: typeof STORE_NAME
 	): SelectFromMap< typeof selectors > & WPDataSelectors;
+	function resolveSelect(
+		key: typeof STORE_NAME
+	): PromiseifySelectors< SelectFromMap< typeof selectors > >;
 }

--- a/packages/js/data/src/export/index.ts
+++ b/packages/js/data/src/export/index.ts
@@ -13,6 +13,7 @@ import * as actions from './actions';
 import reducer, { State } from './reducer';
 import { WPDataSelectors } from '../types';
 import controls from '../controls';
+import { PromiseifySelectors } from '../types/promiseify-selectors';
 export * from './types';
 export type { State };
 
@@ -33,4 +34,7 @@ declare module '@wordpress/data' {
 	function select(
 		key: typeof STORE_NAME
 	): SelectFromMap< typeof selectors > & WPDataSelectors;
+	function resolveSelect(
+		key: typeof STORE_NAME
+	): PromiseifySelectors< SelectFromMap< typeof selectors > >;
 }

--- a/packages/js/data/src/import/index.ts
+++ b/packages/js/data/src/import/index.ts
@@ -14,6 +14,7 @@ import * as actions from './actions';
 import * as resolvers from './resolvers';
 import reducer, { State } from './reducer';
 import { WPDataSelectors } from '../types';
+import { PromiseifySelectors } from '../types/promiseify-selectors';
 export * from './types';
 export type { State };
 
@@ -35,4 +36,7 @@ declare module '@wordpress/data' {
 	function select(
 		key: typeof STORE_NAME
 	): SelectFromMap< typeof selectors > & WPDataSelectors;
+	function resolveSelect(
+		key: typeof STORE_NAME
+	): PromiseifySelectors< SelectFromMap< typeof selectors > >;
 }

--- a/packages/js/data/src/items/index.ts
+++ b/packages/js/data/src/items/index.ts
@@ -15,6 +15,7 @@ import reducer, { State } from './reducer';
 import controls from '../controls';
 import { WPDataActions, WPDataSelectors } from '../types';
 import { getItemsType } from './selectors';
+import { PromiseifySelectors } from '../types/promiseify-selectors';
 export * from './types';
 export type { State };
 
@@ -40,4 +41,7 @@ declare module '@wordpress/data' {
 		key: typeof STORE_NAME
 	): DispatchFromMap< typeof actions & WPDataActions >;
 	function select( key: typeof STORE_NAME ): ItemsSelector;
+	function resolveSelect(
+		key: typeof STORE_NAME
+	): PromiseifySelectors< ItemsSelector >;
 }

--- a/packages/js/data/src/navigation/index.ts
+++ b/packages/js/data/src/navigation/index.ts
@@ -16,6 +16,7 @@ import reducer, { State } from './reducer';
 import * as resolvers from './resolvers';
 import initDispatchers from './dispatchers';
 import { WPDataActions, WPDataSelectors } from '../types';
+import { PromiseifySelectors } from '../types/promiseify-selectors';
 
 registerStore< State >( STORE_NAME, {
 	reducer: reducer as Reducer< State, AnyAction >,
@@ -35,4 +36,7 @@ declare module '@wordpress/data' {
 	function select(
 		key: typeof STORE_NAME
 	): SelectFromMap< typeof selectors > & WPDataSelectors;
+	function resolveSelect(
+		key: typeof STORE_NAME
+	): PromiseifySelectors< SelectFromMap< typeof selectors > >;
 }

--- a/packages/js/data/src/notes/index.ts
+++ b/packages/js/data/src/notes/index.ts
@@ -15,6 +15,7 @@ import * as selectors from './selectors';
 import * as actions from './actions';
 import * as resolvers from './resolvers';
 import reducer, { State } from './reducer';
+import { PromiseifySelectors } from '../types/promiseify-selectors';
 
 export * from './types';
 export type { State };
@@ -36,4 +37,7 @@ declare module '@wordpress/data' {
 	function select(
 		key: typeof STORE_NAME
 	): SelectFromMap< typeof selectors > & WPDataSelectors;
+	function resolveSelect(
+		key: typeof STORE_NAME
+	): PromiseifySelectors< SelectFromMap< typeof selectors > >;
 }

--- a/packages/js/data/src/onboarding/index.ts
+++ b/packages/js/data/src/onboarding/index.ts
@@ -14,6 +14,7 @@ import * as actions from './actions';
 import * as resolvers from './resolvers';
 import reducer, { State } from './reducer';
 import { WPDataActions, WPDataSelectors } from '../types';
+import { PromiseifySelectors } from '../types/promiseify-selectors';
 export * from './types';
 export type { State };
 
@@ -35,4 +36,7 @@ declare module '@wordpress/data' {
 		key: typeof STORE_NAME
 	): DispatchFromMap< typeof actions & WPDataActions >;
 	function select( key: typeof STORE_NAME ): OnboardingSelector;
+	function resolveSelect(
+		key: typeof STORE_NAME
+	): PromiseifySelectors< OnboardingSelector >;
 }

--- a/packages/js/data/src/options/index.ts
+++ b/packages/js/data/src/options/index.ts
@@ -14,6 +14,7 @@ import * as resolvers from './resolvers';
 import reducer, { State } from './reducer';
 import { controls } from './controls';
 import { WPDataActions, WPDataSelectors } from '../types';
+import { PromiseifySelectors } from '../types/promiseify-selectors';
 export * from './types';
 export type { State };
 
@@ -34,4 +35,7 @@ declare module '@wordpress/data' {
 	function select(
 		key: typeof STORE_NAME
 	): SelectFromMap< typeof selectors > & WPDataSelectors;
+	function resolveSelect(
+		key: typeof STORE_NAME
+	): PromiseifySelectors< SelectFromMap< typeof selectors > >;
 }

--- a/packages/js/data/src/payment-gateways/index.ts
+++ b/packages/js/data/src/payment-gateways/index.ts
@@ -14,6 +14,7 @@ import * as selectors from './selectors';
 import reducer from './reducer';
 import { STORE_KEY } from './constants';
 import { WPDataActions } from '../types';
+import { PromiseifySelectors } from '../types/promiseify-selectors';
 
 export const PAYMENT_GATEWAYS_STORE_NAME = STORE_KEY;
 
@@ -33,4 +34,7 @@ declare module '@wordpress/data' {
 	function select(
 		key: typeof STORE_KEY
 	): SelectFromMap< typeof selectors > & WPDataActions;
+	function resolveSelect(
+		key: typeof STORE_KEY
+	): PromiseifySelectors< SelectFromMap< typeof selectors > >;
 }

--- a/packages/js/data/src/plugins/index.ts
+++ b/packages/js/data/src/plugins/index.ts
@@ -13,6 +13,7 @@ import * as actions from './actions';
 import * as resolvers from './resolvers';
 import reducer, { State } from './reducer';
 import { WPDataActions, WPDataSelectors } from '../types';
+import { PromiseifySelectors } from '../types/promiseify-selectors';
 export * from './types';
 export type { State };
 
@@ -33,4 +34,7 @@ declare module '@wordpress/data' {
 	function select(
 		key: typeof STORE_NAME
 	): SelectFromMap< typeof selectors > & WPDataSelectors;
+	function resolveSelect(
+		key: typeof STORE_NAME
+	): PromiseifySelectors< SelectFromMap< typeof selectors > >;
 }

--- a/packages/js/data/src/product-form/index.ts
+++ b/packages/js/data/src/product-form/index.ts
@@ -14,6 +14,7 @@ import * as actions from './actions';
 import * as resolvers from './resolvers';
 import reducer, { State } from './reducer';
 import { WPDataSelectors } from '../types';
+import { PromiseifySelectors } from '../types/promiseify-selectors';
 export * from './types';
 export type { State };
 
@@ -34,4 +35,7 @@ declare module '@wordpress/data' {
 	function select(
 		key: typeof STORE_NAME
 	): SelectFromMap< typeof selectors > & WPDataSelectors;
+	function resolveSelect(
+		key: typeof STORE_NAME
+	): PromiseifySelectors< SelectFromMap< typeof selectors > >;
 }

--- a/packages/js/data/src/reports/index.ts
+++ b/packages/js/data/src/reports/index.ts
@@ -24,6 +24,7 @@ import {
 	ReportStatObjectInfer,
 	ReportStatQueryParams,
 } from './types';
+import { PromiseifySelectors } from '../types/promiseify-selectors';
 export * from './types';
 export type { State };
 
@@ -57,4 +58,7 @@ declare module '@wordpress/data' {
 		key: typeof STORE_NAME
 	): DispatchFromMap< typeof actions & WPDataActions >;
 	function select( key: typeof STORE_NAME ): ReportsSelect;
+	function resolveSelect(
+		key: typeof STORE_NAME
+	): PromiseifySelectors< ReportsSelect >;
 }

--- a/packages/js/data/src/reviews/index.ts
+++ b/packages/js/data/src/reviews/index.ts
@@ -16,6 +16,7 @@ import * as resolvers from './resolvers';
 import controls from '../controls';
 import reducer, { State } from './reducer';
 import { WPDataActions, WPDataSelectors } from '../types';
+import { PromiseifySelectors } from '../types/promiseify-selectors';
 
 export * from './types';
 export type { State };
@@ -39,4 +40,7 @@ declare module '@wordpress/data' {
 	function select(
 		key: typeof STORE_NAME
 	): SelectFromMap< typeof selectors > & WPDataSelectors;
+	function resolveSelect(
+		key: typeof STORE_NAME
+	): PromiseifySelectors< ReviewSelector >;
 }

--- a/packages/js/data/src/settings/index.ts
+++ b/packages/js/data/src/settings/index.ts
@@ -17,6 +17,7 @@ import * as actions from './actions';
 import * as resolvers from './resolvers';
 import reducer, { State } from './reducer';
 import { SettingsState } from './types';
+import { PromiseifySelectors } from '../types/promiseify-selectors';
 export * from './types';
 export type { State };
 
@@ -37,4 +38,7 @@ declare module '@wordpress/data' {
 	function select(
 		key: typeof STORE_NAME
 	): SelectFromMap< typeof selectors > & WPDataSelectors;
+	function resolveSelect(
+		key: typeof STORE_NAME
+	): PromiseifySelectors< SelectFromMap< typeof selectors > >;
 }

--- a/packages/js/data/src/types/promiseify-selectors.ts
+++ b/packages/js/data/src/types/promiseify-selectors.ts
@@ -1,0 +1,13 @@
+/**
+ * Type helper that maps select() return types to their resolveSelect() return types.
+ * This works by mapping over each Selector, and returning a function that
+ * returns a Promise of the Selector's return type.
+ */
+
+export type PromiseifySelectors< Selectors > = {
+	[ SelectorFunction in keyof Selectors ]: Selectors[ SelectorFunction ] extends (
+		...args: infer SelectorArgs
+	) => infer SelectorReturnType
+		? ( ...args: SelectorArgs ) => Promise< SelectorReturnType >
+		: never;
+};


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add typings for resolveSelect() based on transforms from select(). These types were previously missing due to low usage of resolveSelect outside of @woocommerce/data, but it looks like with some of our newer developments we might be using it a fair bit.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Dev tooling only, does not have any impact on production builds

1. Repo should still build with no type errors

<!-- End testing instructions -->