### PR TITLE
Fix dynamic property declaration warnings in gateway code (PHP 8.2+)

### DIFF
--- a/plugins/woocommerce/changelog/php8-dynamic-prop-gateways
+++ b/plugins/woocommerce/changelog/php8-dynamic-prop-gateways
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix dynamic property declaration warnings in gateway code (PHP 8.2+).

--- a/plugins/woocommerce/includes/gateways/bacs/class-wc-gateway-bacs.php
+++ b/plugins/woocommerce/includes/gateways/bacs/class-wc-gateway-bacs.php
@@ -29,6 +29,20 @@ class WC_Gateway_BACS extends WC_Payment_Gateway {
 	public $locale;
 
 	/**
+	 * Gateway instructions that will be added to the thank you page and emails.
+	 *
+	 * @var string
+	 */
+	public $instructions;
+
+	/**
+	 * Account details.
+	 *
+	 * @var array
+	 */
+	public $account_details;
+
+	/**
 	 * Constructor for the gateway.
 	 */
 	public function __construct() {

--- a/plugins/woocommerce/includes/gateways/cheque/class-wc-gateway-cheque.php
+++ b/plugins/woocommerce/includes/gateways/cheque/class-wc-gateway-cheque.php
@@ -22,6 +22,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WC_Gateway_Cheque extends WC_Payment_Gateway {
 
 	/**
+	 * Gateway instructions that will be added to the thank you page and emails.
+	 *
+	 * @var string
+	 */
+	public $instructions;
+
+	/**
 	 * Constructor for the gateway.
 	 */
 	public function __construct() {

--- a/plugins/woocommerce/includes/gateways/cod/class-wc-gateway-cod.php
+++ b/plugins/woocommerce/includes/gateways/cod/class-wc-gateway-cod.php
@@ -24,6 +24,27 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WC_Gateway_COD extends WC_Payment_Gateway {
 
 	/**
+	 * Gateway instructions that will be added to the thank you page and emails.
+	 *
+	 * @var string
+	 */
+	public $instructions;
+
+	/**
+	 * Enable for shipping methods.
+	 *
+	 * @var array
+	 */
+	public $enable_for_methods;
+
+	/**
+	 * Enable for virtual products.
+	 *
+	 * @var bool
+	 */
+	public $enable_for_virtual;
+
+	/**
 	 * Constructor for the gateway.
 	 */
 	public function __construct() {

--- a/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/plugins/woocommerce/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -36,6 +36,42 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 	public static $log = false;
 
 	/**
+	 * Whether the test mode is enabled.
+	 *
+	 * @var bool
+	 */
+	public $testmode;
+
+	/**
+	 * Whether the debug mode is enabled.
+	 *
+	 * @var bool
+	 */
+	public $debug;
+
+	/**
+	 * Email address to send payments to.
+	 *
+	 * @var string
+	 */
+	public $email;
+
+	/**
+	 * Receiver email.
+	 *
+	 * @var string
+	 */
+	public $receiver_email;
+
+	/**
+	 * Identity token.
+	 *
+	 * @var string
+	 */
+	public $identity_token;
+
+
+	/**
 	 * Constructor for the gateway.
 	 */
 	public function __construct() {


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes PHP Deprecated:  Creation of dynamic property warnings in HPOS-related code when running on PHP 8.2+.

Supersedes part of https://github.com/woocommerce/woocommerce/pull/37063.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure your environment is running PHP 8.2.x and has logging enabled.
2. Go to WC > Settings > Payments and enable the default gateways: Direct bank transfer, Check payments, Cash on delivery.
3. Go to the frontend and add an item to the cart.
4. Go to the checkout page.
5. Use grep (`grep 'includes/gateways' logfile.log`) or manual inspection to confirm that:
   - On `trunk`, a few warnings from `includes/gateways` are present.
   - On this branch, those warnings no longer appear.
<!-- End testing instructions -->
