### PR TITLE
E2e/gutenberg latest nightly 0

### DIFF
--- a/.github/workflows/smoke-test-daily.yml
+++ b/.github/workflows/smoke-test-daily.yml
@@ -333,9 +333,9 @@ jobs:
                     # - plugin: 'WooCommerce Subscriptions'
                     #   repo: WC_SUBSCRIPTIONS_REPO
                     #   private: true
-                    - plugin: 'Gutenberg' # latest stable
+                    - plugin: 'Gutenberg'
                       repo: 'WordPress/gutenberg'
-                    - plugin: 'Gutenberg' # nightly
+                    - plugin: 'Gutenberg - Nightly'
                       repo: 'bph/gutenberg'
         steps:
             - name: Download test report artifact

--- a/.github/workflows/smoke-test-daily.yml
+++ b/.github/workflows/smoke-test-daily.yml
@@ -203,9 +203,9 @@ jobs:
                     # - plugin: 'WooCommerce Subscriptions'
                     #   repo: WC_SUBSCRIPTIONS_REPO
                     #   private: true
-                    - plugin: 'Gutenberg' # latest stable
+                    - plugin: 'Gutenberg'
                       repo: 'WordPress/gutenberg'
-                    - plugin: 'Gutenberg' # nightly
+                    - plugin: 'Gutenberg - Nightly'
                       repo: 'bph/gutenberg'
         steps:
             - uses: actions/checkout@v3

--- a/.github/workflows/smoke-test-daily.yml
+++ b/.github/workflows/smoke-test-daily.yml
@@ -211,6 +211,8 @@ jobs:
 
             - name: Setup WooCommerce Monorepo
               uses: ./.github/actions/setup-woocommerce-monorepo
+              with:
+                  build-filters: woocommerce
 
             - name: Launch wp-env e2e environment
               working-directory: plugins/woocommerce
@@ -232,7 +234,8 @@ jobs:
               working-directory: plugins/woocommerce
               env:
                   E2E_MAX_FAILURES: 15
-              run: pnpm exec playwright test --config=tests/e2e-pw/playwright.config.js
+              # mytodo remove basic.spec
+              run: pnpm exec playwright test --config=tests/e2e-pw/playwright.config.js basic.spec.js
 
             - name: Generate E2E Test report.
               if: success() || failure()
@@ -307,55 +310,56 @@ jobs:
     #                 -f s3_root=public \
     #                 --repo woocommerce/woocommerce-test-reports
 
-    plugins-results:
-        name: Publish report on Smoke tests on trunk with plugins
-        if: |
-            ( success() || failure() ) &&
-            ! github.event.pull_request.head.repo.fork
-        runs-on: ubuntu-20.04
-        # needs: [e2e-tests, test-plugins, k6-tests]
-        needs: [test-plugins] # mytodo revert to the above
-        env:
-            GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
-            RUN_ID: ${{ github.run_id }}
-            ARTIFACT: Smoke tests on trunk with ${{ matrix.plugin }} plugin installed (run ${{ github.run_number }})
-        strategy:
-            fail-fast: false
-            matrix:
-                include:
-                    # mytodo uncomment
-                    # - plugin: 'WooCommerce Payments'
-                    #   repo: 'automattic/woocommerce-payments'
-                    # - plugin: 'WooCommerce PayPal Payments'
-                    #   repo: 'woocommerce/woocommerce-paypal-payments'
-                    # - plugin: 'WooCommerce Shipping & Tax'
-                    #   repo: 'automattic/woocommerce-services'
-                    # - plugin: 'WooCommerce Subscriptions'
-                    #   repo: WC_SUBSCRIPTIONS_REPO
-                    #   private: true
-                    - plugin: 'Gutenberg'
-                      repo: 'WordPress/gutenberg'
-                    - plugin: 'Gutenberg - Nightly'
-                      repo: 'bph/gutenberg'
-        steps:
-            - name: Download test report artifact
-              uses: actions/download-artifact@v3
-              with:
-                  name: ${{ env.ARTIFACT }}
+    # plugins-results:
+    #     name: Publish report on Smoke tests on trunk with plugins
+    #     if: |
+    #         ( success() || failure() ) &&
+    #         ! github.event.pull_request.head.repo.fork
+    #     runs-on: ubuntu-20.04
+    #     # needs: [e2e-tests, test-plugins, k6-tests]
+    #     needs: [test-plugins] # mytodo revert to the above
+    #     env:
+    #         GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+    #         RUN_ID: ${{ github.run_id }}
+    #         ARTIFACT: Smoke tests on trunk with ${{ matrix.plugin }} plugin installed (run ${{ github.run_number }})
+    #     strategy:
+    #         fail-fast: false
+    #         matrix:
+    #             include:
+    #                 # mytodo uncomment
+    #                 # - plugin: 'WooCommerce Payments'
+    #                 #   repo: 'automattic/woocommerce-payments'
+    #                 # - plugin: 'WooCommerce PayPal Payments'
+    #                 #   repo: 'woocommerce/woocommerce-paypal-payments'
+    #                 # - plugin: 'WooCommerce Shipping & Tax'
+    #                 #   repo: 'automattic/woocommerce-services'
+    #                 # - plugin: 'WooCommerce Subscriptions'
+    #                 #   repo: WC_SUBSCRIPTIONS_REPO
+    #                 #   private: true
+    #                 - plugin: 'Gutenberg'
+    #                   repo: 'WordPress/gutenberg'
+    #                 - plugin: 'Gutenberg - Nightly'
+    #                   repo: 'bph/gutenberg'
+    #     steps:
+    #         - name: Download test report artifact
+    #           uses: actions/download-artifact@v3
+    #           with:
+    #               name: ${{ env.ARTIFACT }}
 
-            - name: Get slug
-              id: get-slug
-              uses: actions/github-script@v6
-              with:
-                  result-encoding: string
-                  script: return "${{ matrix.repo }}".split( '/' ).pop()
+    #         # mytodo fix this, same slug between Gutenberg and its nightly
+    #         - name: Get slug
+    #           id: get-slug
+    #           uses: actions/github-script@v6
+    #           with:
+    #               result-encoding: string
+    #               script: return "${{ matrix.repo }}".split( '/' ).pop()
 
-            - name: Publish reports
-              run: |
-                  gh workflow run publish-test-reports-daily-plugins.yml \
-                    -f run_id=$RUN_ID \
-                    -f artifact="${{ env.ARTIFACT }}" \
-                    -f plugin="${{ matrix.plugin }}" \
-                    -f slug="${{ steps.get-slug.outputs.result }}" \
-                    -f s3_root=public \
-                    --repo woocommerce/woocommerce-test-reports
+    #         - name: Publish reports
+    #           run: |
+    #               gh workflow run publish-test-reports-daily-plugins.yml \
+    #                 -f run_id=$RUN_ID \
+    #                 -f artifact="${{ env.ARTIFACT }}" \
+    #                 -f plugin="${{ matrix.plugin }}" \
+    #                 -f slug="${{ steps.get-slug.outputs.result }}" \
+    #                 -f s3_root=public \
+    #                 --repo woocommerce/woocommerce-test-reports

--- a/.github/workflows/smoke-test-daily.yml
+++ b/.github/workflows/smoke-test-daily.yml
@@ -75,6 +75,7 @@ jobs:
 
     e2e-tests:
         name: E2E tests on nightly build
+        if: false # mytodo re-enable
         runs-on: ubuntu-20.04
         permissions:
             contents: read
@@ -133,7 +134,8 @@ jobs:
         permissions:
             contents: read
         needs: [api-tests]
-        if: success() || failure()
+        # if: success() || failure()
+        if: false # mytodo re-enable
         steps:
             - uses: actions/checkout@v3
 
@@ -191,19 +193,20 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    - plugin: 'WooCommerce Payments'
-                      repo: 'automattic/woocommerce-payments'
-                    - plugin: 'WooCommerce PayPal Payments'
-                      repo: 'woocommerce/woocommerce-paypal-payments'
-                    - plugin: 'WooCommerce Shipping & Tax'
-                      repo: 'automattic/woocommerce-services'
-                    - plugin: 'WooCommerce Subscriptions'
-                      repo: WC_SUBSCRIPTIONS_REPO
-                      private: true
-                    - plugin: 'WordPress SEO' # Yoast SEO in the UI, but the slug is wordpress-seo
-                      repo: 'Yoast/wordpress-seo'
-                    - plugin: 'Contact Form 7'
-                      repo: 'takayukister/contact-form-7'
+                    # mytodo uncomment
+                    # - plugin: 'WooCommerce Payments'
+                    #   repo: 'automattic/woocommerce-payments'
+                    # - plugin: 'WooCommerce PayPal Payments'
+                    #   repo: 'woocommerce/woocommerce-paypal-payments'
+                    # - plugin: 'WooCommerce Shipping & Tax'
+                    #   repo: 'automattic/woocommerce-services'
+                    # - plugin: 'WooCommerce Subscriptions'
+                    #   repo: WC_SUBSCRIPTIONS_REPO
+                    #   private: true
+                    - plugin: 'Gutenberg' # latest stable
+                      repo: 'WordPress/gutenberg'
+                    - plugin: 'Gutenberg' # nightly
+                      repo: 'bph/gutenberg'
         steps:
             - uses: actions/checkout@v3
 
@@ -250,9 +253,10 @@ jobs:
 
     trunk-results:
         name: Publish report on smoke tests on nightly build
-        if: |
-            ( success() || failure() ) &&
-            ! github.event.pull_request.head.repo.fork
+        # if: |
+        #     ( success() || failure() ) &&
+        #     ! github.event.pull_request.head.repo.fork
+        if: false # mytodo re-enable
         runs-on: ubuntu-20.04
         permissions:
             contents: read
@@ -320,16 +324,20 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    - plugin: 'WooCommerce Payments'
-                      repo: 'automattic/woocommerce-payments'
-                    - plugin: 'WooCommerce PayPal Payments'
-                      repo: 'woocommerce/woocommerce-paypal-payments'
-                    - plugin: 'WooCommerce Shipping & Tax'
-                      repo: 'automattic/woocommerce-services'
-                    - plugin: 'WordPress SEO' # Yoast SEO in the UI, but the slug is wordpress-seo
-                      repo: 'Yoast/wordpress-seo'
-                    - plugin: 'Contact Form 7'
-                      repo: 'takayukister/contact-form-7'
+                    # mytodo uncomment
+                    # - plugin: 'WooCommerce Payments'
+                    #   repo: 'automattic/woocommerce-payments'
+                    # - plugin: 'WooCommerce PayPal Payments'
+                    #   repo: 'woocommerce/woocommerce-paypal-payments'
+                    # - plugin: 'WooCommerce Shipping & Tax'
+                    #   repo: 'automattic/woocommerce-services'
+                    # - plugin: 'WooCommerce Subscriptions'
+                    #   repo: WC_SUBSCRIPTIONS_REPO
+                    #   private: true
+                    - plugin: 'Gutenberg' # latest stable
+                      repo: 'WordPress/gutenberg'
+                    - plugin: 'Gutenberg' # nightly
+                      repo: 'bph/gutenberg'
         steps:
             - name: Download test report artifact
               uses: actions/download-artifact@v3

--- a/.github/workflows/smoke-test-daily.yml
+++ b/.github/workflows/smoke-test-daily.yml
@@ -228,14 +228,14 @@ jobs:
                   PLUGIN_REPOSITORY: ${{ matrix.private && secrets[matrix.repo] || matrix.repo }}
                   PLUGIN_NAME: ${{ matrix.plugin }}
                   GITHUB_TOKEN: ${{ secrets.E2E_GH_TOKEN }}
-              run: pnpm exec playwright test --config=tests/e2e-pw/playwright.config.js upload-plugin.spec.js
+              run: pnpm test:e2e-pw upload-plugin.spec.js
 
             - name: Run the rest of E2E tests
               working-directory: plugins/woocommerce
               env:
                   E2E_MAX_FAILURES: 15
               # mytodo remove basic.spec
-              run: pnpm exec playwright test --config=tests/e2e-pw/playwright.config.js basic.spec.js
+              run: pnpm test:e2e-pw basic.spec.js
 
             - name: Generate E2E Test report.
               if: success() || failure()

--- a/.github/workflows/smoke-test-daily.yml
+++ b/.github/workflows/smoke-test-daily.yml
@@ -310,56 +310,47 @@ jobs:
     #                 -f s3_root=public \
     #                 --repo woocommerce/woocommerce-test-reports
 
-    # plugins-results:
-    #     name: Publish report on Smoke tests on trunk with plugins
-    #     if: |
-    #         ( success() || failure() ) &&
-    #         ! github.event.pull_request.head.repo.fork
-    #     runs-on: ubuntu-20.04
-    #     # needs: [e2e-tests, test-plugins, k6-tests]
-    #     needs: [test-plugins] # mytodo revert to the above
-    #     env:
-    #         GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
-    #         RUN_ID: ${{ github.run_id }}
-    #         ARTIFACT: Smoke tests on trunk with ${{ matrix.plugin }} plugin installed (run ${{ github.run_number }})
-    #     strategy:
-    #         fail-fast: false
-    #         matrix:
-    #             include:
-    #                 # mytodo uncomment
-    #                 # - plugin: 'WooCommerce Payments'
-    #                 #   repo: 'automattic/woocommerce-payments'
-    #                 # - plugin: 'WooCommerce PayPal Payments'
-    #                 #   repo: 'woocommerce/woocommerce-paypal-payments'
-    #                 # - plugin: 'WooCommerce Shipping & Tax'
-    #                 #   repo: 'automattic/woocommerce-services'
-    #                 # - plugin: 'WooCommerce Subscriptions'
-    #                 #   repo: WC_SUBSCRIPTIONS_REPO
-    #                 #   private: true
-    #                 - plugin: 'Gutenberg'
-    #                   repo: 'WordPress/gutenberg'
-    #                 - plugin: 'Gutenberg - Nightly'
-    #                   repo: 'bph/gutenberg'
-    #     steps:
-    #         - name: Download test report artifact
-    #           uses: actions/download-artifact@v3
-    #           with:
-    #               name: ${{ env.ARTIFACT }}
+    plugins-results:
+        name: Publish report on Smoke tests on trunk with plugins
+        if: |
+            ( success() || failure() ) &&
+            ! github.event.pull_request.head.repo.fork
+        runs-on: ubuntu-20.04
+        # needs: [e2e-tests, test-plugins, k6-tests]
+        needs: [test-plugins] # mytodo revert to the above
+        env:
+            GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+            RUN_ID: ${{ github.run_id }}
+            ARTIFACT: Smoke tests on trunk with ${{ matrix.plugin }} plugin installed (run ${{ github.run_number }})
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    # mytodo uncomment
+                    # - plugin: 'WooCommerce Payments'
+                    #   slug: woocommerce-payments
+                    # - plugin: 'WooCommerce PayPal Payments'
+                    #   slug: woocommerce-paypal-payments
+                    # - plugin: 'WooCommerce Shipping & Tax'
+                    #   slug: woocommerce-services
+                    # - plugin: 'WooCommerce Subscriptions'
+                    #   slug: woocommerce-subscriptions
+                    - plugin: 'Gutenberg'
+                      slug: gutenberg
+                    - plugin: 'Gutenberg - Nightly'
+                      slug: gutenberg-nightly
+        steps:
+            - name: Download test report artifact
+              uses: actions/download-artifact@v3
+              with:
+                  name: ${{ env.ARTIFACT }}
 
-    #         # mytodo fix this, same slug between Gutenberg and its nightly
-    #         - name: Get slug
-    #           id: get-slug
-    #           uses: actions/github-script@v6
-    #           with:
-    #               result-encoding: string
-    #               script: return "${{ matrix.repo }}".split( '/' ).pop()
-
-    #         - name: Publish reports
-    #           run: |
-    #               gh workflow run publish-test-reports-daily-plugins.yml \
-    #                 -f run_id=$RUN_ID \
-    #                 -f artifact="${{ env.ARTIFACT }}" \
-    #                 -f plugin="${{ matrix.plugin }}" \
-    #                 -f slug="${{ steps.get-slug.outputs.result }}" \
-    #                 -f s3_root=public \
-    #                 --repo woocommerce/woocommerce-test-reports
+            - name: Publish reports
+              run: |
+                  gh workflow run publish-test-reports-daily-plugins.yml \
+                    -f run_id=$RUN_ID \
+                    -f artifact="${{ env.ARTIFACT }}" \
+                    -f plugin="${{ matrix.plugin }}" \
+                    -f slug="${{ matrix.slug }}" \
+                    -f s3_root=public \
+                    --repo woocommerce/woocommerce-test-reports

--- a/.github/workflows/smoke-test-daily.yml
+++ b/.github/workflows/smoke-test-daily.yml
@@ -16,174 +16,173 @@ concurrency:
 permissions: {}
 
 jobs:
-    # api-tests:
-    #     name: API tests on nightly build
-    #     runs-on: ubuntu-20.04
-    #     permissions:
-    #         contents: read
-    #     env:
-    #         ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/test-results/allure-results
-    #         ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/test-results/allure-report
-    #         BASE_URL: ${{ secrets.SMOKE_TEST_URL }}
-    #         ADMIN_USER: ${{ secrets.SMOKE_TEST_ADMIN_USER }}
-    #         ADMIN_PASSWORD: ${{ secrets.SMOKE_TEST_ADMIN_PASSWORD }}
-    #         ADMIN_USER_EMAIL: ${{ secrets.SMOKE_TEST_ADMIN_USER_EMAIL }}
-    #         CUSTOMER_USER: ${{ secrets.SMOKE_TEST_CUSTOMER_USER }}
-    #         CUSTOMER_PASSWORD: ${{ secrets.SMOKE_TEST_CUSTOMER_PASSWORD }}
-    #         DEFAULT_TIMEOUT_OVERRIDE: 120000
-    #     steps:
-    #         - uses: actions/checkout@v3
+    api-tests:
+        name: API tests on nightly build
+        runs-on: ubuntu-20.04
+        permissions:
+            contents: read
+        env:
+            ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/test-results/allure-results
+            ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/test-results/allure-report
+            BASE_URL: ${{ secrets.SMOKE_TEST_URL }}
+            ADMIN_USER: ${{ secrets.SMOKE_TEST_ADMIN_USER }}
+            ADMIN_PASSWORD: ${{ secrets.SMOKE_TEST_ADMIN_PASSWORD }}
+            ADMIN_USER_EMAIL: ${{ secrets.SMOKE_TEST_ADMIN_USER_EMAIL }}
+            CUSTOMER_USER: ${{ secrets.SMOKE_TEST_CUSTOMER_USER }}
+            CUSTOMER_PASSWORD: ${{ secrets.SMOKE_TEST_CUSTOMER_PASSWORD }}
+            DEFAULT_TIMEOUT_OVERRIDE: 120000
+        steps:
+            - uses: actions/checkout@v3
 
-    #         - name: Setup WooCommerce Monorepo
-    #           uses: ./.github/actions/setup-woocommerce-monorepo
-    #           with:
-    #               install-filters: woocommerce
-    #               build: false
+            - name: Setup WooCommerce Monorepo
+              uses: ./.github/actions/setup-woocommerce-monorepo
+              with:
+                  install-filters: woocommerce
+                  build: false
 
-    #         - name: Download and install Chromium browser.
-    #           working-directory: plugins/woocommerce
-    #           run: pnpm exec playwright install chromium
+            - name: Download and install Chromium browser.
+              working-directory: plugins/woocommerce
+              run: pnpm exec playwright install chromium
 
-    #         - name: Run 'Update WooCommerce' test.
-    #           working-directory: plugins/woocommerce
-    #           env:
-    #               UPDATE_WC: nightly
-    #           run: pnpm exec playwright test --config=tests/e2e-pw/daily.playwright.config.js update-woocommerce.spec.js
+            - name: Run 'Update WooCommerce' test.
+              working-directory: plugins/woocommerce
+              env:
+                  UPDATE_WC: nightly
+              run: pnpm exec playwright test --config=tests/e2e-pw/daily.playwright.config.js update-woocommerce.spec.js
 
-    #         - name: Run API tests.
-    #           working-directory: plugins/woocommerce
-    #           env:
-    #               USER_KEY: ${{ secrets.SMOKE_TEST_ADMIN_USER }}
-    #               USER_SECRET: ${{ secrets.SMOKE_TEST_ADMIN_PASSWORD }}
-    #           run: pnpm exec playwright test --config=tests/api-core-tests/playwright.config.js hello.test.js
+            - name: Run API tests.
+              working-directory: plugins/woocommerce
+              env:
+                  USER_KEY: ${{ secrets.SMOKE_TEST_ADMIN_USER }}
+                  USER_SECRET: ${{ secrets.SMOKE_TEST_ADMIN_PASSWORD }}
+              run: pnpm exec playwright test --config=tests/api-core-tests/playwright.config.js hello.test.js
 
