### PR TITLE
Product route not updated after save initially failed and succeeded after

### DIFF
--- a/packages/js/product-editor/changelog/fix-38319
+++ b/packages/js/product-editor/changelog/fix-38319
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Product route not updated after save initially failed and succeeded after#38319

--- a/packages/js/product-editor/src/components/editor/editor.tsx
+++ b/packages/js/product-editor/src/components/editor/editor.tsx
@@ -67,7 +67,7 @@ export function Editor( { product, settings }: EditorProps ) {
 								<InterfaceSkeleton
 									header={
 										<Header
-											productName={ product.name }
+											productId={ product.id }
 											onTabSelect={ setSelectedTab }
 										/>
 									}

--- a/packages/js/product-editor/src/components/editor/editor.tsx
+++ b/packages/js/product-editor/src/components/editor/editor.tsx
@@ -67,7 +67,6 @@ export function Editor( { product, settings }: EditorProps ) {
 								<InterfaceSkeleton
 									header={
 										<Header
-											productId={ product.id }
 											onTabSelect={ setSelectedTab }
 										/>
 									}

--- a/packages/js/product-editor/src/components/header/header.tsx
+++ b/packages/js/product-editor/src/components/header/header.tsx
@@ -19,11 +19,16 @@ import { PublishButton } from './publish-button';
 import { Tabs } from '../tabs';
 
 export type HeaderProps = {
-	productId: Product[ 'id' ];
 	onTabSelect: ( tabId: string | null ) => void;
 };
 
-export function Header( { productId, onTabSelect }: HeaderProps ) {
+export function Header( { onTabSelect }: HeaderProps ) {
+	const [ productId ] = useEntityProp< number >(
+		'postType',
+		'product',
+		'id'
+	);
+
 	const lastPersistedProduct = useSelect(
 		( select ) => {
 			const { getEntityRecord } = select( 'core' );
@@ -61,17 +66,14 @@ export function Header( { productId, onTabSelect }: HeaderProps ) {
 
 				<div className="woocommerce-product-header__actions">
 					<SaveDraftButton
-						productId={ lastPersistedProduct.id }
 						productStatus={ lastPersistedProduct.status }
 					/>
 
 					<PreviewButton
-						productId={ lastPersistedProduct.id }
 						productStatus={ lastPersistedProduct.status }
 					/>
 
 					<PublishButton
-						productId={ lastPersistedProduct.id }
 						productStatus={ lastPersistedProduct.status }
 					/>
 

--- a/packages/js/product-editor/src/components/header/header.tsx
+++ b/packages/js/product-editor/src/components/header/header.tsx
@@ -1,10 +1,12 @@
 /**
  * External dependencies
  */
+import { WooHeaderItem } from '@woocommerce/admin-layout';
+import { Product } from '@woocommerce/data';
 import { useEntityProp } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
 import { createElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { WooHeaderItem } from '@woocommerce/admin-layout';
 
 /**
  * Internal dependencies
@@ -17,11 +19,23 @@ import { PublishButton } from './publish-button';
 import { Tabs } from '../tabs';
 
 export type HeaderProps = {
+	productId: Product[ 'id' ];
 	onTabSelect: ( tabId: string | null ) => void;
-	productName: string;
 };
 
-export function Header( { onTabSelect, productName }: HeaderProps ) {
+export function Header( { productId, onTabSelect }: HeaderProps ) {
+	const lastPersistedProduct = useSelect(
+		( select ) => {
+			const { getEntityRecord } = select( 'core' );
+			return getEntityRecord< Product >(
+				'postType',
+				'product',
+				productId
+			);
+		},
+		[ productId ]
+	);
+
 	const [ editedProductName ] = useEntityProp< string >(
 		'postType',
 		'product',
@@ -39,15 +53,27 @@ export function Header( { onTabSelect, productName }: HeaderProps ) {
 				<div />
 
 				<h1 className="woocommerce-product-header__title">
-					{ getHeaderTitle( editedProductName, productName ) }
+					{ getHeaderTitle(
+						editedProductName,
+						lastPersistedProduct.name
+					) }
 				</h1>
 
 				<div className="woocommerce-product-header__actions">
-					<SaveDraftButton />
+					<SaveDraftButton
+						productId={ lastPersistedProduct.id }
+						productStatus={ lastPersistedProduct.status }
+					/>
 
-					<PreviewButton />
+					<PreviewButton
+						productId={ lastPersistedProduct.id }
+						productStatus={ lastPersistedProduct.status }
+					/>
 
-					<PublishButton />
+					<PublishButton
+						productId={ lastPersistedProduct.id }
+						productStatus={ lastPersistedProduct.status }
+					/>
 
 					<WooHeaderItem.Slot name="product" />
 					<MoreMenu />

--- a/packages/js/product-editor/src/components/header/hooks/use-preview/use-preview.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-preview/use-preview.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Product, ProductStatus } from '@woocommerce/data';
+import { Product } from '@woocommerce/data';
 import { Button } from '@wordpress/components';
 import { useEntityProp } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -14,29 +14,22 @@ import { MouseEvent } from 'react';
  */
 import { useValidations } from '../../../../contexts/validation-context';
 import { WPError } from '../../../../utils/get-product-error-message';
+import { PreviewButtonProps } from '../../preview-button';
 
 export function usePreview( {
+	productId,
+	productStatus,
 	disabled,
 	onClick,
 	onSaveSuccess,
 	onSaveError,
 	...props
-}: Omit< Button.AnchorProps, 'aria-disabled' | 'variant' | 'href' > & {
+}: PreviewButtonProps & {
 	onSaveSuccess?( product: Product ): void;
 	onSaveError?( error: WPError ): void;
 } ): Button.AnchorProps {
 	const anchorRef = useRef< HTMLAnchorElement >();
 
-	const [ productId ] = useEntityProp< number >(
-		'postType',
-		'product',
-		'id'
-	);
-	const [ productStatus ] = useEntityProp< ProductStatus >(
-		'postType',
-		'product',
-		'status'
-	);
 	const [ permalink ] = useEntityProp< string >(
 		'postType',
 		'product',
@@ -133,7 +126,13 @@ export function usePreview( {
 			}
 		} catch ( error ) {
 			if ( onSaveError ) {
-				onSaveError( error as WPError );
+				let wpError = error as WPError;
+				if ( ! wpError.code ) {
+					wpError = {
+						code: 'product_preview_error',
+					} as WPError;
+				}
+				onSaveError( wpError );
 			}
 		}
 	}

--- a/packages/js/product-editor/src/components/header/hooks/use-preview/use-preview.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-preview/use-preview.tsx
@@ -17,7 +17,6 @@ import { WPError } from '../../../../utils/get-product-error-message';
 import { PreviewButtonProps } from '../../preview-button';
 
 export function usePreview( {
-	productId,
 	productStatus,
 	disabled,
 	onClick,
@@ -29,6 +28,12 @@ export function usePreview( {
 	onSaveError?( error: WPError ): void;
 } ): Button.AnchorProps {
 	const anchorRef = useRef< HTMLAnchorElement >();
+
+	const [ productId ] = useEntityProp< number >(
+		'postType',
+		'product',
+		'id'
+	);
 
 	const [ permalink ] = useEntityProp< string >(
 		'postType',

--- a/packages/js/product-editor/src/components/header/hooks/use-publish/use-publish.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-publish/use-publish.tsx
@@ -3,6 +3,7 @@
  */
 import { Product } from '@woocommerce/data';
 import { Button } from '@wordpress/components';
+import { useEntityProp } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { MouseEvent } from 'react';
@@ -15,7 +16,6 @@ import { WPError } from '../../../../utils/get-product-error-message';
 import { PublishButtonProps } from '../../publish-button';
 
 export function usePublish( {
-	productId,
 	productStatus,
 	disabled,
 	onClick,
@@ -27,6 +27,12 @@ export function usePublish( {
 	onPublishError?( error: WPError ): void;
 } ): Button.ButtonProps {
 	const { isValidating, validate } = useValidations();
+
+	const [ productId ] = useEntityProp< number >(
+		'postType',
+		'product',
+		'id'
+	);
 
 	const { isSaving } = useSelect(
 		( select ) => {

--- a/packages/js/product-editor/src/components/header/hooks/use-save-draft/use-save-draft.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-save-draft/use-save-draft.tsx
@@ -3,6 +3,7 @@
  */
 import { Product } from '@woocommerce/data';
 import { Button, Icon } from '@wordpress/components';
+import { useEntityProp } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { check } from '@wordpress/icons';
@@ -17,7 +18,6 @@ import { WPError } from '../../../../utils/get-product-error-message';
 import { SaveDraftButtonProps } from '../../save-draft-button';
 
 export function useSaveDraft( {
-	productId,
 	productStatus,
 	disabled,
 	onClick,
@@ -28,6 +28,12 @@ export function useSaveDraft( {
 	onSaveSuccess?( product: Product ): void;
 	onSaveError?( error: WPError ): void;
 } ): Button.ButtonProps {
+	const [ productId ] = useEntityProp< number >(
+		'postType',
+		'product',
+		'id'
+	);
+
 	const { hasEdits, isDisabled } = useSelect(
 		( select ) => {
 			const { hasEditsForEntityRecord, isSavingEntityRecord } =

--- a/packages/js/product-editor/src/components/header/hooks/use-save-draft/use-save-draft.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-save-draft/use-save-draft.tsx
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import { Product, ProductStatus } from '@woocommerce/data';
+import { Product } from '@woocommerce/data';
 import { Button, Icon } from '@wordpress/components';
-import { useEntityProp } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { check } from '@wordpress/icons';
@@ -15,28 +14,20 @@ import { MouseEvent, ReactNode } from 'react';
  */
 import { useValidations } from '../../../../contexts/validation-context';
 import { WPError } from '../../../../utils/get-product-error-message';
+import { SaveDraftButtonProps } from '../../save-draft-button';
 
 export function useSaveDraft( {
+	productId,
+	productStatus,
 	disabled,
 	onClick,
 	onSaveSuccess,
 	onSaveError,
 	...props
-}: Omit< Button.ButtonProps, 'aria-disabled' | 'variant' | 'children' > & {
+}: SaveDraftButtonProps & {
 	onSaveSuccess?( product: Product ): void;
 	onSaveError?( error: WPError ): void;
 } ): Button.ButtonProps {
-	const [ productId ] = useEntityProp< number >(
-		'postType',
-		'product',
-		'id'
-	);
-	const [ productStatus ] = useEntityProp< ProductStatus >(
-		'postType',
-		'product',
-		'status'
-	);
-
 	const { hasEdits, isDisabled } = useSelect(
 		( select ) => {
 			const { hasEditsForEntityRecord, isSavingEntityRecord } =

--- a/packages/js/product-editor/src/components/header/preview-button/index.ts
+++ b/packages/js/product-editor/src/components/header/preview-button/index.ts
@@ -1,1 +1,2 @@
 export * from './preview-button';
+export * from './types';

--- a/packages/js/product-editor/src/components/header/preview-button/preview-button.tsx
+++ b/packages/js/product-editor/src/components/header/preview-button/preview-button.tsx
@@ -1,35 +1,27 @@
 /**
  * External dependencies
  */
-import { Product, ProductStatus } from '@woocommerce/data';
+import { Product } from '@woocommerce/data';
 import { getNewPath, navigateTo } from '@woocommerce/navigation';
 import { Button } from '@wordpress/components';
-import { useEntityProp } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
 import { createElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { getProductErrorMessage } from '../../../utils/get-product-error-message';
 import { usePreview } from '../hooks/use-preview';
+import { PreviewButtonProps } from './types';
 
 export function PreviewButton( {
+	productStatus,
 	...props
-}: Omit<
-	Button.AnchorProps,
-	'aria-disabled' | 'variant' | 'href' | 'children'
-> ) {
-	const [ productStatus ] = useEntityProp< ProductStatus >(
-		'postType',
-		'product',
-		'status'
-	);
-
+}: PreviewButtonProps ) {
 	const { createErrorNotice } = useDispatch( 'core/notices' );
 
 	const previewButtonProps = usePreview( {
+		productStatus,
 		...props,
 		onSaveSuccess( savedProduct: Product ) {
 			if ( productStatus === 'auto-draft' ) {
@@ -39,10 +31,7 @@ export function PreviewButton( {
 		},
 		onSaveError( error ) {
 			const message = getProductErrorMessage( error );
-
-			createErrorNotice(
-				message || __( 'Failed to preview product.', 'woocommerce' )
-			);
+			createErrorNotice( message );
 		},
 	} );
 

--- a/packages/js/product-editor/src/components/header/preview-button/types.ts
+++ b/packages/js/product-editor/src/components/header/preview-button/types.ts
@@ -8,6 +8,5 @@ export type PreviewButtonProps = Omit<
 	Button.AnchorProps,
 	'aria-disabled' | 'variant' | 'href' | 'children'
 > & {
-	productId: Product[ 'id' ];
 	productStatus: Product[ 'status' ];
 };

--- a/packages/js/product-editor/src/components/header/preview-button/types.ts
+++ b/packages/js/product-editor/src/components/header/preview-button/types.ts
@@ -1,0 +1,13 @@
+/**
+ * External dependencies
+ */
+import { Product } from '@woocommerce/data';
+import { Button } from '@wordpress/components';
+
+export type PreviewButtonProps = Omit<
+	Button.AnchorProps,
+	'aria-disabled' | 'variant' | 'href' | 'children'
+> & {
+	productId: Product[ 'id' ];
+	productStatus: Product[ 'status' ];
+};

--- a/packages/js/product-editor/src/components/header/publish-button/index.ts
+++ b/packages/js/product-editor/src/components/header/publish-button/index.ts
@@ -1,1 +1,2 @@
 export * from './publish-button';
+export * from './types';

--- a/packages/js/product-editor/src/components/header/publish-button/publish-button.tsx
+++ b/packages/js/product-editor/src/components/header/publish-button/publish-button.tsx
@@ -33,8 +33,8 @@ export function PublishButton( {
 			const isPublished = productStatus === 'publish';
 
 			const noticeContent = isPublished
-				? __( 'Product published.', 'woocommerce' )
-				: __( 'Product successfully created.', 'woocommerce' );
+				? __( 'Product updated.', 'woocommerce' )
+				: __( 'Product added.', 'woocommerce' );
 			const noticeOptions = {
 				icon: '🎉',
 				actions: [

--- a/packages/js/product-editor/src/components/header/publish-button/publish-button.tsx
+++ b/packages/js/product-editor/src/components/header/publish-button/publish-button.tsx
@@ -6,9 +6,8 @@ import { Button } from '@wordpress/components';
 import { createElement } from '@wordpress/element';
 import { getNewPath, navigateTo } from '@woocommerce/navigation';
 import { MouseEvent } from 'react';
-import { Product, ProductStatus } from '@woocommerce/data';
+import { Product } from '@woocommerce/data';
 import { useDispatch } from '@wordpress/data';
-import { useEntityProp } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -16,25 +15,22 @@ import { useEntityProp } from '@wordpress/core-data';
 import { getProductErrorMessage } from '../../../utils/get-product-error-message';
 import { recordProductEvent } from '../../../utils/record-product-event';
 import { usePublish } from '../hooks/use-publish';
+import { PublishButtonProps } from './types';
 
-export function PublishButton(
-	props: Omit< Button.ButtonProps, 'aria-disabled' | 'variant' | 'children' >
-) {
-	const [ productStatus ] = useEntityProp< ProductStatus >(
-		'postType',
-		'product',
-		'status'
-	);
-
-	const isPublished = productStatus === 'publish';
-
+export function PublishButton( {
+	productStatus,
+	...props
+}: PublishButtonProps ) {
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( 'core/notices' );
 
 	const publishButtonProps = usePublish( {
+		productStatus,
 		...props,
 		onPublishSuccess( savedProduct: Product ) {
 			recordProductEvent( 'product_update', savedProduct );
+
+			const isPublished = productStatus === 'publish';
 
 			const noticeContent = isPublished
 				? __( 'Product published.', 'woocommerce' )
@@ -64,12 +60,8 @@ export function PublishButton(
 			}
 		},
 		onPublishError( error ) {
-			const defaultMessage = isPublished
-				? __( 'Failed to publish product.', 'woocommerce' )
-				: __( 'Failed to create product.', 'woocommerce' );
-
 			const message = getProductErrorMessage( error );
-			createErrorNotice( message || defaultMessage );
+			createErrorNotice( message );
 		},
 	} );
 

--- a/packages/js/product-editor/src/components/header/publish-button/types.ts
+++ b/packages/js/product-editor/src/components/header/publish-button/types.ts
@@ -1,0 +1,13 @@
+/**
+ * External dependencies
+ */
+import { Product } from '@woocommerce/data';
+import { Button } from '@wordpress/components';
+
+export type PublishButtonProps = Omit<
+	Button.ButtonProps,
+	'aria-disabled' | 'variant' | 'children'
+> & {
+	productId: Product[ 'id' ];
+	productStatus: Product[ 'status' ];
+};

--- a/packages/js/product-editor/src/components/header/publish-button/types.ts
+++ b/packages/js/product-editor/src/components/header/publish-button/types.ts
@@ -8,6 +8,5 @@ export type PublishButtonProps = Omit<
 	Button.ButtonProps,
 	'aria-disabled' | 'variant' | 'children'
 > & {
-	productId: Product[ 'id' ];
 	productStatus: Product[ 'status' ];
 };

--- a/packages/js/product-editor/src/components/header/save-draft-button/index.ts
+++ b/packages/js/product-editor/src/components/header/save-draft-button/index.ts
@@ -1,1 +1,2 @@
 export * from './save-draft-button';
+export * from './types';

--- a/packages/js/product-editor/src/components/header/save-draft-button/save-draft-button.tsx
+++ b/packages/js/product-editor/src/components/header/save-draft-button/save-draft-button.tsx
@@ -5,9 +5,8 @@ import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { createElement } from '@wordpress/element';
 import { getNewPath, navigateTo } from '@woocommerce/navigation';
-import { Product, ProductStatus } from '@woocommerce/data';
+import { Product } from '@woocommerce/data';
 import { useDispatch } from '@wordpress/data';
-import { useEntityProp } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -15,20 +14,17 @@ import { useEntityProp } from '@wordpress/core-data';
 import { getProductErrorMessage } from '../../../utils/get-product-error-message';
 import { recordProductEvent } from '../../../utils/record-product-event';
 import { useSaveDraft } from '../hooks/use-save-draft';
+import { SaveDraftButtonProps } from './types';
 
-export function SaveDraftButton(
-	props: Omit< Button.ButtonProps, 'aria-disabled' | 'variant' | 'children' >
-) {
-	const [ productStatus ] = useEntityProp< ProductStatus >(
-		'postType',
-		'product',
-		'status'
-	);
-
+export function SaveDraftButton( {
+	productStatus,
+	...props
+}: SaveDraftButtonProps ) {
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( 'core/notices' );
 
 	const saveDraftButtonProps = useSaveDraft( {
+		productStatus,
 		...props,
 		onSaveSuccess( savedProduct: Product ) {
 			recordProductEvent( 'product_edit', savedProduct );
@@ -44,10 +40,7 @@ export function SaveDraftButton(
 		},
 		onSaveError( error ) {
 			const message = getProductErrorMessage( error );
-
-			createErrorNotice(
-				message || __( 'Failed to update product.', 'woocommerce' )
-			);
+			createErrorNotice( message );
 		},
 	} );
 

--- a/packages/js/product-editor/src/components/header/save-draft-button/types.ts
+++ b/packages/js/product-editor/src/components/header/save-draft-button/types.ts
@@ -8,6 +8,5 @@ export type SaveDraftButtonProps = Omit<
 	Button.ButtonProps,
 	'aria-disabled' | 'variant' | 'children'
 > & {
-	productId: Product[ 'id' ];
 	productStatus: Product[ 'status' ];
 };

--- a/packages/js/product-editor/src/components/header/save-draft-button/types.ts
+++ b/packages/js/product-editor/src/components/header/save-draft-button/types.ts
@@ -1,0 +1,13 @@
+/**
+ * External dependencies
+ */
+import { Product } from '@woocommerce/data';
+import { Button } from '@wordpress/components';
+
+export type SaveDraftButtonProps = Omit<
+	Button.ButtonProps,
+	'aria-disabled' | 'variant' | 'children'
+> & {
+	productId: Product[ 'id' ];
+	productStatus: Product[ 'status' ];
+};

--- a/packages/js/product-editor/src/utils/get-product-error-message.ts
+++ b/packages/js/product-editor/src/utils/get-product-error-message.ts
@@ -3,8 +3,14 @@
  */
 import { __ } from '@wordpress/i18n';
 
+export type WPErrorCode =
+	| 'product_invalid_sku'
+	| 'product_create_error'
+	| 'product_publish_error'
+	| 'product_preview_error';
+
 export type WPError = {
-	code: string;
+	code: WPErrorCode;
 	message: string;
 	data: {
 		[ key: string ]: unknown;
@@ -12,9 +18,16 @@ export type WPError = {
 };
 
 export function getProductErrorMessage( error: WPError ) {
-	if ( error.code === 'product_invalid_sku' ) {
-		return __( 'Invalid or duplicated SKU.', 'woocommerce' );
+	switch ( error.code ) {
+		case 'product_invalid_sku':
+			return __( 'Invalid or duplicated SKU.', 'woocommerce' );
+		case 'product_create_error':
+			return __( 'Failed to create product.', 'woocommerce' );
+		case 'product_publish_error':
+			return __( 'Failed to publish product.', 'woocommerce' );
+		case 'product_preview_error':
+			return __( 'Failed to preview product.', 'woocommerce' );
+		default:
+			return __( 'Failed to save product.', 'woocommerce' );
 	}
-
-	return null;
 }

--- a/packages/js/product-editor/src/utils/test/get-product-error-message.ts
+++ b/packages/js/product-editor/src/utils/test/get-product-error-message.ts
@@ -12,11 +12,9 @@ describe( 'getProductErrorMessage', () => {
 		expect( message ).toBe( 'Invalid or duplicated SKU.' );
 	} );
 
-	it( 'should return null when no error message exists', () => {
-		const error = {
-			code: 'unanticipated_error_code',
-		} as WPError;
-		const status = getProductErrorMessage( error );
-		expect( status ).toBeNull();
+	it( 'should return a default message when the error code is not mapped', () => {
+		const error = {} as WPError;
+		const message = getProductErrorMessage( error );
+		expect( message ).toBe( 'Failed to save product.' );
 	} );
 } );


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #38319

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Got to `/wp-admin/tools.php?page=woocommerce-admin-test-helper`
2. Under Features tab make sure to enable `product-block-editor`
3. Then visit `/wp-admin/admin.php?page=wc-admin&path=/add-product`
4. The product form should not have the problem described in #38319

<!-- End testing instructions -->
