### PR TITLE
Core Profiler - replace install-async with install-activate-async

### DIFF
--- a/plugins/woocommerce/changelog/update-38410-update-install-async-to-activate-plugins
+++ b/plugins/woocommerce/changelog/update-38410-update-install-async-to-activate-plugins
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Renamed install-async to install-activate-async to activate installed plugins

--- a/plugins/woocommerce/src/Admin/API/OnboardingPlugins.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingPlugins.php
@@ -44,11 +44,11 @@ class OnboardingPlugins extends WC_REST_Data_Controller {
 	public function register_routes() {
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/install-activate-async',
+			'/' . $this->rest_base . '/install-and-activate-async',
 			array(
 				array(
 					'methods'             => 'POST',
-					'callback'            => array( $this, 'install_activate_async' ),
+					'callback'            => array( $this, 'install_and_activate_async' ),
 					'permission_callback' => array( $this, 'can_install_and_activate_plugins' ),
 					'args'                => array(
 						'plugins' => array(
@@ -119,7 +119,7 @@ class OnboardingPlugins extends WC_REST_Data_Controller {
 	 *
 	 * @return array
 	 */
-	public function install_activate_async( WP_REST_Request $request ) {
+	public function install_and_activate_async( WP_REST_Request $request ) {
 		$plugins = $request->get_param( 'plugins' );
 		$job_id  = uniqid();
 

--- a/plugins/woocommerce/src/Admin/API/OnboardingPlugins.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingPlugins.php
@@ -44,12 +44,12 @@ class OnboardingPlugins extends WC_REST_Data_Controller {
 	public function register_routes() {
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/install-async',
+			'/' . $this->rest_base . '/install-activate-async',
 			array(
 				array(
 					'methods'             => 'POST',
-					'callback'            => array( $this, 'install_async' ),
-					'permission_callback' => array( $this, 'can_install_plugins' ),
+					'callback'            => array( $this, 'install_activate_async' ),
+					'permission_callback' => array( $this, 'can_install_and_activate_plugins' ),
 					'args'                => array(
 						'plugins' => array(
 							'description'       => 'A list of plugins to install',
@@ -119,7 +119,7 @@ class OnboardingPlugins extends WC_REST_Data_Controller {
 	 *
 	 * @return array
 	 */
-	public function install_async( WP_REST_Request $request ) {
+	public function install_activate_async( WP_REST_Request $request ) {
 		$plugins = $request->get_param( 'plugins' );
 		$job_id  = uniqid();
 

--- a/plugins/woocommerce/src/Admin/API/OnboardingPlugins.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingPlugins.php
@@ -123,7 +123,7 @@ class OnboardingPlugins extends WC_REST_Data_Controller {
 		$plugins = $request->get_param( 'plugins' );
 		$job_id  = uniqid();
 
-		WC()->queue()->add( 'woocommerce_plugins_install_async_callback', array( $plugins, $job_id ) );
+		WC()->queue()->add( 'woocommerce_plugins_install_and_activate_async_callback', array( $plugins, $job_id ) );
 
 		$plugin_status = array();
 		foreach ( $plugins as $plugin ) {
@@ -152,7 +152,7 @@ class OnboardingPlugins extends WC_REST_Data_Controller {
 
 		$actions = WC()->queue()->search(
 			array(
-				'hook'    => 'woocommerce_plugins_install_async_callback',
+				'hook'    => 'woocommerce_plugins_install_and_activate_async_callback',
 				'search'  => $job_id,
 				'orderby' => 'date',
 				'order'   => 'DESC',
@@ -175,7 +175,7 @@ class OnboardingPlugins extends WC_REST_Data_Controller {
 			'status' => $actions[0]['status'],
 		);
 
-		$option = get_option( 'woocommerce_onboarding_plugins_install_async_' . $job_id );
+		$option = get_option( 'woocommerce_onboarding_plugins_install_and_activate_async_' . $job_id );
 		if ( isset( $option['plugins'] ) ) {
 			$response['plugins'] = $option['plugins'];
 		}

--- a/plugins/woocommerce/src/Admin/PluginsHelper.php
+++ b/plugins/woocommerce/src/Admin/PluginsHelper.php
@@ -33,7 +33,7 @@ class PluginsHelper {
 	 */
 	public static function init() {
 		add_action( 'woocommerce_plugins_install_callback', array( __CLASS__, 'install_plugins' ), 10, 2 );
-		add_action( 'woocommerce_plugins_install_async_callback', array( __CLASS__, 'install_plugins_async_callback' ), 10, 2 );
+		add_action( 'woocommerce_plugins_install_and_activate_async_callback', array( __CLASS__, 'install_and_activate_plugins_async_callback' ), 10, 2 );
 		add_action( 'woocommerce_plugins_activate_callback', array( __CLASS__, 'activate_plugins' ), 10, 2 );
 	}
 
@@ -326,8 +326,8 @@ class PluginsHelper {
 	 * @param string $job_id An unique job I.D.
 	 * @return bool
 	 */
-	public function install_plugins_async_callback( array $plugins, string $job_id ) {
-		$option_name = 'woocommerce_onboarding_plugins_install_async_' . $job_id;
+	public static function install_and_activate_plugins_async_callback( array $plugins, string $job_id ) {
+		$option_name = 'woocommerce_onboarding_plugins_install_and_activate_async_' . $job_id;
 		$logger      = new AsyncPluginsInstallLogger( $option_name );
 		self::install_plugins( $plugins, $logger );
 		self::activate_plugins( $plugins, $logger );

--- a/plugins/woocommerce/src/Admin/PluginsHelper.php
+++ b/plugins/woocommerce/src/Admin/PluginsHelper.php
@@ -318,9 +318,9 @@ class PluginsHelper {
 	}
 
 	/**
-	 * Callback regsitered by OnboardingPlugins::install_async.
+	 * Callback regsitered by OnboardingPlugins::install_and_activate_async.
 	 *
-	 * It is used to call install_plugins with a custom logger.
+	 * It is used to call install_plugins and activate_plugins with a custom logger.
 	 *
 	 * @param array  $plugins A list of plugins to install.
 	 * @param string $job_id An unique job I.D.
@@ -330,6 +330,7 @@ class PluginsHelper {
 		$option_name = 'woocommerce_onboarding_plugins_install_async_' . $job_id;
 		$logger      = new AsyncPluginsInstallLogger( $option_name );
 		self::install_plugins( $plugins, $logger );
+		self::activate_plugins( $plugins, $logger );
 		return true;
 	}
 
@@ -358,11 +359,12 @@ class PluginsHelper {
 	/**
 	 * Activate the requested plugins.
 	 *
-	 * @param array $plugins Plugins.
+	 * @param array                     $plugins Plugins.
+	 * @param PluginsInstallLogger|null $logger Logger.
 	 *
 	 * @return WP_Error|array Plugin Status
 	 */
-	public static function activate_plugins( $plugins ) {
+	public static function activate_plugins( $plugins, PluginsInstallLogger $logger = null ) {
 		if ( empty( $plugins ) || ! is_array( $plugins ) ) {
 			return new WP_Error(
 				'woocommerce_plugins_invalid_plugins',
@@ -394,11 +396,13 @@ class PluginsHelper {
 			$path = isset( $plugin_paths[ $slug ] ) ? $plugin_paths[ $slug ] : false;
 
 			if ( ! $path ) {
+				/* translators: %s: plugin slug (example: woocommerce-services) */
+				$message = sprintf( __( 'The requested plugin `%s`. is not yet installed.', 'woocommerce' ), $slug );
 				$errors->add(
 					$plugin,
-					/* translators: %s: plugin slug (example: woocommerce-services) */
-					sprintf( __( 'The requested plugin `%s`. is not yet installed.', 'woocommerce' ), $slug )
+					$message
 				);
+				$logger && $logger->add_error( $plugin, $message );
 				continue;
 			}
 
@@ -414,15 +418,19 @@ class PluginsHelper {
 				 */
 				do_action( 'woocommerce_plugins_activate_error', $slug, $result );
 
+				/* translators: %s: plugin slug (example: woocommerce-services) */
+				$message = sprintf( __( 'The requested plugin `%s` could not be activated.', 'woocommerce' ), $slug );
 				$errors->add(
 					$plugin,
-					/* translators: %s: plugin slug (example: woocommerce-services) */
-					sprintf( __( 'The requested plugin `%s` could not be activated.', 'woocommerce' ), $slug )
+					$message
 				);
+				$logger && $logger->add_error( $plugin, $message );
+
 				continue;
 			}
 
 			$activated_plugins[] = $plugin;
+			$logger && $logger->activated( $plugin );
 		}
 
 		$data = array(

--- a/plugins/woocommerce/src/Admin/PluginsInstallLoggers/AsynPluginsInstallLogger.php
+++ b/plugins/woocommerce/src/Admin/PluginsInstallLoggers/AsynPluginsInstallLogger.php
@@ -101,6 +101,20 @@ class AsyncPluginsInstallLogger implements PluginsInstallLogger {
 	}
 
 	/**
+	 * Change status to activated.
+	 *
+	 * @param string $plugin_name plugin name.
+	 *
+	 * @return void
+	 */
+	public function activated( string $plugin_name ) {
+		$option = $this->get();
+
+		$option['plugins'][ $plugin_name ]['status'] = 'activated';
+		$this->update( $option );
+	}
+
+	/**
 	 * Add an error.
 	 *
 	 * @param string      $plugin_name plugin name.

--- a/plugins/woocommerce/src/Admin/PluginsInstallLoggers/PluginsInstallLogger.php
+++ b/plugins/woocommerce/src/Admin/PluginsInstallLoggers/PluginsInstallLogger.php
@@ -23,6 +23,7 @@ interface PluginsInstallLogger {
 	 * @return mixed
 	 */
 	public function installed( string $plugin_name, int $duration);
+	public function activated( string $plugin_name );
 
 	/**
 	 * Called when an error occurred while installing a plugin.

--- a/plugins/woocommerce/src/Admin/PluginsInstallLoggers/PluginsInstallLogger.php
+++ b/plugins/woocommerce/src/Admin/PluginsInstallLoggers/PluginsInstallLogger.php
@@ -23,6 +23,13 @@ interface PluginsInstallLogger {
 	 * @return mixed
 	 */
 	public function installed( string $plugin_name, int $duration);
+
+	/**
+	 * Called when a plugin activated successfully.
+	 *
+	 * @param string $plugin_name plugin name.
+	 * @return mixed
+	 */
 	public function activated( string $plugin_name );
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Admin/API/OnboardingPluginsTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/API/OnboardingPluginsTest.php
@@ -93,7 +93,7 @@ class OnboardingPluginsTest extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_response_format() {
 		$data = $this->request(
-			'/install-async',
+			'/install-and-activate-async',
 			wp_json_encode(
 				array(
 					'plugins' => array( 'test' ),
@@ -133,7 +133,7 @@ class OnboardingPluginsTest extends WC_REST_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_it_returns_404_with_unknown_job_id() {
-		$request  = new WP_REST_Request( 'GET', self::ENDPOINT . '/scheduled-installs/i-do-not-exist' );
+		$request  = new WP_REST_Request( 'GET', self::ENDPOINT . '/scheduled-installs/646e6a35121601' );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 404, $response->get_status() );
 	}
@@ -145,7 +145,7 @@ class OnboardingPluginsTest extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_permissions() {
 		$this->useUserWithoutPluginsPermission();
-		foreach ( array( '/install-and-activate', '/install-async' ) as $endpoint ) {
+		foreach ( array( '/install-and-activate', '/install-and-activate-async' ) as $endpoint ) {
 			$response = $this->request(
 				$endpoint,
 				wp_json_encode(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #38410 

This PR replaces `install-async` endpoint with `install-and-activate-async` to activate installed plugins.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:



1. Make a request to POST `/wp-json/wc-admin/onboarding/plugins/install-and-activate-async` with the following JSON request

```
{
    "plugins": ["test"]
}
```

2. The response should contain `job_id` field. Copy it.
3. Make a request to GET `/wp-json/wc-admin/onboarding/plugins/scheduled-installs/:job_id`. It should return the following response.

```
{
    "job_id": ":job_id",
    "status": "complete",
    "plugins": {
        "test": {
            "status": "failed",
            "errors": [
                "The requested plugin `test` could not be installed. Plugin API call failed."
            ],
            "install_duration": 0
        }
    }
}
```

4. Repeat steps 1 ~ 3, but with a valid plug-in name this time. When everything goes well, `plugins.:name.status` field value should be `activated`

<!-- End testing instructions -->
