### PR TITLE
Add `wcadmin_settings_change` tracks event when adding/removing entries in shipping

### DIFF
--- a/plugins/woocommerce/changelog/update-add-delete-shipping
+++ b/plugins/woocommerce/changelog/update-add-delete-shipping
@@ -1,0 +1,5 @@
+Significance: patch
+Type: enhancement
+Comment: Add wcadmin_settings_change tracks event when adding/removing entries in shipping
+
+

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -2994,6 +2994,17 @@ class WC_AJAX {
 					// That's fine, it's not in the database anyways. NEXT!
 					continue;
 				}
+				/**
+				 * Notify that a non-option setting has been deleted.
+				 *
+				 * @since 7.8.0
+				 */
+				do_action(
+					'woocommerce_delete_non_option_setting',
+					array(
+						'id'      => 'shipping_zone'
+					)
+				);
 				WC_Shipping_Zones::delete_zone( $zone_id );
 				continue;
 			}
@@ -3023,19 +3034,18 @@ class WC_AJAX {
 					);
 					$zone->set_zone_order( $zone_data['zone_order'] );
 				}
-
-				global $current_tab;
-				$current_tab = 'shipping';
-				/**
-				 * Completes the saving process for options.
-				 *
-				 * @since 7.8.0
-				 */
-				do_action( 'woocommerce_update_options' );
 				$zone->save();
 			}
 		}
 
