### PR TITLE
Update WooCommerce Blocks package to 10.2.1

### DIFF
--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-10.2.1
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-10.2.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update WooCommerce Blocks to 10.2.1

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -21,7 +21,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.5.4",
-		"woocommerce/woocommerce-blocks": "10.2.0"
+		"woocommerce/woocommerce-blocks": "10.2.1"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.3.0",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -628,16 +628,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "10.2.0",
+            "version": "10.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "d836f1a0886ab2c5cb8f0b49b16cf050523a78af"
+                "reference": "7b5192d251e9c6f5502d2c8ab147498639f0eb84"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/d836f1a0886ab2c5cb8f0b49b16cf050523a78af",
-                "reference": "d836f1a0886ab2c5cb8f0b49b16cf050523a78af",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/7b5192d251e9c6f5502d2c8ab147498639f0eb84",
+                "reference": "7b5192d251e9c6f5502d2c8ab147498639f0eb84",
                 "shasum": ""
             },
             "require": {
@@ -683,9 +683,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v10.2.0"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v10.2.1"
             },
-            "time": "2023-05-11T11:21:00+00:00"
+            "time": "2023-05-25T12:56:45+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 10.2.1. This is intended to be merged into WooCommerce 7.8.

Related PR for WooCommerce 7.7: https://github.com/woocommerce/woocommerce/pull/38427.

## Blocks 10.2.1

* [Release PR](https://github.com/woocommerce/woocommerce-blocks/pull/9599)
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/1021.md)

### Changelog entry

#### Bug Fixes

- Fix a conflict between the Mini-Cart block and the Page Optimize and Product Bundles extensions. ([9586](https://github.com/woocommerce/woocommerce-blocks/pull/9586))


