### PR TITLE
Fix race condition when rendering product attributes tab empty state

### DIFF
--- a/plugins/woocommerce/changelog/fix-product-add-attributes-race-condition
+++ b/plugins/woocommerce/changelog/fix-product-add-attributes-race-condition
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixes a race condition when adding the first attribute form to the product edit screen.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1141,7 +1141,6 @@ $default-line-height: 18px;
 	}
 	.toolbar-top {
 		.button,
-		.attribute_taxonomy,
 		.select2-container {
 			margin: 1px;
 		}

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -502,11 +502,9 @@ jQuery( function ( $ ) {
 			const $attributesListContainer = $( '#product_attributes .product_attributes' );
 			const product_type = $( 'select#product-type' ).val();
 
-			$attributesListContainer.append( newAttributeListItemHtml );
+			const $attributeListItem = $( newAttributeListItemHtml ).appendTo( $attributesListContainer );
 
-			if ( 'variable' !== product_type ) {
-				$attributesListContainer.find( '.enable_variation' ).hide();
-			}
+			show_and_hide_controls( $attributeListItem );
 
 			$( document.body ).trigger( 'wc-enhanced-select-init' );
 

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -419,7 +419,7 @@ jQuery( function ( $ ) {
 		$( '.product_attributes' ).append( el );
 	} );
 
-	function attribute_row_indexes() {
+	function update_attribute_row_indexes() {
 		$( '.product_attributes .woocommerce_attribute' ).each( function (
 			index,
 			el
@@ -507,7 +507,7 @@ jQuery( function ( $ ) {
 
 			$( document.body ).trigger( 'wc-enhanced-select-init' );
 
-			attribute_row_indexes();
+			update_attribute_row_indexes();
 
 			$attributeListItem.find( 'h3' ).trigger( 'click' );
 
@@ -694,7 +694,7 @@ jQuery( function ( $ ) {
 				} else {
 					$parent.find( 'select, input[type=text]' ).val( '' );
 					$parent.hide();
-					attribute_row_indexes();
+					update_attribute_row_indexes();
 				}
 
 				$parent.remove();
@@ -725,7 +725,7 @@ jQuery( function ( $ ) {
 		},
 		stop: function ( event, ui ) {
 			ui.item.removeAttr( 'style' );
-			attribute_row_indexes();
+			update_attribute_row_indexes();
 		},
 	} );
 

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -246,12 +246,12 @@ jQuery( function ( $ ) {
 				return;
 			}
 
-			var $invisble = $children.filter( function () {
+			var $invisible = $children.filter( function () {
 				return 'none' === $( this ).css( 'display' );
 			} );
 
 			// Hide panel.
-			if ( $invisble.length === $children.length ) {
+			if ( $invisible.length === $children.length ) {
 				var $id = $( this ).prop( 'id' );
 				$( '.product_data_tabs' )
 					.find( 'li a[href="#' + $id + '"]' )

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -489,7 +489,6 @@ jQuery( function ( $ ) {
 
 			$attributesTabContainer.unblock();
 
-			$( document.body ).trigger( 'woocommerce_added_attribute' );
 			jQuery.maybe_disable_save_button();
 		} );
 	}

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -500,7 +500,6 @@ jQuery( function ( $ ) {
 			const newAttributeListItemHtml = await get_new_attribute_list_item_html( numberOfAttributesInList, globalAttributeId );
 
 			const $attributesListContainer = $( '#product_attributes .product_attributes' );
-			const product_type = $( 'select#product-type' ).val();
 
 			const $attributeListItem = $( newAttributeListItemHtml ).appendTo( $attributesListContainer );
 
@@ -510,11 +509,7 @@ jQuery( function ( $ ) {
 
 			attribute_row_indexes();
 
-			$attributesListContainer
-				.find( '.woocommerce_attribute' )
-				.last()
-				.find( 'h3' )
-				.trigger( 'click' );
+			$attributeListItem.find( 'h3' ).trigger( 'click' );
 
 			jQuery.maybe_disable_save_button();
 		} finally {

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -492,6 +492,10 @@ jQuery( function ( $ ) {
 		$attributesTabContainer.unblock();
 	}
 
+	function toggle_expansion_of_attribute_list_item( $attributeListItem ) {
+		$attributeListItem.find( 'h3' ).trigger( 'click' );
+	}
+
 	async function add_attribute_to_list( globalAttributeId ) {
 		try {
 			block_attributes_tab_container();
@@ -509,7 +513,7 @@ jQuery( function ( $ ) {
 
 			update_attribute_row_indexes();
 
-			$attributeListItem.find( 'h3' ).trigger( 'click' );
+			toggle_expansion_of_attribute_list_item( $attributeListItem );
 
 			jQuery.maybe_disable_save_button();
 		} finally {

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -398,7 +398,7 @@ jQuery( function ( $ ) {
 	$( function add_blank_custom_attribute_if_no_attributes() {
 
 		if ( woocommerce_attribute_items.length === 0  ) {
-			$( 'button.add_custom_attribute' ).trigger( 'click' );
+			add_custom_attribute_to_list();
 		}
 	} );
 

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -183,7 +183,7 @@ jQuery( function ( $ ) {
 		}
 	}
 
-	function show_and_hide_panels() {
+	function show_and_hide_controls( context ) {
 		var product_type = $( 'select#product-type' ).val();
 		var is_virtual = $( 'input#_virtual:checked' ).length;
 		var is_downloadable = $( 'input#_downloadable:checked' ).length;
@@ -200,15 +200,15 @@ jQuery( function ( $ ) {
 			show_classes = show_classes + ', .show_if_' + value;
 		} );
 
-		$( hide_classes ).show();
-		$( show_classes ).hide();
+		$( hide_classes, context ).show();
+		$( show_classes, context ).hide();
 
 		// Shows rules.
 		if ( is_downloadable ) {
-			$( '.show_if_downloadable' ).show();
+			$( '.show_if_downloadable', context ).show();
 		}
 		if ( is_virtual ) {
-			$( '.show_if_virtual' ).show();
+			$( '.show_if_virtual', context ).show();
 
 			// If user enables virtual while on shipping tab, switch to general tab.
 			if ( $( '.shipping_options.shipping_tab' ).hasClass( 'active' ) ) {
@@ -216,17 +216,21 @@ jQuery( function ( $ ) {
 			}
 		}
 
-		$( '.show_if_' + product_type ).show();
+		$( '.show_if_' + product_type, context ).show();
 
 		// Hide rules.
 		if ( is_downloadable ) {
-			$( '.hide_if_downloadable' ).hide();
+			$( '.hide_if_downloadable', context ).hide();
 		}
 		if ( is_virtual ) {
-			$( '.hide_if_virtual' ).hide();
+			$( '.hide_if_virtual', context ).hide();
 		}
 
-		$( '.hide_if_' + product_type ).hide();
+		$( '.hide_if_' + product_type, context ).hide();
+	}
+
+	function show_and_hide_panels() {
+		show_and_hide_controls();
 
 		$( 'input#_manage_stock' ).trigger( 'change' );
 

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -467,8 +467,7 @@ jQuery( function ( $ ) {
 		} );
 	}
 
-	async function add_attribute_to_list( globalAttributeId ) {
-		const numberOfAttributesInList = $( '.product_attributes .woocommerce_attribute' ).length;
+	function block_attributes_tab_container() {
 		const $attributesTabContainer = $( '#product_attributes' );
 
 		$attributesTabContainer.block( {
@@ -478,31 +477,43 @@ jQuery( function ( $ ) {
 				opacity: 0.6,
 			},
 		} );
+	}
 
-		const newAttributeListItemHtml = await get_new_attribute_list_item_html( numberOfAttributesInList, globalAttributeId );
-
-		const $attributesListContainer = $attributesTabContainer.find( '.product_attributes' );
-		const product_type = $( 'select#product-type' ).val();
-
-		$attributesListContainer.append( newAttributeListItemHtml );
-
-		if ( 'variable' !== product_type ) {
-			$attributesListContainer.find( '.enable_variation' ).hide();
-		}
-
-		$( document.body ).trigger( 'wc-enhanced-select-init' );
-
-		attribute_row_indexes();
-
-		$attributesListContainer
-			.find( '.woocommerce_attribute' )
-			.last()
-			.find( 'h3' )
-			.trigger( 'click' );
-
+	function unblock_attributes_tab_container() {
+		const $attributesTabContainer = $( '#product_attributes' );
 		$attributesTabContainer.unblock();
+	}
 
-		jQuery.maybe_disable_save_button();
+	async function add_attribute_to_list( globalAttributeId ) {
+		try {
+			block_attributes_tab_container();
+
+			const numberOfAttributesInList = $( '.product_attributes .woocommerce_attribute' ).length;
+			const newAttributeListItemHtml = await get_new_attribute_list_item_html( numberOfAttributesInList, globalAttributeId );
+
+			const $attributesListContainer = $( '#product_attributes .product_attributes' );
+			const product_type = $( 'select#product-type' ).val();
+
+			$attributesListContainer.append( newAttributeListItemHtml );
+
+			if ( 'variable' !== product_type ) {
+				$attributesListContainer.find( '.enable_variation' ).hide();
+			}
+
+			$( document.body ).trigger( 'wc-enhanced-select-init' );
+
+			attribute_row_indexes();
+
+			$attributesListContainer
+				.find( '.woocommerce_attribute' )
+				.last()
+				.find( 'h3' )
+				.trigger( 'click' );
+
+			jQuery.maybe_disable_save_button();
+		} finally {
+			unblock_attributes_tab_container();
+		}
 	}
 
 	function add_global_attribute_to_list( globalAttributeId ) {

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -491,13 +491,6 @@ jQuery( function ( $ ) {
 			$( document.body ).trigger( 'woocommerce_added_attribute' );
 			jQuery.maybe_disable_save_button();
 		} );
-
-		if ( attribute ) {
-			$( 'select.attribute_taxonomy' )
-				.find( 'option[value="' + attribute + '"]' )
-				.attr( 'disabled', 'disabled' );
-			$( 'select.attribute_taxonomy' ).val( '' );
-		}
 	}
 
 	function add_if_not_exists( arr, item ) {

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -520,6 +520,9 @@ jQuery( function ( $ ) {
 			toggle_expansion_of_attribute_list_item( $attributeListItem );
 
 			jQuery.maybe_disable_save_button();
+		} catch ( error ) {
+			alert( woocommerce_admin_meta_boxes.i18n_add_attribute_error_notice );
+			throw error;
 		} finally {
 			unblock_attributes_tab_container();
 		}

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -447,14 +447,12 @@ jQuery( function ( $ ) {
 		selectedAttributes
 	);
 
-	function add_attribute( element, attribute ) {
+	function add_attribute_to_list( globalAttributeId ) {
 		var size = $( '.product_attributes .woocommerce_attribute' ).length;
-		var $wrapper = $( element ).closest( '#product_attributes' );
-		var $attributes = $wrapper.find( '.product_attributes' );
-		var product_type = $( 'select#product-type' ).val();
+		var $wrapper = $( '#product_attributes' );
 		var data = {
 			action: 'woocommerce_add_attribute',
-			taxonomy: attribute,
+			taxonomy: globalAttributeId ?? '',
 			i: size,
 			security: woocommerce_admin_meta_boxes.add_attribute_nonce,
 		};
@@ -470,6 +468,9 @@ jQuery( function ( $ ) {
 		$.post( woocommerce_admin_meta_boxes.ajax_url, data, function (
 			response
 		) {
+			var $attributes = $wrapper.find( '.product_attributes' );
+			var product_type = $( 'select#product-type' ).val();
+
 			$attributes.append( response );
 
 			if ( 'variable' !== product_type ) {
@@ -491,6 +492,14 @@ jQuery( function ( $ ) {
 			$( document.body ).trigger( 'woocommerce_added_attribute' );
 			jQuery.maybe_disable_save_button();
 		} );
+	}
+
+	function add_global_attribute_to_list( globalAttributeId ) {
+		add_attribute_to_list( globalAttributeId );
+	}
+
+	function add_custom_attribute_to_list() {
+		add_attribute_to_list();
 	}
 
 	function add_if_not_exists( arr, item ) {
@@ -522,7 +531,7 @@ jQuery( function ( $ ) {
 		if ( attributeId ) {
 			remove_blank_custom_attribute_if_no_other_attributes();
 
-			add_attribute( this, attributeId );
+			add_global_attribute_to_list( attributeId );
 
 			selectedAttributes = add_if_not_exists( selectedAttributes, attributeId );
 			disable_in_attribute_search( selectedAttributes );
@@ -537,7 +546,7 @@ jQuery( function ( $ ) {
 	// Add rows.
 
 	$( 'button.add_custom_attribute' ).on( 'click', function () {
-		add_attribute( this, '' );
+		add_custom_attribute_to_list();
 
 		return false;
 	} );

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -468,8 +468,8 @@ jQuery( function ( $ ) {
 	}
 
 	async function add_attribute_to_list( globalAttributeId ) {
-		var numberOfAttributesInList = $( '.product_attributes .woocommerce_attribute' ).length;
-		var $attributesTabContainer = $( '#product_attributes' );
+		const numberOfAttributesInList = $( '.product_attributes .woocommerce_attribute' ).length;
+		const $attributesTabContainer = $( '#product_attributes' );
 
 		$attributesTabContainer.block( {
 			message: null,
@@ -481,20 +481,20 @@ jQuery( function ( $ ) {
 
 		const newAttributeListItemHtml = await get_new_attribute_list_item_html( numberOfAttributesInList, globalAttributeId );
 
-		var $attributesList = $attributesTabContainer.find( '.product_attributes' );
-		var product_type = $( 'select#product-type' ).val();
+		const $attributesListContainer = $attributesTabContainer.find( '.product_attributes' );
+		const product_type = $( 'select#product-type' ).val();
 
-		$attributesList.append( newAttributeListItemHtml );
+		$attributesListContainer.append( newAttributeListItemHtml );
 
 		if ( 'variable' !== product_type ) {
-			$attributesList.find( '.enable_variation' ).hide();
+			$attributesListContainer.find( '.enable_variation' ).hide();
 		}
 
 		$( document.body ).trigger( 'wc-enhanced-select-init' );
 
 		attribute_row_indexes();
 
-		$attributesList
+		$attributesListContainer
 			.find( '.woocommerce_attribute' )
 			.last()
 			.find( 'h3' )

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -448,12 +448,12 @@ jQuery( function ( $ ) {
 	);
 
 	function add_attribute_to_list( globalAttributeId ) {
-		var size = $( '.product_attributes .woocommerce_attribute' ).length;
+		var numberOfAttributesInList = $( '.product_attributes .woocommerce_attribute' ).length;
 		var $wrapper = $( '#product_attributes' );
 		var data = {
 			action: 'woocommerce_add_attribute',
 			taxonomy: globalAttributeId ?? '',
-			i: size,
+			i: numberOfAttributesInList,
 			security: woocommerce_admin_meta_boxes.add_attribute_nonce,
 		};
 

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -151,8 +151,17 @@ jQuery( function ( $ ) {
 		} )
 		.trigger( 'change' );
 
-	$( 'input#_downloadable, input#_virtual' ).on( 'change', function () {
+	$( 'input#_downloadable' ).on( 'change', function () {
 		show_and_hide_panels();
+	} );
+
+	$( 'input#_virtual' ).on( 'change', function () {
+		show_and_hide_panels();
+
+		// If user enables virtual while on shipping tab, switch to general tab.
+		if ( $( this ).is( ':checked' ) && $( '.shipping_options.shipping_tab' ).hasClass( 'active' ) ) {
+			$( '.general_options.general_tab > a' ).trigger( 'click' );
+		}
 	} );
 
 	function change_product_type_tip( content ) {
@@ -209,11 +218,6 @@ jQuery( function ( $ ) {
 		}
 		if ( is_virtual ) {
 			$( '.show_if_virtual', context ).show();
-
-			// If user enables virtual while on shipping tab, switch to general tab.
-			if ( $( '.shipping_options.shipping_tab' ).hasClass( 'active' ) ) {
-				$( '.general_options.general_tab > a' ).trigger( 'click' );
-			}
 		}
 
 		$( '.show_if_' + product_type, context ).show();

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -449,7 +449,7 @@ jQuery( function ( $ ) {
 
 	function add_attribute_to_list( globalAttributeId ) {
 		var numberOfAttributesInList = $( '.product_attributes .woocommerce_attribute' ).length;
-		var $wrapper = $( '#product_attributes' );
+		var $attributesTabContainer = $( '#product_attributes' );
 		var data = {
 			action: 'woocommerce_add_attribute',
 			taxonomy: globalAttributeId ?? '',
@@ -457,7 +457,7 @@ jQuery( function ( $ ) {
 			security: woocommerce_admin_meta_boxes.add_attribute_nonce,
 		};
 
-		$wrapper.block( {
+		$attributesTabContainer.block( {
 			message: null,
 			overlayCSS: {
 				background: '#fff',
@@ -466,28 +466,28 @@ jQuery( function ( $ ) {
 		} );
 
 		$.post( woocommerce_admin_meta_boxes.ajax_url, data, function (
-			response
+			newAttributeListItem
 		) {
-			var $attributes = $wrapper.find( '.product_attributes' );
+			var $attributesList = $attributesTabContainer.find( '.product_attributes' );
 			var product_type = $( 'select#product-type' ).val();
 
-			$attributes.append( response );
+			$attributesList.append( newAttributeListItem );
 
 			if ( 'variable' !== product_type ) {
-				$attributes.find( '.enable_variation' ).hide();
+				$attributesList.find( '.enable_variation' ).hide();
 			}
 
 			$( document.body ).trigger( 'wc-enhanced-select-init' );
 
 			attribute_row_indexes();
 
-			$attributes
+			$attributesList
 				.find( '.woocommerce_attribute' )
 				.last()
 				.find( 'h3' )
 				.trigger( 'click' );
 
-			$wrapper.unblock();
+			$attributesTabContainer.unblock();
 
 			$( document.body ).trigger( 'woocommerce_added_attribute' );
 			jQuery.maybe_disable_save_button();

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -496,6 +496,10 @@ jQuery( function ( $ ) {
 		$attributeListItem.find( 'h3' ).trigger( 'click' );
 	}
 
+	function init_select_controls() {
+		$( document.body ).trigger( 'wc-enhanced-select-init' );
+	}
+
 	async function add_attribute_to_list( globalAttributeId ) {
 		try {
 			block_attributes_tab_container();
@@ -509,7 +513,7 @@ jQuery( function ( $ ) {
 
 			show_and_hide_controls( $attributeListItem );
 
-			$( document.body ).trigger( 'wc-enhanced-select-init' );
+			init_select_controls(); // make sure any new select controls in the new list item are initialized
 
 			update_attribute_row_indexes();
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -434,6 +434,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					/* translators: %1$s: maximum file size */
 					'i18n_product_image_tip'             => sprintf( __( 'For best results, upload JPEG or PNG files that are 1000 by 1000 pixels or larger. Maximum upload file size: %1$s.', 'woocommerce' ) , size_format( wp_max_upload_size() ) ),
 					'i18n_remove_used_attribute_confirmation_message' => __( 'If you remove this attribute, customers will no longer be able to purchase some variations of this product.', 'woocommerce' ),
+					'i18n_add_attribute_error_notice'    => __( 'Adding new attribute failed.', 'woocommerce' ),
 				);
 
 				wp_localize_script( 'wc-admin-meta-boxes', 'woocommerce_admin_meta_boxes', $params );


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes a race condition that could occur when the first (empty) attribute form was automatically added to the attributes tab of the product (the updated empty state from #38126).

Basically, in an environment such as our e2e tests, where the UI interactions occurred very quickly, the new attribute form would be added using a stale value of the product type, resulting in a missing "Used for variations" checkbox. Note that this is very unlikely to be reproducible manually, as humans just aren't that fast when interacting with the UI.

Flow in code that caused issue:
- Product edit screen loads
- Ajax call to get new attribute form (empty state) was automatically made, with product type `Simple`
- Product type was switched to `Variable` by user
- Controls were shown/hidden based on updated product type
- Ajax call to get new attribute form returned, and used the stale product type `Simple` to determine if "Used for variations" on the newly added attribute should be shown (thus hiding it)

The implementation has been updated to check the product type immediately before showing/hiding control on the new attribute form.

In addition, a number of refactors have been made to make this area of the code simpler and more maintainable, to lessen the chance of similar issues occurring in the future when further changes to the code are made.

**There are no visible UI changes introduced in this PR, outside of the fixing of the visibility of the "Used for variations" checkbox.**

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

As this bug was introduced in #38126, the same test instructions from there should be followed (see below).

In addition, general smoke testing surrounding the following should be done:
- Changing product type, and making sure controls/tabs show/hide appropriately

#### Common instructions

- To create a new product, go to `Products` > `Add New`
- To edit an existing product, go to `Products` > `All Products`
- To add or remove global attributes, go to `Products` > `Attributes`
- To save attributes, click `Save attributes` button on the `Attributes` tab
- To save a product, click `Publish` (or `Update`, if an existing product)
- To see Tracks events
    - `Tools` > `WCA Test Helper` > `Tools` > `Enable wc-admin Tracking` 
    - Filter by `recordevent` in the browser dev console

#### No global attributes in system

1. Remove all global attributes from the system
2. Create a new product
3. Go to the `Attributes` tab
4. Verify that the empty attribute form is shown
5. Fill out the attribute and save it
6. Save the product and verify the attributes are correct
7. Reload the product and verify the attributes are correct

#### Global attributes in system, adding a new local attribute

1. Add at least one global attribute to the system, and configure terms for it
2. Create a new product
3. Go to the `Attributes` tab
4. Verify that the empty attribute form is shown
5. Fill out the attribute and save it
6. Save the product and verify the attributes are correct
7. Reload the product and verify the attributes are correct

#### Global attributes in system, adding a global attribute

1. Add at least one global attribute to the system, and configure terms for it
2. Create a new product
3. Go to the `Attributes` tab
4. Verify that the empty attribute form is shown
5. Select a global attribute from the `Add existing` dropdown
6. Verify the empty attribute form is removed
7. Verify the same global attribute cannot be selected again from the `Add existing` dropdown
8. Select terms for the global attribute and save it
9. Save the product and verify the attributes are correct
10. Reload the product and verify the attributes are correct

#### Editing an existing product with no attributes

1. Edit one of your existing products no attributes
2. Verify the empty attribute form is automatically shown when the `Attributes` tab is shown

#### Editing an existing product with local attributes

1. Edit one of your existing products with local attributes (either saved from above or before)
2. Verify the empty attribute form is not automatically shown when the `Attributes` tab is shown
3. Verify the attributes are correct

#### Editing an existing product with global attributes

1. Edit one of your existing products with global attributes (either saved from above or before)
2. Verify the empty attribute form is not automatically shown when the `Attributes` tab is shown
3. Verify the attributes are correct

#### Tracks events

1. Clicking on `Add new` should log `wcadmin_product_attributes_buttons` with `action: 'add_new'`
2. Clicking on an existing attribute in `Add existing` should log `wcadmin_product_attributes_buttons` with `action: 'add_existing'`
3. Clicking on `Create value` for a global attribute should log `wcadmin_product_attributes_add_term`

#### Error handling

1. Clicking on `Add new` when offline (or any other server-side error), should show a browser alert message and log the error to the browser console log.

<!-- End testing instructions -->