### PR TITLE
Load custom editor-only blocks in the block-based product editor

### DIFF
--- a/plugins/woocommerce/changelog/fix-load-editor-only-blocks-in-product-editor
+++ b/plugins/woocommerce/changelog/fix-load-editor-only-blocks-in-product-editor
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Support custom editor-only blocks in the block-based product editor.

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -658,7 +658,7 @@ class Init {
 	public function set_current_screen_to_block_editor_if_wc_admin() {
 		$screen = get_current_screen();
 
-		// we can't check the $_GET['path'] because client-side routing is used within wc-admin,
+		// we can't check the 'path' query param because client-side routing is used within wc-admin,
 		// so this action handler is only called on the initial page load from the server, which might
 		// not be the product edit page (it mostly likely isn't).
 		if ( isset( $_GET['page'] ) && 'wc-admin' === $_GET['page'] ) {

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -658,6 +658,8 @@ class Init {
 	public function set_current_screen_to_block_editor_if_wc_admin() {
 		$screen = get_current_screen();
 
+		// phpcs:ignore Squiz.PHP.CommentedOutCode.Found
+		// (no idea why I need that phpcs:ignore above, but I'm tired trying to re-write this comment to get it to pass)
 		// we can't check the 'path' query param because client-side routing is used within wc-admin,
 		// so this action handler is only called on the initial page load from the server, which might
 		// not be the product edit page (it mostly likely isn't).

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -663,7 +663,7 @@ class Init {
 		// we can't check the 'path' query param because client-side routing is used within wc-admin,
 		// so this action handler is only called on the initial page load from the server, which might
 		// not be the product edit page (it mostly likely isn't).
-		if ( isset( $_GET['page'] ) && 'wc-admin' === $_GET['page'] ) {
+		if ( PageController::is_admin_page() ) {
 			$screen->is_block_editor( true );
 		}
 	}

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -31,6 +31,9 @@ class Init {
 			}
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 			add_filter( 'woocommerce_register_post_type_product', array( $this, 'add_product_template' ) );
+
+			add_action( 'current_screen', array( $this, 'set_current_screen_to_block_editor_if_wc_admin' ) );
+
 			$block_registry = new BlockRegistry();
 			$block_registry->init();
 		}
@@ -647,5 +650,19 @@ class Init {
 			);
 		}
 		return $args;
+	}
+
+	/**
+	 * Sets the current screen to the block editor if a wc-admin page.
+	 */
+	public function set_current_screen_to_block_editor_if_wc_admin() {
+		$screen = get_current_screen();
+
+		// we can't check the $_GET['path'] because client-side routing is used within wc-admin,
+		// so this action handler is only called on the initial page load from the server, which might
+		// not be the product edit page (it mostly likely isn't).
+		if ( isset( $_GET['page'] ) && 'wc-admin' === $_GET['page'] ) {
+			$screen->is_block_editor( true );
+		}
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR sets the current screen as the block editor if it is a wc-admin page, which allows custom editor-only blocks to load in the block-based product editor.

#### Before

<img width="1115" alt="Screenshot 2023-05-26 at 16 36 33" src="https://github.com/woocommerce/woocommerce/assets/2098816/2cfbe947-cd72-4095-ad20-c5634e0b2c60">

#### After

<img width="1115" alt="Screenshot 2023-05-26 at 16 36 12" src="https://github.com/woocommerce/woocommerce/assets/2098816/359f61d1-d543-426b-aa86-cdfb740a35ff">

Closes #38394.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Use the [create-product-editor-block template](https://github.com/woocommerce/woocommerce/blob/trunk/packages/js/create-product-editor-block/README.md) to generate a new custom block extension.
    - Note: since we haven't published `@woocommerce/create-product-editor-block` yet, use the following form of the command to point to a local path:

```
npx @wordpress/create-block --template ./path/to/woocommerce/packages/js/create-product-editor-block
```

2. Remove the `script` property from the `block.json` in the custom block extension and rebuild it.
3. Load the block-based product editor.
4. Verify the custom block is rendered.

<!-- End testing instructions -->
