### PR TITLE
Limit 'email me when stock reaches' field to numerical only

### DIFF
--- a/packages/js/product-editor/changelog/fix-38244
+++ b/packages/js/product-editor/changelog/fix-38244
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Limit 'email me when stock reaches' field to numerical only#38244

--- a/packages/js/product-editor/src/blocks/inventory-email/index.ts
+++ b/packages/js/product-editor/src/blocks/inventory-email/index.ts
@@ -1,22 +1,29 @@
 /**
+ * External dependencies
+ */
+import { createElement } from '@wordpress/element';
+import { BlockConfiguration } from '@wordpress/blocks';
+
+/**
  * Internal dependencies
  */
-import { initBlock } from '../../utils';
-import metadata from './block.json';
+import { initBlock } from '../../utils/init-blocks';
+import blockConfiguration from './block.json';
 import { Edit } from './edit';
+import { InventoryEmailBlockAttributes } from './types';
 
-const { name } = metadata;
+const { name, ...metadata } =
+	blockConfiguration as BlockConfiguration< InventoryEmailBlockAttributes >;
 
 export { metadata, name };
 
-export const settings = {
+export const settings: Partial<
+	BlockConfiguration< InventoryEmailBlockAttributes >
+> = {
 	example: {},
 	edit: Edit,
 };
 
-export const init = () =>
-	initBlock( {
-		name,
-		metadata: metadata as never,
-		settings,
-	} );
+export function init() {
+	return initBlock( { name, metadata, settings } );
+}

--- a/packages/js/product-editor/src/blocks/inventory-email/types.ts
+++ b/packages/js/product-editor/src/blocks/inventory-email/types.ts
@@ -1,0 +1,8 @@
+/**
+ * External dependencies
+ */
+import { BlockAttributes } from '@wordpress/blocks';
+
+export interface InventoryEmailBlockAttributes extends BlockAttributes {
+	name: string;
+}


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #38244

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Got to `/wp-admin/tools.php?page=woocommerce-admin-test-helper`
2. Under Features tab make sure to enable `product-block-editor`
3. Then visit `/wp-admin/admin.php?page=wc-admin&path=/add-product`
4. Under `Inventory` tab and within `Inventory` section make sure `Track stock quantity for this product` toggle is enabled.
5. When `Advanced` sub section is expanded the field `EMAIL ME WHEN STOCK REACHES` should be shown.
6. Try to type any non positive number you should see a validation message.
7. Pressing arrow up/down should increase/decrease the number within the input field

<!-- End testing instructions -->