### PR TITLE
Hide HPOS plugin incompatibility warning from users with no 'activate_plugins' perm

### DIFF
--- a/plugins/woocommerce/changelog/fix-37505
+++ b/plugins/woocommerce/changelog/fix-37505
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Do not show HPOS plugin incompat warning to users with insufficient access permissions.

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -815,6 +815,10 @@ class FeaturesController {
 	 * there's already a "You are viewing
 	 */
 	private function maybe_display_feature_incompatibility_warning(): void {
+		if ( ! current_user_can( 'activate_plugins' ) ) {
+			return;
+		}
+
 		$incompatible_plugins = false;
 
 		foreach ( $this->plugin_util->get_woocommerce_aware_plugins( true ) as $plugin ) {


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #37505.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable HPOS.
2. Create a test plugin in `wp-content/plugins` with content such as
   ```php
   <?php
   /**
    * Plugin Name: My test plugin
    * Description: Just for testing purposes.
    */
   ```
3. Activate said plugin in the Plugins screen.
4. Edit the plugin file to include a WC header. For example:
   ```php
   <?php
   /**
    * Plugin Name: Development Plugin
    * Description: This plugin contains no real code. Edit its content to quickly test things out.
    * WC tested up to: 7.5.0
    * WC requires at least: 6.8
    */
   ```
5. As admin, go to WC > Orders and confirm you see the warning about incompatibilities (screenshot below).
   <img width="991" alt="Screenshot 2023-05-30 at 15 01 28" src="https://github.com/woocommerce/woocommerce/assets/184724/87558640-8f22-40fa-9f8f-041d5782de1d">
6. Create a non-admin user with access to the admin side. A "shop manager" will do.
7. Log in as the user created in the previous step and go to WC > Orders.
8.
   - On `trunk`, you should be able to see the warning from step 5 but clicking the link triggers an error.
   - On this branch, the warning from step 5 does not appear.
<!-- End testing instructions -->
