### PR TITLE
Fix spelling errors in Remote Inbox Notifications Transformers documentation

### DIFF
--- a/plugins/woocommerce/changelog/fix-spelling-errors-rin-transformers-readme
+++ b/plugins/woocommerce/changelog/fix-spelling-errors-rin-transformers-readme
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Fix spelling errors in Remote Inbox Notifications Transformers documentation.

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/Transformers/README.md
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/Transformers/README.md
@@ -82,7 +82,7 @@ Use `array_column` to extract `array("media", "software")` then choose the first
         }
     },
     {
-    	"use": "dot_noation",
+    	"use": "dot_notation",
     	"arguments": {
     		"key": "0"
     	}
@@ -114,7 +114,7 @@ Flattens a nested array.
 
 #### Example:
 
-Given the follwoing data
+Given the following data
 
 ```php
 array(
@@ -167,7 +167,7 @@ PHP's built-in `array_keys` to return keys from an array. For more information a
 
 #### Example:
 
-Given the follwing data
+Given the following data
 
 ```php
 array(
@@ -241,7 +241,7 @@ PHP's built-in array_values to return values from an array. For more information
 
 #### Example:
 
-Given the follwoing data
+Given the following data
 
 ```php
 array (
@@ -286,7 +286,7 @@ Uses dot notation to select a value in an array. Dot notation lets you access an
 
 
 
-Given the follwoing data
+Given the following data
 
 ```php
 array(
@@ -343,7 +343,7 @@ PHP's built-in count to return the number of values from a countable, such as an
 
 #### Example:
 
-Given the follwing list of usernames
+Given the following list of usernames
 
 ```php
 array(


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes spelling errors in the Remote Inbox Notifications Transformers README.md.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. View README.md (note: you can use GitHub's "Display the rich diff" to visually view the changes).
2. Verify spelling errors were fixed.

<!-- End testing instructions -->