### PR TITLE
cast url to string for str_replace

### DIFF
--- a/plugins/woocommerce/changelog/fix-force-ssl-null-url
+++ b/plugins/woocommerce/changelog/fix-force-ssl-null-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+cast url to string for str_replace

--- a/plugins/woocommerce/includes/class-wc-https.php
+++ b/plugins/woocommerce/includes/class-wc-https.php
@@ -59,7 +59,7 @@ class WC_HTTPS {
 			if ( is_array( $content ) ) {
 				$content = array_map( 'WC_HTTPS::force_https_url', $content );
 			} else {
-				$content = str_replace( 'http:', 'https:', $content );
+				$content = str_replace( 'http:', 'https:', (string) $content );
 			}
 		}
 		return $content;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes a deprecated warning in PHP 8.1 when the URL passed to `force_https_url` is `null`.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### To demonstrate the bug
1. Install and activate the query monitor plugin
2. Register a null source script
```
	wp_register_script(
		'src-is-null',
		null,
		array(),
		false,
		true
	);
```
3. Load the site home page in `trunk`
4. Error log should contain
```
30-May-2023 16:58:40 UTC] PHP Deprecated:  str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /Users/ronrennick/Sites/wc/wp-content/woocommerce/plugins/woocommerce/includes/class-wc-https.php on line 62
```

#### Test this fix
1. Switch to this branch
2. Reload the site home page
3. No messages sent to error log

