### PR TITLE
Compatibilize HPOS order query arguments with non-HPOS

### DIFF
--- a/plugins/woocommerce/changelog/add-hpos_order_query_arguments_compatibility_with_old_syntax
+++ b/plugins/woocommerce/changelog/add-hpos_order_query_arguments_compatibility_with_old_syntax
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add query syntax compatibility with old arguments in OrdersTableQuery

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
@@ -5,8 +5,6 @@ use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
 use Automattic\WooCommerce\RestApi\UnitTests\HPOSToggleTrait;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 
-require_once __DIR__ . '/../../../../helpers/HPOSToggleTrait.php';
-
 /**
  * Class OrdersTableQueryTests.
  */


### PR DESCRIPTION
- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Modify `OrdersTableQuery` to admit the same set of arguments that are passed via `meta_query` when HPOS is disabled (and thus `WP_Query` is used under the hood instead). The arguments that are admitted are those returned by the `get_meta_column_config` method in these classes: `PostToOrderTableMigrator`, `PostToOrderOpTableMigrator`, `PostToOrderAddressTableMigrator` (billing and shipping)

Closes #37564.

### How to test the changes in this Pull Request:

Run the new unit tests. Alternatively you can test for additional input arguments by using via command line, e.g.:

```
 wp eval "print_r(wc_get_orders(['return' => 'ids','meta_query' => [['key'=>'_billing_email', 'value' => 'customer@example.com']]]));"
```