### PR TITLE
Reload page when toggling new-product-management-experience

### DIFF
--- a/plugins/woocommerce-beta-tester/changelog/fix-reload-when-toggle
+++ b/plugins/woocommerce-beta-tester/changelog/fix-reload-when-toggle
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Reload page when toggling new-product-management-experience
+Reload page when toggling new-product-management-experience and product-block-editor

--- a/plugins/woocommerce-beta-tester/changelog/fix-reload-when-toggle
+++ b/plugins/woocommerce-beta-tester/changelog/fix-reload-when-toggle
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Reload page when toggling new-product-management-experience

--- a/plugins/woocommerce-beta-tester/src/features/index.js
+++ b/plugins/woocommerce-beta-tester/src/features/index.js
@@ -25,7 +25,10 @@ function Features() {
 
 	const afterToggleCallback = {
 		'new-product-management-experience': () => {
-			location.reload();
+			window.location.reload();
+		},
+		'product-block-editor': () => {
+			window.location.reload();
 		},
 	};
 
@@ -51,9 +54,7 @@ function Features() {
 								checked={ features[ feature_name ] }
 								onChange={ async () => {
 									await toggleFeature( feature_name );
-									if ( afterToggleCallback[ feature_name ] ) {
-										afterToggleCallback[ feature_name ]();
-									}
+									afterToggleCallback[ feature_name ]?.();
 								} }
 							/>
 						</li>

--- a/plugins/woocommerce-beta-tester/src/features/index.js
+++ b/plugins/woocommerce-beta-tester/src/features/index.js
@@ -23,6 +23,12 @@ function Features() {
 
 	const sortedFeatureNames = Object.keys( features ).sort();
 
+	const afterToggleCallback = {
+		'new-product-management-experience': () => {
+			location.reload();
+		},
+	};
+
 	return (
 		<div id="wc-admin-test-helper-features">
 			<h2>
@@ -43,8 +49,11 @@ function Features() {
 							<ToggleControl
 								label={ feature_name }
 								checked={ features[ feature_name ] }
-								onChange={ () => {
-									toggleFeature( feature_name );
+								onChange={ async () => {
+									await toggleFeature( feature_name );
+									if ( afterToggleCallback[ feature_name ] ) {
+										afterToggleCallback[ feature_name ]();
+									}
 								} }
 							/>
 						</li>


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

When toggling the new product management experience, we previously had to manually reload the page, otherwise it wouldn't work if you headed directly to Product > Add New. 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Having woocommerce beta tester installed, go to Tools > WCA Test Helper.
2. Go to the Features tab.
3. Toggle new-product-management-experience.
4. Check if the page has reloaded.
5. Go to Products > Add New.
6. Check if the right product manager opened.
7. Repeat the steps 1 to 6 to test for the other product manager.

<!-- End testing instructions -->