### PR TITLE
Only register blocks when user navigates to the product edit page

### DIFF
--- a/packages/js/product-editor/changelog/add-38200
+++ b/packages/js/product-editor/changelog/add-38200
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Only register blocks when user navigates to the product edit page#38200

--- a/packages/js/product-editor/src/components/editor/editor.tsx
+++ b/packages/js/product-editor/src/components/editor/editor.tsx
@@ -36,9 +36,6 @@ import { FullscreenMode, InterfaceSkeleton } from '@wordpress/interface';
  */
 import { Header } from '../header';
 import { BlockEditor } from '../block-editor';
-import { initBlocks } from './init-blocks';
-
-initBlocks();
 
 export type ProductEditorSettings = Partial<
 	EditorSettings & EditorBlockListSettings

--- a/packages/js/product-editor/src/components/editor/index.ts
+++ b/packages/js/product-editor/src/components/editor/index.ts
@@ -1,1 +1,2 @@
 export * from './editor';
+export * from './init-blocks';

--- a/packages/js/product-editor/src/components/editor/init-blocks.ts
+++ b/packages/js/product-editor/src/components/editor/init-blocks.ts
@@ -1,7 +1,11 @@
 /**
  * External dependencies
  */
-import { BlockInstance, getBlockType } from '@wordpress/blocks';
+import {
+	BlockInstance,
+	getBlockType,
+	unregisterBlockType,
+} from '@wordpress/blocks';
 import {
 	registerCoreBlocks,
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -14,7 +18,7 @@ import {
  */
 import * as productBlocks from '../../blocks';
 
-export const initBlocks = () => {
+export function initBlocks() {
 	const coreBlocks = __experimentalGetCoreBlocks();
 	const blocks = coreBlocks.filter( ( block: BlockInstance ) => {
 		return ! getBlockType( block.name );
@@ -23,5 +27,15 @@ export const initBlocks = () => {
 	// @ts-ignore An argument is allowed to specify which blocks to register.
 	registerCoreBlocks( blocks );
 
-	Object.values( productBlocks ).forEach( ( init ) => init() );
-};
+	const woocommerceBlocks = Object.values( productBlocks ).map( ( init ) =>
+		init()
+	);
+
+	const registeredBlocks = [ ...blocks, ...woocommerceBlocks ];
+
+	return function unregisterBlocks() {
+		registeredBlocks.forEach(
+			( block ) => block && unregisterBlockType( block.name )
+		);
+	};
+}

--- a/packages/js/product-editor/src/components/index.ts
+++ b/packages/js/product-editor/src/components/index.ts
@@ -13,6 +13,7 @@ export { DetailsDescriptionField as __experimentalDetailsDescriptionField } from
 export { WooProductMoreMenuItem as __experimentalWooProductMoreMenuItem } from './header';
 export {
 	Editor as __experimentalEditor,
+	initBlocks as __experimentalInitBlocks,
 	ProductEditorSettings,
 } from './editor';
 export {

--- a/plugins/woocommerce-admin/client/products/product-page.tsx
+++ b/plugins/woocommerce-admin/client/products/product-page.tsx
@@ -3,11 +3,12 @@
  */
 import {
 	__experimentalEditor as Editor,
+	__experimentalInitBlocks as initBlocks,
 	ProductEditorSettings,
 	productApiFetchMiddleware,
 } from '@woocommerce/product-editor';
-
 import { Spinner } from '@wordpress/components';
+import { useEffect } from '@wordpress/element';
 import { useParams } from 'react-router-dom';
 
 /**
@@ -25,6 +26,10 @@ export default function ProductPage() {
 	const { productId } = useParams();
 
 	const product = useProductEntityRecord( productId );
+
+	useEffect( () => {
+		initBlocks();
+	}, [] );
 
 	if ( ! product?.id ) {
 		return <Spinner />;

--- a/plugins/woocommerce-admin/client/products/product-page.tsx
+++ b/plugins/woocommerce-admin/client/products/product-page.tsx
@@ -28,7 +28,7 @@ export default function ProductPage() {
 	const product = useProductEntityRecord( productId );
 
 	useEffect( () => {
-		initBlocks();
+		return initBlocks();
 	}, [] );
 
 	if ( ! product?.id ) {

--- a/plugins/woocommerce/changelog/add-38200
+++ b/plugins/woocommerce/changelog/add-38200
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Only register blocks when user navigates to the product edit page#38200


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #38200

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Got to `/wp-admin/tools.php?page=woocommerce-admin-test-helper`
2. Under Features tab make sure to enable `product-block-editor`
3. Then visit `/wp-admin/admin.php?page=wc-admin&path=/add-product`
4. By running `wp.blocks.getBlockTypes()` in the browser console a list of `woocommerce/**` blocks should be shown
5. Visit a different page like `Woocommerce -> Home`
6. By running the same script of point 4 no `woocommerce/**` blocks should be shown in the browser console

<!-- End testing instructions -->