### PR TITLE
Don't show confirmation message when removing a non-variation attribute from a product

### DIFF
--- a/plugins/woocommerce/changelog/update-remove-non-variation-attribute-no-confirm
+++ b/plugins/woocommerce/changelog/update-remove-non-variation-attribute-no-confirm
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Don't show confirmation message when removing a non-variation attribute from a product.

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -680,13 +680,12 @@ jQuery( function ( $ ) {
 		'.product_attributes .remove_row',
 		function () {
 			var $parent = $( this ).parent().parent();
-			var confirmMessage = $parent
-				.find( 'input[name^="attribute_variation"]' )
-				.is( ':visible:checked' )
-				? woocommerce_admin_meta_boxes.i18n_remove_used_attribute_confirmation_message
-				: woocommerce_admin_meta_boxes.remove_attribute;
+			var isUsedForVariations = $parent
+			.find( 'input[name^="attribute_variation"]' )
+			.is( ':visible:checked' )
 
-			if ( window.confirm( confirmMessage ) ) {
+			if ( ! isUsedForVariations
+					|| window.confirm( woocommerce_admin_meta_boxes.i18n_remove_used_attribute_confirmation_message ) ) {
 				if ( $parent.is( '.taxonomy' ) ) {
 					$parent.find( 'select, input[type=text]' ).val( '' );
 					$parent.hide();

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -374,7 +374,6 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					'i18n_delete_refund'                 => __( 'Are you sure you wish to delete this refund? This action cannot be undone.', 'woocommerce' ),
 					'i18n_delete_tax'                    => __( 'Are you sure you wish to delete this tax column? This action cannot be undone.', 'woocommerce' ),
 					'remove_item_meta'                   => __( 'Remove this item meta?', 'woocommerce' ),
-					'remove_attribute'                   => __( 'Remove this attribute?', 'woocommerce' ),
 					'name_label'                         => __( 'Name', 'woocommerce' ),
 					'remove_label'                       => __( 'Remove', 'woocommerce' ),
 					'click_to_toggle'                    => __( 'Click to toggle', 'woocommerce' ),


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR follows up from #38355 to not shown a confirmation when removing an attribute from a non-variation product.

#### Before

<img width="460" alt="Screenshot 2023-05-18 at 16 48 13" src="https://github.com/woocommerce/woocommerce/assets/2098816/112ab450-9b59-4c7e-943b-b31edf997658">

#### After

No confirmation shown.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

#### With a `Simple` product

1. Click "Remove" on an attribute on a `Simple` product.
2. Verify no confirmation message is shown.

#### With a `Variable` product

1. Click "Remove" on an attribute with the "Used for variations" checkbox checked.
2. Verify the confirmation message mentions "variations".
3. Click "Remove" on an attribute with the "Used for variations" checkbox unchecked.
4. Verify no confirmation message is shown.

<!-- End testing instructions -->