### PR TITLE
Fix dynamic property declaration warnings in shipping code (PHP 8.2+)

### DIFF
--- a/plugins/woocommerce/changelog/php8-dynamic-prop-shipping
+++ b/plugins/woocommerce/changelog/php8-dynamic-prop-shipping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix dynamic property declaration warnings in shipping-related code (PHP 8.2+).

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-shipping-method.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-shipping-method.php
@@ -135,6 +135,30 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 	public $countries = array();
 
 	/**
+	 * Shipping method order.
+	 *
+	 * @var int
+	 */
+	public $method_order;
+
+	/**
+	 * Whether the shipping method has settings or not. Preferably, use {@see has_settings()} instead.
+	 *
+	 * @var bool
+	 */
+	public $has_settings;
+
+	/**
+	 * When the method supports the settings modal, this is the admin settings HTML.
+	 * Preferably, use {@see get_admin_options_html()} instead.
+	 *
+	 * @var string|bool
+	 */
+	public $settings_html;
+
+
+
+	/**
 	 * Constructor.
 	 *
 	 * @param int $instance_id Instance ID.

--- a/plugins/woocommerce/includes/class-wc-countries.php
+++ b/plugins/woocommerce/includes/class-wc-countries.php
@@ -60,6 +60,13 @@ class WC_Countries {
 	 */
 	public function get_countries() {
 		if ( empty( $this->geo_cache['countries'] ) ) {
+			/**
+			 * Allows filtering of the list of countries in WC.
+			 *
+			 * @since 1.5.3
+			 *
+			 * @param array $countries
+			 */
 			$this->geo_cache['countries'] = apply_filters( 'woocommerce_countries', include WC()->plugin_path() . '/i18n/countries.php' );
 			if ( apply_filters( 'woocommerce_sort_countries', true ) ) {
 				wc_asort_by_locale( $this->geo_cache['countries'] );
@@ -87,6 +94,13 @@ class WC_Countries {
 	 */
 	public function get_continents() {
 		if ( empty( $this->geo_cache['continents'] ) ) {
+			/**
+			 * Allows filtering of continents in WC.
+			 *
+			 * @since 2.6.0
+			 *
+			 * @param array[array] $continents
+			 */
 			$this->geo_cache['continents'] = apply_filters( 'woocommerce_continents', include WC()->plugin_path() . '/i18n/continents.php' );
 		}
 
@@ -166,7 +180,15 @@ class WC_Countries {
 	public function load_country_states() {
 		global $states;
 
-		$states       = include WC()->plugin_path() . '/i18n/states.php';
+		$states = include WC()->plugin_path() . '/i18n/states.php';
+
+		/**
+		 * Allows filtering of country states in WC.
+		 *
+		 * @since 1.5.3
+		 *
+		 * @param array $states
+		 */
 		$this->geo_cache['states'] = apply_filters( 'woocommerce_states', $states );
 	}
 
@@ -178,6 +200,13 @@ class WC_Countries {
 	 */
 	public function get_states( $cc = null ) {
 		if ( ! isset( $this->geo_cache['states'] ) ) {
+			/**
+			 * Allows filtering of country states in WC.
+			 *
+			 * @since 1.5.3
+			 *
+			 * @param array $states
+			 */
 			$this->geo_cache['states'] = apply_filters( 'woocommerce_states', include WC()->plugin_path() . '/i18n/states.php' );
 		}
 

--- a/plugins/woocommerce/includes/class-wc-countries.php
+++ b/plugins/woocommerce/includes/class-wc-countries.php
@@ -28,6 +28,16 @@ class WC_Countries {
 	public $address_formats = array();
 
 	/**
+	 * Cache of geographical regions.
+	 *
+	 * Only to be used by the get_* and load_* methods, as other methods may expect the regions to be
+	 * loaded on demand.
+	 *
+	 * @var array
+	 */
+	private $geo_cache = array();
+
+	/**
 	 * Auto-load in-accessible properties on demand.
 	 *
 	 * @param  mixed $key Key.
@@ -38,6 +48,8 @@ class WC_Countries {
 			return $this->get_countries();
 		} elseif ( 'states' === $key ) {
 			return $this->get_states();
+		} elseif ( 'continents' === $key ) {
+			return $this->get_continents();
 		}
 	}
 
@@ -47,14 +59,14 @@ class WC_Countries {
 	 * @return array
 	 */
 	public function get_countries() {
-		if ( empty( $this->countries ) ) {
-			$this->countries = apply_filters( 'woocommerce_countries', include WC()->plugin_path() . '/i18n/countries.php' );
+		if ( empty( $this->geo_cache['countries'] ) ) {
+			$this->geo_cache['countries'] = apply_filters( 'woocommerce_countries', include WC()->plugin_path() . '/i18n/countries.php' );
 			if ( apply_filters( 'woocommerce_sort_countries', true ) ) {
-				wc_asort_by_locale( $this->countries );
+				wc_asort_by_locale( $this->geo_cache['countries'] );
 			}
 		}
 
-		return $this->countries;
+		return $this->geo_cache['countries'];
 	}
 
 	/**
@@ -74,11 +86,11 @@ class WC_Countries {
 	 * @return array
 	 */
 	public function get_continents() {
-		if ( empty( $this->continents ) ) {
-			$this->continents = apply_filters( 'woocommerce_continents', include WC()->plugin_path() . '/i18n/continents.php' );
+		if ( empty( $this->geo_cache['continents'] ) ) {
+			$this->geo_cache['continents'] = apply_filters( 'woocommerce_continents', include WC()->plugin_path() . '/i18n/continents.php' );
 		}
 
-		return $this->continents;
+		return $this->geo_cache['continents'];
 	}
 
 	/**
@@ -155,7 +167,7 @@ class WC_Countries {
 		global $states;
 
 		$states       = include WC()->plugin_path() . '/i18n/states.php';
-		$this->states = apply_filters( 'woocommerce_states', $states );
+		$this->geo_cache['states'] = apply_filters( 'woocommerce_states', $states );
 	}
 
 	/**
@@ -165,14 +177,14 @@ class WC_Countries {
 	 * @return false|array of states
 	 */
 	public function get_states( $cc = null ) {
-		if ( ! isset( $this->states ) ) {
-			$this->states = apply_filters( 'woocommerce_states', include WC()->plugin_path() . '/i18n/states.php' );
+		if ( ! isset( $this->geo_cache['states'] ) ) {
+			$this->geo_cache['states'] = apply_filters( 'woocommerce_states', include WC()->plugin_path() . '/i18n/states.php' );
 		}
 
 		if ( ! is_null( $cc ) ) {
-			return isset( $this->states[ $cc ] ) ? $this->states[ $cc ] : false;
+			return isset( $this->geo_cache['states'][ $cc ] ) ? $this->geo_cache['states'][ $cc ] : false;
 		} else {
-			return $this->states;
+			return $this->geo_cache['states'];
 		}
 	}
 

--- a/plugins/woocommerce/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
+++ b/plugins/woocommerce/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
@@ -21,6 +21,20 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 	protected $fee_cost = '';
 
 	/**
+	 * Shipping method cost.
+	 *
+	 * @var string
+	 */
+	public $cost;
+
+	/**
+	 * Shipping method type.
+	 *
+	 * @var string
+	 */
+	public $type;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param int $instance_id Shipping method instance ID.

--- a/plugins/woocommerce/includes/shipping/free-shipping/class-wc-shipping-free-shipping.php
+++ b/plugins/woocommerce/includes/shipping/free-shipping/class-wc-shipping-free-shipping.php
@@ -37,6 +37,15 @@ class WC_Shipping_Free_Shipping extends WC_Shipping_Method {
 	public $requires = '';
 
 	/**
+	 * Ignore discounts.
+	 *
+	 * If set, free shipping would be available based on pre-discount order amount.
+	 *
+	 * @var string
+	 */
+	public $ignore_discounts;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param int $instance_id Shipping method instance.

--- a/plugins/woocommerce/includes/shipping/legacy-flat-rate/class-wc-shipping-legacy-flat-rate.php
+++ b/plugins/woocommerce/includes/shipping/legacy-flat-rate/class-wc-shipping-legacy-flat-rate.php
@@ -28,6 +28,28 @@ class WC_Shipping_Legacy_Flat_Rate extends WC_Shipping_Method {
 	protected $fee_cost = '';
 
 	/**
+	 * Shipping method cost.
+	 *
+	 * @var string
+	 */
+	public $cost;
+
+	/**
+	 * Shipping method type.
+	 *
+	 * @var string
+	 */
+	public $type;
+
+	/**
+	 * Shipping method options.
+	 *
+	 * @deprecated 2.4.0
+	 * @var string
+	 */
+	public $options;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {

--- a/plugins/woocommerce/includes/shipping/legacy-local-delivery/class-wc-shipping-legacy-local-delivery.php
+++ b/plugins/woocommerce/includes/shipping/legacy-local-delivery/class-wc-shipping-legacy-local-delivery.php
@@ -21,6 +21,22 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WC_Shipping_Legacy_Local_Delivery extends WC_Shipping_Local_Pickup {
 
 	/**
+	 * Shipping method fee type.
+	 *
+	 * How to calculate delivery charges.
+	 *
+	 * @var string
+	 */
+	public $type;
+
+	/**
+	 * Allowed post/zip codes for the shipping method.
+	 *
+	 * @var string
+	 */
+	public $codes;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -66,7 +82,6 @@ class WC_Shipping_Legacy_Local_Delivery extends WC_Shipping_Local_Pickup {
 		$this->title        = $this->get_option( 'title' );
 		$this->type         = $this->get_option( 'type' );
 		$this->fee          = $this->get_option( 'fee' );
-		$this->type         = $this->get_option( 'type' );
 		$this->codes        = $this->get_option( 'codes' );
 		$this->availability = $this->get_option( 'availability' );
 		$this->countries    = $this->get_option( 'countries' );

--- a/plugins/woocommerce/includes/shipping/legacy-local-pickup/class-wc-shipping-legacy-local-pickup.php
+++ b/plugins/woocommerce/includes/shipping/legacy-local-pickup/class-wc-shipping-legacy-local-pickup.php
@@ -21,6 +21,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WC_Shipping_Legacy_Local_Pickup extends WC_Shipping_Method {
 
 	/**
+	 * Allowed post/zip codes for the shipping method.
+	 *
+	 * @var string
+	 */
+	public $codes;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {

--- a/plugins/woocommerce/includes/shipping/local-pickup/class-wc-shipping-local-pickup.php
+++ b/plugins/woocommerce/includes/shipping/local-pickup/class-wc-shipping-local-pickup.php
@@ -21,6 +21,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WC_Shipping_Local_Pickup extends WC_Shipping_Method {
 
 	/**
+	 * Shipping method cost.
+	 *
+	 * @var string
+	 */
+	public $cost;
+
+
+	/**
 	 * Constructor.
 	 *
 	 * @param int $instance_id Instance ID.


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

Fixes PHP Deprecated: Creation of dynamic property warnings in shipping-related code when running on PHP 8.2+.

Supersedes part of https://github.com/woocommerce/woocommerce/pull/37063.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure your environment is running PHP 8.2.x and has logging enabled.
2. Go to the frontend and add an item to the cart.
3. Go to the checkout page.
5. Use grep (`grep -i 'countries\|includes/shipping' logfile.log`) or manual inspection to confirm that:
   - On `trunk`, a few warnings from `includes/shipping` and `WC_Countries` are present.
   - On this branch, those warnings no longer appear.

Note: You will see a warning from WooCommerce Analytics

```
PHP Deprecated:  Creation of dynamic property Automattic\WooCommerce\Admin\API\Init::$Automattic\WooCommerce\Admin\API\DataCountries is deprecated in wp-content/woocommerce/plugins/woocommerce/src/Admin/API/Init.php on line 144
```

<!-- End testing instructions -->