-    #         - name: Generate API Test report.
-    #           if: success() || failure()
-    #           working-directory: plugins/woocommerce
-    #           run: pnpm exec allure generate --clean ${{ env.ALLURE_RESULTS_DIR }} --output ${{ env.ALLURE_REPORT_DIR }}
+            - name: Generate API Test report.
+              if: success() || failure()
+              working-directory: plugins/woocommerce
+              run: pnpm exec allure generate --clean ${{ env.ALLURE_RESULTS_DIR }} --output ${{ env.ALLURE_REPORT_DIR }}
 
-    #         - name: Archive API test report
-    #           if: success() || failure()
-    #           uses: actions/upload-artifact@v3
-    #           with:
-    #               name: ${{ env.API_ARTIFACT }}
-    #               path: |
-    #                   ${{ env.ALLURE_RESULTS_DIR }}
-    #                   ${{ env.ALLURE_REPORT_DIR }}
-    #               if-no-files-found: ignore
-    #               retention-days: 5
+            - name: Archive API test report
+              if: success() || failure()
+              uses: actions/upload-artifact@v3
+              with:
+                  name: ${{ env.API_ARTIFACT }}
+                  path: |
+                      ${{ env.ALLURE_RESULTS_DIR }}
+                      ${{ env.ALLURE_REPORT_DIR }}
+                  if-no-files-found: ignore
+                  retention-days: 5
 
-    # e2e-tests:
-    #     name: E2E tests on nightly build
-    #     runs-on: ubuntu-20.04
-    #     permissions:
-    #         contents: read
-    #     needs: [api-tests]
-    #     env:
-    #         ADMIN_PASSWORD: ${{ secrets.SMOKE_TEST_ADMIN_PASSWORD }}
-    #         ADMIN_USER: ${{ secrets.SMOKE_TEST_ADMIN_USER }}
-    #         ADMIN_USER_EMAIL: ${{ secrets.SMOKE_TEST_ADMIN_USER_EMAIL }}
-    #         ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-report
-    #         ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-results
-    #         BASE_URL: ${{ secrets.SMOKE_TEST_URL }}
-    #         CUSTOMER_PASSWORD: ${{ secrets.SMOKE_TEST_CUSTOMER_PASSWORD }}
-    #         CUSTOMER_USER: ${{ secrets.SMOKE_TEST_CUSTOMER_USER }}
-    #         DEFAULT_TIMEOUT_OVERRIDE: 120000
+    e2e-tests:
+        name: E2E tests on nightly build
+        runs-on: ubuntu-20.04
+        permissions:
+            contents: read
+        needs: [api-tests]
+        env:
+            ADMIN_PASSWORD: ${{ secrets.SMOKE_TEST_ADMIN_PASSWORD }}
+            ADMIN_USER: ${{ secrets.SMOKE_TEST_ADMIN_USER }}
+            ADMIN_USER_EMAIL: ${{ secrets.SMOKE_TEST_ADMIN_USER_EMAIL }}
+            ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-report
+            ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-results
+            BASE_URL: ${{ secrets.SMOKE_TEST_URL }}
+            CUSTOMER_PASSWORD: ${{ secrets.SMOKE_TEST_CUSTOMER_PASSWORD }}
+            CUSTOMER_USER: ${{ secrets.SMOKE_TEST_CUSTOMER_USER }}
+            DEFAULT_TIMEOUT_OVERRIDE: 120000
 
-    #     steps:
-    #         - uses: actions/checkout@v3
+        steps:
+            - uses: actions/checkout@v3
 
-    #         - name: Setup WooCommerce Monorepo
-    #           uses: ./.github/actions/setup-woocommerce-monorepo
-    #           with:
-    #               install-filters: woocommerce
-    #               build: false
+            - name: Setup WooCommerce Monorepo
+              uses: ./.github/actions/setup-woocommerce-monorepo
+              with:
+                  install-filters: woocommerce
+                  build: false
 
-    #         - name: Download and install Chromium browser.
-    #           working-directory: plugins/woocommerce
-    #           run: pnpm exec playwright install chromium
+            - name: Download and install Chromium browser.
+              working-directory: plugins/woocommerce
+              run: pnpm exec playwright install chromium
 
-    #         - name: Run E2E tests.
-    #           timeout-minutes: 60
-    #           working-directory: plugins/woocommerce
-    #           env:
-    #               E2E_MAX_FAILURES: 25
-    #               RESET_SITE: true
-    #           run: pnpm exec playwright test --config=tests/e2e-pw/playwright.config.js
+            - name: Run E2E tests.
+              timeout-minutes: 60
+              working-directory: plugins/woocommerce
+              env:
+                  E2E_MAX_FAILURES: 25
+                  RESET_SITE: true
+              run: pnpm exec playwright test --config=tests/e2e-pw/playwright.config.js
 
-    #         - name: Generate Playwright E2E Test report.
-    #           if: success() || failure()
-    #           working-directory: plugins/woocommerce
-    #           run: pnpm exec allure generate --clean ${{ env.ALLURE_RESULTS_DIR }} --output ${{ env.ALLURE_REPORT_DIR }}
+            - name: Generate Playwright E2E Test report.
+              if: success() || failure()
+              working-directory: plugins/woocommerce
+              run: pnpm exec allure generate --clean ${{ env.ALLURE_RESULTS_DIR }} --output ${{ env.ALLURE_REPORT_DIR }}
 
-    #         - name: Archive E2E test report
-    #           if: success() || failure()
-    #           uses: actions/upload-artifact@v3
-    #           with:
-    #               name: ${{ env.E2E_ARTIFACT }}
-    #               path: |
-    #                   ${{ env.ALLURE_RESULTS_DIR }}
-    #                   ${{ env.ALLURE_REPORT_DIR }}
-    #               if-no-files-found: ignore
-    #               retention-days: 5
+            - name: Archive E2E test report
+              if: success() || failure()
+              uses: actions/upload-artifact@v3
+              with:
+                  name: ${{ env.E2E_ARTIFACT }}
+                  path: |
+                      ${{ env.ALLURE_RESULTS_DIR }}
+                      ${{ env.ALLURE_REPORT_DIR }}
+                  if-no-files-found: ignore
+                  retention-days: 5
 
-    # k6-tests:
-    #     name: k6 tests on nightly build
-    #     runs-on: ubuntu-20.04
-    #     permissions:
-    #         contents: read
-    #     needs: [api-tests]
-    #     if: success() || failure()
-    #     steps:
-    #         - uses: actions/checkout@v3
+    k6-tests:
+        name: k6 tests on nightly build
+        runs-on: ubuntu-20.04
+        permissions:
+            contents: read
+        needs: [api-tests]
+        if: success() || failure()
+        steps:
+            - uses: actions/checkout@v3
 
-    #         - name: Setup WooCommerce Monorepo
-    #           uses: ./.github/actions/setup-woocommerce-monorepo
-    #           with:
-    #               install-filters: woocommerce
-    #               build: false
+            - name: Setup WooCommerce Monorepo
+              uses: ./.github/actions/setup-woocommerce-monorepo
+              with:
+                  install-filters: woocommerce
+                  build: false
 
-    #         - name: Download and install Chromium browser.
-    #           working-directory: plugins/woocommerce
-    #           run: pnpm exec playwright install chromium
+            - name: Download and install Chromium browser.
+              working-directory: plugins/woocommerce
+              run: pnpm exec playwright install chromium
 
-    #         - name: Update performance test site with E2E test
-    #           working-directory: plugins/woocommerce
-    #           env:
-    #               BASE_URL: ${{ secrets.SMOKE_TEST_PERF_URL }}/
-    #               ADMIN_USER: ${{ secrets.SMOKE_TEST_PERF_ADMIN_USER }}
-    #               ADMIN_PASSWORD: ${{ secrets.SMOKE_TEST_PERF_ADMIN_PASSWORD }}
-    #               CUSTOMER_USER: ${{ secrets.SMOKE_TEST_PERF_ADMIN_USER }}
-    #               CUSTOMER_PASSWORD: ${{ secrets.SMOKE_TEST_PERF_ADMIN_PASSWORD }}
-    #               UPDATE_WC: nightly
-    #               DEFAULT_TIMEOUT_OVERRIDE: 120000
-    #           run: |
-    #               pnpm exec playwright test --config=tests/e2e-pw/playwright.config.js update-woocommerce.spec.js
-    #           continue-on-error: true
+            - name: Update performance test site with E2E test
+              working-directory: plugins/woocommerce
+              env:
+                  BASE_URL: ${{ secrets.SMOKE_TEST_PERF_URL }}/
+                  ADMIN_USER: ${{ secrets.SMOKE_TEST_PERF_ADMIN_USER }}
+                  ADMIN_PASSWORD: ${{ secrets.SMOKE_TEST_PERF_ADMIN_PASSWORD }}
+                  CUSTOMER_USER: ${{ secrets.SMOKE_TEST_PERF_ADMIN_USER }}
+                  CUSTOMER_PASSWORD: ${{ secrets.SMOKE_TEST_PERF_ADMIN_PASSWORD }}
+                  UPDATE_WC: nightly
+                  DEFAULT_TIMEOUT_OVERRIDE: 120000
+              run: |
+                  pnpm exec playwright test --config=tests/e2e-pw/playwright.config.js update-woocommerce.spec.js
+              continue-on-error: true
 
-    #         - name: Install k6
-    #           run: |
-    #               curl https://github.com/grafana/k6/releases/download/v0.33.0/k6-v0.33.0-linux-amd64.tar.gz -L | tar xvz --strip-components 1
+            - name: Install k6
+              run: |
+                  curl https://github.com/grafana/k6/releases/download/v0.33.0/k6-v0.33.0-linux-amd64.tar.gz -L | tar xvz --strip-components 1
 
-    #         - name: Run k6 smoke tests
-    #           env:
-    #               URL: ${{ secrets.SMOKE_TEST_PERF_URL }}
-    #               HOST: ${{ secrets.SMOKE_TEST_PERF_HOST }}
-    #               A_USER: ${{ secrets.SMOKE_TEST_PERF_ADMIN_USER }}
-    #               A_PW: ${{ secrets.SMOKE_TEST_PERF_ADMIN_PASSWORD }}
-    #               C_USER: ${{ secrets.SMOKE_TEST_PERF_ADMIN_USER }}
-    #               C_PW: ${{ secrets.SMOKE_TEST_PERF_ADMIN_PASSWORD }}
-    #               P_ID: 22733
-    #           run: |
-    #               ./k6 run plugins/woocommerce/tests/performance/tests/gh-action-daily-ext-requests.js
+            - name: Run k6 smoke tests
+              env:
+                  URL: ${{ secrets.SMOKE_TEST_PERF_URL }}
+                  HOST: ${{ secrets.SMOKE_TEST_PERF_HOST }}
+                  A_USER: ${{ secrets.SMOKE_TEST_PERF_ADMIN_USER }}
+                  A_PW: ${{ secrets.SMOKE_TEST_PERF_ADMIN_PASSWORD }}
+                  C_USER: ${{ secrets.SMOKE_TEST_PERF_ADMIN_USER }}
+                  C_PW: ${{ secrets.SMOKE_TEST_PERF_ADMIN_PASSWORD }}
+                  P_ID: 22733
+              run: |
+                  ./k6 run plugins/woocommerce/tests/performance/tests/gh-action-daily-ext-requests.js
 
     test-plugins:
         name: Smoke tests on trunk with ${{ matrix.plugin }} plugin installed
         runs-on: ubuntu-20.04
         permissions:
             contents: read
-        # mytodo uncomment
-        # needs: [api-tests]
+        needs: [api-tests]
         env:
             USE_WP_ENV: 1
             ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/allure-results
@@ -192,16 +191,15 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    # mytodo uncomment
-                    # - plugin: 'WooCommerce Payments'
-                    #   repo: 'automattic/woocommerce-payments'
-                    # - plugin: 'WooCommerce PayPal Payments'
-                    #   repo: 'woocommerce/woocommerce-paypal-payments'
-                    # - plugin: 'WooCommerce Shipping & Tax'
-                    #   repo: 'automattic/woocommerce-services'
-                    # - plugin: 'WooCommerce Subscriptions'
-                    #   repo: WC_SUBSCRIPTIONS_REPO
-                    #   private: true
+                    - plugin: 'WooCommerce Payments'
+                      repo: 'automattic/woocommerce-payments'
+                    - plugin: 'WooCommerce PayPal Payments'
+                      repo: 'woocommerce/woocommerce-paypal-payments'
+                    - plugin: 'WooCommerce Shipping & Tax'
+                      repo: 'automattic/woocommerce-services'
+                    - plugin: 'WooCommerce Subscriptions'
+                      repo: WC_SUBSCRIPTIONS_REPO
+                      private: true
                     - plugin: 'Gutenberg'
                       repo: 'WordPress/gutenberg'
                     - plugin: 'Gutenberg - Nightly'
@@ -234,8 +232,7 @@ jobs:
               working-directory: plugins/woocommerce
               env:
                   E2E_MAX_FAILURES: 15
-              # mytodo remove basic.spec
-              run: pnpm test:e2e-pw basic.spec.js
+              run: pnpm test:e2e-pw
 
             - name: Generate E2E Test report.
               if: success() || failure()
@@ -253,62 +250,62 @@ jobs:
                   if-no-files-found: ignore
                   retention-days: 5
 
-    # trunk-results:
-    #     name: Publish report on smoke tests on nightly build
-    #     if: |
-    #         ( success() || failure() ) &&
-    #         ! github.event.pull_request.head.repo.fork
-    #     runs-on: ubuntu-20.04
-    #     permissions:
-    #         contents: read
-    #     needs: [e2e-tests, test-plugins, k6-tests]
-    #     steps:
-    #         - name: Create dirs
-    #           run: |
-    #               mkdir -p repo
-    #               mkdir -p artifacts/api
-    #               mkdir -p artifacts/e2e
-    #               mkdir -p output
+    trunk-results:
+        name: Publish report on smoke tests on nightly build
+        if: |
+            ( success() || failure() ) &&
+            ! github.event.pull_request.head.repo.fork
+        runs-on: ubuntu-20.04
+        permissions:
+            contents: read
+        needs: [e2e-tests, test-plugins, k6-tests]
+        steps:
+            - name: Create dirs
+              run: |
+                  mkdir -p repo
+                  mkdir -p artifacts/api
+                  mkdir -p artifacts/e2e
+                  mkdir -p output
 
-    #         - name: Checkout code
-    #           uses: actions/checkout@v3
-    #           with:
-    #               path: repo
+            - name: Checkout code
+              uses: actions/checkout@v3
+              with:
+                  path: repo
 
-    #         - name: Download API test report artifact
-    #           uses: actions/download-artifact@v3
-    #           with:
-    #               name: ${{ env.API_ARTIFACT }}
-    #               path: artifacts/api
+            - name: Download API test report artifact
+              uses: actions/download-artifact@v3
+              with:
+                  name: ${{ env.API_ARTIFACT }}
+                  path: artifacts/api
 
-    #         - name: Download E2E test report artifact
-    #           uses: actions/download-artifact@v3
-    #           with:
-    #               name: ${{ env.E2E_ARTIFACT }}
-    #               path: artifacts/e2e
+            - name: Download E2E test report artifact
+              uses: actions/download-artifact@v3
+              with:
+                  name: ${{ env.E2E_ARTIFACT }}
+                  path: artifacts/e2e
 
-    #         - name: Post test summary
-    #           uses: actions/github-script@v6
-    #           env:
-    #               API_SUMMARY_PATH: ${{ github.workspace }}/artifacts/api/allure-report/widgets/summary.json
-    #               E2E_PW_SUMMARY_PATH: ${{ github.workspace }}/artifacts/e2e/allure-report/widgets/summary.json
-    #           with:
-    #               result-encoding: string
-    #               script: |
-    #                   const script = require( './repo/.github/workflows/scripts/prepare-test-summary-daily.js' )
-    #                   return await script( { core } )
+            - name: Post test summary
+              uses: actions/github-script@v6
+              env:
+                  API_SUMMARY_PATH: ${{ github.workspace }}/artifacts/api/allure-report/widgets/summary.json
+                  E2E_PW_SUMMARY_PATH: ${{ github.workspace }}/artifacts/e2e/allure-report/widgets/summary.json
+              with:
+                  result-encoding: string
+                  script: |
+                      const script = require( './repo/.github/workflows/scripts/prepare-test-summary-daily.js' )
+                      return await script( { core } )
 
-    #         - name: Publish report
-    #           env:
-    #               GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
-    #               RUN_ID: ${{ github.run_id }}
-    #           run: |
-    #               gh workflow run publish-test-reports-daily.yml \
-    #                 -f run_id=$RUN_ID \
-    #                 -f api_artifact="$API_ARTIFACT" \
-    #                 -f e2e_artifact="$E2E_ARTIFACT" \
-    #                 -f s3_root=public \
-    #                 --repo woocommerce/woocommerce-test-reports
+            - name: Publish report
+              env:
+                  GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+                  RUN_ID: ${{ github.run_id }}
+              run: |
+                  gh workflow run publish-test-reports-daily.yml \
+                    -f run_id=$RUN_ID \
+                    -f api_artifact="$API_ARTIFACT" \
+                    -f e2e_artifact="$E2E_ARTIFACT" \
+                    -f s3_root=public \
+                    --repo woocommerce/woocommerce-test-reports
 
     plugins-results:
         name: Publish report on Smoke tests on trunk with plugins
@@ -316,8 +313,7 @@ jobs:
             ( success() || failure() ) &&
             ! github.event.pull_request.head.repo.fork
         runs-on: ubuntu-20.04
-        # needs: [e2e-tests, test-plugins, k6-tests]
-        needs: [test-plugins] # mytodo revert to the above
+        needs: [e2e-tests, test-plugins, k6-tests]
         env:
             GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
             RUN_ID: ${{ github.run_id }}
@@ -326,15 +322,14 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    # mytodo uncomment
-                    # - plugin: 'WooCommerce Payments'
-                    #   slug: woocommerce-payments
-                    # - plugin: 'WooCommerce PayPal Payments'
-                    #   slug: woocommerce-paypal-payments
-                    # - plugin: 'WooCommerce Shipping & Tax'
-                    #   slug: woocommerce-services
-                    # - plugin: 'WooCommerce Subscriptions'
-                    #   slug: woocommerce-subscriptions
+                    - plugin: 'WooCommerce Payments'
+                      slug: woocommerce-payments
+                    - plugin: 'WooCommerce PayPal Payments'
+                      slug: woocommerce-paypal-payments
+                    - plugin: 'WooCommerce Shipping & Tax'
+                      slug: woocommerce-services
+                    - plugin: 'WooCommerce Subscriptions'
+                      slug: woocommerce-subscriptions
                     - plugin: 'Gutenberg'
                       slug: gutenberg
                     - plugin: 'Gutenberg - Nightly'

--- a/.github/workflows/smoke-test-daily.yml
+++ b/.github/workflows/smoke-test-daily.yml
@@ -16,175 +16,174 @@ concurrency:
 permissions: {}
 
 jobs:
-    api-tests:
-        name: API tests on nightly build
-        runs-on: ubuntu-20.04
-        permissions:
-            contents: read
-        env:
-            ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/test-results/allure-results
-            ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/test-results/allure-report
-            BASE_URL: ${{ secrets.SMOKE_TEST_URL }}
-            ADMIN_USER: ${{ secrets.SMOKE_TEST_ADMIN_USER }}
-            ADMIN_PASSWORD: ${{ secrets.SMOKE_TEST_ADMIN_PASSWORD }}
-            ADMIN_USER_EMAIL: ${{ secrets.SMOKE_TEST_ADMIN_USER_EMAIL }}
-            CUSTOMER_USER: ${{ secrets.SMOKE_TEST_CUSTOMER_USER }}
-            CUSTOMER_PASSWORD: ${{ secrets.SMOKE_TEST_CUSTOMER_PASSWORD }}
-            DEFAULT_TIMEOUT_OVERRIDE: 120000
-        steps:
-            - uses: actions/checkout@v3
+    # api-tests:
+    #     name: API tests on nightly build
+    #     runs-on: ubuntu-20.04
+    #     permissions:
+    #         contents: read
+    #     env:
+    #         ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/test-results/allure-results
+    #         ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/test-results/allure-report
+    #         BASE_URL: ${{ secrets.SMOKE_TEST_URL }}
+    #         ADMIN_USER: ${{ secrets.SMOKE_TEST_ADMIN_USER }}
+    #         ADMIN_PASSWORD: ${{ secrets.SMOKE_TEST_ADMIN_PASSWORD }}
+    #         ADMIN_USER_EMAIL: ${{ secrets.SMOKE_TEST_ADMIN_USER_EMAIL }}
+    #         CUSTOMER_USER: ${{ secrets.SMOKE_TEST_CUSTOMER_USER }}
+    #         CUSTOMER_PASSWORD: ${{ secrets.SMOKE_TEST_CUSTOMER_PASSWORD }}
+    #         DEFAULT_TIMEOUT_OVERRIDE: 120000
+    #     steps:
+    #         - uses: actions/checkout@v3
 
