### PR TITLE
Fix WooCommerce name typo in Codisto extension description in test

### DIFF
--- a/plugins/woocommerce-admin/client/marketing/components/CreateNewCampaignModal/CreateNewCampaignModal.test.tsx
+++ b/plugins/woocommerce-admin/client/marketing/components/CreateNewCampaignModal/CreateNewCampaignModal.test.tsx
@@ -62,7 +62,7 @@ const pinterest = {
 const amazon = {
 	title: 'Amazon, eBay & Walmart Integration for WooCommerce',
 	description:
-		'Convert Woocommerce into a fully-featured omnichannel commerce platform, leveraging powerful automation and real-time sync to connect your brand with millions of new customers on the world\u2019s largest online marketplaces.',
+		'Convert WooCommerce into a fully-featured omnichannel commerce platform, leveraging powerful automation and real-time sync to connect your brand with millions of new customers on the world’s largest online marketplaces.',
 	url: 'https://woocommerce.com/products/amazon-ebay-integration/?utm_source=marketingtab&utm_medium=product&utm_campaign=wcaddons',
 	direct_install: false,
 	icon: 'https://woocommerce.com/wp-content/plugins/wccom-plugins/marketing-tab-rest-api/icons/amazon-ebay.svg',

--- a/plugins/woocommerce/changelog/fix-codisto-woocommerce-name-typo
+++ b/plugins/woocommerce/changelog/fix-codisto-woocommerce-name-typo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update Codisto extension description and fix WooCommerce name typo in test.


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This is related to PR https://github.com/Automattic/woocommerce.com/pull/17007.

There is a "Woocommerce" typo in the Codisto extension description in a component test.

In this PR, we fix the typo to the correct "WooCommerce" name and update the extension description, so that it is the same as the one in https://github.com/Automattic/woocommerce.com/pull/17007.

### How to test the changes in this Pull Request:

1. Run test with `pnpm --filter=woocommerce/client/admin run test`. Test should pass.
