### PR TITLE
Wait for editor changes to be debounced before closing modal

### DIFF
--- a/packages/js/product-editor/changelog/fix-38020-2
+++ b/packages/js/product-editor/changelog/fix-38020-2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Wait for editor changes to be debounced before closing modal

--- a/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
@@ -30,15 +30,17 @@ import { ResizableEditor } from './resizable-editor';
 
 type IframeEditorProps = {
 	initialBlocks?: BlockInstance[];
-	onChange: ( blocks: BlockInstance[] ) => void;
+	onChange?: ( blocks: BlockInstance[] ) => void;
 	onClose?: () => void;
+	onInput?: ( blocks: BlockInstance[] ) => void;
 	settings?: Partial< EditorSettings & EditorBlockListSettings > | undefined;
 };
 
 export function IframeEditor( {
 	initialBlocks = [],
-	onChange,
+	onChange = () => {},
 	onClose,
+	onInput,
 	settings: __settings,
 }: IframeEditorProps ) {
 	const [ resizeObserver, sizes ] = useResizeObserver();
@@ -76,6 +78,7 @@ export function IframeEditor( {
 					setBlocks( updatedBlocks );
 					onChange( updatedBlocks );
 				} }
+				onInput={ onInput }
 				useSubRegistry={ true }
 			>
 				<BlockTools

--- a/packages/js/product-editor/src/components/modal-editor/modal-editor.tsx
+++ b/packages/js/product-editor/src/components/modal-editor/modal-editor.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { BlockInstance } from '@wordpress/blocks';
-import { createElement, useEffect, useRef, useState } from '@wordpress/element';
+import { createElement } from '@wordpress/element';
 import {
 	EditorSettings,
 	EditorBlockListSettings,
@@ -29,28 +29,16 @@ export function ModalEditor( {
 	onClose,
 	title,
 }: ModalEditorProps ) {
-	const [ isDebouncing, setIsDebouncing ] = useState( false );
-	const [ isClosing, setIsClosing ] = useState( false );
-
-	useEffect( () => {
-		// Only close the modal once editor changes have persisted after debouncing.
-		if ( isClosing && ! isDebouncing ) {
-			onClose();
-		}
-	}, [ isDebouncing, isClosing, onClose ] );
-
 	const debouncedOnChange = useDebounce( ( blocks: BlockInstance[] ) => {
 		onChange( blocks );
-		setIsDebouncing( false );
 	}, 250 );
 
-	function handleInput( blocks: BlockInstance[] ) {
-		setIsDebouncing( true );
-		debouncedOnChange( blocks );
-	}
-
 	function handleClose() {
-		setIsClosing( true );
+		const blocks = debouncedOnChange.flush();
+		if ( blocks ) {
+			onChange( blocks );
+		}
+		onClose();
 	}
 
 	return (
@@ -62,7 +50,8 @@ export function ModalEditor( {
 		>
 			<IframeEditor
 				initialBlocks={ initialBlocks }
-				onInput={ handleInput }
+				onInput={ debouncedOnChange }
+				onChange={ debouncedOnChange }
 			/>
 		</Modal>
 	);


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Making changes within the modal editor and quickly closing the editor previously would result in some of the changes being missed.

This PR capture the changes immediately, debounces on the onchange handler, and only closes the modal once the debouncing is complete.

<img width="519" alt="Screen Shot 2023-05-11 at 12 16 05 PM" src="https://github.com/woocommerce/woocommerce/assets/10561050/75c28f9b-894a-43bf-ab5f-ee6ce6dc5295">


Closes #38020  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Navigate to Tools -> WCA Test Helper -> Features and enable the new product blocks editing experience
2. Navigate to Products -> Add new
3. Click on the "Add description" button
4. Make changes within the editor and quickly close the modal
5. Note that all changes are reflected in the preview (or reopen the modal to confirm)
6. Open and close the editor without changes to make sure it closes without issue

<!-- End testing instructions -->