### PR TITLE
Fix save settings error within Analytics

### DIFF
--- a/plugins/woocommerce-admin/client/layout/controller.js
+++ b/plugins/woocommerce-admin/client/layout/controller.js
@@ -443,6 +443,12 @@ export function updateLinkHref( item, nextQuery, excludedScreens ) {
 				...nextQuery,
 			} );
 		}
+		// Remove undefined keys.
+		for ( const [ key, value ] of Array.from( query.entries() ) ) {
+			if ( value === 'undefined' || value === undefined ) {
+				query.delete( key );
+			}
+		}
 
 		const href = 'admin.php?' + query.toString();
 

--- a/plugins/woocommerce-admin/client/layout/test/index.js
+++ b/plugins/woocommerce-admin/client/layout/test/index.js
@@ -69,6 +69,20 @@ describe( 'updateLinkHref', () => {
 
 		expect( item.href ).toBe( WP_ADMIN_URL );
 	} );
+
+	it( 'should filter out undefined query values', () => {
+		const item = { href: REPORT_URL };
+		updateLinkHref(
+			item,
+			{ ...nextQuery, test: undefined, anotherParam: undefined },
+			timeExcludedScreens
+		);
+		const encodedPath = encodeURIComponent( '/analytics/orders' );
+
+		expect( item.href ).toBe(
+			`admin.php?page=wc-admin&path=${ encodedPath }&fruit=apple&dish=cobbler`
+		);
+	} );
 } );
 
 describe( 'Layout', () => {

--- a/plugins/woocommerce/changelog/fix-38538_save_settings_error
+++ b/plugins/woocommerce/changelog/fix-38538_save_settings_error
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix issue where undefined query params where not removed from links, causing unexpected behaviour in Analytics.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

This updates the `updateLinkHref` function to make sure `undefined` query params are removed from the URL, this is something that the `parse` function from `qs` was doing previously ( https://github.com/woocommerce/woocommerce/pull/35128/files#diff-e8cae4b4e030d5120191e67ffdbb1e3843ff79d92a445c8bcb0e4778cde4133e ), but this was removed to make use of `URLSearchParams` instead.

Closes #38538  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to WooCommerce > Home. If you're taken to the OBW, skip it.
2. Go to Analytics > Overview page. Notice that it loads just fine.
3. Go to Analytics > Settings.
4. Without changing anything in the Settings, click "Save settings".
5. Open up the browser console.
6. Go back to Analytics > Overview.
7. The overview page should load fine and no errors within the console, also note that the URL doesn't contain `undefined` params within its query params.
8. Change the date range to something different from the default (like last month)
9. The Overview page should still load correctly
10. Navigate to some of the other report pages, the date should persist (as it is set within the url query params)
<!-- End testing instructions -->
