### PR TITLE
Add compatibility with CPT's search result filters in HPOS.

### DIFF
--- a/plugins/woocommerce/changelog/enhance-add-search-filter
+++ b/plugins/woocommerce/changelog/enhance-add-search-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add compatibility with CPT's search result filters in HPOS.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -515,10 +515,17 @@ class ListTable extends WP_List_Table {
 	private function set_search_args(): void {
 		$search_term = trim( sanitize_text_field( $this->request['s'] ) );
 
-		if ( ! empty( $search_term ) ) {
-			$this->order_query_args['s'] = $search_term;
-			$this->has_filter            = true;
+		if ( empty( $search_term ) ) {
+			return;
 		}
+
+		if ( has_filter( 'woocommerce_shop_order_search_results' ) ) {
+			$order_ids                         = wc_order_search( $search_term );
+			$this->order_query_args['include'] = $order_ids;
+		} else {
+			$this->order_query_args['s'] = $search_term;
+		}
+		$this->has_filter = true;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -939,7 +939,14 @@ WHERE
 		 * @param int[]  $order_ids Search results as an array of order IDs.
 		 * @param string $term      The search term.
 		 */
-		return array_map( 'intval', (array) apply_filters( 'woocommerce_cot_shop_order_search_results', $order_ids, $term ) );
+		$order_ids = array_map( 'intval', (array) apply_filters( 'woocommerce_cot_shop_order_search_results', $order_ids, $term ) );
+
+		/**
+		 * Adding actual compatibility as well with CPT's woocommerce_shop_order_search_results.
+		 *
+		 * @since 7.8.0.
+		 */
+		return array_map( 'intval', (array) apply_filters( 'woocommerce_shop_order_search_results', $order_ids, $term ) );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -215,6 +215,7 @@ class OrdersTableQuery {
 			'posts_per_page'      => 'limit',
 			'p'                   => 'id',
 			'post__in'            => 'id',
+			'include'             => 'id',
 			'post_type'           => 'type',
 			'fields'              => 'return',
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
@@ -42,12 +42,16 @@ class OrdersTableSearchQuery {
 		$this->query       = $query;
 		$this->search_term = "'" . esc_sql( '%' . urldecode( $query->get( 's' ) ) . '%' ) . "'";
 
-		/**
-		 * Compatibility for similarly named filter in the CPT data store.
-		 * If someone wants to query only billing email, phone, then fields query is a better option, so we don't list it here.
-		 */
 		$this->search_fields = array_map(
 			'wc_clean',
+			/**
+			 * Compatibility for similarly named filter in the CPT data store.
+			 * If someone wants to query only billing email, phone, then fields query is a better option, so we don't list it here.
+			 *
+			 * @since 7.8.0
+			 *
+			 * @param array
+			 */
 			apply_filters(
 				'woocommerce_shop_order_search_fields',
 				array(

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
@@ -25,6 +25,13 @@ class OrdersTableSearchQuery {
 	private $search_term;
 
 	/**
+	 * Fields to search through in the meta query.
+	 *
+	 * @var array
+	 */
+	private $search_fields;
+
+	/**
 	 * Creates the JOIN and WHERE clauses needed to execute a search of orders.
 	 *
 	 * @internal
@@ -34,6 +41,21 @@ class OrdersTableSearchQuery {
 	public function __construct( OrdersTableQuery $query ) {
 		$this->query       = $query;
 		$this->search_term = "'" . esc_sql( '%' . urldecode( $query->get( 's' ) ) . '%' ) . "'";
+
+		/**
+		 * Compatibility for similarly named filter in the CPT data store.
+		 * If someone wants to query only billing email, phone, then fields query is a better option, so we don't list it here.
+		 */
+		$this->search_fields = array_map(
+			'wc_clean',
+			apply_filters(
+				'woocommerce_shop_order_search_fields',
+				array(
+					'_billing_address_index',
+					'_shipping_address_index',
+				)
+			)
+		);
 	}
 
 	/**
@@ -62,6 +84,9 @@ class OrdersTableSearchQuery {
 	 * @return string
 	 */
 	private function generate_join(): string {
+		if ( empty( $this->search_fields ) ) {
+			return '';
+		}
 		$orders_table = $this->query->get_table_name( 'orders' );
 		$items_table  = $this->query->get_table_name( 'items' );
 
@@ -85,6 +110,14 @@ class OrdersTableSearchQuery {
 		// Support the passing of an order ID as the search term.
 		if ( (string) $this->query->get( 's' ) === $possible_order_id ) {
 			$where = "`$order_table`.id = $possible_order_id OR ";
+		}
+
+		if ( empty( $this->search_fields ) ) {
+			/**
+			 * If search_fields are empty, then likely `woocommerce_shop_order_search_fields` is being used to replace the DB search process.
+			 * So let's shot the query in this case.
+			 */
+			return $where . ' 1=0 ';
 		}
 
 		$meta_sub_query = $this->generate_where_for_meta_table();
@@ -139,13 +172,10 @@ GROUP BY search_query_meta.order_id
 		 */
 		$meta_keys = apply_filters(
 			'woocommerce_order_table_search_query_meta_keys',
-			array(
-				'_billing_address_index',
-				'_shipping_address_index',
-			)
+			$this->search_fields
 		);
 
-		$meta_keys = (array) array_map(
+		$meta_keys = array_map(
 			function ( string $meta_key ): string {
 				return "'" . esc_sql( wc_clean( $meta_key ) ) . "'";
 			},

--- a/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-order-functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/order/class-wc-tests-order-functions.php
@@ -1545,6 +1545,9 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		// Should find order searching by order item name.
 		$this->assertEquals( array( $order->get_id() ), wc_order_search( 'Dummy Product' ) );
 
+		// Should find order searching by billing email.
+		$this->assertEquals( array( $order->get_id() ), wc_order_search( 'admin@example.org' ) );
+
 		// Should return nothing when searching for nonexistent term.
 		$this->assertEmpty( wc_order_search( 'Nonexistent term' ) );
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
@@ -146,7 +146,12 @@ class OrdersTableQueryTests extends WC_Unit_Test_Case {
 
 		$this->assertEmpty( wc_order_search( 'admin@example.org' ) );
 
-		add_filter( 'woocommerce_shop_order_search_results', function () { return array( 5 ); } );
+		add_filter(
+			'woocommerce_shop_order_search_results',
+			function () {
+				return array( 5 );
+			}
+		);
 
 		$this->assertEquals( array( 5 ), wc_order_search( 'admin@example.org' ) );
 

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
@@ -133,4 +133,24 @@ class OrdersTableQueryTests extends WC_Unit_Test_Case {
 		$this->assertEquals( 1, count( $queried_orders ) );
 		$this->assertContains( $orders[1]->get_id(), $queried_orders );
 	}
+
+	/**
+	 * @testDox Search query is fully customizable and compatible with filters from CPT data store too.
+	 */
+	public function test_search_query_is_fully_customizable() {
+		$order = OrderHelper::create_order();
+
+		$this->assertEquals( array( $order->get_id() ), wc_order_search( 'admin@example.org' ) );
+
+		add_filter( 'woocommerce_shop_order_search_fields', '__return_empty_array' );
+
+		$this->assertEmpty( wc_order_search( 'admin@example.org' ) );
+
+		add_filter( 'woocommerce_shop_order_search_results', function () { return array( 5 ); } );
+
+		$this->assertEquals( array( 5 ), wc_order_search( 'admin@example.org' ) );
+
+		remove_filter( 'woocommerce_shop_order_search_fields', '__return_empty_array' );
+		remove_all_filters( 'woocommerce_shop_order_search_results' );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In CPT order data store, we have combination of two filters: `woocommerce_shop_order_search_fields` and `woocommerce_shop_order_search_results` which can be used to bypass DB search completely. This PR adds the same filters to HPOS as well, so that the same filters can be used to bypass the search and offload the query to some external system.

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

It's primarily adding filters, so no functionality is changed. However, this can be smoke tested by:

1. With HPOS enabled, search any string from order admin list screen and make sure you see results as expected.
2. To test the new filters, note ID of any existing order, say XXX, and add the following in your code:
```php
add_filter( 'woocommerce_shop_order_search_fields', '__return_empty_array' );
add_filter( 'woocommerce_shop_order_search_results', function () { return array( XXX ); } ); // <- Make sure to change the XXX to an existing order ID.
```
3. Go to order admin list screen, and search for anything. If the filters are working correctly, it will always return the XXX order irrespective of what is being searched.

<!-- End testing instructions -->