-            - name: Setup WooCommerce Monorepo
-              uses: ./.github/actions/setup-woocommerce-monorepo
-              with:
-                  install-filters: woocommerce
-                  build: false
+    #         - name: Setup WooCommerce Monorepo
+    #           uses: ./.github/actions/setup-woocommerce-monorepo
+    #           with:
+    #               install-filters: woocommerce
+    #               build: false
 
-            - name: Download and install Chromium browser.
-              working-directory: plugins/woocommerce
-              run: pnpm exec playwright install chromium
+    #         - name: Download and install Chromium browser.
+    #           working-directory: plugins/woocommerce
+    #           run: pnpm exec playwright install chromium
 
-            - name: Run 'Update WooCommerce' test.
-              working-directory: plugins/woocommerce
-              env:
-                  UPDATE_WC: nightly
-              run: pnpm exec playwright test --config=tests/e2e-pw/daily.playwright.config.js update-woocommerce.spec.js
+    #         - name: Run 'Update WooCommerce' test.
+    #           working-directory: plugins/woocommerce
+    #           env:
+    #               UPDATE_WC: nightly
+    #           run: pnpm exec playwright test --config=tests/e2e-pw/daily.playwright.config.js update-woocommerce.spec.js
 
-            - name: Run API tests.
-              working-directory: plugins/woocommerce
-              env:
-                  USER_KEY: ${{ secrets.SMOKE_TEST_ADMIN_USER }}
-                  USER_SECRET: ${{ secrets.SMOKE_TEST_ADMIN_PASSWORD }}
-              run: pnpm exec playwright test --config=tests/api-core-tests/playwright.config.js hello.test.js
+    #         - name: Run API tests.
+    #           working-directory: plugins/woocommerce
+    #           env:
+    #               USER_KEY: ${{ secrets.SMOKE_TEST_ADMIN_USER }}
+    #               USER_SECRET: ${{ secrets.SMOKE_TEST_ADMIN_PASSWORD }}
+    #           run: pnpm exec playwright test --config=tests/api-core-tests/playwright.config.js hello.test.js
 
-            - name: Generate API Test report.
-              if: success() || failure()
-              working-directory: plugins/woocommerce
-              run: pnpm exec allure generate --clean ${{ env.ALLURE_RESULTS_DIR }} --output ${{ env.ALLURE_REPORT_DIR }}
+    #         - name: Generate API Test report.
+    #           if: success() || failure()
+    #           working-directory: plugins/woocommerce
+    #           run: pnpm exec allure generate --clean ${{ env.ALLURE_RESULTS_DIR }} --output ${{ env.ALLURE_REPORT_DIR }}
 
-            - name: Archive API test report
-              if: success() || failure()
-              uses: actions/upload-artifact@v3
-              with:
-                  name: ${{ env.API_ARTIFACT }}
-                  path: |
-                      ${{ env.ALLURE_RESULTS_DIR }}
-                      ${{ env.ALLURE_REPORT_DIR }}
-                  if-no-files-found: ignore
-                  retention-days: 5
+    #         - name: Archive API test report
+    #           if: success() || failure()
+    #           uses: actions/upload-artifact@v3
+    #           with:
+    #               name: ${{ env.API_ARTIFACT }}
+    #               path: |
+    #                   ${{ env.ALLURE_RESULTS_DIR }}
+    #                   ${{ env.ALLURE_REPORT_DIR }}
+    #               if-no-files-found: ignore
+    #               retention-days: 5
 
-    e2e-tests:
-        name: E2E tests on nightly build
-        if: false # mytodo re-enable
-        runs-on: ubuntu-20.04
-        permissions:
-            contents: read
-        needs: [api-tests]
-        env:
-            ADMIN_PASSWORD: ${{ secrets.SMOKE_TEST_ADMIN_PASSWORD }}
-            ADMIN_USER: ${{ secrets.SMOKE_TEST_ADMIN_USER }}
-            ADMIN_USER_EMAIL: ${{ secrets.SMOKE_TEST_ADMIN_USER_EMAIL }}
-            ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-report
-            ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-results
-            BASE_URL: ${{ secrets.SMOKE_TEST_URL }}
-            CUSTOMER_PASSWORD: ${{ secrets.SMOKE_TEST_CUSTOMER_PASSWORD }}
-            CUSTOMER_USER: ${{ secrets.SMOKE_TEST_CUSTOMER_USER }}
-            DEFAULT_TIMEOUT_OVERRIDE: 120000
+    # e2e-tests:
+    #     name: E2E tests on nightly build
+    #     runs-on: ubuntu-20.04
+    #     permissions:
+    #         contents: read
+    #     needs: [api-tests]
+    #     env:
+    #         ADMIN_PASSWORD: ${{ secrets.SMOKE_TEST_ADMIN_PASSWORD }}
+    #         ADMIN_USER: ${{ secrets.SMOKE_TEST_ADMIN_USER }}
+    #         ADMIN_USER_EMAIL: ${{ secrets.SMOKE_TEST_ADMIN_USER_EMAIL }}
+    #         ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-report
+    #         ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-results
+    #         BASE_URL: ${{ secrets.SMOKE_TEST_URL }}
+    #         CUSTOMER_PASSWORD: ${{ secrets.SMOKE_TEST_CUSTOMER_PASSWORD }}
+    #         CUSTOMER_USER: ${{ secrets.SMOKE_TEST_CUSTOMER_USER }}
+    #         DEFAULT_TIMEOUT_OVERRIDE: 120000
 
-        steps:
-            - uses: actions/checkout@v3
+    #     steps:
+    #         - uses: actions/checkout@v3
 
-            - name: Setup WooCommerce Monorepo
-              uses: ./.github/actions/setup-woocommerce-monorepo
-              with:
-                  install-filters: woocommerce
-                  build: false
+    #         - name: Setup WooCommerce Monorepo
+    #           uses: ./.github/actions/setup-woocommerce-monorepo
+    #           with:
+    #               install-filters: woocommerce
+    #               build: false
 
-            - name: Download and install Chromium browser.
-              working-directory: plugins/woocommerce
-              run: pnpm exec playwright install chromium
+    #         - name: Download and install Chromium browser.
+    #           working-directory: plugins/woocommerce
+    #           run: pnpm exec playwright install chromium
 
-            - name: Run E2E tests.
-              timeout-minutes: 60
-              working-directory: plugins/woocommerce
-              env:
-                  E2E_MAX_FAILURES: 25
-                  RESET_SITE: true
-              run: pnpm exec playwright test --config=tests/e2e-pw/playwright.config.js
+    #         - name: Run E2E tests.
+    #           timeout-minutes: 60
+    #           working-directory: plugins/woocommerce
+    #           env:
+    #               E2E_MAX_FAILURES: 25
+    #               RESET_SITE: true
+    #           run: pnpm exec playwright test --config=tests/e2e-pw/playwright.config.js
 
-            - name: Generate Playwright E2E Test report.
-              if: success() || failure()
-              working-directory: plugins/woocommerce
-              run: pnpm exec allure generate --clean ${{ env.ALLURE_RESULTS_DIR }} --output ${{ env.ALLURE_REPORT_DIR }}
+    #         - name: Generate Playwright E2E Test report.
+    #           if: success() || failure()
+    #           working-directory: plugins/woocommerce
+    #           run: pnpm exec allure generate --clean ${{ env.ALLURE_RESULTS_DIR }} --output ${{ env.ALLURE_REPORT_DIR }}
 
-            - name: Archive E2E test report
-              if: success() || failure()
-              uses: actions/upload-artifact@v3
-              with:
-                  name: ${{ env.E2E_ARTIFACT }}
-                  path: |
-                      ${{ env.ALLURE_RESULTS_DIR }}
-                      ${{ env.ALLURE_REPORT_DIR }}
-                  if-no-files-found: ignore
-                  retention-days: 5
+    #         - name: Archive E2E test report
+    #           if: success() || failure()
+    #           uses: actions/upload-artifact@v3
+    #           with:
+    #               name: ${{ env.E2E_ARTIFACT }}
+    #               path: |
+    #                   ${{ env.ALLURE_RESULTS_DIR }}
+    #                   ${{ env.ALLURE_REPORT_DIR }}
+    #               if-no-files-found: ignore
+    #               retention-days: 5
 
-    k6-tests:
-        name: k6 tests on nightly build
-        runs-on: ubuntu-20.04
-        permissions:
-            contents: read
-        needs: [api-tests]
-        # if: success() || failure()
-        if: false # mytodo re-enable
-        steps:
-            - uses: actions/checkout@v3
+    # k6-tests:
+    #     name: k6 tests on nightly build
+    #     runs-on: ubuntu-20.04
+    #     permissions:
+    #         contents: read
+    #     needs: [api-tests]
+    #     if: success() || failure()
+    #     steps:
+    #         - uses: actions/checkout@v3
 
-            - name: Setup WooCommerce Monorepo
-              uses: ./.github/actions/setup-woocommerce-monorepo
-              with:
-                  install-filters: woocommerce
-                  build: false
+    #         - name: Setup WooCommerce Monorepo
+    #           uses: ./.github/actions/setup-woocommerce-monorepo
+    #           with:
+    #               install-filters: woocommerce
+    #               build: false
 
-            - name: Download and install Chromium browser.
-              working-directory: plugins/woocommerce
-              run: pnpm exec playwright install chromium
+    #         - name: Download and install Chromium browser.
+    #           working-directory: plugins/woocommerce
+    #           run: pnpm exec playwright install chromium
 
-            - name: Update performance test site with E2E test
-              working-directory: plugins/woocommerce
-              env:
-                  BASE_URL: ${{ secrets.SMOKE_TEST_PERF_URL }}/
-                  ADMIN_USER: ${{ secrets.SMOKE_TEST_PERF_ADMIN_USER }}
-                  ADMIN_PASSWORD: ${{ secrets.SMOKE_TEST_PERF_ADMIN_PASSWORD }}
-                  CUSTOMER_USER: ${{ secrets.SMOKE_TEST_PERF_ADMIN_USER }}
-                  CUSTOMER_PASSWORD: ${{ secrets.SMOKE_TEST_PERF_ADMIN_PASSWORD }}
-                  UPDATE_WC: nightly
-                  DEFAULT_TIMEOUT_OVERRIDE: 120000
-              run: |
-                  pnpm exec playwright test --config=tests/e2e-pw/playwright.config.js update-woocommerce.spec.js
-              continue-on-error: true
+    #         - name: Update performance test site with E2E test
+    #           working-directory: plugins/woocommerce
+    #           env:
+    #               BASE_URL: ${{ secrets.SMOKE_TEST_PERF_URL }}/
+    #               ADMIN_USER: ${{ secrets.SMOKE_TEST_PERF_ADMIN_USER }}
+    #               ADMIN_PASSWORD: ${{ secrets.SMOKE_TEST_PERF_ADMIN_PASSWORD }}
+    #               CUSTOMER_USER: ${{ secrets.SMOKE_TEST_PERF_ADMIN_USER }}
+    #               CUSTOMER_PASSWORD: ${{ secrets.SMOKE_TEST_PERF_ADMIN_PASSWORD }}
+    #               UPDATE_WC: nightly
+    #               DEFAULT_TIMEOUT_OVERRIDE: 120000
+    #           run: |
+    #               pnpm exec playwright test --config=tests/e2e-pw/playwright.config.js update-woocommerce.spec.js
+    #           continue-on-error: true
 
-            - name: Install k6
-              run: |
-                  curl https://github.com/grafana/k6/releases/download/v0.33.0/k6-v0.33.0-linux-amd64.tar.gz -L | tar xvz --strip-components 1
+    #         - name: Install k6
+    #           run: |
+    #               curl https://github.com/grafana/k6/releases/download/v0.33.0/k6-v0.33.0-linux-amd64.tar.gz -L | tar xvz --strip-components 1
 
-            - name: Run k6 smoke tests
-              env:
-                  URL: ${{ secrets.SMOKE_TEST_PERF_URL }}
-                  HOST: ${{ secrets.SMOKE_TEST_PERF_HOST }}
-                  A_USER: ${{ secrets.SMOKE_TEST_PERF_ADMIN_USER }}
-                  A_PW: ${{ secrets.SMOKE_TEST_PERF_ADMIN_PASSWORD }}
-                  C_USER: ${{ secrets.SMOKE_TEST_PERF_ADMIN_USER }}
-                  C_PW: ${{ secrets.SMOKE_TEST_PERF_ADMIN_PASSWORD }}
-                  P_ID: 22733
-              run: |
-                  ./k6 run plugins/woocommerce/tests/performance/tests/gh-action-daily-ext-requests.js
+    #         - name: Run k6 smoke tests
+    #           env:
+    #               URL: ${{ secrets.SMOKE_TEST_PERF_URL }}
+    #               HOST: ${{ secrets.SMOKE_TEST_PERF_HOST }}
+    #               A_USER: ${{ secrets.SMOKE_TEST_PERF_ADMIN_USER }}
+    #               A_PW: ${{ secrets.SMOKE_TEST_PERF_ADMIN_PASSWORD }}
+    #               C_USER: ${{ secrets.SMOKE_TEST_PERF_ADMIN_USER }}
+    #               C_PW: ${{ secrets.SMOKE_TEST_PERF_ADMIN_PASSWORD }}
+    #               P_ID: 22733
+    #           run: |
+    #               ./k6 run plugins/woocommerce/tests/performance/tests/gh-action-daily-ext-requests.js
 
     test-plugins:
         name: Smoke tests on trunk with ${{ matrix.plugin }} plugin installed
         runs-on: ubuntu-20.04
         permissions:
             contents: read
-        needs: [api-tests]
+        # mytodo uncomment
+        # needs: [api-tests]
         env:
             USE_WP_ENV: 1
             ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/allure-results
@@ -251,63 +250,62 @@ jobs:
                   if-no-files-found: ignore
                   retention-days: 5
 
-    trunk-results:
-        name: Publish report on smoke tests on nightly build
-        # if: |
-        #     ( success() || failure() ) &&
-        #     ! github.event.pull_request.head.repo.fork
-        if: false # mytodo re-enable
-        runs-on: ubuntu-20.04
-        permissions:
-            contents: read
-        needs: [e2e-tests, test-plugins, k6-tests]
-        steps:
-            - name: Create dirs
-              run: |
-                  mkdir -p repo
-                  mkdir -p artifacts/api
-                  mkdir -p artifacts/e2e
-                  mkdir -p output
+    # trunk-results:
+    #     name: Publish report on smoke tests on nightly build
+    #     if: |
+    #         ( success() || failure() ) &&
+    #         ! github.event.pull_request.head.repo.fork
+    #     runs-on: ubuntu-20.04
+    #     permissions:
+    #         contents: read
+    #     needs: [e2e-tests, test-plugins, k6-tests]
+    #     steps:
+    #         - name: Create dirs
+    #           run: |
+    #               mkdir -p repo
+    #               mkdir -p artifacts/api
+    #               mkdir -p artifacts/e2e
+    #               mkdir -p output
 
-            - name: Checkout code
-              uses: actions/checkout@v3
-              with:
-                  path: repo
+    #         - name: Checkout code
+    #           uses: actions/checkout@v3
+    #           with:
+    #               path: repo
 
-            - name: Download API test report artifact
-              uses: actions/download-artifact@v3
-              with:
-                  name: ${{ env.API_ARTIFACT }}
-                  path: artifacts/api
+    #         - name: Download API test report artifact
+    #           uses: actions/download-artifact@v3
+    #           with:
+    #               name: ${{ env.API_ARTIFACT }}
+    #               path: artifacts/api
 
-            - name: Download E2E test report artifact
-              uses: actions/download-artifact@v3
-              with:
-                  name: ${{ env.E2E_ARTIFACT }}
-                  path: artifacts/e2e
+    #         - name: Download E2E test report artifact
+    #           uses: actions/download-artifact@v3
+    #           with:
+    #               name: ${{ env.E2E_ARTIFACT }}
+    #               path: artifacts/e2e
 
-            - name: Post test summary
-              uses: actions/github-script@v6
-              env:
-                  API_SUMMARY_PATH: ${{ github.workspace }}/artifacts/api/allure-report/widgets/summary.json
-                  E2E_PW_SUMMARY_PATH: ${{ github.workspace }}/artifacts/e2e/allure-report/widgets/summary.json
-              with:
-                  result-encoding: string
-                  script: |
-                      const script = require( './repo/.github/workflows/scripts/prepare-test-summary-daily.js' )
-                      return await script( { core } )
+    #         - name: Post test summary
+    #           uses: actions/github-script@v6
+    #           env:
+    #               API_SUMMARY_PATH: ${{ github.workspace }}/artifacts/api/allure-report/widgets/summary.json
+    #               E2E_PW_SUMMARY_PATH: ${{ github.workspace }}/artifacts/e2e/allure-report/widgets/summary.json
+    #           with:
+    #               result-encoding: string
+    #               script: |
+    #                   const script = require( './repo/.github/workflows/scripts/prepare-test-summary-daily.js' )
+    #                   return await script( { core } )
 
-            - name: Publish report
-              env:
-                  GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
-                  RUN_ID: ${{ github.run_id }}
-              run: |
-                  gh workflow run publish-test-reports-daily.yml \
-                    -f run_id=$RUN_ID \
-                    -f api_artifact="$API_ARTIFACT" \
-                    -f e2e_artifact="$E2E_ARTIFACT" \
-                    -f s3_root=public \
-                    --repo woocommerce/woocommerce-test-reports
+    #         - name: Publish report
+    #           env:
+    #               GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+    #               RUN_ID: ${{ github.run_id }}
+    #           run: |
+    #               gh workflow run publish-test-reports-daily.yml \
+    #                 -f run_id=$RUN_ID \
+    #                 -f api_artifact="$API_ARTIFACT" \
+    #                 -f e2e_artifact="$E2E_ARTIFACT" \
+    #                 -f s3_root=public \
+    #                 --repo woocommerce/woocommerce-test-reports
 
     plugins-results:
         name: Publish report on Smoke tests on trunk with plugins
@@ -315,7 +313,8 @@ jobs:
             ( success() || failure() ) &&
             ! github.event.pull_request.head.repo.fork
         runs-on: ubuntu-20.04
-        needs: [e2e-tests, test-plugins, k6-tests]
+        # needs: [e2e-tests, test-plugins, k6-tests]
+        needs: [test-plugins] # mytodo revert to the above
         env:
             GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
             RUN_ID: ${{ github.run_id }}
@@ -343,8 +342,6 @@ jobs:
               uses: actions/download-artifact@v3
               with:
                   name: ${{ env.ARTIFACT }}
-
-            # TODO: Add step to post job summary
 
             - name: Get slug
               id: get-slug

--- a/.github/workflows/smoke-test-release.yml
+++ b/.github/workflows/smoke-test-release.yml
@@ -61,501 +61,501 @@ jobs:
                   GH_TOKEN: ${{ secrets.E2E_GH_TOKEN }}
               run: echo "created=$(gh release view ${{ steps.get-tag.outputs.tag }} --json assets --jq .assets[0].createdAt --repo woocommerce/woocommerce)" >> $GITHUB_OUTPUT
 
-    e2e-update-wc:
-        name: Test WooCommerce update
-        runs-on: ubuntu-20.04
-        needs: [get-tag]
-        permissions:
-            contents: read
-        env:
-            ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-report
-            ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-results
-        steps:
-            - uses: actions/checkout@v3
+    # e2e-update-wc:
+    #     name: Test WooCommerce update
+    #     runs-on: ubuntu-20.04
+    #     needs: [get-tag]
+    #     permissions:
+    #         contents: read
+    #     env:
+    #         ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-report
+    #         ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-results
+    #     steps:
+    #         - uses: actions/checkout@v3
 
