### PR TITLE
Product Block Editor: Fix product summary field top margin

### DIFF
--- a/packages/js/product-editor/changelog/fix-product-summary-field-margin
+++ b/packages/js/product-editor/changelog/fix-product-summary-field-margin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix product summary field margin.

--- a/packages/js/product-editor/src/blocks/summary/editor.scss
+++ b/packages/js/product-editor/src/blocks/summary/editor.scss
@@ -1,3 +1,10 @@
+.wp-block-woocommerce-product-summary-field-wrapper {
+	& .wp-block-woocommerce-product-summary-field {
+		margin-top: 0;
+		margin-bottom: 0;
+	}
+}
+
 .components-summary-control {
 	width: 100%;
 	min-height: calc($gap-larger * 3);


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes the product summary field top margin in the block-based product editor.

Incorrect margins have been reported and reproduced with the following setup:

* WordPress 6.2 (built-in Gutenberg, enabled)
* **Theme: Storefront 4.2.0 (does not happen with Twenty Twenty-Tree)**
* WooCommerce: latest trunk
* Browser: Edge, Chrome, Firefox (probably others too)
* No plugins other the WooCommerce Beta Tester (just to enable feature: `product-block-editor`)

The incorrect margins on the `.wp-block-woocommerce-product-summary-field` block in this component are being set by the following rule from `classic.css?ver=6.2`:

```css
html :where(.wp-block) {
    margin-bottom: 28px;
    margin-top: 28px;
    max-width: 840px;
}
```

#### Before

<img width="640" alt="Screenshot 2023-05-11 at 10 54 11" src="https://github.com/woocommerce/woocommerce/assets/2098816/adf45f70-3581-40e6-856e-15bd51a7facf">

#### After

<img width="640" alt="Screenshot 2023-05-11 at 10 52 48" src="https://github.com/woocommerce/woocommerce/assets/2098816/50186d35-0a39-4270-9073-b8a33e79ba26">

Note: Top margin is correct. Bottom margin is correct (unchanged).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Note: Make sure you have **Storefront 4.2.0** set as your theme.

1. Enable the block-based product editor (feature: `product-block-editor`).
2. Go to `Products` > `Add New`
3. Verify the `General` > `Basic details` > `Summary` field's top and bottom margins are correct.

<!-- End testing instructions -->