### PR TITLE
Remove eslint-plugin-react plugin warnings from lint

### DIFF
--- a/packages/js/eslint-plugin/changelog/dev-remove-eslint-react-warnings
+++ b/packages/js/eslint-plugin/changelog/dev-remove-eslint-react-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Tell eslint-react-plugin to assume React version 17.0.2

--- a/packages/js/eslint-plugin/configs/recommended.js
+++ b/packages/js/eslint-plugin/configs/recommended.js
@@ -66,6 +66,7 @@ module.exports = {
 		'import/core-modules': [ '@woocommerce/settings', 'lodash', 'react' ],
 		react: {
 			pragma: 'createElement',
+			version: '17.0.2',
 		},
 	},
 	overrides: [


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Right now if you run a lint over the code base you'll see a lot of warnings that because `React` is not a dependency of a package that eslint cannot detect its version. 

The most correct thing would be for those projects that don't have React enabled to not have this config, but thats a more complex and wide-ranging change to make sure each package consumes a config based on whether React is a dependency.

Fixing the React version does not break any existing lints and is consistent with the React version we sync across the codebase. Later on we could consider creating a new config for non-React packages.

### How to test the changes in this Pull Request:


1. Look at some recent PR's and the ` Lint and Test JS` CI check has warnings about eslint-react-plugin
2. See the CI check on this PR does not produce those warnings but still passes.


<!-- End testing instructions -->