-            - name: Setup WooCommerce Monorepo
-              uses: ./.github/actions/setup-woocommerce-monorepo
-              with:
-                  install-filters: woocommerce
-                  build: false
+    #         - name: Setup WooCommerce Monorepo
+    #           uses: ./.github/actions/setup-woocommerce-monorepo
+    #           with:
+    #               install-filters: woocommerce
+    #               build: false
 
-            - name: Run E2E tests
-              id: run-e2e-composite-action
-              timeout-minutes: 60
-              uses: ./.github/actions/tests/run-e2e-tests
-              with:
-                  report-name: ${{ env.E2E_UPDATE_WC_ARTIFACT }}
-                  tests: update-woocommerce.spec.js
-              env:
-                  ADMIN_PASSWORD: ${{ secrets.RELEASE_TEST_ADMIN_PASSWORD }}
-                  ADMIN_USER: ${{ secrets.RELEASE_TEST_ADMIN_USER }}
-                  BASE_URL: ${{ secrets.RELEASE_TEST_URL }}
-                  CUSTOMER_PASSWORD: ${{ secrets.RELEASE_TEST_CUSTOMER_PASSWORD }}
-                  CUSTOMER_USER: ${{ secrets.RELEASE_TEST_CUSTOMER_USER }}
-                  DEFAULT_TIMEOUT_OVERRIDE: 120000
-                  GITHUB_TOKEN: ${{ secrets.E2E_GH_TOKEN }}
-                  UPDATE_WC: ${{ needs.get-tag.outputs.tag }}
+    #         - name: Run E2E tests
+    #           id: run-e2e-composite-action
+    #           timeout-minutes: 60
+    #           uses: ./.github/actions/tests/run-e2e-tests
+    #           with:
+    #               report-name: ${{ env.E2E_UPDATE_WC_ARTIFACT }}
+    #               tests: update-woocommerce.spec.js
+    #           env:
+    #               ADMIN_PASSWORD: ${{ secrets.RELEASE_TEST_ADMIN_PASSWORD }}
+    #               ADMIN_USER: ${{ secrets.RELEASE_TEST_ADMIN_USER }}
+    #               BASE_URL: ${{ secrets.RELEASE_TEST_URL }}
+    #               CUSTOMER_PASSWORD: ${{ secrets.RELEASE_TEST_CUSTOMER_PASSWORD }}
+    #               CUSTOMER_USER: ${{ secrets.RELEASE_TEST_CUSTOMER_USER }}
+    #               DEFAULT_TIMEOUT_OVERRIDE: 120000
+    #               GITHUB_TOKEN: ${{ secrets.E2E_GH_TOKEN }}
+    #               UPDATE_WC: ${{ needs.get-tag.outputs.tag }}
 
-            - name: Upload Allure artifacts to bucket
-              if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
-              uses: ./.github/actions/tests/upload-allure-files-to-bucket
-              with:
-                  aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
-                  aws-region: ${{ secrets.REPORTS_AWS_REGION }}
-                  aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
-                  artifact-name: ${{ env.E2E_WP_LATEST_ARTIFACT }}
-                  s3-bucket: ${{ secrets.REPORTS_BUCKET }}
+    #         - name: Upload Allure artifacts to bucket
+    #           if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
+    #           uses: ./.github/actions/tests/upload-allure-files-to-bucket
+    #           with:
+    #               aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
+    #               aws-region: ${{ secrets.REPORTS_AWS_REGION }}
+    #               aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
+    #               artifact-name: ${{ env.E2E_WP_LATEST_ARTIFACT }}
+    #               s3-bucket: ${{ secrets.REPORTS_BUCKET }}
 
-            - name: Publish E2E Allure report
-              if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
-              env:
-                  GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
-                  ENV_DESCRIPTION: wp-latest
-              run: |
-                  gh workflow run publish-test-reports-release.yml \
-                    -f created_at="${{ needs.get-tag.outputs.created }}" \
-                    -f run_id=${{ github.run_id }} \
-                    -f run_number=${{ github.run_number }} \
-                    -f release_tag=${{ needs.get-tag.outputs.tag }} \
-                    -f artifact="${{ env.E2E_WP_LATEST_ARTIFACT }}" \
-                    -f env_description="${{ env.ENV_DESCRIPTION }}" \
-                    -f test_type="e2e" \
-                    --repo woocommerce/woocommerce-test-reports
+    #         - name: Publish E2E Allure report
+    #           if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
+    #           env:
+    #               GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+    #               ENV_DESCRIPTION: wp-latest
+    #           run: |
+    #               gh workflow run publish-test-reports-release.yml \
+    #                 -f created_at="${{ needs.get-tag.outputs.created }}" \
+    #                 -f run_id=${{ github.run_id }} \
+    #                 -f run_number=${{ github.run_number }} \
+    #                 -f release_tag=${{ needs.get-tag.outputs.tag }} \
+    #                 -f artifact="${{ env.E2E_WP_LATEST_ARTIFACT }}" \
+    #                 -f env_description="${{ env.ENV_DESCRIPTION }}" \
+    #                 -f test_type="e2e" \
+    #                 --repo woocommerce/woocommerce-test-reports
 
-    api-wp-latest:
-        name: API on WP Latest
-        runs-on: ubuntu-20.04
-        needs: [get-tag, e2e-update-wc]
-        permissions:
-            contents: read
-        env:
-            ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/api-test-report/allure-report
-            ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/api-test-report/allure-results
-            API_WP_LATEST_ARTIFACT: API test on release smoke test site with WP Latest (run ${{ github.run_number }})
-        steps:
-            - uses: actions/checkout@v3
+    # api-wp-latest:
+    #     name: API on WP Latest
+    #     runs-on: ubuntu-20.04
+    #     needs: [get-tag, e2e-update-wc]
+    #     permissions:
+    #         contents: read
+    #     env:
+    #         ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/api-test-report/allure-report
+    #         ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/api-test-report/allure-results
+    #         API_WP_LATEST_ARTIFACT: API test on release smoke test site with WP Latest (run ${{ github.run_number }})
+    #     steps:
+    #         - uses: actions/checkout@v3
 
-            - name: Setup WooCommerce Monorepo
-              uses: ./.github/actions/setup-woocommerce-monorepo
-              with:
-                  install-filters: woocommerce
-                  build: false
+    #         - name: Setup WooCommerce Monorepo
+    #           uses: ./.github/actions/setup-woocommerce-monorepo
+    #           with:
+    #               install-filters: woocommerce
+    #               build: false
 
-            - name: Run API tests
-              id: run-api-composite-action
-              uses: ./.github/actions/tests/run-api-tests
-              with:
-                  report-name: ${{ env.API_WP_LATEST_ARTIFACT }}
-                  tests: hello
-              env:
-                  BASE_URL: ${{ secrets.RELEASE_TEST_URL }}
-                  USER_KEY: ${{ secrets.RELEASE_TEST_ADMIN_USER }}
-                  USER_SECRET: ${{ secrets.RELEASE_TEST_ADMIN_PASSWORD }}
+    #         - name: Run API tests
+    #           id: run-api-composite-action
+    #           uses: ./.github/actions/tests/run-api-tests
+    #           with:
+    #               report-name: ${{ env.API_WP_LATEST_ARTIFACT }}
+    #               tests: hello
+    #           env:
+    #               BASE_URL: ${{ secrets.RELEASE_TEST_URL }}
+    #               USER_KEY: ${{ secrets.RELEASE_TEST_ADMIN_USER }}
+    #               USER_SECRET: ${{ secrets.RELEASE_TEST_ADMIN_PASSWORD }}
 
-            - name: Upload Allure artifacts to bucket
-              if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
-              uses: ./.github/actions/tests/upload-allure-files-to-bucket
-              with:
-                  aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
-                  aws-region: ${{ secrets.REPORTS_AWS_REGION }}
-                  aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
-                  artifact-name: ${{ env.API_WP_LATEST_ARTIFACT }}
-                  s3-bucket: ${{ secrets.REPORTS_BUCKET }}
+    #         - name: Upload Allure artifacts to bucket
+    #           if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
+    #           uses: ./.github/actions/tests/upload-allure-files-to-bucket
+    #           with:
+    #               aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
+    #               aws-region: ${{ secrets.REPORTS_AWS_REGION }}
+    #               aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
+    #               artifact-name: ${{ env.API_WP_LATEST_ARTIFACT }}
+    #               s3-bucket: ${{ secrets.REPORTS_BUCKET }}
 
-            - name: Publish API Allure report
-              if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
-              env:
-                  GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
-                  ENV_DESCRIPTION: wp-latest
-              run: |
-                  gh workflow run publish-test-reports-release.yml \
-                    -f created_at="${{ needs.get-tag.outputs.created }}" \
-                    -f run_id=${{ github.run_id }} \
-                    -f run_number=${{ github.run_number }} \
-                    -f release_tag=${{ needs.get-tag.outputs.tag }} \
-                    -f artifact="${{ env.API_WP_LATEST_ARTIFACT }}" \
-                    -f env_description="${{ env.ENV_DESCRIPTION }}" \
-                    -f test_type="api" \
-                    --repo woocommerce/woocommerce-test-reports
+    #         - name: Publish API Allure report
+    #           if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
+    #           env:
+    #               GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+    #               ENV_DESCRIPTION: wp-latest
+    #           run: |
+    #               gh workflow run publish-test-reports-release.yml \
+    #                 -f created_at="${{ needs.get-tag.outputs.created }}" \
+    #                 -f run_id=${{ github.run_id }} \
+    #                 -f run_number=${{ github.run_number }} \
+    #                 -f release_tag=${{ needs.get-tag.outputs.tag }} \
+    #                 -f artifact="${{ env.API_WP_LATEST_ARTIFACT }}" \
+    #                 -f env_description="${{ env.ENV_DESCRIPTION }}" \
+    #                 -f test_type="api" \
+    #                 --repo woocommerce/woocommerce-test-reports
 
-    e2e-wp-latest:
-        name: E2E on WP Latest
-        runs-on: ubuntu-20.04
-        needs: [get-tag, api-wp-latest]
-        permissions:
-            contents: read
-        env:
-            ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-report
-            ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-results
-        steps:
-            - uses: actions/checkout@v3
+    # e2e-wp-latest:
+    #     name: E2E on WP Latest
+    #     runs-on: ubuntu-20.04
+    #     needs: [get-tag, api-wp-latest]
+    #     permissions:
+    #         contents: read
+    #     env:
+    #         ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-report
+    #         ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-results
+    #     steps:
+    #         - uses: actions/checkout@v3
 
-            - name: Setup WooCommerce Monorepo
-              uses: ./.github/actions/setup-woocommerce-monorepo
-              with:
-                  install-filters: woocommerce
-                  build: false
+    #         - name: Setup WooCommerce Monorepo
+    #           uses: ./.github/actions/setup-woocommerce-monorepo
+    #           with:
+    #               install-filters: woocommerce
+    #               build: false
 
-            - name: Run E2E tests
-              id: run-e2e-composite-action
-              timeout-minutes: 60
-              uses: ./.github/actions/tests/run-e2e-tests
-              with:
-                  report-name: e2e-wp-latest--partial--run-${{ github.run_number }}
-                  playwright-config: ignore-plugin-tests.playwright.config.js
-              env:
-                  ADMIN_PASSWORD: ${{ secrets.RELEASE_TEST_ADMIN_PASSWORD }}
-                  ADMIN_USER: ${{ secrets.RELEASE_TEST_ADMIN_USER }}
-                  ADMIN_USER_EMAIL: ${{ secrets.RELEASE_TEST_ADMIN_USER_EMAIL }}
-                  BASE_URL: ${{ secrets.RELEASE_TEST_URL }}
-                  CUSTOMER_PASSWORD: ${{ secrets.RELEASE_TEST_CUSTOMER_PASSWORD }}
-                  CUSTOMER_USER: ${{ secrets.RELEASE_TEST_CUSTOMER_USER }}
-                  DEFAULT_TIMEOUT_OVERRIDE: 120000
-                  E2E_MAX_FAILURES: 25
-                  RESET_SITE: true
+    #         - name: Run E2E tests
+    #           id: run-e2e-composite-action
+    #           timeout-minutes: 60
+    #           uses: ./.github/actions/tests/run-e2e-tests
+    #           with:
+    #               report-name: e2e-wp-latest--partial--run-${{ github.run_number }}
+    #               playwright-config: ignore-plugin-tests.playwright.config.js
+    #           env:
+    #               ADMIN_PASSWORD: ${{ secrets.RELEASE_TEST_ADMIN_PASSWORD }}
+    #               ADMIN_USER: ${{ secrets.RELEASE_TEST_ADMIN_USER }}
+    #               ADMIN_USER_EMAIL: ${{ secrets.RELEASE_TEST_ADMIN_USER_EMAIL }}
+    #               BASE_URL: ${{ secrets.RELEASE_TEST_URL }}
+    #               CUSTOMER_PASSWORD: ${{ secrets.RELEASE_TEST_CUSTOMER_PASSWORD }}
+    #               CUSTOMER_USER: ${{ secrets.RELEASE_TEST_CUSTOMER_USER }}
+    #               DEFAULT_TIMEOUT_OVERRIDE: 120000
+    #               E2E_MAX_FAILURES: 25
+    #               RESET_SITE: true
 
-            - name: Download 'e2e-update-wc' artifact
-              if: success() || failure()
-              uses: actions/download-artifact@v3
-              with:
-                  name: ${{ env.E2E_UPDATE_WC_ARTIFACT }}
-                  path: plugins/woocommerce/tmp
+    #         - name: Download 'e2e-update-wc' artifact
+    #           if: success() || failure()
+    #           uses: actions/download-artifact@v3
+    #           with:
+    #               name: ${{ env.E2E_UPDATE_WC_ARTIFACT }}
+    #               path: plugins/woocommerce/tmp
 
-            - name: Add allure-results from 'e2e-update-wc'
-              if: success() || failure()
-              working-directory: plugins/woocommerce
-              run: cp -r tmp/allure-results tests/e2e-pw/test-results
+    #         - name: Add allure-results from 'e2e-update-wc'
+    #           if: success() || failure()
+    #           working-directory: plugins/woocommerce
+    #           run: cp -r tmp/allure-results tests/e2e-pw/test-results
 
-            - name: Generate E2E Test report.
-              if: success() || failure()
-              working-directory: plugins/woocommerce
-              run: pnpm exec allure generate --clean ${{ env.ALLURE_RESULTS_DIR }} --output ${{ env.ALLURE_REPORT_DIR }}
+    #         - name: Generate E2E Test report.
+    #           if: success() || failure()
+    #           working-directory: plugins/woocommerce
+    #           run: pnpm exec allure generate --clean ${{ env.ALLURE_RESULTS_DIR }} --output ${{ env.ALLURE_REPORT_DIR }}
 
-            - name: Archive E2E test report
-              if: success() || failure()
-              uses: actions/upload-artifact@v3
-              with:
-                  name: ${{ env.E2E_WP_LATEST_ARTIFACT }}
-                  path: |
-                      ${{ env.ALLURE_RESULTS_DIR }}
-                      ${{ env.ALLURE_REPORT_DIR }}
-                  if-no-files-found: ignore
-                  retention-days: 5
+    #         - name: Archive E2E test report
+    #           if: success() || failure()
+    #           uses: actions/upload-artifact@v3
+    #           with:
+    #               name: ${{ env.E2E_WP_LATEST_ARTIFACT }}
+    #               path: |
+    #                   ${{ env.ALLURE_RESULTS_DIR }}
+    #                   ${{ env.ALLURE_REPORT_DIR }}
+    #               if-no-files-found: ignore
+    #               retention-days: 5
 
-            - name: Upload Allure artifacts to bucket
-              if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
-              uses: ./.github/actions/tests/upload-allure-files-to-bucket
-              with:
-                  aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
-                  aws-region: ${{ secrets.REPORTS_AWS_REGION }}
-                  aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
-                  artifact-name: ${{ env.E2E_WP_LATEST_ARTIFACT }}
-                  s3-bucket: ${{ secrets.REPORTS_BUCKET }}
+    #         - name: Upload Allure artifacts to bucket
+    #           if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
+    #           uses: ./.github/actions/tests/upload-allure-files-to-bucket
+    #           with:
+    #               aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
+    #               aws-region: ${{ secrets.REPORTS_AWS_REGION }}
+    #               aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
+    #               artifact-name: ${{ env.E2E_WP_LATEST_ARTIFACT }}
+    #               s3-bucket: ${{ secrets.REPORTS_BUCKET }}
 
-            - name: Publish E2E Allure report
-              if: success() || failure()
-              env:
-                  GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
-                  ENV_DESCRIPTION: wp-latest
-              run: |
-                  gh workflow run publish-test-reports-release.yml \
-                    -f created_at="${{ needs.get-tag.outputs.created }}" \
-                    -f run_id=${{ github.run_id }} \
-                    -f run_number=${{ github.run_number }} \
-                    -f release_tag=${{ needs.get-tag.outputs.tag }} \
-                    -f artifact="${{ env.E2E_WP_LATEST_ARTIFACT }}" \
-                    -f env_description="${{ env.ENV_DESCRIPTION }}" \
-                    -f test_type="e2e" \
-                    --repo woocommerce/woocommerce-test-reports
+    #         - name: Publish E2E Allure report
+    #           if: success() || failure()
+    #           env:
+    #               GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+    #               ENV_DESCRIPTION: wp-latest
+    #           run: |
+    #               gh workflow run publish-test-reports-release.yml \
+    #                 -f created_at="${{ needs.get-tag.outputs.created }}" \
+    #                 -f run_id=${{ github.run_id }} \
+    #                 -f run_number=${{ github.run_number }} \
+    #                 -f release_tag=${{ needs.get-tag.outputs.tag }} \
+    #                 -f artifact="${{ env.E2E_WP_LATEST_ARTIFACT }}" \
+    #                 -f env_description="${{ env.ENV_DESCRIPTION }}" \
+    #                 -f test_type="e2e" \
+    #                 --repo woocommerce/woocommerce-test-reports
 
-    get-wp-versions:
-        name: Get WP L-1 & L-2 version numbers
-        needs: [get-tag]
-        runs-on: ubuntu-20.04
-        permissions:
-            contents: read
-        outputs:
-            matrix: ${{ steps.get-versions.outputs.versions }}
-            tag: ${{ needs.get-tag.outputs.tag }}
-            created: ${{ needs.get-tag.outputs.created }}
-        steps:
-            - name: Create dirs
-              run: |
-                  mkdir script
-                  mkdir repo
+    # get-wp-versions:
+    #     name: Get WP L-1 & L-2 version numbers
+    #     needs: [get-tag]
+    #     runs-on: ubuntu-20.04
+    #     permissions:
+    #         contents: read
+    #     outputs:
+    #         matrix: ${{ steps.get-versions.outputs.versions }}
+    #         tag: ${{ needs.get-tag.outputs.tag }}
+    #         created: ${{ needs.get-tag.outputs.created }}
+    #     steps:
+    #         - name: Create dirs
+    #           run: |
+    #               mkdir script
+    #               mkdir repo
 
-            - name: Checkout
-              uses: actions/checkout@v3
-              with:
-                  path: repo
+    #         - name: Checkout
+    #           uses: actions/checkout@v3
+    #           with:
+    #               path: repo
 
-            - name: Copy script to get previous WP versions
-              run: cp repo/plugins/woocommerce/tests/e2e-pw/utils/wordpress.js script
+    #         - name: Copy script to get previous WP versions
+    #           run: cp repo/plugins/woocommerce/tests/e2e-pw/utils/wordpress.js script
 
-            - name: Install axios
-              working-directory: script
-              run: npm install axios
+    #         - name: Install axios
+    #           working-directory: script
+    #           run: npm install axios
 
-            - name: Get version numbers
-              id: get-versions
-              uses: actions/github-script@v6
-              with:
-                  script: |
-                      const { getPreviousTwoVersions } = require('./script/wordpress');
-                      const versions = await getPreviousTwoVersions();
-                      console.log(versions);
-                      core.setOutput('versions', versions);
+    #         - name: Get version numbers
+    #           id: get-versions
+    #           uses: actions/github-script@v6
+    #           with:
+    #               script: |
+    #                   const { getPreviousTwoVersions } = require('./script/wordpress');
+    #                   const versions = await getPreviousTwoVersions();
+    #                   console.log(versions);
+    #                   core.setOutput('versions', versions);
 
