### PR TITLE
Rename tracks event `product_attributes_add` to `product_attributes_save` on the product page and update attributes

### DIFF
--- a/plugins/woocommerce-admin/client/wp-admin-scripts/attributes-tracking/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/attributes-tracking/index.js
@@ -19,11 +19,6 @@ addNewAttribute?.addEventListener( 'click', function () {
 		name: name?.value,
 		slug: slug?.value,
 		page: 'attributes',
-		total_attributes_count: null,
-		local_attributes_count: null,
-		global_attributes_count: null,
-		visible_on_product_page_count: null,
-		used_for_variations_count: null,
 	} );
 } );
 

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/attributes-tracking/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/attributes-tracking/index.js
@@ -19,6 +19,11 @@ addNewAttribute?.addEventListener( 'click', function () {
 		name: name?.value,
 		slug: slug?.value,
 		page: 'attributes',
+		total_attributes_count: null,
+		local_attributes_count: null,
+		global_attributes_count: null,
+		visible_on_product_page_count: null,
+		used_for_variations_count: null,
 	} );
 } );
 

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
@@ -496,10 +496,6 @@ const attachProductAttributesTracks = () => {
 		},
 	] );
 
-	const attributesCount = document.querySelectorAll(
-		'.woocommerce_attribute'
-	).length;
-
 	document
 		.querySelector( '.save_attributes' )
 		?.addEventListener( 'click', ( event ) => {
@@ -510,37 +506,29 @@ const attachProductAttributesTracks = () => {
 				// skip in case the button is disabled
 				return;
 			}
-			const newAttributesCount = document.querySelectorAll(
-				'.woocommerce_attribute'
+			const globalAttributesCount = document.querySelectorAll(
+				'.woocommerce_attribute:not(.taxonomy)'
 			).length;
-			if ( newAttributesCount > attributesCount ) {
-				const local_attributes = [
-					...document.querySelectorAll(
-						'.woocommerce_attribute:not(.pa_glbattr)'
-					),
-				].map( ( attr ) => {
-					const terms =
-						(
-							attr.querySelector(
-								"[name^='attribute_values']"
-							) as HTMLTextAreaElement
-						 )?.value.split( '|' ).length ?? 0;
-					return {
-						name: (
-							attr.querySelector(
-								'[name^="attribute_names"]'
-							) as HTMLInputElement
-						 )?.value,
-						terms,
-					};
-				} );
-				recordEvent( 'product_attributes_add', {
-					page: 'product',
-					enable_archive: '',
-					default_sort_order: '',
-					local_attributes,
-				} );
-			}
+
+			const localAttributesCount = document.querySelectorAll(
+				'.woocommerce_attribute.taxonomy'
+			).length;
+
+			recordEvent( 'product_attributes_add', {
+				page: 'product',
+				enable_archive: '',
+				default_sort_order: '',
+				total_attributes_count:
+					globalAttributesCount + localAttributesCount,
+				local_attributes_count: localAttributesCount,
+				global_attributes_count: globalAttributesCount,
+				visible_on_product_page_count: document.querySelectorAll(
+					'input[name^="attribute_visibility"]:checked'
+				).length,
+				used_for_variations_count: document.querySelectorAll(
+					'input[name^="attribute_variation"]:checked'
+				).length,
+			} );
 		} );
 };
 

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
@@ -506,6 +506,7 @@ const attachProductAttributesTracks = () => {
 				// skip in case the button is disabled
 				return;
 			}
+
 			const globalAttributesCount = document.querySelectorAll(
 				'.woocommerce_attribute:not(.taxonomy)'
 			).length;
@@ -525,9 +526,16 @@ const attachProductAttributesTracks = () => {
 				visible_on_product_page_count: document.querySelectorAll(
 					'input[name^="attribute_visibility"]:checked'
 				).length,
-				used_for_variations_count: document.querySelectorAll(
-					'input[name^="attribute_variation"]:checked'
-				).length,
+				used_for_variations_count:
+					(
+						document.querySelector(
+							'#product-type'
+						) as HTMLSelectElement
+					 )?.value === 'variable'
+						? document.querySelectorAll(
+								'input[name^="attribute_variation"]:checked'
+						  ).length
+						: null,
 			} );
 		} );
 };

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
@@ -454,6 +454,17 @@ const attachAddExistingAttributeTracks = () => {
 };
 
 /**
+ * Gets number of attributes with 'Used for variations' checked.
+ */
+const getUsedForVariationsAttributesCount = () =>
+	( document.querySelector( '#product-type' ) as HTMLSelectElement )
+		?.value === 'variable'
+		? document.querySelectorAll(
+				'input[name^="attribute_variation"]:checked'
+		  ).length
+		: 0;
+
+/**
  * Attaches product attributes tracks.
  */
 const attachProductAttributesTracks = () => {
@@ -507,20 +518,16 @@ const attachProductAttributesTracks = () => {
 				return;
 			}
 
-			const globalAttributesCount = document.querySelectorAll(
+			const localAttributesCount = document.querySelectorAll(
 				'.woocommerce_attribute:not(.taxonomy)'
 			).length;
 
-			const localAttributesCount = document.querySelectorAll(
+			const globalAttributesCount = document.querySelectorAll(
 				'.woocommerce_attribute.taxonomy'
 			).length;
 
-			recordEvent( 'product_attributes_add', {
+			recordEvent( 'product_attributes_save', {
 				page: 'product',
-				enable_archive: '',
-				default_sort_order: '',
-				name: null,
-				slug: null,
 				total_attributes_count:
 					globalAttributesCount + localAttributesCount,
 				local_attributes_count: localAttributesCount,
@@ -529,15 +536,7 @@ const attachProductAttributesTracks = () => {
 					'input[name^="attribute_visibility"]:checked'
 				).length,
 				used_for_variations_count:
-					(
-						document.querySelector(
-							'#product-type'
-						) as HTMLSelectElement
-					 )?.value === 'variable'
-						? document.querySelectorAll(
-								'input[name^="attribute_variation"]:checked'
-						  ).length
-						: null,
+					getUsedForVariationsAttributesCount(),
 			} );
 		} );
 };

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
@@ -519,6 +519,8 @@ const attachProductAttributesTracks = () => {
 				page: 'product',
 				enable_archive: '',
 				default_sort_order: '',
+				name: null,
+				slug: null,
 				total_attributes_count:
 					globalAttributesCount + localAttributesCount,
 				local_attributes_count: localAttributesCount,

--- a/plugins/woocommerce/changelog/update-product_attributes_add
+++ b/plugins/woocommerce/changelog/update-product_attributes_add
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Change attributes of product_attribute_add tracks event

--- a/plugins/woocommerce/changelog/update-product_attributes_add
+++ b/plugins/woocommerce/changelog/update-product_attributes_add
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Change attributes of product_attribute_add tracks event
+Rename tracks event product_attributes_add to product_attributes_save on the product page and update attributes


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Rename tracks event product_attributes_add to product_attributes_save on the product page and update attributes

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #38171 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to current product editor and create a new product.
2. Change to Variable product type.
3. Go to attributes tab.
4. Add a combination of Global attributes, local attributes, some with 'Visible on the product' page checked, and some with 'Used for variations' checked.
5. Click 'Save attributes'.
6. Verify that the tracks event `wcadmin_product_attributes_save` was fired with the expected parameters.
7. Create another product with 'Simple' product type.
8. Add a combination of Global attributes, local attributes, some with 'Visible on the product' page checked.
9. Click 'Save attributes'.
10. Verify that the tracks event `wcadmin_product_attributes_save` was fired with the expected parameters.

<!-- End testing instructions -->