### PR TITLE
Opt out of Reset and Help buttons in DateTimePickerControl

### DIFF
--- a/packages/js/components/changelog/fix-date-time-picker-reset
+++ b/packages/js/components/changelog/fix-date-time-picker-reset
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Opt out of Reset and Help buttons in DateTimePickerControl, as these will be removed in a future @wordpress/components version.

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -369,6 +369,10 @@ export const DateTimePickerControl = forwardRef(
 								)
 							}
 							is12Hour={ is12HourPicker }
+							// Opt out of the Reset and Help buttons, as they are going to be removed.
+							// These properties are removed in @wordpress/components 25.0.0 (Gutenberg 15.9.0).
+							__nextRemoveResetButton
+							__nextRemoveHelpButton
 						/>
 					);
 				} }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR removes the "Reset" and "Calendar Help" links present at the bottom of `DateTimePickerControl`'s dropdown.

This is done by adding the following props to the `DateTime` picker:

* `__nextRemoveResetButton`
* `__nextRemoveHelpButton`

This removes the links in systems running a version of `@wordpress/components` prior to `25.0.0`. From Version `25.0.0` onward, these links are always removed (and those props do nothing and do not cause any warnings/errors at runtime). This will be the experience in [Gutenberg `15.9.0`](https://github.com/WordPress/gutenberg/releases/tag/v15.9.0-rc.1) (and I assume WordPress 6.3 or 6.4?).

#### Before

"Reset" and "Calendar Help" links present at bottom of dropdown.

<img width="653" alt="Screenshot 2023-05-26 at 10 54 28" src="https://github.com/woocommerce/woocommerce/assets/2098816/59ddb5fe-e688-4be8-ae77-af562523b00b">


#### After

"Reset" and "Calendar Help" links not present at bottom of dropdown.

<img width="653" alt="Screenshot 2023-05-26 at 10 38 56" src="https://github.com/woocommerce/woocommerce/assets/2098816/d3c42dc0-b568-4c8f-bf51-633bd2a43556">

Closes #38213.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Enable the block-based product editor
2. Go to `Products` > `Add New`
3. Go to the `Pricing` tab
4. Enter a `List price` and `Sale price`
5. Enable `Schedule` sale
6. Verify the dropdown in the date fields do not contain "Reset" and "Calendar Help" links

<!-- End testing instructions -->
