### PR TITLE
Add support to verify specific order types.

### DIFF
--- a/plugins/woocommerce/changelog/fix-38317
+++ b/plugins/woocommerce/changelog/fix-38317
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add support to verify specific order types.

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -302,7 +302,7 @@ class CLIRunner {
 	 * [--order-types]
 	 * : Comma seperated list of order types that needs to be verified. For example, --order-types=shop_order,shop_order_refund
 	 * ---
-	 * default: Output of function
+	 * default: Output of function `wc_get_order_types( 'cot-migration' )`
 	 *
 	 * ## EXAMPLES
 	 *

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -299,6 +299,11 @@ class CLIRunner {
 	 * default: false
 	 * ---
 	 *
+	 * [--order-types]
+	 * : Comma seperated list of order types that needs to be verified. For example, --order-types=shop_order,shop_order_refund
+	 * ---
+	 * default: Output of function
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     # Verify migrated order data, 500 orders at a time.
@@ -317,10 +322,11 @@ class CLIRunner {
 		$assoc_args = wp_parse_args(
 			$assoc_args,
 			array(
-				'batch-size' => 500,
-				'start-from' => 0,
-				'end-at'     => -1,
-				'verbose'    => false,
+				'batch-size'  => 500,
+				'start-from'  => 0,
+				'end-at'      => - 1,
+				'verbose'     => false,
+				'order-types' => '',
 			)
 		);
 
@@ -331,9 +337,27 @@ class CLIRunner {
 		$order_id_start = (int) $assoc_args['start-from'];
 		$order_id_end   = (int) $assoc_args['end-at'];
 		$order_id_end   = -1 === $order_id_end ? PHP_INT_MAX : $order_id_end;
-		$order_count    = $this->get_verify_order_count( $order_id_start, $order_id_end, false );
 		$batch_size     = ( (int) $assoc_args['batch-size'] ) === 0 ? 500 : (int) $assoc_args['batch-size'];
 		$verbose        = (bool) $assoc_args['verbose'];
+		$order_types    = wc_get_order_types( 'cot-migration' );
+		if ( ! empty( $assoc_args['order-types'] ) ) {
+			$passed_order_types = array_map( 'trim', explode( ',', $assoc_args['order-types'] ) );
+			$order_types        = array_intersect( $order_types, $passed_order_types );
+		}
+
+		if ( 0 === count( $order_types ) ) {
+			return WP_CLI::error(
+				sprintf(
+				/* Translators: %s is the comma seperated list of order types. */
+					__( 'Passed order type does not match any registered order types. Following order types are registered: %s', 'woocommerce' ),
+					implode( ',', wc_get_order_types( 'cot-migration' ) )
+				)
+			);
+		}
+
+		$order_types_pl = implode( ',', array_fill( 0, count( $order_types ), '%s' ) );
+
+		$order_count = $this->get_verify_order_count( $order_id_start, $order_id_end, $order_types, false );
 
 		$progress = WP_CLI\Utils\make_progress_bar( 'Order Data Verification', $order_count / $batch_size );
 
@@ -351,14 +375,21 @@ class CLIRunner {
 				)
 			);
 
-			$order_ids                   = $wpdb->get_col(
+			// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Inputs are prepared.
+			$order_ids = $wpdb->get_col(
 				$wpdb->prepare(
-					"SELECT ID FROM $wpdb->posts WHERE post_type = 'shop_order' AND ID >= %d AND ID <= %d ORDER BY ID ASC LIMIT %d",
-					$order_id_start,
-					$order_id_end,
-					$batch_size
+					"SELECT ID FROM $wpdb->posts WHERE post_type in ( $order_types_pl ) AND ID >= %d AND ID <= %d ORDER BY ID ASC LIMIT %d",
+					array_merge(
+						$order_types,
+						array(
+							$order_id_start,
+							$order_id_end,
+							$batch_size,
+						)
+					)
 				)
 			);
+			// phpcs:enable
 			$batch_start_time            = microtime( true );
 			$failed_ids_in_current_batch = $this->post_to_cot_migrator->verify_migrated_orders( $order_ids );
 			$failed_ids_in_current_batch = $this->verify_meta_data( $order_ids, $failed_ids_in_current_batch );
@@ -399,7 +430,7 @@ class CLIRunner {
 			);
 
 			$order_id_start  = max( $order_ids ) + 1;
-			$remaining_count = $this->get_verify_order_count( $order_id_start, $order_id_end, false );
+			$remaining_count = $this->get_verify_order_count( $order_id_start, $order_id_end, $order_types, false );
 			if ( $remaining_count === $order_count ) {
 				return WP_CLI::error( __( 'Infinite loop detected, aborting. No errors found.', 'woocommerce' ) );
 			}
@@ -464,22 +495,32 @@ class CLIRunner {
 	/**
 	 * Helper method to get count for orders needing verification.
 	 *
-	 * @param int  $order_id_start Order ID to start from.
-	 * @param int  $order_id_end   Order ID to end at.
-	 * @param bool $log Whether to also log an error message.
+	 * @param int   $order_id_start Order ID to start from.
+	 * @param int   $order_id_end Order ID to end at.
+	 * @param array $order_types List of order types to verify.
+	 * @param bool  $log Whether to also log an error message.
 	 *
 	 * @return int Order count.
 	 */
-	private function get_verify_order_count( int $order_id_start, int $order_id_end, $log = true ) : int {
+	private function get_verify_order_count( int $order_id_start, int $order_id_end, array $order_types, bool $log = true ) : int {
 		global $wpdb;
 
+		$order_types_placeholder = implode( ',', array_fill( 0, count( $order_types ), '%s' ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Inputs are prepared.
 		$order_count = (int) $wpdb->get_var(
 			$wpdb->prepare(
-				"SELECT COUNT(*) FROM $wpdb->posts WHERE post_type = 'shop_order' AND ID >= %d AND ID <= %d",
-				$order_id_start,
-				$order_id_end
+				"SELECT COUNT(*) FROM $wpdb->posts WHERE post_type in ($order_types_placeholder) AND ID >= %d AND ID <= %d",
+				array_merge(
+					$order_types,
+					array(
+						$order_id_start,
+						$order_id_end,
+					)
+				)
 			)
 		);
+		// phpcs:enable
 
 		if ( $log ) {
 			WP_CLI::log(


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes the bug the where we were only verifying `shop_order ` orders. This also adds the option to provide a list separated by `,` of order types to verify.

Closes #38317 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. With posts table as authoritative, make sure that posts and HPOS tables are in sync (by running the `wp wc cot sync` command).
2. Switch the sync from WooCommerce > Settings > Advanced > Custom data stores and unchecking the box for keeping orders and post data as sync. Posts should be authoritative data source.
3. Refund any order (so that it creates a shop_order_refund order).
4. Run the verify command like so: `wp wc cot verify_cot_data --order-types=shop_order_refund`. Check that it picks up the refund order as error (expected).

<!-- End testing instructions -->