### PR TITLE
WIP - Maybe default the selected state as the first one when it's "*"

### DIFF
--- a/changelog/pr-38467
+++ b/changelog/pr-38467
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Default to the first state in a country for the country dropdown options when only the country was previously saved

--- a/plugins/woocommerce/includes/class-wc-countries.php
+++ b/plugins/woocommerce/includes/class-wc-countries.php
@@ -474,6 +474,11 @@ class WC_Countries {
 			foreach ( $this->countries as $key => $value ) {
 				$states = $this->get_states( $key );
 				if ( $states ) {
+					// Maybe default the selected state as the first one.
+					if ( '*' === $selected_state ) {
+						$selected_state = key( $states );						
+					}
+
 					echo '<optgroup label="' . esc_attr( $value ) . '">';
 					foreach ( $states as $state_key => $state_value ) {
 						echo '<option value="' . esc_attr( $key ) . ':' . esc_attr( $state_key ) . '"';

--- a/plugins/woocommerce/includes/class-wc-countries.php
+++ b/plugins/woocommerce/includes/class-wc-countries.php
@@ -476,7 +476,7 @@ class WC_Countries {
 				if ( $states ) {
 					// Maybe default the selected state as the first one.
 					if ( '*' === $selected_state ) {
-						$selected_state = key( $states );						
+						$selected_state = key( $states );
 					}
 
 					echo '<optgroup label="' . esc_attr( $value ) . '">';


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When WC is provided only the country for the option `woocommerce_default_country` then it will fail to select a default state within the listed states.

Try this by manually setting `woocommerce_default_country` to "US" and you will see it selects the first country in the list instead of the first state within that country.

This only happens for countries that have states like US and CA for instance.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. 
2.
3.

<!-- End testing instructions -->
