### PR TITLE
skip k6 api batch update when batch create fails

### DIFF
--- a/plugins/woocommerce/changelog/fix-k6-api-batch-orders
+++ b/plugins/woocommerce/changelog/fix-k6-api-batch-orders
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+skip k6 batch update when batch create fails

--- a/plugins/woocommerce/tests/performance/requests/api/orders.js
+++ b/plugins/woocommerce/tests/performance/requests/api/orders.js
@@ -186,6 +186,10 @@ export function ordersAPI() {
 	group( 'API Batch Update Orders', function () {
 		let updateBatchItem;
 
+		if ( ! post_ids ) {
+			return;
+		}
+
 		for ( let index = 0; index < batchSize; index++ ) {
 			updateBatchItem = {
 				id: `${ post_ids[ index ] }`,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When running K6 tests I was seeing lots of the following error:

```
ERRO[0595] TypeError: Cannot read property '0' of undefined
Run    [at file:///Users/nobody/Sites/wc/wp-content/woocommerce/plugins/woocommerce/tests/performance/requests/api/orders.js:191:22(14)
	at go.k6.io/k6/js/modules/k6.(*K6).Group-fm (native)
	at ordersAPI (file:///Users/nobody/Sites/wc/wp-content/woocommerce/plugins/woocommerce/tests/performance/requests/api/orders.js:186:8(186))
	at allAPIFlow (file:///Users/nobody/Sites/wc/wp-content/woocommerce/plugins/woocommerce/tests/performance/tests/wc-baseline-load.js:329:1(4))
```

This PR adds a check to ensure that the batch add request returned a list of order IDs.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. In the `plugins/woocommerce` folder, run `pnpm run env:dev --filter=woocommerce `
2. Run `pnpm run env:performance-init --filter=woocommerce`
3. In the `tests/performance` folder, run `k6 run tests/wc-baseline-load.js`
5. Test suite should run successfully without logging the errors above.

<!-- End testing instructions -->