### PR TITLE
Orders: Changed modified date when a line item is changed

### DIFF
--- a/plugins/woocommerce/changelog/fix-28969-edit-order-lines
+++ b/plugins/woocommerce/changelog/fix-28969-edit-order-lines
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Change an order's modified date when a line item in the order changes.

--- a/plugins/woocommerce/includes/admin/wc-admin-functions.php
+++ b/plugins/woocommerce/includes/admin/wc-admin-functions.php
@@ -338,6 +338,7 @@ function wc_save_order_items( $order_id, $items ) {
 					$qty_change_order_notes[] = $item->get_name() . ' &ndash; ' . $changed_stock['from'] . '&rarr;' . $changed_stock['to'];
 				}
 				$item->delete();
+				$order->set_date_modified( time() );
 				continue;
 			}
 
@@ -380,6 +381,10 @@ function wc_save_order_items( $order_id, $items ) {
 			/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
 			do_action( 'woocommerce_before_save_order_item', $item );
 			/* phpcs: enable */
+
+			if ( count( $item->get_changes() ) > 0 ) {
+				$order->set_date_modified( time() );
+			}
 
 			$item->save();
 
@@ -441,11 +446,13 @@ function wc_save_order_items( $order_id, $items ) {
 				}
 			}
 
+			if ( count( $item->get_changes() ) > 0 ) {
+				$order->set_date_modified( time() );
+			}
+
 			$item->save();
 		}
 	}
-
-	$order = wc_get_order( $order_id );
 
 	if ( ! empty( $qty_change_order_notes ) ) {
 		/* translators: %s item name. */


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This addresses the second part of [#28969](https://github.com/woocommerce/woocommerce/issues/28969#issuecomment-1442682025).

This ensures that regardless of HPOS state, adding/changing/deleting a line item in an order also updates the order's `modified` date. As discussed by some participants in the related issue, checking the `modified` date is often the way to determine when things have changed, so it's important for it to be accurate.

Fixes #28969

### Progress

Will keep this updated as the PR progresses until everything is updating.

| Action | CPT | HPOS |
|--------|--------|--------|
| Add product | ❌ | ❌ |
| Change product | ✅ | ✅ |
| Delete product | ❌ | ✅ |
| Add shipping | ❌ | ❌ |
| Change shipping | ✅ | ✅ | 
| Delete shipping | ❌ | ✅ | 
| Add fee | ❌ | ✅ | 
| Change fee | ✅ | ✅ | 
| Delete fee | ❌ | ✅ | 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

As mentioned in #37047, WC Admin doesn't surface the modified date of an order anywhere in the UI. We can remedy this by outputting it in an admin notice at the top of the Edit Order screen. Add this snippet to a file in `wp-content/mu-plugins`:

```php
<?php

// For testing #38570
add_action(
	'admin_notices',
	function() {
		$order = wc_get_order();

		if ( $order ) {
			echo '<div class="notice notice-info"><pre>';
			printf(
				'Date modified: %s',
				gmdate( 'Y-m-d H:i:s', strtotime( $order->get_date_modified() ) )
			);
			echo '</pre></div>';
		}
	}
);
```

Do the following steps _before_ checking out this PR branch to see existing behavior:

1. Under WooCommerce > Settings > Advanced > Features, enable the high performance order storage feature. Then switch to the Custom data stores tab and choose "Use the WordPress posts table" and check the box to keep the tables synchronized. Having the posts table set as authoritative is the state where the issue arises that this PR fixes.
2. Create a new order. Add some product and shipping line items. Set the status to "pending payment" so that these line items can still be edited. Click the "Update" button to make sure all your changes are saved.
3. While still on the Edit Order screen, note the admin notice at the top of the screen showing the "Date modified" of the order. Now change one of the product line items in the order (e.g. change the quantity) and click the Save button.
4. Since modifying the line item is performed via ajax, you'll now need to refresh the browser screen. Note that the "Date modified" in the admin notice has _not_ changed.
5. Add a new product line item. After a refresh, "Date modified" should _not_ change.
6. Delete a product line item. After a refresh, "Date modified" should _not_ change.
7. Do the same procedure with shipping line items. After a refresh, "Date modified" should _not_ change.
8. Do the same prodedure with fee items. After a refresh, "Date modified" should _not_ change.

Now check out this branch and do the same steps (you can use the same order you already created). This time, each line item change/addition/deletion should cause "Date modified" to change. Also with this branch, switch to using HPOS ("Use the WooCommerce orders table") and do the same steps, and again, each line item change/addition/deletion should cause "Date modified" to change.

<!-- End testing instructions -->
