### PR TITLE
Adding tracks events to title generation and language detection

### DIFF
--- a/plugins/woo-ai/assets/images/icons/alert.svg
+++ b/plugins/woo-ai/assets/images/icons/alert.svg
@@ -1,0 +1,15 @@
+<svg
+	width="24"
+	height="24"
+	viewBox="0 0 24 24"
+	fill="none"
+	xmlns="http://www.w3.org/2000/svg"
+>
+	<path
+		d="M12 20C16.4183 20 20 16.4183 20 12C20 7.58172 16.4183 4 12 4C7.58172 4 4 7.58172 4 12C4 16.4183 7.58172 20 12 20Z"
+		stroke="#CC1818"
+		stroke-width="1.5"
+	/>
+	<path d="M13 7H11V13H13V7Z" fill="#CC1818" />
+	<path d="M13 15H11V17H13V15Z" fill="#CC1818" />
+</svg>

--- a/plugins/woo-ai/package.json
+++ b/plugins/woo-ai/package.json
@@ -16,7 +16,6 @@
 		"@types/react-dom": "^17.0.2",
 		"@types/wordpress__components": "^19.10.3",
 		"@types/wordpress__data": "^6.0.0",
-		"@types/wordpress__plugins": "^3.0.0",
 		"@woocommerce/dependency-extraction-webpack-plugin": "workspace:*",
 		"@woocommerce/eslint-plugin": "workspace:*",
 		"@wordpress/env": "^7.0.0",
@@ -33,13 +32,10 @@
 		"@types/prop-types": "^15.7.4",
 		"@types/react-outside-click-handler": "^1.3.1",
 		"@woocommerce/components": "workspace:*",
-		"@woocommerce/data": "workspace:*",
 		"@woocommerce/tracks": "workspace:*",
 		"@wordpress/api-fetch": "wp-6.0",
 		"@wordpress/components": "wp-6.0",
 		"@wordpress/compose": "wp-6.0",
-		"@wordpress/data": "wp-6.0",
-		"@wordpress/data-controls": "wp-6.0",
 		"@wordpress/element": "wp-6.0",
 		"@wordpress/hooks": "wp-6.0",
 		"@wordpress/i18n": "wp-6.0",
@@ -51,7 +47,8 @@
 		"@types/react": "^17.0.2",
 		"@types/react-dom": "^17.0.2",
 		"react": "^17.0.2",
