### PR TITLE
Prevent theme styles from being used in the block-based product editor

### DIFF
--- a/packages/js/product-editor/changelog/fix-product-editor-theme-bleed
+++ b/packages/js/product-editor/changelog/fix-product-editor-theme-bleed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent theme styles from being used in the product editor.

--- a/packages/js/product-editor/src/components/block-editor/block-editor.tsx
+++ b/packages/js/product-editor/src/components/block-editor/block-editor.tsx
@@ -19,9 +19,6 @@ import {
 	EditorSettings,
 	EditorBlockListSettings,
 	ObserveTyping,
-	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-	// @ts-ignore No types for this exist yet.
-	__unstableEditorStyles as EditorStyles,
 } from '@wordpress/block-editor';
 // It doesn't seem to notice the External dependency block whn @ts-ignore is added.
 // eslint-disable-next-line @woocommerce/dependency-group
@@ -103,7 +100,6 @@ export function BlockEditor( {
 					onChange={ onChange }
 					settings={ settings }
 				>
-					<EditorStyles styles={ settings?.styles } />
 					<div className="editor-styles-wrapper">
 						{ /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */ }
 						{ /* @ts-ignore No types for this exist yet. */ }

--- a/packages/js/product-editor/src/components/content-preview/content-preview.tsx
+++ b/packages/js/product-editor/src/components/content-preview/content-preview.tsx
@@ -1,7 +1,19 @@
 /**
  * External dependencies
  */
-import { createElement } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { createElement, Fragment } from '@wordpress/element';
+import {
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore No types for this exist yet.
+	__unstableIframe as Iframe,
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore No types for this exist yet.
+	__unstableEditorStyles as EditorStyles,
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -47,13 +59,35 @@ const CONTENT_ATTR = [
 ];
 
 export function ContentPreview( { content }: ContentPreviewProps ) {
+	const parentEditorSettings = useSelect( ( select ) => {
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		return select( blockEditorStore ).getSettings();
+	} );
+
 	return (
-		<div
-			className="woocommerce-content-preview"
-			dangerouslySetInnerHTML={ sanitizeHTML( content, {
-				tags: CONTENT_TAGS,
-				attr: CONTENT_ATTR,
-			} ) }
-		/>
+		<div className="woocommerce-content-preview">
+			<Iframe
+				head={
+					<>
+						<EditorStyles styles={ parentEditorSettings?.styles } />
+						<style>
+							{ `body {
+									overflow: hidden;
+								}` }
+						</style>
+					</>
+				}
+				className="woocommerce-content-preview__iframe"
+			>
+				<div
+					className="woocommerce-content-preview__content"
+					dangerouslySetInnerHTML={ sanitizeHTML( content, {
+						tags: CONTENT_TAGS,
+						attr: CONTENT_ATTR,
+					} ) }
+				/>
+			</Iframe>
+		</div>
 	);
 }

--- a/packages/js/product-editor/src/components/content-preview/style.scss
+++ b/packages/js/product-editor/src/components/content-preview/style.scss
@@ -1,17 +1,9 @@
 .woocommerce-content-preview {
     border: 1px solid $gray-300;
-    max-height: 144px;
-    overflow: hidden;
-    padding: $gap-large;
+	max-height: 144px;
+	width: 100%;
+	overflow: hidden;
     margin-top: $gap-largest;
-
-    >:first-child {
-        margin-top: 0;
-    }
-
-    > * {
-        max-width: 100%;
-    }
 
     &:after {
         content: '';
@@ -23,4 +15,21 @@
         width: 100%;
         background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, #FFFFFF 89.5%);
     }
+
+	&__iframe {
+		width: 100%;
+	}
+
+	&__content {
+		box-sizing: border-box;
+		padding: $gap-large;
+
+		>:first-child {
+			margin-top: 0;
+		}
+
+		> * {
+			max-width: 100%;
+		}
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR changes the implementation to only apply the editor styles to the description content preview. Previously, it was being applied to the entire product editor, which was unexpected and undesired.

Note: The editor styles are still being applied to the modal editor used to edit the description, as is expected.


#### Before

<img width="1116" alt="Screenshot 2023-05-26 at 11 20 28" src="https://github.com/woocommerce/woocommerce/assets/2098816/49a0d24a-0bba-4742-9e04-d5caaa69aedc">

#### After

<img width="1115" alt="Screenshot 2023-05-26 at 15 02 21" src="https://github.com/woocommerce/woocommerce/assets/2098816/cfd2de1e-ff6c-483b-94c8-0476cf08d526">

Closes #38279.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the experimental block-based product editor.
2. Activate a theme such as Twenty Twenty-Three.
3. Activate a style for the theme that results in easy to spot differences (such as the background), such as "Block out" or "Pilgrimage", via the Styles panel in the Site Editor.
4. Go to the block-based product editor.
5. Verify the theme styles are not affecting the product editor.
6. Verify the theme styles are applied to the description content preview.
7. Verify the theme styles are applied to the modal editor for the description.

<!-- End testing instructions -->
