### PR TITLE
List price gets reset on blur when error is shown

### DIFF
--- a/packages/js/product-editor/changelog/fix-38221
+++ b/packages/js/product-editor/changelog/fix-38221
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+List price gets reset on blur when error is shown#38221

--- a/packages/js/product-editor/src/blocks/pricing/edit.tsx
+++ b/packages/js/product-editor/src/blocks/pricing/edit.tsx
@@ -2,18 +2,13 @@
  * External dependencies
  */
 import { Link } from '@woocommerce/components';
-import { CurrencyContext } from '@woocommerce/currency';
 import { getNewPath } from '@woocommerce/navigation';
 import { recordEvent } from '@woocommerce/tracks';
 import { useBlockProps } from '@wordpress/block-editor';
 import { BlockEditProps } from '@wordpress/blocks';
 import { useInstanceId } from '@wordpress/compose';
 import { useEntityProp } from '@wordpress/core-data';
-import {
-	createElement,
-	useContext,
-	createInterpolateElement,
-} from '@wordpress/element';
+import { createElement, createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import {
 	BaseControl,
@@ -25,7 +20,6 @@ import {
  * Internal dependencies
  */
 import { useCurrencyInputProps } from '../../hooks/use-currency-input-props';
-import { formatCurrencyDisplayValue } from '../../utils';
 import { PricingBlockAttributes } from './types';
 
 export function Edit( {
@@ -38,12 +32,9 @@ export function Edit( {
 		'product',
 		name
 	);
-	const context = useContext( CurrencyContext );
-	const { getCurrencyConfig, formatAmount } = context;
-	const currencyConfig = getCurrencyConfig();
 	const inputProps = useCurrencyInputProps( {
 		value: price,
-		setValue: setPrice,
+		onChange: setPrice,
 	} );
 
 	const interpolatedHelp = help
@@ -71,13 +62,7 @@ export function Edit( {
 					{ ...inputProps }
 					id={ priceId }
 					name={ name }
-					onChange={ setPrice }
 					label={ label || __( 'Price', 'woocommerce' ) }
-					value={ formatCurrencyDisplayValue(
-						String( price ),
-						currencyConfig,
-						formatAmount
-					) }
 				/>
 			</BaseControl>
 		</div>

--- a/packages/js/product-editor/src/blocks/regular-price/edit.tsx
+++ b/packages/js/product-editor/src/blocks/regular-price/edit.tsx
@@ -3,7 +3,6 @@
  */
 import classNames from 'classnames';
 import { Link } from '@woocommerce/components';
-import { CurrencyContext } from '@woocommerce/currency';
 import { Product } from '@woocommerce/data';
 import { getNewPath } from '@woocommerce/navigation';
 import { recordEvent } from '@woocommerce/tracks';
@@ -11,11 +10,7 @@ import { useBlockProps } from '@wordpress/block-editor';
 import { BlockEditProps } from '@wordpress/blocks';
 import { useInstanceId } from '@wordpress/compose';
 import { useEntityProp } from '@wordpress/core-data';
-import {
-	createElement,
-	useContext,
-	createInterpolateElement,
-} from '@wordpress/element';
+import { createElement, createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import {
 	BaseControl,
@@ -26,10 +21,9 @@ import {
 /**
  * Internal dependencies
  */
-import { useCurrencyInputProps } from '../../hooks/use-currency-input-props';
-import { formatCurrencyDisplayValue } from '../../utils';
-import { SalePriceBlockAttributes } from './types';
 import { useValidation } from '../../contexts/validation-context';
+import { useCurrencyInputProps } from '../../hooks/use-currency-input-props';
+import { SalePriceBlockAttributes } from './types';
 
 export function Edit( {
 	attributes,
@@ -47,12 +41,9 @@ export function Edit( {
 		'product',
 		'sale_price'
 	);
-	const context = useContext( CurrencyContext );
-	const { getCurrencyConfig, formatAmount } = context;
-	const currencyConfig = getCurrencyConfig();
 	const inputProps = useCurrencyInputProps( {
 		value: regularPrice,
-		setValue: setRegularPrice,
+		onChange: setRegularPrice,
 	} );
 
 	const interpolatedHelp = help
@@ -121,12 +112,6 @@ export function Edit( {
 					name={ 'regular_price' }
 					ref={ regularPriceRef }
 					label={ label }
-					value={ formatCurrencyDisplayValue(
-						String( regularPrice ),
-						currencyConfig,
-						formatAmount
-					) }
-					onChange={ setRegularPrice }
 					onBlur={ validateRegularPrice }
 				/>
 			</BaseControl>

--- a/packages/js/product-editor/src/blocks/sale-price/edit.tsx
+++ b/packages/js/product-editor/src/blocks/sale-price/edit.tsx
@@ -2,13 +2,12 @@
  * External dependencies
  */
 import classNames from 'classnames';
-import { CurrencyContext } from '@woocommerce/currency';
 import { Product } from '@woocommerce/data';
 import { useBlockProps } from '@wordpress/block-editor';
 import { BlockEditProps } from '@wordpress/blocks';
 import { useInstanceId } from '@wordpress/compose';
 import { useEntityProp } from '@wordpress/core-data';
-import { createElement, useContext } from '@wordpress/element';
+import { createElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import {
 	BaseControl,
@@ -19,10 +18,9 @@ import {
 /**
  * Internal dependencies
  */
-import { useCurrencyInputProps } from '../../hooks/use-currency-input-props';
-import { formatCurrencyDisplayValue } from '../../utils';
-import { SalePriceBlockAttributes } from './types';
 import { useValidation } from '../../contexts/validation-context';
+import { useCurrencyInputProps } from '../../hooks/use-currency-input-props';
+import { SalePriceBlockAttributes } from './types';
 
 export function Edit( {
 	attributes,
@@ -40,12 +38,9 @@ export function Edit( {
 		'product',
 		'sale_price'
 	);
-	const context = useContext( CurrencyContext );
-	const { getCurrencyConfig, formatAmount } = context;
-	const currencyConfig = getCurrencyConfig();
 	const inputProps = useCurrencyInputProps( {
 		value: salePrice,
-		setValue: setSalePrice,
+		onChange: setSalePrice,
 	} );
 
 	const salePriceId = useInstanceId(
@@ -98,13 +93,7 @@ export function Edit( {
 					id={ salePriceId }
 					name={ 'sale_price' }
 					ref={ salePriceRef }
-					onChange={ setSalePrice }
 					label={ label }
-					value={ formatCurrencyDisplayValue(
-						String( salePrice ),
-						currencyConfig,
-						formatAmount
-					) }
 					onBlur={ validateSalePrice }
 				/>
 			</BaseControl>

--- a/packages/js/product-editor/src/hooks/use-currency-input-props.ts
+++ b/packages/js/product-editor/src/hooks/use-currency-input-props.ts
@@ -8,37 +8,45 @@ import { useContext } from '@wordpress/element';
  * Internal dependencies
  */
 import { useProductHelper } from './use-product-helper';
+import { formatCurrencyDisplayValue } from '../utils';
 
 export type CurrencyInputProps = {
 	prefix: string;
 	className: string;
+	value: string;
 	sanitize: ( value: string | number ) => string;
+	onChange: ( value: string ) => void;
 	onFocus: ( event: React.FocusEvent< HTMLInputElement > ) => void;
 	onKeyUp: ( event: React.KeyboardEvent< HTMLInputElement > ) => void;
 };
 
 type Props = {
 	value: string;
-	setValue: ( value: string ) => void;
+	onChange: ( value: string ) => void;
 	onFocus?: ( event: React.FocusEvent< HTMLInputElement > ) => void;
 	onKeyUp?: ( event: React.KeyboardEvent< HTMLInputElement > ) => void;
 };
 
 export const useCurrencyInputProps = ( {
 	value,
-	setValue,
+	onChange,
 	onFocus,
 	onKeyUp,
 }: Props ) => {
 	const { sanitizePrice } = useProductHelper();
 
 	const context = useContext( CurrencyContext );
-	const { getCurrencyConfig } = context;
+	const { getCurrencyConfig, formatAmount } = context;
 	const currencyConfig = getCurrencyConfig();
 
 	const currencyInputProps: CurrencyInputProps = {
 		prefix: currencyConfig.symbol,
-		className: 'half-width-field components-currency-control',
+		className: 'components-currency-control',
+		value: formatCurrencyDisplayValue(
+			String( value ),
+			currencyConfig,
+			formatAmount
+		),
 		sanitize: ( val: string | number ) => {
 			return sanitizePrice( String( val ) );
 		},
@@ -63,13 +71,19 @@ export const useCurrencyInputProps = ( {
 			const amount = Number.parseFloat( sanitizePrice( value || '0' ) );
 			const step = Number( event.currentTarget.step || '1' );
 			if ( event.code === 'ArrowUp' ) {
-				setValue( String( amount + step ) );
+				onChange( String( amount + step ) );
 			}
 			if ( event.code === 'ArrowDown' ) {
-				setValue( String( amount - step ) );
+				onChange( String( amount - step ) );
 			}
 			if ( onKeyUp ) {
 				onKeyUp( event );
+			}
+		},
+		onChange( value: string ) {
+			const sanitizeValue = sanitizePrice( value || '0' );
+			if ( onChange ) {
+				onChange( sanitizeValue );
 			}
 		},
 	};

--- a/packages/js/product-editor/src/hooks/use-currency-input-props.ts
+++ b/packages/js/product-editor/src/hooks/use-currency-input-props.ts
@@ -80,8 +80,8 @@ export const useCurrencyInputProps = ( {
 				onKeyUp( event );
 			}
 		},
-		onChange( value: string ) {
-			const sanitizeValue = sanitizePrice( value || '0' );
+		onChange( newValue: string ) {
+			const sanitizeValue = sanitizePrice( newValue || '0' );
 			if ( onChange ) {
 				onChange( sanitizeValue );
 			}


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #38221

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Got to `/wp-admin/tools.php?page=woocommerce-admin-test-helper`
2. Under Features tab make sure to enable `product-block-editor`
3. Then visit `/wp-admin/admin.php?page=wc-admin&path=/add-product`
4. Under `General` and `Pricing` sections the `List price` and `Sale price` should not have the problem described in #38221

<!-- End testing instructions -->
