### PR TITLE
Add woocommerce_suggest_jetpack filter to exlude Jetpack suggestion in OBW

### DIFF
--- a/plugins/woocommerce/changelog/add-38285-add-filter-to-free-extensions-rest-endpoint
+++ b/plugins/woocommerce/changelog/add-38285-add-filter-to-free-extensions-rest-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a filter to free extensions REST endpoint

--- a/plugins/woocommerce/src/Admin/API/OnboardingFreeExtensions.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingFreeExtensions.php
@@ -73,6 +73,9 @@ class OnboardingFreeExtensions extends \WC_REST_Data_Controller {
 	 * @return \WP_Error|\WP_REST_Response
 	 */
 	public function get_available_extensions( $request ) {
+		/**
+		* Allows filtering the extension list.
+		*/
 		return apply_filters( 'woocommerce_rest_onboarding_free_extensions_response', RemoteFreeExtensions::get_extensions() );
 	}
 

--- a/plugins/woocommerce/src/Admin/API/OnboardingFreeExtensions.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingFreeExtensions.php
@@ -80,7 +80,7 @@ class OnboardingFreeExtensions extends WC_REST_Data_Controller {
 	public function get_available_extensions( $request ) {
 		$extensions = RemoteFreeExtensions::get_extensions();
 		/**
-		* Remove Jetpack, WooCommerce Shipping & Tax when woocommerce_suggest_jetpack is false.
+		* Remove Jetpack when woocommerce_suggest_jetpack is false.
 		 *
 		 * @since 7.8
 		*/

--- a/plugins/woocommerce/src/Admin/API/OnboardingFreeExtensions.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingFreeExtensions.php
@@ -10,6 +10,11 @@ namespace Automattic\WooCommerce\Admin\API;
 defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Internal\Admin\RemoteFreeExtensions\Init as RemoteFreeExtensions;
+use WC_REST_Data_Controller;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
 
 /**
  * Onboarding Payments Controller.
@@ -17,7 +22,7 @@ use Automattic\WooCommerce\Internal\Admin\RemoteFreeExtensions\Init as RemoteFre
  * @internal
  * @extends WC_REST_Data_Controller
  */
-class OnboardingFreeExtensions extends \WC_REST_Data_Controller {
+class OnboardingFreeExtensions extends WC_REST_Data_Controller {
 
 	/**
 	 * Endpoint namespace.
@@ -42,7 +47,7 @@ class OnboardingFreeExtensions extends \WC_REST_Data_Controller {
 			'/' . $this->rest_base,
 			array(
 				array(
-					'methods'             => \WP_REST_Server::READABLE,
+					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_available_extensions' ),
 					'permission_callback' => array( $this, 'get_items_permissions_check' ),
 				),
@@ -59,7 +64,7 @@ class OnboardingFreeExtensions extends \WC_REST_Data_Controller {
 	 */
 	public function get_items_permissions_check( $request ) {
 		if ( ! wc_rest_check_manager_permissions( 'settings', 'read' ) ) {
-			return new \WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		return true;
@@ -68,15 +73,29 @@ class OnboardingFreeExtensions extends \WC_REST_Data_Controller {
 	/**
 	 * Return available payment methods.
 	 *
-	 * @param \WP_REST_Request $request Request data.
+	 * @param WP_REST_Request $request Request data.
 	 *
-	 * @return \WP_Error|\WP_REST_Response
+	 * @return WP_Error|WP_REST_Response
 	 */
 	public function get_available_extensions( $request ) {
+		$extensions = RemoteFreeExtensions::get_extensions();
 		/**
-		* Allows filtering the extension list.
+		* Remove Jetpack, WooCommerce Shipping & Tax when woocommerce_suggest_jetpack is false.
+		 *
+		 * @since 7.8
 		*/
-		return apply_filters( 'woocommerce_rest_onboarding_free_extensions_response', RemoteFreeExtensions::get_extensions() );
+		if ( false === apply_filters( 'woocommerce_suggest_jetpack', true ) ) {
+			foreach ( $extensions as &$extension ) {
+				$extension['plugins'] = array_filter(
+					$extension['plugins'],
+					function( $plugin ) {
+						return 'jetpack' !== $plugin->key;
+					}
+				);
+			}
+		}
+
+		return new WP_REST_Response( $extensions );
 	}
 
 }

--- a/plugins/woocommerce/src/Admin/API/OnboardingFreeExtensions.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingFreeExtensions.php
@@ -73,7 +73,7 @@ class OnboardingFreeExtensions extends \WC_REST_Data_Controller {
 	 * @return \WP_Error|\WP_REST_Response
 	 */
 	public function get_available_extensions( $request ) {
-		return RemoteFreeExtensions::get_extensions();
+		return apply_filters( 'woocommerce_rest_onboarding_free_extensions_response', RemoteFreeExtensions::get_extensions() );
 	}
 
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #38285

This PR adds `woocommerce_suggest_jetpack` filter to the free extensions REST endpoint to exclude Jetpack suggestion in OBW.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Download this [plugin](https://gist.github.com/moon0326/494af6e3754ec84668ea41ed6aa8bd16) and activate it
2. Start with a fresh site or make sure to remove Jetpack completely
3. Start OBW
4. Confirm Jetpack is not listed in `Business Details -> Free features`
<!-- End testing instructions -->