### PR TITLE
add: core profiler fetch extensions

### DIFF
--- a/plugins/woocommerce-admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { createMachine, assign, DoneInvokeEvent, actions } from 'xstate';
+import { createMachine, assign, DoneInvokeEvent, actions, spawn } from 'xstate';
 import { useMachine } from '@xstate/react';
 import { useEffect, useMemo } from '@wordpress/element';
 import { resolveSelect, dispatch } from '@wordpress/data';
@@ -11,6 +11,8 @@ import {
 	OPTIONS_STORE_NAME,
 	COUNTRIES_STORE_NAME,
 	Country,
+	ONBOARDING_STORE_NAME,
+	Extension,
 } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { getSetting } from '@woocommerce/settings';
@@ -25,6 +27,7 @@ import { BusinessInfo } from './pages/BusinessInfo';
 import { BusinessLocation } from './pages/BusinessLocation';
 import { getCountryStateOptions } from './services/country';
 import { Loader } from './pages/Loader';
+import { Extensions } from './pages/Extensions';
 
 import './style.scss';
 
@@ -91,34 +94,6 @@ export type CoreProfilerStateMachineContext = {
 	};
 };
 
-const Extensions = ( {
-	context,
-	sendEvent,
-}: {
-	context: CoreProfilerStateMachineContext;
-	sendEvent: ( payload: ExtensionsEvent ) => void;
-} ) => {
-	return (
-		// TOOD: we need to fetch the extensions list from the API as part of initializing the profiler
-		<>
-			<div>Extensions</div>
-			<div>{ context.extensionsAvailable }</div>
-			<button
-				onClick={ () =>
-					sendEvent( {
-						type: 'EXTENSIONS_COMPLETED',
-						payload: {
-							extensionsSelected: [ 'woocommerce-payments' ],
-						},
-					} )
-				}
-			>
-				Next
-			</button>
-		</>
-	);
-};
-
 const getAllowTrackingOption = async () =>
 	resolveSelect( OPTIONS_STORE_NAME ).getOption(
 		'woocommerce_allow_tracking'
@@ -129,6 +104,17 @@ const handleTrackingOption = assign( {
 		_context,
 		event: DoneInvokeEvent< 'no' | 'yes' | undefined >
 	) => event.data !== 'no',
+} );
+
+/**
+ * Prefetch it so that @wp/data caches it and there won't be a loading delay when its used
+ */
+const preFetchGetCountries = assign( {
+	spawnGetCountriesRef: () =>
+		spawn(
+			resolveSelect( COUNTRIES_STORE_NAME ).getCountries(),
+			'core-profiler-prefetch-countries'
+		),
 } );
 
 const getCountries = async () =>
@@ -217,9 +203,38 @@ const assignOptInDataSharing = assign( {
 		event.payload.optInDataSharing,
 } );
 
+/**
+ * Prefetch it so that @wp/data caches it and there won't be a loading delay when its used
+ */
+const preFetchGetExtensions = assign( {
+	extensionsRef: () =>
+		spawn(
+			resolveSelect( ONBOARDING_STORE_NAME ).getFreeExtensions(),
+			'core-profiler-prefetch-extensions'
+		),
+} );
+
+const getExtensions = async () => {
+	const extensionsBundles = await resolveSelect(
+		ONBOARDING_STORE_NAME
+	).getFreeExtensions();
+	return (
+		extensionsBundles.find( ( bundle ) => bundle.key === 'obw/grow' )
+			?.plugins || []
+	);
+};
+
+const handleExtensions = assign( {
+	extensionsAvailable: ( _context, event: DoneInvokeEvent< Extension[] > ) =>
+		event.data,
+} );
+
 const coreProfilerMachineActions = {
 	updateTrackingOption,
+	preFetchGetExtensions,
+	preFetchGetCountries,
 	handleTrackingOption,
+	handleExtensions,
 	recordTracksIntroCompleted,
 	recordTracksIntroSkipped,
 	recordTracksIntroViewed,
@@ -233,6 +248,7 @@ const coreProfilerMachineActions = {
 const coreProfilerMachineServices = {
 	getAllowTrackingOption,
 	getCountries,
+	getExtensions,
 };
 export const coreProfilerStateMachineDefinition = createMachine( {
 	id: 'coreProfiler',
@@ -257,6 +273,7 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 					target: 'introOptIn',
 				},
 			},
+			entry: [ 'preFetchGetExtensions', 'preFetchGetCountries' ],
 			invoke: [
 				{
 					src: 'getAllowTrackingOption',
@@ -462,13 +479,12 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 			},
 		},
 		preExtensions: {
-			always: [
-				// immediately transition to extensions without any events as long as extensions fetching parallel has completed
-				{
-					target: 'extensions',
-					cond: () => true, // TODO: use a custom function to check on the parallel state using meta when we implement that. https://xstate.js.org/docs/guides/guards.html#guards-condition-functions
-				},
-			],
+			invoke: {
+				src: 'getExtensions',
+				onDone: [
+					{ target: 'extensions', actions: 'handleExtensions' },
+				],
+			},
 			// add exit action to filter the extensions using a custom function here and assign it to context.extensionsAvailable
 			exit: assign( {
 				extensionsAvailable: ( context ) => {

--- a/plugins/woocommerce-admin/client/core-profiler/pages/Extensions.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/pages/Extensions.tsx
@@ -1,0 +1,31 @@
+/**
+ * Internal dependencies
+ */
+import { CoreProfilerStateMachineContext, ExtensionsEvent } from '../index';
+
+export const Extensions = ( {
+	context,
+	sendEvent,
+}: {
+	context: CoreProfilerStateMachineContext;
+	sendEvent: ( payload: ExtensionsEvent ) => void;
+} ) => {
+	return (
+		<>
+			<div>Extensions</div>
+			<div>{ JSON.stringify( context.extensionsAvailable ) }</div>
+			<button
+				onClick={ () =>
+					sendEvent( {
+						type: 'EXTENSIONS_COMPLETED',
+						payload: {
+							extensionsSelected: [ 'woocommerce-payments' ],
+						},
+					} )
+				}
+			>
+				Next
+			</button>
+		</>
+	);
+};

--- a/plugins/woocommerce/changelog/add-core-profiler-fetch-extensions
+++ b/plugins/woocommerce/changelog/add-core-profiler-fetch-extensions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Added async fetching for extensions and countries lists in new core profiler


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Adds a prefetch call in the background for fetching extensions and countries in the init state without blocking the UI state.

This makes it so that subsequently when these calls are made, there won't be any loading time

Closes #37992.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Intermediate PR without user facing feature, QA testing not required

1.  Clone repo
2. Go to new profiler page
3. Note that there is no loading time for the 'skip flow'
4. Reload profiler
5. Note that Extensions page has the extensions populated, and also without loading time

<!-- End testing instructions -->