### PR TITLE
Add @woocommerce/create-product-editor-block package

### DIFF
--- a/packages/js/create-product-editor-block/README.md
+++ b/packages/js/create-product-editor-block/README.md
@@ -6,6 +6,8 @@ Create Product Editor Block scaffolds a fully functional modern development envi
 
 You can use the built-in [wp-env](https://github.com/WordPress/gutenberg/tree/trunk/packages/env) support to easily get a local WordPress environment up and running. It is configured to load the latest released version of WordPress, the latest WooCommerce nightly build and the latest version of the [WooCommerce Beta Tester](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce-beta-tester).
 
+If you want to change which version of WordPress and WooCommerce are used, you can do so by modifying the `.wp-env.override.json` file.
+
 Tooling support for linting, code formatting, and compilation are configured by default.
 
 If you already have a local WordPress development environment configured, you can map the generated project folder under your `plugins` folder.

--- a/packages/js/create-product-editor-block/README.md
+++ b/packages/js/create-product-editor-block/README.md
@@ -15,7 +15,7 @@ If you already have a local WordPress development environment configured, you ca
 ### Generate project folder
 
 ```
-npx @wordpress/create-block -t @woocommerce/create-product-editor-block my-extension-name
+npx @wordpress/create-block --template @woocommerce/create-product-editor-block my-extension-name
 ```
 
 ### Get started developing
@@ -43,7 +43,7 @@ npm run build # Build the javascript
 For development of this tool itself, you can also point to a local directory when creating a product editor block:
 
 ```bash
-npx @wordpress/create-block -t ./path/to/woocommerce/packages/js/create-product-editor-block my-extension-name
+npx @wordpress/create-block --template ./path/to/woocommerce/packages/js/create-product-editor-block my-extension-name
 ```
 
 This tool is a template to be used with [`@wordpress/create-block`](https://github.com/WordPress/gutenberg/tree/trunk/packages/create-block) to create a WooCommerce Product Editor Block starting point.

--- a/packages/js/create-product-editor-block/README.md
+++ b/packages/js/create-product-editor-block/README.md
@@ -1,0 +1,49 @@
+# @woocommerce/create-product-editor-block
+
+Create Product Editor Block scaffolds a fully functional modern development environment for developing block-based extensions to the new block-based product editor in WooCommerce.
+
+## Default tooling
+
+You can use the built-in [wp-env](https://github.com/WordPress/gutenberg/tree/trunk/packages/env) support to easily get a local WordPress environment up and running. It is configured to load the latest released version of WordPress, the latest WooCommerce nightly build and the latest version of the [WooCommerce Beta Tester](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce-beta-tester).
+
+Tooling support for linting, code formatting, and compilation are configured by default.
+
+If you already have a local WordPress development environment configured, you can map the generated project folder under your `plugins` folder.
+
+## Usage
+
+### Generate project folder
+
+```
+npx @wordpress/create-block -t @woocommerce/create-product-editor-block my-extension-name
+```
+
+### Get started developing
+
+
+```bash
+cd my-extension-name
+npx wp-env start # Start Wordpress environment
+```
+
+By default, the `wp-env` environment created will have the new block-based product editor enabled. You can disable this by using the WooCommerce Beta Tester (disable the `product-block-editor` feature).
+
+Navigate to http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fadd-product to check out your new block!
+
+### Make changes and re-build your block
+
+```bash
+cd my-extension-name
+npm install # Install dependencies
+npm run build # Build the javascript
+```
+
+## Development of this tool
+
+For development of this tool itself, you can also point to a local directory when creating a product editor block:
+
+```bash
+npx @wordpress/create-block -t ./path/to/woocommerce/packages/js/create-product-editor-block my-extension-name
+```
+
+This tool is a template to be used with [`@wordpress/create-block`](https://github.com/WordPress/gutenberg/tree/trunk/packages/create-block) to create a WooCommerce Product Editor Block starting point.

--- a/packages/js/create-product-editor-block/block-templates/edit.tsx.mustache
+++ b/packages/js/create-product-editor-block/block-templates/edit.tsx.mustache
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import type { BlockAttributes } from '@wordpress/blocks';
+import { useBlockProps } from '@wordpress/block-editor';
+import { createElement } from '@wordpress/element';
+
+/**
+ * The edit function describes the structure of your block in the context of the
+ * editor. This represents what the editor will render when the block is used.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#edit
+ *
+ */
+export function Edit( { attributes }: { attributes: BlockAttributes } ) {
+	/**
+	 * React hook that is used to mark the block wrapper element.
+	 * It provides all the necessary props like the class name.
+	 *
+	 * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-block-editor/#useblockprops
+	 */
+	const blockProps = useBlockProps();
+	return <div { ...blockProps }>{ attributes.message }</div>;
+}

--- a/packages/js/create-product-editor-block/block-templates/editor.scss.mustache
+++ b/packages/js/create-product-editor-block/block-templates/editor.scss.mustache
@@ -1,0 +1,12 @@
+/**
+ * The following styles get applied inside the editor only.
+ *
+ * Replace them with your own styles or remove the file completely.
+ */
+
+.wp-block-{{namespace}}-{{slug}} {
+	font-size: 32px;
+	padding: 25px;
+	background: yellow;
+	border: 1px solid black;
+}

--- a/packages/js/create-product-editor-block/block-templates/index.ts.mustache
+++ b/packages/js/create-product-editor-block/block-templates/index.ts.mustache
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { BlockConfiguration, registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import './editor.scss'; // see https://www.npmjs.com/package/@wordpress/scripts#using-css
+
+/**
+ * Internal dependencies
+ */
+import { Edit } from './edit';
+import metadata from './block.json';
+
+/**
+ * Every block starts by registering a new block type definition.
+ *
+ * @see https://developer.wordpress.org/block-editor/developers/block-api/#registering-a-block
+ */
+registerBlockType( metadata as BlockConfiguration, {
+	/**
+	 * Used to construct a preview for the block to be shown in the block inserter.
+	 */
+	example: {
+		attributes: {
+			message: '{{title}}',
+		},
+	},
+	/**
+	 * @see ./edit.js
+	 */
+	edit: Edit,
+} );

--- a/packages/js/create-product-editor-block/block-templates/index.ts.mustache
+++ b/packages/js/create-product-editor-block/block-templates/index.ts.mustache
@@ -21,14 +21,6 @@ import metadata from './block.json';
  */
 registerBlockType( metadata as BlockConfiguration, {
 	/**
-	 * Used to construct a preview for the block to be shown in the block inserter.
-	 */
-	example: {
-		attributes: {
-			message: '{{title}}',
-		},
-	},
-	/**
 	 * @see ./edit.js
 	 */
 	edit: Edit,

--- a/packages/js/create-product-editor-block/changelog/add-create-product-editor-block
+++ b/packages/js/create-product-editor-block/changelog/add-create-product-editor-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Initial version of @woocommerce/create-product-editor-block

--- a/packages/js/create-product-editor-block/composer.json
+++ b/packages/js/create-product-editor-block/composer.json
@@ -1,0 +1,32 @@
+{
+	"name": "woocommerce/extend-cart-checkout-block",
+	"description": "A template to be used with `@wordpress/create-block` to create a WooCommerce extension.",
+	"type": "library",
+	"license": "GPL-3.0-or-later",
+	"minimum-stability": "dev",
+	"require-dev": {
+		"automattic/jetpack-changelogger": "3.3.0"
+	},
+	"config": {
+		"platform": {
+			"php": "7.2"
+		}
+	},
+	"extra": {
+		"changelogger": {
+			"formatter": {
+				"filename": "../../../tools/changelogger/class-package-formatter.php"
+			},
+			"types": {
+				"fix": "Fixes an existing bug",
+				"add": "Adds functionality",
+				"update": "Update existing functionality",
+				"dev": "Development related task",
+				"tweak": "A minor adjustment to the codebase",
+				"performance": "Address performance issues",
+				"enhancement": "Improve existing functionality"
+			},
+			"changelog": "CHANGELOG.md"
+		}
+	}
+}

--- a/packages/js/create-product-editor-block/composer.lock
+++ b/packages/js/create-product-editor-block/composer.lock
@@ -1,0 +1,483 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "e22045358357e9c229d188944b337d8f",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "automattic/jetpack-changelogger",
+            "version": "v3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-changelogger.git",
+                "reference": "8f63c829b8d1b0d7b1d5de93510d78523ed18959"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-changelogger/zipball/8f63c829b8d1b0d7b1d5de93510d78523ed18959",
+                "reference": "8f63c829b8d1b0d7b1d5de93510d78523ed18959",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "symfony/console": "^3.4 || ^5.2 || ^6.0",
+                "symfony/process": "^3.4 || ^5.2 || ^6.0",
+                "wikimedia/at-ease": "^1.2 || ^2.0"
+            },
+            "require-dev": {
+                "wikimedia/testing-access-wrapper": "^1.0 || ^2.0",
+                "yoast/phpunit-polyfills": "1.0.4"
+            },
+            "bin": [
+                "bin/changelogger"
+            ],
+            "type": "project",
+            "extra": {
+                "autotagger": true,
+                "branch-alias": {
+                    "dev-trunk": "3.3.x-dev"
+                },
+                "mirror-repo": "Automattic/jetpack-changelogger",
+                "version-constants": {
+                    "::VERSION": "src/Application.php"
+                },
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-changelogger/compare/${old}...${new}"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Automattic\\Jetpack\\Changelog\\": "lib",
+                    "Automattic\\Jetpack\\Changelogger\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Jetpack Changelogger tool. Allows for managing changelogs by dropping change files into a changelog directory with each PR.",
+            "support": {
+                "source": "https://github.com/Automattic/jetpack-changelogger/tree/v3.3.0"
+            },
+            "time": "2022-12-26T13:49:01+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/1.1.4"
+            },
+            "time": "2021-05-03T11:20:27+00:00"
+        },
+        {
+            "name": "symfony/console",
+            "version": "3.4.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "a10b1da6fc93080c180bba7219b5ff5b7518fe81"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/a10b1da6fc93080c180bba7219b5ff5b7518fe81",
+                "reference": "a10b1da6fc93080c180bba7219b5ff5b7518fe81",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8",
+                "symfony/debug": "~2.8|~3.0|~4.0",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<3.4",
+                "symfony/process": "<3.3"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~3.3|~4.0",
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/event-dispatcher": "~2.8|~3.0|~4.0",
+                "symfony/lock": "~3.4|~4.0",
+                "symfony/process": "~3.3|~4.0"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/lock": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Console Component",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/console/tree/3.4"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-24T10:57:07+00:00"
+        },
+        {
+            "name": "symfony/debug",
+            "version": "4.4.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/debug.git",
+                "reference": "1a692492190773c5310bc7877cb590c04c2f05be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/1a692492190773c5310bc7877cb590c04c2f05be",
+                "reference": "1a692492190773c5310bc7877cb590c04c2f05be",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.3",
+                "psr/log": "^1|^2|^3"
+            },
+            "conflict": {
+                "symfony/http-kernel": "<3.4"
+            },
+            "require-dev": {
+                "symfony/http-kernel": "^3.4|^4.0|^5.0"
+            },
+            "default-branch": true,
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Debug\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools to ease debugging PHP code",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/debug/tree/v4.4.44"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "abandoned": "symfony/error-handler",
+            "time": "2022-07-28T16:29:46+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "dev-main",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "f9c7affe77a00ae32ca127ca6833d034e6d33f25"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/f9c7affe77a00ae32ca127ca6833d034e6d33f25",
+                "reference": "f9c7affe77a00ae32ca127ca6833d034e6d33f25",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "default-branch": true,
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.28-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/main"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-01-30T17:25:47+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "3.4.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "b8648cf1d5af12a44a51d07ef9bf980921f15fca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/b8648cf1d5af12a44a51d07ef9bf980921f15fca",
+                "reference": "b8648cf1d5af12a44a51d07ef9bf980921f15fca",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Process Component",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/process/tree/3.4"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-24T10:57:07+00:00"
+        },
+        {
+            "name": "wikimedia/at-ease",
+            "version": "v2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wikimedia/at-ease.git",
+                "reference": "013ac61929797839c80a111a3f1a4710d8248e7a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wikimedia/at-ease/zipball/013ac61929797839c80a111a3f1a4710d8248e7a",
+                "reference": "013ac61929797839c80a111a3f1a4710d8248e7a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.99"
+            },
+            "require-dev": {
+                "jakub-onderka/php-console-highlighter": "0.3.2",
+                "jakub-onderka/php-parallel-lint": "1.0.0",
+                "mediawiki/mediawiki-codesniffer": "22.0.0",
+                "mediawiki/minus-x": "0.3.1",
+                "ockcyp/covers-validator": "0.5.1 || 0.6.1",
+                "phpunit/phpunit": "4.8.36 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/Wikimedia/Functions.php"
+                ],
+                "psr-4": {
+                    "Wikimedia\\AtEase\\": "src/Wikimedia/AtEase/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Tim Starling",
+                    "email": "tstarling@wikimedia.org"
+                },
+                {
+                    "name": "MediaWiki developers",
+                    "email": "wikitech-l@lists.wikimedia.org"
+                }
+            ],
+            "description": "Safe replacement to @ for suppressing warnings.",
+            "homepage": "https://www.mediawiki.org/wiki/at-ease",
+            "support": {
+                "source": "https://github.com/wikimedia/at-ease/tree/master"
+            },
+            "time": "2018-10-10T15:39:06+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "dev",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "7.2"
+    },
+    "plugin-api-version": "2.3.0"
+}

--- a/packages/js/create-product-editor-block/index.js
+++ b/packages/js/create-product-editor-block/index.js
@@ -30,6 +30,7 @@ module.exports = {
 			'@woocommerce/dependency-extraction-webpack-plugin',
 			'@woocommerce/eslint-plugin',
 			'@wordpress/prettier-config',
+			'@wordpress/stylelint-config',
 			'eslint-import-resolver-typescript',
 		],
 		customScripts: {

--- a/packages/js/create-product-editor-block/index.js
+++ b/packages/js/create-product-editor-block/index.js
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+const { join } = require( 'path' );
+
+module.exports = {
+	defaultValues: {
+		namespace: 'extension',
+		slug: 'example-product-editor-block',
+		version: '0.1.0',
+		category: 'widgets',
+		title: 'Example Product Editor Block',
+		description: 'A block to demonstrate extending the Product Editor',
+		dashicon: 'flag',
+		license: 'GPL-3.0+',
+		attributes: {
+			message: {
+				type: 'string',
+				source: 'text',
+				selector: 'div',
+			},
+		},
+		supports: {
+			html: false,
+			inserter: false,
+		},
+		npmDevDependencies: [
+			'@types/wordpress__block-editor@^7.0.0',
+			'@types/wordpress__blocks@^11.0.9',
+			'@woocommerce/dependency-extraction-webpack-plugin',
+			'@woocommerce/eslint-plugin',
+			'@wordpress/prettier-config',
+			'eslint-import-resolver-typescript',
+		],
+		customScripts: {
+			postinstall: 'composer install',
+		},
+		wpScripts: true,
+		wpEnv: true,
+		editorScript: 'file:./index.js',
+		editorStyle: 'file:./index.css',
+		style: 'file:./index.css',
+		customBlockJSON: {
+			script: 'file:./index.js',
+		},
+	},
+	pluginTemplatesPath: join( __dirname, 'plugin-templates' ),
+	blockTemplatesPath: join( __dirname, 'block-templates' ),
+};

--- a/packages/js/create-product-editor-block/package.json
+++ b/packages/js/create-product-editor-block/package.json
@@ -1,0 +1,25 @@
+{
+	"name": "@woocommerce/create-product-editor-block",
+	"version": "0.0.1",
+	"description": "A template to be used with `@wordpress/create-block` to create a Product Editor block.",
+	"main": "index.js",
+	"engines": {
+		"node": "^16.14.1",
+		"pnpm": "^8.3.1"
+	},
+	"scripts": {
+		"postinstall": "composer install",
+		"changelog": "composer exec -- changelogger"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/woocommerce/woocommerce.git"
+	},
+	"keywords": [],
+	"author": "",
+	"license": "GPL-3.0+",
+	"bugs": {
+		"url": "https://github.com/woocommerce/woocommerce/issues"
+	},
+	"homepage": "https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/create-product-editor-block-extensionv#readme"
+}

--- a/packages/js/create-product-editor-block/plugin-templates/$slug.php.mustache
+++ b/packages/js/create-product-editor-block/plugin-templates/$slug.php.mustache
@@ -1,33 +1,34 @@
 <?php
 /**
- * Plugin Name:       {{title}}
+ * Plugin Name:          {{title}}
 {{#pluginURI}}
- * Plugin URI:        {{{pluginURI}}}
+ * Plugin URI:           {{{pluginURI}}}
 {{/pluginURI}}
 {{#description}}
- * Description:       {{description}}
+ * Description:          {{description}}
 {{/description}}
- * Version:           {{version}}
- * Requires at least: 6.2
- * Requires PHP:      7.3
+ * Version:              {{version}}
+ * Requires at least:    6.2
+ * WC requires at least: 7.8
+ * Requires PHP:         7.3
 {{#author}}
- * Author:            {{author}}
+ * Author:               {{author}}
 {{/author}}
 {{#license}}
- * License:           {{license}}
+ * License:              {{license}}
 {{/license}}
 {{#licenseURI}}
- * License URI:       {{{licenseURI}}}
+ * License URI:          {{{licenseURI}}}
 {{/licenseURI}}
- * Text Domain:       {{textdomain}}
+ * Text Domain:          {{textdomain}}
 {{#domainPath}}
- * Domain Path:       {{{domainPath}}}
+ * Domain Path:          {{{domainPath}}}
 {{/domainPath}}
 {{#updateURI}}
- * Update URI:        {{{updateURI}}}
+ * Update URI:           {{{updateURI}}}
 {{/updateURI}}
  *
- * @package           {{namespace}}
+ * @package              {{namespace}}
  */
 
 /**

--- a/packages/js/create-product-editor-block/plugin-templates/$slug.php.mustache
+++ b/packages/js/create-product-editor-block/plugin-templates/$slug.php.mustache
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Plugin Name:       {{title}}
+{{#pluginURI}}
+ * Plugin URI:        {{{pluginURI}}}
+{{/pluginURI}}
+{{#description}}
+ * Description:       {{description}}
+{{/description}}
+ * Version:           {{version}}
+ * Requires at least: 6.1
+ * Requires PHP:      7.0
+{{#author}}
+ * Author:            {{author}}
+{{/author}}
+{{#license}}
+ * License:           {{license}}
+{{/license}}
+{{#licenseURI}}
+ * License URI:       {{{licenseURI}}}
+{{/licenseURI}}
+ * Text Domain:       {{textdomain}}
+{{#domainPath}}
+ * Domain Path:       {{{domainPath}}}
+{{/domainPath}}
+{{#updateURI}}
+ * Update URI:        {{{updateURI}}}
+{{/updateURI}}
+ *
+ * @package           {{namespace}}
+ */
+
+/**
+ * Registers the block using the metadata loaded from the `block.json` file.
+ * Behind the scenes, it registers also all assets so they can be enqueued
+ * through the block editor in the corresponding context.
+ *
+ * @see https://developer.wordpress.org/reference/functions/register_block_type/
+ */
+function {{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init() {
+	register_block_type( __DIR__ . '/build' );
+}
+add_action( 'init', '{{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init' );
+
+function {{namespaceSnakeCase}}_{{slugSnakeCase}}_add_block_to_product_editor( $args ) {
+	$template = $args['template'];
+
+	// find the 'Basic details' section and add our block to the end of it
+	foreach ( $template as $tab_index => $tab ) {
+		$tab_properties = $tab[1];
+
+		if ( 'general' === $tab_properties['id'] ) {
+			$tab_sections = $tab[2];
+
+			foreach ( $tab_sections as $section_index => $section ) {
+				$section_properties = $section[1];
+
+				// TODO: this is not the right way to do this, since it is checking a localized string.
+				if ( 'Basic details' === $section_properties['title'] ) {
+					$section_fields = $section[2];
+
+					// add our block to the end of the section
+					$section_fields[] = [
+						'{{namespace}}/{{slug}}',
+						[
+							'message' => '{{title}}',
+						]
+					];
+
+					// update the template with our new block
+					$args[ 'template' ][ $tab_index ][2][ $section_index ][2] = $section_fields;
+
+					break;
+				}
+			}
+
+			break;
+		}
+	}
+
+	return $args;
+}
+add_filter( 'woocommerce_register_post_type_product', '{{namespaceSnakeCase}}_{{slugSnakeCase}}_add_block_to_product_editor' );

--- a/packages/js/create-product-editor-block/plugin-templates/$slug.php.mustache
+++ b/packages/js/create-product-editor-block/plugin-templates/$slug.php.mustache
@@ -38,7 +38,27 @@
  * @see https://developer.wordpress.org/reference/functions/register_block_type/
  */
 function {{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init() {
-	register_block_type( __DIR__ . '/build' );
+	if ( isset( $_GET['page'] ) && $_GET['page'] === 'wc-admin' ) {
+		// WordPress 6.2 and earlier needs this to be called;
+		// WordPress 6.3 and later does not need this to be called
+		register_block_type( __DIR__ . '/build' );
+
+		// WordPress 6.3 and later needs these to be called;
+		// WordPress 6.2 and earlier does not need these to be called
+		wp_enqueue_script(
+			'{{namespace}}-{{slug}}',
+			plugins_url( 'build/index.js', __FILE__ ),
+			[  'wp-blocks', 'wp-element', 'wp-block-editor' ],
+			filemtime( plugin_dir_path( __FILE__ ) . 'build/index.js' )
+		);
+
+		wp_enqueue_style(
+			'{{namespace}}-{{slug}}',
+			plugins_url( 'build/index.css', __FILE__ ),
+			[],
+			filemtime( plugin_dir_path( __FILE__ ) . 'build/index.css' )
+		);
+	}
 }
 add_action( 'init', '{{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init' );
 

--- a/packages/js/create-product-editor-block/plugin-templates/$slug.php.mustache
+++ b/packages/js/create-product-editor-block/plugin-templates/$slug.php.mustache
@@ -80,4 +80,4 @@ function {{namespaceSnakeCase}}_{{slugSnakeCase}}_add_block_to_product_editor( $
 
 	return $args;
 }
-add_filter( 'woocommerce_register_post_type_product', '{{namespaceSnakeCase}}_{{slugSnakeCase}}_add_block_to_product_editor' );
+add_filter( 'woocommerce_register_post_type_product', '{{namespaceSnakeCase}}_{{slugSnakeCase}}_add_block_to_product_editor', 100 );

--- a/packages/js/create-product-editor-block/plugin-templates/$slug.php.mustache
+++ b/packages/js/create-product-editor-block/plugin-templates/$slug.php.mustache
@@ -8,8 +8,8 @@
  * Description:       {{description}}
 {{/description}}
  * Version:           {{version}}
- * Requires at least: 6.1
- * Requires PHP:      7.0
+ * Requires at least: 6.2
+ * Requires PHP:      7.3
 {{#author}}
  * Author:            {{author}}
 {{/author}}

--- a/packages/js/create-product-editor-block/plugin-templates/$slug.php.mustache
+++ b/packages/js/create-product-editor-block/plugin-templates/$slug.php.mustache
@@ -46,6 +46,17 @@ function {{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init() {
 add_action( 'init', '{{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init' );
 
 function {{namespaceSnakeCase}}_{{slugSnakeCase}}_add_block_to_product_editor( $args ) {
+	// if the product block editor is not enabled, return the args as-is
+	if ( ! class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) ||
+			! \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_block_editor' ) ) {
+		return $args;
+	}
+
+	// if the template is not set or is not an array, return the args as-is
+	if ( ! isset( $args['template'] ) || ! is_array( $args['template'] ) ) {
+		return $args;
+	}
+
 	$template = $args['template'];
 
 	// find the 'Basic details' section and add our block to the end of it

--- a/packages/js/create-product-editor-block/plugin-templates/$slug.php.mustache
+++ b/packages/js/create-product-editor-block/plugin-templates/$slug.php.mustache
@@ -39,25 +39,7 @@
  */
 function {{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init() {
 	if ( isset( $_GET['page'] ) && $_GET['page'] === 'wc-admin' ) {
-		// WordPress 6.2 and earlier needs this to be called;
-		// WordPress 6.3 and later does not need this to be called
 		register_block_type( __DIR__ . '/build' );
-
-		// WordPress 6.3 and later needs these to be called;
-		// WordPress 6.2 and earlier does not need these to be called
-		wp_enqueue_script(
-			'{{namespace}}-{{slug}}',
-			plugins_url( 'build/index.js', __FILE__ ),
-			[  'wp-blocks', 'wp-element', 'wp-block-editor' ],
-			filemtime( plugin_dir_path( __FILE__ ) . 'build/index.js' )
-		);
-
-		wp_enqueue_style(
-			'{{namespace}}-{{slug}}',
-			plugins_url( 'build/index.css', __FILE__ ),
-			[],
-			filemtime( plugin_dir_path( __FILE__ ) . 'build/index.css' )
-		);
 	}
 }
 add_action( 'init', '{{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init' );

--- a/packages/js/create-product-editor-block/plugin-templates/.editorconfig.mustache
+++ b/packages/js/create-product-editor-block/plugin-templates/.editorconfig.mustache
@@ -1,0 +1,27 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+# WordPress Coding Standards
+# https://make.wordpress.org/core/handbook/coding-standards/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+tab_width = 4
+indent_style = tab
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.txt]
+trim_trailing_whitespace = false
+
+[*.{md,json,yml}]
+trim_trailing_whitespace = false
+indent_style = space
+indent_size = 2
+
+[*.json]
+indent_style = tab

--- a/packages/js/create-product-editor-block/plugin-templates/.eslintrc.js.mustache
+++ b/packages/js/create-product-editor-block/plugin-templates/.eslintrc.js.mustache
@@ -1,0 +1,6 @@
+module.exports = {
+	extends: [ 'plugin:@woocommerce/eslint-plugin/recommended' ],
+	rules: {
+		'react/react-in-jsx-scope': 'off',
+	},
+};

--- a/packages/js/create-product-editor-block/plugin-templates/.gitignore.mustache
+++ b/packages/js/create-product-editor-block/plugin-templates/.gitignore.mustache
@@ -1,0 +1,62 @@
+
+# Operating System files
+.DS_Store
+Thumbs.db
+
+# IDE files
+.idea
+.vscode/*
+project.xml
+project.properties
+.project
+.settings*
+*.sublime-project
+*.sublime-workspace
+.sublimelinterrc
+
+# Sass
+.sass-cache/
+
+# Logs
+logs/
+
+# Environment files
+wp-cli.local.yml
+yarn-error.log
+npm-debug.log
+.pnpm-debug.log
+
+# Build files
+*.sql
+*.swp
+*.zip
+
+# Built packages
+build/
+build-module/
+build-style/
+build-types/
+dist/
+
+# Project files
+node_modules/
+vendor/
+
+# TypeScript files
+tsconfig.tsbuildinfo
+
+# Node Package Dependencies
+package-lock.json
+
+# wp-env config
+.wp-env.override.json
+
+# Unit tests
+tmp/
+
+# Composer
+vendor/
+bin/composer/**/vendor/
+lib/vendor/
+contributors.md
+contributors.html

--- a/packages/js/create-product-editor-block/plugin-templates/.prettierrc.json.mustache
+++ b/packages/js/create-product-editor-block/plugin-templates/.prettierrc.json.mustache
@@ -1,0 +1,1 @@
+"@wordpress/prettier-config"

--- a/packages/js/create-product-editor-block/plugin-templates/.stylelintrc.mustache
+++ b/packages/js/create-product-editor-block/plugin-templates/.stylelintrc.mustache
@@ -1,0 +1,3 @@
+{
+	"extends": "@wordpress/stylelint-config"
+}

--- a/packages/js/create-product-editor-block/plugin-templates/.wp-env.json.mustache
+++ b/packages/js/create-product-editor-block/plugin-templates/.wp-env.json.mustache
@@ -1,0 +1,13 @@
+{
+	"phpVersion": null,
+	"core": null,
+	"plugins": [
+		"https://downloads.wordpress.org/plugin/woocommerce.7.7.0.zip",
+		"."
+	],
+	"config": {
+		"JETPACK_AUTOLOAD_DEV": true,
+		"WP_DEBUG": true,
+		"SCRIPT_DEBUG": true
+	}
+}

--- a/packages/js/create-product-editor-block/plugin-templates/.wp-env.override.json.mustache
+++ b/packages/js/create-product-editor-block/plugin-templates/.wp-env.override.json.mustache
@@ -14,5 +14,5 @@
 		"SCRIPT_DEBUG": true,
 		"ALTERNATE_WP_CRON": true,
 	},
-	"afterSetup": "npx wp-env run cli \"wp option update wc_admin_helper_feature_values '{\\\"product-block-editor\\\": true}' --format=json\""
+	"afterSetup": "npx wp-env run cli \"wp option update woocommerce_feature_product_block_editor_enabled 'yes'\""
 }

--- a/packages/js/create-product-editor-block/plugin-templates/.wp-env.override.json.mustache
+++ b/packages/js/create-product-editor-block/plugin-templates/.wp-env.override.json.mustache
@@ -14,5 +14,7 @@
 		"SCRIPT_DEBUG": true,
 		"ALTERNATE_WP_CRON": true,
 	},
-	"afterSetup": "npx wp-env run cli \"wp option update woocommerce_feature_product_block_editor_enabled 'yes'\""
+	"lifecycleScripts": {
+		"afterStart": "npx wp-env run cli wp option update woocommerce_feature_product_block_editor_enabled 'yes'"
+	}
 }

--- a/packages/js/create-product-editor-block/plugin-templates/.wp-env.override.json.mustache
+++ b/packages/js/create-product-editor-block/plugin-templates/.wp-env.override.json.mustache
@@ -13,5 +13,6 @@
 		"WP_DEBUG_DISPLAY": false,
 		"SCRIPT_DEBUG": true,
 		"ALTERNATE_WP_CRON": true,
-	}
+	},
+	"afterSetup": "wp-env run cli \"wp option update wc_admin_helper_feature_values '{\\\"product-block-editor\\\": true}' --format=json\""
 }

--- a/packages/js/create-product-editor-block/plugin-templates/.wp-env.override.json.mustache
+++ b/packages/js/create-product-editor-block/plugin-templates/.wp-env.override.json.mustache
@@ -14,5 +14,5 @@
 		"SCRIPT_DEBUG": true,
 		"ALTERNATE_WP_CRON": true,
 	},
-	"afterSetup": "wp-env run cli \"wp option update wc_admin_helper_feature_values '{\\\"product-block-editor\\\": true}' --format=json\""
+	"afterSetup": "npx wp-env run cli \"wp option update wc_admin_helper_feature_values '{\\\"product-block-editor\\\": true}' --format=json\""
 }

--- a/packages/js/create-product-editor-block/plugin-templates/.wp-env.override.json.mustache
+++ b/packages/js/create-product-editor-block/plugin-templates/.wp-env.override.json.mustache
@@ -1,6 +1,6 @@
 {
 	"phpVersion": "8.2",
-	"core": "https://wordpress.org/wordpress-6.2.zip",
+	"core": "https://wordpress.org/wordpress-6.2.1.zip",
 	"plugins": [
 		"https://github.com/woocommerce/woocommerce/releases/download/nightly/woocommerce-trunk-nightly.zip",
 		"https://github.com/woocommerce/woocommerce/releases/download/wc-beta-tester-2.3.0/woocommerce-beta-tester.zip",

--- a/packages/js/create-product-editor-block/plugin-templates/.wp-env.override.json.mustache
+++ b/packages/js/create-product-editor-block/plugin-templates/.wp-env.override.json.mustache
@@ -1,8 +1,7 @@
 {
-	"phpVersion": null,
-	"core": null,
 	"plugins": [
 		"https://downloads.wordpress.org/plugin/woocommerce.7.7.0.zip",
+		"https://downloads.wordpress.org/plugin/woocommerce-beta-tester.2.1.0.zip",
 		"."
 	],
 	"config": {

--- a/packages/js/create-product-editor-block/plugin-templates/.wp-env.override.json.mustache
+++ b/packages/js/create-product-editor-block/plugin-templates/.wp-env.override.json.mustache
@@ -1,12 +1,17 @@
 {
+	"phpVersion": "8.2",
+	"core": "https://wordpress.org/wordpress-6.2.zip",
 	"plugins": [
-		"https://downloads.wordpress.org/plugin/woocommerce.7.7.0.zip",
-		"https://downloads.wordpress.org/plugin/woocommerce-beta-tester.2.1.0.zip",
+		"https://github.com/woocommerce/woocommerce/releases/download/nightly/woocommerce-trunk-nightly.zip",
+		"https://github.com/woocommerce/woocommerce/releases/download/wc-beta-tester-2.3.0/woocommerce-beta-tester.zip",
 		"."
 	],
 	"config": {
 		"JETPACK_AUTOLOAD_DEV": true,
 		"WP_DEBUG": true,
-		"SCRIPT_DEBUG": true
+		"WP_DEBUG_LOG": true,
+		"WP_DEBUG_DISPLAY": false,
+		"SCRIPT_DEBUG": true,
+		"ALTERNATE_WP_CRON": true,
 	}
 }

--- a/packages/js/create-product-editor-block/plugin-templates/README.md.mustache
+++ b/packages/js/create-product-editor-block/plugin-templates/README.md.mustache
@@ -1,0 +1,19 @@
+# {{title}}
+
+A Product Editor Block inspired by [Create Product Editor Block](https://github.com/woocommerce/woocommerce/blob/trunk/packages/js/create-product-editor-block/README.md).
+
+## Getting Started
+
+### Prerequisites
+
+-   [NPM](https://www.npmjs.com/)
+-   [Composer](https://getcomposer.org/download/)
+-   [wp-env](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/)
+
+### Installation and Build
+
+```
+npm install
+npm run build
+wp-env start
+```

--- a/packages/js/create-product-editor-block/plugin-templates/README.md.mustache
+++ b/packages/js/create-product-editor-block/plugin-templates/README.md.mustache
@@ -15,5 +15,5 @@ A Product Editor Block inspired by [Create Product Editor Block](https://github.
 ```
 npm install
 npm run build
-wp-env start
+npx wp-env start
 ```

--- a/packages/js/create-product-editor-block/plugin-templates/README.md.mustache
+++ b/packages/js/create-product-editor-block/plugin-templates/README.md.mustache
@@ -1,6 +1,6 @@
 # {{title}}
 
-A Product Editor Block inspired by [Create Product Editor Block](https://github.com/woocommerce/woocommerce/blob/trunk/packages/js/create-product-editor-block/README.md).
+A WooCommerce Product Editor Block inspired by [Create Product Editor Block](https://github.com/woocommerce/woocommerce/blob/trunk/packages/js/create-product-editor-block/README.md).
 
 ## Getting Started
 
@@ -17,3 +17,5 @@ npm install
 npm run build
 npx wp-env start
 ```
+
+Visit the Add New Product page at http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fadd-product.

--- a/packages/js/create-product-editor-block/plugin-templates/composer.json.mustache
+++ b/packages/js/create-product-editor-block/plugin-templates/composer.json.mustache
@@ -1,0 +1,18 @@
+{
+	"name": "{{namespace}}/{{slug}}",
+	"description": "{{description}}",
+	"autoload": {
+		"psr-4": {
+			"{{slugPascalCase}}\\": "includes/"
+		}
+	},
+	"require-dev": {
+		"phpunit/phpunit": "^9.0",
+		"automattic/jetpack-autoloader": "^2"
+	},
+	"config": {
+		"allow-plugins": {
+			"automattic/jetpack-autoloader": true
+		}
+	}
+}

--- a/packages/js/create-product-editor-block/plugin-templates/readme.txt.mustache
+++ b/packages/js/create-product-editor-block/plugin-templates/readme.txt.mustache
@@ -1,0 +1,61 @@
+=== {{title}} ===
+{{#author}}
+Contributors:      {{author}}
+{{/author}}
+Tags:              block
+Tested up to:      6.1
+Stable tag:        {{version}}
+{{#license}}
+License:           {{license}}
+{{/license}}
+{{#licenseURI}}
+License URI:       {{{licenseURI}}}
+{{/licenseURI}}
+
+{{description}}
+
+== Description ==
+
+This is the long description. No limit, and you can use Markdown (as well as in the following sections).
+
+For backwards compatibility, if this section is missing, the full length of the short description will be used, and
+Markdown parsed.
+
+== Installation ==
+
+This section describes how to install the plugin and get it working.
+
+e.g.
+
+1. Upload the plugin files to the `/wp-content/plugins/{{slug}}` directory, or install the plugin through the WordPress plugins screen directly.
+1. Activate the plugin through the 'Plugins' screen in WordPress
+
+
+== Frequently Asked Questions ==
+
+= A question that someone might have =
+
+An answer to that question.
+
+= What about foo bar? =
+
+Answer to foo bar dilemma.
+
+== Screenshots ==
+
+1. This screen shot description corresponds to screenshot-1.(png|jpg|jpeg|gif). Note that the screenshot is taken from
+the /assets directory or the directory that contains the stable readme.txt (tags or trunk). Screenshots in the /assets
+directory take precedence. For example, `/assets/screenshot-1.png` would win over `/tags/4.3/screenshot-1.png`
+(or jpg, jpeg, gif).
+2. This is the second screen shot
+
+== Changelog ==
+
+= {{version}} =
+* Release
+
+== Arbitrary section ==
+
+You may provide arbitrary sections, in the same format as the ones above. This may be of use for extremely complicated
+plugins where more information needs to be conveyed that doesn't fit into the categories of "description" or
+"installation." Arbitrary sections will be shown below the built-in sections outlined above.

--- a/packages/js/create-product-editor-block/plugin-templates/tsconfig.json.mustache
+++ b/packages/js/create-product-editor-block/plugin-templates/tsconfig.json.mustache
@@ -1,0 +1,34 @@
+{
+	"compilerOptions": {
+		"target": "es2019",
+		"module": "esnext",
+		"moduleResolution": "node",
+		"allowJs": true,
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"jsx": "react",
+		"jsxFactory": "createElement",
+		"jsxFragmentFactory": "Fragment",
+		"rootDir": "src",
+		"outDir": "build-module",
+		"declaration": true,
+		"declarationMap": true,
+		"declarationDir": "./build-types",
+		"resolveJsonModule": true,
+		"typeRoots": ["./typings", "./node_modules/@types"]
+	},
+	"exclude": [
+		"node_modules",
+		"**/stories",
+		"**/build",
+		"**/build-module",
+		"**/build-types",
+		"**/test/*",
+		"**/jest.config.js",
+		"**/jest-preset.js",
+		"**/webpack.*.js",
+		"**/babel.config.js"
+	],
+	"include": ["**/*.d.ts", "src/**/*", "src/**/*.json"]
+}

--- a/packages/js/create-product-editor-block/plugin-templates/webpack.config.js.mustache
+++ b/packages/js/create-product-editor-block/plugin-templates/webpack.config.js.mustache
@@ -1,0 +1,13 @@
+const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
+const WooCommerceDependencyExtractionWebpackPlugin = require( '@woocommerce/dependency-extraction-webpack-plugin' );
+
+module.exports = {
+	...defaultConfig,
+	plugins: [
+		...defaultConfig.plugins.filter(
+			( plugin ) =>
+				plugin.constructor.name !== 'DependencyExtractionWebpackPlugin'
+		),
+		new WooCommerceDependencyExtractionWebpackPlugin(),
+	],
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -645,6 +645,8 @@ importers:
         specifier: ^3.3.12
         version: 3.3.12(webpack@5.70.0)
 
+  packages/js/create-product-editor-block: {}
+
   packages/js/create-woo-extension: {}
 
   packages/js/csv-export:


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR introduces a new `@woocommerce/create-product-editor-block` package, which is a template that can be used with the `@wordpress/create-block` tool to quickly get the skeleton of a new block-based extension to the new block-based product editor up-and-running.

The skeleton project generated has support for:

- `wp-env`
    - WordPress 6.2
    - WooCommerce trunk nightly
    - WooCommerce Beta Tester
- linting and code formatting
- TypeScript

The example block generated simply renders a message. Support for interactivity in the example block will be added in future PRs.

<img width="1276" alt="Screenshot 2023-05-15 at 16 43 57" src="https://github.com/woocommerce/woocommerce/assets/2098816/f0dcefbe-d663-424c-b34e-87701b25fd54">


The aim is to get devs up and running with block-based extensibility in a few simple commands.

Closes #38143.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Follow the instructions in the package's README.md (note, since this package hasn't been published yet, you will need to use the `npx @wordpress/create-block --template ./path/to/woocommerce/packages/js/create-product-editor-block my-extension-name` form of the command, with a local path to the template)
2. Verify that the generated skeleton project can be used, with the built-in `wp-env` support, to render the example block in the block-based product form, with no modifications of any files or any commands other than those mentioned in the README.md.
3. Verify the generated skeleton project's files look reasonable.

<!-- End testing instructions -->