-    test-wp-versions:
-        name: Test against ${{ matrix.version.description }} (${{ matrix.version.number }})
-        runs-on: ubuntu-20.04
-        needs: [get-wp-versions]
-        strategy:
-            fail-fast: false
-            matrix: ${{ fromJSON(needs.get-wp-versions.outputs.matrix) }}
-        env:
-            API_ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/api/allure-report
-            API_ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/api/allure-results
-            API_WP_LATEST_X_ARTIFACT: API test on wp-env with WordPress ${{ matrix.version.number }} (run ${{ github.run_number }})
-            E2E_ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/e2e/allure-report
-            E2E_ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/e2e/allure-results
-            E2E_WP_LATEST_X_ARTIFACT: E2E test on wp-env with WordPress ${{ matrix.version.number }} (run ${{ github.run_number }})
-        permissions:
-            contents: read
-        steps:
-            - name: Checkout WooCommerce repo
-              uses: actions/checkout@v3
+    # test-wp-versions:
+    #     name: Test against ${{ matrix.version.description }} (${{ matrix.version.number }})
+    #     runs-on: ubuntu-20.04
+    #     needs: [get-wp-versions]
+    #     strategy:
+    #         fail-fast: false
+    #         matrix: ${{ fromJSON(needs.get-wp-versions.outputs.matrix) }}
+    #     env:
+    #         API_ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/api/allure-report
+    #         API_ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/api/allure-results
+    #         API_WP_LATEST_X_ARTIFACT: API test on wp-env with WordPress ${{ matrix.version.number }} (run ${{ github.run_number }})
+    #         E2E_ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/e2e/allure-report
+    #         E2E_ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/e2e/allure-results
+    #         E2E_WP_LATEST_X_ARTIFACT: E2E test on wp-env with WordPress ${{ matrix.version.number }} (run ${{ github.run_number }})
+    #     permissions:
+    #         contents: read
+    #     steps:
+    #         - name: Checkout WooCommerce repo
+    #           uses: actions/checkout@v3
 
-            - name: Setup WooCommerce Monorepo
-              uses: ./.github/actions/setup-woocommerce-monorepo
+    #         - name: Setup WooCommerce Monorepo
+    #           uses: ./.github/actions/setup-woocommerce-monorepo
 
-            - name: Launch WP Env
-              working-directory: plugins/woocommerce
-              run: pnpm run env:test
+    #         - name: Launch WP Env
+    #           working-directory: plugins/woocommerce
+    #           run: pnpm run env:test
 
-            - name: Download release zip
-              env:
-                  GH_TOKEN: ${{ secrets.E2E_GH_TOKEN }}
-              run: gh release download ${{ needs.get-wp-versions.outputs.tag }} --dir tmp
+    #         - name: Download release zip
+    #           env:
+    #               GH_TOKEN: ${{ secrets.E2E_GH_TOKEN }}
+    #           run: gh release download ${{ needs.get-wp-versions.outputs.tag }} --dir tmp
 
-            - name: Replace `plugins/woocommerce` with unzipped woocommerce release build
-              run: unzip -d plugins -o tmp/woocommerce.zip
+    #         - name: Replace `plugins/woocommerce` with unzipped woocommerce release build
+    #           run: unzip -d plugins -o tmp/woocommerce.zip
 
-            - name: Downgrade WordPress version to ${{ matrix.version.number }}
-              working-directory: plugins/woocommerce
-              run: |
-                  pnpm exec wp-env run tests-cli "wp core update --version=${{ matrix.version.number }} --force"
-                  pnpm exec wp-env run tests-cli "wp core update-db"
+    #         - name: Downgrade WordPress version to ${{ matrix.version.number }}
+    #           working-directory: plugins/woocommerce
+    #           run: |
+    #               pnpm exec wp-env run tests-cli "wp core update --version=${{ matrix.version.number }} --force"
+    #               pnpm exec wp-env run tests-cli "wp core update-db"
 
-            - name: Verify environment details
-              working-directory: plugins/woocommerce
-              run: |
-                  pnpm exec wp-env run tests-cli "wp core version"
-                  pnpm exec wp-env run tests-cli "wp plugin list"
-                  pnpm exec wp-env run tests-cli "wp theme list"
-                  pnpm exec wp-env run tests-cli "wp user list"
+    #         - name: Verify environment details
+    #           working-directory: plugins/woocommerce
+    #           run: |
+    #               pnpm exec wp-env run tests-cli "wp core version"
+    #               pnpm exec wp-env run tests-cli "wp plugin list"
+    #               pnpm exec wp-env run tests-cli "wp theme list"
+    #               pnpm exec wp-env run tests-cli "wp user list"
 
-            - name: Run API tests
-              id: run-api-composite-action
-              uses: ./.github/actions/tests/run-api-tests
-              with:
-                  report-name: ${{ env.API_WP_LATEST_X_ARTIFACT }}
-                  tests: hello
-              env:
-                  ALLURE_RESULTS_DIR: ${{ env.API_ALLURE_RESULTS_DIR }}
-                  ALLURE_REPORT_DIR: ${{ env.API_ALLURE_REPORT_DIR }}
+    #         - name: Run API tests
+    #           id: run-api-composite-action
+    #           uses: ./.github/actions/tests/run-api-tests
+    #           with:
+    #               report-name: ${{ env.API_WP_LATEST_X_ARTIFACT }}
+    #               tests: hello
+    #           env:
+    #               ALLURE_RESULTS_DIR: ${{ env.API_ALLURE_RESULTS_DIR }}
+    #               ALLURE_REPORT_DIR: ${{ env.API_ALLURE_REPORT_DIR }}
 
-            - name: Upload Allure artifacts to bucket
-              if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
-              uses: ./.github/actions/tests/upload-allure-files-to-bucket
-              env:
-                  ALLURE_RESULTS_DIR: ${{ env.API_ALLURE_RESULTS_DIR }}
-                  ALLURE_REPORT_DIR: ${{ env.API_ALLURE_REPORT_DIR }}
-              with:
-                  aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
-                  aws-region: ${{ secrets.REPORTS_AWS_REGION }}
-                  aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
-                  artifact-name: ${{ env.API_WP_LATEST_X_ARTIFACT }}
-                  s3-bucket: ${{ secrets.REPORTS_BUCKET }}
+    #         - name: Upload Allure artifacts to bucket
+    #           if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
+    #           uses: ./.github/actions/tests/upload-allure-files-to-bucket
+    #           env:
+    #               ALLURE_RESULTS_DIR: ${{ env.API_ALLURE_RESULTS_DIR }}
+    #               ALLURE_REPORT_DIR: ${{ env.API_ALLURE_REPORT_DIR }}
+    #           with:
+    #               aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
+    #               aws-region: ${{ secrets.REPORTS_AWS_REGION }}
+    #               aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
+    #               artifact-name: ${{ env.API_WP_LATEST_X_ARTIFACT }}
+    #               s3-bucket: ${{ secrets.REPORTS_BUCKET }}
 
-            - name: Publish API Allure report
-              if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
-              env:
-                  GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
-                  ENV_DESCRIPTION: ${{ matrix.version.env_description }}
-              run: |
-                  gh workflow run publish-test-reports-release.yml \
-                    -f created_at="${{ needs.get-wp-versions.outputs.created }}" \
-                    -f run_id=${{ github.run_id }} \
-                    -f run_number=${{ github.run_number }} \
-                    -f release_tag=${{ needs.get-wp-versions.outputs.tag }} \
-                    -f artifact="${{ env.API_WP_LATEST_X_ARTIFACT }}" \
-                    -f env_description="${{ env.ENV_DESCRIPTION }}" \
-                    -f test_type="api" \
-                    --repo woocommerce/woocommerce-test-reports
+    #         - name: Publish API Allure report
+    #           if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
+    #           env:
+    #               GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+    #               ENV_DESCRIPTION: ${{ matrix.version.env_description }}
+    #           run: |
+    #               gh workflow run publish-test-reports-release.yml \
+    #                 -f created_at="${{ needs.get-wp-versions.outputs.created }}" \
+    #                 -f run_id=${{ github.run_id }} \
+    #                 -f run_number=${{ github.run_number }} \
+    #                 -f release_tag=${{ needs.get-wp-versions.outputs.tag }} \
+    #                 -f artifact="${{ env.API_WP_LATEST_X_ARTIFACT }}" \
+    #                 -f env_description="${{ env.ENV_DESCRIPTION }}" \
+    #                 -f test_type="api" \
+    #                 --repo woocommerce/woocommerce-test-reports
 
-            - name: Run E2E tests
-              id: run-e2e-composite-action
-              timeout-minutes: 60
-              uses: ./.github/actions/tests/run-e2e-tests
-              env:
-                  E2E_MAX_FAILURES: 15
-                  ALLURE_RESULTS_DIR: ${{ env.E2E_ALLURE_RESULTS_DIR }}
-                  ALLURE_REPORT_DIR: ${{ env.E2E_ALLURE_REPORT_DIR }}
-                  DEFAULT_TIMEOUT_OVERRIDE: 120000
-              with:
-                  report-name: ${{ env.E2E_WP_LATEST_X_ARTIFACT }}
+    #         - name: Run E2E tests
+    #           id: run-e2e-composite-action
+    #           timeout-minutes: 60
+    #           uses: ./.github/actions/tests/run-e2e-tests
+    #           env:
+    #               E2E_MAX_FAILURES: 15
+    #               ALLURE_RESULTS_DIR: ${{ env.E2E_ALLURE_RESULTS_DIR }}
+    #               ALLURE_REPORT_DIR: ${{ env.E2E_ALLURE_REPORT_DIR }}
+    #               DEFAULT_TIMEOUT_OVERRIDE: 120000
+    #           with:
+    #               report-name: ${{ env.E2E_WP_LATEST_X_ARTIFACT }}
 
-            - name: Upload Allure artifacts to bucket
-              if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
-              uses: ./.github/actions/tests/upload-allure-files-to-bucket
-              env:
-                  ALLURE_RESULTS_DIR: ${{ env.E2E_ALLURE_RESULTS_DIR }}
-                  ALLURE_REPORT_DIR: ${{ env.E2E_ALLURE_REPORT_DIR }}
-              with:
-                  aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
-                  aws-region: ${{ secrets.REPORTS_AWS_REGION }}
-                  aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
-                  artifact-name: ${{ env.E2E_WP_LATEST_X_ARTIFACT }}
-                  s3-bucket: ${{ secrets.REPORTS_BUCKET }}
+    #         - name: Upload Allure artifacts to bucket
+    #           if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
+    #           uses: ./.github/actions/tests/upload-allure-files-to-bucket
+    #           env:
+    #               ALLURE_RESULTS_DIR: ${{ env.E2E_ALLURE_RESULTS_DIR }}
+    #               ALLURE_REPORT_DIR: ${{ env.E2E_ALLURE_REPORT_DIR }}
+    #           with:
+    #               aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
+    #               aws-region: ${{ secrets.REPORTS_AWS_REGION }}
+    #               aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
+    #               artifact-name: ${{ env.E2E_WP_LATEST_X_ARTIFACT }}
+    #               s3-bucket: ${{ secrets.REPORTS_BUCKET }}
 
-            - name: Publish E2E Allure report
-              if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
-              env:
-                  GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
-                  ENV_DESCRIPTION: ${{ matrix.version.env_description }}
-              run: |
-                  gh workflow run publish-test-reports-release.yml \
-                    -f created_at="${{ needs.get-wp-versions.outputs.created }}" \
-                    -f run_id=${{ github.run_id }} \
-                    -f run_number=${{ github.run_number }} \
-                    -f release_tag=${{ needs.get-wp-versions.outputs.tag }} \
-                    -f artifact="${{ env.E2E_WP_LATEST_X_ARTIFACT }}" \
-                    -f env_description="${{ env.ENV_DESCRIPTION }}" \
-                    -f test_type="e2e" \
-                    --repo woocommerce/woocommerce-test-reports
+    #         - name: Publish E2E Allure report
+    #           if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
+    #           env:
+    #               GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+    #               ENV_DESCRIPTION: ${{ matrix.version.env_description }}
+    #           run: |
+    #               gh workflow run publish-test-reports-release.yml \
+    #                 -f created_at="${{ needs.get-wp-versions.outputs.created }}" \
+    #                 -f run_id=${{ github.run_id }} \
+    #                 -f run_number=${{ github.run_number }} \
+    #                 -f release_tag=${{ needs.get-wp-versions.outputs.tag }} \
+    #                 -f artifact="${{ env.E2E_WP_LATEST_X_ARTIFACT }}" \
+    #                 -f env_description="${{ env.ENV_DESCRIPTION }}" \
+    #                 -f test_type="e2e" \
+    #                 --repo woocommerce/woocommerce-test-reports
 
-    test-php-versions:
-        name: Test against PHP ${{ matrix.php_version }}
-        runs-on: ubuntu-20.04
-        needs: [get-tag]
-        strategy:
-            fail-fast: false
-            matrix:
-                php_version: ['7.4', '8.1']
-        env:
-            API_ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/test-results/allure-report
-            API_ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/test-results/allure-results
-            API_ARTIFACT: API test on wp-env with PHP ${{ matrix.php_version }} (run ${{ github.run_number }})
-            E2E_ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-report
-            E2E_ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-results
-            E2E_ARTIFACT: E2E test on wp-env with PHP ${{ matrix.php_version }} (run ${{ github.run_number }})
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v3
+    # test-php-versions:
+    #     name: Test against PHP ${{ matrix.php_version }}
+    #     runs-on: ubuntu-20.04
+    #     needs: [get-tag]
+    #     strategy:
+    #         fail-fast: false
+    #         matrix:
+    #             php_version: ['7.4', '8.1']
+    #     env:
+    #         API_ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/test-results/allure-report
+    #         API_ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/test-results/allure-results
+    #         API_ARTIFACT: API test on wp-env with PHP ${{ matrix.php_version }} (run ${{ github.run_number }})
+    #         E2E_ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-report
+    #         E2E_ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-results
+    #         E2E_ARTIFACT: E2E test on wp-env with PHP ${{ matrix.php_version }} (run ${{ github.run_number }})
+    #     steps:
+    #         - name: Checkout
+    #           uses: actions/checkout@v3
 
-            - name: Setup WooCommerce Monorepo
-              uses: ./.github/actions/setup-woocommerce-monorepo
+    #         - name: Setup WooCommerce Monorepo
+    #           uses: ./.github/actions/setup-woocommerce-monorepo
 
-            - name: Launch WP Env
-              working-directory: plugins/woocommerce
-              env:
-                  WP_ENV_PHP_VERSION: ${{ matrix.php_version }}
-              run: pnpm run env:test
+    #         - name: Launch WP Env
+    #           working-directory: plugins/woocommerce
+    #           env:
+    #               WP_ENV_PHP_VERSION: ${{ matrix.php_version }}
+    #           run: pnpm run env:test
 
-            - name: Verify PHP version
-              working-directory: .github/workflows/scripts
-              env:
-                  EXPECTED_PHP_VERSION: ${{ matrix.php_version }}
-              run: bash verify-php-version.sh
+    #         - name: Verify PHP version
+    #           working-directory: .github/workflows/scripts
+    #           env:
+    #               EXPECTED_PHP_VERSION: ${{ matrix.php_version }}
+    #           run: bash verify-php-version.sh
 
-            - name: Download release zip
-              env:
-                  GH_TOKEN: ${{ secrets.E2E_GH_TOKEN }}
-              run: gh release download ${{ needs.get-tag.outputs.tag }} --dir tmp
+    #         - name: Download release zip
+    #           env:
+    #               GH_TOKEN: ${{ secrets.E2E_GH_TOKEN }}
+    #           run: gh release download ${{ needs.get-tag.outputs.tag }} --dir tmp
 
-            - name: Replace `plugins/woocommerce` with unzipped woocommerce release build
-              run: unzip -d plugins -o tmp/woocommerce.zip
+    #         - name: Replace `plugins/woocommerce` with unzipped woocommerce release build
+    #           run: unzip -d plugins -o tmp/woocommerce.zip
 
-            - name: Run API tests
-              id: run-api-composite-action
-              uses: ./.github/actions/tests/run-api-tests
-              with:
-                  report-name: ${{ env.API_ARTIFACT }}
-                  tests: hello
-              env:
-                  ALLURE_RESULTS_DIR: ${{ env.API_ALLURE_RESULTS_DIR }}
-                  ALLURE_REPORT_DIR: ${{ env.API_ALLURE_REPORT_DIR }}
+    #         - name: Run API tests
+    #           id: run-api-composite-action
+    #           uses: ./.github/actions/tests/run-api-tests
+    #           with:
+    #               report-name: ${{ env.API_ARTIFACT }}
+    #               tests: hello
+    #           env:
+    #               ALLURE_RESULTS_DIR: ${{ env.API_ALLURE_RESULTS_DIR }}
+    #               ALLURE_REPORT_DIR: ${{ env.API_ALLURE_REPORT_DIR }}
 
-            - name: Upload Allure artifacts to bucket
-              if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
-              uses: ./.github/actions/tests/upload-allure-files-to-bucket
-              env:
-                  ALLURE_RESULTS_DIR: ${{ env.API_ALLURE_RESULTS_DIR }}
-                  ALLURE_REPORT_DIR: ${{ env.API_ALLURE_REPORT_DIR }}
-              with:
-                  aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
-                  aws-region: ${{ secrets.REPORTS_AWS_REGION }}
-                  aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
-                  artifact-name: ${{ env.API_ARTIFACT }}
-                  s3-bucket: ${{ secrets.REPORTS_BUCKET }}
+    #         - name: Upload Allure artifacts to bucket
+    #           if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
+    #           uses: ./.github/actions/tests/upload-allure-files-to-bucket
+    #           env:
+    #               ALLURE_RESULTS_DIR: ${{ env.API_ALLURE_RESULTS_DIR }}
+    #               ALLURE_REPORT_DIR: ${{ env.API_ALLURE_REPORT_DIR }}
+    #           with:
+    #               aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
+    #               aws-region: ${{ secrets.REPORTS_AWS_REGION }}
+    #               aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
+    #               artifact-name: ${{ env.API_ARTIFACT }}
+    #               s3-bucket: ${{ secrets.REPORTS_BUCKET }}
 
-            - name: Publish API Allure report
-              if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
-              env:
-                  GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
-                  ENV_DESCRIPTION: php-${{ matrix.php_version }}
-              run: |
-                  gh workflow run publish-test-reports-release.yml \
-                    -f created_at="${{ needs.get-tag.outputs.created }}" \
-                    -f run_id=${{ github.run_id }} \
-                    -f run_number=${{ github.run_number }} \
-                    -f release_tag=${{ needs.get-tag.outputs.tag }} \
-                    -f artifact="${{ env.API_ARTIFACT }}" \
-                    -f env_description="${{ env.ENV_DESCRIPTION }}" \
-                    -f test_type="api" \
-                    --repo woocommerce/woocommerce-test-reports
+    #         - name: Publish API Allure report
+    #           if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
+    #           env:
+    #               GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+    #               ENV_DESCRIPTION: php-${{ matrix.php_version }}
+    #           run: |
+    #               gh workflow run publish-test-reports-release.yml \
+    #                 -f created_at="${{ needs.get-tag.outputs.created }}" \
+    #                 -f run_id=${{ github.run_id }} \
+    #                 -f run_number=${{ github.run_number }} \
+    #                 -f release_tag=${{ needs.get-tag.outputs.tag }} \
+    #                 -f artifact="${{ env.API_ARTIFACT }}" \
+    #                 -f env_description="${{ env.ENV_DESCRIPTION }}" \
+    #                 -f test_type="api" \
+    #                 --repo woocommerce/woocommerce-test-reports
 
-            - name: Run E2E tests
-              id: run-e2e-composite-action
-              timeout-minutes: 60
-              uses: ./.github/actions/tests/run-e2e-tests
-              env:
-                  ALLURE_RESULTS_DIR: ${{ env.E2E_ALLURE_RESULTS_DIR }}
-                  ALLURE_REPORT_DIR: ${{ env.E2E_ALLURE_REPORT_DIR }}
-                  DEFAULT_TIMEOUT_OVERRIDE: 120000
-                  E2E_MAX_FAILURES: 15
-              with:
-                  report-name: ${{ env.E2E_ARTIFACT }}
+    #         - name: Run E2E tests
+    #           id: run-e2e-composite-action
+    #           timeout-minutes: 60
+    #           uses: ./.github/actions/tests/run-e2e-tests
+    #           env:
+    #               ALLURE_RESULTS_DIR: ${{ env.E2E_ALLURE_RESULTS_DIR }}
+    #               ALLURE_REPORT_DIR: ${{ env.E2E_ALLURE_REPORT_DIR }}
+    #               DEFAULT_TIMEOUT_OVERRIDE: 120000
+    #               E2E_MAX_FAILURES: 15
+    #           with:
+    #               report-name: ${{ env.E2E_ARTIFACT }}
 
