### PR TITLE
Update DateTimePickerControl's dropdown positioning

### DIFF
--- a/packages/js/components/changelog/update-date-time-picker-control-dropdown
+++ b/packages/js/components/changelog/update-date-time-picker-control-dropdown
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Update positioning of DateTimePickerControl's dropdown.

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -346,6 +346,7 @@ export const DateTimePickerControl = forwardRef(
 					</BaseControl>
 				) }
 				popoverProps={ {
+					anchor: inputControl.current,
 					className: 'woocommerce-date-time-picker-control__popover',
 					placement: 'bottom-start',
 				} }

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -284,7 +284,6 @@ export const DateTimePickerControl = forwardRef(
 					'woocommerce-date-time-picker-control',
 					className
 				) }
-				position="bottom left"
 				focusOnMount={ false }
 				// @ts-expect-error `onToggle` does exist.
 				onToggle={ callOnBlurIfDropdownIsNotOpening }
@@ -348,6 +347,7 @@ export const DateTimePickerControl = forwardRef(
 				) }
 				popoverProps={ {
 					className: 'woocommerce-date-time-picker-control__popover',
+					placement: 'bottom-start',
 				} }
 				renderContent={ () => {
 					const Picker = isDateOnlyPicker


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR updates the positioning of the `DateTimePickerControl`'s dropdown to use `popoverProps.placement` instead of the deprecated `position` prop. This accomplishes to 

It also sets the `popoverProps.anchor` to tweak the positioning of the dropdown (it will stay closer to the input control in all orientations).

Closes #38447.

#### Before

Note that the dropdown is *not* left-aligned with the input control.

<img width="653" alt="Screenshot 2023-05-25 at 16 14 46" src="https://github.com/woocommerce/woocommerce/assets/2098816/32c915f7-a846-4edd-9def-f7e886033728">

#### After

Note that the dropdown is left-aligned with the input control.

<img width="653" alt="Screenshot 2023-05-25 at 15 16 31" src="https://github.com/woocommerce/woocommerce/assets/2098816/8c010f37-ae99-47ac-8e64-7838db065481">


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the block-based product editor
2. Go to `Products` > `Add New`
3. Go to the `Pricing` tab
4. Enter a `List price` and `Sale price`
5. Enable `Schedule` sale
6. Verify the positioning of the dropdown in the date fields is correct.
7. Verify the following warning does *not* appear in the browser console.

```
`position` prop in wp.components.Dropdown is deprecated since version 6.2. Please use `popoverProps.placement` prop instead. Note: Note that the `position` prop will override any values passed through the `popoverProps.placement` prop.
```

<!-- End testing instructions -->
