### PR TITLE
Fix site crash when activating plugin without OPEN_AI_KEY defined.

### DIFF
--- a/plugins/woo-ai/woo-ai.php
+++ b/plugins/woo-ai/woo-ai.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Woo AI
- * Plugin URI: https://github.com/woocommerce/woo-ai
+ * Plugin URI: https://github.com/woocommerce
  * Description: Enable AI experiments within the WooCommerce experience.
  * Version: 0.1.0
  * Author: WooCommerce

--- a/plugins/woo-ai/woo-ai.php
+++ b/plugins/woo-ai/woo-ai.php
@@ -17,6 +17,11 @@
 
 defined( 'ABSPATH' ) || exit;
 
+// If the key is not defined, don't load the plugin.
+if ( ! defined( 'OPEN_AI_KEY' ) || ! OPEN_AI_KEY ) {
+	return;
+}
+
 // Define WOO_AI_FILE.
 if ( ! defined( 'WOO_AI_FILE' ) ) {
 	define( 'WOO_AI_FILE', __FILE__ );
@@ -56,7 +61,7 @@ function _woo_ai_bootstrap() {
 
 add_action(
 	'wp_loaded',
-	function() {
+	function () {
 		require 'api/api.php';
 	}
 );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Perform a basic check for the existence of the `OPEN_AI_KEY` constant and that it's not empty before loading the plugin. Otherwise, you could create a fatal:

![Screen Shot 2023-05-25 at 15 30 19](https://github.com/woocommerce/woocommerce/assets/6723003/641a0d0e-e3e8-403c-93ec-5bd370cf462a)

### How to test the changes in this Pull Request:

1. Build the Woo AI plugin by running `pnpm run build:zip`
2. Upload this ZIP to a self-hosted or Atomic site.
3. Observe the fatal error when loading a page on the site.