### PR TITLE
Fix RIM rules processor

### DIFF
--- a/plugins/woocommerce/changelog/fix-38167_RIM_rules_processor
+++ b/plugins/woocommerce/changelog/fix-38167_RIM_rules_processor
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix RIM rules processor

--- a/plugins/woocommerce/changelog/fix-38167_RIM_rules_processor
+++ b/plugins/woocommerce/changelog/fix-38167_RIM_rules_processor
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Fix RIM rules processor
+Add "PrepareUrl" transformer to RIM rules processor

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/ComparisonOperation.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/ComparisonOperation.php
@@ -33,9 +33,15 @@ class ComparisonOperation {
 			case '!=':
 				return $left_operand !== $right_operand;
 			case 'contains':
-				return in_array( $right_operand, $left_operand, true );
+				if ( is_array( $left_operand ) && is_string( $right_operand ) ) {
+					return in_array( $right_operand, $left_operand, true );
+				}
+				return strpos( $left_operand, $right_operand ) !== false;
 			case '!contains':
-				return ! in_array( $right_operand, $left_operand, true );
+				if ( is_array( $left_operand ) && is_string( $right_operand ) ) {
+					return ! in_array( $right_operand, $left_operand, true );
+				}
+				return strpos( $left_operand, $right_operand ) === false;
 		}
 
 		return false;

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/ComparisonOperation.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/ComparisonOperation.php
@@ -36,12 +36,12 @@ class ComparisonOperation {
 				if ( is_array( $left_operand ) && is_string( $right_operand ) ) {
 					return in_array( $right_operand, $left_operand, true );
 				}
-				return strpos( $left_operand, $right_operand ) !== false;
+				return strpos( $right_operand, $left_operand ) !== false;
 			case '!contains':
 				if ( is_array( $left_operand ) && is_string( $right_operand ) ) {
 					return ! in_array( $right_operand, $left_operand, true );
 				}
-				return strpos( $left_operand, $right_operand ) === false;
+				return strpos( $right_operand, $left_operand ) === false;
 		}
 
 		return false;

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/OptionRuleProcessor.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/OptionRuleProcessor.php
@@ -20,11 +20,10 @@ class OptionRuleProcessor implements RuleProcessorInterface {
 	 * @return bool The result of the operation.
 	 */
 	public function process( $rule, $stored_state ) {
-		$is_contains       = $rule->operation && strpos( $rule->operation, 'contains' ) !== false;
-		$default_value     = $is_contains ? array() : false;
-		$default           = isset( $rule->default ) ? $rule->default : $default_value;
-		$option_value      = get_option( $rule->option_name, $default );
-		$is_siteurl_option = 'siteurl' === $rule->option_name;
+		$is_contains   = $rule->operation && strpos( $rule->operation, 'contains' ) !== false;
+		$default_value = $is_contains ? array() : false;
+		$default       = isset( $rule->default ) ? $rule->default : $default_value;
+		$option_value  = get_option( $rule->option_name, $default );
 
 		if ( $is_contains && ! is_array( $option_value ) ) {
 			$logger = wc_get_logger();
@@ -46,30 +45,11 @@ class OptionRuleProcessor implements RuleProcessorInterface {
 			$option_value = TransformerService::apply( $option_value, $rule->transformers, $default );
 		}
 
-		$rule_value = $rule->value;
-
-		if ( $is_siteurl_option ) {
-			$rule_value   = $this->getRuleValue( $rule_value );
-			$option_value = $this->getRuleValue( $option_value );
-		}
-
 		return ComparisonOperation::compare(
 			$option_value,
-			$rule_value,
+			$rule->value,
 			$rule->operation
 		);
-	}
-
-	/**
-	 * Helper function to get the rule value for 'siteurl' option.
-	 *
-	 * @param string $url The URL to parse.
-	 *
-	 * @return string
-	 */
-	protected function getRuleValue( $url ) {
-		$url_parts = wp_parse_url( rtrim( $url, '/' ) );
-		return isset( $url_parts['path'] ) ? $url_parts['host'] . $url_parts['path'] : $url_parts['host'];
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/OptionRuleProcessor.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/OptionRuleProcessor.php
@@ -23,7 +23,7 @@ class OptionRuleProcessor implements RuleProcessorInterface {
 		$is_contains   = $rule->operation && strpos( $rule->operation, 'contains' ) !== false;
 		$default_value = $is_contains ? array() : false;
 		$default       = isset( $rule->default ) ? $rule->default : $default_value;
-		$option_value = $this->get_option_value( $rule, $default, $is_contains );
+		$option_value  = $this->get_option_value( $rule, $default, $is_contains );
 
 		if ( isset( $rule->transformers ) && is_array( $rule->transformers ) ) {
 			$option_value = TransformerService::apply( $option_value, $rule->transformers, $default );
@@ -46,7 +46,7 @@ class OptionRuleProcessor implements RuleProcessorInterface {
 	 * @return mixed The option value.
 	 */
 	private function get_option_value( $rule, $default, $is_contains ) {
-		$option_value = get_option( $rule->option_name, $default );
+		$option_value      = get_option( $rule->option_name, $default );
 		$is_contains_valid = $is_contains && ( is_array( $option_value ) || ( is_string( $option_value ) && is_string( $rule->value ) ) );
 
 		if ( ! $is_contains_valid ) {

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/OptionRuleProcessor.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/OptionRuleProcessor.php
@@ -49,7 +49,7 @@ class OptionRuleProcessor implements RuleProcessorInterface {
 		$option_value      = get_option( $rule->option_name, $default );
 		$is_contains_valid = $is_contains && ( is_array( $option_value ) || ( is_string( $option_value ) && is_string( $rule->value ) ) );
 
-		if ( ! $is_contains_valid ) {
+		if ( $is_contains && ! $is_contains_valid ) {
 			$logger = wc_get_logger();
 			$logger->warning(
 				sprintf(

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/OptionRuleProcessor.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/OptionRuleProcessor.php
@@ -20,10 +20,11 @@ class OptionRuleProcessor implements RuleProcessorInterface {
 	 * @return bool The result of the operation.
 	 */
 	public function process( $rule, $stored_state ) {
-		$is_contains   = $rule->operation && strpos( $rule->operation, 'contains' ) !== false;
-		$default_value = $is_contains ? array() : false;
-		$default       = isset( $rule->default ) ? $rule->default : $default_value;
-		$option_value  = get_option( $rule->option_name, $default );
+		$is_contains       = $rule->operation && strpos( $rule->operation, 'contains' ) !== false;
+		$default_value     = $is_contains ? array() : false;
+		$default           = isset( $rule->default ) ? $rule->default : $default_value;
+		$option_value      = get_option( $rule->option_name, $default );
+		$is_siteurl_option = 'siteurl' === $rule->option_name;
 
 		if ( $is_contains && ! is_array( $option_value ) ) {
 			$logger = wc_get_logger();
@@ -45,11 +46,29 @@ class OptionRuleProcessor implements RuleProcessorInterface {
 			$option_value = TransformerService::apply( $option_value, $rule->transformers, $default );
 		}
 
+		$rule_value = $rule->value;
+
+		if ( $is_siteurl_option ) {
+			$rule_value = $this->getRuleValue( $rule_value );
+			$option_value = $this->getRuleValue( $option_value );
+		}
+
 		return ComparisonOperation::compare(
 			$option_value,
-			$rule->value,
+			$rule_value,
 			$rule->operation
 		);
+	}
+
+	/**
+	 * Helper function to get the rule value for 'siteurl' option.
+	 *
+	 * @param string $url
+	 * @return string
+	 */
+	protected function getRuleValue( $url ) {
+		$url_parts = parse_url( rtrim( $url, '/' ) );
+		return isset( $url_parts['path'] ) ? $url_parts['host'] . $url_parts['path'] : $url_parts['host'];
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/OptionRuleProcessor.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/OptionRuleProcessor.php
@@ -25,7 +25,7 @@ class OptionRuleProcessor implements RuleProcessorInterface {
 		$default       = isset( $rule->default ) ? $rule->default : $default_value;
 		$option_value  = get_option( $rule->option_name, $default );
 
-		if ( $is_contains && ! is_array( $option_value ) ) {
+		if ( $is_contains && ! is_array( $option_value ) && ( ! is_string( $option_value ) || ! is_string( $rule->value ) ) ) {
 			$logger = wc_get_logger();
 			$logger->warning(
 				sprintf(

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/OptionRuleProcessor.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/OptionRuleProcessor.php
@@ -23,9 +23,33 @@ class OptionRuleProcessor implements RuleProcessorInterface {
 		$is_contains   = $rule->operation && strpos( $rule->operation, 'contains' ) !== false;
 		$default_value = $is_contains ? array() : false;
 		$default       = isset( $rule->default ) ? $rule->default : $default_value;
-		$option_value  = get_option( $rule->option_name, $default );
+		$option_value = $this->get_option_value( $rule, $default, $is_contains );
 
-		if ( $is_contains && ! is_array( $option_value ) && ( ! is_string( $option_value ) || ! is_string( $rule->value ) ) ) {
+		if ( isset( $rule->transformers ) && is_array( $rule->transformers ) ) {
+			$option_value = TransformerService::apply( $option_value, $rule->transformers, $default );
+		}
+
+		return ComparisonOperation::compare(
+			$option_value,
+			$rule->value,
+			$rule->operation
+		);
+	}
+
+	/**
+	 * Retrieves the option value and handles logging if necessary.
+	 *
+	 * @param object $rule         The specific rule being processed.
+	 * @param mixed  $default      The default value.
+	 * @param bool   $is_contains  Indicates whether the operation is "contains".
+	 *
+	 * @return mixed The option value.
+	 */
+	private function get_option_value( $rule, $default, $is_contains ) {
+		$option_value = get_option( $rule->option_name, $default );
+		$is_contains_valid = $is_contains && ( is_array( $option_value ) || ( is_string( $option_value ) && is_string( $rule->value ) ) );
+
+		if ( ! $is_contains_valid ) {
 			$logger = wc_get_logger();
 			$logger->warning(
 				sprintf(
@@ -41,15 +65,7 @@ class OptionRuleProcessor implements RuleProcessorInterface {
 			$option_value = array();
 		}
 
-		if ( isset( $rule->transformers ) && is_array( $rule->transformers ) ) {
-			$option_value = TransformerService::apply( $option_value, $rule->transformers, $default );
-		}
-
-		return ComparisonOperation::compare(
-			$option_value,
-			$rule->value,
-			$rule->operation
-		);
+		return $option_value;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/OptionRuleProcessor.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/OptionRuleProcessor.php
@@ -49,7 +49,7 @@ class OptionRuleProcessor implements RuleProcessorInterface {
 		$rule_value = $rule->value;
 
 		if ( $is_siteurl_option ) {
-			$rule_value = $this->getRuleValue( $rule_value );
+			$rule_value   = $this->getRuleValue( $rule_value );
 			$option_value = $this->getRuleValue( $option_value );
 		}
 
@@ -63,11 +63,12 @@ class OptionRuleProcessor implements RuleProcessorInterface {
 	/**
 	 * Helper function to get the rule value for 'siteurl' option.
 	 *
-	 * @param string $url
+	 * @param string $url The URL to parse.
+	 *
 	 * @return string
 	 */
 	protected function getRuleValue( $url ) {
-		$url_parts = parse_url( rtrim( $url, '/' ) );
+		$url_parts = wp_parse_url( rtrim( $url, '/' ) );
 		return isset( $url_parts['path'] ) ? $url_parts['host'] . $url_parts['path'] : $url_parts['host'];
 	}
 

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/Transformers/PrepareUrl.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/Transformers/PrepareUrl.php
@@ -21,7 +21,7 @@ class PrepareUrl implements TransformerInterface {
 	 * @return mixed|null
 	 */
 	public function transform( $value, stdClass $arguments = null, $default = null ) {
-		$url_parts = wp_parse_url( rtrim( $url, '/' ) );
+		$url_parts = wp_parse_url( rtrim( $value, '/' ) );
 		return isset( $url_parts['path'] ) ? $url_parts['host'] . $url_parts['path'] : $url_parts['host'];
 	}
 

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/Transformers/PrepareUrl.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/Transformers/PrepareUrl.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Automattic\WooCommerce\Admin\RemoteInboxNotifications\Transformers;
+
+use Automattic\WooCommerce\Admin\RemoteInboxNotifications\TransformerInterface;
+use stdClass;
+
+/**
+ * Prepare site URL for comparison.
+ *
+ * @package Automattic\WooCommerce\Admin\RemoteInboxNotifications\Transformers
+ */
+class PrepareUrl implements TransformerInterface {
+	/**
+	 * Prepares the site URL by removing the protocol and trailing slash.
+	 *
+	 * @param mixed         $value a value to transform.
+	 * @param stdClass|null $arguments arguments.
+	 * @param string|null   $default default value.
+	 *
+	 * @return mixed|null
+	 */
+	public function transform( $value, stdClass $arguments = null, $default = null ) {
+		$url_parts = wp_parse_url( rtrim( $url, '/' ) );
+		return isset( $url_parts['path'] ) ? $url_parts['host'] . $url_parts['path'] : $url_parts['host'];
+	}
+
+	/**
+	 * Validate Transformer arguments.
+	 *
+	 * @param stdClass|null $arguments arguments to validate.
+	 *
+	 * @return mixed
+	 */
+	public function validate( stdClass $arguments = null ) {
+		return true;
+	}
+}

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/Transformers/README.md
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/Transformers/README.md
@@ -365,4 +365,38 @@ Let's count # of users with `count`
 
 **Output:** 3
 
+## prepare_url
 
+This prepares the site URL by removing the protocol and the last slash.
+
+#### Arguments: N/A
+
+####Definition:
+
+```php
+"transformers": [
+    {
+        "use": "prepare_url"
+    }
+],
+```
+
+#### Example:
+
+Given the following data
+
+```php
+$siteurl = "https://mysite.com/"
+```
+
+Removes the protocol and the last slash.
+
+```php
+"transformers": [
+    {
+        "use": "prepare_url",
+    }
+],
+```
+
+**Output:** "mysite.com"

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-inbox-notifications/Transformers/prepare-url.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-inbox-notifications/Transformers/prepare-url.php
@@ -20,12 +20,12 @@ class WC_Admin_Tests_RemoteInboxNotifications_Transformers_PrepareUrl extends WC
 			'https://www.example.com/',
 			'http://www.example.com',
 			'http://www.example.com/',
-			'test://www.example.com/'
+			'test://www.example.com/',
 		);
 
 		$prepare_url = new PrepareUrl();
 
-		foreach( $urls as $url ) {
+		foreach ( $urls as $url ) {
 			$result = $prepare_url->transform( $url );
 			$this->assertEquals( 'www.example.com', $result );
 		}

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-inbox-notifications/Transformers/prepare-url.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-inbox-notifications/Transformers/prepare-url.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * PrepareUrl tests.
+ *
+ * @package WooCommerce\Admin\Tests\RemoteInboxNotifications
+ */
+
+use Automattic\WooCommerce\Admin\RemoteInboxNotifications\Transformers\PrepareUrl;
+
+/**
+ * class WC_Admin_Tests_RemoteInboxNotifications_Transformers_PrepareUrl
+ */
+class WC_Admin_Tests_RemoteInboxNotifications_Transformers_PrepareUrl extends WC_Unit_Test_Case {
+	/**
+	 * Test it returns url without protocol and trailing slash.
+	 */
+	public function test_it_returns_flatten_array() {
+		$urls = array(
+			'https://www.example.com',
+			'https://www.example.com/',
+			'http://www.example.com',
+			'http://www.example.com/',
+			'test://www.example.com/'
+		);
+
+		$prepare_url = new PrepareUrl();
+
+		foreach( $urls as $url ) {
+			$result = $prepare_url->transform( $url );
+			$this->assertEquals( 'www.example.com', $result );
+		}
+	}
+}

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-inbox-notifications/option-rule-processor.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-inbox-notifications/option-rule-processor.php
@@ -63,14 +63,14 @@ class WC_Admin_Tests_RemoteInboxNotifications_OptionRuleProcessor extends WC_Uni
 	 *
 	 * @group fast
 	 */
-	public function test_rule_passes_for_contains() {
-		add_option( 'contain_item', array( 'test' ) );
+	public function test_rule_passes_for_contains_array() {
+		add_option( 'array_contain_item', array( 'test' ) );
 		$processor = new OptionRuleProcessor();
 		$rule      = json_decode(
 			'
 			{
 				"type": "option",
-				"option_name": "contain_item",
+				"option_name": "array_contain_item",
 				"value": "test",
 				"default": [],
 				"operation": "contains"
@@ -84,7 +84,36 @@ class WC_Admin_Tests_RemoteInboxNotifications_OptionRuleProcessor extends WC_Uni
 		$rule->value = 'not_included';
 		$result      = $processor->process( $rule, null );
 		$this->assertEquals( false, $result );
-		delete_option( 'contain_item' );
+		delete_option( 'array_contain_item' );
+	}
+
+	/**
+	 * Test contains of substring
+	 *
+	 * @group fast
+	 */
+	public function test_rule_passes_for_contains_substring() {
+		add_option( 'string_contain_substring', array( 'test' ) );
+		$processor = new OptionRuleProcessor();
+		$rule      = json_decode(
+			'
+			{
+				"type": "option",
+				"option_name": "string_contain_substring",
+				"value": "test",
+				"default": "",
+				"operation": "contains"
+			}
+			'
+		);
+
+		$result = $processor->process( $rule, null );
+		$this->assertEquals( true, $result );
+
+		$rule->value = 'not_included';
+		$result      = $processor->process( $rule, null );
+		$this->assertEquals( false, $result );
+		delete_option( 'string_contain_substring' );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR introduces code to accurately parse the `siteurl` during the execution of the remote inbox messages rules processor.
Closes #38167.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install WooCommerce Payments, [WC Beta tester](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce-beta-tester) or [WC-Admin Test Helper](https://github.com/woocommerce/woocommerce-admin-test-helper).
2. To facilitate testing, I created [this plugin](https://gist.github.com/octaedro/3b8c4921b0657bd5063bac5ad68b1ffa). Install and activate it.
3. Go to `Tools > WCA Test Helper > Options` and delete the options: `_transient_timeout_woocommerce_admin_remote_inbox_notifications_specs` and `_transient_woocommerce_admin_remote_inbox_notifications_specs`
4. Go to `Tools > WCA Test Helper > Tools` and press the `Run` button next to `Run wc_admin_daily job`
5. The message titled `Increase conversions with WooPay — our fastest checkout yet` should be visible four times under the Inbox section. 

_I'm going to add some unit tests in a follow-up PR._

<!-- End testing instructions -->