### PR TITLE
Add powered by AI UI elements and other enhancements

### DIFF
--- a/plugins/woo-ai/src/components/description-completion-buttons.tsx
+++ b/plugins/woo-ai/src/components/description-completion-buttons.tsx
@@ -45,7 +45,7 @@ export const WriteItForMeBtn = ( {
 		<MagicButton
 			disabled={ disabled }
 			onClick={ onClick }
-			label={ __( 'Write it for me', 'woocommerce' ) }
+			label={ __( 'Write with AI', 'woocommerce' ) }
 			title={
 				disabled
 					? sprintf(

--- a/plugins/woo-ai/src/constants.ts
+++ b/plugins/woo-ai/src/constants.ts
@@ -1,3 +1,3 @@
 export const WOO_AI_PLUGIN_FEATURE_NAME = 'woo_ai_plugin';
 export const MAX_TITLE_LENGTH = 200;
-export const MIN_TITLE_LENGTH_FOR_DESCRIPTION = 20;
+export const MIN_TITLE_LENGTH_FOR_DESCRIPTION = 15;

--- a/plugins/woo-ai/src/product-description/product-description-button-container.tsx
+++ b/plugins/woo-ai/src/product-description/product-description-button-container.tsx
@@ -89,15 +89,19 @@ export function WriteItForMeButtonContainer() {
 
 	useEffect( () => {
 		const title = titleEl.current;
-		const titleKeyupHandler = ( e: KeyboardEvent ) => {
+
+		const updateTitleHandler = ( e: Event ) => {
 			setProductTitle(
 				( e.target as HTMLInputElement ).value.trim() || ''
 			);
 		};
-		title?.addEventListener( 'keyup', titleKeyupHandler );
+
+		title?.addEventListener( 'keyup', updateTitleHandler );
+		title?.addEventListener( 'change', updateTitleHandler );
 
 		return () => {
-			title?.removeEventListener( 'keyup', titleKeyupHandler );
+			title?.removeEventListener( 'keyup', updateTitleHandler );
+			title?.removeEventListener( 'change', updateTitleHandler );
 		};
 	}, [ titleEl ] );
 

--- a/plugins/woo-ai/src/product-description/product-description-button-container.tsx
+++ b/plugins/woo-ai/src/product-description/product-description-button-container.tsx
@@ -69,7 +69,7 @@ export function WriteItForMeButtonContainer() {
 				if ( reason === 'finished' ) {
 					showSnackbar( {
 						label: __(
-							'Description added. How is it?',
+							'Was the AI-generated description helpful?',
 							'woocommerce'
 						),
 						onPositiveResponse: () => {

--- a/plugins/woo-ai/src/product-name/index.ts
+++ b/plugins/woo-ai/src/product-name/index.ts
@@ -1,1 +1,4 @@
 export * from './product-name-suggestions';
+export * from './powered-by-link';
+export * from './suggestion-item';
+export * from './name-utils';

--- a/plugins/woo-ai/src/product-name/name-utils.ts
+++ b/plugins/woo-ai/src/product-name/name-utils.ts
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies
+ */
+import { recordTracksFactory, getPostId } from '../utils';
+
+type TracksData = Record<
+	string,
+	string | number | Array< Record< string, string | number > >
+>;
+
+export const recordNameTracks = recordTracksFactory< TracksData >(
+	'name_completion',
+	() => ( {
+		post_id: getPostId(),
+	} )
+);

--- a/plugins/woo-ai/src/product-name/powered-by-link.tsx
+++ b/plugins/woo-ai/src/product-name/powered-by-link.tsx
@@ -17,7 +17,7 @@ export const PoweredByLink = () => (
 			{
 				link: (
 					<Link
-						href={ `` }
+						href="https://wordpress.org/documentation/"
 						target="_blank"
 						type="external"
 						onClick={ () => {

--- a/plugins/woo-ai/src/product-name/powered-by-link.tsx
+++ b/plugins/woo-ai/src/product-name/powered-by-link.tsx
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { createInterpolateElement } from '@wordpress/element';
+import { Link } from '@woocommerce/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { recordNameTracks } from './index';
+
+export const PoweredByLink = () => (
+	<span className="woo-ai-get-suggestions-legal_text">
+		{ createInterpolateElement(
+			__( 'Powered by experimental AI. <link/>', 'woocommerce' ),
+			{
+				link: (
+					<Link
+						href={ `` }
+						target="_blank"
+						type="external"
+						onClick={ () => {
+							recordNameTracks( 'learn_more_click' );
+						} }
+					>
+						{ __( 'Learn more', 'woocommerce' ) }
+					</Link>
+				),
+			}
+		) }
+	</span>
+);

--- a/plugins/woo-ai/src/product-name/powered-by-link.tsx
+++ b/plugins/woo-ai/src/product-name/powered-by-link.tsx
@@ -11,7 +11,7 @@ import { __ } from '@wordpress/i18n';
 import { recordNameTracks } from './index';
 
 export const PoweredByLink = () => (
-	<span className="woo-ai-get-suggestions-legal_text">
+	<span className="woo-ai-get-suggestions-powered_by">
 		{ createInterpolateElement(
 			__( 'Powered by experimental AI. <link/>', 'woocommerce' ),
 			{

--- a/plugins/woo-ai/src/product-name/powered-by-link.tsx
+++ b/plugins/woo-ai/src/product-name/powered-by-link.tsx
@@ -17,7 +17,7 @@ export const PoweredByLink = () => (
 			{
 				link: (
 					<Link
-						href="https://wordpress.org/documentation/"
+						href="https://automattic.com/ai-guidelines"
 						target="_blank"
 						type="external"
 						onClick={ () => {

--- a/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
+++ b/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
@@ -118,9 +118,15 @@ export const ProductNameSuggestions = () => {
 	}, [] );
 
 	const updateProductName = ( newName: string ) => {
-		if ( ! nameInputRef.current || ! newName.length ) return;
+		if ( ! nameInputRef.current || ! newName.length ) {
+			return;
+		}
 		nameInputRef.current.value = newName;
 		nameInputRef.current.setAttribute( 'value', newName );
+
+		// Ensure change event is fired for other interactions.
+		nameInputRef.current.dispatchEvent( new Event( 'change' ) );
+
 		setProductName( newName );
 	};
 

--- a/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
+++ b/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
@@ -42,7 +42,7 @@ declare const tinymce: {
 const MagicImage = () => (
 	<img
 		className="wc-product-name-suggestions__magic-image"
-		src={ `${ MagicIcon }` }
+		src={ MagicIcon }
 		alt=""
 	/>
 );

--- a/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
+++ b/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
@@ -143,7 +143,7 @@ export const ProductNameSuggestions = () => {
 
 	const handleSuggestionClick = ( suggestion: ProductDataSuggestion ) => {
 		recordNameTracks( 'select', {
-			selectedTitle: suggestion.content,
+			selected_title: suggestion.content,
 		} );
 
 		updateProductName( suggestion.content );
@@ -162,7 +162,7 @@ export const ProductNameSuggestions = () => {
 			const currentProductData = productData();
 
 			recordNameTracks( 'start', {
-				currentTitle: currentProductData.name,
+				current_title: currentProductData.name,
 			} );
 
 			const request: ProductDataSuggestionRequest = {

--- a/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
+++ b/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
@@ -4,21 +4,19 @@
 import React from 'react';
 import { __ } from '@wordpress/i18n';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
-import { Pill } from '@woocommerce/components';
-import { Tooltip } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import MagicIcon from '../../assets/images/icons/magic.svg';
 import AlertIcon from '../../assets/images/icons/alert.svg';
-import { productData, recordTracksFactory, getPostId } from '../utils';
+import { productData } from '../utils';
 import { useProductDataSuggestions } from '../hooks/useProductDataSuggestions';
 import {
 	ProductDataSuggestion,
 	ProductDataSuggestionRequest,
 } from '../utils/types';
-import SuggestionItem from './suggestion-item';
+import { SuggestionItem, PoweredByLink, recordNameTracks } from './index';
 import { RandomLoadingMessage } from '../components';
 
 const MIN_TITLE_LENGTH = 10;
@@ -40,18 +38,6 @@ declare const tinymce: {
 		thing?: boolean
 	) => void;
 };
-
-type TracksData = Record<
-	string,
-	string | number | Array< Record< string, string | number > >
->;
-
-const recordNameTracks = recordTracksFactory< TracksData >(
-	'name_completion',
-	() => ( {
-		post_id: getPostId(),
-	} )
-);
 
 export const ProductNameSuggestions = () => {
 	const [ suggestionsState, setSuggestionsState ] =
@@ -147,7 +133,12 @@ export const ProductNameSuggestions = () => {
 		setSuggestions( [] );
 	};
 
-	const fetchProductSuggestions = async () => {
+	const fetchProductSuggestions = async (
+		event: React.MouseEvent< HTMLElement >
+	) => {
+		if ( ( event.target as Element )?.closest( 'a' ) ) {
+			return;
+		}
 		setSuggestions( [] );
 		setSuggestionsState( SuggestionsState.Fetching );
 		try {
@@ -212,13 +203,18 @@ export const ProductNameSuggestions = () => {
 				) }
 			{ productName.length < MIN_TITLE_LENGTH &&
 				suggestionsState === SuggestionsState.None && (
-					<p className="wc-product-name-suggestions__tip-message">
-						<img src={ MagicIcon } alt="" />
-						{ __(
-							'Enter a few descriptive words to generate product name using AI.',
-							'woocommerce'
-						) }
-					</p>
+					<>
+						<div className="wc-product-name-suggestions__tip-message">
+							<div>
+								<img src={ MagicIcon } alt="" />
+								{ __(
+									'Enter a few descriptive words to generate product name.',
+									'woocommerce'
+								) }
+							</div>
+							<PoweredByLink />
+						</div>
+					</>
 				) }
 			{ suggestionsState !== SuggestionsState.Failed && (
 				<button
@@ -235,23 +231,7 @@ export const ProductNameSuggestions = () => {
 						<img src={ MagicIcon } alt="" />
 						{ getSuggestionsButtonLabel() }
 					</div>
-					<Tooltip
-						text={ __(
-							'AI features are in their experimental phase. While we strive to provide accurate and useful results, there is a possibility of generating misleading or incorrect content.',
-							'woocommerce'
-						) }
-						position="top center"
-						// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-						// @ts-ignore Incorrect types.
-						className={
-							'woo-ai-get-suggestions__experimental-tooltip'
-						}
-						delay={ 0 }
-					>
-						<span>
-							<Pill>{ __( 'Experimental', 'woocommerce' ) }</Pill>
-						</span>
-					</Tooltip>
+					<PoweredByLink />
 				</button>
 			) }
 			{ suggestionsState === SuggestionsState.Fetching && (

--- a/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
+++ b/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
@@ -79,9 +79,11 @@ export const ProductNameSuggestions = () => {
 
 			// Need to capture errant handlediv click that happens on load as well
 			if (
-				target?.matches( '.handlediv' ) ||
-				! target?.matches(
-					'#woocommerce-ai-app-product-name-suggestions *, #title'
+				! (
+					target?.matches( 'h3:has(.handlediv)' ) ||
+					target?.matches(
+						'#woocommerce-ai-app-product-name-suggestions *, #title'
+					)
 				)
 			) {
 				setVisible( false );

--- a/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
+++ b/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
@@ -77,9 +77,10 @@ export const ProductNameSuggestions = () => {
 		const onBodyClick = ( e: MouseEvent ) => {
 			const target = e.target as HTMLElement;
 
-			// Need to capture errant handlediv click that happens on load as well
 			if (
 				! (
+					nameInput?.ownerDocument.activeElement === nameInput ||
+					// Need to capture errant handlediv click that happens on load as well
 					Boolean( target.querySelector( ':scope > .handlediv' ) ) ||
 					target?.matches(
 						'#woocommerce-ai-app-product-name-suggestions *, #title'

--- a/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
+++ b/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
@@ -80,7 +80,7 @@ export const ProductNameSuggestions = () => {
 			// Need to capture errant handlediv click that happens on load as well
 			if (
 				! (
-					target?.matches( 'h3:has(.handlediv)' ) ||
+					Boolean( target.querySelector( ':scope > .handlediv' ) ) ||
 					target?.matches(
 						'#woocommerce-ai-app-product-name-suggestions *, #title'
 					)

--- a/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
+++ b/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
@@ -39,6 +39,14 @@ declare const tinymce: {
 	) => void;
 };
 
+const MagicImage = () => (
+	<img
+		className="wc-product-name-suggestions__magic-image"
+		src={ `${ MagicIcon }` }
+		alt=""
+	/>
+);
+
 export const ProductNameSuggestions = () => {
 	const [ suggestionsState, setSuggestionsState ] =
 		useState< SuggestionsState >( SuggestionsState.None );
@@ -215,7 +223,7 @@ export const ProductNameSuggestions = () => {
 					<>
 						<div className="wc-product-name-suggestions__tip-message">
 							<div>
-								<img src={ MagicIcon } alt="" />
+								<MagicImage />
 								{ __(
 									'Enter a few descriptive words to generate product name.',
 									'woocommerce'
@@ -237,7 +245,7 @@ export const ProductNameSuggestions = () => {
 					} }
 				>
 					<div className="woo-ai-get-suggestions-btn__content">
-						<img src={ MagicIcon } alt="" />
+						<MagicImage />
 						{ getSuggestionsButtonLabel() }
 					</div>
 					<PoweredByLink />

--- a/plugins/woo-ai/src/product-name/product-name.scss
+++ b/plugins/woo-ai/src/product-name/product-name.scss
@@ -23,6 +23,11 @@ $border-radius: 4px;
   z-index: $z-index-container;
   box-sizing: border-box;
 
+  .wc-product-name-suggestions__magic-image {
+	height: 24px;
+	width: 24px;
+  }
+
   .woo-ai-get-suggestions-btn {
     border: none;
     width: 100%;
@@ -34,6 +39,7 @@ $border-radius: 4px;
     align-items: center;
     justify-content: space-between;
     margin: 0;
+	line-height: 18px;
 
     img {
       vertical-align: middle;

--- a/plugins/woo-ai/src/product-name/product-name.scss
+++ b/plugins/woo-ai/src/product-name/product-name.scss
@@ -169,7 +169,7 @@ $border-radius: 4px;
 
 	a {
 		text-decoration: none;
-		padding: 3px;
+		padding: 0 3px 3px 3px;
 
 		&:after {
 			font: 16px/11px dashicons;

--- a/plugins/woo-ai/src/product-name/product-name.scss
+++ b/plugins/woo-ai/src/product-name/product-name.scss
@@ -164,7 +164,7 @@ $border-radius: 4px;
   z-index: $z-index-header;
 }
 
-.woo-ai-get-suggestions-legal_text {
+.woo-ai-get-suggestions-powered_by {
 	color: #8d8b8b;
 
 	a {

--- a/plugins/woo-ai/src/product-name/product-name.scss
+++ b/plugins/woo-ai/src/product-name/product-name.scss
@@ -146,6 +146,7 @@ $border-radius: 4px;
     padding: 10px;
     display: flex;
     align-items: center;
+	justify-content: space-between;
 
     img {
       vertical-align: middle;
@@ -157,10 +158,20 @@ $border-radius: 4px;
   z-index: $z-index-header;
 }
 
-.woo-ai-get-suggestions__experimental-tooltip {
-	.components-popover__content {
-		width: 200px;
-		min-width: auto;
-		white-space: normal !important;
+.woo-ai-get-suggestions-legal_text {
+	color: #8d8b8b;
+
+	a {
+		text-decoration: none;
+		padding: 3px;
+
+		&:after {
+			font: 16px/11px dashicons;
+			content: "\f504";
+			font-weight: normal;
+			top: 2px;
+			position: relative;
+			margin-left: 3px;
+		}
 	}
 }

--- a/plugins/woo-ai/src/product-name/suggestion-item.tsx
+++ b/plugins/woo-ai/src/product-name/suggestion-item.tsx
@@ -3,7 +3,7 @@
  */
 import { ProductDataSuggestion } from '../utils/types';
 
-const SuggestionItem = ( {
+export const SuggestionItem = ( {
 	suggestion,
 	onSuggestionClick,
 }: {
@@ -24,5 +24,3 @@ const SuggestionItem = ( {
 		</button>
 	</li>
 );
-
-export default SuggestionItem;

--- a/plugins/woo-ai/woo-ai.php
+++ b/plugins/woo-ai/woo-ai.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Woo AI
  * Plugin URI: https://github.com/woocommerce/woocommerce/
- * Description: Enable AI experiments within the WooCommerce experience.
+ * Description: Enable AI experiments within the WooCommerce experience. <a href="https://automattic.com/ai-guidelines" target="_blank" rel="noopener noreferrer">Learn more</a>.
  * Version: 0.1.0
  * Author: WooCommerce
  * Author URI: http://woocommerce.com/


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #38572 .

<!-- Begin testing instructions -->


### Screenshots 
![image](https://github.com/woocommerce/woocommerce/assets/444632/29c183cb-f197-4cf8-af2c-051a1d98bbf1)


### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. I've been using this with a WoA dev site ([guide](pb5gDS-1rQ-p2)). Following that guide, but with [this modified script](https://gist.github.com/joelclimbsthings/d0144f525e165d4943650feeec09c9a4).
2. Once you've copied the plugin over, ensure the `Woo AI` plugin is activated.
3. Go to Products -> Add new
4. Click on the product title field.
5. You should have the drop-down widget appear which includes the "powered by" text as in the screenshot above.
6. Type a > 10 character product title in to the field. 
7. The widget contents will change to provide the "Generate with.." button. It should still include the "powered by..." text and working link.
8. Click on the link. It should open a new tab, but not trigger the generation behavior.

<!-- End testing instructions -->