### PR TITLE
fix string + string for PHP 8.X

### DIFF
--- a/plugins/woocommerce/changelog/fix-38444-unsupported-operands
+++ b/plugins/woocommerce/changelog/fix-38444-unsupported-operands
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix string + string for PHP 8.X

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -489,9 +489,9 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 */
 	public function get_total_discount( $ex_tax = true ) {
 		if ( $ex_tax ) {
-			$total_discount = $this->get_discount_total();
+			$total_discount = (float) $this->get_discount_total();
 		} else {
-			$total_discount = $this->get_discount_total() + $this->get_discount_tax();
+			$total_discount = (float) $this->get_discount_total() + (float) $this->get_discount_tax();
 		}
 		return apply_filters( 'woocommerce_order_get_total_discount', NumberUtil::round( $total_discount, WC_ROUNDING_PRECISION ), $this );
 	}
@@ -2176,7 +2176,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			} else {
 
 				// Show shipping including tax.
-				$shipping = wc_price( $this->get_shipping_total() + $this->get_shipping_tax(), array( 'currency' => $this->get_currency() ) );
+				$shipping = wc_price( (float) $this->get_shipping_total() + (float) $this->get_shipping_tax(), array( 'currency' => $this->get_currency() ) );
 
 				if ( (float) $this->get_shipping_tax() > 0 && ! $this->get_prices_include_tax() ) {
 					$shipping .= apply_filters( 'woocommerce_order_shipping_to_display_tax_label', '&nbsp;<small class="tax_label">' . WC()->countries->inc_tax_or_vat() . '</small>', $this, $tax_display );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR explicitly converts the string return values to float values.

Closes #38444.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Update to PHP 8.1
2. Set all price tax settings to inclusive
3. Create an order with a product, shipping, and a coupon
4. Leave the order status as pending payment
5. Load the customer payment page
6. The customer payment page should show the correct amounts
7. No errors should be logged to the error log
