### PR TITLE
Update test timeout to 90 seconds, and suggest using `DEFAULT_TIMEOUT_OVERRIDE` in E2E README

### DIFF
--- a/plugins/woocommerce/changelog/e2e-update-timeout-readme
+++ b/plugins/woocommerce/changelog/e2e-update-timeout-readme
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update the E2E test timeout to 90 sec, and update the E2E README.

--- a/plugins/woocommerce/tests/e2e-pw/README.md
+++ b/plugins/woocommerce/tests/e2e-pw/README.md
@@ -53,7 +53,12 @@ Other ways of running tests (make sure you are in the `plugins/woocommerce` fold
 -   `pnpm test:e2e-pw --headed` (headed -- displaying browser window and test interactions)
 -   `pnpm test:e2e-pw --debug` (runs tests in debug mode)
 -   `pnpm test:e2e-pw ./tests/e2e-pw/tests/activate-and-setup/basic-setup.spec.js` (runs a single test)
--   `pnpm test:e2e-pw --ui` (open tests in [Playwright UI mode](https://playwright.dev/docs/test-ui-mode))
+-   `pnpm test:e2e-pw --ui` (open tests in [Playwright UI mode](https://playwright.dev/docs/test-ui-mode)). You may need to increase the [test timeout](https://playwright.dev/docs/api/class-testconfig#test-config-timeout) from the 90-second default, as tests might take longer to execute when ran through the Playwright UI. You may do this by setting the `DEFAULT_TIMEOUT_OVERRIDE` environment variable like so:
+	```bash
+	# Increase test timeout to 3 minutes
+	export DEFAULT_TIMEOUT_OVERRIDE=180000
+	pnpm test:e2e-pw --ui
+	```
 
 To see all options, make sure you are in the `plugins/woocommerce` folder and run `pnpm playwright test --help`
 

--- a/plugins/woocommerce/tests/e2e-pw/playwright.config.js
+++ b/plugins/woocommerce/tests/e2e-pw/playwright.config.js
@@ -11,7 +11,7 @@ const {
 const config = {
 	timeout: DEFAULT_TIMEOUT_OVERRIDE
 		? Number( DEFAULT_TIMEOUT_OVERRIDE )
-		: 300 * 1000,
+		: 90 * 1000,
 	expect: { timeout: 20 * 1000 },
 	outputDir: './test-results/report',
 	globalSetup: require.resolve( './global-setup' ),


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR returns the default test timeout to 90 seconds, and adds a suggestion in the E2E README file to increase the value of `DEFAULT_TIMEOUT_OVERRIDE` when running Playwright in UI mode.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Just make sure that [this](https://github.com/woocommerce/woocommerce/pull/38288/files#diff-7278e11f22f3f5e1233ee9eb52d3f04c038d89729ec989fd7ef38120cbe1374eL56-R61) update in the README contains no mistakes.

<!-- End testing instructions -->