### PR TITLE
View should scroll to the top when navigating between tabs

### DIFF
--- a/plugins/woocommerce-admin/client/products/product-page.scss
+++ b/plugins/woocommerce-admin/client/products/product-page.scss
@@ -42,3 +42,9 @@
 		z-index: 100;
 	}
 }
+
+html.interface-interface-skeleton__html-container {
+	@include breakpoint( '<782px' ) {
+		position: inherit;
+	}
+}

--- a/plugins/woocommerce/changelog/add-38150
+++ b/plugins/woocommerce/changelog/add-38150
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Override the interface skeleton container so it can be scrollable


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #38150

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Got to `/wp-admin/tools.php?page=woocommerce-admin-test-helper`
2. Under Features tab make sure to enable `product-block-editor`
3. Then visit `/wp-admin/admin.php?page=wc-admin&path=/add-product`
4. The product form should not have the problem described in #38150

<!-- End testing instructions -->
