### PR TITLE
fix Unsupported operand string * float

### DIFF
--- a/plugins/woocommerce/changelog/fix-38009-unsupported-operand
+++ b/plugins/woocommerce/changelog/fix-38009-unsupported-operand
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix Unsupported operand string * float

--- a/plugins/woocommerce/includes/class-wc-tax.php
+++ b/plugins/woocommerce/includes/class-wc-tax.php
@@ -165,6 +165,7 @@ class WC_Tax {
 	 */
 	public static function calc_exclusive_tax( $price, $rates ) {
 		$taxes = array();
+		$price = (float) $price;
 
 		if ( ! empty( $rates ) ) {
 			foreach ( $rates as $key => $rate ) {
@@ -172,13 +173,13 @@ class WC_Tax {
 					continue;
 				}
 
-				$tax_amount = $price * ( $rate['rate'] / 100 );
+				$tax_amount = $price * ( floatval( $rate['rate'] ) / 100 );
 				$tax_amount = apply_filters( 'woocommerce_price_ex_tax_amount', $tax_amount, $key, $rate, $price ); // ADVANCED: Allow third parties to modify this rate.
 
 				if ( ! isset( $taxes[ $key ] ) ) {
-					$taxes[ $key ] = $tax_amount;
+					$taxes[ $key ] = (float) $tax_amount;
 				} else {
-					$taxes[ $key ] += $tax_amount;
+					$taxes[ $key ] += (float) $tax_amount;
 				}
 			}
 
@@ -189,14 +190,14 @@ class WC_Tax {
 				if ( 'no' === $rate['compound'] ) {
 					continue;
 				}
-				$the_price_inc_tax = $price + ( $pre_compound_total );
-				$tax_amount        = $the_price_inc_tax * ( $rate['rate'] / 100 );
+				$the_price_inc_tax = $price + $pre_compound_total;
+				$tax_amount        = $the_price_inc_tax * ( floatval( $rate['rate'] ) / 100 );
 				$tax_amount        = apply_filters( 'woocommerce_price_ex_tax_amount', $tax_amount, $key, $rate, $price, $the_price_inc_tax, $pre_compound_total ); // ADVANCED: Allow third parties to modify this rate.
 
 				if ( ! isset( $taxes[ $key ] ) ) {
-					$taxes[ $key ] = $tax_amount;
+					$taxes[ $key ] = (float) $tax_amount;
 				} else {
-					$taxes[ $key ] += $tax_amount;
+					$taxes[ $key ] += (float) $tax_amount;
 				}
 
 				$pre_compound_total = array_sum( $taxes );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR addresses possible operand data type mismatches in `calc_exclusive_tax()` which may throw deprecated warnings or errors in PHP 8.1.

Closes #38009.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Switch to PHP 8.1
2. Set all price settings to tax inclusive
3. Add two tax rates where shipping tax is enabled and one of the tax rates is compound. 
4. Enable flat rate shipping for the same zone with a price of $10
5. Create an order in the dashboard where the customer address is in the above zone
6. Add a physical product to the order
7. Add shipping to the order & save the order
8. Edit the shipping and zero out the shipping amount
9. Click recalculate
10. The order should recalculate correctly
