### PR TITLE
Don't generate singletons for Octokit and GraphQL until they're used at runtime.

### DIFF
--- a/tools/monorepo-utils/src/code-freeze/commands/milestone/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/milestone/index.ts
@@ -89,8 +89,7 @@ export const milestoneCommand = new Command( 'milestone' )
 		}
 
 		try {
-			const octokit = octokitWithAuth();
-			await octokit.request(
+			await octokitWithAuth().request(
 				`POST /repos/${ owner }/${ name }/milestones`,
 				{
 					title: nextMilestone,

--- a/tools/monorepo-utils/src/code-freeze/commands/milestone/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/milestone/index.ts
@@ -89,7 +89,8 @@ export const milestoneCommand = new Command( 'milestone' )
 		}
 
 		try {
-			await octokitWithAuth.request(
+			const octokit = octokitWithAuth();
+			await octokit.request(
 				`POST /repos/${ owner }/${ name }/milestones`,
 				{
 					title: nextMilestone,

--- a/tools/monorepo-utils/src/core/github/__tests__/index.ts
+++ b/tools/monorepo-utils/src/core/github/__tests__/index.ts
@@ -5,46 +5,47 @@ import { getLatestGithubReleaseVersion } from '../repo';
 
 jest.mock( '../api', () => {
 	return {
-		graphqlWithAuth: jest.fn().mockResolvedValue( {
-			repository: {
-				releases: {
-					nodes: [
-						{
-							tagName: 'nightly',
-							isLatest: false,
-						},
-						{
-							tagName: 'wc-beta-tester-99.99.0',
-							isLatest: false,
-						},
-						{
-							tagName: '1.0.0',
-							isLatest: false,
-						},
-						{
-							tagName: '1.1.0',
-							isLatest: false,
-						},
-						{
-							tagName: '1.2.0',
-							isLatest: false,
-						},
-						{
-							tagName: '2.0.0',
-							isLatest: false,
-						},
-						{
-							tagName: '2.0.1',
-							isLatest: true,
-						},
-						{
-							tagName: '1.0.1',
-							isLatest: false,
-						},
-					],
+		graphqlWithAuth: () =>
+			jest.fn().mockResolvedValue( {
+				repository: {
+					releases: {
+						nodes: [
+							{
+								tagName: 'nightly',
+								isLatest: false,
+							},
+							{
+								tagName: 'wc-beta-tester-99.99.0',
+								isLatest: false,
+							},
+							{
+								tagName: '1.0.0',
+								isLatest: false,
+							},
+							{
+								tagName: '1.1.0',
+								isLatest: false,
+							},
+							{
+								tagName: '1.2.0',
+								isLatest: false,
+							},
+							{
+								tagName: '2.0.0',
+								isLatest: false,
+							},
+							{
+								tagName: '2.0.1',
+								isLatest: true,
+							},
+							{
+								tagName: '1.0.1',
+								isLatest: false,
+							},
+						],
+					},
 				},
-			},
-		} ),
+			} ),
 	};
 } );
 

--- a/tools/monorepo-utils/src/core/github/api.ts
+++ b/tools/monorepo-utils/src/core/github/api.ts
@@ -1,20 +1,52 @@
 /**
  * External dependencies
  */
-import { graphql } from '@octokit/graphql';
+import { graphql as gql } from '@octokit/graphql';
 import { Octokit } from 'octokit';
+import { graphql } from '@octokit/graphql/dist-types/types';
 
 /**
  * Internal dependencies
  */
 import { getEnvVar } from '../environment';
 
-export const graphqlWithAuth = graphql.defaults( {
-	headers: {
-		authorization: `Bearer ${ getEnvVar( 'GITHUB_TOKEN', true ) }`,
-	},
-} );
+let graphqlWithAuthInstance;
+let octokitWithAuthInstance;
 
-export const octokitWithAuth = new Octokit( {
-	auth: getEnvVar( 'GITHUB_TOKEN', true ),
-} );
+/**
+ * Returns a graphql instance with auth headers, throws an Exception if
+ * `GITHUB_TOKEN` env var is not present.
+ *
+ * @return graphql instance
+ */
+export const graphqlWithAuth = (): graphql => {
+	if ( graphqlWithAuthInstance ) {
+		return graphqlWithAuthInstance;
+	}
+
+	graphqlWithAuthInstance = gql.defaults( {
+		headers: {
+			authorization: `Bearer ${ getEnvVar( 'GITHUB_TOKEN', true ) }`,
+		},
+	} );
+
+	return graphqlWithAuthInstance;
+};
+
+/**
+ * Returns an Octokit instance with auth headers, throws an Exception if
+ * `GITHUB_TOKEN` env var is not present.
+ *
+ * @return graphql instance
+ */
+export const octokitWithAuth = (): Octokit => {
+	if ( octokitWithAuthInstance ) {
+		return octokitWithAuthInstance;
+	}
+
+	octokitWithAuthInstance = new Octokit( {
+		auth: getEnvVar( 'GITHUB_TOKEN', true ),
+	} );
+
+	return octokitWithAuthInstance;
+};

--- a/tools/monorepo-utils/src/core/github/repo.ts
+++ b/tools/monorepo-utils/src/core/github/repo.ts
@@ -47,7 +47,7 @@ export const doesGithubBranchExist = async (
 
 	try {
 		const branchOnGithub = await octokitWithAuth().request(
-			'GET /repos/{owner}/{rsepo}/branches/{branch}',
+			'GET /repos/{owner}/{repo}/branches/{branch}',
 			{
 				owner,
 				repo: name,

--- a/tools/monorepo-utils/src/core/github/repo.ts
+++ b/tools/monorepo-utils/src/core/github/repo.ts
@@ -14,9 +14,8 @@ export const getLatestGithubReleaseVersion = async ( options: {
 	name?: string;
 } ): Promise< string > => {
 	const { owner, name } = options;
-	const gql = graphqlWithAuth();
 
-	const data = await gql< { repository: Repository } >( `
+	const data = await graphqlWithAuth()< { repository: Repository } >( `
 			{
 			    repository(owner: "${ owner }", name: "${ name }") {
 					releases(
@@ -45,9 +44,9 @@ export const doesGithubBranchExist = async (
 	nextReleaseBranch: string
 ): Promise< boolean > => {
 	const { owner, name } = options;
-	const octokit = octokitWithAuth();
+
 	try {
-		const branchOnGithub = await octokit.request(
+		const branchOnGithub = await octokitWithAuth().request(
 			'GET /repos/{owner}/{rsepo}/branches/{branch}',
 			{
 				owner,
@@ -75,8 +74,7 @@ export const getRefFromGithubBranch = async (
 	source: string
 ): Promise< string > => {
 	const { owner, name } = options;
-	const gql = graphqlWithAuth();
-	const { repository } = await gql< {
+	const { repository } = await graphqlWithAuth()< {
 		repository: Repository;
 	} >( `
 			{
@@ -106,9 +104,8 @@ export const createGithubBranch = async (
 	branch: string,
 	ref: string
 ): Promise< void > => {
-	const octokit = octokitWithAuth();
 	const { owner, name } = options;
-	await octokit.request( 'POST /repos/{owner}/{repo}/git/refs', {
+	await octokitWithAuth().request( 'POST /repos/{owner}/{repo}/git/refs', {
 		owner,
 		repo: name,
 		ref: `refs/heads/${ branch }`,
@@ -123,9 +120,8 @@ export const deleteGithubBranch = async (
 	},
 	branch: string
 ): Promise< void > => {
-	const octokit = octokitWithAuth();
 	const { owner, name } = options;
-	await octokit.request(
+	await octokitWithAuth().request(
 		'DELETE /repos/{owner}/{repo}/git/refs/heads/{ref}',
 		{
 			owner,
@@ -155,9 +151,8 @@ export const createPullRequest = async ( options: {
 	title: string;
 	body: string;
 } ): Promise< PullRequestEndpointResponse[ 'data' ] > => {
-	const octokit = octokitWithAuth();
 	const { head, base, owner, name, title, body } = options;
-	const pullRequest = await octokit.request(
+	const pullRequest = await octokitWithAuth().request(
 		'POST /repos/{owner}/{repo}/pulls',
 		{
 			owner,


### PR DESCRIPTION
@psealock noted that recently the `verify-day` command fails if you don't provide an env variable for `GITHUB_TOKEN`. This shouldn't happen since that command does not need `GITHUB_TOKEN`. The reason it happens is because in our Commander.js command we import all the commands at the index, and those commands sometimes import `api`. API when imported immediately tries to create the graphql and octokit instances.

To fix this problem, I've moved those instances into singleton variables that will not get generated on import, but rather they will be generated when you first call their respective functions. To keep it easier with refactoring I've named the functions that generate the instances the same as the original exports so the only change is just to call the function before making the request.

## Testing instructions

1. Checkout this branch and ensure that the build was run on monorepo utils (its postinstall step so if postinstall didn't happen, go to monorepo utils and run `pnpm build`.

2. Ensure that you don't have a variable called `GITHUB_TOKEN` defined in your environment, now try run `verify-day`. It should not throw any errors to say the token is missing.

4. Also there should be no error when running `pnpm utils` from the root without `GITHUB_TOKEN` defined. This was happening before as well due to the import.