### PR TITLE
add: wccom migrate link in nux

### DIFF
--- a/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -14,6 +14,7 @@ import {
 	FlexItem,
 	CheckboxControl,
 	Spinner,
+	Notice,
 } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { Form, TextControl, SelectControl } from '@woocommerce/components';
@@ -114,6 +115,11 @@ export const prepareExtensionTrackingInstallationData = (
 	return data;
 };
 
+export const isShowWccomMigrationNotice = ( selectedOption ) =>
+	[ 'other-woocommerce', 'other', 'brick-mortar-other' ].includes(
+		selectedOption
+	);
+
 export const isSellingElsewhere = ( selectedOption ) =>
 	[
 		'other',
@@ -121,6 +127,10 @@ export const isSellingElsewhere = ( selectedOption ) =>
 		'brick-mortar-other',
 		'other-woocommerce',
 	].includes( selectedOption );
+
+const getWccomMigrationUrl = ( selectedOption ) => {
+	return `https://woocommerce.com/migrate/?utm_source=nux&utm_medium=product&utm_campaign=migrate&utm_content=${ selectedOption }`;
+};
 
 export const isSellingOtherPlatformInPerson = ( selectedOption ) =>
 	[ 'other', 'brick-mortar-other' ].includes( selectedOption );
@@ -524,7 +534,34 @@ class BusinessDetails extends Component {
 											'selling_venues'
 										) }
 									/>
-
+									{ isShowWccomMigrationNotice(
+										values.selling_venues
+									) && (
+										<Notice
+											className="woocommerce-profile-wizard__wccom-migration-notice"
+											status="info"
+											isDismissible={ false }
+										>
+											{ __(
+												'Need help moving your store?',
+												'woocommerce'
+											) }
+											&nbsp;
+											<Button
+												href={ getWccomMigrationUrl(
+													values.selling_venues
+												) }
+												target="_blank"
+												rel="noopener noreferrer"
+												variant="link"
+											>
+												{ __(
+													'Get free expert advice',
+													'woocommerce'
+												) }
+											</Button>
+										</Notice>
+									) }
 									{ isSellingElsewhere(
 										values.selling_venues
 									) && (

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/flows/selective-bundle/style.scss
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/flows/selective-bundle/style.scss
@@ -20,3 +20,13 @@
 		}
 	}
 }
+
+.woocommerce-profile-wizard__wccom-migration-notice {
+	margin: 0;
+	background: #f0f9fc;
+	height: 50px;
+	font-size: 14px;
+	a {
+		font-size: 14px;
+	}
+}

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/flows/selective-bundle/style.scss
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/flows/selective-bundle/style.scss
@@ -24,7 +24,7 @@
 .woocommerce-profile-wizard__wccom-migration-notice {
 	margin: 0;
 	background: #f0f9fc;
-	height: 50px;
+	height: 48px;
 	font-size: 14px;
 	a {
 		font-size: 14px;

--- a/plugins/woocommerce/changelog/add-core-profiler-business-location copy
+++ b/plugins/woocommerce/changelog/add-core-profiler-business-location copy
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add wccom/migrate link in nux


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

Adds a link out to woocommerce.com/migrate inside the onboarding wizard when certain options are selected for the business details input.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
![image](https://github.com/woocommerce/woocommerce/assets/27843274/a36edb0e-5149-43d8-bfa0-9c60988f21ee)


Closes #38420 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install WooCommerce and go through the onboarding wizard until the "Business Details" page. Input values do not matter until then.
2. Observe that when the "Currently selling elsewhere?" dropdown is set to one of "Yes, on another platform", "Yes, I own a different store powered by WooCommerce", or "Yes, on another platform and in person", there is a notice that shows up "Get free expert advice"
3. Clicking on the link should bring up a new window leading to https://woocommerce.com/migrate, with the `&utm_content` parameter corresponding to one of "other", "other-woocommerce", or "brick-mortar-other"
<!-- End testing instructions -->