-            - name: Upload Allure artifacts to bucket
-              if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
-              uses: ./.github/actions/tests/upload-allure-files-to-bucket
-              env:
-                  ALLURE_RESULTS_DIR: ${{ env.E2E_ALLURE_RESULTS_DIR }}
-                  ALLURE_REPORT_DIR: ${{ env.E2E_ALLURE_REPORT_DIR }}
-              with:
-                  aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
-                  aws-region: ${{ secrets.REPORTS_AWS_REGION }}
-                  aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
-                  artifact-name: ${{ env.E2E_ARTIFACT }}
-                  s3-bucket: ${{ secrets.REPORTS_BUCKET }}
+    #         - name: Upload Allure artifacts to bucket
+    #           if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
+    #           uses: ./.github/actions/tests/upload-allure-files-to-bucket
+    #           env:
+    #               ALLURE_RESULTS_DIR: ${{ env.E2E_ALLURE_RESULTS_DIR }}
+    #               ALLURE_REPORT_DIR: ${{ env.E2E_ALLURE_REPORT_DIR }}
+    #           with:
+    #               aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
+    #               aws-region: ${{ secrets.REPORTS_AWS_REGION }}
+    #               aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
+    #               artifact-name: ${{ env.E2E_ARTIFACT }}
+    #               s3-bucket: ${{ secrets.REPORTS_BUCKET }}
 
-            - name: Publish E2E Allure report
-              if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
-              env:
-                  GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
-                  ENV_DESCRIPTION: php-${{ matrix.php_version }}
-              run: |
-                  gh workflow run publish-test-reports-release.yml \
-                    -f created_at="${{ needs.get-tag.outputs.created }}" \
-                    -f run_id=${{ github.run_id }} \
-                    -f run_number=${{ github.run_number }} \
-                    -f release_tag=${{ needs.get-tag.outputs.tag }} \
-                    -f artifact="${{ env.E2E_ARTIFACT }}" \
-                    -f env_description="${{ env.ENV_DESCRIPTION }}" \
-                    -f test_type="e2e" \
-                    --repo woocommerce/woocommerce-test-reports
+    #         - name: Publish E2E Allure report
+    #           if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
+    #           env:
+    #               GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+    #               ENV_DESCRIPTION: php-${{ matrix.php_version }}
+    #           run: |
+    #               gh workflow run publish-test-reports-release.yml \
+    #                 -f created_at="${{ needs.get-tag.outputs.created }}" \
+    #                 -f run_id=${{ github.run_id }} \
+    #                 -f run_number=${{ github.run_number }} \
+    #                 -f release_tag=${{ needs.get-tag.outputs.tag }} \
+    #                 -f artifact="${{ env.E2E_ARTIFACT }}" \
+    #                 -f env_description="${{ env.ENV_DESCRIPTION }}" \
+    #                 -f test_type="e2e" \
+    #                 --repo woocommerce/woocommerce-test-reports
 
     test-plugins:
         name: With ${{ matrix.plugin }}
@@ -569,25 +569,26 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    - plugin: 'WooCommerce Payments'
-                      repo: 'automattic/woocommerce-payments'
-                      env_description: 'woocommerce-payments'
-                    - plugin: 'WooCommerce PayPal Payments'
-                      repo: 'woocommerce/woocommerce-paypal-payments'
-                      env_description: 'woocommerce-paypal-payments'
-                    - plugin: 'WooCommerce Shipping & Tax'
-                      repo: 'automattic/woocommerce-services'
-                      env_description: 'woocommerce-shipping-&-tax'
-                    - plugin: 'WooCommerce Subscriptions'
-                      repo: WC_SUBSCRIPTIONS_REPO
-                      private: true
-                      env_description: 'woocommerce-subscriptions'
-                    - plugin: 'WordPress SEO' # Yoast SEO in the UI, but the slug is wordpress-seo
-                      repo: 'Yoast/wordpress-seo'
-                      env_description: 'wordpress-seo'
-                    - plugin: 'Contact Form 7'
-                      repo: 'takayukister/contact-form-7'
-                      env_description: 'contact-form-7'
+                    # mytodo uncomment
+                    # - plugin: 'WooCommerce Payments'
+                    #   repo: 'automattic/woocommerce-payments'
+                    #   env_description: 'woocommerce-payments'
+                    # - plugin: 'WooCommerce PayPal Payments'
+                    #   repo: 'woocommerce/woocommerce-paypal-payments'
+                    #   env_description: 'woocommerce-paypal-payments'
+                    # - plugin: 'WooCommerce Shipping & Tax'
+                    #   repo: 'automattic/woocommerce-services'
+                    #   env_description: 'woocommerce-shipping-&-tax'
+                    # - plugin: 'WooCommerce Subscriptions'
+                    #   repo: WC_SUBSCRIPTIONS_REPO
+                    #   private: true
+                    #   env_description: 'woocommerce-subscriptions'
+                    - plugin: 'Gutenberg'
+                      repo: 'WordPress/gutenberg'
+                      env_description: 'gutenberg'
+                    - plugin: 'Gutenberg - Nightly'
+                      repo: 'bph/gutenberg'
+                      env_description: 'gutenberg-nightly'
         steps:
             - name: Checkout
               uses: actions/checkout@v3
@@ -626,6 +627,7 @@ jobs:
               with:
                   playwright-config: ignore-plugin-tests.playwright.config.js
                   report-name: ${{ env.ARTIFACT_NAME }}
+                  tests: basic.spec.js # mytodo remove
               env:
                   E2E_MAX_FAILURES: 15
 

--- a/.github/workflows/smoke-test-release.yml
+++ b/.github/workflows/smoke-test-release.yml
@@ -61,501 +61,501 @@ jobs:
                   GH_TOKEN: ${{ secrets.E2E_GH_TOKEN }}
               run: echo "created=$(gh release view ${{ steps.get-tag.outputs.tag }} --json assets --jq .assets[0].createdAt --repo woocommerce/woocommerce)" >> $GITHUB_OUTPUT
 
-    # e2e-update-wc:
-    #     name: Test WooCommerce update
-    #     runs-on: ubuntu-20.04
-    #     needs: [get-tag]
-    #     permissions:
-    #         contents: read
-    #     env:
-    #         ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-report
-    #         ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-results
-    #     steps:
-    #         - uses: actions/checkout@v3
+    e2e-update-wc:
+        name: Test WooCommerce update
+        runs-on: ubuntu-20.04
+        needs: [get-tag]
+        permissions:
+            contents: read
+        env:
+            ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-report
+            ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-results
+        steps:
+            - uses: actions/checkout@v3
 
-    #         - name: Setup WooCommerce Monorepo
-    #           uses: ./.github/actions/setup-woocommerce-monorepo
-    #           with:
-    #               install-filters: woocommerce
-    #               build: false
+            - name: Setup WooCommerce Monorepo
+              uses: ./.github/actions/setup-woocommerce-monorepo
+              with:
+                  install-filters: woocommerce
+                  build: false
 
-    #         - name: Run E2E tests
-    #           id: run-e2e-composite-action
-    #           timeout-minutes: 60
-    #           uses: ./.github/actions/tests/run-e2e-tests
-    #           with:
-    #               report-name: ${{ env.E2E_UPDATE_WC_ARTIFACT }}
-    #               tests: update-woocommerce.spec.js
-    #           env:
-    #               ADMIN_PASSWORD: ${{ secrets.RELEASE_TEST_ADMIN_PASSWORD }}
-    #               ADMIN_USER: ${{ secrets.RELEASE_TEST_ADMIN_USER }}
-    #               BASE_URL: ${{ secrets.RELEASE_TEST_URL }}
-    #               CUSTOMER_PASSWORD: ${{ secrets.RELEASE_TEST_CUSTOMER_PASSWORD }}
-    #               CUSTOMER_USER: ${{ secrets.RELEASE_TEST_CUSTOMER_USER }}
-    #               DEFAULT_TIMEOUT_OVERRIDE: 120000
-    #               GITHUB_TOKEN: ${{ secrets.E2E_GH_TOKEN }}
-    #               UPDATE_WC: ${{ needs.get-tag.outputs.tag }}
+            - name: Run E2E tests
+              id: run-e2e-composite-action
+              timeout-minutes: 60
+              uses: ./.github/actions/tests/run-e2e-tests
+              with:
+                  report-name: ${{ env.E2E_UPDATE_WC_ARTIFACT }}
+                  tests: update-woocommerce.spec.js
+              env:
+                  ADMIN_PASSWORD: ${{ secrets.RELEASE_TEST_ADMIN_PASSWORD }}
+                  ADMIN_USER: ${{ secrets.RELEASE_TEST_ADMIN_USER }}
+                  BASE_URL: ${{ secrets.RELEASE_TEST_URL }}
+                  CUSTOMER_PASSWORD: ${{ secrets.RELEASE_TEST_CUSTOMER_PASSWORD }}
+                  CUSTOMER_USER: ${{ secrets.RELEASE_TEST_CUSTOMER_USER }}
+                  DEFAULT_TIMEOUT_OVERRIDE: 120000
+                  GITHUB_TOKEN: ${{ secrets.E2E_GH_TOKEN }}
+                  UPDATE_WC: ${{ needs.get-tag.outputs.tag }}
 
-    #         - name: Upload Allure artifacts to bucket
-    #           if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
-    #           uses: ./.github/actions/tests/upload-allure-files-to-bucket
-    #           with:
-    #               aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
-    #               aws-region: ${{ secrets.REPORTS_AWS_REGION }}
-    #               aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
-    #               artifact-name: ${{ env.E2E_WP_LATEST_ARTIFACT }}
-    #               s3-bucket: ${{ secrets.REPORTS_BUCKET }}
+            - name: Upload Allure artifacts to bucket
+              if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
+              uses: ./.github/actions/tests/upload-allure-files-to-bucket
+              with:
+                  aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
+                  aws-region: ${{ secrets.REPORTS_AWS_REGION }}
+                  aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
+                  artifact-name: ${{ env.E2E_WP_LATEST_ARTIFACT }}
+                  s3-bucket: ${{ secrets.REPORTS_BUCKET }}
 
-    #         - name: Publish E2E Allure report
-    #           if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
-    #           env:
-    #               GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
-    #               ENV_DESCRIPTION: wp-latest
-    #           run: |
-    #               gh workflow run publish-test-reports-release.yml \
-    #                 -f created_at="${{ needs.get-tag.outputs.created }}" \
-    #                 -f run_id=${{ github.run_id }} \
-    #                 -f run_number=${{ github.run_number }} \
-    #                 -f release_tag=${{ needs.get-tag.outputs.tag }} \
-    #                 -f artifact="${{ env.E2E_WP_LATEST_ARTIFACT }}" \
-    #                 -f env_description="${{ env.ENV_DESCRIPTION }}" \
-    #                 -f test_type="e2e" \
-    #                 --repo woocommerce/woocommerce-test-reports
+            - name: Publish E2E Allure report
+              if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
+              env:
+                  GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+                  ENV_DESCRIPTION: wp-latest
+              run: |
+                  gh workflow run publish-test-reports-release.yml \
+                    -f created_at="${{ needs.get-tag.outputs.created }}" \
+                    -f run_id=${{ github.run_id }} \
+                    -f run_number=${{ github.run_number }} \
+                    -f release_tag=${{ needs.get-tag.outputs.tag }} \
+                    -f artifact="${{ env.E2E_WP_LATEST_ARTIFACT }}" \
+                    -f env_description="${{ env.ENV_DESCRIPTION }}" \
+                    -f test_type="e2e" \
+                    --repo woocommerce/woocommerce-test-reports
 
-    # api-wp-latest:
-    #     name: API on WP Latest
-    #     runs-on: ubuntu-20.04
-    #     needs: [get-tag, e2e-update-wc]
-    #     permissions:
-    #         contents: read
-    #     env:
-    #         ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/api-test-report/allure-report
-    #         ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/api-test-report/allure-results
-    #         API_WP_LATEST_ARTIFACT: API test on release smoke test site with WP Latest (run ${{ github.run_number }})
-    #     steps:
-    #         - uses: actions/checkout@v3
+    api-wp-latest:
+        name: API on WP Latest
+        runs-on: ubuntu-20.04
+        needs: [get-tag, e2e-update-wc]
+        permissions:
+            contents: read
+        env:
+            ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/api-test-report/allure-report
+            ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/api-test-report/allure-results
+            API_WP_LATEST_ARTIFACT: API test on release smoke test site with WP Latest (run ${{ github.run_number }})
+        steps:
+            - uses: actions/checkout@v3
 
-    #         - name: Setup WooCommerce Monorepo
-    #           uses: ./.github/actions/setup-woocommerce-monorepo
-    #           with:
-    #               install-filters: woocommerce
-    #               build: false
+            - name: Setup WooCommerce Monorepo
+              uses: ./.github/actions/setup-woocommerce-monorepo
+              with:
+                  install-filters: woocommerce
+                  build: false
 
-    #         - name: Run API tests
-    #           id: run-api-composite-action
-    #           uses: ./.github/actions/tests/run-api-tests
-    #           with:
-    #               report-name: ${{ env.API_WP_LATEST_ARTIFACT }}
-    #               tests: hello
-    #           env:
-    #               BASE_URL: ${{ secrets.RELEASE_TEST_URL }}
-    #               USER_KEY: ${{ secrets.RELEASE_TEST_ADMIN_USER }}
-    #               USER_SECRET: ${{ secrets.RELEASE_TEST_ADMIN_PASSWORD }}
+            - name: Run API tests
+              id: run-api-composite-action
+              uses: ./.github/actions/tests/run-api-tests
+              with:
+                  report-name: ${{ env.API_WP_LATEST_ARTIFACT }}
+                  tests: hello
+              env:
+                  BASE_URL: ${{ secrets.RELEASE_TEST_URL }}
+                  USER_KEY: ${{ secrets.RELEASE_TEST_ADMIN_USER }}
+                  USER_SECRET: ${{ secrets.RELEASE_TEST_ADMIN_PASSWORD }}
 
-    #         - name: Upload Allure artifacts to bucket
-    #           if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
-    #           uses: ./.github/actions/tests/upload-allure-files-to-bucket
-    #           with:
-    #               aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
-    #               aws-region: ${{ secrets.REPORTS_AWS_REGION }}
-    #               aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
-    #               artifact-name: ${{ env.API_WP_LATEST_ARTIFACT }}
-    #               s3-bucket: ${{ secrets.REPORTS_BUCKET }}
+            - name: Upload Allure artifacts to bucket
+              if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
+              uses: ./.github/actions/tests/upload-allure-files-to-bucket
+              with:
+                  aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
+                  aws-region: ${{ secrets.REPORTS_AWS_REGION }}
+                  aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
+                  artifact-name: ${{ env.API_WP_LATEST_ARTIFACT }}
+                  s3-bucket: ${{ secrets.REPORTS_BUCKET }}
 
-    #         - name: Publish API Allure report
-    #           if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
-    #           env:
-    #               GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
-    #               ENV_DESCRIPTION: wp-latest
-    #           run: |
-    #               gh workflow run publish-test-reports-release.yml \
-    #                 -f created_at="${{ needs.get-tag.outputs.created }}" \
-    #                 -f run_id=${{ github.run_id }} \
-    #                 -f run_number=${{ github.run_number }} \
-    #                 -f release_tag=${{ needs.get-tag.outputs.tag }} \
-    #                 -f artifact="${{ env.API_WP_LATEST_ARTIFACT }}" \
-    #                 -f env_description="${{ env.ENV_DESCRIPTION }}" \
-    #                 -f test_type="api" \
-    #                 --repo woocommerce/woocommerce-test-reports
+            - name: Publish API Allure report
+              if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
+              env:
+                  GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+                  ENV_DESCRIPTION: wp-latest
+              run: |
+                  gh workflow run publish-test-reports-release.yml \
+                    -f created_at="${{ needs.get-tag.outputs.created }}" \
+                    -f run_id=${{ github.run_id }} \
+                    -f run_number=${{ github.run_number }} \
+                    -f release_tag=${{ needs.get-tag.outputs.tag }} \
+                    -f artifact="${{ env.API_WP_LATEST_ARTIFACT }}" \
+                    -f env_description="${{ env.ENV_DESCRIPTION }}" \
+                    -f test_type="api" \
+                    --repo woocommerce/woocommerce-test-reports
 
-    # e2e-wp-latest:
-    #     name: E2E on WP Latest
-    #     runs-on: ubuntu-20.04
-    #     needs: [get-tag, api-wp-latest]
-    #     permissions:
-    #         contents: read
-    #     env:
-    #         ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-report
-    #         ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-results
-    #     steps:
-    #         - uses: actions/checkout@v3
+    e2e-wp-latest:
+        name: E2E on WP Latest
+        runs-on: ubuntu-20.04
+        needs: [get-tag, api-wp-latest]
+        permissions:
+            contents: read
+        env:
+            ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-report
+            ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-results
+        steps:
+            - uses: actions/checkout@v3
 
-    #         - name: Setup WooCommerce Monorepo
-    #           uses: ./.github/actions/setup-woocommerce-monorepo
-    #           with:
-    #               install-filters: woocommerce
-    #               build: false
+            - name: Setup WooCommerce Monorepo
+              uses: ./.github/actions/setup-woocommerce-monorepo
+              with:
+                  install-filters: woocommerce
+                  build: false
 
-    #         - name: Run E2E tests
-    #           id: run-e2e-composite-action
-    #           timeout-minutes: 60
-    #           uses: ./.github/actions/tests/run-e2e-tests
-    #           with:
-    #               report-name: e2e-wp-latest--partial--run-${{ github.run_number }}
-    #               playwright-config: ignore-plugin-tests.playwright.config.js
-    #           env:
-    #               ADMIN_PASSWORD: ${{ secrets.RELEASE_TEST_ADMIN_PASSWORD }}
-    #               ADMIN_USER: ${{ secrets.RELEASE_TEST_ADMIN_USER }}
-    #               ADMIN_USER_EMAIL: ${{ secrets.RELEASE_TEST_ADMIN_USER_EMAIL }}
-    #               BASE_URL: ${{ secrets.RELEASE_TEST_URL }}
-    #               CUSTOMER_PASSWORD: ${{ secrets.RELEASE_TEST_CUSTOMER_PASSWORD }}
-    #               CUSTOMER_USER: ${{ secrets.RELEASE_TEST_CUSTOMER_USER }}
-    #               DEFAULT_TIMEOUT_OVERRIDE: 120000
-    #               E2E_MAX_FAILURES: 25
-    #               RESET_SITE: true
+            - name: Run E2E tests
+              id: run-e2e-composite-action
+              timeout-minutes: 60
+              uses: ./.github/actions/tests/run-e2e-tests
+              with:
+                  report-name: e2e-wp-latest--partial--run-${{ github.run_number }}
+                  playwright-config: ignore-plugin-tests.playwright.config.js
+              env:
+                  ADMIN_PASSWORD: ${{ secrets.RELEASE_TEST_ADMIN_PASSWORD }}
+                  ADMIN_USER: ${{ secrets.RELEASE_TEST_ADMIN_USER }}
+                  ADMIN_USER_EMAIL: ${{ secrets.RELEASE_TEST_ADMIN_USER_EMAIL }}
+                  BASE_URL: ${{ secrets.RELEASE_TEST_URL }}
+                  CUSTOMER_PASSWORD: ${{ secrets.RELEASE_TEST_CUSTOMER_PASSWORD }}
+                  CUSTOMER_USER: ${{ secrets.RELEASE_TEST_CUSTOMER_USER }}
+                  DEFAULT_TIMEOUT_OVERRIDE: 120000
+                  E2E_MAX_FAILURES: 25
+                  RESET_SITE: true
 
-    #         - name: Download 'e2e-update-wc' artifact
-    #           if: success() || failure()
-    #           uses: actions/download-artifact@v3
-    #           with:
-    #               name: ${{ env.E2E_UPDATE_WC_ARTIFACT }}
-    #               path: plugins/woocommerce/tmp
+            - name: Download 'e2e-update-wc' artifact
+              if: success() || failure()
+              uses: actions/download-artifact@v3
+              with:
+                  name: ${{ env.E2E_UPDATE_WC_ARTIFACT }}
+                  path: plugins/woocommerce/tmp
 