-		"react-dom": "^17.0.2"
+		"react-dom": "^17.0.2",
+		"@wordpress/data": "wp-6.0"
 	},
 	"scripts": {
 		"postinstall": "composer install",

--- a/plugins/woo-ai/src/components/description-completion-buttons.tsx
+++ b/plugins/woo-ai/src/components/description-completion-buttons.tsx
@@ -8,7 +8,7 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import MagicIcon from '../../assets/images/icons/magic.svg';
-import { MIN_TITLE_LENGTH } from '../constants';
+import { MIN_TITLE_LENGTH_FOR_DESCRIPTION } from '../constants';
 
 type MagicButtonProps = {
 	title?: string;
@@ -54,7 +54,7 @@ export const WriteItForMeBtn = ( {
 								'Please create a product title before generating a description. It must be %d characters or longer.',
 								'woocommerce'
 							),
-							MIN_TITLE_LENGTH
+							MIN_TITLE_LENGTH_FOR_DESCRIPTION
 					  )
 					: undefined
 			}

--- a/plugins/woo-ai/src/components/random-loading-message/index.ts
+++ b/plugins/woo-ai/src/components/random-loading-message/index.ts
@@ -1,0 +1,1 @@
+export * from './random-loading-message';

--- a/plugins/woo-ai/src/components/random-loading-message/random-loading-message.tsx
+++ b/plugins/woo-ai/src/components/random-loading-message/random-loading-message.tsx
@@ -93,7 +93,7 @@ const getRandomLoadingPhrase = ( phrasesStack: string[] ): string => {
 	return poppedMessage;
 };
 
-const RandomLoadingMessage: React.FC< RandomLoadingMessageProps > = ( {
+export const RandomLoadingMessage: React.FC< RandomLoadingMessageProps > = ( {
 	isLoading,
 } ) => {
 	const messageUpdateTimeout = useRef< number >();
@@ -135,5 +135,3 @@ const RandomLoadingMessage: React.FC< RandomLoadingMessageProps > = ( {
 		</>
 	);
 };
-
-export default RandomLoadingMessage;

--- a/plugins/woo-ai/src/constants.ts
+++ b/plugins/woo-ai/src/constants.ts
@@ -1,1 +1,1 @@
-export const MIN_TITLE_LENGTH = 20;
+export const MIN_TITLE_LENGTH = 10;

--- a/plugins/woo-ai/src/constants.ts
+++ b/plugins/woo-ai/src/constants.ts
@@ -1,1 +1,1 @@
-export const MIN_TITLE_LENGTH = 10;
+export const MIN_TITLE_LENGTH_FOR_DESCRIPTION = 20;

--- a/plugins/woo-ai/src/hooks/useTinyEditor.ts
+++ b/plugins/woo-ai/src/hooks/useTinyEditor.ts
@@ -1,37 +1,8 @@
-type TinyContent = {
-	getContent: () => string;
-	setContent: ( str: string ) => void;
-};
-
-declare const tinymce: { get: ( str: string ) => TinyContent };
+/**
+ * Internal dependencies
+ */
+import { setTinyContent, getTinyContent } from '../utils/tiny-tools';
 
 export const useTinyEditor = () => {
-	const getTinyContentObject = () =>
-		typeof tinymce === 'object' ? tinymce.get( 'content' ) : null;
-
-	const setTinyContent = ( str: string ) => {
-		if ( ! str.length ) {
-			return;
-		}
-
-		const contentTinyMCE = getTinyContentObject();
-		if ( contentTinyMCE ) {
-			contentTinyMCE.setContent( str );
-		} else {
-			{
-				const el: HTMLInputElement | null = document.querySelector(
-					'#wp-content-editor-container .wp-editor-area'
-				);
-				if ( el ) {
-					el.value = str;
-				}
-			}
-		}
-	};
-
-	const getTinyContent = () => {
-		return getTinyContentObject()?.getContent();
-	};
-
 	return { setContent: setTinyContent, getContent: getTinyContent };
 };

--- a/plugins/woo-ai/src/product-description/product-description-button-container.tsx
+++ b/plugins/woo-ai/src/product-description/product-description-button-container.tsx
@@ -17,7 +17,7 @@ const DESCRIPTION_MAX_LENGTH = 300;
 
 const getApiError = () => {
 	return __(
-		`Apologies, this is an experimental feature and there was an error with this service. Please try again.`,
+		`❗ We're currently experiencing high demand for our experimental feature. Please check back in shortly!`,
 		'woocommerce'
 	);
 };

--- a/plugins/woo-ai/src/product-description/product-description-button-container.tsx
+++ b/plugins/woo-ai/src/product-description/product-description-button-container.tsx
@@ -11,14 +11,9 @@ import { useState, useEffect, useRef } from '@wordpress/element';
 import { MIN_TITLE_LENGTH } from '../constants';
 import { WriteItForMeBtn, StopCompletionBtn } from '../components';
 import { useTinyEditor, useCompletion, useFeedbackSnackbar } from '../hooks';
-import { recordTracksFactory } from '../utils';
+import { recordTracksFactory, getPostId } from '../utils';
 
 const DESCRIPTION_MAX_LENGTH = 300;
-
-const getPostId = () =>
-	Number(
-		( document.querySelector( '#post_ID' ) as HTMLInputElement )?.value
-	);
 
 const getApiError = () => {
 	return __(

--- a/plugins/woo-ai/src/product-description/product-description-button-container.tsx
+++ b/plugins/woo-ai/src/product-description/product-description-button-container.tsx
@@ -34,8 +34,6 @@ export function WriteItForMeButtonContainer() {
 		document.querySelector( '#title' )
 	);
 	const [ fetching, setFetching ] = useState< boolean >( false );
-	const [ titleIsGenerated, setTitleIsGenerated ] =
-		useState< boolean >( false );
 	const [ productTitle, setProductTitle ] = useState< string >(
 		titleEl.current?.value || ''
 	);
@@ -88,42 +86,19 @@ export function WriteItForMeButtonContainer() {
 	useEffect( () => {
 		const title = titleEl.current;
 		const titleKeyupHandler = ( e: KeyboardEvent ) => {
-			setTitleIsGenerated( false );
 			setProductTitle(
 				( e.target as HTMLInputElement ).value.trim() || ''
 			);
 		};
 		title?.addEventListener( 'keyup', titleKeyupHandler );
 
-		// This observer is used to detect when the title is generated.
-		const titleObserver = new MutationObserver( ( mutations ) => {
-			const generatedAttrs = mutations.filter(
-				( mutation ) =>
-					mutation.type === 'attributes' &&
-					mutation.attributeName === 'data-generated'
-			);
-			if ( generatedAttrs.length ) {
-				setTitleIsGenerated( true );
-			}
-		} );
-
-		if ( title ) {
-			titleObserver.observe( title, {
-				attributes: true,
-			} );
-		}
-
 		return () => {
 			title?.removeEventListener( 'keyup', titleKeyupHandler );
-			titleObserver.disconnect();
 		};
 	}, [ titleEl ] );
 
 	const writeItForMeEnabled =
-		productTitle.length &&
-		! fetching &&
-		( titleIsGenerated ||
-			productTitle.length >= MIN_TITLE_LENGTH_FOR_DESCRIPTION );
+		! fetching && productTitle.length >= MIN_TITLE_LENGTH_FOR_DESCRIPTION;
 
 	const buildPrompt = () => {
 		const instructions = [

--- a/plugins/woo-ai/src/product-description/product-description-button-container.tsx
+++ b/plugins/woo-ai/src/product-description/product-description-button-container.tsx
@@ -86,7 +86,9 @@ export function WriteItForMeButtonContainer() {
 	useEffect( () => {
 		const title = titleEl.current;
 		const titleKeyupHandler = ( e: KeyboardEvent ) =>
-			setProductTitle( ( e.target as HTMLInputElement ).value || '' );
+			setProductTitle(
+				( e.target as HTMLInputElement ).value.trim() || ''
+			);
 
 		title?.addEventListener( 'keyup', titleKeyupHandler );
 

--- a/plugins/woo-ai/src/product-description/product-description-button-container.tsx
+++ b/plugins/woo-ai/src/product-description/product-description-button-container.tsx
@@ -58,6 +58,7 @@ export function WriteItForMeButtonContainer() {
 				recordDescriptionTracks( 'stop', {
 					reason,
 					character_count: content.length,
+					current_title: productTitle,
 				} );
 
 				setFetching( false );

--- a/plugins/woo-ai/src/product-description/product-description-button-container.tsx
+++ b/plugins/woo-ai/src/product-description/product-description-button-container.tsx
@@ -17,7 +17,7 @@ const DESCRIPTION_MAX_LENGTH = 300;
 
 const getApiError = () => {
 	return __(
-		`❗ We're currently experiencing high demand for our experimental feature. Please check back in shortly!`,
+		`❗ We're currently experiencing high demand for our experimental feature. Please check back in shortly.`,
 		'woocommerce'
 	);
 };

--- a/plugins/woo-ai/src/product-description/product-description-button-container.tsx
+++ b/plugins/woo-ai/src/product-description/product-description-button-container.tsx
@@ -38,7 +38,7 @@ export function WriteItForMeButtonContainer() {
 		titleEl.current?.value || ''
 	);
 	const tinyEditor = useTinyEditor();
-	const { showSnackbar } = useFeedbackSnackbar();
+	const { showSnackbar, removeSnackbar } = useFeedbackSnackbar();
 	const { requestCompletion, completionActive, stopCompletion } =
 		useCompletion( {
 			onStreamMessage: ( content ) => {
@@ -62,7 +62,7 @@ export function WriteItForMeButtonContainer() {
 
 				setFetching( false );
 
-				if ( reason !== 'abort' ) {
+				if ( reason === 'finished' ) {
 					showSnackbar( {
 						label: __(
 							'Description added. How is it?',
@@ -112,19 +112,23 @@ export function WriteItForMeButtonContainer() {
 		return instructions.join( '\n' );
 	};
 
+	const onWriteItForMeClick = () => {
+		setFetching( true );
+		removeSnackbar();
+
+		const prompt = buildPrompt();
+		recordDescriptionTracks( 'start', {
+			prompt,
+		} );
+		requestCompletion( prompt );
+	};
+
 	return completionActive ? (
 		<StopCompletionBtn onClick={ stopCompletion } />
 	) : (
 		<WriteItForMeBtn
 			disabled={ writeItForMeDisabled }
-			onClick={ () => {
-				setFetching( true );
-				const prompt = buildPrompt();
-				recordDescriptionTracks( 'start', {
-					prompt,
-				} );
-				requestCompletion( prompt );
-			} }
+			onClick={ onWriteItForMeClick }
 		/>
 	);
 }

--- a/plugins/woo-ai/src/product-description/product-description-button-container.tsx
+++ b/plugins/woo-ai/src/product-description/product-description-button-container.tsx
@@ -101,6 +101,7 @@ export function WriteItForMeButtonContainer() {
 	const buildPrompt = () => {
 		const instructions = [
 			`Write a product description with the following product title: "${ productTitle }."`,
+			'Identify the language used in this product title and use the same language in your response.',
 			'Use a 9th grade reading level.',
 			`Make the description ${ DESCRIPTION_MAX_LENGTH } words or less.`,
 			'Structure the description into paragraphs using standard HTML <p> tags.',

--- a/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
+++ b/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import { __ } from '@wordpress/i18n';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
-import React from 'react';
 import { Pill } from '@woocommerce/components';
 import { Tooltip } from '@wordpress/components';
 

--- a/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
+++ b/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
@@ -53,7 +53,7 @@ const recordNameTracks = recordTracksFactory< TracksData >(
 
 export const ProductNameSuggestions = () => {
 	const [ suggestionsState, setSuggestionsState ] =
-		useState< SuggestionsState >( SuggestionsState.Failed );
+		useState< SuggestionsState >( SuggestionsState.None );
 	const [ isFirstLoad, setIsFirstLoad ] = useState< boolean >( true );
 	const [ visible, setVisible ] = useState< boolean >( false );
 	const [ suggestions, setSuggestions ] = useState< ProductDataSuggestion[] >(

--- a/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
+++ b/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
@@ -169,6 +169,10 @@ export const ProductNameSuggestions = () => {
 			setSuggestionsState( SuggestionsState.None );
 			setIsFirstLoad( false );
 		} catch ( e ) {
+			recordNameTracks( 'stop', {
+				reason: 'error',
+				error: ( e as { message?: string } )?.message || '',
+			} );
 			setSuggestionsState( SuggestionsState.Failed );
 		}
 	};

--- a/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
+++ b/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
@@ -134,7 +134,6 @@ export const ProductNameSuggestions = () => {
 		if ( ! nameInputRef.current || ! newName.length ) return;
 		nameInputRef.current.value = newName;
 		nameInputRef.current.setAttribute( 'value', newName );
-		nameInputRef.current.setAttribute( 'data-generated', 'ai' );
 		setProductName( newName );
 	};
 

--- a/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
+++ b/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
@@ -20,7 +20,8 @@ import {
 } from '../utils/types';
 import SuggestionItem from './suggestion-item';
 import { RandomLoadingMessage } from '../components';
-import { MIN_TITLE_LENGTH } from '../constants';
+
+const MIN_TITLE_LENGTH = 10;
 
 enum SuggestionsState {
 	Fetching = 'fetching',
@@ -133,6 +134,7 @@ export const ProductNameSuggestions = () => {
 		if ( ! nameInputRef.current || ! newName.length ) return;
 		nameInputRef.current.value = newName;
 		nameInputRef.current.setAttribute( 'value', newName );
+		nameInputRef.current.setAttribute( 'data-generated', 'ai' );
 		setProductName( newName );
 	};
 

--- a/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
+++ b/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
@@ -11,6 +11,7 @@ import { Tooltip } from '@wordpress/components';
  * Internal dependencies
  */
 import MagicIcon from '../../assets/images/icons/magic.svg';
+import AlertIcon from '../../assets/images/icons/alert.svg';
 import { productData, recordTracksFactory, getPostId } from '../utils';
 import { useProductDataSuggestions } from '../hooks/useProductDataSuggestions';
 import {
@@ -52,8 +53,7 @@ const recordNameTracks = recordTracksFactory< TracksData >(
 
 export const ProductNameSuggestions = () => {
 	const [ suggestionsState, setSuggestionsState ] =
-		useState< SuggestionsState >( SuggestionsState.None );
-	const [ error, setError ] = useState< string >( '' );
+		useState< SuggestionsState >( SuggestionsState.Failed );
 	const [ isFirstLoad, setIsFirstLoad ] = useState< boolean >( true );
 	const [ visible, setVisible ] = useState< boolean >( false );
 	const [ suggestions, setSuggestions ] = useState< ProductDataSuggestion[] >(
@@ -66,11 +66,6 @@ export const ProductNameSuggestions = () => {
 	const [ productName, setProductName ] = useState< string >(
 		nameInputRef.current?.value || ''
 	);
-
-	const resetError = () => {
-		setError( '' );
-		setSuggestionsState( SuggestionsState.None );
-	};
 
 	useEffect( () => {
 		const nameInput = nameInputRef.current;
@@ -147,11 +142,9 @@ export const ProductNameSuggestions = () => {
 
 		updateProductName( suggestion.content );
 		setSuggestions( [] );
-		resetError();
 	};
 
 	const fetchProductSuggestions = async () => {
-		resetError();
 		setSuggestions( [] );
 		setSuggestionsState( SuggestionsState.Fetching );
 		try {
@@ -177,7 +170,6 @@ export const ProductNameSuggestions = () => {
 			setIsFirstLoad( false );
 		} catch ( e ) {
 			setSuggestionsState( SuggestionsState.Failed );
-			setError( e instanceof Error ? e.message : '' );
 		}
 	};
 
@@ -212,7 +204,7 @@ export const ProductNameSuggestions = () => {
 					</ul>
 				) }
 			{ productName.length < 10 &&
-				suggestionsState !== SuggestionsState.Fetching && (
+				suggestionsState === SuggestionsState.None && (
 					<p className="wc-product-name-suggestions__tip-message">
 						<img src={ MagicIcon } alt="" />
 						{ __(
@@ -230,7 +222,7 @@ export const ProductNameSuggestions = () => {
 				} }
 			>
 				<div className="woo-ai-get-suggestions-btn__content">
-					<img src={ MagicIcon } alt="magic button icon" />
+					<img src={ MagicIcon } alt="" />
 					{ getSuggestionsButtonLabel() }
 				</div>
 				<Tooltip
@@ -260,7 +252,11 @@ export const ProductNameSuggestions = () => {
 			) }
 			{ suggestionsState === SuggestionsState.Failed && (
 				<p className="wc-product-name-suggestions__error-message">
-					{ error }
+					<img src={ AlertIcon } alt="" />
+					{ __(
+						`We're currently experiencing high demand for our experimental feature. Please check back in shortly!`,
+						'woocommerce'
+					) }
 				</p>
 			) }
 		</div>

--- a/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
+++ b/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
@@ -19,7 +19,8 @@ import {
 	ProductDataSuggestionRequest,
 } from '../utils/types';
 import SuggestionItem from './suggestion-item';
-import RandomLoadingMessage from '../components/random-loading-message';
+import { RandomLoadingMessage } from '../components';
+import { MIN_TITLE_LENGTH } from '../constants';
 
 enum SuggestionsState {
 	Fetching = 'fetching',
@@ -179,7 +180,7 @@ export const ProductNameSuggestions = () => {
 
 	const shouldRenderSuggestionsButton = useCallback( () => {
 		return (
-			productName.length >= 10 &&
+			productName.length >= MIN_TITLE_LENGTH &&
 			suggestionsState !== SuggestionsState.Fetching
 		);
 	}, [ productName, suggestionsState ] );
@@ -207,7 +208,7 @@ export const ProductNameSuggestions = () => {
 						) ) }
 					</ul>
 				) }
-			{ productName.length < 10 &&
+			{ productName.length < MIN_TITLE_LENGTH &&
 				suggestionsState === SuggestionsState.None && (
 					<p className="wc-product-name-suggestions__tip-message">
 						<img src={ MagicIcon } alt="" />

--- a/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
+++ b/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
@@ -80,6 +80,7 @@ export const ProductNameSuggestions = () => {
 				setVisible( false );
 			}
 
+			setSuggestions( [] );
 			setProductName( ( e.target as HTMLInputElement ).value || '' );
 		};
 

--- a/plugins/woo-ai/src/product-name/product-name.scss
+++ b/plugins/woo-ai/src/product-name/product-name.scss
@@ -2,7 +2,6 @@ $border-color: #8c8f94;
 $base-bg-color: #fff;
 $hover-bg-color: #f0f0f1;
 $base-text-color: #757575;
-$error-message-bg-color: #eeaeaf;
 $z-index-container: 1001;
 $z-index-header: 1002;
 $border-radius: 4px;
@@ -132,9 +131,14 @@ $border-radius: 4px;
   }
 
   .wc-product-name-suggestions__error-message {
+	display: flex;
+	align-items: center;
     margin: 0;
     padding: 10px;
-    background-color: $error-message-bg-color;
+
+	img {
+		margin-right: 10px;
+	}
   }
 
   .wc-product-name-suggestions__tip-message {

--- a/plugins/woo-ai/src/utils/get-post-id.ts
+++ b/plugins/woo-ai/src/utils/get-post-id.ts
@@ -1,0 +1,4 @@
+export const getPostId = () =>
+	Number(
+		( document.querySelector( '#post_ID' ) as HTMLInputElement )?.value
+	);

--- a/plugins/woo-ai/src/utils/index.ts
+++ b/plugins/woo-ai/src/utils/index.ts
@@ -3,3 +3,4 @@ export * from './shuffleArray';
 export * from './jetpack-completion';
 export * from './recordTracksFactory';
 export * from './get-post-id';
+export * from './tiny-tools';

--- a/plugins/woo-ai/src/utils/index.ts
+++ b/plugins/woo-ai/src/utils/index.ts
@@ -2,3 +2,4 @@ export * from './productData';
 export * from './shuffleArray';
 export * from './jetpack-completion';
 export * from './recordTracksFactory';
+export * from './get-post-id';

--- a/plugins/woo-ai/src/utils/productData.ts
+++ b/plugins/woo-ai/src/utils/productData.ts
@@ -1,9 +1,8 @@
 /**
  * Internal dependencies
  */
-import { Attribute, ProductData, TinyContent } from './types';
-
-declare const tinymce: { get: ( str: string ) => TinyContent };
+import { Attribute, ProductData } from './types';
+import { getTinyContent } from '../utils/tiny-tools';
 
 const isElementVisible = ( element: HTMLElement ) =>
 	! ( window.getComputedStyle( element ).display === 'none' );
@@ -70,26 +69,23 @@ const getDescription = (): string => {
 	const isBlockEditor =
 		document.querySelectorAll( '.block-editor' ).length > 0;
 
-	let description_value = '';
-
 	if ( ! isBlockEditor ) {
 		const content = document.querySelector(
 			'#content'
 		) as HTMLInputElement;
+		const tinyContent = getTinyContent();
 		if ( content && isElementVisible( content ) ) {
-			description_value = content.value;
-		} else if ( typeof tinymce === 'object' && tinymce.get( 'content' ) ) {
-			description_value = tinymce.get( 'content' ).getContent();
+			return content.value;
+		} else if ( tinyContent ) {
+			return tinyContent;
 		}
-	} else {
-		description_value = (
-			document.querySelector(
-				'.block-editor-rich-text__editable'
-			) as HTMLInputElement
-		 )?.value;
 	}
 
-	return description_value;
+	return (
+		document.querySelector(
+			'.block-editor-rich-text__editable'
+		) as HTMLInputElement
+	 )?.value;
 };
 
 const getProductName = (): string => {

--- a/plugins/woo-ai/src/utils/recordTracksFactory.ts
+++ b/plugins/woo-ai/src/utils/recordTracksFactory.ts
@@ -3,11 +3,11 @@
  */
 import { recordEvent } from '@woocommerce/tracks';
 
-export const recordTracksFactory = (
+export const recordTracksFactory = < T = Record< string, string | number > >(
 	feature: string,
-	propertiesCallback: () => Record< string, string | number > = () => ( {} )
+	propertiesCallback: () => Record< string, string | number >
 ) => {
-	return ( name: string, properties?: Record< string, string | number > ) =>
+	return ( name: string, properties?: T ) =>
 		recordEvent( `woo_ai_product_${ feature }_${ name }`, {
 			...propertiesCallback(),
 			...properties,

--- a/plugins/woo-ai/src/utils/tiny-tools.ts
+++ b/plugins/woo-ai/src/utils/tiny-tools.ts
@@ -1,0 +1,33 @@
+type TinyContent = {
+	getContent: () => string;
+	setContent: ( str: string ) => void;
+};
+
+declare const tinymce: { get: ( str: string ) => TinyContent };
+
+const getTinyContentObject = () =>
+	typeof tinymce === 'object' ? tinymce.get( 'content' ) : null;
+
+export const setTinyContent = ( str: string ) => {
+	if ( ! str.length ) {
+		return;
+	}
+
+	const contentTinyMCE = getTinyContentObject();
+	if ( contentTinyMCE ) {
+		contentTinyMCE.setContent( str );
+	} else {
+		{
+			const el: HTMLInputElement | null = document.querySelector(
+				'#wp-content-editor-container .wp-editor-area'
+			);
+			if ( el ) {
+				el.value = str;
+			}
+		}
+	}
+};
+
+export const getTinyContent = () => {
+	return getTinyContentObject()?.getContent();
+};

--- a/plugins/woo-ai/src/utils/types.ts
+++ b/plugins/woo-ai/src/utils/types.ts
@@ -1,8 +1,3 @@
-export type TinyContent = {
-	getContent: () => string;
-	setContent: ( str: string ) => void;
-};
-
 export type Attribute = {
 	name: string;
 	value: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2303,9 +2303,6 @@ importers:
       '@woocommerce/components':
         specifier: workspace:*
         version: link:../../packages/js/components
-      '@woocommerce/data':
-        specifier: workspace:*
-        version: link:../../packages/js/data
       '@woocommerce/tracks':
         specifier: workspace:*
         version: link:../../packages/js/tracks
@@ -2321,9 +2318,6 @@ importers:
       '@wordpress/data':
         specifier: wp-6.0
         version: 6.6.1(react@17.0.2)
-      '@wordpress/data-controls':
-        specifier: wp-6.0
-        version: 2.6.1(react@17.0.2)
       '@wordpress/element':
         specifier: wp-6.0
         version: 4.4.1
@@ -2367,9 +2361,6 @@ importers:
       '@types/wordpress__data':
         specifier: ^6.0.0
         version: 6.0.2
-      '@types/wordpress__plugins':
-        specifier: ^3.0.0
-        version: 3.0.0(react-dom@17.0.2)(react@17.0.2)
       '@woocommerce/dependency-extraction-webpack-plugin':
         specifier: workspace:*
         version: link:../../packages/js/dependency-extraction-webpack-plugin
@@ -4260,6 +4251,24 @@ packages:
       lru-cache: 5.1.1
       semver: 6.3.0
 
+  /@babel/helper-create-class-features-plugin@7.17.6(@babel/core@7.12.9):
+    resolution: {integrity: sha512-SogLLSxXm2OkBbSsHZMM4tUi8fUzjs63AT/d0YQIzr6GSd8Hxsbk2KYDX0k0DweAzGMj/YWeiCsorIdtdcW8Eg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.12.9
+      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-function-name': 7.21.0
+      '@babel/helper-member-expression-to-functions': 7.21.0
+      '@babel/helper-optimise-call-expression': 7.18.6
+      '@babel/helper-replace-supers': 7.20.7
+      '@babel/helper-split-export-declaration': 7.18.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/helper-create-class-features-plugin@7.17.6(@babel/core@7.17.8):
     resolution: {integrity: sha512-SogLLSxXm2OkBbSsHZMM4tUi8fUzjs63AT/d0YQIzr6GSd8Hxsbk2KYDX0k0DweAzGMj/YWeiCsorIdtdcW8Eg==}
     engines: {node: '>=6.9.0'}
@@ -4276,6 +4285,24 @@ packages:
       '@babel/helper-split-export-declaration': 7.18.6
     transitivePeerDependencies:
       - supports-color
+
+  /@babel/helper-create-class-features-plugin@7.17.6(@babel/core@7.21.3):
+    resolution: {integrity: sha512-SogLLSxXm2OkBbSsHZMM4tUi8fUzjs63AT/d0YQIzr6GSd8Hxsbk2KYDX0k0DweAzGMj/YWeiCsorIdtdcW8Eg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.21.3
+      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-function-name': 7.21.0
+      '@babel/helper-member-expression-to-functions': 7.21.0
+      '@babel/helper-optimise-call-expression': 7.18.6
+      '@babel/helper-replace-supers': 7.20.7
+      '@babel/helper-split-export-declaration': 7.18.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /@babel/helper-create-class-features-plugin@7.19.0(@babel/core@7.12.9):
     resolution: {integrity: sha512-NRz8DwF4jT3UfrmUoZjd0Uph9HQnP30t7Ash+weACcyNkiYTywpIjDBgReJMKgr+n86sn2nPVVmJ28Dm053Kqw==}
@@ -4979,7 +5006,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-create-class-features-plugin': 7.19.0(@babel/core@7.12.9)
+      '@babel/helper-create-class-features-plugin': 7.17.6(@babel/core@7.12.9)
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
@@ -5004,7 +5031,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-create-class-features-plugin': 7.19.0(@babel/core@7.21.3)
+      '@babel/helper-create-class-features-plugin': 7.17.6(@babel/core@7.21.3)
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
@@ -5916,7 +5943,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-create-class-features-plugin': 7.19.0(@babel/core@7.12.9)
+      '@babel/helper-create-class-features-plugin': 7.17.6(@babel/core@7.12.9)
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
@@ -5942,7 +5969,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-create-class-features-plugin': 7.19.0(@babel/core@7.21.3)
+      '@babel/helper-create-class-features-plugin': 7.17.6(@babel/core@7.21.3)
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
@@ -6844,7 +6871,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-module-imports': 7.16.7
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-remap-async-to-generator': 7.16.8
     transitivePeerDependencies:
       - supports-color
@@ -6872,7 +6899,7 @@ packages:
     dependencies:
       '@babel/core': 7.21.3
       '@babel/helper-module-imports': 7.16.7
-      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-remap-async-to-generator': 7.16.8
     transitivePeerDependencies:
       - supports-color
@@ -21012,13 +21039,13 @@ packages:
     peerDependencies:
       eslint: '>= 4.12.1'
     dependencies:
-      '@babel/code-frame': 7.16.7
-      '@babel/parser': 7.17.8
-      '@babel/traverse': 7.17.3
-      '@babel/types': 7.17.0
+      '@babel/code-frame': 7.18.6
+      '@babel/parser': 7.21.3
+      '@babel/traverse': 7.21.3
+      '@babel/types': 7.21.3
       eslint: 7.32.0
       eslint-visitor-keys: 1.3.0
-      resolve: 1.20.0
+      resolve: 1.22.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -37965,7 +37992,7 @@ packages:
       is-touch-device: 1.0.1
       lodash: 4.17.21
       moment: 2.29.4
-      object.assign: 4.1.2
+      object.assign: 4.1.4
       object.values: 1.1.5
       prop-types: 15.8.1
       raf: 3.4.1


### PR DESCRIPTION
- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- Adding basic tracks events for name generation
- Updating error messages
- Ensuring description generation is available for generated titles
- Feedback snackbar will now not disappear until you explicitly do so or you generate another description.

Currently we have different character limits for generating titles and descriptions (20 for descriptions, 10 for titles).

We _may_ want to make those the same but uncertain. We also have the issue that the character counts will make sense for some languages, and not others (ie a valid title in Japanese may only be a few characters long).

Closes #38411 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. I've been using this with a WoA dev site ([guide](https://explorersp2.wordpress.com/2021/11/08/wordpress-on-atomic-development-workflow/)). Following that guide, but with [this modified script](https://gist.github.com/joelclimbsthings/d0144f525e165d4943650feeec09c9a4).
2. Once you've copied the plugin over, ensure the `Woo AI` plugin is activated.
3. Go to Products -> Add new
4. Open the console and enter `localStorage.setItem( 'debug', '*tracks*' );`. This will enable you to view tracks events as they're fired in the console.
5. Add a product title, and then click the "Get more ideas" button that appears.
6. You should see the `wcadmin_woo_ai_product_name_completion_start` event fire with the `currentTitle` and `post_id` properties.
7. Let it finish, and then you should see the `wcadmin_woo_ai_product_name_completion_stop` tracks event, with the `reason` property set to `finished`, and the `post_id` property present.
8. Select one of the options, and you should see the `wcadmin_woo_ai_product_name_completion_select` tracks event with the `selectedTitle` and `post_id` properties present.
9. Enter a product title in another language (ie spanish) and hit the "Write it for me" button to generate a description. It should return a description in the same language.
10. After selecting a generated product title, it should always enable the "Write it for me" button, even if the title is less than 20 characters (the usual limit).

<!-- End testing instructions -->
