### PR TITLE
Add HPOS compat queries for tracker.

### DIFF
--- a/plugins/woocommerce/changelog/fix-38148
+++ b/plugins/woocommerce/changelog/fix-38148
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add HPOS compat queries for tracker.

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -384,9 +384,8 @@ class WC_Tracker {
 	 */
 	private static function get_order_counts() {
 		$order_count      = array();
-		$order_count_data = wp_count_posts( 'shop_order' );
 		foreach ( wc_get_order_statuses() as $status_slug => $status_name ) {
-			$order_count[ $status_slug ] = $order_count_data->{ $status_slug };
+			$order_count[ $status_slug ] = wc_orders_count( $status_slug );
 		}
 		return $order_count;
 	}

--- a/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
@@ -64,4 +64,52 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 		$this->assertArrayHasKey( 'wc_admin_disabled', $tracking_data );
 		$this->assertEquals( 'no', $tracking_data['wc_admin_disabled'] );
 	}
+
+	public function test_get_tracking_data_orders() {
+		$dummy_product          = WC_Helper_Product::create_simple_product();
+		$status_entries         = array( 'wc-processing', 'wc-completed', 'wc-refunded', 'wc-pending' );
+		$created_via_entries    = array( 'api', 'checkout', 'admin' );
+		$payment_method_entries = array( 'paypal', 'stripe', 'cod' );
+
+		$order_count = count( $status_entries ) * count( $created_via_entries ) * count( $payment_method_entries );
+
+		foreach ( $status_entries as $status_entry ) {
+			foreach ( $created_via_entries as $created_via_entry ) {
+				foreach ( $payment_method_entries as $payment_method_entry ) {
+					$order = wc_create_order(
+						array(
+							'status'         => $status_entry,
+							'created_via'    => $created_via_entry,
+							'payment_method' => $payment_method_entry,
+						)
+					);
+					$order->add_product( $dummy_product );
+					$order->save();
+					$order->calculate_totals();
+				}
+			}
+		}
+
+		$order_data = WC_Tracker::get_tracking_data()['orders'];
+
+		foreach ( $status_entries as $status_entry ) {
+			$this->assertEquals( $order_count / count( $status_entries ), $order_data[ $status_entry ] );
+		}
+
+		// Gross revenue is for wc-completed and wc-refunded status, so we calculate expected revenue per status, multiply by 2, and then multiply by 10 to account for the 10 USD per status.
+		$this->assertEquals( ( $order_count / count( $status_entries ) ) * 2 * 10, $order_data['gross'] );
+
+		// Gross revenue is for wc-pending status, so we calculate expected revenue per status, multiply by 1, and then multiply by 10 to account for the 10 USD per status.
+		$this->assertEquals( ( $order_count / count( $status_entries ) ) * 1 * 10, $order_data['processing_gross'] );
+
+		// Order count per gateway is calculated for three status (completed, processing and refunded) so we multiply order count by 3 and then divide by the number of status entries.
+		$this->assertEquals( ( $order_count * 3 / count( $status_entries ) ), $order_data['gateway__USD_count'] );
+
+		// Order revenue per gateway is calculated for three status (completed, processing and refunded) so we multiply order count by 3, then by 10 to account for 10 USD per order and then divide by the number of status entries.
+		$this->assertEquals( ( $order_count * 3 * 10 / count( $status_entries ) ), $order_data['gateway__USD_total'] );
+
+		foreach ( $created_via_entries as $created_via_entry ) {
+			$this->assertEquals( ( $order_count / count( $created_via_entries ) ), $order_data[ 'created_via'][ $created_via_entry ] );
+		}
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
@@ -92,6 +92,7 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 
 		$order_data = WC_Tracker::get_tracking_data()['orders'];
 
+		print_r( $order_data );
 		foreach ( $status_entries as $status_entry ) {
 			$this->assertEquals( $order_count / count( $status_entries ), $order_data[ $status_entry ] );
 		}

--- a/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
@@ -5,10 +5,13 @@
  * @package WooCommerce\Tests\WC_Tracker.
  */
 
+// phpcs:disable Squiz.Classes.ClassFileName.NoMatch, Squiz.Classes.ValidClassName.NotCamelCaps -- Backward compatibility.
 /**
  * Class WC_Tracker_Test
  */
 class WC_Tracker_Test extends \WC_Unit_Test_Case {
+	// phpcs:enable
+
 	/**
 	 * Test the tracking of wc_admin being disabled via filter.
 	 */
@@ -65,6 +68,9 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 		$this->assertEquals( 'no', $tracking_data['wc_admin_disabled'] );
 	}
 
+	/**
+	 * @testDox Test orders tracking data.
+	 */
 	public function test_get_tracking_data_orders() {
 		$dummy_product          = WC_Helper_Product::create_simple_product();
 		$status_entries         = array( 'wc-processing', 'wc-completed', 'wc-refunded', 'wc-pending' );
@@ -92,7 +98,6 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 
 		$order_data = WC_Tracker::get_tracking_data()['orders'];
 
-		print_r( $order_data );
 		foreach ( $status_entries as $status_entry ) {
 			$this->assertEquals( $order_count / count( $status_entries ), $order_data[ $status_entry ] );
 		}
@@ -110,7 +115,7 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 		$this->assertEquals( ( $order_count * 3 * 10 / count( $status_entries ) ), $order_data['gateway__USD_total'] );
 
 		foreach ( $created_via_entries as $created_via_entry ) {
-			$this->assertEquals( ( $order_count / count( $created_via_entries ) ), $order_data[ 'created_via'][ $created_via_entry ] );
+			$this->assertEquals( ( $order_count / count( $created_via_entries ) ), $order_data['created_via'][ $created_via_entry ] );
 		}
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds compatible queries for HPOS in WC_Tracker class so that we continue to get accurate data as expected.

Closes #38148 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. With posts as authoritative data store and sync disabled, generate about 100 orders using [WC Smooth Generator](https://github.com/woocommerce/wc-smooth-generator).
2. On a shell, run the following command: `WC_Tracker::get_tracking_data()['orders'];`. Copy paste the result somewhere.
3. Run the migration using the CLI command: `wp wc cot sync'`
4. Once migration finishes, run the shell command again: `WC_Tracker::get_tracking_data()['orders'];`. Compare this result with the result from step 2. It should be same.

<!-- End testing instructions -->