### PR TITLE
Make DateTimePickerControl a ForwardedRef

### DIFF
--- a/packages/js/components/changelog/add-38248
+++ b/packages/js/components/changelog/add-38248
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Make DateTimePickerControl a ForwardedRef component"

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { Ref } from 'react';
 import { format as formatDate } from '@wordpress/date';
 import {
 	createElement,
@@ -9,6 +10,7 @@ import {
 	useEffect,
 	useMemo,
 	useRef,
+	forwardRef,
 } from '@wordpress/element';
 import { Icon, calendar } from '@wordpress/icons';
 import moment, { Moment } from 'moment';
@@ -48,306 +50,328 @@ export type DateTimePickerControlProps = {
 	placeholder?: string;
 	help?: string | null;
 	onChangeDebounceWait?: number;
-} & Omit< React.HTMLAttributes< HTMLDivElement >, 'onChange' >;
+} & Omit< React.HTMLAttributes< HTMLInputElement >, 'onChange' >;
 
-export const DateTimePickerControl: React.FC< DateTimePickerControlProps > = ( {
-	currentDate,
-	isDateOnlyPicker = false,
-	is12HourPicker = true,
-	timeForDateOnly = 'start-of-day',
-	dateTimeFormat,
-	disabled = false,
-	onChange,
-	onBlur,
-	label,
-	placeholder,
-	help,
-	className = '',
-	onChangeDebounceWait = 500,
-}: DateTimePickerControlProps ) => {
-	const instanceId = useInstanceId( DateTimePickerControl );
-	const id = `inspector-date-time-picker-control-${ instanceId }`;
-	const inputControl = useRef< InputControl >();
+export const DateTimePickerControl: React.FC< DateTimePickerControlProps > =
+	forwardRef( function ForwardedDateTimePickerControl(
+		{
+			currentDate,
+			isDateOnlyPicker = false,
+			is12HourPicker = true,
+			timeForDateOnly = 'start-of-day',
+			dateTimeFormat,
+			disabled = false,
+			onChange,
+			onBlur,
+			label,
+			placeholder,
+			help,
+			className = '',
+			onChangeDebounceWait = 500,
+			...props
+		}: DateTimePickerControlProps,
+		ref: Ref< HTMLInputElement >
+	) {
+		const id = useInstanceId(
+			DateTimePickerControl,
+			'inspector-date-time-picker-control',
+			props.id
+		) as string;
+		const inputControl = useRef< InputControl >();
 
-	const displayFormat = useMemo( () => {
-		if ( dateTimeFormat ) {
-			return dateTimeFormat;
-		}
-
-		if ( isDateOnlyPicker ) {
-			return defaultDateFormat;
-		}
-
-		if ( is12HourPicker ) {
-			return default12HourDateTimeFormat;
-		}
-
-		return default24HourDateTimeFormat;
-	}, [ dateTimeFormat, isDateOnlyPicker, is12HourPicker ] );
-
-	function parseAsISODateTime(
-		dateString?: string | null,
-		assumeLocalTime = false
-	): Moment {
-		return assumeLocalTime
-			? moment( dateString, moment.ISO_8601, true ).utc()
-			: moment.utc( dateString, moment.ISO_8601, true );
-	}
-
-	function parseAsLocalDateTime( dateString: string | null ): Moment {
-		// parse input date string as local time;
-		// be lenient of user input and try to match any format Moment can
-		return moment( dateString );
-	}
-
-	const maybeForceTime = useCallback(
-		( momentDate: Moment ) => {
-			if ( ! isDateOnlyPicker || ! momentDate.isValid() )
-				return momentDate;
-
-			// We want to set to the start/end of the local time, so
-			// we need to put our Moment instance into "local" mode
-			const updatedMomentDate = momentDate.clone().local();
-
-			if ( timeForDateOnly === 'start-of-day' ) {
-				updatedMomentDate.startOf( 'day' );
-			} else if ( timeForDateOnly === 'end-of-day' ) {
-				updatedMomentDate.endOf( 'day' );
+		const displayFormat = useMemo( () => {
+			if ( dateTimeFormat ) {
+				return dateTimeFormat;
 			}
 
-			return updatedMomentDate;
-		},
-		[ isDateOnlyPicker, timeForDateOnly ]
-	);
+			if ( isDateOnlyPicker ) {
+				return defaultDateFormat;
+			}
 
-	function hasFocusLeftInputAndDropdownContent(
-		event: React.FocusEvent< HTMLInputElement >
-	): boolean {
-		return ! event.relatedTarget?.closest(
-			'.components-dropdown__content'
+			if ( is12HourPicker ) {
+				return default12HourDateTimeFormat;
+			}
+
+			return default24HourDateTimeFormat;
+		}, [ dateTimeFormat, isDateOnlyPicker, is12HourPicker ] );
+
+		function parseAsISODateTime(
+			dateString?: string | null,
+			assumeLocalTime = false
+		): Moment {
+			return assumeLocalTime
+				? moment( dateString, moment.ISO_8601, true ).utc()
+				: moment.utc( dateString, moment.ISO_8601, true );
+		}
+
+		function parseAsLocalDateTime( dateString: string | null ): Moment {
+			// parse input date string as local time;
+			// be lenient of user input and try to match any format Moment can
+			return moment( dateString );
+		}
+
+		const maybeForceTime = useCallback(
+			( momentDate: Moment ) => {
+				if ( ! isDateOnlyPicker || ! momentDate.isValid() )
+					return momentDate;
+
+				// We want to set to the start/end of the local time, so
+				// we need to put our Moment instance into "local" mode
+				const updatedMomentDate = momentDate.clone().local();
+
+				if ( timeForDateOnly === 'start-of-day' ) {
+					updatedMomentDate.startOf( 'day' );
+				} else if ( timeForDateOnly === 'end-of-day' ) {
+					updatedMomentDate.endOf( 'day' );
+				}
+
+				return updatedMomentDate;
+			},
+			[ isDateOnlyPicker, timeForDateOnly ]
 		);
-	}
 
-	const formatDateTimeForDisplay = useCallback(
-		( dateTime: Moment ) => {
+		function hasFocusLeftInputAndDropdownContent(
+			event: React.FocusEvent< HTMLInputElement >
+		): boolean {
+			return ! event.relatedTarget?.closest(
+				'.components-dropdown__content'
+			);
+		}
+
+		const formatDateTimeForDisplay = useCallback(
+			( dateTime: Moment ) => {
+				return dateTime.isValid()
+					? // @ts-expect-error TODO - fix this type error with moment
+					  formatDate( displayFormat, dateTime.local() )
+					: dateTime.creationData().input?.toString() || '';
+			},
+			[ displayFormat ]
+		);
+
+		function formatDateTimeAsISO( dateTime: Moment ): string {
 			return dateTime.isValid()
-				? // @ts-expect-error TODO - fix this type error with moment
-				  formatDate( displayFormat, dateTime.local() )
+				? dateTime.utc().toISOString()
 				: dateTime.creationData().input?.toString() || '';
-		},
-		[ displayFormat ]
-	);
-
-	function formatDateTimeAsISO( dateTime: Moment ): string {
-		return dateTime.isValid()
-			? dateTime.utc().toISOString()
-			: dateTime.creationData().input?.toString() || '';
-	}
-
-	const currentDateTime = parseAsISODateTime( currentDate );
-
-	const [ inputString, setInputString ] = useState(
-		currentDateTime.isValid()
-			? formatDateTimeForDisplay( maybeForceTime( currentDateTime ) )
-			: ''
-	);
-
-	const inputStringDateTime = useMemo( () => {
-		return maybeForceTime( parseAsLocalDateTime( inputString ) );
-	}, [ inputString, maybeForceTime ] );
-
-	// We keep a ref to the onChange prop so that we can be sure we are
-	// always using the more up-to-date value, even if it changes
-	// it while a debounced onChange handler is in progress
-	const onChangeRef = useRef<
-		DateTimePickerControlOnChangeHandler | undefined
-	>();
-	useEffect( () => {
-		onChangeRef.current = onChange;
-	}, [ onChange ] );
-
-	const setInputStringAndMaybeCallOnChange = useCallback(
-		( newInputString: string, isUserTypedInput: boolean ) => {
-			// InputControl doesn't fire an onChange if what the user has typed
-			// matches the current value of the input field. To get around this,
-			// we pull the value directly out of the input field. This fixes
-			// the issue where the user ends up typing the same value. Unless they
-			// are typing extra slow. Without this workaround, we miss the last
-			// character typed.
-			const lastTypedValue = inputControl.current.value;
-
-			const newDateTime = maybeForceTime(
-				isUserTypedInput
-					? parseAsLocalDateTime( lastTypedValue )
-					: parseAsISODateTime( newInputString, true )
-			);
-			const isDateTimeSame = newDateTime.isSame( inputStringDateTime );
-
-			if ( isUserTypedInput ) {
-				setInputString( lastTypedValue );
-			} else if ( ! isDateTimeSame ) {
-				setInputString( formatDateTimeForDisplay( newDateTime ) );
-			}
-
-			if (
-				typeof onChangeRef.current === 'function' &&
-				! isDateTimeSame
-			) {
-				onChangeRef.current(
-					newDateTime.isValid()
-						? formatDateTimeAsISO( newDateTime )
-						: lastTypedValue,
-					newDateTime.isValid()
-				);
-			}
-		},
-		[ formatDateTimeForDisplay, inputStringDateTime, maybeForceTime ]
-	);
-
-	const debouncedSetInputStringAndMaybeCallOnChange = useDebounce(
-		setInputStringAndMaybeCallOnChange,
-		onChangeDebounceWait
-	);
-
-	function focusInputControl() {
-		if ( inputControl.current ) {
-			inputControl.current.focus();
 		}
-	}
 
-	const getUserInputOrUpdatedCurrentDate = useCallback( () => {
-		if ( currentDate !== undefined ) {
-			const newDateTime = maybeForceTime(
-				parseAsISODateTime( currentDate, false )
-			);
+		const currentDateTime = parseAsISODateTime( currentDate );
 
-			if ( ! newDateTime.isValid() ) {
-				// keep the invalid string, so the user can correct it
-				return currentDate;
+		const [ inputString, setInputString ] = useState(
+			currentDateTime.isValid()
+				? formatDateTimeForDisplay( maybeForceTime( currentDateTime ) )
+				: ''
+		);
+
+		const inputStringDateTime = useMemo( () => {
+			return maybeForceTime( parseAsLocalDateTime( inputString ) );
+		}, [ inputString, maybeForceTime ] );
+
+		// We keep a ref to the onChange prop so that we can be sure we are
+		// always using the more up-to-date value, even if it changes
+		// it while a debounced onChange handler is in progress
+		const onChangeRef = useRef<
+			DateTimePickerControlOnChangeHandler | undefined
+		>();
+		useEffect( () => {
+			onChangeRef.current = onChange;
+		}, [ onChange ] );
+
+		const setInputStringAndMaybeCallOnChange = useCallback(
+			( newInputString: string, isUserTypedInput: boolean ) => {
+				// InputControl doesn't fire an onChange if what the user has typed
+				// matches the current value of the input field. To get around this,
+				// we pull the value directly out of the input field. This fixes
+				// the issue where the user ends up typing the same value. Unless they
+				// are typing extra slow. Without this workaround, we miss the last
+				// character typed.
+				const lastTypedValue = inputControl.current.value;
+
+				const newDateTime = maybeForceTime(
+					isUserTypedInput
+						? parseAsLocalDateTime( lastTypedValue )
+						: parseAsISODateTime( newInputString, true )
+				);
+				const isDateTimeSame =
+					newDateTime.isSame( inputStringDateTime );
+
+				if ( isUserTypedInput ) {
+					setInputString( lastTypedValue );
+				} else if ( ! isDateTimeSame ) {
+					setInputString( formatDateTimeForDisplay( newDateTime ) );
+				}
+
+				if (
+					typeof onChangeRef.current === 'function' &&
+					! isDateTimeSame
+				) {
+					onChangeRef.current(
+						newDateTime.isValid()
+							? formatDateTimeAsISO( newDateTime )
+							: lastTypedValue,
+						newDateTime.isValid()
+					);
+				}
+			},
+			[ formatDateTimeForDisplay, inputStringDateTime, maybeForceTime ]
+		);
+
+		const debouncedSetInputStringAndMaybeCallOnChange = useDebounce(
+			setInputStringAndMaybeCallOnChange,
+			onChangeDebounceWait
+		);
+
+		function focusInputControl() {
+			if ( inputControl.current ) {
+				inputControl.current.focus();
+			}
+		}
+
+		const getUserInputOrUpdatedCurrentDate = useCallback( () => {
+			if ( currentDate !== undefined ) {
+				const newDateTime = maybeForceTime(
+					parseAsISODateTime( currentDate, false )
+				);
+
+				if ( ! newDateTime.isValid() ) {
+					// keep the invalid string, so the user can correct it
+					return currentDate;
+				}
+
+				if ( ! newDateTime.isSame( inputStringDateTime ) ) {
+					return formatDateTimeForDisplay( newDateTime );
+				}
+
+				// the new currentDate is the same date as the inputString,
+				// so keep exactly what the user typed in
+				return inputString;
 			}
 
-			if ( ! newDateTime.isSame( inputStringDateTime ) ) {
-				return formatDateTimeForDisplay( newDateTime );
-			}
-
-			// the new currentDate is the same date as the inputString,
-			// so keep exactly what the user typed in
+			// the component is uncontrolled (not using currentDate),
+			// so just return the input string
 			return inputString;
-		}
+		}, [
+			currentDate,
+			formatDateTimeForDisplay,
+			inputString,
+			maybeForceTime,
+		] );
 
-		// the component is uncontrolled (not using currentDate),
-		// so just return the input string
-		return inputString;
-	}, [ currentDate, formatDateTimeForDisplay, inputString, maybeForceTime ] );
+		// We keep a ref to the onBlur prop so that we can be sure we are
+		// always using the more up-to-date value, otherwise, we get in
+		// any infinite loop when calling onBlur
+		const onBlurRef = useRef< () => void >();
+		useEffect( () => {
+			onBlurRef.current = onBlur;
+		}, [ onBlur ] );
 
-	// We keep a ref to the onBlur prop so that we can be sure we are
-	// always using the more up-to-date value, otherwise, we get in
-	// any infinite loop when calling onBlur
-	const onBlurRef = useRef< () => void >();
-	useEffect( () => {
-		onBlurRef.current = onBlur;
-	}, [ onBlur ] );
-
-	const callOnBlurIfDropdownIsNotOpening = useCallback( ( willOpen ) => {
-		if ( ! willOpen && typeof onBlurRef.current === 'function' ) {
-			// in case the component is blurred before a debounced
-			// change has been processed, immediately set the input string
-			// to the current value of the input field, so that
-			// it won't be set back to the pre-change value
-			setInputStringAndMaybeCallOnChange(
-				inputControl.current.value,
-				true
-			);
-			onBlurRef.current();
-		}
-	}, [] );
-
-	return (
-		<Dropdown
-			className={ classNames(
-				'woocommerce-date-time-picker-control',
-				className
-			) }
-			position="bottom left"
-			focusOnMount={ false }
-			// @ts-expect-error `onToggle` does exist.
-			onToggle={ callOnBlurIfDropdownIsNotOpening }
-			renderToggle={ ( { isOpen, onClose, onToggle } ) => (
-				<BaseControl id={ id } label={ label } help={ help }>
-					<InputControl
-						id={ id }
-						ref={ inputControl }
-						disabled={ disabled }
-						value={ getUserInputOrUpdatedCurrentDate() }
-						onChange={ ( newValue: string ) =>
-							debouncedSetInputStringAndMaybeCallOnChange(
-								newValue,
-								true
-							)
-						}
-						onBlur={ (
-							event: React.FocusEvent< HTMLInputElement >
-						) => {
-							if (
-								hasFocusLeftInputAndDropdownContent( event )
-							) {
-								// close the dropdown, which will also trigger
-								// the component's onBlur to be called
-								onClose();
-							}
-						} }
-						suffix={
-							<Icon
-								icon={ calendar }
-								className="calendar-icon woocommerce-date-time-picker-control__input-control__suffix"
-								onClick={ focusInputControl }
-								size={ 16 }
-							/>
-						}
-						placeholder={ placeholder }
-						describedBy={ sprintf(
-							/* translators: A datetime format */
-							__(
-								'Date input describing a selected date in format %s',
-								'woocommerce'
-							),
-							dateTimeFormat
-						) }
-						onFocus={ () => {
-							if ( isOpen ) {
-								return; // the dropdown is already open, do we don't need to do anything
-							}
-
-							onToggle(); // show the dropdown
-						} }
-						aria-expanded={ isOpen }
-					/>
-				</BaseControl>
-			) }
-			popoverProps={ {
-				className: 'woocommerce-date-time-picker-control__popover',
-			} }
-			renderContent={ () => {
-				const Picker = isDateOnlyPicker ? DatePicker : WpDateTimePicker;
-
-				return (
-					<Picker
-						// @ts-expect-error null is valid for currentDate
-						currentDate={
-							inputStringDateTime.isValid()
-								? formatDateTimeAsISO( inputStringDateTime )
-								: null
-						}
-						onChange={ ( newDateTimeISOString: string ) =>
-							setInputStringAndMaybeCallOnChange(
-								newDateTimeISOString,
-								false
-							)
-						}
-						is12Hour={ is12HourPicker }
-					/>
+		const callOnBlurIfDropdownIsNotOpening = useCallback( ( willOpen ) => {
+			if ( ! willOpen && typeof onBlurRef.current === 'function' ) {
+				// in case the component is blurred before a debounced
+				// change has been processed, immediately set the input string
+				// to the current value of the input field, so that
+				// it won't be set back to the pre-change value
+				setInputStringAndMaybeCallOnChange(
+					inputControl.current.value,
+					true
 				);
-			} }
-		/>
-	);
-};
+				onBlurRef.current();
+			}
+		}, [] );
+
+		return (
+			<Dropdown
+				className={ classNames(
+					'woocommerce-date-time-picker-control',
+					className
+				) }
+				position="bottom left"
+				focusOnMount={ false }
+				// @ts-expect-error `onToggle` does exist.
+				onToggle={ callOnBlurIfDropdownIsNotOpening }
+				renderToggle={ ( { isOpen, onClose, onToggle } ) => (
+					<BaseControl id={ id } label={ label } help={ help }>
+						<InputControl
+							{ ...props }
+							id={ id }
+							ref={ ( element: HTMLInputElement ) => {
+								inputControl.current = element;
+								if ( typeof ref === 'function' ) {
+									ref( element );
+								}
+							} }
+							disabled={ disabled }
+							value={ getUserInputOrUpdatedCurrentDate() }
+							onChange={ ( newValue: string ) =>
+								debouncedSetInputStringAndMaybeCallOnChange(
+									newValue,
+									true
+								)
+							}
+							onBlur={ (
+								event: React.FocusEvent< HTMLInputElement >
+							) => {
+								if (
+									hasFocusLeftInputAndDropdownContent( event )
+								) {
+									// close the dropdown, which will also trigger
+									// the component's onBlur to be called
+									onClose();
+								}
+							} }
+							suffix={
+								<Icon
+									icon={ calendar }
+									className="calendar-icon woocommerce-date-time-picker-control__input-control__suffix"
+									onClick={ focusInputControl }
+									size={ 16 }
+								/>
+							}
+							placeholder={ placeholder }
+							describedBy={ sprintf(
+								/* translators: A datetime format */
+								__(
+									'Date input describing a selected date in format %s',
+									'woocommerce'
+								),
+								dateTimeFormat
+							) }
+							onFocus={ () => {
+								if ( isOpen ) {
+									return; // the dropdown is already open, do we don't need to do anything
+								}
+
+								onToggle(); // show the dropdown
+							} }
+							aria-expanded={ isOpen }
+						/>
+					</BaseControl>
+				) }
+				popoverProps={ {
+					className: 'woocommerce-date-time-picker-control__popover',
+				} }
+				renderContent={ () => {
+					const Picker = isDateOnlyPicker
+						? DatePicker
+						: WpDateTimePicker;
+
+					return (
+						<Picker
+							// @ts-expect-error null is valid for currentDate
+							currentDate={
+								inputStringDateTime.isValid()
+									? formatDateTimeAsISO( inputStringDateTime )
+									: null
+							}
+							onChange={ ( newDateTimeISOString: string ) =>
+								setInputStringAndMaybeCallOnChange(
+									newDateTimeISOString,
+									false
+								)
+							}
+							is12Hour={ is12HourPicker }
+						/>
+					);
+				} }
+			/>
+		);
+	} );

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -52,8 +52,8 @@ export type DateTimePickerControlProps = {
 	onChangeDebounceWait?: number;
 } & Omit< React.HTMLAttributes< HTMLInputElement >, 'onChange' >;
 
-export const DateTimePickerControl: React.FC< DateTimePickerControlProps > =
-	forwardRef( function ForwardedDateTimePickerControl(
+export const DateTimePickerControl = forwardRef(
+	function ForwardedDateTimePickerControl(
 		{
 			currentDate,
 			isDateOnlyPicker = false,
@@ -374,4 +374,5 @@ export const DateTimePickerControl: React.FC< DateTimePickerControlProps > =
 				} }
 			/>
 		);
-	} );
+	}
+);

--- a/packages/js/product-editor/changelog/add-38248
+++ b/packages/js/product-editor/changelog/add-38248
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Make DateTimePickerControl a ForwardedRef

--- a/packages/js/product-editor/src/blocks/schedule-sale/edit.tsx
+++ b/packages/js/product-editor/src/blocks/schedule-sale/edit.tsx
@@ -88,7 +88,7 @@ export function Edit( {
 	const _dateOnSaleTo = moment( dateOnSaleToGmt, moment.ISO_8601, true );
 
 	const {
-		// ref: dateOnSaleFromGmtRef,
+		ref: dateOnSaleFromGmtRef,
 		error: dateOnSaleFromGmtValidationError,
 		validate: validateDateOnSaleFromGmt,
 	} = useValidation< Product >(
@@ -111,7 +111,7 @@ export function Edit( {
 	);
 
 	const {
-		// ref: dateOnSaleToGmtRef,
+		ref: dateOnSaleToGmtRef,
 		error: dateOnSaleToGmtValidationError,
 		validate: validateDateOnSaleToGmt,
 	} = useValidation< Product >(
@@ -146,7 +146,9 @@ export function Edit( {
 				<div className="wp-block-columns">
 					<div className="wp-block-column">
 						<DateTimePickerControl
-							// ref={ dateOnSaleFromGmtRef }
+							ref={
+								dateOnSaleFromGmtRef as React.Ref< HTMLInputElement >
+							}
 							label={ __( 'From', 'woocommerce' ) }
 							placeholder={ __(
 								'Sale start date and time (optional)',
@@ -165,7 +167,9 @@ export function Edit( {
 
 					<div className="wp-block-column">
 						<DateTimePickerControl
-							// ref={ dateOnSaleToGmtRef }
+							ref={
+								dateOnSaleToGmtRef as React.Ref< HTMLInputElement >
+							}
 							label={ __( 'To', 'woocommerce' ) }
 							placeholder={ __(
 								'Sale end date and time (optional)',


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #38248

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Got to `/wp-admin/tools.php?page=woocommerce-admin-test-helper`
2. Under Features tab make sure to enable `product-block-editor`
3. Then visit `/wp-admin/admin.php?page=wc-admin&path=/add-product`
4. Under `Pricing` tab and within `Pricing` section make sure `Schedule sale` toggle is enabled.
5. Write any invalid string in the `From` field and then try to save the product.
6. The `From` field should receives the focus.

<!-- End testing instructions -->