-    #         - name: Add allure-results from 'e2e-update-wc'
-    #           if: success() || failure()
-    #           working-directory: plugins/woocommerce
-    #           run: cp -r tmp/allure-results tests/e2e-pw/test-results
+            - name: Add allure-results from 'e2e-update-wc'
+              if: success() || failure()
+              working-directory: plugins/woocommerce
+              run: cp -r tmp/allure-results tests/e2e-pw/test-results
 
-    #         - name: Generate E2E Test report.
-    #           if: success() || failure()
-    #           working-directory: plugins/woocommerce
-    #           run: pnpm exec allure generate --clean ${{ env.ALLURE_RESULTS_DIR }} --output ${{ env.ALLURE_REPORT_DIR }}
+            - name: Generate E2E Test report.
+              if: success() || failure()
+              working-directory: plugins/woocommerce
+              run: pnpm exec allure generate --clean ${{ env.ALLURE_RESULTS_DIR }} --output ${{ env.ALLURE_REPORT_DIR }}
 
-    #         - name: Archive E2E test report
-    #           if: success() || failure()
-    #           uses: actions/upload-artifact@v3
-    #           with:
-    #               name: ${{ env.E2E_WP_LATEST_ARTIFACT }}
-    #               path: |
-    #                   ${{ env.ALLURE_RESULTS_DIR }}
-    #                   ${{ env.ALLURE_REPORT_DIR }}
-    #               if-no-files-found: ignore
-    #               retention-days: 5
+            - name: Archive E2E test report
+              if: success() || failure()
+              uses: actions/upload-artifact@v3
+              with:
+                  name: ${{ env.E2E_WP_LATEST_ARTIFACT }}
+                  path: |
+                      ${{ env.ALLURE_RESULTS_DIR }}
+                      ${{ env.ALLURE_REPORT_DIR }}
+                  if-no-files-found: ignore
+                  retention-days: 5
 
-    #         - name: Upload Allure artifacts to bucket
-    #           if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
-    #           uses: ./.github/actions/tests/upload-allure-files-to-bucket
-    #           with:
-    #               aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
-    #               aws-region: ${{ secrets.REPORTS_AWS_REGION }}
-    #               aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
-    #               artifact-name: ${{ env.E2E_WP_LATEST_ARTIFACT }}
-    #               s3-bucket: ${{ secrets.REPORTS_BUCKET }}
+            - name: Upload Allure artifacts to bucket
+              if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
+              uses: ./.github/actions/tests/upload-allure-files-to-bucket
+              with:
+                  aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
+                  aws-region: ${{ secrets.REPORTS_AWS_REGION }}
+                  aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
+                  artifact-name: ${{ env.E2E_WP_LATEST_ARTIFACT }}
+                  s3-bucket: ${{ secrets.REPORTS_BUCKET }}
 
-    #         - name: Publish E2E Allure report
-    #           if: success() || failure()
-    #           env:
-    #               GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
-    #               ENV_DESCRIPTION: wp-latest
-    #           run: |
-    #               gh workflow run publish-test-reports-release.yml \
-    #                 -f created_at="${{ needs.get-tag.outputs.created }}" \
-    #                 -f run_id=${{ github.run_id }} \
-    #                 -f run_number=${{ github.run_number }} \
-    #                 -f release_tag=${{ needs.get-tag.outputs.tag }} \
-    #                 -f artifact="${{ env.E2E_WP_LATEST_ARTIFACT }}" \
-    #                 -f env_description="${{ env.ENV_DESCRIPTION }}" \
-    #                 -f test_type="e2e" \
-    #                 --repo woocommerce/woocommerce-test-reports
+            - name: Publish E2E Allure report
+              if: success() || failure()
+              env:
+                  GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+                  ENV_DESCRIPTION: wp-latest
+              run: |
+                  gh workflow run publish-test-reports-release.yml \
+                    -f created_at="${{ needs.get-tag.outputs.created }}" \
+                    -f run_id=${{ github.run_id }} \
+                    -f run_number=${{ github.run_number }} \
+                    -f release_tag=${{ needs.get-tag.outputs.tag }} \
+                    -f artifact="${{ env.E2E_WP_LATEST_ARTIFACT }}" \
+                    -f env_description="${{ env.ENV_DESCRIPTION }}" \
+                    -f test_type="e2e" \
+                    --repo woocommerce/woocommerce-test-reports
 
-    # get-wp-versions:
-    #     name: Get WP L-1 & L-2 version numbers
-    #     needs: [get-tag]
-    #     runs-on: ubuntu-20.04
-    #     permissions:
-    #         contents: read
-    #     outputs:
-    #         matrix: ${{ steps.get-versions.outputs.versions }}
-    #         tag: ${{ needs.get-tag.outputs.tag }}
-    #         created: ${{ needs.get-tag.outputs.created }}
-    #     steps:
-    #         - name: Create dirs
-    #           run: |
-    #               mkdir script
-    #               mkdir repo
+    get-wp-versions:
+        name: Get WP L-1 & L-2 version numbers
+        needs: [get-tag]
+        runs-on: ubuntu-20.04
+        permissions:
+            contents: read
+        outputs:
+            matrix: ${{ steps.get-versions.outputs.versions }}
+            tag: ${{ needs.get-tag.outputs.tag }}
+            created: ${{ needs.get-tag.outputs.created }}
+        steps:
+            - name: Create dirs
+              run: |
+                  mkdir script
+                  mkdir repo
 
-    #         - name: Checkout
-    #           uses: actions/checkout@v3
-    #           with:
-    #               path: repo
+            - name: Checkout
+              uses: actions/checkout@v3
+              with:
+                  path: repo
 
-    #         - name: Copy script to get previous WP versions
-    #           run: cp repo/plugins/woocommerce/tests/e2e-pw/utils/wordpress.js script
+            - name: Copy script to get previous WP versions
+              run: cp repo/plugins/woocommerce/tests/e2e-pw/utils/wordpress.js script
 
-    #         - name: Install axios
-    #           working-directory: script
-    #           run: npm install axios
+            - name: Install axios
+              working-directory: script
+              run: npm install axios
 
-    #         - name: Get version numbers
-    #           id: get-versions
-    #           uses: actions/github-script@v6
-    #           with:
-    #               script: |
-    #                   const { getPreviousTwoVersions } = require('./script/wordpress');
-    #                   const versions = await getPreviousTwoVersions();
-    #                   console.log(versions);
-    #                   core.setOutput('versions', versions);
+            - name: Get version numbers
+              id: get-versions
+              uses: actions/github-script@v6
+              with:
+                  script: |
+                      const { getPreviousTwoVersions } = require('./script/wordpress');
+                      const versions = await getPreviousTwoVersions();
+                      console.log(versions);
+                      core.setOutput('versions', versions);
 
-    # test-wp-versions:
-    #     name: Test against ${{ matrix.version.description }} (${{ matrix.version.number }})
-    #     runs-on: ubuntu-20.04
-    #     needs: [get-wp-versions]
-    #     strategy:
-    #         fail-fast: false
-    #         matrix: ${{ fromJSON(needs.get-wp-versions.outputs.matrix) }}
-    #     env:
-    #         API_ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/api/allure-report
-    #         API_ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/api/allure-results
-    #         API_WP_LATEST_X_ARTIFACT: API test on wp-env with WordPress ${{ matrix.version.number }} (run ${{ github.run_number }})
-    #         E2E_ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/e2e/allure-report
-    #         E2E_ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/e2e/allure-results
-    #         E2E_WP_LATEST_X_ARTIFACT: E2E test on wp-env with WordPress ${{ matrix.version.number }} (run ${{ github.run_number }})
-    #     permissions:
-    #         contents: read
-    #     steps:
-    #         - name: Checkout WooCommerce repo
-    #           uses: actions/checkout@v3
+    test-wp-versions:
+        name: Test against ${{ matrix.version.description }} (${{ matrix.version.number }})
+        runs-on: ubuntu-20.04
+        needs: [get-wp-versions]
+        strategy:
+            fail-fast: false
+            matrix: ${{ fromJSON(needs.get-wp-versions.outputs.matrix) }}
+        env:
+            API_ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/api/allure-report
+            API_ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/api/allure-results
+            API_WP_LATEST_X_ARTIFACT: API test on wp-env with WordPress ${{ matrix.version.number }} (run ${{ github.run_number }})
+            E2E_ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/e2e/allure-report
+            E2E_ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/e2e/allure-results
+            E2E_WP_LATEST_X_ARTIFACT: E2E test on wp-env with WordPress ${{ matrix.version.number }} (run ${{ github.run_number }})
+        permissions:
+            contents: read
+        steps:
+            - name: Checkout WooCommerce repo
+              uses: actions/checkout@v3
 
-    #         - name: Setup WooCommerce Monorepo
-    #           uses: ./.github/actions/setup-woocommerce-monorepo
+            - name: Setup WooCommerce Monorepo
+              uses: ./.github/actions/setup-woocommerce-monorepo
 
-    #         - name: Launch WP Env
-    #           working-directory: plugins/woocommerce
-    #           run: pnpm run env:test
+            - name: Launch WP Env
+              working-directory: plugins/woocommerce
+              run: pnpm run env:test
 
-    #         - name: Download release zip
-    #           env:
-    #               GH_TOKEN: ${{ secrets.E2E_GH_TOKEN }}
-    #           run: gh release download ${{ needs.get-wp-versions.outputs.tag }} --dir tmp
+            - name: Download release zip
+              env:
+                  GH_TOKEN: ${{ secrets.E2E_GH_TOKEN }}
+              run: gh release download ${{ needs.get-wp-versions.outputs.tag }} --dir tmp
 
-    #         - name: Replace `plugins/woocommerce` with unzipped woocommerce release build
-    #           run: unzip -d plugins -o tmp/woocommerce.zip
+            - name: Replace `plugins/woocommerce` with unzipped woocommerce release build
+              run: unzip -d plugins -o tmp/woocommerce.zip
 
-    #         - name: Downgrade WordPress version to ${{ matrix.version.number }}
-    #           working-directory: plugins/woocommerce
-    #           run: |
-    #               pnpm exec wp-env run tests-cli "wp core update --version=${{ matrix.version.number }} --force"
-    #               pnpm exec wp-env run tests-cli "wp core update-db"
+            - name: Downgrade WordPress version to ${{ matrix.version.number }}
+              working-directory: plugins/woocommerce
+              run: |
+                  pnpm exec wp-env run tests-cli "wp core update --version=${{ matrix.version.number }} --force"
+                  pnpm exec wp-env run tests-cli "wp core update-db"
 
-    #         - name: Verify environment details
-    #           working-directory: plugins/woocommerce
-    #           run: |
-    #               pnpm exec wp-env run tests-cli "wp core version"
-    #               pnpm exec wp-env run tests-cli "wp plugin list"
-    #               pnpm exec wp-env run tests-cli "wp theme list"
-    #               pnpm exec wp-env run tests-cli "wp user list"
+            - name: Verify environment details
+              working-directory: plugins/woocommerce
+              run: |
+                  pnpm exec wp-env run tests-cli "wp core version"
+                  pnpm exec wp-env run tests-cli "wp plugin list"
+                  pnpm exec wp-env run tests-cli "wp theme list"
+                  pnpm exec wp-env run tests-cli "wp user list"
 
-    #         - name: Run API tests
-    #           id: run-api-composite-action
-    #           uses: ./.github/actions/tests/run-api-tests
-    #           with:
-    #               report-name: ${{ env.API_WP_LATEST_X_ARTIFACT }}
-    #               tests: hello
-    #           env:
-    #               ALLURE_RESULTS_DIR: ${{ env.API_ALLURE_RESULTS_DIR }}
-    #               ALLURE_REPORT_DIR: ${{ env.API_ALLURE_REPORT_DIR }}
+            - name: Run API tests
+              id: run-api-composite-action
+              uses: ./.github/actions/tests/run-api-tests
+              with:
+                  report-name: ${{ env.API_WP_LATEST_X_ARTIFACT }}
+                  tests: hello
+              env:
+                  ALLURE_RESULTS_DIR: ${{ env.API_ALLURE_RESULTS_DIR }}
+                  ALLURE_REPORT_DIR: ${{ env.API_ALLURE_REPORT_DIR }}
 
-    #         - name: Upload Allure artifacts to bucket
-    #           if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
-    #           uses: ./.github/actions/tests/upload-allure-files-to-bucket
-    #           env:
-    #               ALLURE_RESULTS_DIR: ${{ env.API_ALLURE_RESULTS_DIR }}
-    #               ALLURE_REPORT_DIR: ${{ env.API_ALLURE_REPORT_DIR }}
-    #           with:
-    #               aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
-    #               aws-region: ${{ secrets.REPORTS_AWS_REGION }}
-    #               aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
-    #               artifact-name: ${{ env.API_WP_LATEST_X_ARTIFACT }}
-    #               s3-bucket: ${{ secrets.REPORTS_BUCKET }}
+            - name: Upload Allure artifacts to bucket
+              if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
+              uses: ./.github/actions/tests/upload-allure-files-to-bucket
+              env:
+                  ALLURE_RESULTS_DIR: ${{ env.API_ALLURE_RESULTS_DIR }}
+                  ALLURE_REPORT_DIR: ${{ env.API_ALLURE_REPORT_DIR }}
+              with:
+                  aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
+                  aws-region: ${{ secrets.REPORTS_AWS_REGION }}
+                  aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
+                  artifact-name: ${{ env.API_WP_LATEST_X_ARTIFACT }}
+                  s3-bucket: ${{ secrets.REPORTS_BUCKET }}
 
-    #         - name: Publish API Allure report
-    #           if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
-    #           env:
-    #               GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
-    #               ENV_DESCRIPTION: ${{ matrix.version.env_description }}
-    #           run: |
-    #               gh workflow run publish-test-reports-release.yml \
-    #                 -f created_at="${{ needs.get-wp-versions.outputs.created }}" \
-    #                 -f run_id=${{ github.run_id }} \
-    #                 -f run_number=${{ github.run_number }} \
-    #                 -f release_tag=${{ needs.get-wp-versions.outputs.tag }} \
-    #                 -f artifact="${{ env.API_WP_LATEST_X_ARTIFACT }}" \
-    #                 -f env_description="${{ env.ENV_DESCRIPTION }}" \
-    #                 -f test_type="api" \
-    #                 --repo woocommerce/woocommerce-test-reports
+            - name: Publish API Allure report
+              if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
+              env:
+                  GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+                  ENV_DESCRIPTION: ${{ matrix.version.env_description }}
+              run: |
+                  gh workflow run publish-test-reports-release.yml \
+                    -f created_at="${{ needs.get-wp-versions.outputs.created }}" \
+                    -f run_id=${{ github.run_id }} \
+                    -f run_number=${{ github.run_number }} \
+                    -f release_tag=${{ needs.get-wp-versions.outputs.tag }} \
+                    -f artifact="${{ env.API_WP_LATEST_X_ARTIFACT }}" \
+                    -f env_description="${{ env.ENV_DESCRIPTION }}" \
+                    -f test_type="api" \
+                    --repo woocommerce/woocommerce-test-reports
 
-    #         - name: Run E2E tests
-    #           id: run-e2e-composite-action
-    #           timeout-minutes: 60
-    #           uses: ./.github/actions/tests/run-e2e-tests
-    #           env:
-    #               E2E_MAX_FAILURES: 15
-    #               ALLURE_RESULTS_DIR: ${{ env.E2E_ALLURE_RESULTS_DIR }}
-    #               ALLURE_REPORT_DIR: ${{ env.E2E_ALLURE_REPORT_DIR }}
-    #               DEFAULT_TIMEOUT_OVERRIDE: 120000
-    #           with:
-    #               report-name: ${{ env.E2E_WP_LATEST_X_ARTIFACT }}
+            - name: Run E2E tests
+              id: run-e2e-composite-action
+              timeout-minutes: 60
+              uses: ./.github/actions/tests/run-e2e-tests
+              env:
+                  E2E_MAX_FAILURES: 15
+                  ALLURE_RESULTS_DIR: ${{ env.E2E_ALLURE_RESULTS_DIR }}
+                  ALLURE_REPORT_DIR: ${{ env.E2E_ALLURE_REPORT_DIR }}
+                  DEFAULT_TIMEOUT_OVERRIDE: 120000
+              with:
+                  report-name: ${{ env.E2E_WP_LATEST_X_ARTIFACT }}
 
-    #         - name: Upload Allure artifacts to bucket
-    #           if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
-    #           uses: ./.github/actions/tests/upload-allure-files-to-bucket
-    #           env:
-    #               ALLURE_RESULTS_DIR: ${{ env.E2E_ALLURE_RESULTS_DIR }}
-    #               ALLURE_REPORT_DIR: ${{ env.E2E_ALLURE_REPORT_DIR }}
-    #           with:
-    #               aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
-    #               aws-region: ${{ secrets.REPORTS_AWS_REGION }}
-    #               aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
-    #               artifact-name: ${{ env.E2E_WP_LATEST_X_ARTIFACT }}
-    #               s3-bucket: ${{ secrets.REPORTS_BUCKET }}
+            - name: Upload Allure artifacts to bucket
+              if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
+              uses: ./.github/actions/tests/upload-allure-files-to-bucket
+              env:
+                  ALLURE_RESULTS_DIR: ${{ env.E2E_ALLURE_RESULTS_DIR }}
+                  ALLURE_REPORT_DIR: ${{ env.E2E_ALLURE_REPORT_DIR }}
+              with:
+                  aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
+                  aws-region: ${{ secrets.REPORTS_AWS_REGION }}
+                  aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
+                  artifact-name: ${{ env.E2E_WP_LATEST_X_ARTIFACT }}
+                  s3-bucket: ${{ secrets.REPORTS_BUCKET }}
 
-    #         - name: Publish E2E Allure report
-    #           if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
-    #           env:
-    #               GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
-    #               ENV_DESCRIPTION: ${{ matrix.version.env_description }}
-    #           run: |
-    #               gh workflow run publish-test-reports-release.yml \
-    #                 -f created_at="${{ needs.get-wp-versions.outputs.created }}" \
-    #                 -f run_id=${{ github.run_id }} \
-    #                 -f run_number=${{ github.run_number }} \
-    #                 -f release_tag=${{ needs.get-wp-versions.outputs.tag }} \
-    #                 -f artifact="${{ env.E2E_WP_LATEST_X_ARTIFACT }}" \
-    #                 -f env_description="${{ env.ENV_DESCRIPTION }}" \
-    #                 -f test_type="e2e" \
-    #                 --repo woocommerce/woocommerce-test-reports
+            - name: Publish E2E Allure report
+              if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
+              env:
+                  GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+                  ENV_DESCRIPTION: ${{ matrix.version.env_description }}
+              run: |
+                  gh workflow run publish-test-reports-release.yml \
+                    -f created_at="${{ needs.get-wp-versions.outputs.created }}" \
+                    -f run_id=${{ github.run_id }} \
+                    -f run_number=${{ github.run_number }} \
+                    -f release_tag=${{ needs.get-wp-versions.outputs.tag }} \
+                    -f artifact="${{ env.E2E_WP_LATEST_X_ARTIFACT }}" \
+                    -f env_description="${{ env.ENV_DESCRIPTION }}" \
+                    -f test_type="e2e" \
+                    --repo woocommerce/woocommerce-test-reports
 
-    # test-php-versions:
-    #     name: Test against PHP ${{ matrix.php_version }}
-    #     runs-on: ubuntu-20.04
-    #     needs: [get-tag]
-    #     strategy:
-    #         fail-fast: false
-    #         matrix:
-    #             php_version: ['7.4', '8.1']
-    #     env:
-    #         API_ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/test-results/allure-report
-    #         API_ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/test-results/allure-results
-    #         API_ARTIFACT: API test on wp-env with PHP ${{ matrix.php_version }} (run ${{ github.run_number }})
-    #         E2E_ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-report
-    #         E2E_ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-results
-    #         E2E_ARTIFACT: E2E test on wp-env with PHP ${{ matrix.php_version }} (run ${{ github.run_number }})
-    #     steps:
-    #         - name: Checkout
-    #           uses: actions/checkout@v3
+    test-php-versions:
+        name: Test against PHP ${{ matrix.php_version }}
+        runs-on: ubuntu-20.04
+        needs: [get-tag]
+        strategy:
+            fail-fast: false
+            matrix:
+                php_version: ['7.4', '8.1']
+        env:
+            API_ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/test-results/allure-report
+            API_ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/test-results/allure-results
+            API_ARTIFACT: API test on wp-env with PHP ${{ matrix.php_version }} (run ${{ github.run_number }})
+            E2E_ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-report
+            E2E_ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-results
+            E2E_ARTIFACT: E2E test on wp-env with PHP ${{ matrix.php_version }} (run ${{ github.run_number }})
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
 
