### PR TITLE
Support values written in exponential notation for HPOS migrations.

### DIFF
--- a/plugins/woocommerce/changelog/fix-38470
+++ b/plugins/woocommerce/changelog/fix-38470
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Support values written in exponential notation for HPOS migrations.

--- a/plugins/woocommerce/src/Database/Migrations/MetaToCustomTableMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/MetaToCustomTableMigrator.php
@@ -571,7 +571,7 @@ WHERE
 	private function validate_data( $value, string $type ) {
 		switch ( $type ) {
 			case 'decimal':
-				$value = wc_format_decimal( $value, false, true );
+				$value = wc_format_decimal( floatval( $value ), false, true );
 				break;
 			case 'int':
 				$value = (int) $value;
@@ -843,8 +843,8 @@ WHERE $where_clause
 			if ( '' === $row[ $alias ] || null === $row[ $alias ] ) {
 				$row[ $alias ] = 0; // $wpdb->prepare forces empty values to 0.
 			}
-			$row[ $alias ]             = wc_format_decimal( $row[ $alias ], false, true );
-			$row[ $destination_alias ] = wc_format_decimal( $row[ $destination_alias ], false, true );
+			$row[ $alias ]             = wc_format_decimal( floatval( $row[ $alias ] ), false, true );
+			$row[ $destination_alias ] = wc_format_decimal( floatval( $row[ $destination_alias ] ), false, true );
 		}
 		if ( 'bool' === $schema['type'] ) {
 			$row[ $alias ]             = wc_string_to_bool( $row[ $alias ] );

--- a/plugins/woocommerce/tests/php/src/Database/Migrations/CustomOrderTable/PostsToOrdersMigrationControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Database/Migrations/CustomOrderTable/PostsToOrdersMigrationControllerTest.php
@@ -837,15 +837,16 @@ WHERE order_id = {$order_id} AND meta_key = 'non_unique_key_1' AND meta_value in
 		$this->sut->migrate_order( $order->get_id() );
 
 		$errors = $this->sut->verify_migrated_orders( array( $order->get_id() ) );
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r -- Intentional for informative debug message.
 		$this->assertEmpty( $errors, 'Errors found in migrated data: ' . print_r( $errors, true ) );
 
-		$order_tax = $wpdb->get_var( "SELECT tax_amount FROM {$wpdb->prefix}wc_orders WHERE id = {$order->get_id()}" );
+		$order_tax = $wpdb->get_var( $wpdb->prepare( "SELECT tax_amount FROM {$wpdb->prefix}wc_orders WHERE id = %d", $order->get_id() ) );
 		$this->assertEquals( 0, $order_tax );
 
-		$order_total = $wpdb->get_var( "SELECT total_amount FROM {$wpdb->prefix}wc_orders WHERE id = {$order->get_id()}" );
+		$order_total = $wpdb->get_var( $wpdb->prepare( "SELECT total_amount FROM {$wpdb->prefix}wc_orders WHERE id = %d", $order->get_id() ) );
 		$this->assertEquals( 0.12, $order_total );
 
-		$cart_discount_tax = $wpdb->get_var( "SELECT discount_tax_amount FROM {$wpdb->prefix}wc_order_operational_data WHERE order_id = {$order->get_id()}" );
+		$cart_discount_tax = $wpdb->get_var( $wpdb->prepare( "SELECT discount_tax_amount FROM {$wpdb->prefix}wc_order_operational_data WHERE order_id = %d", $order->get_id() ) );
 		$this->assertEquals( 12.37, $cart_discount_tax );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When migrating, we were passing values through `wc_format_decimal` function. Unfortunately, this function does not supports exponential notation, so any values with exponential notation will get converted to an incorrect value (basically, number before `E` is considered the final number).

With this PR, we now run the input through `floatval` function, which does takes care of the exponential notation.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #38470.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


Unfortunately, it's not possible to test this fix directly since we do not allow numbers in exponential notation, either from our interface or from the API, however, it's possible that number with this notation can come in from a plugin or a payment gateway. To test:

1. With posts table authoritative and sync off, create an order with some product. Let's say the ID of this order is XXX.
2. Update the order total directly using CLI to 32.18 in exponential notation `3218E-2` like so: `wp post meta update XXX  _order_total "3218E-2"`
3. Migrate the order by enabling sync.
4. Switch to HPOS as authoritative.
5. Open the order edit page again for order with ID XXX, make sure that it's total is 32.18.


<!-- End testing instructions -->
