### PR TITLE
Check for unsaved changes before leaving product editor

### DIFF
--- a/packages/js/product-editor/changelog/add-38253
+++ b/packages/js/product-editor/changelog/add-38253
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Check for unsaved changes before leaving product editor

--- a/packages/js/product-editor/src/blocks/schedule-sale/edit.tsx
+++ b/packages/js/product-editor/src/blocks/schedule-sale/edit.tsx
@@ -27,7 +27,7 @@ export function Edit( {
 	clientId,
 }: BlockEditProps< ScheduleSalePricingBlockAttributes > ) {
 	const blockProps = useBlockProps();
-	const { edits } = useProductEdits();
+	const { hasEdit } = useProductEdits();
 
 	const dateTimeFormat = getSettings().formats.datetime;
 
@@ -71,10 +71,7 @@ export function Edit( {
 	// Hide and clean date fields if the user manually changes
 	// the sale price to zero or less.
 	useEffect( () => {
-		if (
-			edits.hasOwnProperty( 'sale_price' ) &&
-			! isSalePriceGreaterThanZero
-		) {
+		if ( hasEdit( 'sale_price' ) && ! isSalePriceGreaterThanZero ) {
 			setShowScheduleSale( false );
 			setDateOnSaleFromGmt( '' );
 			setDateOnSaleToGmt( '' );

--- a/packages/js/product-editor/src/blocks/schedule-sale/edit.tsx
+++ b/packages/js/product-editor/src/blocks/schedule-sale/edit.tsx
@@ -20,12 +20,14 @@ import { getSettings } from '@wordpress/date';
  * Internal dependencies
  */
 import { ScheduleSalePricingBlockAttributes } from './types';
+import { useProductEdits } from '../../hooks/use-product-edits';
 import { useValidation } from '../../contexts/validation-context';
 
 export function Edit( {
 	clientId,
 }: BlockEditProps< ScheduleSalePricingBlockAttributes > ) {
 	const blockProps = useBlockProps();
+	const { edits } = useProductEdits();
 
 	const dateTimeFormat = getSettings().formats.datetime;
 
@@ -66,10 +68,13 @@ export function Edit( {
 		}
 	}
 
-	// Hide and clean date fields if the user manually change
+	// Hide and clean date fields if the user manually changes
 	// the sale price to zero or less.
 	useEffect( () => {
-		if ( ! isSalePriceGreaterThanZero ) {
+		if (
+			edits.hasOwnProperty( 'sale_price' ) &&
+			! isSalePriceGreaterThanZero
+		) {
 			setShowScheduleSale( false );
 			setDateOnSaleFromGmt( '' );
 			setDateOnSaleToGmt( '' );

--- a/packages/js/product-editor/src/components/block-editor/block-editor.tsx
+++ b/packages/js/product-editor/src/components/block-editor/block-editor.tsx
@@ -31,6 +31,11 @@ import {
 	useEntityBlockEditor,
 } from '@wordpress/core-data';
 
+/**
+ * Internal dependencies
+ */
+import { useConfirmUnsavedProductChanges } from '../../hooks/use-confirm-unsaved-product-changes';
+
 type BlockEditorProps = {
 	context: {
 		[ key: string ]: unknown;
@@ -48,6 +53,8 @@ export function BlockEditor( {
 	settings: _settings,
 	product,
 }: BlockEditorProps ) {
+	useConfirmUnsavedProductChanges();
+
 	const canUserCreateMedia = useSelect( ( select: typeof WPSelect ) => {
 		const { canUser } = select( 'core' );
 		return canUser( 'create', 'media', '' ) !== false;

--- a/packages/js/product-editor/src/hooks/use-confirm-unsaved-product-changes.ts
+++ b/packages/js/product-editor/src/hooks/use-confirm-unsaved-product-changes.ts
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { useConfirmUnsavedChanges } from '@woocommerce/navigation';
+import { useEntityProp } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { preventLeavingProductForm } from '../utils/prevent-leaving-product-form';
+import { useProductEdits } from './use-product-edits';
+
+export function useConfirmUnsavedProductChanges() {
+	const [ productId ] = useEntityProp< number >(
+		'postType',
+		'product',
+		'id'
+	);
+	const { hasEdits } = useProductEdits();
+	const { isSaving } = useSelect(
+		( select ) => {
+			const { isSavingEntityRecord } = select( 'core' );
+
+			return {
+				isSaving: isSavingEntityRecord< boolean >(
+					'postType',
+					'product',
+					productId
+				),
+			};
+		},
+		[ productId ]
+	);
+
+	useConfirmUnsavedChanges( hasEdits || isSaving, preventLeavingProductForm );
+}

--- a/packages/js/product-editor/src/hooks/use-product-edits.ts
+++ b/packages/js/product-editor/src/hooks/use-product-edits.ts
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import { useEntityProp } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+
+type EntityEdits = {
+	[ key: string ]: unknown;
+};
+
+// Filter out the "content" and "blocks" properties of the edits since
+// we do not use these properties within the product editor and they
+// will always create false positives.
+function filterProductEdits( edits: EntityEdits ) {
+	delete edits.content;
+	delete edits.blocks;
+	return edits;
+}
+
+export function useProductEdits() {
+	const [ productId ] = useEntityProp< number >(
+		'postType',
+		'product',
+		'id'
+	);
+
+	const { edits } = useSelect(
+		( select ) => {
+			const { getEntityRecordNonTransientEdits } = select( 'core' );
+
+			const _edits = getEntityRecordNonTransientEdits(
+				'postType',
+				'product',
+				productId
+			) as EntityEdits;
+
+			return {
+				edits: filterProductEdits( _edits ),
+			};
+		},
+		[ productId ]
+	);
+
+	return {
+		hasEdits: Object.keys( edits ).length > 0,
+		edits,
+	};
+}

--- a/packages/js/product-editor/src/hooks/use-product-edits.ts
+++ b/packages/js/product-editor/src/hooks/use-product-edits.ts
@@ -41,8 +41,12 @@ export function useProductEdits() {
 		[ productId ]
 	);
 
+	function hasEdit( fieldName: string ) {
+		return edits.hasOwnProperty( fieldName );
+	}
+
 	return {
+		hasEdit,
 		hasEdits: Object.keys( edits ).length > 0,
-		edits,
 	};
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

Checks for unsaved changes before leaving the product editor.

Note that some false positives were shown for making edits based on the entity data store and this PR corrects those:
* We don't count `content` or `blocks` as part of changes since we aren't a typical content editor
* We check for changes to the sale price before resetting sale dates to avoid making edits to these fields
<img width="280" alt="Screen Shot 2023-05-24 at 10 11 56 AM" src="https://github.com/woocommerce/woocommerce/assets/10561050/805b1d8a-e310-41fb-9c9f-c566cc926124">



Closes #38253 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to `/wp-admin/tools.php?page=woocommerce-admin-test-helper`
2. Under Features tab make sure to enable product-block-editor
3. Then visit `/wp-admin/admin.php?page=wc-admin&path=/add-product`
4. Don't make any changes and navigate away from the page
5. Make sure no confirmation for unsaved changes is shown
6. Navigate back to the add product page
7. Make some changes in the editor
8. Navigate away to another page
9. Make sure that the confirmation for unsaved changes is shown
10. Navigate between product tabs and make sure that this does not trigger the unsaved changes confirmation

<!-- End testing instructions -->
