### PR TITLE
Filter which packages install and build in Lint / Test JS CI check

### DIFF
--- a/.github/workflows/pr-lint-test-js.yml
+++ b/.github/workflows/pr-lint-test-js.yml
@@ -22,8 +22,12 @@ jobs:
             - name: Setup WooCommerce Monorepo
               uses: ./.github/actions/setup-woocommerce-monorepo
               with:
-                  install-filters: './packages/js/*'
-                  build-filters: './packages/js/*'
+                  install-filters: 'woocommerce/client/admin...
+                      !@woocommerce/e2e*
+                      !@woocommerce/api'
+                  build-filters: 'woocommerce/client/admin...
+                      !@woocommerce/e2e*
+                      !@woocommerce/api'
 
             - name: Lint
               run: pnpm run -r --filter='release-posts' --filter='woocommerce/client/admin...' --filter='!@woocommerce/e2e*' --filter='!@woocommerce/api' --color lint

--- a/.github/workflows/pr-lint-test-js.yml
+++ b/.github/workflows/pr-lint-test-js.yml
@@ -22,10 +22,12 @@ jobs:
             - name: Setup WooCommerce Monorepo
               uses: ./.github/actions/setup-woocommerce-monorepo
               with:
-                  install-filters: 'woocommerce/client/admin...
+                  install-filters: 'woocommerce/client/admin
+                      ./packages/js/*
                       !@woocommerce/e2e*
                       !@woocommerce/api'
-                  build-filters: 'woocommerce/client/admin...
+                  build-filters: 'woocommerce/client/admin
+                      ./packages/js/*
                       !@woocommerce/e2e*
                       !@woocommerce/api'
 

--- a/.github/workflows/pr-lint-test-js.yml
+++ b/.github/workflows/pr-lint-test-js.yml
@@ -22,8 +22,8 @@ jobs:
             - name: Setup WooCommerce Monorepo
               uses: ./.github/actions/setup-woocommerce-monorepo
               with:
-                  install-filters: '@woocommerce/*'
-                  build-filters: '@woocommerce/*'
+                  install-filters: './packages/js/*'
+                  build-filters: './packages/js/*'
 
             - name: Lint
               run: pnpm run -r --filter='release-posts' --filter='woocommerce/client/admin...' --filter='!@woocommerce/e2e*' --filter='!@woocommerce/api' --color lint

--- a/.github/workflows/pr-lint-test-js.yml
+++ b/.github/workflows/pr-lint-test-js.yml
@@ -21,6 +21,8 @@ jobs:
 
             - name: Setup WooCommerce Monorepo
               uses: ./.github/actions/setup-woocommerce-monorepo
+              with:
+                  build: false
 
             - name: Lint
               run: pnpm run -r --filter='release-posts' --filter='woocommerce/client/admin...' --filter='!@woocommerce/e2e*' --filter='!@woocommerce/api' --color lint

--- a/.github/workflows/pr-lint-test-js.yml
+++ b/.github/workflows/pr-lint-test-js.yml
@@ -22,7 +22,8 @@ jobs:
             - name: Setup WooCommerce Monorepo
               uses: ./.github/actions/setup-woocommerce-monorepo
               with:
-                  build: false
+                  install-filters: '@woocommerce/*'
+                  build-filters: '@woocommerce/*'
 
             - name: Lint
               run: pnpm run -r --filter='release-posts' --filter='woocommerce/client/admin...' --filter='!@woocommerce/e2e*' --filter='!@woocommerce/api' --color lint

--- a/.github/workflows/pr-lint-test-js.yml
+++ b/.github/workflows/pr-lint-test-js.yml
@@ -22,15 +22,8 @@ jobs:
             - name: Setup WooCommerce Monorepo
               uses: ./.github/actions/setup-woocommerce-monorepo
               with:
-                  install-filters: 'woocommerce/client/admin
-                      ./packages/js/*
-                      !@woocommerce/e2e*
-                      !@woocommerce/api'
-                  build-filters: 'woocommerce/client/admin
-                      ./packages/js/*
-                      !@woocommerce/e2e*
-                      !@woocommerce/api'
-
+                  install-filters: './packages/js/*'
+                  build-filters: './packages/js/*'
             - name: Lint
               run: pnpm run -r --filter='release-posts' --filter='woocommerce/client/admin...' --filter='!@woocommerce/e2e*' --filter='!@woocommerce/api' --color lint
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When performing the lint and test JS task we only need to build the TS packages to ensure deps are resolved properly when linting. This filters the install and build to just those packages to speed up monorepo setup on this check.


1. in the CI check the `Lint and Test JS` runs correctly, lints correctly and passes as it did before. This will require that the monorepo setup task has successfully passed anyway. In theory it should be faster too, a full install and build usually takes ~7 minutes whereas runs of these filters seem to sit at about 4 mins.

<!-- End testing instructions -->
