### PR TITLE
Always show product variations empty state with message when there are no "used for variations" attributes

### DIFF
--- a/plugins/woocommerce/changelog/update-variations-empty-state
+++ b/plugins/woocommerce/changelog/update-variations-empty-state
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Always show the product variations empty state with message when there are no "used for variations" attributes on a product.

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -186,14 +186,12 @@ class WC_Meta_Box_Product_Data {
 		global $post, $wpdb, $product_object;
 
 		/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
-		$global_attributes_count        = count( wc_get_attribute_taxonomies() );
-		$variation_attributes           = array_filter( $product_object->get_attributes(), array( __CLASS__, 'filter_variation_attributes' ) );
-		$non_variation_attributes_count = count( array_filter( $product_object->get_attributes(), array( __CLASS__, 'filter_non_variation_attributes' ) ) );
-		$default_attributes             = $product_object->get_default_attributes();
-		$variations_count               = absint( apply_filters( 'woocommerce_admin_meta_boxes_variations_count', $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(ID) FROM $wpdb->posts WHERE post_parent = %d AND post_type = 'product_variation' AND post_status IN ('publish', 'private')", $post->ID ) ), $post->ID ) );
-		$variations_per_page            = absint( apply_filters( 'woocommerce_admin_meta_boxes_variations_per_page', 15 ) );
-		$variations_total_pages         = ceil( $variations_count / $variations_per_page );
-		$modal_title                    = get_bloginfo( 'name' ) . __( ' says', 'woocommerce' );
+		$variation_attributes   = array_filter( $product_object->get_attributes(), array( __CLASS__, 'filter_variation_attributes' ) );
+		$default_attributes     = $product_object->get_default_attributes();
+		$variations_count       = absint( apply_filters( 'woocommerce_admin_meta_boxes_variations_count', $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(ID) FROM $wpdb->posts WHERE post_parent = %d AND post_type = 'product_variation' AND post_status IN ('publish', 'private')", $post->ID ) ), $post->ID ) );
+		$variations_per_page    = absint( apply_filters( 'woocommerce_admin_meta_boxes_variations_per_page', 15 ) );
+		$variations_total_pages = ceil( $variations_count / $variations_per_page );
+		$modal_title            = get_bloginfo( 'name' ) . __( ' says', 'woocommerce' );
 		/* phpcs: enable */
 
 		include __DIR__ . '/views/html-product-data-variations.php';

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-variations.php
@@ -16,7 +16,7 @@ $arrow_img_url          = WC_ADMIN_IMAGES_FOLDER_URL . '/product_data/no-variati
 <div id="variable_product_options" class="panel wc-metaboxes-wrapper hidden">
 	<div id="variable_product_options_inner">
 
-		<?php if ( ! count( $variation_attributes ) && ( ( $global_attributes_count > 0 ) || ( $non_variation_attributes_count > 0 ) ) ) : ?>
+		<?php if ( ! count( $variation_attributes ) ) : ?>
 
 		<div class="add-attributes-container">
 			<div class="add-attributes-message">
@@ -36,27 +36,6 @@ $arrow_img_url          = WC_ADMIN_IMAGES_FOLDER_URL . '/product_data/no-variati
 			</div>
 		</div>
 
-		<?php elseif ( ! count( $variation_attributes ) ) : ?>
-
-		<div id="message" class="inline notice woocommerce-message">
-			<p>
-				<?php echo esc_html_e( 'Offer customers multiple product options, like size and color. Start by creating a new custom attribute and enter available values (they’ll be shown as selectable product options).', 'woocommerce' ); ?> <a target="_blank" href="https://woocommerce.com/document/variable-product/#add-variations"><?php esc_html_e( 'Learn more about creating variations', 'woocommerce' ); ?></a>
-			</p>
-		</div>
-		<div class="wc-metabox">
-			<div class="woocommerce_variation_new_attribute_data wc-metabox-content">
-			<?php
-				$i                    = 0;
-				$is_variations_screen = true;
-				$attribute            = new WC_Product_Attribute();
-				$attribute->set_variation( true );
-				require __DIR__ . '/html-product-attribute-inner.php';
-			?>
-				<div class="toolbar">
-					<button type="button" aria-disabled="true" class="button button-primary create-variations disabled"><?php esc_html_e( 'Create variations', 'woocommerce' ); ?></button>
-				</div>
-			</div>
-		</div>
 		<?php else : ?>
 
 			<div class="toolbar toolbar-variations-defaults">


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR changes the empty state for the product variations tab for a `Variable` product with no "Used for variations" attributes to always show a message

#### Before 

Would show when there were no "Used for variations" attributes on a product and there were global attributes in the system or non-variation attributes on the product.

![Screenshot 2023-05-04 at 13 29 04](https://user-images.githubusercontent.com/1314156/236266741-32042038-dda1-407d-8412-e80e06c330af.png)

#### After

Shows whenever there are no "Used for variations" attributes on a product.

<img width="793" alt="Screenshot 2023-05-19 at 00 21 49" src="https://github.com/woocommerce/woocommerce/assets/2098816/c40e6875-f010-4fc1-a5f0-003c7c769867">

Closes #38120.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

With both global attributes in the system and without....

1. Go to `Products` > `Add New`
2. Change product type to `Variable`
3. Go to `Variations` tab
4. Verify empty state
5. Go to `Attributes` tab
6. Add an attribute, marking as "Used for variations"
7. `Save attributes`
8. Go to `Variations` tab
9. Verify the following is shown

<img width="793" alt="Screenshot 2023-05-19 at 00 26 36" src="https://github.com/woocommerce/woocommerce/assets/2098816/d7b44e9e-2d09-4c2d-9a07-7605ef92f5e7">

<!-- End testing instructions -->