### PR TITLE
 Make option API fail when using a disallowed option name in non-produciton environments

### DIFF
--- a/plugins/woocommerce/changelog/update-options-api
+++ b/plugins/woocommerce/changelog/update-options-api
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Make option API fail when using a disallowed option name in non-produciton environments

--- a/plugins/woocommerce/src/Admin/API/Options.php
+++ b/plugins/woocommerce/src/Admin/API/Options.php
@@ -77,6 +77,14 @@ class Options extends \WC_REST_Data_Controller {
 
 		foreach ( $params as $option ) {
 			if ( ! $this->user_has_permission( $option, $request ) ) {
+				if ( 'production' !== wp_get_environment_type() ) {
+					return new \WP_Error(
+						'woocommerce_rest_cannot_view',
+						__( 'Sorry, you cannot view these options, please remember to update the option permissions in Options API to allow viewing these options in non-production environments.', 'woocommerce' ),
+						array( 'status' => rest_authorization_required_code() )
+					);
+				}
+
 				return new \WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot view these options.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 			}
 		}
@@ -97,6 +105,11 @@ class Options extends \WC_REST_Data_Controller {
 
 		if ( isset( $permissions[ $option ] ) ) {
 			return $permissions[ $option ];
+		}
+
+		// Don't allow to update options in non-production environments if the option is not whitelisted. This is to force developers to update the option permissions when adding new options.
+		if ( 'production' !== wp_get_environment_type() ) {
+			return false;
 		}
 
 		wc_deprecated_function( 'Automattic\WooCommerce\Admin\API\Options::' . ( $is_update ? 'update_options' : 'get_options' ), '3.1' );
@@ -191,6 +204,11 @@ class Options extends \WC_REST_Data_Controller {
 			'woocommerce_product_tour_modal_hidden',
 			'woocommerce_revenue_report_date_tour_shown',
 			'woocommerce_date_type',
+			'date_format',
+			'time_format',
+			// WC Test helper options.
+			'wc-admin-test-helper-rest-api-filters',
+			'wc_admin_helper_feature_values',
 		);
 
 		$theme_permissions = array(

--- a/plugins/woocommerce/src/Admin/API/Options.php
+++ b/plugins/woocommerce/src/Admin/API/Options.php
@@ -112,7 +112,7 @@ class Options extends \WC_REST_Data_Controller {
 			return false;
 		}
 
-		wc_deprecated_function( 'Automattic\WooCommerce\Admin\API\Options::' . ( $is_update ? 'update_options' : 'get_options' ), '3.1' );
+		wc_deprecated_function( 'Automattic\WooCommerce\Admin\API\Options::' . ( $is_update ? 'update_options' : 'get_options' ), '6.3' );
 		return current_user_can( 'manage_options' );
 	}
 
@@ -146,7 +146,7 @@ class Options extends \WC_REST_Data_Controller {
 	 */
 	public function get_option_permissions( $request ) {
 		$permissions = self::get_default_option_permissions();
-		return apply_filters_deprecated( 'woocommerce_rest_api_option_permissions', array( $permissions, $request ), '3.1.0' );
+		return apply_filters_deprecated( 'woocommerce_rest_api_option_permissions', array( $permissions, $request ), '6.3.0' );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:


pdibGW-1Yx-p2#comment-1399

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR updates the option API to make it return a `WP_Error` when using a disallowed option name in non-produciton environments. This is to force developers to update the option permissions when adding new options to prevent https://github.com/woocommerce/woocommerce/issues/32863 from happing again.

I also updated the option allowlist for WC Test helper options and new add product pages.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set your `WP_ENVIRONMENT_TYPES` in wp-config to a non-production environment.
2. Make a request to GET `/wp-json/wc-admin/options?options=woocommerce_shop_page_id`
3. The response should be 403 with a  message `Sorry, you cannot view these options, please remember to update the option permissions in Options API to allow viewing these options in non-production environments.`

<!-- End testing instructions -->