-    #         - name: Setup WooCommerce Monorepo
-    #           uses: ./.github/actions/setup-woocommerce-monorepo
+            - name: Setup WooCommerce Monorepo
+              uses: ./.github/actions/setup-woocommerce-monorepo
 
-    #         - name: Launch WP Env
-    #           working-directory: plugins/woocommerce
-    #           env:
-    #               WP_ENV_PHP_VERSION: ${{ matrix.php_version }}
-    #           run: pnpm run env:test
+            - name: Launch WP Env
+              working-directory: plugins/woocommerce
+              env:
+                  WP_ENV_PHP_VERSION: ${{ matrix.php_version }}
+              run: pnpm run env:test
 
-    #         - name: Verify PHP version
-    #           working-directory: .github/workflows/scripts
-    #           env:
-    #               EXPECTED_PHP_VERSION: ${{ matrix.php_version }}
-    #           run: bash verify-php-version.sh
+            - name: Verify PHP version
+              working-directory: .github/workflows/scripts
+              env:
+                  EXPECTED_PHP_VERSION: ${{ matrix.php_version }}
+              run: bash verify-php-version.sh
 
-    #         - name: Download release zip
-    #           env:
-    #               GH_TOKEN: ${{ secrets.E2E_GH_TOKEN }}
-    #           run: gh release download ${{ needs.get-tag.outputs.tag }} --dir tmp
+            - name: Download release zip
+              env:
+                  GH_TOKEN: ${{ secrets.E2E_GH_TOKEN }}
+              run: gh release download ${{ needs.get-tag.outputs.tag }} --dir tmp
 
-    #         - name: Replace `plugins/woocommerce` with unzipped woocommerce release build
-    #           run: unzip -d plugins -o tmp/woocommerce.zip
+            - name: Replace `plugins/woocommerce` with unzipped woocommerce release build
+              run: unzip -d plugins -o tmp/woocommerce.zip
 
-    #         - name: Run API tests
-    #           id: run-api-composite-action
-    #           uses: ./.github/actions/tests/run-api-tests
-    #           with:
-    #               report-name: ${{ env.API_ARTIFACT }}
-    #               tests: hello
-    #           env:
-    #               ALLURE_RESULTS_DIR: ${{ env.API_ALLURE_RESULTS_DIR }}
-    #               ALLURE_REPORT_DIR: ${{ env.API_ALLURE_REPORT_DIR }}
+            - name: Run API tests
+              id: run-api-composite-action
+              uses: ./.github/actions/tests/run-api-tests
+              with:
+                  report-name: ${{ env.API_ARTIFACT }}
+                  tests: hello
+              env:
+                  ALLURE_RESULTS_DIR: ${{ env.API_ALLURE_RESULTS_DIR }}
+                  ALLURE_REPORT_DIR: ${{ env.API_ALLURE_REPORT_DIR }}
 
-    #         - name: Upload Allure artifacts to bucket
-    #           if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
-    #           uses: ./.github/actions/tests/upload-allure-files-to-bucket
-    #           env:
-    #               ALLURE_RESULTS_DIR: ${{ env.API_ALLURE_RESULTS_DIR }}
-    #               ALLURE_REPORT_DIR: ${{ env.API_ALLURE_REPORT_DIR }}
-    #           with:
-    #               aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
-    #               aws-region: ${{ secrets.REPORTS_AWS_REGION }}
-    #               aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
-    #               artifact-name: ${{ env.API_ARTIFACT }}
-    #               s3-bucket: ${{ secrets.REPORTS_BUCKET }}
+            - name: Upload Allure artifacts to bucket
+              if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
+              uses: ./.github/actions/tests/upload-allure-files-to-bucket
+              env:
+                  ALLURE_RESULTS_DIR: ${{ env.API_ALLURE_RESULTS_DIR }}
+                  ALLURE_REPORT_DIR: ${{ env.API_ALLURE_REPORT_DIR }}
+              with:
+                  aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
+                  aws-region: ${{ secrets.REPORTS_AWS_REGION }}
+                  aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
+                  artifact-name: ${{ env.API_ARTIFACT }}
+                  s3-bucket: ${{ secrets.REPORTS_BUCKET }}
 
-    #         - name: Publish API Allure report
-    #           if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
-    #           env:
-    #               GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
-    #               ENV_DESCRIPTION: php-${{ matrix.php_version }}
-    #           run: |
-    #               gh workflow run publish-test-reports-release.yml \
-    #                 -f created_at="${{ needs.get-tag.outputs.created }}" \
-    #                 -f run_id=${{ github.run_id }} \
-    #                 -f run_number=${{ github.run_number }} \
-    #                 -f release_tag=${{ needs.get-tag.outputs.tag }} \
-    #                 -f artifact="${{ env.API_ARTIFACT }}" \
-    #                 -f env_description="${{ env.ENV_DESCRIPTION }}" \
-    #                 -f test_type="api" \
-    #                 --repo woocommerce/woocommerce-test-reports
+            - name: Publish API Allure report
+              if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
+              env:
+                  GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+                  ENV_DESCRIPTION: php-${{ matrix.php_version }}
+              run: |
+                  gh workflow run publish-test-reports-release.yml \
+                    -f created_at="${{ needs.get-tag.outputs.created }}" \
+                    -f run_id=${{ github.run_id }} \
+                    -f run_number=${{ github.run_number }} \
+                    -f release_tag=${{ needs.get-tag.outputs.tag }} \
+                    -f artifact="${{ env.API_ARTIFACT }}" \
+                    -f env_description="${{ env.ENV_DESCRIPTION }}" \
+                    -f test_type="api" \
+                    --repo woocommerce/woocommerce-test-reports
 
-    #         - name: Run E2E tests
-    #           id: run-e2e-composite-action
-    #           timeout-minutes: 60
-    #           uses: ./.github/actions/tests/run-e2e-tests
-    #           env:
-    #               ALLURE_RESULTS_DIR: ${{ env.E2E_ALLURE_RESULTS_DIR }}
-    #               ALLURE_REPORT_DIR: ${{ env.E2E_ALLURE_REPORT_DIR }}
-    #               DEFAULT_TIMEOUT_OVERRIDE: 120000
-    #               E2E_MAX_FAILURES: 15
-    #           with:
-    #               report-name: ${{ env.E2E_ARTIFACT }}
+            - name: Run E2E tests
+              id: run-e2e-composite-action
+              timeout-minutes: 60
+              uses: ./.github/actions/tests/run-e2e-tests
+              env:
+                  ALLURE_RESULTS_DIR: ${{ env.E2E_ALLURE_RESULTS_DIR }}
+                  ALLURE_REPORT_DIR: ${{ env.E2E_ALLURE_REPORT_DIR }}
+                  DEFAULT_TIMEOUT_OVERRIDE: 120000
+                  E2E_MAX_FAILURES: 15
+              with:
+                  report-name: ${{ env.E2E_ARTIFACT }}
 
-    #         - name: Upload Allure artifacts to bucket
-    #           if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
-    #           uses: ./.github/actions/tests/upload-allure-files-to-bucket
-    #           env:
-    #               ALLURE_RESULTS_DIR: ${{ env.E2E_ALLURE_RESULTS_DIR }}
-    #               ALLURE_REPORT_DIR: ${{ env.E2E_ALLURE_REPORT_DIR }}
-    #           with:
-    #               aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
-    #               aws-region: ${{ secrets.REPORTS_AWS_REGION }}
-    #               aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
-    #               artifact-name: ${{ env.E2E_ARTIFACT }}
-    #               s3-bucket: ${{ secrets.REPORTS_BUCKET }}
+            - name: Upload Allure artifacts to bucket
+              if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
+              uses: ./.github/actions/tests/upload-allure-files-to-bucket
+              env:
+                  ALLURE_RESULTS_DIR: ${{ env.E2E_ALLURE_RESULTS_DIR }}
+                  ALLURE_REPORT_DIR: ${{ env.E2E_ALLURE_REPORT_DIR }}
+              with:
+                  aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
+                  aws-region: ${{ secrets.REPORTS_AWS_REGION }}
+                  aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
+                  artifact-name: ${{ env.E2E_ARTIFACT }}
+                  s3-bucket: ${{ secrets.REPORTS_BUCKET }}
 
-    #         - name: Publish E2E Allure report
-    #           if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
-    #           env:
-    #               GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
-    #               ENV_DESCRIPTION: php-${{ matrix.php_version }}
-    #           run: |
-    #               gh workflow run publish-test-reports-release.yml \
-    #                 -f created_at="${{ needs.get-tag.outputs.created }}" \
-    #                 -f run_id=${{ github.run_id }} \
-    #                 -f run_number=${{ github.run_number }} \
-    #                 -f release_tag=${{ needs.get-tag.outputs.tag }} \
-    #                 -f artifact="${{ env.E2E_ARTIFACT }}" \
-    #                 -f env_description="${{ env.ENV_DESCRIPTION }}" \
-    #                 -f test_type="e2e" \
-    #                 --repo woocommerce/woocommerce-test-reports
+            - name: Publish E2E Allure report
+              if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
+              env:
+                  GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+                  ENV_DESCRIPTION: php-${{ matrix.php_version }}
+              run: |
+                  gh workflow run publish-test-reports-release.yml \
+                    -f created_at="${{ needs.get-tag.outputs.created }}" \
+                    -f run_id=${{ github.run_id }} \
+                    -f run_number=${{ github.run_number }} \
+                    -f release_tag=${{ needs.get-tag.outputs.tag }} \
+                    -f artifact="${{ env.E2E_ARTIFACT }}" \
+                    -f env_description="${{ env.ENV_DESCRIPTION }}" \
+                    -f test_type="e2e" \
+                    --repo woocommerce/woocommerce-test-reports
 
     test-plugins:
         name: With ${{ matrix.plugin }}
@@ -569,20 +569,19 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    # mytodo uncomment
-                    # - plugin: 'WooCommerce Payments'
-                    #   repo: 'automattic/woocommerce-payments'
-                    #   env_description: 'woocommerce-payments'
-                    # - plugin: 'WooCommerce PayPal Payments'
-                    #   repo: 'woocommerce/woocommerce-paypal-payments'
-                    #   env_description: 'woocommerce-paypal-payments'
-                    # - plugin: 'WooCommerce Shipping & Tax'
-                    #   repo: 'automattic/woocommerce-services'
-                    #   env_description: 'woocommerce-shipping-&-tax'
-                    # - plugin: 'WooCommerce Subscriptions'
-                    #   repo: WC_SUBSCRIPTIONS_REPO
-                    #   private: true
-                    #   env_description: 'woocommerce-subscriptions'
+                    - plugin: 'WooCommerce Payments'
+                      repo: 'automattic/woocommerce-payments'
+                      env_description: 'woocommerce-payments'
+                    - plugin: 'WooCommerce PayPal Payments'
+                      repo: 'woocommerce/woocommerce-paypal-payments'
+                      env_description: 'woocommerce-paypal-payments'
+                    - plugin: 'WooCommerce Shipping & Tax'
+                      repo: 'automattic/woocommerce-services'
+                      env_description: 'woocommerce-shipping-&-tax'
+                    - plugin: 'WooCommerce Subscriptions'
+                      repo: WC_SUBSCRIPTIONS_REPO
+                      private: true
+                      env_description: 'woocommerce-subscriptions'
                     - plugin: 'Gutenberg'
                       repo: 'WordPress/gutenberg'
                       env_description: 'gutenberg'
@@ -627,7 +626,6 @@ jobs:
               with:
                   playwright-config: ignore-plugin-tests.playwright.config.js
                   report-name: ${{ env.ARTIFACT_NAME }}
-                  tests: basic.spec.js # mytodo remove
               env:
                   E2E_MAX_FAILURES: 15
 

--- a/plugins/woocommerce/changelog/e2e-gutenberg-latest-nightly
+++ b/plugins/woocommerce/changelog/e2e-gutenberg-latest-nightly
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add Gutenberg nightly and latest stable into the daily and release smoke tests.

--- a/plugins/woocommerce/tests/e2e-pw/tests/smoke-tests/upload-plugin.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/smoke-tests/upload-plugin.spec.js
@@ -35,20 +35,29 @@ test.describe( `${ PLUGIN_NAME } plugin can be uploaded and activated`, () => {
 	test.beforeAll( async ( { playwright, baseURL } ) => {
 		pluginSlug = path.basename( PLUGIN_REPOSITORY );
 
-		// Download plugin.
-		pluginPath = await downloadZip( {
-			repository: PLUGIN_REPOSITORY,
-			authorizationToken: GITHUB_TOKEN,
-		} );
+		pluginPath = await test.step(
+			`Download ${ PLUGIN_NAME } plugin zip`,
+			async () => {
+				return downloadZip( {
+					repository: PLUGIN_REPOSITORY,
+					authorizationToken: GITHUB_TOKEN,
+				} );
+			}
+		);
 
 		// Delete plugin from test site if it's installed.
-		await deletePlugin( {
-			request: playwright.request,
-			baseURL,
-			slug: pluginSlug,
-			username: admin.username,
-			password: admin.password,
-		} );
+		await test.step(
+			"Delete plugin from test site if it's installed.",
+			async () => {
+				await deletePlugin( {
+					request: playwright.request,
+					baseURL,
+					slug: pluginSlug,
+					username: admin.username,
+					password: admin.password,
+				} );
+			}
+		);
 	} );
 
 	test.afterAll( async ( {} ) => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/smoke-tests/upload-plugin.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/smoke-tests/upload-plugin.spec.js
@@ -15,7 +15,6 @@ const {
 } = require( '../../utils/plugin-utils' );
 
 const skipMessage = 'Skipping this test because PLUGIN_REPOSITORY is undefined';
-const pluginSlug = path.basename( PLUGIN_REPOSITORY );
 const deletePluginFromSite = async ( { request, baseURL } ) => {
 	await deletePlugin( {
 		request,
@@ -26,7 +25,7 @@ const deletePluginFromSite = async ( { request, baseURL } ) => {
 	} );
 };
 
-let pluginPath;
+let pluginSlug, pluginPath;
 
 test.skip( () => {
 	const shouldSkip = ! PLUGIN_REPOSITORY;
@@ -42,6 +41,8 @@ test.describe( `${ PLUGIN_NAME } plugin can be uploaded and activated`, () => {
 	test.use( { storageState: ADMINSTATE } );
 
 	test.beforeAll( async ( { playwright, baseURL } ) => {
+		pluginSlug = path.basename( PLUGIN_REPOSITORY );
+
 		pluginPath = await test.step(
 			`Download ${ PLUGIN_NAME } plugin zip`,
 			async () => {

--- a/plugins/woocommerce/tests/e2e-pw/utils/plugin-utils.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/plugin-utils.js
@@ -38,6 +38,7 @@ export const deletePlugin = async ( {
 		baseURL,
 		extraHTTPHeaders: {
 			Authorization: `Basic ${ encodeCredentials( username, password ) }`,
+			cookie: '',
 		},
 	} );
 	const listPluginsResponse = await apiContext.get(
@@ -55,37 +56,12 @@ export const deletePlugin = async ( {
 	if ( pluginToDelete ) {
 		const { plugin } = pluginToDelete;
 		const requestURL = `/wp-json/wp/v2/plugins/${ plugin }`;
-		let response;
 
-		// Some plugins do not respond to some of the WP REST API endpoints like Contact Form 7.
-		// Print warning in such cases.
-		const warn = async ( response, warningMsg ) => {
-			console.warn( warningMsg );
-			console.warn(
-				`Response status: ${ response.status() } ${ response.statusText() }`
-			);
-			console.warn( `Response body:` );
-			console.warn( await response.json() );
-			console.warn( '\n' );
-		};
-
-		response = await apiContext.put( requestURL, {
+		await apiContext.put( requestURL, {
 			data: { status: 'inactive' },
 		} );
-		if ( ! response.ok() ) {
-			await warn(
-				response,
-				`WARNING: Failed to deactivate plugin ${ plugin }`
-			);
-		}
 
-		response = await apiContext.delete( requestURL );
-		if ( ! response.ok() ) {
-			await warn(
-				response,
-				`WARNING: Failed to delete plugin ${ plugin }`
-			);
-		}
+		await apiContext.delete( requestURL );
 	}
 };
 
@@ -164,10 +140,8 @@ export const downloadZip = async ( {
  * @param {string} zipFilePath Local file path to the ZIP.
  */
 export const deleteZip = async ( zipFilePath ) => {
-	console.log( `Deleting file located in ${ zipFilePath }...` );
 	await fs.unlink( zipFilePath, ( err ) => {
 		if ( err ) throw err;
-		console.log( `Successfully deleted!` );
 	} );
 };
 


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR replaces "WordPress SEO" and "Contact Form 7" with "Gutenberg" and "Gutenberg - Nightly" in the matrix of plugins that our daily and release smoke tests use.

Other minor changes include:

- Use the PNPM script `pnpm test:e2e-pw` instead of the longer `pnpm exec playwright...` command as shown [here](https://github.com/woocommerce/woocommerce/pull/38287/files#diff-3b2ff7d93606602bcae1ce86708096f7755e592f68aff14ade8d6656027b81fcL227-R229).
- Add `test.step()`'s in `upload-plugin` spec.
- Add 2 assertions in the `upload-plugin` spec to make sure the shop and the WooCommerce homepage loads successfully after installing the plugin

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Test the `upload-plugin` spec locally

1. Run the usual setup commands to launch the E2E environment locally.
1. Run the `upload-plugin` spec with `Gutenberg` plugin by running these commands in the `plugins/woocommerce` directory, and make sure the test passed:
   ```
   export PLUGIN_NAME="Gutenberg"
   export PLUGIN_REPOSITORY="WordPress/gutenberg"
   pnpm test:e2e-pw upload-plugin.spec.js
   ```
1. Run the `upload-plugin` spec with `Gutenberg - Nightly` plugin by running these commands in the `plugins/woocommerce` directory, and make sure the test passed:
   ```
   export PLUGIN_NAME="Gutenberg - Nightly"
   export PLUGIN_REPOSITORY="bph/gutenberg"
   pnpm test:e2e-pw upload-plugin.spec.js
   ```

#### Test the "Smoke test daily" workflow

1. Go to the [Smoke test daily](https://github.com/woocommerce/woocommerce/actions/workflows/smoke-test-daily.yml) page.
1. Select this branch `e2e/gutenberg-latest-nightly-0` and start the workflow.
1. Wait for all the jobs to finish.
1. Go to the [WooCommerce Test Reports Dashboard > Daily smoke tests](https://woocommerce.github.io/woocommerce-test-reports/daily/) page.
1. Verify that clicking the `E2E` links for `Gutenberg` and `Gutenberg - Nightly` will take you to the correct Allure reports
   - Make sure that the plugin name, time, and date shown in the Allure report are correct.
     <img width="389" alt="xRvFGUMh4c" src="https://github.com/woocommerce/woocommerce/assets/4509348/69fbec69-9c8a-4f9a-ac3e-b182d0914b39">
     <img width="374" alt="5NoFlm2wEO" src="https://github.com/woocommerce/woocommerce/assets/4509348/cf4f72e7-0447-465c-9353-75d17347ad7d">


#### Test the "Smoke test release" workflow

1. Go to the [Smoke test release](https://github.com/woocommerce/woocommerce/actions/workflows/smoke-test-release.yml) page.
1. Select this branch `e2e/gutenberg-latest-nightly-0`
1. Enter any release version such as `7.0.0`.
1. Run the workflow.
1. Wait for all the jobs to finish.
1. Go to the [WooCommerce Test Reports Dashboard > Smoke Tests on Releases](https://woocommerce.github.io/woocommerce-test-reports/release/) page.
1. Verify that clicking the `E2E` links for `Gutenberg` and `Gutenberg - Nightly` will take you to the correct Allure reports
   - Make sure that the plugin name, time, and date shown in the Allure report are correct.
   <img width="351" alt="sW8EkXZRSw" src="https://github.com/woocommerce/woocommerce/assets/4509348/d079e846-d7c3-4039-99bd-59834474e570">

<!-- End testing instructions -->
