### PR TITLE
Publishing product in classic editor redirects back to new editor

### DIFF
--- a/packages/js/product-editor/changelog/add-38243
+++ b/packages/js/product-editor/changelog/add-38243
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Turn off the product_block_editor feature when user choose to use the classic editor

--- a/packages/js/product-editor/src/components/product-mvp-feedback-modal-container/product-mvp-feedback-modal-container.tsx
+++ b/packages/js/product-editor/src/components/product-mvp-feedback-modal-container/product-mvp-feedback-modal-container.tsx
@@ -29,8 +29,12 @@ export const ProductMVPFeedbackModalContainer: React.FC< {
 	const productId = _productId ?? values.id;
 
 	const classicEditorUrl = productId
-		? getAdminLink( `post.php?post=${ productId }&action=edit` )
-		: getAdminLink( 'post-new.php?post_type=product' );
+		? getAdminLink(
+				`post.php?post=${ productId }&action=edit&product_block_editor=0`
+		  )
+		: getAdminLink(
+				'post-new.php?post_type=product&product_block_editor=0'
+		  );
 
 	const recordScore = ( checked: string[], comments: string ) => {
 		recordEvent( 'product_mvp_feedback', {

--- a/packages/js/product-editor/src/components/product-mvp-feedback-modal-container/product-mvp-feedback-modal-container.tsx
+++ b/packages/js/product-editor/src/components/product-mvp-feedback-modal-container/product-mvp-feedback-modal-container.tsx
@@ -5,7 +5,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { createElement } from '@wordpress/element';
 import { STORE_KEY } from '@woocommerce/customer-effort-score';
 import { recordEvent } from '@woocommerce/tracks';
-import { getAdminLink } from '@woocommerce/settings';
+import { getAdminLink, getSetting } from '@woocommerce/settings';
 import { useFormContext } from '@woocommerce/components';
 import { Product } from '@woocommerce/data';
 
@@ -28,12 +28,17 @@ export const ProductMVPFeedbackModalContainer: React.FC< {
 
 	const productId = _productId ?? values.id;
 
+	const { _feature_nonce } = getSetting< { _feature_nonce: string } >(
+		'admin',
+		{}
+	);
+
 	const classicEditorUrl = productId
 		? getAdminLink(
-				`post.php?post=${ productId }&action=edit&product_block_editor=0`
+				`post.php?post=${ productId }&action=edit&product_block_editor=0&_feature_nonce=${ _feature_nonce }`
 		  )
 		: getAdminLink(
-				'post-new.php?post_type=product&product_block_editor=0'
+				`post-new.php?post_type=product&product_block_editor=0&_feature_nonce=${ _feature_nonce }`
 		  );
 
 	const recordScore = ( checked: string[], comments: string ) => {

--- a/plugins/woocommerce-admin/client/products/fills/more-menu-items/classic-editor-menu-item.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/more-menu-items/classic-editor-menu-item.tsx
@@ -26,9 +26,8 @@ export const ClassicEditorMenuItem = ( {
 	const { showProductMVPFeedbackModal } = useDispatch( CES_STORE_KEY );
 
 	const { allowTracking, resolving: isLoading } = useSelect( ( select ) => {
-		const { getOption, hasFinishedResolution } = select(
-			OPTIONS_STORE_NAME
-		);
+		const { getOption, hasFinishedResolution } =
+			select( OPTIONS_STORE_NAME );
 
 		const allowTrackingOption =
 			getOption( ALLOW_TRACKING_OPTION_NAME ) || 'no';

--- a/plugins/woocommerce-admin/client/products/fills/more-menu-items/classic-editor-menu-item.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/more-menu-items/classic-editor-menu-item.tsx
@@ -10,7 +10,6 @@ import {
 	ALLOW_TRACKING_OPTION_NAME,
 	STORE_KEY as CES_STORE_KEY,
 } from '@woocommerce/customer-effort-score';
-import { NEW_PRODUCT_MANAGEMENT_ENABLED_OPTION_NAME } from '@woocommerce/product-editor';
 
 /**
  * Internal dependencies
@@ -25,11 +24,11 @@ export const ClassicEditorMenuItem = ( {
 	onClose: () => void;
 } ) => {
 	const { showProductMVPFeedbackModal } = useDispatch( CES_STORE_KEY );
-	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
 
 	const { allowTracking, resolving: isLoading } = useSelect( ( select ) => {
-		const { getOption, hasFinishedResolution } =
-			select( OPTIONS_STORE_NAME );
+		const { getOption, hasFinishedResolution } = select(
+			OPTIONS_STORE_NAME
+		);
 
 		const allowTrackingOption =
 			getOption( ALLOW_TRACKING_OPTION_NAME ) || 'no';
@@ -45,8 +44,12 @@ export const ClassicEditorMenuItem = ( {
 	} );
 
 	const classicEditorUrl = productId
-		? getAdminLink( `post.php?post=${ productId }&action=edit` )
-		: getAdminLink( 'post-new.php?post_type=product' );
+		? getAdminLink(
+				`post.php?post=${ productId }&action=edit&product_block_editor=0`
+		  )
+		: getAdminLink(
+				'post-new.php?post_type=product&product_block_editor=0'
+		  );
 
 	if ( isLoading ) {
 		return null;
@@ -56,15 +59,11 @@ export const ClassicEditorMenuItem = ( {
 		<MenuItem
 			onClick={ () => {
 				if ( allowTracking ) {
-					updateOptions( {
-						[ NEW_PRODUCT_MANAGEMENT_ENABLED_OPTION_NAME ]: 'no',
-					} );
 					showProductMVPFeedbackModal();
-					onClose();
 				} else {
 					window.location.href = classicEditorUrl;
-					onClose();
 				}
+				onClose();
 			} }
 			icon={ <ClassicEditorIcon /> }
 			iconPosition="right"

--- a/plugins/woocommerce-admin/client/products/fills/more-menu-items/classic-editor-menu-item.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/more-menu-items/classic-editor-menu-item.tsx
@@ -15,6 +15,7 @@ import {
  * Internal dependencies
  */
 import { ClassicEditorIcon } from '../../images/classic-editor-icon';
+import { getAdminSetting } from '~/utils/admin-settings';
 
 export const ClassicEditorMenuItem = ( {
 	onClose,
@@ -42,12 +43,14 @@ export const ClassicEditorMenuItem = ( {
 		};
 	} );
 
+	const { _feature_nonce } = getAdminSetting( '_feature_nonce' );
+
 	const classicEditorUrl = productId
 		? getAdminLink(
-				`post.php?post=${ productId }&action=edit&product_block_editor=0`
+				`post.php?post=${ productId }&action=edit&product_block_editor=0&_feature_nonce=${ _feature_nonce }`
 		  )
 		: getAdminLink(
-				'post-new.php?post_type=product&product_block_editor=0'
+				`post-new.php?post_type=product&product_block_editor=0&_feature_nonce=${ _feature_nonce }`
 		  );
 
 	if ( isLoading ) {

--- a/plugins/woocommerce/changelog/add-38243
+++ b/plugins/woocommerce/changelog/add-38243
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add support to change features through the url as query parameters

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -38,15 +38,15 @@ class Init {
 			$block_registry->init();
 		}
 
-		add_action( 'admin_init', array( $this, 'maybe_swap_old_product_form_and_new_product_block_editor' ), 30, 0 );
+		add_action( 'admin_init', array( $this, 'maybe_redirect_to_new_editor' ), 30, 0 );
+		add_action( 'admin_init', array( $this, 'maybe_redirect_to_old_editor' ), 30, 0 );
 	}
 
 	/**
 	 * Redirects from old product form to the new product form if the
-	 * feature `product_block_editor` is enabled. If the feature is
-	 * disabled then the redirection happens in reverse order.
+	 * feature `product_block_editor` is enabled.
 	 */
-	public function maybe_swap_old_product_form_and_new_product_block_editor(): void {
+	public function maybe_redirect_to_new_editor(): void {
 		if ( \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_block_editor' ) ) {
 			if ( isset( $_SERVER['REQUEST_URI'] ) ) {
 				$request_uri = esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) );
@@ -62,7 +62,15 @@ class Init {
 					exit();
 				}
 			}
-		} else {
+		}
+	}
+
+	/**
+	 * Redirects from new product form to the old product form if the
+	 * feature `product_block_editor` is enabled.
+	 */
+	public function maybe_redirect_to_old_editor(): void {
+		if ( ! \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_block_editor' ) ) {
 			if ( \Automattic\WooCommerce\Admin\PageController::is_admin_page() && isset( $_GET['path'] ) ) {
 				$path = esc_url_raw( wp_unslash( $_GET['path'] ) );
 

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -38,8 +38,8 @@ class Init {
 			$block_registry->init();
 		}
 
-		add_action( 'admin_init', array( $this, 'maybe_redirect_to_new_editor' ), 30, 0 );
-		add_action( 'admin_init', array( $this, 'maybe_redirect_to_old_editor' ), 30, 0 );
+		add_action( 'current_screen', array( $this, 'maybe_redirect_to_new_editor' ), 30, 0 );
+		add_action( 'current_screen', array( $this, 'maybe_redirect_to_old_editor' ), 30, 0 );
 	}
 
 	/**
@@ -48,15 +48,15 @@ class Init {
 	 */
 	public function maybe_redirect_to_new_editor(): void {
 		if ( \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_block_editor' ) ) {
-			if ( isset( $_SERVER['REQUEST_URI'] ) ) {
-				$request_uri = esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) );
+			$screen = get_current_screen();
 
-				if ( preg_match( '/^\/wp-admin\/post-new.php/', $request_uri ) && isset( $_GET['post_type'] ) && 'product' === $_GET['post_type'] ) {
+			if ( 'post' === $screen->base && 'product' === $screen->post_type ) {
+				if ( 'add' === $screen->action ) {
 					wp_safe_redirect( admin_url( 'admin.php?page=wc-admin&path=/add-product' ) );
 					exit();
 				}
 
-				if ( preg_match( '/^\/wp-admin\/post.php/', $request_uri ) && isset( $_GET['post'] ) && isset( $_GET['action'] ) && 'edit' === $_GET['action'] ) {
+				if ( isset( $_GET['post'] ) && isset( $_GET['action'] ) && 'edit' === $_GET['action'] ) {
 					$product_id = absint( $_GET['post'] );
 					wp_safe_redirect( admin_url( 'admin.php?page=wc-admin&path=/product/' . $product_id ) );
 					exit();

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -37,6 +37,41 @@ class Init {
 			$block_registry = new BlockRegistry();
 			$block_registry->init();
 		}
+
+		add_action( 'admin_init', array( $this, 'maybe_swap_old_product_form_and_new_product_block_editor' ), 30, 0 );
+	}
+
+	/**
+	 * Redirects from old product form to the new product form if the 
+	 * feature `product_block_editor` is enabled. If the feature is 
+	 * disabled then the redirection happens in reverse order.
+	 */
+	public function maybe_swap_old_product_form_and_new_product_block_editor(): void {
+		if ( \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_block_editor' ) ) {
+			if ( 0 === strpos( $_SERVER['REQUEST_URI'], '/wp-admin/post-new.php') && 'product' === $_GET['post_type'] ) {
+				wp_safe_redirect( '/wp-admin/admin.php?page=wc-admin&path=/add-product' );
+				exit();
+			}
+
+			if ( 0 === strpos( $_SERVER['REQUEST_URI'], '/wp-admin/post.php') && isset( $_GET['post'] ) && 'edit' === $_GET['action'] ) {
+				$product_id = $_GET['post'];
+				wp_safe_redirect( '/wp-admin/admin.php?page=wc-admin&path=/product/' . $product_id );
+				exit();
+			}
+		} else {
+			if ( \Automattic\WooCommerce\Admin\PageController::is_admin_page() ) {
+				if ( '/add-product' === $_GET['path'] ) {
+					wp_safe_redirect( '/wp-admin/post-new.php?post_type=product' );
+					exit();
+				}
+
+				if ( preg_match( '/^\/product\/(.*)/', $_GET['path'], $matches ) ) {
+					$product_id = $matches[1];
+					wp_safe_redirect( '/wp-admin/post.php?post=' . $product_id . '&action=edit' );
+					exit();
+				}
+			}
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -72,15 +72,16 @@ class Init {
 	public function maybe_redirect_to_old_editor(): void {
 		if ( ! \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_block_editor' ) ) {
 			if ( \Automattic\WooCommerce\Admin\PageController::is_admin_page() && isset( $_GET['path'] ) ) {
-				$path = esc_url_raw( wp_unslash( $_GET['path'] ) );
+				$path        = esc_url_raw( wp_unslash( $_GET['path'] ) );
+				$parsed_path = explode( '/', wp_parse_url( $path, PHP_URL_PATH ) );
 
-				if ( preg_match( '/^\/add-product$/', $path ) ) {
+				if ( 'add-product' === $parsed_path[1] ) {
 					wp_safe_redirect( admin_url( 'post-new.php?post_type=product' ) );
 					exit();
 				}
 
-				if ( preg_match( '/^\/product\/(\d+)$/', $path, $matches ) ) {
-					$product_id = absint( $matches[1] );
+				if ( 'product' === $parsed_path[1] ) {
+					$product_id = absint( $parsed_path[2] );
 					wp_safe_redirect( admin_url( 'post.php?post=' . $product_id . '&action=edit' ) );
 					exit();
 				}

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -1091,19 +1091,21 @@ class FeaturesController {
 	/**
 	 * Changes the feature given it's id and a toggle value as a query param.
 	 *
-	 * `/wp-admin/post.php?product_block_editor=1`, 1 for on 
+	 * `/wp-admin/post.php?product_block_editor=1`, 1 for on
 	 * `/wp-admin/post.php?product_block_editor=0`, 0 for off
 	 */
 	private function change_feature_enable_from_query_params(): void {
-		if ( ! is_admin() ) {
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
 			return;
 		}
 
 		foreach ( array_keys( $this->features ) as $feature_id ) {
-			if ( isset( $_GET[ $feature_id ] ) ) {
-				if ( '1' === $_GET[ $feature_id ] ) {
+			if ( isset( $_GET[ $feature_id ] ) && is_numeric( $_GET[ $feature_id ] ) ) {
+				$value = absint( $_GET[ $feature_id ] );
+
+				if ( 1 === $value ) {
 					$this->change_feature_enable( $feature_id, true );
-				} elseif ( '0' === $_GET[ $feature_id ] ) {
+				} elseif ( 0 === $value ) {
 					$this->change_feature_enable( $feature_id, false );
 				}
 			}

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -137,6 +137,7 @@ class FeaturesController {
 		self::add_action( 'after_plugin_row', array( $this, 'handle_plugin_list_rows' ), 10, 2 );
 		self::add_action( 'current_screen', array( $this, 'enqueue_script_to_fix_plugin_list_html' ), 10, 1 );
 		self::add_filter( 'views_plugins', array( $this, 'handle_plugins_page_views_list' ), 10, 1 );
+		self::add_action( 'admin_init', array( $this, 'change_feature_enable_from_query_params' ), 20, 0 );
 	}
 
 	/**
@@ -1085,5 +1086,27 @@ class FeaturesController {
 			'all'                       => $all_link,
 			'incompatible_with_feature' => $incompatible_link,
 		);
+	}
+
+	/**
+	 * Changes the feature given it's id and a toggle value as a query param.
+	 *
+	 * `/wp-admin/post.php?product_block_editor=1`, 1 for on 
+	 * `/wp-admin/post.php?product_block_editor=0`, 0 for off
+	 */
+	private function change_feature_enable_from_query_params(): void {
+		if ( ! is_admin() ) {
+			return;
+		}
+
+		foreach ( array_keys( $this->features ) as $feature_id ) {
+			if ( isset( $_GET[ $feature_id ] ) ) {
+				if ( '1' === $_GET[ $feature_id ] ) {
+					$this->change_feature_enable( $feature_id, true );
+				} elseif ( '0' === $_GET[ $feature_id ] ) {
+					$this->change_feature_enable( $feature_id, false );
+				}
+			}
+		}
 	}
 }

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -1108,17 +1108,20 @@ class FeaturesController {
 	 * `/wp-admin/post.php?product_block_editor=0&_feature_nonce=1234`, 0 for off
 	 */
 	private function change_feature_enable_from_query_params(): void {
-		if ( ! isset( $_GET['_feature_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_feature_nonce'] ) ), 'change_feature_enable' ) ) {
-			return;
-		}
-
 		if ( ! current_user_can( 'manage_woocommerce' ) ) {
 			return;
 		}
 
+		$is_feature_nonce_invalid = ( ! isset( $_GET['_feature_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_feature_nonce'] ) ), 'change_feature_enable' ) );
+
 		foreach ( array_keys( $this->features ) as $feature_id ) {
 			if ( isset( $_GET[ $feature_id ] ) && is_numeric( $_GET[ $feature_id ] ) ) {
 				$value = absint( $_GET[ $feature_id ] );
+
+				if ( $is_feature_nonce_invalid ) {
+					wp_die( esc_html__( 'Action failed. Please refresh the page and retry.', 'woocommerce' ) );
+					return;
+				}
 
 				if ( 1 === $value ) {
 					$this->change_feature_enable( $feature_id, true );


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #38243

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features` and check the `New product editor`.
2. Then go to `Products -> Add new` from the side menu.
3. The new product block editor should be shown. 
4. On the top right corner of the screen click the `Options` dropdown menu button. Then click on `Use the classic editor`.
5. Skip the feedback modal if it shows up. 
6. The classic product form should be shown.
7. Go to `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features` and uncheck the `New product editor`.
8. Then go to `Products -> Add new` from the side menu.
9. The new Product block editor should be shown.

<!-- End testing instructions -->
