### PR TITLE
Fix number of orders under tax report

### DIFF
--- a/plugins/woocommerce/changelog/fix-38347_tax_report_count_number_of_orders
+++ b/plugins/woocommerce/changelog/fix-38347_tax_report_count_number_of_orders
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix number of orders under tax report

--- a/plugins/woocommerce/includes/admin/reports/class-wc-report-taxes-by-code.php
+++ b/plugins/woocommerce/includes/admin/reports/class-wc-report-taxes-by-code.php
@@ -158,8 +158,8 @@ class WC_Report_Taxes_By_Code extends WC_Admin_Report {
 
 		// Merge.
 		$tax_rows = array();
-		// Initialize an associative array to store unique post_ids
-		$unique_post_ids = [];
+		// Initialize an associative array to store unique post_ids.
+		$unique_post_ids = array();
 
 		foreach ( $tax_rows_orders + $tax_rows_partial_refunds as $tax_row ) {
 			$key                                    = $tax_row->rate_id;

--- a/plugins/woocommerce/includes/admin/reports/class-wc-report-taxes-by-code.php
+++ b/plugins/woocommerce/includes/admin/reports/class-wc-report-taxes-by-code.php
@@ -162,7 +162,7 @@ class WC_Report_Taxes_By_Code extends WC_Admin_Report {
 		$unique_post_ids = array();
 
 		foreach ( $tax_rows_orders + $tax_rows_partial_refunds as $tax_row ) {
-			$key                                    = $tax_row->rate_id;
+			$key                                    = $tax_row->tax_rate;
 			$tax_rows[ $key ]                       = isset( $tax_rows[ $key ] ) ? $tax_rows[ $key ] : (object) array(
 				'tax_amount'          => 0,
 				'shipping_tax_amount' => 0,
@@ -172,8 +172,12 @@ class WC_Report_Taxes_By_Code extends WC_Admin_Report {
 			$tax_rows[ $key ]->tax_rate             = $tax_row->tax_rate;
 			$tax_rows[ $key ]->tax_amount          += wc_round_tax_total( $tax_row->tax_amount );
 			$tax_rows[ $key ]->shipping_tax_amount += wc_round_tax_total( $tax_row->shipping_tax_amount );
+			if ( ! isset( $unique_post_ids[ $key ] ) || ! in_array( $tax_row->post_id, $unique_post_ids[ $key ], true ) ) {
+				$unique_post_ids[ $key ] = isset( $unique_post_ids[ $key ] ) ? $unique_post_ids[ $key ] : array();
+				$unique_post_ids[ $key ][] = $tax_row->post_id;
+				$tax_rows[ $key ]->total_orders += 1;
+			}
 		}
-		$tax_rows[ $key ]->total_orders = count( $unique_post_ids );
 
 		foreach ( $tax_rows_full_refunds as $tax_row ) {
 			$key                                    = $tax_row->rate_id;

--- a/plugins/woocommerce/includes/admin/reports/class-wc-report-taxes-by-code.php
+++ b/plugins/woocommerce/includes/admin/reports/class-wc-report-taxes-by-code.php
@@ -168,7 +168,6 @@ class WC_Report_Taxes_By_Code extends WC_Admin_Report {
 				'shipping_tax_amount' => 0,
 				'total_orders'        => 0,
 			);
-			$unique_post_ids[ $tax_row->post_id ]   = true;
 			$tax_rows[ $key ]->tax_rate             = $tax_row->tax_rate;
 			$tax_rows[ $key ]->tax_amount          += wc_round_tax_total( $tax_row->tax_amount );
 			$tax_rows[ $key ]->shipping_tax_amount += wc_round_tax_total( $tax_row->shipping_tax_amount );
@@ -180,7 +179,7 @@ class WC_Report_Taxes_By_Code extends WC_Admin_Report {
 		}
 
 		foreach ( $tax_rows_full_refunds as $tax_row ) {
-			$key                                    = $tax_row->rate_id;
+			$key                                    = $tax_row->tax_rate;
 			$tax_rows[ $key ]                       = isset( $tax_rows[ $key ] ) ? $tax_rows[ $key ] : (object) array(
 				'tax_amount'          => 0,
 				'shipping_tax_amount' => 0,

--- a/plugins/woocommerce/includes/admin/reports/class-wc-report-taxes-by-code.php
+++ b/plugins/woocommerce/includes/admin/reports/class-wc-report-taxes-by-code.php
@@ -173,8 +173,8 @@ class WC_Report_Taxes_By_Code extends WC_Admin_Report {
 			$tax_rows[ $key ]->tax_amount          += wc_round_tax_total( $tax_row->tax_amount );
 			$tax_rows[ $key ]->shipping_tax_amount += wc_round_tax_total( $tax_row->shipping_tax_amount );
 			if ( ! isset( $unique_post_ids[ $key ] ) || ! in_array( $tax_row->post_id, $unique_post_ids[ $key ], true ) ) {
-				$unique_post_ids[ $key ] = isset( $unique_post_ids[ $key ] ) ? $unique_post_ids[ $key ] : array();
-				$unique_post_ids[ $key ][] = $tax_row->post_id;
+				$unique_post_ids[ $key ]         = isset( $unique_post_ids[ $key ] ) ? $unique_post_ids[ $key ] : array();
+				$unique_post_ids[ $key ][]       = $tax_row->post_id;
 				$tax_rows[ $key ]->total_orders += 1;
 			}
 		}

--- a/plugins/woocommerce/includes/admin/reports/class-wc-report-taxes-by-code.php
+++ b/plugins/woocommerce/includes/admin/reports/class-wc-report-taxes-by-code.php
@@ -158,6 +158,8 @@ class WC_Report_Taxes_By_Code extends WC_Admin_Report {
 
 		// Merge.
 		$tax_rows = array();
+		// Initialize an associative array to store unique post_ids
+		$unique_post_ids = [];
 
 		foreach ( $tax_rows_orders + $tax_rows_partial_refunds as $tax_row ) {
 			$key                                    = $tax_row->rate_id;
@@ -166,11 +168,12 @@ class WC_Report_Taxes_By_Code extends WC_Admin_Report {
 				'shipping_tax_amount' => 0,
 				'total_orders'        => 0,
 			);
-			$tax_rows[ $key ]->total_orders        += 1;
+			$unique_post_ids[ $tax_row->post_id ]   = true;
 			$tax_rows[ $key ]->tax_rate             = $tax_row->tax_rate;
 			$tax_rows[ $key ]->tax_amount          += wc_round_tax_total( $tax_row->tax_amount );
 			$tax_rows[ $key ]->shipping_tax_amount += wc_round_tax_total( $tax_row->shipping_tax_amount );
 		}
+		$tax_rows[ $key ]->total_orders = count( $unique_post_ids );
 
 		foreach ( $tax_rows_full_refunds as $tax_row ) {
 			$key                                    = $tax_row->rate_id;


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Under `WooCommerce > Reports > Taxes`, the number of orders displayed is incorrect. Currently, it shows the count of applied taxes instead of the actual number of orders that are charging taxes.

Before
![Screenshot 2023-05-31 at 11 27 43](https://github.com/woocommerce/woocommerce/assets/1314156/faa67ca4-4ac2-49fe-8efb-d8cf452a9c3a)

After
![Screenshot 2023-05-31 at 11 10 13](https://github.com/woocommerce/woocommerce/assets/1314156/88c50e4d-267d-45b6-a2e0-689730f9957e)


Partially fixes issue [38347](https://github.com/woocommerce/woocommerce/issues/38347).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set up a store with a tax plugin like `Avalara Avatax`.
2. Create a product and create an order. You may want to use a California address so multiple tax rules are applied.
3. Complete the order and make sure all the actions are run under **WooCommerce > Status > Scheduled Actions**
4. Go to **WooCommerce > Reports > Taxes**
5. Tax numbers should show correctly here.
6. Now checkout `trunk`, rebuild the project, and refresh the page.
7. The bug should be visible again.

<!-- End testing instructions -->
