### PR TITLE
Always show pricing group fields, disable if not available for a product type

### DIFF
--- a/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/product-tracking/shared.ts
@@ -541,6 +541,27 @@ const attachProductAttributesTracks = () => {
 		} );
 };
 
+const attachGeneralTabTracks = () => {
+	document
+		.querySelector(
+			'#general_product_data .woocommerce-message .variations-tab-navigation-link'
+		)
+		?.addEventListener( 'click', () => {
+			recordEvent( 'disabled_general_tab', {
+				action: 'go_to_variations',
+			} );
+		} );
+	document
+		.querySelector(
+			'#general_product_data .woocommerce-message .linked-products-navigation-link'
+		)
+		?.addEventListener( 'click', () => {
+			recordEvent( 'disabled_general_tab', {
+				action: 'go_to_linked_products',
+			} );
+		} );
+};
+
 /**
  * Attaches product variations tracks.
  */
@@ -731,6 +752,7 @@ export const initProductScreenTracks = () => {
 	attachProductVariationsTracks();
 	attachProductTabsTracks();
 	attachProductInventoryTabTracks();
+	attachGeneralTabTracks();
 };
 
 export function addExitPageListener( pageId: string ) {

--- a/plugins/woocommerce/changelog/add-always-show-pricinggroup
+++ b/plugins/woocommerce/changelog/add-always-show-pricinggroup
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Always show pricing group fields, disable if not available for a product type

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -5364,6 +5364,10 @@ img.help_tip {
 		padding: 0;
 		margin: 0 0 0 -150px;
 
+		&.disabled {
+			opacity: 0.5;
+		}
+
 		.req {
 			font-weight: 700;
 			font-style: normal;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -959,6 +959,7 @@
 
 #variable_product_options #message,
 #inventory_product_data .notice,
+#general_product_data .notice,
 #variable_product_options .notice {
 	display: flex;
 	margin: 10px;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -5364,9 +5364,6 @@ img.help_tip {
 		padding: 0;
 		margin: 0 0 0 -150px;
 
-		&.disabled {
-			opacity: 0.5;
-		}
 
 		.req {
 			font-weight: 700;
@@ -5382,6 +5379,14 @@ img.help_tip {
 		margin: 0 0 0 7px;
 		clear: none;
 		display: inline;
+	}
+
+	label,
+	input {
+		&.disabled {
+			opacity: 0.5;
+			cursor: not-allowed;
+		}
 	}
 
 	input:not([type="checkbox"]):not([type="radio"]) + .description {

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -139,6 +139,7 @@ jQuery( function ( $ ) {
 			}
 
 			show_and_hide_panels();
+			disable_or_enable_fields();
 			change_product_type_tip( get_product_tip_content( select_val ) );
 
 			$( 'ul.wc-tabs li:visible' ).eq( 0 ).find( 'a' ).trigger( 'click' );
@@ -257,6 +258,33 @@ jQuery( function ( $ ) {
 					.find( 'li a[href="#' + $id + '"]' )
 					.parent()
 					.hide();
+			}
+		} );
+	}
+
+	function disable_or_enable_fields() {
+		var product_type = $( 'select#product-type' ).val();
+		$( `.disable_if_grouped` ).each( function () {
+			if ( $( this ).is( 'label' ) ) {
+				$( this ).removeClass( 'disabled' );
+			} else {
+				$( this ).prop( 'disabled', false ).css( 'cursor', 'initial' );
+			}
+		} );
+		$( `.disable_if_variable` ).each( function () {
+			if ( $( this ).is( 'label' ) ) {
+				$( this ).removeClass( 'disabled' );
+			} else {
+				$( this ).prop( 'disabled', false ).css( 'cursor', 'initial' );
+			}
+		} );
+		$( `.disable_if_${ product_type }` ).each( function () {
+			if ( $( this ).is( 'label' ) ) {
+				$( this ).addClass( 'disabled' );
+			} else {
+				$( this )
+					.prop( 'disabled', true )
+					.css( 'cursor', 'not-allowed' );
 			}
 		} );
 	}

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -264,24 +264,35 @@ jQuery( function ( $ ) {
 
 	function disable_or_enable_fields() {
 		var product_type = $( 'select#product-type' ).val();
-		$( `.disable_if_grouped` ).each( function () {
-			$( this ).removeClass( 'disabled' );
-			if ( $( this ).is('input')) {
-				$( this ).prop( 'disabled', false )
-			}
-		} );
-		$( `.disable_if_variable` ).each( function () {
-			$( this ).removeClass( 'disabled' );
-			if ( $( this ).is('input')) {
-				$( this ).prop( 'disabled', false )
-			}
-		} );
-		$( `.disable_if_${ product_type }` ).each( function () {
+		var hasDisabledFields = true;
+		$( `.enable_if_simple` ).each( function () {
 			$( this ).addClass( 'disabled' );
-			if ( $( this ).is('input')) {
-				$( this ).prop( 'disabled', true )
+			if ( $( this ).is( 'input' ) ) {
+				$( this ).prop( 'disabled', true );
 			}
 		} );
+		$( `.enable_if_external` ).each( function () {
+			$( this ).addClass( 'disabled' );
+			if ( $( this ).is( 'input' ) ) {
+				$( this ).prop( 'disabled', true );
+			}
+		} );
+		$( `.enable_if_${ product_type }` ).each( function () {
+			hasDisabledFields = false;
+			$( this ).removeClass( 'disabled' );
+			if ( $( this ).is( 'input' ) ) {
+				$( this ).prop( 'disabled', false );
+			}
+		} );
+
+		if (
+			hasDisabledFields &&
+			! $( '#general_product_data .woocommerce-message' ).is( ':visible' )
+		) {
+			$( `.pricing_disabled_fallback_message` ).show();
+		} else {
+			$( `.pricing_disabled_fallback_message` ).hide();
+		}
 	}
 
 	// Sale price schedule.

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -925,7 +925,7 @@ jQuery( function ( $ ) {
 	} );
 
 	// Go to attributes tab when clicking on link in variations message
-	$( document.body ).on(
+	$( '#woocommerce-product-data' ).on(
 		'click',
 		'#variable_product_options .add-attributes-message a[href="#product_attributes"]',
 		function () {
@@ -937,7 +937,7 @@ jQuery( function ( $ ) {
 	);
 
 	// Go to variations tab when clicking on link in the general tab message
-	$( document.body ).on(
+	$( '#woocommerce-product-data' ).on(
 		'click',
 		'#general_product_data .woocommerce-message a[href="#variable_product_options"]',
 		function () {
@@ -949,7 +949,7 @@ jQuery( function ( $ ) {
 	);
 
 	// Go to linked products tab when clicking on link in the general tab message
-	$( document.body ).on(
+	$( '#woocommerce-product-data' ).on(
 		'click',
 		'#general_product_data .woocommerce-message a[href="#linked_product_data"]',
 		function () {

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -265,26 +265,21 @@ jQuery( function ( $ ) {
 	function disable_or_enable_fields() {
 		var product_type = $( 'select#product-type' ).val();
 		$( `.disable_if_grouped` ).each( function () {
-			if ( $( this ).is( 'label' ) ) {
-				$( this ).removeClass( 'disabled' );
-			} else {
-				$( this ).prop( 'disabled', false ).css( 'cursor', 'initial' );
+			$( this ).removeClass( 'disabled' );
+			if ( $( this ).is('input')) {
+				$( this ).prop( 'disabled', false )
 			}
 		} );
 		$( `.disable_if_variable` ).each( function () {
-			if ( $( this ).is( 'label' ) ) {
-				$( this ).removeClass( 'disabled' );
-			} else {
-				$( this ).prop( 'disabled', false ).css( 'cursor', 'initial' );
+			$( this ).removeClass( 'disabled' );
+			if ( $( this ).is('input')) {
+				$( this ).prop( 'disabled', false )
 			}
 		} );
 		$( `.disable_if_${ product_type }` ).each( function () {
-			if ( $( this ).is( 'label' ) ) {
-				$( this ).addClass( 'disabled' );
-			} else {
-				$( this )
-					.prop( 'disabled', true )
-					.css( 'cursor', 'not-allowed' );
+			$( this ).addClass( 'disabled' );
+			if ( $( this ).is('input')) {
+				$( this ).prop( 'disabled', true )
 			}
 		} );
 	}
@@ -929,6 +924,34 @@ jQuery( function ( $ ) {
 			return false;
 		}
 	);
+
+	// Go to variations tab when clicking on link in the general tab message
+	$( document.body ).on(
+		'click',
+		'#general_product_data .woocommerce-message a[href="#variable_product_options"]',
+		function () {
+			$(
+				'#woocommerce-product-data .variations_tab a[href="#variable_product_options"]'
+			).trigger( 'click' );
+			return false;
+		}
+	);
+
+	// Go to linked products tab when clicking on link in the general tab message
+	$( document.body ).on(
+		'click',
+		'#general_product_data .woocommerce-message a[href="#linked_product_data"]',
+		function () {
+			$(
+				'#woocommerce-product-data .linked_product_tab a[href="#linked_product_data"]'
+			).trigger( 'click' );
+			return false;
+		}
+	);
+
+
+
+
 
 	// Uploading files.
 	var downloadable_file_frame;

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -89,7 +89,7 @@ class WC_Meta_Box_Product_Data {
 				'general'        => array(
 					'label'    => __( 'General', 'woocommerce' ),
 					'target'   => 'general_product_data',
-					'class'    => array( 'hide_if_grouped' ),
+					'class'    => array( 'show_if_simple', 'show_if_variable', 'show_if_grouped', 'show_if_external' ),
 					'priority' => 10,
 				),
 				'inventory'      => array(

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -89,7 +89,7 @@ class WC_Meta_Box_Product_Data {
 				'general'        => array(
 					'label'    => __( 'General', 'woocommerce' ),
 					'target'   => 'general_product_data',
-					'class'    => array( 'show_if_simple', 'show_if_variable', 'show_if_grouped', 'show_if_external' ),
+					'class'    => array(),
 					'priority' => 10,
 				),
 				'inventory'      => array(

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-general.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-general.php
@@ -38,13 +38,13 @@ defined( 'ABSPATH' ) || exit;
 
 	<div class="inline notice woocommerce-message show_if_variable">
 		<p>
-			<?php echo esc_html_e( 'You can manage pricing and other details individually for each product variation.', 'woocommerce' ); ?> <a href="#variable_product_options"><?php esc_html_e( 'Go to Variations', 'woocommerce' ); ?></a>
+			<?php echo esc_html_e( 'You can manage pricing and other details individually for each product variation.', 'woocommerce' ); ?> <a class="variations-tab-navigation-link" href="#variable_product_options"><?php esc_html_e( 'Go to Variations', 'woocommerce' ); ?></a>
 		</p>
 	</div>
 
 	<div class="inline notice woocommerce-message show_if_grouped">
 		<p>
-			<?php echo esc_html_e( 'You can manage pricing and other details individually for each product added to this group.', 'woocommerce' ); ?> <a href="#linked_product_data"><?php esc_html_e( 'Go to Linked Products', 'woocommerce' ); ?></a>
+			<?php echo esc_html_e( 'You can manage pricing and other details individually for each product added to this group.', 'woocommerce' ); ?> <a class="linked-products-navigation-link" href="#linked_product_data"><?php esc_html_e( 'Go to Linked Products', 'woocommerce' ); ?></a>
 		</p>
 	</div>
 

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-general.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-general.php
@@ -46,7 +46,7 @@ defined( 'ABSPATH' ) || exit;
 			 */
 			echo esc_html( apply_filters( 'woocommerce_general_pricing_disabled_message', __( 'You can manage pricing and other details individually for each product variation.', 'woocommerce' ), 'variable' ) );
 			?>
-			 <a class="variations-tab-navigation-link" href="#variable_product_options">
+			<a class="variations-tab-navigation-link" href="#variable_product_options">
 			<?php
 			esc_html_e( 'Go to Variations', 'woocommerce' );
 			?>
@@ -64,7 +64,7 @@ defined( 'ABSPATH' ) || exit;
 			 */
 			echo esc_html( apply_filters( 'woocommerce_general_pricing_disabled_message', __( 'You can manage pricing and other details individually for each product added to this group.', 'woocommerce' ), 'grouped' ) );
 			?>
-			 <a class="linked-products-navigation-link" href="#linked_product_data"><?php esc_html_e( 'Go to Linked Products', 'woocommerce' ); ?></a>
+			<a class="linked-products-navigation-link" href="#linked_product_data"><?php esc_html_e( 'Go to Linked Products', 'woocommerce' ); ?></a>
 		</p>
 	</div>
 
@@ -142,7 +142,7 @@ defined( 'ABSPATH' ) || exit;
 
 					if ( $downloadable_files ) {
 						foreach ( $downloadable_files as $key => $file ) {
-							$disabled_download = isset( $file['enabled'] ) && false === $file['enabled'];
+							$disabled_download         = isset( $file['enabled'] ) && false === $file['enabled'];
 							$disabled_downloads_count += (int) $disabled_download;
 							include __DIR__ . '/html-product-download.php';
 						}
@@ -154,8 +154,8 @@ defined( 'ABSPATH' ) || exit;
 						<th colspan="2">
 							<a href="#" class="button insert" data-row="
 							<?php
-								$key  = '';
-								$file = array(
+								$key               = '';
+								$file              = array(
 									'file' => '',
 									'name' => '',
 								);

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-general.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-general.php
@@ -38,13 +38,13 @@ defined( 'ABSPATH' ) || exit;
 
 	<div class="inline notice woocommerce-message show_if_variable">
 		<p>
-			<?php echo esc_html_e( 'You can manage pricing and other details individually for each product variation.', 'woocommerce' ); ?> <a class="variations-tab-navigation-link" href="#variable_product_options"><?php esc_html_e( 'Go to Variations', 'woocommerce' ); ?></a>
+			<?php echo esc_html( apply_filters( 'woocommerce_general_pricing_disabled_message', __( 'You can manage pricing and other details individually for each product variation.', 'woocommerce' ), 'variable' ) ); ?> <a class="variations-tab-navigation-link" href="#variable_product_options"><?php esc_html_e( 'Go to Variations', 'woocommerce' ); ?></a>
 		</p>
 	</div>
 
 	<div class="inline notice woocommerce-message show_if_grouped">
 		<p>
-			<?php echo esc_html_e( 'You can manage pricing and other details individually for each product added to this group.', 'woocommerce' ); ?> <a class="linked-products-navigation-link" href="#linked_product_data"><?php esc_html_e( 'Go to Linked Products', 'woocommerce' ); ?></a>
+			<?php echo esc_html( apply_filters( 'woocommerce_general_pricing_disabled_message', __( 'You can manage pricing and other details individually for each product added to this group.', 'woocommerce' ), 'grouped' ) ); ?> <a class="linked-products-navigation-link" href="#linked_product_data"><?php esc_html_e( 'Go to Linked Products', 'woocommerce' ); ?></a>
 		</p>
 	</div>
 

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-general.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-general.php
@@ -38,19 +38,37 @@ defined( 'ABSPATH' ) || exit;
 
 	<div class="inline notice woocommerce-message show_if_variable">
 		<p>
-			<?php echo esc_html( apply_filters( 'woocommerce_general_pricing_disabled_message', __( 'You can manage pricing and other details individually for each product variation.', 'woocommerce' ), 'variable' ) ); ?> <a class="variations-tab-navigation-link" href="#variable_product_options"><?php esc_html_e( 'Go to Variations', 'woocommerce' ); ?></a>
+			<?php
+			/**
+			 * Allow developers to change the general pricing message.
+			 *
+			 * @since 7.9.0
+			 */
+			echo esc_html( apply_filters( 'woocommerce_general_pricing_disabled_message', __( 'You can manage pricing and other details individually for each product variation.', 'woocommerce' ), 'variable' ) ); ?> <a class="variations-tab-navigation-link" href="#variable_product_options"><?php esc_html_e( 'Go to Variations', 'woocommerce' ); ?></a>
 		</p>
 	</div>
 
 	<div class="inline notice woocommerce-message show_if_grouped">
 		<p>
-			<?php echo esc_html( apply_filters( 'woocommerce_general_pricing_disabled_message', __( 'You can manage pricing and other details individually for each product added to this group.', 'woocommerce' ), 'grouped' ) ); ?> <a class="linked-products-navigation-link" href="#linked_product_data"><?php esc_html_e( 'Go to Linked Products', 'woocommerce' ); ?></a>
+			<?php
+			/**
+			 * Allow developers to change the general pricing message.
+			 *
+			 * @since 7.9.0
+			 */
+			echo esc_html( apply_filters( 'woocommerce_general_pricing_disabled_message', __( 'You can manage pricing and other details individually for each product added to this group.', 'woocommerce' ), 'grouped' ) ); ?> <a class="linked-products-navigation-link" href="#linked_product_data"><?php esc_html_e( 'Go to Linked Products', 'woocommerce' ); ?></a>
 		</p>
 	</div>
 
 	<div class="inline notice woocommerce-message pricing_disabled_fallback_message">
 		<p>
-			<?php echo esc_html( apply_filters( 'woocommerce_general_pricing_disabled_message', __( 'You can manage pricing and other details in one of the other tabs.', 'woocommerce' ), 'grouped' ) ); ?>
+			<?php
+			/**
+			 * Allow developers to change the general pricing message.
+			 *
+			 * @since 7.9.0
+			 */
+			echo esc_html( apply_filters( 'woocommerce_general_pricing_disabled_message', __( 'You can manage pricing and other details in one of the other tabs.', 'woocommerce' ), 'grouped' ) ); ?>
 		</p>
 	</div>
 

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-general.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-general.php
@@ -38,13 +38,13 @@ defined( 'ABSPATH' ) || exit;
 
 	<div class="inline notice woocommerce-message show_if_variable">
 		<p>
-			<?php echo esc_html_e( 'You can manage pricing and other details individually for each product variation.', 'woocommerce' ); ?> <a href="#product_attributes"><?php esc_html_e( 'Go to Variations', 'woocommerce' ); ?></a>
+			<?php echo esc_html_e( 'You can manage pricing and other details individually for each product variation.', 'woocommerce' ); ?> <a href="#variable_product_options"><?php esc_html_e( 'Go to Variations', 'woocommerce' ); ?></a>
 		</p>
 	</div>
 
 	<div class="inline notice woocommerce-message show_if_grouped">
 		<p>
-			<?php echo esc_html_e( 'You can manage pricing and other details individually for each product added to this group.', 'woocommerce' ); ?> <a href="#product_attributes"><?php esc_html_e( 'Go to Linked Products', 'woocommerce' ); ?></a>
+			<?php echo esc_html_e( 'You can manage pricing and other details individually for each product added to this group.', 'woocommerce' ); ?> <a href="#linked_product_data"><?php esc_html_e( 'Go to Linked Products', 'woocommerce' ); ?></a>
 		</p>
 	</div>
 

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-general.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-general.php
@@ -48,17 +48,22 @@ defined( 'ABSPATH' ) || exit;
 		</p>
 	</div>
 
+	<div class="inline notice woocommerce-message pricing_disabled_fallback_message">
+		<p>
+			<?php echo esc_html( apply_filters( 'woocommerce_general_pricing_disabled_message', __( 'You can manage pricing and other details in one of the other tabs.', 'woocommerce' ), 'grouped' ) ); ?>
+		</p>
+	</div>
 
-	<div class="options_group pricing show_if_simple show_if_external show_if_variable show_if_grouped hidden">
+	<div class="options_group pricing">
 		<?php
 		woocommerce_wp_text_input(
 			array(
 				'id'          => '_regular_price',
 				'value'       => $product_object->get_regular_price( 'edit' ),
 				'label'       => __( 'Regular price', 'woocommerce' ) . ' (' . get_woocommerce_currency_symbol() . ')',
-				'label_class' => 'disable_if_variable disable_if_grouped',
+				'label_class' => 'enable_if_simple enable_if_external',
 				'data_type'   => 'price',
-				'class'       => 'disable_if_variable disable_if_grouped',
+				'class'       => 'enable_if_simple enable_if_external',
 			)
 		);
 
@@ -68,9 +73,9 @@ defined( 'ABSPATH' ) || exit;
 				'value'       => $product_object->get_sale_price( 'edit' ),
 				'data_type'   => 'price',
 				'label'       => __( 'Sale price', 'woocommerce' ) . ' (' . get_woocommerce_currency_symbol() . ')',
-				'label_class' => 'disable_if_variable disable_if_grouped',
-				'description' => '<a href="#" class="sale_schedule hide_if_variable hide_if_grouped">' . __( 'Schedule', 'woocommerce' ) . '</a>',
-				'class'       => 'disable_if_variable disable_if_grouped',
+				'label_class' => 'enable_if_simple enable_if_external',
+				'description' => '<a href="#" class="sale_schedule show_if_simple show_if_external">' . __( 'Schedule', 'woocommerce' ) . '</a>',
+				'class'       => 'enable_if_simple enable_if_external',
 			)
 		);
 

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-general.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-general.php
@@ -36,7 +36,20 @@ defined( 'ABSPATH' ) || exit;
 		?>
 	</div>
 
-	<div class="options_group pricing show_if_simple show_if_external hidden">
+	<div class="inline notice woocommerce-message show_if_variable">
+		<p>
+			<?php echo esc_html_e( 'You can manage pricing and other details individually for each product variation.', 'woocommerce' ); ?> <a href="#product_attributes"><?php esc_html_e( 'Go to Variations', 'woocommerce' ); ?></a>
+		</p>
+	</div>
+
+	<div class="inline notice woocommerce-message show_if_grouped">
+		<p>
+			<?php echo esc_html_e( 'You can manage pricing and other details individually for each product added to this group.', 'woocommerce' ); ?> <a href="#product_attributes"><?php esc_html_e( 'Go to Linked Products', 'woocommerce' ); ?></a>
+		</p>
+	</div>
+
+
+	<div class="options_group pricing show_if_simple show_if_external show_if_variable show_if_grouped hidden">
 		<?php
 		woocommerce_wp_text_input(
 			array(

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-general.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-general.php
@@ -53,10 +53,12 @@ defined( 'ABSPATH' ) || exit;
 		<?php
 		woocommerce_wp_text_input(
 			array(
-				'id'        => '_regular_price',
-				'value'     => $product_object->get_regular_price( 'edit' ),
-				'label'     => __( 'Regular price', 'woocommerce' ) . ' (' . get_woocommerce_currency_symbol() . ')',
-				'data_type' => 'price',
+				'id'          => '_regular_price',
+				'value'       => $product_object->get_regular_price( 'edit' ),
+				'label'       => __( 'Regular price', 'woocommerce' ) . ' (' . get_woocommerce_currency_symbol() . ')',
+				'label_class' => 'disable_if_variable disable_if_grouped',
+				'data_type'   => 'price',
+				'class'       => 'disable_if_variable disable_if_grouped',
 			)
 		);
 
@@ -66,7 +68,9 @@ defined( 'ABSPATH' ) || exit;
 				'value'       => $product_object->get_sale_price( 'edit' ),
 				'data_type'   => 'price',
 				'label'       => __( 'Sale price', 'woocommerce' ) . ' (' . get_woocommerce_currency_symbol() . ')',
-				'description' => '<a href="#" class="sale_schedule">' . __( 'Schedule', 'woocommerce' ) . '</a>',
+				'label_class' => 'disable_if_variable disable_if_grouped',
+				'description' => '<a href="#" class="sale_schedule hide_if_variable hide_if_grouped">' . __( 'Schedule', 'woocommerce' ) . '</a>',
+				'class'       => 'disable_if_variable disable_if_grouped',
 			)
 		);
 

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-general.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-general.php
@@ -44,7 +44,13 @@ defined( 'ABSPATH' ) || exit;
 			 *
 			 * @since 7.9.0
 			 */
-			echo esc_html( apply_filters( 'woocommerce_general_pricing_disabled_message', __( 'You can manage pricing and other details individually for each product variation.', 'woocommerce' ), 'variable' ) ); ?> <a class="variations-tab-navigation-link" href="#variable_product_options"><?php esc_html_e( 'Go to Variations', 'woocommerce' ); ?></a>
+			echo esc_html( apply_filters( 'woocommerce_general_pricing_disabled_message', __( 'You can manage pricing and other details individually for each product variation.', 'woocommerce' ), 'variable' ) );
+			?>
+			 <a class="variations-tab-navigation-link" href="#variable_product_options">
+			<?php
+			esc_html_e( 'Go to Variations', 'woocommerce' );
+			?>
+			</a>
 		</p>
 	</div>
 
@@ -56,7 +62,9 @@ defined( 'ABSPATH' ) || exit;
 			 *
 			 * @since 7.9.0
 			 */
-			echo esc_html( apply_filters( 'woocommerce_general_pricing_disabled_message', __( 'You can manage pricing and other details individually for each product added to this group.', 'woocommerce' ), 'grouped' ) ); ?> <a class="linked-products-navigation-link" href="#linked_product_data"><?php esc_html_e( 'Go to Linked Products', 'woocommerce' ); ?></a>
+			echo esc_html( apply_filters( 'woocommerce_general_pricing_disabled_message', __( 'You can manage pricing and other details individually for each product added to this group.', 'woocommerce' ), 'grouped' ) );
+			?>
+			 <a class="linked-products-navigation-link" href="#linked_product_data"><?php esc_html_e( 'Go to Linked Products', 'woocommerce' ); ?></a>
 		</p>
 	</div>
 
@@ -68,7 +76,8 @@ defined( 'ABSPATH' ) || exit;
 			 *
 			 * @since 7.9.0
 			 */
-			echo esc_html( apply_filters( 'woocommerce_general_pricing_disabled_message', __( 'You can manage pricing and other details in one of the other tabs.', 'woocommerce' ), 'grouped' ) ); ?>
+			echo esc_html( apply_filters( 'woocommerce_general_pricing_disabled_message', __( 'You can manage pricing and other details in one of the other tabs.', 'woocommerce' ), 'grouped' ) );
+			?>
 		</p>
 	</div>
 

--- a/plugins/woocommerce/includes/admin/wc-meta-box-functions.php
+++ b/plugins/woocommerce/includes/admin/wc-meta-box-functions.php
@@ -66,14 +66,10 @@ function woocommerce_wp_text_input( $field, WC_Data $data = null ) {
 		}
 	}
 
+	$label_class = ! empty( $field['label_class'] ) ? 'class="' . esc_attr( $field['label_class'] ) . '" ' : '';
+
 	echo '<p class="form-field ' . esc_attr( $field['id'] ) . '_field ' . esc_attr( $field['wrapper_class'] ) . '">
-		<label ';
-
-	if ( ! empty( $field['label_class'] ) ) {
-		echo 'class="' . esc_attr( $field['label_class'] ) . '" ';
-	}
-
-	echo 'for="' . esc_attr( $field['id'] ) . '">' . wp_kses_post( $field['label'] ) . '</label>';
+		<label ' . esc_attr( $label_class ) . ' for="' . esc_attr( $field['id'] ) . '">' . wp_kses_post( $field['label'] ) . '</label>';
 
 	if ( ! empty( $field['description'] ) && false !== $field['desc_tip'] ) {
 		echo wc_help_tip( $field['description'] );

--- a/plugins/woocommerce/includes/admin/wc-meta-box-functions.php
+++ b/plugins/woocommerce/includes/admin/wc-meta-box-functions.php
@@ -31,6 +31,7 @@ function woocommerce_wp_text_input( $field, WC_Data $data = null ) {
 	$field['name']          = isset( $field['name'] ) ? $field['name'] : $field['id'];
 	$field['type']          = isset( $field['type'] ) ? $field['type'] : 'text';
 	$field['desc_tip']      = isset( $field['desc_tip'] ) ? $field['desc_tip'] : false;
+	$field['label_class']   = isset( $field['label_class'] ) ? $field['label_class'] : '';
 	$data_type              = empty( $field['data_type'] ) ? '' : $field['data_type'];
 
 	switch ( $data_type ) {
@@ -66,7 +67,13 @@ function woocommerce_wp_text_input( $field, WC_Data $data = null ) {
 	}
 
 	echo '<p class="form-field ' . esc_attr( $field['id'] ) . '_field ' . esc_attr( $field['wrapper_class'] ) . '">
-		<label for="' . esc_attr( $field['id'] ) . '">' . wp_kses_post( $field['label'] ) . '</label>';
+		<label ';
+
+	if ( ! empty( $field['label_class'] ) ) {
+		echo 'class="' . esc_attr( $field['label_class'] ) . '" ';
+	}
+
+	echo 'for="' . esc_attr( $field['id'] ) . '">' . wp_kses_post( $field['label'] ) . '</label>';
 
 	if ( ! empty( $field['description'] ) && false !== $field['desc_tip'] ) {
 		echo wc_help_tip( $field['description'] );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/add-variable-product/update-variations.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/add-variable-product/update-variations.spec.js
@@ -138,7 +138,7 @@ test.describe( 'Update variations', () => {
 		} );
 
 		await test.step( 'Click on the "Variations" tab.', async () => {
-			await page.locator( 'a[href="#variable_product_options"]' ).click();
+			await page.locator( '.variations_tab > a[href="#variable_product_options"]' ).click();
 		} );
 
 		await test.step( 'Expand all variations.', async () => {
@@ -231,7 +231,7 @@ test.describe( 'Update variations', () => {
 		} );
 
 		await test.step( 'Click on the "Variations" tab.', async () => {
-			await page.locator( 'a[href="#variable_product_options"]' ).click();
+			await page.locator( '.variations_tab > a[href="#variable_product_options"]' ).click();
 		} );
 
 		await test.step( 'Expand all variations.', async () => {
@@ -344,7 +344,7 @@ test.describe( 'Update variations', () => {
 		} );
 
 		await test.step( 'Click on the "Variations" tab.', async () => {
-			await page.locator( 'a[href="#variable_product_options"]' ).click();
+			await page.locator( '.variations_tab > a[href="#variable_product_options"]' ).click();
 		} );
 
 		await test.step(
@@ -387,7 +387,7 @@ test.describe( 'Update variations', () => {
 		} );
 
 		await test.step( 'Click on the "Variations" tab.', async () => {
-			await page.locator( 'a[href="#variable_product_options"]' ).click();
+			await page.locator( '.variations_tab > a[href="#variable_product_options"]' ).click();
 		} );
 
 		await test.step(
@@ -418,7 +418,7 @@ test.describe( 'Update variations', () => {
 		} );
 
 		await test.step( 'Click on the "Variations" tab.', async () => {
-			await page.locator( 'a[href="#variable_product_options"]' ).click();
+			await page.locator( '.variations_tab > a[href="#variable_product_options"]' ).click();
 		} );
 
 		await test.step( 'Expand all variations', async () => {
@@ -538,7 +538,7 @@ test.describe( 'Update variations', () => {
 		} );
 
 		await test.step( 'Click on the "Variations" tab.', async () => {
-			await page.locator( 'a[href="#variable_product_options"]' ).click();
+			await page.locator( '.variations_tab > a[href="#variable_product_options"]' ).click();
 		} );
 
 		await test.step( 'Select variation defaults', async () => {
@@ -598,7 +598,7 @@ test.describe( 'Update variations', () => {
 		} );
 
 		await test.step( 'Click on the "Variations" tab.', async () => {
-			await page.locator( 'a[href="#variable_product_options"]' ).click();
+			await page.locator( '.variations_tab > a[href="#variable_product_options"]' ).click();
 		} );
 
 		await test.step( 'Click "Remove" on a variation', async () => {


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Always show Regular Price and Sale Price fields in the General tab regardless of product type, only enabling them when 'simple' or 'external' product types.

Closes #33540 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Have the WooCommerce Bookings extension installed.
2. Go to Products > Add New on the legacy product manager.
3. Set product type to "Grouped".
4. Verify that the General tab is still visible, Regular and Sale Price are disabled and you see a message with a link to "Linked products" tab.
5. Set product type to "Variable".
6. Verify that the General tab is still visible, Regular and Sale Price are disabled and you see a message with a link to "Variations" tab.
7. Switch to "Simple".
8. Verify that the fields are enabled again.
9. Switch to "External"
10. Verify that the fields are still enabled.
11. Switch to "Bookable product".
12. Verify that the General tab is still visible, Regular and Sale Price are disabled and you see a generic message 'You can manage pricing and other details in one of the other tabs.'.

<!-- End testing instructions -->
