### PR TITLE
Update "Set up additional payment options" task view & complete logic

### DIFF
--- a/plugins/woocommerce-admin/client/task-lists/fills/PaymentGatewaySuggestions/index.js
+++ b/plugins/woocommerce-admin/client/task-lists/fills/PaymentGatewaySuggestions/index.js
@@ -202,26 +202,24 @@ export const PaymentGatewaySuggestions = ( { onComplete, query } ) => {
 		'To start accepting online payments',
 		'woocommerce'
 	);
-	if ( isWCPaySupported ) {
-		if ( isWCPayOrOtherCategoryDoneSetup ) {
-			additionalSectionHeading = __(
-				'Additional payment options',
-				'woocommerce'
-			);
-			additionalSectionHeadingDescription = __(
-				'Give your customers additional choices in ways to pay.',
-				'woocommerce'
-			);
-		} else {
-			additionalSectionHeading = __(
-				'Other payment providers',
-				'woocommerce'
-			);
-			additionalSectionHeadingDescription = __(
-				'Try one of the alternative payment providers.',
-				'woocommerce'
-			);
-		}
+	if ( isWCPayOrOtherCategoryDoneSetup ) {
+		additionalSectionHeading = __(
+			'Additional payment options',
+			'woocommerce'
+		);
+		additionalSectionHeadingDescription = __(
+			'Give your customers additional choices in ways to pay.',
+			'woocommerce'
+		);
+	} else if ( isWCPaySupported ) {
+		additionalSectionHeading = __(
+			'Other payment providers',
+			'woocommerce'
+		);
+		additionalSectionHeadingDescription = __(
+			'Try one of the alternative payment providers.',
+			'woocommerce'
+		);
 	}
 
 	const additionalSection = !! additionalGateways.length && (

--- a/plugins/woocommerce-admin/client/task-lists/fills/PaymentGatewaySuggestions/test/index.js
+++ b/plugins/woocommerce-admin/client/task-lists/fills/PaymentGatewaySuggestions/test/index.js
@@ -223,7 +223,7 @@ describe( 'PaymentGatewaySuggestions', () => {
 		expect( getByText( 'Finish setup' ) ).toBeInTheDocument();
 	} );
 
-	test( 'should show "category_additional" gateways only after WCPay is set up', () => {
+	test( 'should show "category_additional" gateways after WCPay is set up', () => {
 		const onComplete = jest.fn();
 		const query = {};
 		useSelect.mockImplementation( () => ( {
@@ -263,6 +263,54 @@ describe( 'PaymentGatewaySuggestions', () => {
 
 		expect( paymentTitles ).toEqual( [
 			'PayPal Payments',
+			'Eway',
+			'Cash on delivery',
+			'Direct bank transfer',
+		] );
+	} );
+
+	test( 'should show "category_additional" gateways after a primary gateway (other than WCPay) is set up', () => {
+		const onComplete = jest.fn();
+		const query = {};
+		useSelect.mockImplementation( () => ( {
+			isResolving: false,
+			getPaymentGateway: jest.fn(),
+			paymentGatewaySuggestions,
+			installedPaymentGateways: [
+				{
+					id: 'ppcp-gateway',
+					title: 'PayPal Payments',
+					content:
+						"Safe and secure payments using credit cards or your customer's PayPal account.",
+					image: 'http://localhost:8888/wp-content/plugins/woocommerce/assets/images/paypal.png',
+					plugins: [ 'woocommerce-paypal-payments' ],
+					is_visible: true,
+				},
+			],
+			countryCode: 'US',
+		} ) );
+
+		const { container } = render(
+			<PaymentGatewaySuggestions
+				onComplete={ onComplete }
+				query={ query }
+			/>
+		);
+
+		expect(
+			screen.getByText( 'Additional payment options' )
+		).toBeInTheDocument();
+
+		const paymentTitleElements = container.querySelectorAll(
+			'.woocommerce-task-payment__title'
+		);
+
+		const paymentTitles = Array.from( paymentTitleElements ).map(
+			( e ) => e.textContent
+		);
+
+		expect( paymentTitles ).toEqual( [
+			'PayPal PaymentsSetup required',
 			'Eway',
 			'Cash on delivery',
 			'Direct bank transfer',

--- a/plugins/woocommerce/changelog/update-additional-payment-task-view-logic
+++ b/plugins/woocommerce/changelog/update-additional-payment-task-view-logic
@@ -1,4 +1,4 @@
 Significance: patch
 Type: update
 
-Update "Set up additional payment" task view logic
+Update "Set up additional payment" task view & complete logic

--- a/plugins/woocommerce/changelog/update-additional-payment-task-view-logic
+++ b/plugins/woocommerce/changelog/update-additional-payment-task-view-logic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update "Set up additional payment" task view logic

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/AdditionalPayments.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/AdditionalPayments.php
@@ -5,7 +5,6 @@ namespace Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks;
 
 use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\Payments;
-use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\WooCommercePayments;
 
 /**
  * Payments Task
@@ -14,6 +13,7 @@ class AdditionalPayments extends Payments {
 
 	/**
 	 * Used to cache is_complete() method result.
+	 *
 	 * @var null
 	 */
 	private $is_complete_result = null;
@@ -85,14 +85,10 @@ class AdditionalPayments extends Payments {
 			return false;
 		}
 
-		$woocommerce_payments = new WooCommercePayments();
+		$payment_task = $this->task_list->get_task( 'payments' );
+		$wc_pay_task  = $this->task_list->get_task( 'woocommerce-payments' );
 
-		if ( ! $woocommerce_payments->is_requested() || ! $woocommerce_payments->is_supported() || ! $woocommerce_payments->is_connected() ) {
-			// Hide task if WC Pay is not installed via OBW, or is not connected, or the store is located in a country that is not supported by WC Pay.
-			return false;
-		}
-
-		return true;
+		return $payment_task->is_complete() || $wc_pay_task->is_complete();
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/AdditionalPayments.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/AdditionalPayments.php
@@ -94,7 +94,7 @@ class AdditionalPayments extends Payments {
 			return false;
 		}
 
-		if ( $this->can_view_result !== null ) {
+		if ( null !== $this->can_view_result ) {
 			return $this->can_view_result;
 		}
 
@@ -122,11 +122,12 @@ class AdditionalPayments extends Payments {
 	 * @return bool
 	 */
 	private static function has_enabled_other_category_gateways() {
-		$other_gateways = self::get_suggestion_gateways( 'category_other' );
+		$other_gateways     = self::get_suggestion_gateways( 'category_other' );
+		$other_gateways_ids = wp_list_pluck( $other_gateways, 'id' );
 
 		return self::has_enabled_gateways(
-			function( $gateway ) use ( $other_gateways ) {
-				return in_array( $gateway->id, array_keys( $other_gateways ), true );
+			function( $gateway ) use ( $other_gateways_ids ) {
+				return in_array( $gateway->id, $other_gateways_ids, true );
 			}
 		);
 	}
@@ -137,12 +138,13 @@ class AdditionalPayments extends Payments {
 	 * @return bool
 	 */
 	private static function has_enabled_additional_gateways() {
-		$additional_gateways = self::get_suggestion_gateways( 'category_additional' );
+		$additional_gateways     = self::get_suggestion_gateways( 'category_additional' );
+		$additional_gateways_ids = wp_list_pluck( $additional_gateways, 'id' );
 
 		return self::has_enabled_gateways(
-			function( $gateway ) use ( $additional_gateways ) {
+			function( $gateway ) use ( $additional_gateways_ids ) {
 				return 'yes' === $gateway->enabled
-				&& in_array( $gateway->id, array_keys( $additional_gateways ), true );
+				&& in_array( $gateway->id, $additional_gateways_ids, true );
 			}
 		);
 	}

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/AdditionalPayments.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/AdditionalPayments.php
@@ -76,7 +76,7 @@ class AdditionalPayments extends Payments {
 	 * @return bool
 	 */
 	public function is_complete() {
-		if ( $this->is_complete_result === null ) {
+		if ( null === $this->is_complete_result ) {
 			$this->is_complete_result = self::has_enabled_additional_gateways();
 		}
 

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/AdditionalPayments.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/AdditionalPayments.php
@@ -5,6 +5,8 @@ namespace Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks;
 
 use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\Payments;
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\WooCommercePayments;
+use Automattic\WooCommerce\Admin\Features\PaymentGatewaySuggestions\Init;
 
 /**
  * Payments Task
@@ -17,6 +19,13 @@ class AdditionalPayments extends Payments {
 	 * @var null
 	 */
 	private $is_complete_result = null;
+
+	/**
+	 * Used to cache can_view() method result.
+	 *
+	 * @var null
+	 */
+	private $can_view_result = null;
 
 
 	/**
@@ -68,7 +77,7 @@ class AdditionalPayments extends Payments {
 	 */
 	public function is_complete() {
 		if ( $this->is_complete_result === null ) {
-			$this->is_complete_result = self::has_gateways();
+			$this->is_complete_result = self::has_enabled_additional_gateways();
 		}
 
 		return $this->is_complete_result;
@@ -85,26 +94,100 @@ class AdditionalPayments extends Payments {
 			return false;
 		}
 
-		$payment_task = $this->task_list->get_task( 'payments' );
-		$wc_pay_task  = $this->task_list->get_task( 'woocommerce-payments' );
+		if ( $this->can_view_result !== null ) {
+			return $this->can_view_result;
+		}
 
-		return $payment_task->is_complete() || $wc_pay_task->is_complete();
+		// Show task if woocommerce-payments is connected or if there are any suggested gateways in other category enabled.
+		$this->can_view_result = (
+			WooCommercePayments::is_connected() ||
+			self::has_enabled_other_category_gateways()
+		);
+
+		// Early return if task is not visible.
+		if ( ! $this->can_view_result ) {
+			return false;
+		}
+
+		// Show task if there are any suggested gateways in additional category.
+		$this->can_view_result = ! empty( self::get_suggestion_gateways( 'category_additional' ) );
+
+		return $this->can_view_result;
 	}
 
+
 	/**
-	 * Check if the store has any enabled gateways.
+	 * Check if the store has any enabled gateways in other category.
 	 *
 	 * @return bool
 	 */
-	public static function has_gateways() {
+	private static function has_enabled_other_category_gateways() {
+		$other_gateways = self::get_suggestion_gateways( 'category_other' );
+
+		return self::has_enabled_gateways(
+			function( $gateway ) use ( $other_gateways ) {
+				return in_array( $gateway->id, array_keys( $other_gateways ), true );
+			}
+		);
+	}
+
+	/**
+	 * Check if the store has any enabled gateways in additional category.
+	 *
+	 * @return bool
+	 */
+	private static function has_enabled_additional_gateways() {
+		$additional_gateways = self::get_suggestion_gateways( 'category_additional' );
+
+		return self::has_enabled_gateways(
+			function( $gateway ) use ( $additional_gateways ) {
+				return 'yes' === $gateway->enabled
+				&& in_array( $gateway->id, array_keys( $additional_gateways ), true );
+			}
+		);
+	}
+
+	/**
+	 * Check if the store has any enabled gateways based on the given criteria.
+	 *
+	 * @param callable|null $filter A callback function to filter the gateways.
+	 * @return bool
+	 */
+	private static function has_enabled_gateways( $filter = null ) {
 		$gateways         = WC()->payment_gateways->get_available_payment_gateways();
 		$enabled_gateways = array_filter(
 			$gateways,
-			function( $gateway ) {
-				return 'yes' === $gateway->enabled && 'woocommerce_payments' !== $gateway->id;
+			function( $gateway ) use ( $filter ) {
+				if ( is_callable( $filter ) ) {
+					return 'yes' === $gateway->enabled && call_user_func( $filter, $gateway );
+				} else {
+					return 'yes' === $gateway->enabled;
+				}
 			}
 		);
 
 		return ! empty( $enabled_gateways );
+	}
+
+	/**
+	 * Get the list of gateways to suggest.
+	 *
+	 * @param string $filter_by Filter by category. "category_additional" or "category_other".
+	 *
+	 * @return array
+	 */
+	private static function get_suggestion_gateways( $filter_by = 'category_additional' ) {
+		$country            = wc_get_base_location()['country'];
+		$plugin_suggestions = Init::get_suggestions();
+		$plugin_suggestions = array_filter(
+			$plugin_suggestions,
+			function( $plugin ) use ( $country, $filter_by ) {
+				if ( ! isset( $plugin->{$filter_by} ) || ! isset( $plugin->plugins[0] ) ) {
+					return false;
+				}
+				return in_array( $country, $plugin->{$filter_by}, true );
+			}
+		);
+		return $plugin_suggestions;
 	}
 }

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/WooCommercePayments.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/WooCommercePayments.php
@@ -13,6 +13,12 @@ use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskList;
  */
 class WooCommercePayments extends Task {
 	/**
+	 * Used to cache is_complete() method result.
+	 * @var null
+	 */
+	private $is_complete_result = null;
+
+	/**
 	 * ID.
 	 *
 	 * @return string
@@ -78,7 +84,11 @@ class WooCommercePayments extends Task {
 	 * @return bool
 	 */
 	public function is_complete() {
-		return self::is_connected();
+		if ( $this->is_complete_result === null ) {
+			$this->is_complete_result = self::is_connected();
+		}
+
+		return $this->is_complete_result;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/WooCommercePayments.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/WooCommercePayments.php
@@ -85,7 +85,7 @@ class WooCommercePayments extends Task {
 	 * @return bool
 	 */
 	public function is_complete() {
-		if ( null === $this->is_complete_result  ) {
+		if ( null === $this->is_complete_result ) {
 			$this->is_complete_result = self::is_connected();
 		}
 

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/WooCommercePayments.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/WooCommercePayments.php
@@ -14,6 +14,7 @@ use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskList;
 class WooCommercePayments extends Task {
 	/**
 	 * Used to cache is_complete() method result.
+	 *
 	 * @var null
 	 */
 	private $is_complete_result = null;
@@ -84,7 +85,7 @@ class WooCommercePayments extends Task {
 	 * @return bool
 	 */
 	public function is_complete() {
-		if ( $this->is_complete_result === null ) {
+		if ( null === $this->is_complete_result  ) {
 			$this->is_complete_result = self::is_connected();
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/38235.

This PR updates the "Set up additional payment options" task view & complete logic such that the task is shown when:

1. The "other category" payment gateway or wcpay is enabled 
2. Additional payment gateways exist. 

I have tried adding unit tests, but I encountered some difficulties when mocking static methods. I want to work on sprint tasks first so I'll revisit and study how to add unit tests later. 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Scenario: No payment gateway is setup**

1. Install and activate WooCommerce in a brand new site
2. Go to Onboarding Wizard  (/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard)
3. Select `United States` as your store country
4. Complete OBW without installing wcpay
5. Go to `WooCommerce > Home`
6. Observe that `Set up additional payment options` task is **not** shown

**Scenario: wcpay is setup**

1. Install and activate `woocommerce-payments`
2. Set up WCPay or return `true` from [is_connected](https://github.com/Automattic/woocommerce-payments/blob/develop/includes/class-wc-payment-gateway-wcpay.php#L453) and return `false` from  [needs_setup](https://github.com/Automattic/woocommerce-payments/blob/develop/includes/class-wc-payment-gateway-wcpay.php#L463)
3. Go to `WooCommerce > Home`
4. Observe that  `Set up additional payment options` task is shown
7. Click on  `Set up additional payment options` task
8. You should see the `Additional payment options` payment lists
9. Install `Code Snippets` plugin
10. Go to Snippets
11. Create and activate a new snipeet using the following code

```php
add_filter( 'woocommerce_available_payment_gateways', 'enable_gateway', 1 );

class Fake_klarna_payments extends WC_Payment_Gateway {
	public $id = 'klarna_payments';
	public $enabled = 'yes';
	
	public function needs_setup() {
		return false;
	}
}


function enable_gateway( $gateways ) {
	$gateways[] = new Fake_klarna_payments();
    return $gateways;
}
```

12. Go to `WooCommerce > Home`
13. Observe that `Additional payment options` task is marked as completed.

**Scenario: "other category" payment is setup**

1. Deactivate  `woocommerce-payments` and turn off the "snippet"
2. Go to `WooCommerce > Home`
3. Observe that  `Set up additional payment options` task is not shown
4. Go to Snippets
5. Create and activate a new snippet using the following code

```php
add_filter( 'woocommerce_available_payment_gateways', 'enable_stripe_gateway', 1 );

class Fake_stripe extends WC_Payment_Gateway {
	public $id = 'stripe';
	public $enabled = 'yes';
	
	public function needs_setup() {
		return false;
	}
}


function enable_stripe_gateway( $gateways ) {
	$gateways[] = new Fake_stripe();
    return $gateways;
}
```

6. Go to `WooCommerce > Home`
7. Observe that  `Set up additional payment options` task is shown
8. Turn on Fake_klarna snippet
9. Observe that `Additional payment options` task is marked as completed.

<!-- End testing instructions -->