### PR TITLE
Wrap selected items in experimental select control

### DIFF
--- a/packages/js/components/changelog/fix-38210
+++ b/packages/js/components/changelog/fix-38210
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Wrap selected items in experimental select control

--- a/packages/js/components/src/experimental-select-control/combo-box.scss
+++ b/packages/js/components/src/experimental-select-control/combo-box.scss
@@ -18,7 +18,6 @@
 .woocommerce-experimental-select-control__items-wrapper {
 	display: flex;
 	flex-grow: 1;
-	flex-wrap: wrap;
 	align-items: center;
 	padding: 2px $gap-smaller;
 

--- a/packages/js/components/src/experimental-select-control/selected-items.scss
+++ b/packages/js/components/src/experimental-select-control/selected-items.scss
@@ -1,7 +1,11 @@
-.woocommerce-experimental-select-control__selected-items.is-read-only {
-    font-size: 13px;
-    color: $gray-900;
-    font-family: var(--wp--preset--font-family--system-font);
+.woocommerce-experimental-select-control__selected-items {
+    flex-wrap: wrap;
+
+    &.is-read-only {
+        font-size: 13px;
+        color: $gray-900;
+        font-family: var(--wp--preset--font-family--system-font);
+    }
 }
 
 .woocommerce-experimental-select-control__selected-item {


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Wraps the items in the dropdown so they don't go outside the dropdown field.

Note that the input is placed to the right of all the items and not next to the last selected item based on previous discussion.  This can be updated in a future PR if we want to place the input next to the selected items.

<img width="688" alt="Screen Shot 2023-05-12 at 10 00 09 AM" src="https://github.com/woocommerce/woocommerce/assets/10561050/77d0b8c1-0e6d-4f32-9bd0-0b0c01600794">

Closes #38210 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to `/wp-admin/tools.php?page=woocommerce-admin-test-helper`
2. Under Features tab make sure to enable product-block-editor
3. Then visit `/wp-admin/admin.php?page=wc-admin&path=/add-product`
4. Add enough categories to the category dropdown that the selected items go beyond the width of dropdown itself
5. Note that items don't go outside the dropdown, but are wrapped underneath other items (stacked)
6. Check other dropdowns to make sure no regressions have occurred

<!-- End testing instructions -->