### PR TITLE
Update WooCommerce Blocks package to 10.0.6

### DIFF
--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-10.0.6
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-10.0.6
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update WooCommerce Blocks to 10.0.6

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -21,7 +21,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.5.4",
-		"woocommerce/woocommerce-blocks": "10.0.5"
+		"woocommerce/woocommerce-blocks": "10.0.6"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.3.0",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -628,16 +628,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "10.0.5",
+            "version": "10.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "a65b09d0bf68efdd7e8b63bf8fb86f386c0b786b"
+                "reference": "2b9bce3b279741cbabc1c29b998d4791fa89121d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/a65b09d0bf68efdd7e8b63bf8fb86f386c0b786b",
-                "reference": "a65b09d0bf68efdd7e8b63bf8fb86f386c0b786b",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/2b9bce3b279741cbabc1c29b998d4791fa89121d",
+                "reference": "2b9bce3b279741cbabc1c29b998d4791fa89121d",
                 "shasum": ""
             },
             "require": {
@@ -683,9 +683,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v10.0.5"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v10.0.6"
             },
-            "time": "2023-05-24T15:46:29+00:00"
+            "time": "2023-05-30T19:43:34+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 10.0.6 for inclusion to WooCommerce 7.7.

## Blocks 10.0.6

* [Release PR](https://github.com/woocommerce/woocommerce-blocks/pull/9651)
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/1006.md)

### Changelog entry

#### Bug Fixes

- Fix some scripts needed by the Mini-Cart block not loading. ([9649](https://github.com/woocommerce/woocommerce-blocks/pull/9649))
