### PR TITLE
Fix editor header hidden in Firefox

### DIFF
--- a/packages/js/product-editor/changelog/fix-38242_editor_hidden_in_firefox
+++ b/packages/js/product-editor/changelog/fix-38242_editor_hidden_in_firefox
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Remove css unrelated to the product block editor.

--- a/packages/js/product-editor/src/components/block-editor/style.scss
+++ b/packages/js/product-editor/src/components/block-editor/style.scss
@@ -101,9 +101,3 @@
 		display: none; // use important or increase specificity.
 	}
 }
-
-.woocommerce-layout:has( .woocommerce-product-block-editor ) {
-	.woocommerce-layout__header {
-		display: none;
-	}
-}

--- a/plugins/woocommerce-admin/client/layout/controller.js
+++ b/plugins/woocommerce-admin/client/layout/controller.js
@@ -182,6 +182,9 @@ export const getPages = () => {
 			navArgs: {
 				id: 'woocommerce-add-product',
 			},
+			layout: {
+				header: false,
+			},
 			wpOpenMenu: 'menu-posts-product',
 			capability: 'manage_woocommerce',
 		} );
@@ -195,6 +198,9 @@ export const getPages = () => {
 			],
 			navArgs: {
 				id: 'woocommerce-edit-product',
+			},
+			layout: {
+				header: false,
 			},
 			wpOpenMenu: 'menu-posts-product',
 			capability: 'manage_woocommerce',

--- a/plugins/woocommerce-admin/client/layout/index.js
+++ b/plugins/woocommerce-admin/client/layout/index.js
@@ -185,7 +185,8 @@ function _Layout( {
 		);
 	}
 
-	const { breadcrumbs } = page;
+	const { breadcrumbs, layout = { header: true, footer: true } } = page;
+	const { header: showHeader = true, footer: showFooter = true } = layout;
 
 	const query = Object.fromEntries(
 		new URLSearchParams( location && location.search )
@@ -199,15 +200,17 @@ function _Layout( {
 		>
 			<SlotFillProvider>
 				<div className="woocommerce-layout">
-					<Header
-						sections={
-							isFunction( breadcrumbs )
-								? breadcrumbs( { match } )
-								: breadcrumbs
-						}
-						isEmbedded={ isEmbedded }
-						query={ query }
-					/>
+					{ showHeader && (
+						<Header
+							sections={
+								isFunction( breadcrumbs )
+									? breadcrumbs( { match } )
+									: breadcrumbs
+							}
+							isEmbedded={ isEmbedded }
+							query={ query }
+						/>
+					) }
 					<TransientNotices />
 					{ ! isEmbedded && (
 						<PrimaryLayout>
@@ -226,7 +229,7 @@ function _Layout( {
 							<WCPayUsageModal />
 						</Suspense>
 					) }
-					<Footer />
+					{ showFooter && <Footer /> }
 					<CustomerEffortScoreModalContainer />
 				</div>
 				<PluginArea scope="woocommerce-admin" />
@@ -273,8 +276,11 @@ const Layout = compose(
 			return;
 		}
 
-		const { getActivePlugins, getInstalledPlugins, isJetpackConnected } =
-			select( PLUGINS_STORE_NAME );
+		const {
+			getActivePlugins,
+			getInstalledPlugins,
+			isJetpackConnected,
+		} = select( PLUGINS_STORE_NAME );
 
 		return {
 			activePlugins: getActivePlugins(),

--- a/plugins/woocommerce-admin/client/layout/index.js
+++ b/plugins/woocommerce-admin/client/layout/index.js
@@ -276,11 +276,8 @@ const Layout = compose(
 			return;
 		}
 
-		const {
-			getActivePlugins,
-			getInstalledPlugins,
-			isJetpackConnected,
-		} = select( PLUGINS_STORE_NAME );
+		const { getActivePlugins, getInstalledPlugins, isJetpackConnected } =
+			select( PLUGINS_STORE_NAME );
 
 		return {
 			activePlugins: getActivePlugins(),

--- a/plugins/woocommerce/changelog/fix-38242_editor_hidden_in_firefox
+++ b/plugins/woocommerce/changelog/fix-38242_editor_hidden_in_firefox
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Add support for `showHeader` config in router config to hide header if needed.


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This removes the use of the `has()` css selector (not supported by Firefox), and replaces it with some logic to add a body class when the product block editor is rendered. Then hiding the header if that class is in use.

Closes #38242  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Load this branch and enable the `product-block-editor` feature flag 
2. Load this in Firefox and go to **Products > Add New**
3. The header should load correctly with the product title and save buttons

<!-- End testing instructions -->