+		global $current_tab;
+		$current_tab = 'shipping';
+		/**
+		 * Completes the saving process for options.
+		 *
+		 * @since 7.8.0
+		 */
+		do_action( 'woocommerce_update_options' );
 		wp_send_json_success(
 			array(
 				'zones' => WC_Shipping_Zones::get_zones( 'json' ),
@@ -3066,12 +3076,12 @@ class WC_AJAX {
 		$zone_id = wc_clean( wp_unslash( $_POST['zone_id'] ) );
 		$zone    = new WC_Shipping_Zone( $zone_id );
 		/**
-		 * Notify that a non-option setting has been updated.
+		 * Notify that a non-option setting has been added.
 		 *
 		 * @since 7.8.0
 		 */
 		do_action(
-			'woocommerce_update_non_option_setting',
+			'woocommerce_add_non_option_setting',
 			array(
 				'id' => 'zone_method',
 			)
@@ -3120,6 +3130,9 @@ class WC_AJAX {
 
 		$zone_id = wc_clean( wp_unslash( $_POST['zone_id'] ) );
 		$zone    = new WC_Shipping_Zone( $zone_id );
+		if ( $zone_id === '') {
+			do_action( 'woocommerce_add_non_option_setting', array( 'id' => 'shipping_zone' ) );
+		}
 		$changes = wp_unslash( $_POST['changes'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		if ( isset( $changes['zone_name'] ) ) {
@@ -3173,12 +3186,6 @@ class WC_AJAX {
 		}
 
 		if ( isset( $changes['methods'] ) ) {
-			/**
-			 * Completes the saving process for options.
-			 *
-			 * @since 7.8.0
-			 */
-			do_action( 'woocommerce_update_non_option_setting', array( 'id' => 'zone_methods' ) );
 			foreach ( $changes['methods'] as $instance_id => $data ) {
 				$method_id = $wpdb->get_var( $wpdb->prepare( "SELECT method_id FROM {$wpdb->prefix}woocommerce_shipping_zone_methods WHERE instance_id = %d", $instance_id ) );
 
@@ -3187,6 +3194,7 @@ class WC_AJAX {
 					$option_key      = $shipping_method->get_instance_option_key();
 					if ( $wpdb->delete( "{$wpdb->prefix}woocommerce_shipping_zone_methods", array( 'instance_id' => $instance_id ) ) ) {
 						delete_option( $option_key );
+						do_action( 'woocommerce_delete_non_option_setting', array( 'id' => 'zone_method' ) );
 						do_action( 'woocommerce_shipping_zone_method_deleted', $instance_id, $method_id, $zone_id );
 					}
 					continue;
@@ -3327,6 +3335,7 @@ class WC_AJAX {
 					// That's fine, it's not in the database anyways. NEXT!
 					continue;
 				}
+				do_action( 'woocommerce_delete_non_option_setting', array( 'id' => 'shipping_class' ) );
 				wp_delete_term( $term_id, 'product_shipping_class' );
 				continue;
 			}
@@ -3368,9 +3377,11 @@ class WC_AJAX {
 				if ( empty( $update_args['name'] ) ) {
 					continue;
 				}
+				do_action( 'woocommerce_add_non_option_setting', array( 'id' => 'shipping_class' ) );
 				$inserted_term = wp_insert_term( $update_args['name'], 'product_shipping_class', $update_args );
 				$term_id       = is_wp_error( $inserted_term ) ? 0 : $inserted_term['term_id'];
 			} else {
+				do_action( 'woocommerce_update_non_option_setting', array( 'id' => 'shipping_class' ) );
 				wp_update_term( $term_id, 'product_shipping_class', $update_args );
 			}
 

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -3000,9 +3000,10 @@ class WC_AJAX {
 				 * @since 7.8.0
 				 */
 				do_action(
-					'woocommerce_delete_non_option_setting',
+					'woocommerce_update_non_option_setting',
 					array(
-						'id' => 'shipping_zone',
+						'id'     => 'shipping_zone',
+						'action' => 'delete',
 					)
 				);
 				WC_Shipping_Zones::delete_zone( $zone_id );
@@ -3075,13 +3076,20 @@ class WC_AJAX {
 
 		$zone_id = wc_clean( wp_unslash( $_POST['zone_id'] ) );
 		$zone    = new WC_Shipping_Zone( $zone_id );
+		// A shipping zone can be created here if the user is adding a method without first saving the shipping zone.
 		if ( '' === $zone_id ) {
 			/**
 			 * Notified that a non-option setting has been added.
 			 *
 			 * @since 7.8.0
 			 */
-			do_action( 'woocommerce_add_non_option_setting', array( 'id' => 'shipping_zone' ) );
+			do_action(
+				'woocommerce_update_non_option_setting',
+				array(
+					'id'     => 'shipping_zone',
+					'action' => 'add',
+				)
+			);
 		}
 		/**
 		 * Notify that a non-option setting has been added.
@@ -3089,9 +3097,10 @@ class WC_AJAX {
 		 * @since 7.8.0
 		 */
 		do_action(
-			'woocommerce_add_non_option_setting',
+			'woocommerce_update_non_option_setting',
 			array(
-				'id' => 'zone_method',
+				'id'     => 'zone_method',
+				'action' => 'add',
 			)
 		);
 		$instance_id = $zone->add_shipping_method( wc_clean( wp_unslash( $_POST['method_id'] ) ) );
@@ -3138,13 +3147,20 @@ class WC_AJAX {
 
 		$zone_id = wc_clean( wp_unslash( $_POST['zone_id'] ) );
 		$zone    = new WC_Shipping_Zone( $zone_id );
+		// A shipping zone can be created here if the user is adding a method without first saving the shipping zone.
 		if ( '' === $zone_id ) {
 			/**
 			 * Notifies that a non-option setting has been added.
 			 *
 			 * @since 7.8.0
 			 */
-			do_action( 'woocommerce_add_non_option_setting', array( 'id' => 'shipping_zone' ) );
+			do_action(
+				'woocommerce_update_non_option_setting',
+				array(
+					'id'     => 'shipping_zone',
+					'action' => 'add',
+				)
+			);
 		}
 		$changes = wp_unslash( $_POST['changes'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
@@ -3212,7 +3228,13 @@ class WC_AJAX {
 						 *
 						 * @since 7.8.0
 						 */
-						do_action( 'woocommerce_delete_non_option_setting', array( 'id' => 'zone_method' ) );
+						do_action(
+							'woocommerce_update_non_option_setting',
+							array(
+								'id'     => 'zone_method',
+								'action' => 'delete',
+							)
+						);
 						do_action( 'woocommerce_shipping_zone_method_deleted', $instance_id, $method_id, $zone_id );
 					}
 					continue;
@@ -3358,7 +3380,13 @@ class WC_AJAX {
 				 *
 				 * @since 7.8.0
 				 */
-				do_action( 'woocommerce_delete_non_option_setting', array( 'id' => 'shipping_class' ) );
+				do_action(
+					'woocommerce_update_non_option_setting',
+					array(
+						'id'     => 'shipping_class',
+						'action' => 'delete',
+					)
+				);
 				wp_delete_term( $term_id, 'product_shipping_class' );
 				continue;
 			}
@@ -3405,7 +3433,13 @@ class WC_AJAX {
 				 *
 				 * @since 7.8.0
 				 */
-				do_action( 'woocommerce_add_non_option_setting', array( 'id' => 'shipping_class' ) );
+				do_action(
+					'woocommerce_update_non_option_setting',
+					array(
+						'id'     => 'shipping_class',
+						'action' => 'add',
+					)
+				);
 				$inserted_term = wp_insert_term( $update_args['name'], 'product_shipping_class', $update_args );
 				$term_id       = is_wp_error( $inserted_term ) ? 0 : $inserted_term['term_id'];
 			} else {

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -3075,6 +3075,14 @@ class WC_AJAX {
 
 		$zone_id = wc_clean( wp_unslash( $_POST['zone_id'] ) );
 		$zone    = new WC_Shipping_Zone( $zone_id );
+		if ( $zone_id === '') {
+			/**
+			 * Notified that a non-option setting has been added.
+			 *
+			 * @since 7.8.0
+			 */
+			do_action( 'woocommerce_add_non_option_setting', array( 'id' => 'shipping_zone' ) );
+		}
 		/**
 		 * Notify that a non-option setting has been added.
 		 *
@@ -3131,13 +3139,18 @@ class WC_AJAX {
 		$zone_id = wc_clean( wp_unslash( $_POST['zone_id'] ) );
 		$zone    = new WC_Shipping_Zone( $zone_id );
 		if ( $zone_id === '') {
+			/**
+			 * Notifies that a non-option setting has been added.
+			 *
+			 * @since 7.8.0
+			 */
 			do_action( 'woocommerce_add_non_option_setting', array( 'id' => 'shipping_zone' ) );
 		}
 		$changes = wp_unslash( $_POST['changes'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		if ( isset( $changes['zone_name'] ) ) {
 			/**
-			 * Completes the saving process for options.
+			 * Notifies that a non-option setting has been updated.
 			 *
 			 * @since 7.8.0
 			 */
@@ -3147,7 +3160,7 @@ class WC_AJAX {
 
 		if ( isset( $changes['zone_locations'] ) ) {
 			/**
-			 * Completes the saving process for options.
+			 * Notifies that a non-option setting has been updated.
 			 *
 			 * @since 7.8.0
 			 */
@@ -3173,7 +3186,7 @@ class WC_AJAX {
 
 		if ( isset( $changes['zone_postcodes'] ) ) {
 			/**
-			 * Completes the saving process for options.
+			 * Notifies that a non-option setting has been updated.
 			 *
 			 * @since 7.8.0
 			 */
@@ -3194,6 +3207,11 @@ class WC_AJAX {
 					$option_key      = $shipping_method->get_instance_option_key();
 					if ( $wpdb->delete( "{$wpdb->prefix}woocommerce_shipping_zone_methods", array( 'instance_id' => $instance_id ) ) ) {
 						delete_option( $option_key );
+						/**
+						 * Notifies that a non-option setting has been deleted.
+						 *
+						 * @since 7.8.0
+						 */
 						do_action( 'woocommerce_delete_non_option_setting', array( 'id' => 'zone_method' ) );
 						do_action( 'woocommerce_shipping_zone_method_deleted', $instance_id, $method_id, $zone_id );
 					}
@@ -3210,7 +3228,7 @@ class WC_AJAX {
 
 				if ( isset( $method_data['method_order'] ) ) {
 					/**
-					 * Completes the saving process for options.
+					 * Notifies that a non-option setting has been updated.
 					 *
 					 * @since 7.8.0
 					 */
@@ -3220,7 +3238,7 @@ class WC_AJAX {
 
 				if ( isset( $method_data['enabled'] ) ) {
 					/**
-					 * Completes the saving process for options.
+					 * Notifies that a non-option setting has been updated.
 					 *
 					 * @since 7.8.0
 					 */
@@ -3335,6 +3353,11 @@ class WC_AJAX {
 					// That's fine, it's not in the database anyways. NEXT!
 					continue;
 				}
+				/**
+				 * Notifies that a non-option setting has been deleted.
+				 *
+				 * @since 7.8.0
+				 */
 				do_action( 'woocommerce_delete_non_option_setting', array( 'id' => 'shipping_class' ) );
 				wp_delete_term( $term_id, 'product_shipping_class' );
 				continue;
@@ -3377,10 +3400,20 @@ class WC_AJAX {
 				if ( empty( $update_args['name'] ) ) {
 					continue;
 				}
+				/**
+				 * Notifies that a non-option setting has been added.
+				 *
+				 * @since 7.8.0
+				 */
 				do_action( 'woocommerce_add_non_option_setting', array( 'id' => 'shipping_class' ) );
 				$inserted_term = wp_insert_term( $update_args['name'], 'product_shipping_class', $update_args );
 				$term_id       = is_wp_error( $inserted_term ) ? 0 : $inserted_term['term_id'];
 			} else {
+				/**
+				 * Notifies that a non-option setting has been updated.
+				 *
+				 * @since 7.8.0
+				 */
 				do_action( 'woocommerce_update_non_option_setting', array( 'id' => 'shipping_class' ) );
 				wp_update_term( $term_id, 'product_shipping_class', $update_args );
 			}

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -3002,7 +3002,7 @@ class WC_AJAX {
 				do_action(
 					'woocommerce_delete_non_option_setting',
 					array(
-						'id'      => 'shipping_zone'
+						'id' => 'shipping_zone',
 					)
 				);
 				WC_Shipping_Zones::delete_zone( $zone_id );
@@ -3075,7 +3075,7 @@ class WC_AJAX {
 
 		$zone_id = wc_clean( wp_unslash( $_POST['zone_id'] ) );
 		$zone    = new WC_Shipping_Zone( $zone_id );
-		if ( $zone_id === '') {
+		if ( '' === $zone_id ) {
 			/**
 			 * Notified that a non-option setting has been added.
 			 *
@@ -3138,7 +3138,7 @@ class WC_AJAX {
 
 		$zone_id = wc_clean( wp_unslash( $_POST['zone_id'] ) );
 		$zone    = new WC_Shipping_Zone( $zone_id );
-		if ( $zone_id === '') {
+		if ( '' === $zone_id ) {
 			/**
 			 * Notifies that a non-option setting has been added.
 			 *

--- a/plugins/woocommerce/includes/tracks/events/class-wc-settings-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-settings-tracking.php
@@ -75,8 +75,6 @@ class WC_Settings_Tracking {
 		add_action( 'woocommerce_settings_page_init', array( $this, 'track_settings_page_view' ) );
 		add_action( 'woocommerce_update_option', array( $this, 'add_option_to_list' ) );
 		add_action( 'woocommerce_update_non_option_setting', array( $this, 'add_option_to_list_and_track_setting_change' ) );
-		add_action( 'woocommerce_delete_non_option_setting', array( $this, 'add_option_to_list_and_track_setting_delete' ) );
-		add_action( 'woocommerce_add_non_option_setting', array( $this, 'add_option_to_list_and_track_setting_added' ) );
 		add_action( 'woocommerce_update_options', array( $this, 'send_settings_change_event' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'possibly_add_settings_tracking_scripts' ) );
 	}
@@ -91,38 +89,12 @@ class WC_Settings_Tracking {
 		if ( ! in_array( $option['id'], $this->allowed_options, true ) ) {
 			$this->allowed_options[] = $option['id'];
 		}
-		if ( ! in_array( $option['id'], $this->updated_options, true ) ) {
-			$this->updated_options[] = $option['id'];
-		}
-	}
-
-	/**
-	 * Adds the option to the allowed and deleted options directly.
-	 * Currently used for settings that don't use update_option.
-	 *
-	 * @param array $option WooCommerce option that should be deleted.
-	 */
-	public function add_option_to_list_and_track_setting_delete( $option ) {
-		if ( ! in_array( $option['id'], $this->allowed_options, true ) ) {
-			$this->allowed_options[] = $option['id'];
-		}
-		if ( ! in_array( $option['id'], $this->deleted_options, true ) ) {
-			$this->deleted_options[] = $option['id'];
-		}
-	}
-
-	/**
-	 * Adds the option to the allowed and added options directly.
-	 * Currently used for settings that don't use update_option.
-	 *
-	 * @param array $option WooCommerce option that should be added.
-	 */
-	public function add_option_to_list_and_track_setting_added( $option ) {
-		if ( ! in_array( $option['id'], $this->allowed_options, true ) ) {
-			$this->allowed_options[] = $option['id'];
-		}
-		if ( ! in_array( $option['id'], $this->added_options, true ) ) {
+		if ( 'add' === $option['action'] ) {
 			$this->added_options[] = $option['id'];
+		} elseif ( 'delete' === $option['action'] ) {
+			$this->deleted_options[] = $option['id'];
+		} elseif ( ! in_array( $option['id'], $this->updated_options, true ) ) {
+			$this->updated_options[] = $option['id'];
 		}
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add wcadmin_settings_change tracks event when adding/removing entries in shipping

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #38432 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure logging is enabled under WooCommerce > Settings > Advanced > WooCommerce.com
2. Go to WooCommerce > Settings > Shipping and add a new shipping zone.
3. In that shipping zone, add a shipping method. It should save automatically.
4. Delete the shipping method and press "Save changes".
5. Go back to the Shipping zones list and delete it.
6. Go to the Shipping Classes tab.
7. Add a new Shipping class.
8. Remove it and press Save.
9. Go to WooCommerce > Status > Logs.
10. Select the latest tracks .log file.
11. Go through all the 'wcadmin_settings_change' events.
12. You should see events with 'added' and 'deleted' for all actions performed (at least 6 of them).

<!-- End testing instructions -->
