### PR TITLE
Add `woocommerce_order_note_deleted` hook for a successful order note…

### DIFF
--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -1148,5 +1148,18 @@ function wc_create_order_note( $order_id, $note, $is_customer_note = false, $add
  * @return bool         True on success, false on failure.
  */
 function wc_delete_order_note( $note_id ) {
-	return wp_delete_comment( $note_id, true );
+	$delete = wp_delete_comment( $note_id, true );
+
+	if($delete) {
+		/**
+		 * Action hook fired after an order note is deleted.
+		 *
+		 * @param int      $note_id	Order note ID.
+		 *
+		 * @since 7.7.0
+		 */
+		do_action( 'woocommerce_order_note_deleted', $note_id);
+	}
+
+	return $delete;
 }

--- a/plugins/woocommerce/includes/wc-order-functions.php
+++ b/plugins/woocommerce/includes/wc-order-functions.php
@@ -1150,7 +1150,7 @@ function wc_create_order_note( $order_id, $note, $is_customer_note = false, $add
 function wc_delete_order_note( $note_id ) {
 	$delete = wp_delete_comment( $note_id, true );
 
-	if($delete) {
+	if ( $delete ) {
 		/**
 		 * Action hook fired after an order note is deleted.
 		 *


### PR DESCRIPTION

### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

As it was written in the README.md, we should have the least possible changes in the legacy code section, and I made a very small change in the function of deleting order notes, and this change can be very useful, such as synchronizing the store with external systems. And in the pull request, I have tried to write the least possible changes of a hook for a successful order note removal.
