### PR TITLE
Add `wcadmin_settings_change` tracks event to shipping fields

### DIFF
--- a/plugins/woocommerce/changelog/add-shipping-tracks
+++ b/plugins/woocommerce/changelog/add-shipping-tracks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Add tracks events to shipping settings

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -3047,7 +3047,7 @@ class WC_AJAX {
 			wp_die();
 		}
 
-		$zone_id = wc_clean( wp_unslash( $_POST['method_id'] ) );
+		$zone_id = wc_clean( wp_unslash( $_POST['zone_id'] ) );
 		$zone    = new WC_Shipping_Zone( $zone_id );
 		/**
 		 * Notify that a non-option setting has been updated.
@@ -3060,7 +3060,7 @@ class WC_AJAX {
 				'id' => 'zone_method',
 			)
 		);
-		$instance_id = $zone->add_shipping_method( $zone_id );
+		$instance_id = $zone->add_shipping_method( wc_clean( wp_unslash( $_POST['method_id'] ) ) );
 
 		global $current_tab;
 		$current_tab = 'shipping';

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -3030,9 +3030,12 @@ class WC_AJAX {
 
 		$zone_id     = wc_clean( wp_unslash( $_POST['zone_id'] ) );
 		$zone        = new WC_Shipping_Zone( $zone_id );
+		do_action( 'woocommerce_update_shipping_setting', array( 'id' => 'zone_method' ) );
 		$instance_id = $zone->add_shipping_method( wc_clean( wp_unslash( $_POST['method_id'] ) ) );
 
-		do_action( 'woocommerce_update_option', array( 'id' => 'zone_id'  ));
+
+		global $current_tab;
+		$current_tab = 'shipping';
 		do_action( 'woocommerce_update_options' );
 
 		wp_send_json_success(

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -3057,7 +3057,7 @@ class WC_AJAX {
 		do_action(
 			'woocommerce_update_non_option_setting',
 			array(
-				'id'        => 'zone_method'
+				'id' => 'zone_method',
 			)
 		);
 		$instance_id = $zone->add_shipping_method( $zone_id );

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -3032,6 +3032,9 @@ class WC_AJAX {
 		$zone        = new WC_Shipping_Zone( $zone_id );
 		$instance_id = $zone->add_shipping_method( wc_clean( wp_unslash( $_POST['method_id'] ) ) );
 
+		do_action( 'woocommerce_update_option', array( 'id' => 'zone_id'  ));
+		do_action( 'woocommerce_update_options' );
+
 		wp_send_json_success(
 			array(
 				'instance_id' => $instance_id,

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -3057,8 +3057,7 @@ class WC_AJAX {
 		do_action(
 			'woocommerce_update_non_option_setting',
 			array(
-				'id'        => 'zone_method',
-				'new_value' => $zone_id,
+				'id'        => 'zone_method'
 			)
 		);
 		$instance_id = $zone->add_shipping_method( $zone_id );

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -3074,10 +3074,12 @@ class WC_AJAX {
 		$changes = wp_unslash( $_POST['changes'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		if ( isset( $changes['zone_name'] ) ) {
+			do_action( 'woocommerce_update_shipping_setting', array( 'id' => 'zone_name' ) );
 			$zone->set_zone_name( wc_clean( $changes['zone_name'] ) );
 		}
 
 		if ( isset( $changes['zone_locations'] ) ) {
+			do_action( 'woocommerce_update_shipping_setting', array( 'id' => 'zone_locations' ) );
 			$zone->clear_locations( array( 'state', 'country', 'continent' ) );
 			$locations = array_filter( array_map( 'wc_clean', (array) $changes['zone_locations'] ) );
 			foreach ( $locations as $location ) {
@@ -3098,6 +3100,7 @@ class WC_AJAX {
 		}
 
 		if ( isset( $changes['zone_postcodes'] ) ) {
+			do_action( 'woocommerce_update_shipping_setting', array( 'id' => 'zone_postcodes' ) );
 			$zone->clear_locations( 'postcode' );
 			$postcodes = array_filter( array_map( 'strtoupper', array_map( 'wc_clean', explode( "\n", $changes['zone_postcodes'] ) ) ) );
 			foreach ( $postcodes as $postcode ) {
@@ -3106,6 +3109,7 @@ class WC_AJAX {
 		}
 
 		if ( isset( $changes['methods'] ) ) {
+			do_action( 'woocommerce_update_shipping_setting', array( 'id' => 'zone_methods' ) );
 			foreach ( $changes['methods'] as $instance_id => $data ) {
 				$method_id = $wpdb->get_var( $wpdb->prepare( "SELECT method_id FROM {$wpdb->prefix}woocommerce_shipping_zone_methods WHERE instance_id = %d", $instance_id ) );
 
@@ -3128,10 +3132,12 @@ class WC_AJAX {
 				);
 
 				if ( isset( $method_data['method_order'] ) ) {
+					do_action( 'woocommerce_update_shipping_setting', array( 'id' => 'zone_methods_order' ) );
 					$wpdb->update( "{$wpdb->prefix}woocommerce_shipping_zone_methods", array( 'method_order' => absint( $method_data['method_order'] ) ), array( 'instance_id' => absint( $instance_id ) ) );
 				}
 
 				if ( isset( $method_data['enabled'] ) ) {
+					do_action( 'woocommerce_update_shipping_setting', array( 'id' => 'zone_methods_enabled' ) );
 					$is_enabled = absint( 'yes' === $method_data['enabled'] );
 					if ( $wpdb->update( "{$wpdb->prefix}woocommerce_shipping_zone_methods", array( 'is_enabled' => $is_enabled ), array( 'instance_id' => absint( $instance_id ) ) ) ) {
 						do_action( 'woocommerce_shipping_zone_method_status_toggled', $instance_id, $method_id, $zone_id, $is_enabled );
@@ -3141,6 +3147,10 @@ class WC_AJAX {
 		}
 
 		$zone->save();
+
+		global $current_tab;
+		$current_tab = 'shipping';
+		do_action( 'woocommerce_update_options' );
 
 		wp_send_json_success(
 			array(

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -3063,9 +3063,13 @@ class WC_AJAX {
 		);
 		$instance_id = $zone->add_shipping_method( $zone_id );
 
-
 		global $current_tab;
 		$current_tab = 'shipping';
+		/**
+		 * Completes the saving process for options.
+		 *
+		 * @since 7.8.0
+		 */
 		do_action( 'woocommerce_update_options' );
 
 		wp_send_json_success(
@@ -3104,11 +3108,21 @@ class WC_AJAX {
 		$changes = wp_unslash( $_POST['changes'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		if ( isset( $changes['zone_name'] ) ) {
+			/**
+			 * Completes the saving process for options.
+			 *
+			 * @since 7.8.0
+			 */
 			do_action( 'woocommerce_update_non_option_setting', array( 'id' => 'zone_name' ) );
 			$zone->set_zone_name( wc_clean( $changes['zone_name'] ) );
 		}
 
 		if ( isset( $changes['zone_locations'] ) ) {
+			/**
+			 * Completes the saving process for options.
+			 *
+			 * @since 7.8.0
+			 */
 			do_action( 'woocommerce_update_non_option_setting', array( 'id' => 'zone_locations' ) );
 			$zone->clear_locations( array( 'state', 'country', 'continent' ) );
 			$locations = array_filter( array_map( 'wc_clean', (array) $changes['zone_locations'] ) );
@@ -3130,6 +3144,11 @@ class WC_AJAX {
 		}
 
 		if ( isset( $changes['zone_postcodes'] ) ) {
+			/**
+			 * Completes the saving process for options.
+			 *
+			 * @since 7.8.0
+			 */
 			do_action( 'woocommerce_update_non_option_setting', array( 'id' => 'zone_postcodes' ) );
 			$zone->clear_locations( 'postcode' );
 			$postcodes = array_filter( array_map( 'strtoupper', array_map( 'wc_clean', explode( "\n", $changes['zone_postcodes'] ) ) ) );
@@ -3139,6 +3158,11 @@ class WC_AJAX {
 		}
 
 		if ( isset( $changes['methods'] ) ) {
+			/**
+			 * Completes the saving process for options.
+			 *
+			 * @since 7.8.0
+			 */
 			do_action( 'woocommerce_update_non_option_setting', array( 'id' => 'zone_methods' ) );
 			foreach ( $changes['methods'] as $instance_id => $data ) {
 				$method_id = $wpdb->get_var( $wpdb->prepare( "SELECT method_id FROM {$wpdb->prefix}woocommerce_shipping_zone_methods WHERE instance_id = %d", $instance_id ) );
@@ -3162,11 +3186,21 @@ class WC_AJAX {
 				);
 
 				if ( isset( $method_data['method_order'] ) ) {
+					/**
+					 * Completes the saving process for options.
+					 *
+					 * @since 7.8.0
+					 */
 					do_action( 'woocommerce_update_non_option_setting', array( 'id' => 'zone_methods_order' ) );
 					$wpdb->update( "{$wpdb->prefix}woocommerce_shipping_zone_methods", array( 'method_order' => absint( $method_data['method_order'] ) ), array( 'instance_id' => absint( $instance_id ) ) );
 				}
 
 				if ( isset( $method_data['enabled'] ) ) {
+					/**
+					 * Completes the saving process for options.
+					 *
+					 * @since 7.8.0
+					 */
 					do_action( 'woocommerce_update_non_option_setting', array( 'id' => 'zone_methods_enabled' ) );
 					$is_enabled = absint( 'yes' === $method_data['enabled'] );
 					if ( $wpdb->update( "{$wpdb->prefix}woocommerce_shipping_zone_methods", array( 'is_enabled' => $is_enabled ), array( 'instance_id' => absint( $instance_id ) ) ) ) {
@@ -3180,6 +3214,11 @@ class WC_AJAX {
 
 		global $current_tab;
 		$current_tab = 'shipping';
+		/**
+		 * Completes the saving process for options.
+		 *
+		 * @since 7.8.0
+		 */
 		do_action( 'woocommerce_update_options' );
 
 		wp_send_json_success(
@@ -3213,12 +3252,22 @@ class WC_AJAX {
 		$instance_id     = absint( $_POST['instance_id'] );
 		$zone            = WC_Shipping_Zones::get_zone_by( 'instance_id', $instance_id );
 		$shipping_method = WC_Shipping_Zones::get_shipping_method( $instance_id );
+		/**
+		 * Notify that a non-option setting has been updated.
+		 *
+		 * @since 7.8.0
+		 */
 		do_action( 'woocommerce_update_non_option_setting', array( 'id' => 'zone_method_settings' ) );
 		$shipping_method->set_post_data( wp_unslash( $_POST['data'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 
 		global $current_tab;
 		$current_tab = 'shipping';
+		/**
+		 * Completes the saving process for options.
+		 *
+		 * @since 7.8.0
+		 */
 		do_action( 'woocommerce_update_options' );
 		$shipping_method->process_admin_options();
 
@@ -3271,16 +3320,31 @@ class WC_AJAX {
 			$update_args = array();
 
 			if ( isset( $data['name'] ) ) {
+				/**
+				 * Notify that a non-option setting has been updated.
+				 *
+				 * @since 7.8.0
+				 */
 				do_action( 'woocommerce_update_non_option_setting', array( 'id' => 'shipping_class_name' ) );
 				$update_args['name'] = wc_clean( $data['name'] );
 			}
 
 			if ( isset( $data['slug'] ) ) {
+				/**
+				 * Notify that a non-option setting has been updated.
+				 *
+				 * @since 7.8.0
+				 */
 				do_action( 'woocommerce_update_non_option_setting', array( 'id' => 'shipping_class_slug' ) );
 				$update_args['slug'] = wc_clean( $data['slug'] );
 			}
 
 			if ( isset( $data['description'] ) ) {
+				/**
+				 * Notify that a non-option setting has been updated.
+				 *
+				 * @since 7.8.0
+				 */
 				do_action( 'woocommerce_update_non_option_setting', array( 'id' => 'shipping_class_description' ) );
 				$update_args['description'] = wc_clean( $data['description'] );
 			}
@@ -3302,6 +3366,11 @@ class WC_AJAX {
 		global $current_tab, $current_section;
 		$current_tab     = 'shipping';
 		$current_section = 'classes';
+		/**
+		 * Completes the saving process for options.
+		 *
+		 * @since 7.8.0
+		 */
 		do_action( 'woocommerce_update_options' );
 		$wc_shipping = WC_Shipping::instance();
 

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -3260,7 +3260,6 @@ class WC_AJAX {
 		do_action( 'woocommerce_update_non_option_setting', array( 'id' => 'zone_method_settings' ) );
 		$shipping_method->set_post_data( wp_unslash( $_POST['data'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
-
 		global $current_tab;
 		$current_tab = 'shipping';
 		/**

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -2994,9 +2994,28 @@ class WC_AJAX {
 				$zone = new WC_Shipping_Zone( $zone_data['zone_id'] );
 
 				if ( isset( $zone_data['zone_order'] ) ) {
+					/**
+					 * Notify that a non-option setting has been updated.
+					 *
+					 * @since 7.8.0
+					 */
+					do_action(
+						'woocommerce_update_non_option_setting',
+						array(
+							'id' => 'zone_order',
+						)
+					);
 					$zone->set_zone_order( $zone_data['zone_order'] );
 				}
 
+				global $current_tab;
+				$current_tab = 'shipping';
+				/**
+				 * Completes the saving process for options.
+				 *
+				 * @since 7.8.0
+				 */
+				do_action( 'woocommerce_update_options' );
 				$zone->save();
 			}
 		}
@@ -3030,7 +3049,13 @@ class WC_AJAX {
 
 		$zone_id = wc_clean( wp_unslash( $_POST['method_id'] ) );
 		$zone    = new WC_Shipping_Zone( $zone_id );
-		do_action( 'woocommerce_update_non_option_setting',
+		/**
+		 * Notify that a non-option setting has been updated.
+		 *
+		 * @since 7.8.0
+		 */
+		do_action(
+			'woocommerce_update_non_option_setting',
 			array(
 				'id'        => 'zone_method',
 				'new_value' => $zone_id,
@@ -3188,7 +3213,13 @@ class WC_AJAX {
 		$instance_id     = absint( $_POST['instance_id'] );
 		$zone            = WC_Shipping_Zones::get_zone_by( 'instance_id', $instance_id );
 		$shipping_method = WC_Shipping_Zones::get_shipping_method( $instance_id );
+		do_action( 'woocommerce_update_non_option_setting', array( 'id' => 'zone_method_settings' ) );
 		$shipping_method->set_post_data( wp_unslash( $_POST['data'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+
+
+		global $current_tab;
+		$current_tab = 'shipping';
+		do_action( 'woocommerce_update_options' );
 		$shipping_method->process_admin_options();
 
 		WC_Cache_Helper::get_transient_version( 'shipping', true );
@@ -3240,14 +3271,17 @@ class WC_AJAX {
 			$update_args = array();
 
 			if ( isset( $data['name'] ) ) {
+				do_action( 'woocommerce_update_non_option_setting', array( 'id' => 'shipping_class_name' ) );
 				$update_args['name'] = wc_clean( $data['name'] );
 			}
 
 			if ( isset( $data['slug'] ) ) {
+				do_action( 'woocommerce_update_non_option_setting', array( 'id' => 'shipping_class_slug' ) );
 				$update_args['slug'] = wc_clean( $data['slug'] );
 			}
 
 			if ( isset( $data['description'] ) ) {
+				do_action( 'woocommerce_update_non_option_setting', array( 'id' => 'shipping_class_description' ) );
 				$update_args['description'] = wc_clean( $data['description'] );
 			}
 
@@ -3265,6 +3299,10 @@ class WC_AJAX {
 			do_action( 'woocommerce_shipping_classes_save_class', $term_id, $data );
 		}
 
+		global $current_tab, $current_section;
+		$current_tab     = 'shipping';
+		$current_section = 'classes';
+		do_action( 'woocommerce_update_options' );
 		$wc_shipping = WC_Shipping::instance();
 
 		wp_send_json_success(
@@ -3317,7 +3355,6 @@ class WC_AJAX {
 					// Disable the gateway.
 					$gateway->update_option( 'enabled', 'no' );
 				}
-
 				do_action( 'woocommerce_update_options' );
 				wp_send_json_success( ! wc_string_to_bool( $enabled ) );
 				wp_die();

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -3028,10 +3028,15 @@ class WC_AJAX {
 			wp_die();
 		}
 
-		$zone_id     = wc_clean( wp_unslash( $_POST['zone_id'] ) );
-		$zone        = new WC_Shipping_Zone( $zone_id );
-		do_action( 'woocommerce_update_shipping_setting', array( 'id' => 'zone_method' ) );
-		$instance_id = $zone->add_shipping_method( wc_clean( wp_unslash( $_POST['method_id'] ) ) );
+		$zone_id = wc_clean( wp_unslash( $_POST['method_id'] ) );
+		$zone    = new WC_Shipping_Zone( $zone_id );
+		do_action( 'woocommerce_update_non_option_setting',
+			array(
+				'id'        => 'zone_method',
+				'new_value' => $zone_id,
+			)
+		);
+		$instance_id = $zone->add_shipping_method( $zone_id );
 
 
 		global $current_tab;
@@ -3074,12 +3079,12 @@ class WC_AJAX {
 		$changes = wp_unslash( $_POST['changes'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		if ( isset( $changes['zone_name'] ) ) {
-			do_action( 'woocommerce_update_shipping_setting', array( 'id' => 'zone_name' ) );
+			do_action( 'woocommerce_update_non_option_setting', array( 'id' => 'zone_name' ) );
 			$zone->set_zone_name( wc_clean( $changes['zone_name'] ) );
 		}
 
 		if ( isset( $changes['zone_locations'] ) ) {
-			do_action( 'woocommerce_update_shipping_setting', array( 'id' => 'zone_locations' ) );
+			do_action( 'woocommerce_update_non_option_setting', array( 'id' => 'zone_locations' ) );
 			$zone->clear_locations( array( 'state', 'country', 'continent' ) );
 			$locations = array_filter( array_map( 'wc_clean', (array) $changes['zone_locations'] ) );
 			foreach ( $locations as $location ) {
@@ -3100,7 +3105,7 @@ class WC_AJAX {
 		}
 
 		if ( isset( $changes['zone_postcodes'] ) ) {
-			do_action( 'woocommerce_update_shipping_setting', array( 'id' => 'zone_postcodes' ) );
+			do_action( 'woocommerce_update_non_option_setting', array( 'id' => 'zone_postcodes' ) );
 			$zone->clear_locations( 'postcode' );
 			$postcodes = array_filter( array_map( 'strtoupper', array_map( 'wc_clean', explode( "\n", $changes['zone_postcodes'] ) ) ) );
 			foreach ( $postcodes as $postcode ) {
@@ -3109,7 +3114,7 @@ class WC_AJAX {
 		}
 
 		if ( isset( $changes['methods'] ) ) {
-			do_action( 'woocommerce_update_shipping_setting', array( 'id' => 'zone_methods' ) );
+			do_action( 'woocommerce_update_non_option_setting', array( 'id' => 'zone_methods' ) );
 			foreach ( $changes['methods'] as $instance_id => $data ) {
 				$method_id = $wpdb->get_var( $wpdb->prepare( "SELECT method_id FROM {$wpdb->prefix}woocommerce_shipping_zone_methods WHERE instance_id = %d", $instance_id ) );
 
@@ -3132,12 +3137,12 @@ class WC_AJAX {
 				);
 
 				if ( isset( $method_data['method_order'] ) ) {
-					do_action( 'woocommerce_update_shipping_setting', array( 'id' => 'zone_methods_order' ) );
+					do_action( 'woocommerce_update_non_option_setting', array( 'id' => 'zone_methods_order' ) );
 					$wpdb->update( "{$wpdb->prefix}woocommerce_shipping_zone_methods", array( 'method_order' => absint( $method_data['method_order'] ) ), array( 'instance_id' => absint( $instance_id ) ) );
 				}
 
 				if ( isset( $method_data['enabled'] ) ) {
-					do_action( 'woocommerce_update_shipping_setting', array( 'id' => 'zone_methods_enabled' ) );
+					do_action( 'woocommerce_update_non_option_setting', array( 'id' => 'zone_methods_enabled' ) );
 					$is_enabled = absint( 'yes' === $method_data['enabled'] );
 					if ( $wpdb->update( "{$wpdb->prefix}woocommerce_shipping_zone_methods", array( 'is_enabled' => $is_enabled ), array( 'instance_id' => absint( $instance_id ) ) ) ) {
 						do_action( 'woocommerce_shipping_zone_method_status_toggled', $instance_id, $method_id, $zone_id, $is_enabled );

--- a/plugins/woocommerce/includes/tracks/events/class-wc-settings-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-settings-tracking.php
@@ -59,8 +59,14 @@ class WC_Settings_Tracking {
 	public function init() {
 		add_action( 'woocommerce_settings_page_init', array( $this, 'track_settings_page_view' ) );
 		add_action( 'woocommerce_update_option', array( $this, 'add_option_to_list' ) );
+		add_action( 'woocommerce_update_shipping_setting', array( $this, 'add_option_to_list_and_track_change' ) );
 		add_action( 'woocommerce_update_options', array( $this, 'send_settings_change_event' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'possibly_add_settings_tracking_scripts' ) );
+	}
+
+	public function add_option_to_list_and_track_change( $option ) {
+		$this->allowed_options[] = $option['id'];
+		$this->updated_options[] = $option['id'];
 	}
 
 	/**

--- a/plugins/woocommerce/includes/tracks/events/class-wc-settings-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-settings-tracking.php
@@ -59,13 +59,20 @@ class WC_Settings_Tracking {
 	public function init() {
 		add_action( 'woocommerce_settings_page_init', array( $this, 'track_settings_page_view' ) );
 		add_action( 'woocommerce_update_option', array( $this, 'add_option_to_list' ) );
-		add_action( 'woocommerce_update_shipping_setting', array( $this, 'add_option_to_list_and_track_change' ) );
+		add_action( 'woocommerce_update_non_option_setting', array( $this, 'add_option_to_list_and_track_setting_change' ) );
 		add_action( 'woocommerce_update_options', array( $this, 'send_settings_change_event' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'possibly_add_settings_tracking_scripts' ) );
 	}
 
-	public function add_option_to_list_and_track_change( $option ) {
+	/**
+	 * Adds the option to the allowed and updated options directly.
+	 * Currently used for settings that don't use update_option.
+	 */
+	public function add_option_to_list_and_track_setting_change( $option ) {
 		$this->allowed_options[] = $option['id'];
+		if ( array_key_exists( 'new_value', $option ) ) {
+			$this->modified_options['id'] = $option['new_value'];
+		}
 		$this->updated_options[] = $option['id'];
 	}
 

--- a/plugins/woocommerce/includes/tracks/events/class-wc-settings-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-settings-tracking.php
@@ -69,11 +69,15 @@ class WC_Settings_Tracking {
 	 * Currently used for settings that don't use update_option.
 	 */
 	public function add_option_to_list_and_track_setting_change( $option ) {
-		$this->allowed_options[] = $option['id'];
+		if ( ! in_array( $option['id'], $this->allowed_options, true ) ) {
+			$this->allowed_options[] = $option['id'];
+		}
 		if ( array_key_exists( 'new_value', $option ) ) {
 			$this->modified_options['id'] = $option['new_value'];
 		}
-		$this->updated_options[] = $option['id'];
+		if ( ! in_array( $option['id'], $this->updated_options, true ) ) {
+			$this->updated_options[] = $option['id'];
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/includes/tracks/events/class-wc-settings-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-settings-tracking.php
@@ -67,13 +67,12 @@ class WC_Settings_Tracking {
 	/**
 	 * Adds the option to the allowed and updated options directly.
 	 * Currently used for settings that don't use update_option.
+	 *
+	 * @param array $option WooCommerce option that should be updated.
 	 */
 	public function add_option_to_list_and_track_setting_change( $option ) {
 		if ( ! in_array( $option['id'], $this->allowed_options, true ) ) {
 			$this->allowed_options[] = $option['id'];
-		}
-		if ( array_key_exists( 'new_value', $option ) ) {
-			$this->modified_options['id'] = $option['new_value'];
 		}
 		if ( ! in_array( $option['id'], $this->updated_options, true ) ) {
 			$this->updated_options[] = $option['id'];


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

I created a new action in the tracking class called `woocommerce_update_non_option_setting ` to make it work for shipping zones, shipping methods and shipping classes, since the class only worked with options that end up calling the `update_option` hook, which is not the case for these settings, so they need to be handled differently.


Closes #34519 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure logging is enabled under WooCommerce > Settings > Advanced > WooCommerce.com
2. Go to WooCommerce > Settings > Shipping and add a new shipping zone
4. Fill the shipping zone fields: zone name, zone regions, post codes, add some shipping methods, and disable some shipping methods. Press 'Save changes'.
5. Go to WooCommerce > Status > Logs and select the log starting with tracks-2022-.... for today's date (this is added by the WooCommerce beta tester)
6. Check all the logged 'wcadmin_settings_change' events. There should be different 'wcadmin_settings_change' events with attributes 'zone_method', 'zone_name,zone_locations,zone_postcodes', 'zone_method_settings', and 'zone_methods,zone_methods_enabled'.
7. Re-order two shipping methods and press 'Save changes'.
8. There should be a new event with attribute 'zone_methods,zone_methods_order'.
9. Go to WooCommerce > Settings > Shipping and go to Shipping classes tab.
10. Add a new shipping class and fill name, slug, and description.
8. There should be a new event with attribute 'shipping_class_name,shipping_class_slug,shipping_class_description'.

<!-- End testing instructions -->