### PR TITLE
Add error specific messages to product save functionality

### DIFF
--- a/packages/js/product-editor/changelog/add-38215
+++ b/packages/js/product-editor/changelog/add-38215
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add error specific messages to product save functionality

--- a/packages/js/product-editor/src/components/header/hooks/use-preview/use-preview.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-preview/use-preview.tsx
@@ -13,6 +13,7 @@ import { MouseEvent } from 'react';
  * Internal dependencies
  */
 import { useValidations } from '../../../../contexts/validation-context';
+import { WPError } from '../../../../utils/get-error-message';
 
 export function usePreview( {
 	disabled,
@@ -22,7 +23,7 @@ export function usePreview( {
 	...props
 }: Omit< Button.AnchorProps, 'aria-disabled' | 'variant' | 'href' > & {
 	onSaveSuccess?( product: Product ): void;
-	onSaveError?( error: Error ): void;
+	onSaveError?( error: WPError ): void;
 } ): Button.AnchorProps {
 	const anchorRef = useRef< HTMLAnchorElement >();
 
@@ -129,7 +130,7 @@ export function usePreview( {
 			}
 		} catch ( error ) {
 			if ( onSaveError ) {
-				onSaveError( error as Error );
+				onSaveError( error as WPError );
 			}
 		}
 	}

--- a/packages/js/product-editor/src/components/header/hooks/use-preview/use-preview.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-preview/use-preview.tsx
@@ -13,7 +13,7 @@ import { MouseEvent } from 'react';
  * Internal dependencies
  */
 import { useValidations } from '../../../../contexts/validation-context';
-import { WPError } from '../../../../utils/get-error-message';
+import { WPError } from '../../../../utils/get-product-error-message';
 
 export function usePreview( {
 	disabled,

--- a/packages/js/product-editor/src/components/header/hooks/use-preview/use-preview.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-preview/use-preview.tsx
@@ -118,7 +118,10 @@ export function usePreview( {
 			const publishedProduct = await saveEditedEntityRecord< Product >(
 				'postType',
 				'product',
-				productId
+				productId,
+				{
+					throwOnError: true,
+				}
 			);
 
 			// Redirect using the default anchor behaviour. This way, the usage

--- a/packages/js/product-editor/src/components/header/hooks/use-publish/use-publish.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-publish/use-publish.tsx
@@ -12,7 +12,7 @@ import { MouseEvent } from 'react';
  * Internal dependencies
  */
 import { useValidations } from '../../../../contexts/validation-context';
-import { WPError } from '../../../../utils/get-error-message';
+import { WPError } from '../../../../utils/get-product-error-message';
 
 export function usePublish( {
 	disabled,

--- a/packages/js/product-editor/src/components/header/hooks/use-publish/use-publish.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-publish/use-publish.tsx
@@ -12,6 +12,7 @@ import { MouseEvent } from 'react';
  * Internal dependencies
  */
 import { useValidations } from '../../../../contexts/validation-context';
+import { WPError } from '../../../../utils/get-error-message';
 
 export function usePublish( {
 	disabled,
@@ -21,7 +22,7 @@ export function usePublish( {
 	...props
 }: Omit< Button.ButtonProps, 'aria-disabled' | 'variant' | 'children' > & {
 	onPublishSuccess?( product: Product ): void;
-	onPublishError?( error: Error ): void;
+	onPublishError?( error: WPError ): void;
 } ): Button.ButtonProps {
 	const [ productId ] = useEntityProp< number >(
 		'postType',
@@ -88,7 +89,7 @@ export function usePublish( {
 			}
 		} catch ( error ) {
 			if ( onPublishError ) {
-				onPublishError( error as Error );
+				onPublishError( error as WPError );
 			}
 		}
 	}

--- a/packages/js/product-editor/src/components/header/hooks/use-publish/use-publish.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-publish/use-publish.tsx
@@ -77,7 +77,10 @@ export function usePublish( {
 			const publishedProduct = await saveEditedEntityRecord< Product >(
 				'postType',
 				'product',
-				productId
+				productId,
+				{
+					throwOnError: true,
+				}
 			);
 
 			if ( publishedProduct && onPublishSuccess ) {

--- a/packages/js/product-editor/src/components/header/hooks/use-save-draft/use-save-draft.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-save-draft/use-save-draft.tsx
@@ -14,6 +14,7 @@ import { MouseEvent, ReactNode } from 'react';
  * Internal dependencies
  */
 import { useValidations } from '../../../../contexts/validation-context';
+import { WPError } from '../../../../utils/get-error-message';
 
 export function useSaveDraft( {
 	disabled,
@@ -23,7 +24,7 @@ export function useSaveDraft( {
 	...props
 }: Omit< Button.ButtonProps, 'aria-disabled' | 'variant' | 'children' > & {
 	onSaveSuccess?( product: Product ): void;
-	onSaveError?( error: Error ): void;
+	onSaveError?( error: WPError ): void;
 } ): Button.ButtonProps {
 	const [ productId ] = useEntityProp< number >(
 		'postType',
@@ -97,7 +98,7 @@ export function useSaveDraft( {
 			}
 		} catch ( error ) {
 			if ( onSaveError ) {
-				onSaveError( error as Error );
+				onSaveError( error as WPError );
 			}
 		}
 	}

--- a/packages/js/product-editor/src/components/header/hooks/use-save-draft/use-save-draft.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-save-draft/use-save-draft.tsx
@@ -14,7 +14,7 @@ import { MouseEvent, ReactNode } from 'react';
  * Internal dependencies
  */
 import { useValidations } from '../../../../contexts/validation-context';
-import { WPError } from '../../../../utils/get-error-message';
+import { WPError } from '../../../../utils/get-product-error-message';
 
 export function useSaveDraft( {
 	disabled,

--- a/packages/js/product-editor/src/components/header/hooks/use-save-draft/use-save-draft.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-save-draft/use-save-draft.tsx
@@ -86,7 +86,10 @@ export function useSaveDraft( {
 			const publishedProduct = await saveEditedEntityRecord< Product >(
 				'postType',
 				'product',
-				productId
+				productId,
+				{
+					throwOnError: true,
+				}
 			);
 
 			if ( onSaveSuccess ) {

--- a/packages/js/product-editor/src/components/header/preview-button/preview-button.tsx
+++ b/packages/js/product-editor/src/components/header/preview-button/preview-button.tsx
@@ -12,7 +12,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { getErrorMessage } from '../../../utils/get-error-message';
+import { getProductErrorMessage } from '../../../utils/get-product-error-message';
 import { usePreview } from '../hooks/use-preview';
 
 export function PreviewButton( {
@@ -38,7 +38,7 @@ export function PreviewButton( {
 			}
 		},
 		onSaveError( error ) {
-			const message = getErrorMessage( error );
+			const message = getProductErrorMessage( error );
 
 			createErrorNotice(
 				message || __( 'Failed to preview product.', 'woocommerce' )

--- a/packages/js/product-editor/src/components/header/preview-button/preview-button.tsx
+++ b/packages/js/product-editor/src/components/header/preview-button/preview-button.tsx
@@ -12,6 +12,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { getErrorMessage } from '../../../utils/get-error-message';
 import { usePreview } from '../hooks/use-preview';
 
 export function PreviewButton( {
@@ -36,9 +37,11 @@ export function PreviewButton( {
 				navigateTo( { url } );
 			}
 		},
-		onSaveError() {
+		onSaveError( error ) {
+			const message = getErrorMessage( error );
+
 			createErrorNotice(
-				__( 'Failed to preview product.', 'woocommerce' )
+				message || __( 'Failed to preview product.', 'woocommerce' )
 			);
 		},
 	} );

--- a/packages/js/product-editor/src/components/header/publish-button/publish-button.tsx
+++ b/packages/js/product-editor/src/components/header/publish-button/publish-button.tsx
@@ -13,7 +13,7 @@ import { useEntityProp } from '@wordpress/core-data';
 /**
  * Internal dependencies
  */
-import { getErrorMessage } from '../../../utils/get-error-message';
+import { getProductErrorMessage } from '../../../utils/get-product-error-message';
 import { recordProductEvent } from '../../../utils/record-product-event';
 import { usePublish } from '../hooks/use-publish';
 
@@ -68,7 +68,7 @@ export function PublishButton(
 				? __( 'Failed to create product.', 'woocommerce' )
 				: __( 'Failed to publish product.', 'woocommerce' );
 
-			const message = getErrorMessage( error );
+			const message = getProductErrorMessage( error );
 			createErrorNotice( message || defaultMessage );
 		},
 	} );

--- a/packages/js/product-editor/src/components/header/publish-button/publish-button.tsx
+++ b/packages/js/product-editor/src/components/header/publish-button/publish-button.tsx
@@ -13,6 +13,7 @@ import { useEntityProp } from '@wordpress/core-data';
 /**
  * Internal dependencies
  */
+import { getErrorMessage } from '../../../utils/get-error-message';
 import { recordProductEvent } from '../../../utils/record-product-event';
 import { usePublish } from '../hooks/use-publish';
 
@@ -62,12 +63,13 @@ export function PublishButton(
 				navigateTo( { url } );
 			}
 		},
-		onPublishError() {
-			const noticeContent = isCreating
+		onPublishError( error ) {
+			const defaultMessage = isCreating
 				? __( 'Failed to create product.', 'woocommerce' )
 				: __( 'Failed to publish product.', 'woocommerce' );
 
-			createErrorNotice( noticeContent );
+			const message = getErrorMessage( error );
+			createErrorNotice( message || defaultMessage );
 		},
 	} );
 

--- a/packages/js/product-editor/src/components/header/save-draft-button/save-draft-button.tsx
+++ b/packages/js/product-editor/src/components/header/save-draft-button/save-draft-button.tsx
@@ -12,6 +12,7 @@ import { useEntityProp } from '@wordpress/core-data';
 /**
  * Internal dependencies
  */
+import { getErrorMessage } from '../../../utils/get-error-message';
 import { recordProductEvent } from '../../../utils/record-product-event';
 import { useSaveDraft } from '../hooks/use-save-draft';
 
@@ -41,9 +42,11 @@ export function SaveDraftButton(
 				navigateTo( { url } );
 			}
 		},
-		onSaveError() {
+		onSaveError( error ) {
+			const message = getErrorMessage( error );
+
 			createErrorNotice(
-				__( 'Failed to update product.', 'woocommerce' )
+				message || __( 'Failed to update product.', 'woocommerce' )
 			);
 		},
 	} );

--- a/packages/js/product-editor/src/components/header/save-draft-button/save-draft-button.tsx
+++ b/packages/js/product-editor/src/components/header/save-draft-button/save-draft-button.tsx
@@ -12,7 +12,7 @@ import { useEntityProp } from '@wordpress/core-data';
 /**
  * Internal dependencies
  */
-import { getErrorMessage } from '../../../utils/get-error-message';
+import { getProductErrorMessage } from '../../../utils/get-product-error-message';
 import { recordProductEvent } from '../../../utils/record-product-event';
 import { useSaveDraft } from '../hooks/use-save-draft';
 
@@ -43,7 +43,7 @@ export function SaveDraftButton(
 			}
 		},
 		onSaveError( error ) {
-			const message = getErrorMessage( error );
+			const message = getProductErrorMessage( error );
 
 			createErrorNotice(
 				message || __( 'Failed to update product.', 'woocommerce' )

--- a/packages/js/product-editor/src/utils/get-error-message.ts
+++ b/packages/js/product-editor/src/utils/get-error-message.ts
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export type WPError = {
+	code: string;
+	message: string;
+	data: {
+		[ key: string ]: unknown;
+	};
+};
+
+export function getErrorMessage( error: WPError ) {
+	if ( error.code === 'product_invalid_sku' ) {
+		return __( 'Invalid or duplicated SKU.', 'woocommerce' );
+	}
+
+	return null;
+}

--- a/packages/js/product-editor/src/utils/get-product-error-message.ts
+++ b/packages/js/product-editor/src/utils/get-product-error-message.ts
@@ -11,7 +11,7 @@ export type WPError = {
 	};
 };
 
-export function getErrorMessage( error: WPError ) {
+export function getProductErrorMessage( error: WPError ) {
 	if ( error.code === 'product_invalid_sku' ) {
 		return __( 'Invalid or duplicated SKU.', 'woocommerce' );
 	}

--- a/packages/js/product-editor/src/utils/test/get-product-error-message.ts
+++ b/packages/js/product-editor/src/utils/test/get-product-error-message.ts
@@ -1,0 +1,22 @@
+/**
+ * Internal dependencies
+ */
+import { getProductErrorMessage, WPError } from '../get-product-error-message';
+
+describe( 'getProductErrorMessage', () => {
+	it( 'should return the correct error message when one exists', () => {
+		const error = {
+			code: 'product_invalid_sku',
+		} as WPError;
+		const message = getProductErrorMessage( error );
+		expect( message ).toBe( 'Invalid or duplicated SKU.' );
+	} );
+
+	it( 'should return null when no error message exists', () => {
+		const error = {
+			code: 'unanticipated_error_code',
+		} as WPError;
+		const status = getProductErrorMessage( error );
+		expect( status ).toBeNull();
+	} );
+} );


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

* Fixes error handling in product saving
* Adds product specific error messages

A couple questions around this PR:

* Currently the client-side message matches the server message exactly `Invalid or duplicated SKU.`.  Seems a little bit redundant and silly, but I still think this is the best approach.  Do we like this language or prefer something else?  cc @jarekmorawski 
* Are there any other common errors we need to account for that should be included in this PR?

<img width="304" alt="Screen Shot 2023-05-15 at 1 25 05 PM" src="https://github.com/woocommerce/woocommerce/assets/10561050/41ca9813-5d70-4498-9a18-a0c2300e95b4">


Closes #38215  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to `/wp-admin/tools.php?page=woocommerce-admin-test-helper`
2. Under Features tab make sure to enable `product-block-editor`
3. Then visit `/wp-admin/admin.php?page=wc-admin&path=/add-product`
4. Add a sku that has already been used by another product in your store under Inventory -> SKU
5. Attempt to Preview | Save draft | Save
6. Make sure that you receive the error message relating to the sku
7. Update the sku to something unique
8. Make sure no error is shown

<!-- End testing instructions -->