### PR TITLE
Fix dynamic property declaration warnings in HPOS code (PHP 8.2+)

### DIFF
--- a/plugins/woocommerce/changelog/php8-dynamic-prop-hpos
+++ b/plugins/woocommerce/changelog/php8-dynamic-prop-hpos
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix dynamic property declaration warnings in HPOS code (PHP 8.2+)

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostMetaToOrderMetaMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostMetaToOrderMetaMigrator.php
@@ -40,7 +40,7 @@ class PostMetaToOrderMetaMigrator extends MetaToMetaTableMigrator {
 	protected function get_meta_config(): array {
 		global $wpdb;
 		// TODO: Remove hardcoding.
-		$this->table_names = array(
+		$table_names = array(
 			'orders'    => $wpdb->prefix . 'wc_orders',
 			'addresses' => $wpdb->prefix . 'wc_order_addresses',
 			'op_data'   => $wpdb->prefix . 'wc_order_operational_data',
@@ -57,7 +57,7 @@ class PostMetaToOrderMetaMigrator extends MetaToMetaTableMigrator {
 					'meta_value_column' => 'meta_value',
 				),
 				'entity'        => array(
-					'table_name'       => $this->table_names['orders'],
+					'table_name'       => $table_names['orders'],
 					'source_id_column' => 'id',
 					'id_column'        => 'id',
 				),
@@ -65,7 +65,7 @@ class PostMetaToOrderMetaMigrator extends MetaToMetaTableMigrator {
 			),
 			'destination' => array(
 				'meta' => array(
-					'table_name'        => $this->table_names['meta'],
+					'table_name'        => $table_names['meta'],
 					'entity_id_column'  => 'order_id',
 					'meta_key_column'   => 'meta_key',
 					'meta_value_column' => 'meta_value',

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostToOrderAddressTableMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostToOrderAddressTableMigrator.php
@@ -39,7 +39,7 @@ class PostToOrderAddressTableMigrator extends MetaToCustomTableMigrator {
 	protected function get_schema_config(): array {
 		global $wpdb;
 		// TODO: Remove hardcoding.
-		$this->table_names = array(
+		$table_names = array(
 			'orders'    => $wpdb->prefix . 'wc_orders',
 			'addresses' => $wpdb->prefix . 'wc_order_addresses',
 			'op_data'   => $wpdb->prefix . 'wc_order_operational_data',
@@ -49,7 +49,7 @@ class PostToOrderAddressTableMigrator extends MetaToCustomTableMigrator {
 		return array(
 			'source'      => array(
 				'entity' => array(
-					'table_name'             => $this->table_names['orders'],
+					'table_name'             => $table_names['orders'],
 					'meta_rel_column'        => 'id',
 					'destination_rel_column' => 'id',
 					'primary_key'            => 'id',
@@ -63,7 +63,7 @@ class PostToOrderAddressTableMigrator extends MetaToCustomTableMigrator {
 				),
 			),
 			'destination' => array(
-				'table_name'        => $this->table_names['addresses'],
+				'table_name'        => $table_names['addresses'],
 				'source_rel_column' => 'order_id',
 				'primary_key'       => 'id',
 				'primary_key_type'  => 'int',

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostToOrderOpTableMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostToOrderOpTableMigrator.php
@@ -23,7 +23,7 @@ class PostToOrderOpTableMigrator extends MetaToCustomTableMigrator {
 	protected function get_schema_config(): array {
 		global $wpdb;
 		// TODO: Remove hardcoding.
-		$this->table_names = array(
+		$table_names = array(
 			'orders'    => $wpdb->prefix . 'wc_orders',
 			'addresses' => $wpdb->prefix . 'wc_order_addresses',
 			'op_data'   => $wpdb->prefix . 'wc_order_operational_data',
@@ -33,7 +33,7 @@ class PostToOrderOpTableMigrator extends MetaToCustomTableMigrator {
 		return array(
 			'source'      => array(
 				'entity' => array(
-					'table_name'             => $this->table_names['orders'],
+					'table_name'             => $table_names['orders'],
 					'meta_rel_column'        => 'id',
 					'destination_rel_column' => 'id',
 					'primary_key'            => 'id',
@@ -47,7 +47,7 @@ class PostToOrderOpTableMigrator extends MetaToCustomTableMigrator {
 				),
 			),
 			'destination' => array(
-				'table_name'        => $this->table_names['op_data'],
+				'table_name'        => $table_names['op_data'],
 				'source_rel_column' => 'order_id',
 				'primary_key'       => 'id',
 				'primary_key_type'  => 'int',

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostToOrderTableMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostToOrderTableMigrator.php
@@ -22,7 +22,7 @@ class PostToOrderTableMigrator extends MetaToCustomTableMigrator {
 	protected function get_schema_config(): array {
 		global $wpdb;
 
-		$this->table_names = array(
+		$table_names = array(
 			'orders'    => $wpdb->prefix . 'wc_orders',
 			'addresses' => $wpdb->prefix . 'wc_order_addresses',
 			'op_data'   => $wpdb->prefix . 'wc_order_operational_data',
@@ -46,7 +46,7 @@ class PostToOrderTableMigrator extends MetaToCustomTableMigrator {
 				),
 			),
 			'destination' => array(
-				'table_name'        => $this->table_names['orders'],
+				'table_name'        => $table_names['orders'],
 				'source_rel_column' => 'id',
 				'primary_key'       => 'id',
 				'primary_key_type'  => 'int',

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -106,7 +106,7 @@ class OrdersTableQuery {
 	 *
 	 * @var array
 	 */
-	private $results = array();
+	private $orders = array();
 
 	/**
 	 * Final SQL query to run after processing of args.
@@ -1156,7 +1156,7 @@ class OrdersTableQuery {
 				return $this->max_num_pages;
 			case 'posts':
 			case 'orders':
-				return $this->results;
+				return $this->orders;
 			case 'request':
 				return $this->sql;
 			default:


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Fixes `PHP Deprecated:  Creation of dynamic property` warnings in HPOS-related code when running on PHP 8.2+.

Supersedes part of #37063.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure your environment is running PHP 8.2.x and has logging enabled.
2. Enable HPOS.
3. Go to WC > Orders.
4.
   - On `trunk`, you should have not so few instances of the following warnings in your log file:
      ```
      PHP Deprecated:  Creation of dynamic property Automattic\WooCommerce\Database\Migrations\CustomOrderTable\PostToOrderTableMigrator::$table_names is deprecated in /.../woocommerce/src/Database/Migrations/CustomOrderTable/PostToOrderTableMigrator.php on line 25
      PHP Deprecated:  Creation of dynamic property Automattic\WooCommerce\Database\Migrations\CustomOrderTable\PostToOrderAddressTableMigrator::$table_names is deprecated in /.../woocommerce/src/Database/Migrations/CustomOrderTable/PostToOrderAddressTableMigrator.php on line 42
      PHP Deprecated:  Creation of dynamic property Automattic\WooCommerce\Database\Migrations\CustomOrderTable\PostToOrderAddressTableMigrator::$table_names is deprecated in /.../woocommerce/src/Database/Migrations/CustomOrderTable/PostToOrderAddressTableMigrator.php on line 42
      PHP Deprecated:  Creation of dynamic property Automattic\WooCommerce\Database\Migrations\CustomOrderTable\PostToOrderOpTableMigrator::$table_names is deprecated in /.../woocommerce/src/Database/Migrations/CustomOrderTable/PostToOrderOpTableMigrator.php on line 26
      PHP Deprecated:  Creation of dynamic property Automattic\WooCommerce\Database\Migrations\CustomOrderTable\PostMetaToOrderMetaMigrator::$table_names is deprecated in /.../woocommerce/src/Database/Migrations/CustomOrderTable/PostMetaToOrderMetaMigrator.php on l
      PHP Deprecated:  Creation of dynamic property Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableQuery::$orders is deprecated in /.../woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php on line 1129
      ```
   - On this branch, those warnings no longer appear. (To confirm this, I'd suggest clearing up the logs first).

<!-- End testing instructions -->
