### PR TITLE
Show correct confirmation message when removing an attribute from a product

### DIFF
--- a/plugins/woocommerce/changelog/fix-remove-product-attribute-message
+++ b/plugins/woocommerce/changelog/fix-remove-product-attribute-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Show correct confirmation message when removing an attribute from a product.

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -646,7 +646,7 @@ jQuery( function ( $ ) {
 			var $parent = $( this ).parent().parent();
 			var confirmMessage = $parent
 				.find( 'input[name^="attribute_variation"]' )
-				.is( ':checked' )
+				.is( ':visible:checked' )
 				? woocommerce_admin_meta_boxes.i18n_remove_used_attribute_confirmation_message
 				: woocommerce_admin_meta_boxes.remove_attribute;
 


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes the confirmation shown when removing an attribute from a product.

Previously, when removing an attribute from a `Simple` product, the confirmation message would make mention of "variations".

#### Before

<img width="460" alt="Screenshot 2023-05-18 at 16 37 53" src="https://github.com/woocommerce/woocommerce/assets/2098816/76910966-13c8-4a5e-8753-6d93c78a787f">

#### After

<img width="460" alt="Screenshot 2023-05-18 at 16 48 13" src="https://github.com/woocommerce/woocommerce/assets/2098816/112ab450-9b59-4c7e-943b-b31edf997658">

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

#### With a `Simple` product

1. Click "Remove" on an attribute on a `Simple` product.
2. Verify the confirmation message does not mention "variations".

#### With a `Variable` product

1. Click "Remove" on an attribute with the "Used for variations" checkbox checked.
2. Verify the confirmation message mentions "variations".
3. Click "Remove" on an attribute with the "Used for variations" checkbox unchecked.
4. Verify the confirmation message does not mention "variations".

<!-- End testing instructions -->