### PR TITLE
dev: refactor installAndActivatePlugins to xstate

### DIFF
--- a/plugins/woocommerce-admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/index.tsx
@@ -362,6 +362,23 @@ const updateBusinessLocation = ( countryAndState: string ) => {
 	} );
 };
 
+const assignStoreLocation = assign( {
+	businessInfo: (
+		context: CoreProfilerStateMachineContext,
+		event: BusinessLocationEvent
+	) => {
+		return {
+			...context.businessInfo,
+			location: event.payload.storeLocation,
+		};
+	},
+} );
+
+const assignUserProfile = assign( {
+	userProfile: ( context, event: UserProfileEvent ) =>
+		event.payload.userProfile, // sets context.userProfile to the payload of the event
+} );
+
 const updateBusinessInfo = async (
 	_context: CoreProfilerStateMachineContext,
 	event: BusinessInfoEvent
@@ -442,8 +459,8 @@ const browserPopstateHandler = () => ( sendBack: Sender< AnyEventObject > ) => {
 };
 
 const handlePlugins = assign( {
-	// @ts-expect-error -- seems to be a flakey type error, will need to investigate further
-	pluginsAvailable: ( _context, event ) => event.data,
+	pluginsAvailable: ( _context, event ) =>
+		( event as DoneInvokeEvent< Extension[] > ).data,
 } );
 
 type ActType = (
@@ -461,6 +478,12 @@ const updateQueryStep: ActType = ( _context, _evt, { action } ) => {
 		updateQueryString( { step: action.step } );
 	}
 };
+
+const assignPluginsSelected = assign( {
+	pluginsSelected: ( _context, event: PluginsInstallationRequestedEvent ) => {
+		return event.payload.plugins.map( getPluginSlug );
+	},
+} );
 
 export const preFetchActions = {
 	preFetchGetPlugins,
@@ -480,6 +503,9 @@ const coreProfilerMachineActions = {
 	handleStoreNameOption,
 	handleStoreCountryOption,
 	assignOptInDataSharing,
+	assignStoreLocation,
+	assignPluginsSelected,
+	assignUserProfile,
 	handleCountries,
 	handleOnboardingProfileOption,
 	assignOnboardingProfile,
@@ -712,25 +738,11 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 					on: {
 						USER_PROFILE_COMPLETED: {
 							target: 'postUserProfile',
-							actions: [
-								assign( {
-									userProfile: (
-										_context,
-										event: UserProfileEvent
-									) => event.payload.userProfile, // sets context.userProfile to the payload of the event
-								} ),
-							],
+							actions: [ 'assignUserProfile' ],
 						},
 						USER_PROFILE_SKIPPED: {
 							target: 'postUserProfile',
-							actions: [
-								assign( {
-									userProfile: (
-										_context,
-										event: UserProfileEvent
-									) => event.payload.userProfile, // assign context.userProfile to the payload of the event
-								} ),
-							],
+							actions: [ 'assignUserProfile' ],
 						},
 					},
 					exit: actions.choose( [
@@ -952,18 +964,7 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 						BUSINESS_LOCATION_COMPLETED: {
 							target: 'postSkipFlowBusinessLocation',
 							actions: [
-								assign( {
-									businessInfo: (
-										_context,
-										event: BusinessLocationEvent
-									) => {
-										return {
-											..._context.businessInfo,
-											location:
-												event.payload.storeLocation,
-										};
-									},
-								} ),
+								'assignStoreLocation',
 								'recordTracksSkipBusinessLocationCompleted',
 							],
 						},
@@ -1108,18 +1109,7 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 						},
 						PLUGINS_INSTALLATION_REQUESTED: {
 							target: 'installPlugins',
-							actions: [
-								assign( {
-									pluginsSelected: (
-										_context,
-										event: PluginsInstallationRequestedEvent
-									) => {
-								        return event.payload.plugins.map(
-									        getPluginSlug
-								        );
-                                    },
-								} ),
-							],
+							actions: [ 'assignPluginsSelected' ],
 						},
 					},
 					meta: {
@@ -1299,6 +1289,7 @@ export const CoreProfilerController = ( {
 	const augmentedStateMachine = useMemo( () => {
 		// When adding extensibility, this is the place to manipulate the state machine definition.
 		return coreProfilerStateMachineDefinition.withConfig( {
+			// @ts-expect-error -- flaky types?
 			actions: {
 				...coreProfilerMachineActions,
 				...actionOverrides,

--- a/plugins/woocommerce-admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/index.tsx
@@ -1262,13 +1262,13 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 						} ),
 					],
 					invoke: {
-			            src: pluginInstallerMachine,
-				        data: ( context ) => {
-					        return {
-						        selectedPlugins: context.pluginsSelected,
-					        };
-				        },					
-                    },
+						src: pluginInstallerMachine,
+						data: ( context ) => {
+							return {
+								selectedPlugins: context.pluginsSelected,
+							};
+						},
+					},
 					meta: {
 						component: Loader,
 					},

--- a/plugins/woocommerce-admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/index.tsx
@@ -1289,7 +1289,8 @@ export const CoreProfilerController = ( {
 	const augmentedStateMachine = useMemo( () => {
 		// When adding extensibility, this is the place to manipulate the state machine definition.
 		return coreProfilerStateMachineDefinition.withConfig( {
-			// @ts-expect-error -- flaky types?
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore -- there seems to be a flaky error here - it fails sometimes and then not on recompile, will need to investigate further.
 			actions: {
 				...coreProfilerMachineActions,
 				...actionOverrides,

--- a/plugins/woocommerce-admin/client/core-profiler/services/installAndActivatePlugins.ts
+++ b/plugins/woocommerce-admin/client/core-profiler/services/installAndActivatePlugins.ts
@@ -160,7 +160,7 @@ export const pluginInstallerMachine = createMachine(
 				invoke: {
 					src: 'queueRemainingPluginsAsync',
 					onDone: {
-						target: 'reportSuccess',
+						target: 'finished',
 					},
 				},
 			},

--- a/plugins/woocommerce-admin/client/core-profiler/services/installAndActivatePlugins.ts
+++ b/plugins/woocommerce-admin/client/core-profiler/services/installAndActivatePlugins.ts
@@ -120,7 +120,6 @@ export const pluginInstallerMachine = createMachine(
 									onDone: {
 										actions: [
 											'assignInstallationSuccessDetails',
-											'updateParentWithPluginProgress',
 										],
 										target: 'removeFromQueue',
 									},
@@ -132,7 +131,10 @@ export const pluginInstallerMachine = createMachine(
 								},
 							},
 							removeFromQueue: {
-								entry: 'removePluginFromQueue',
+								entry: [
+									'removePluginFromQueue',
+									'updateParentWithPluginProgress',
+								],
 								always: [
 									{
 										target: 'installing',

--- a/plugins/woocommerce-admin/client/core-profiler/services/installAndActivatePlugins.ts
+++ b/plugins/woocommerce-admin/client/core-profiler/services/installAndActivatePlugins.ts
@@ -3,7 +3,13 @@
  */
 import { PLUGINS_STORE_NAME, PluginNames } from '@woocommerce/data';
 import { dispatch } from '@wordpress/data';
-import { differenceWith } from 'lodash';
+import {
+	assign,
+	createMachine,
+	sendParent,
+	actions,
+	DoneInvokeEvent,
+} from 'xstate';
 
 /**
  * Internal dependencies
@@ -12,9 +18,9 @@ import {
 	PluginInstalledAndActivatedEvent,
 	PluginsInstallationCompletedEvent,
 	PluginsInstallationCompletedWithErrorsEvent,
-	CoreProfilerStateMachineContext,
 } from '..';
-import { getPluginSlug } from '~/utils';
+
+const { pure } = actions;
 
 export type InstalledPlugin = {
 	plugin: string;
@@ -60,109 +66,205 @@ const createPluginInstalledAndActivatedEvent = (
 	},
 } );
 
-export const InstallAndActivatePlugins =
-	( context: CoreProfilerStateMachineContext ) =>
-	async (
-		send: (
-			event:
-				| PluginInstalledAndActivatedEvent
-				| PluginsInstallationCompletedEvent
-				| PluginsInstallationCompletedWithErrorsEvent
-		) => void
-	) => {
-		let continueInstallation = true;
-		const errors: PluginInstallError[] = [];
-		const installationCompletedResult: InstallationCompletedResult = {
-			installedPlugins: [],
-			totalTime: 0,
-		};
-		const installationStartTime = window.performance.now();
-		const setInstallationCompletedTime = () => {
-			installationCompletedResult.totalTime =
-				window.performance.now() - installationStartTime;
-		};
+export type PluginInstallerMachineContext = {
+	selectedPlugins: PluginNames[];
+	pluginsInstallationQueue: PluginNames[];
+	installedPlugins: InstalledPlugin[];
+	startTime: number;
+	installationDuration: number;
+	errors: PluginInstallError[];
+};
 
-		const handleInstallationCompleted = () => {
-			if ( errors.length ) {
-				return send(
-					createInstallationCompletedWithErrorsEvent( errors )
+type InstallAndActivateErrorResponse = DoneInvokeEvent< {
+	error: string;
+	message: string;
+} >;
+
+type InstallAndActivateSuccessResponse = DoneInvokeEvent< {
+	installed: PluginNames[];
+	results: Record< PluginNames, boolean >;
+	install_time: Record< PluginNames, number >;
+} >;
+
+export const pluginInstallerMachine = createMachine(
+	{
+		id: 'plugin-installer',
+		predictableActionArguments: true,
+		initial: 'installing',
+		context: {
+			selectedPlugins: [] as PluginNames[],
+			pluginsInstallationQueue: [] as PluginNames[],
+			installedPlugins: [] as InstalledPlugin[],
+			startTime: 0,
+			installationDuration: 0,
+			errors: [] as PluginInstallError[],
+		} as PluginInstallerMachineContext,
+		states: {
+			installing: {
+				initial: 'installer',
+				entry: [
+					'populateDefaults',
+					'assignPluginsInstallationQueue',
+					'assignStartTime',
+				],
+				after: {
+					INSTALLATION_TIMEOUT: 'timedOut',
+				},
+				states: {
+					installer: {
+						initial: 'installing',
+						states: {
+							installing: {
+								invoke: {
+									src: 'installPlugin',
+									onDone: {
+										actions: [
+											'assignInstallationSuccessDetails',
+											'updateParentWithPluginProgress',
+										],
+										target: 'removeFromQueue',
+									},
+									onError: {
+										actions:
+											'assignInstallationErrorDetails',
+										target: 'removeFromQueue',
+									},
+								},
+							},
+							removeFromQueue: {
+								entry: 'removePluginFromQueue',
+								always: [
+									{
+										target: 'installing',
+										cond: 'hasPluginsToInstall',
+									},
+									{ target: '#installation-finished' },
+								],
+							},
+						},
+					},
+				},
+			},
+			finished: {
+				id: 'installation-finished',
+				entry: [ 'assignInstallationDuration' ],
+				always: [
+					{ target: 'reportErrors', cond: 'hasErrors' },
+					{ target: 'reportSuccess' },
+				],
+			},
+			timedOut: {
+				entry: [ 'assignInstallationDuration' ],
+				invoke: {
+					src: 'queueRemainingPluginsAsync',
+					onDone: {
+						target: 'reportSuccess',
+					},
+				},
+			},
+			reportErrors: {
+				entry: 'updateParentWithInstallationErrors',
+			},
+			reportSuccess: {
+				entry: 'updateParentWithInstallationSuccess',
+			},
+		},
+	},
+	{
+		delays: {
+			INSTALLATION_TIMEOUT: 30000,
+		},
+		actions: {
+			// populateDefaults needed because passing context from the parents overrides the
+			// full context object of the child. Not needed in xstatev5 because it
+			// becomes a merge
+			populateDefaults: assign( {
+				installedPlugins: [],
+				errors: [],
+				startTime: 0,
+				installationDuration: 0,
+			} ),
+			assignPluginsInstallationQueue: assign( {
+				pluginsInstallationQueue: ( ctx ) => {
+					return ctx.selectedPlugins;
+				},
+			} ),
+			assignStartTime: assign( {
+				startTime: () => window.performance.now(),
+			} ),
+			assignInstallationDuration: assign( {
+				installationDuration: ( ctx ) =>
+					window.performance.now() - ctx.startTime,
+			} ),
+			assignInstallationSuccessDetails: assign( {
+				installedPlugins: ( ctx, evt ) => {
+					const plugin = ctx.pluginsInstallationQueue[ 0 ];
+					return [
+						...ctx.installedPlugins,
+						{
+							plugin,
+							installTime:
+								(
+									evt as DoneInvokeEvent< InstallAndActivateSuccessResponse >
+								 ).data.data.install_time[ plugin ] || 0,
+						},
+					];
+				},
+			} ),
+			assignInstallationErrorDetails: assign( {
+				errors: ( ctx, evt ) => {
+					return [
+						...ctx.errors,
+						{
+							plugin: ctx.pluginsInstallationQueue[ 0 ],
+							error: (
+								evt as DoneInvokeEvent< InstallAndActivateErrorResponse >
+							 ).data.data.message,
+						},
+					];
+				},
+			} ),
+			removePluginFromQueue: assign( {
+				pluginsInstallationQueue: ( ctx ) => {
+					return ctx.pluginsInstallationQueue.slice( 1 );
+				},
+			} ),
+			updateParentWithPluginProgress: pure( ( ctx ) =>
+				sendParent(
+					createPluginInstalledAndActivatedEvent(
+						ctx.selectedPlugins.length,
+						ctx.selectedPlugins.length -
+							ctx.pluginsInstallationQueue.length
+					)
+				)
+			),
+			updateParentWithInstallationErrors: sendParent( ( ctx ) =>
+				createInstallationCompletedWithErrorsEvent( ctx.errors )
+			),
+			updateParentWithInstallationSuccess: sendParent( ( ctx ) =>
+				createInstallationCompletedEvent( {
+					installedPlugins: ctx.installedPlugins,
+					totalTime: ctx.installationDuration,
+				} )
+			),
+		},
+		guards: {
+			hasErrors: ( ctx ) => ctx.errors.length > 0,
+			hasPluginsToInstall: ( ctx ) =>
+				ctx.pluginsInstallationQueue.length > 0,
+		},
+		services: {
+			installPlugin: ( ctx ) => {
+				return dispatch( PLUGINS_STORE_NAME ).installAndActivatePlugins(
+					[ ctx.pluginsInstallationQueue[ 0 ] ]
 				);
-			}
-			setInstallationCompletedTime();
-			send(
-				createInstallationCompletedEvent( installationCompletedResult )
-			);
-		};
-
-		const handlePluginInstalledAndActivated = (
-			installedPluginIndex: number
-		) => {
-			send(
-				createPluginInstalledAndActivatedEvent(
-					context.pluginsSelected.length,
-					installedPluginIndex + 1
-				)
-			);
-		};
-
-		const handlePluginInstallError = ( plugin: string, error: unknown ) => {
-			errors.push( {
-				plugin,
-				error: error instanceof Error ? error.message : String( error ),
-			} );
-		};
-
-		const handlePluginInstallation = async (
-			installedPluginIndex: number
-		) => {
-			// Set by timer when it's up
-			if ( ! continueInstallation ) {
-				return;
-			}
-
-			const plugin = getPluginSlug(
-				context.pluginsSelected[ installedPluginIndex ]
-			);
-			try {
-				const response = await dispatch(
-					PLUGINS_STORE_NAME
-				).installAndActivatePlugins( [ plugin ] );
-
-				installationCompletedResult.installedPlugins.push( {
-					plugin,
-					installTime: response.data?.install_time?.[ plugin ] || 0,
-				} );
-
-				handlePluginInstalledAndActivated( installedPluginIndex );
-			} catch ( error ) {
-				handlePluginInstallError( plugin, error );
-			}
-		};
-
-		const handleTimerExpired = async () => {
-			continueInstallation = false;
-
-			const remainingPlugins = differenceWith(
-				context.pluginsSelected,
-				installationCompletedResult.installedPlugins.map(
-					( plugin ) => plugin.plugin
-				)
-			);
-
-			await dispatch( PLUGINS_STORE_NAME ).installPlugins(
-				remainingPlugins as PluginNames[],
-				true
-			);
-
-			handleInstallationCompleted();
-		};
-
-		const timer = setTimeout( handleTimerExpired, 1000 * 30 );
-
-		for ( let index = 0; index < context.pluginsSelected.length; index++ ) {
-			await handlePluginInstallation( index );
-		}
-
-		clearTimeout( timer );
-		handleInstallationCompleted();
-	};
+			},
+			queueRemainingPluginsAsync: ( ctx ) => {
+				return dispatch( PLUGINS_STORE_NAME ).installPlugins(
+					ctx.pluginsInstallationQueue,
+					true
+				);
+			},
+		},
+	}
+);

--- a/plugins/woocommerce-admin/client/core-profiler/services/test/installAndActivatePlugins.test.ts
+++ b/plugins/woocommerce-admin/client/core-profiler/services/test/installAndActivatePlugins.test.ts
@@ -88,10 +88,3 @@ describe( 'pluginInstallerMachine', () => {
 		} );
 	} );
 } );
-
-// TODO: write more tests, I ran out of time and it's friday night
-// we need tests for:
-// 1. when given multiple plugins it should call the installPlugin service multiple times with the right plugins
-// 2. when given multiple plugins and a mocked delay using the config, we can mock the installs to take longer than the timeout and then some plugins should not finish installing, then it should add the remaining to async queue
-// 3. when a plugin gives an error it should report the error to the parents. we can check this by mocking 'updateParentWithInstallationErrors'
-// 4. it should update parent with the plugin installation progress, we can check this by mocking the action 'updateParentWithPluginProgress'

--- a/plugins/woocommerce-admin/client/core-profiler/services/test/installAndActivatePlugins.test.ts
+++ b/plugins/woocommerce-admin/client/core-profiler/services/test/installAndActivatePlugins.test.ts
@@ -1,0 +1,97 @@
+/**
+ * External dependencies
+ */
+import { PluginNames } from '@woocommerce/data';
+import { interpret } from 'xstate';
+
+/**
+ * Internal dependencies
+ */
+import {
+	pluginInstallerMachine,
+	InstalledPlugin,
+	PluginInstallError,
+} from '../installAndActivatePlugins';
+
+describe( 'pluginInstallerMachine', () => {
+	const dispatchInstallPluginMock = jest.fn();
+	const defaultContext = {
+		selectedPlugins: [] as PluginNames[],
+		pluginsInstallationQueue: [] as PluginNames[],
+		installedPlugins: [] as InstalledPlugin[],
+		startTime: 0,
+		installationDuration: 0,
+		errors: [] as PluginInstallError[],
+	};
+	const mockConfig = {
+		delays: {
+			INSTALLATION_DELAY: 1000,
+		},
+		actions: {
+			updateParentWithPluginProgress: jest.fn(),
+			updateParentWithInstallationErrors: jest.fn(),
+			updateParentWithInstallationSuccess: jest.fn(),
+		},
+		services: {
+			installPlugin: dispatchInstallPluginMock,
+			queueRemainingPluginsAsync: jest.fn(),
+		},
+	};
+
+	beforeEach( () => {
+		jest.resetAllMocks();
+	} );
+
+	it( 'when given one plugin it should call the installPlugin service once', ( done ) => {
+		const machineUnderTest = pluginInstallerMachine
+			.withConfig( mockConfig )
+			.withContext( {
+				...defaultContext,
+				selectedPlugins: [ 'woocommerce-payments' ],
+			} );
+
+		dispatchInstallPluginMock.mockImplementationOnce( ( context ) => {
+			expect( context.pluginsInstallationQueue ).toEqual( [
+				'woocommerce-payments',
+			] );
+			return Promise.resolve( {
+				data: {
+					install_time: {
+						'woocommerce-payments': 1000,
+					},
+				},
+			} );
+		} );
+
+		const service = interpret( machineUnderTest ).start();
+		service.onTransition( ( state ) => {
+			if ( state.matches( 'reportSuccess' ) ) {
+				expect(
+					mockConfig.actions.updateParentWithInstallationSuccess
+				).toHaveBeenCalledWith(
+					// context param
+					expect.objectContaining( {
+						installedPlugins: [
+							{
+								plugin: 'woocommerce-payments',
+								installTime: 1000,
+							},
+						],
+					} ),
+					// event param
+					expect.any( Object ),
+					// meta param
+					expect.any( Object )
+				);
+				done();
+			}
+		} );
+	} );
+} );
+
+// TODO: write more tests, I ran out of time and it's friday night
+// we need tests for:
+// 1. when given multiple plugins it should call the installPlugin service multiple times with the right plugins
+// 2. when given multiple plugins and a mocked delay using the config, we can mock the installs to take longer than the timeout and then some plugins should not finish installing, then it should add the remaining to async queue
+// 3. when a plugin gives an error it should report the error to the parents. we can check this by mocking 'updateParentWithInstallationErrors'
+// 4. it should update parent with the plugin installation progress, we can check this by mocking the action 'updateParentWithPluginProgress'

--- a/plugins/woocommerce/changelog/dev-refactor-core-profiler-install-plugins
+++ b/plugins/woocommerce/changelog/dev-refactor-core-profiler-install-plugins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Refactored Core Profiler's plugin installation step to use XState


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

![image](https://github.com/woocommerce/woocommerce/assets/27843274/87204534-555c-4f38-8b4e-cf8ac84dc7c5)


This is a pure refactor of the core profiler's install plugins page, and no user-facing differences should occur.
The original PR's test instructions can be found here: https://github.com/woocommerce/woocommerce/pull/38405

Follow up issue to supplement test coverage:
235-gh-woocommerce/team-ghidorah

### How to test the changes in this Pull Request:

**Before each test case:**

1. Make sure to remove plugins. You can run `rm -rf woocommerce-payments woocommerce-services jetpack pinterest-for-woocommerce mailpoet tiktok-for-business google-listings-and-ads` in the plugins directory. You might have to visit `/wp-admin/plugins.php` to refresh the plugins cache.
2. Make sure to set woocommerce_show_marketplace_suggestions option to no to use core-profiler. We need to make changes in WCCOM later.

**Installation completes in 30 seconds**

1. Start the core profiler and continue to the plugins page.
3. Confirm the plugins are checked by default.
4. Click `Continue` button.
5. Wait for the installation process to finish.
6. Confirm `storeprofiler_store_extensions_installed_and_activated` tracks
7. Confirm `storeprofiler_step_view` track.

If you have fast internet, installation should finish in 30 seconds, and you should be redirected to WooCommerce Home.

**Installation exceeds 30 seconds.** 

If you have fast internet, this is hard to test since it won't take 30 seconds to install the plugins. We can adjust the timer time in this case.

1. Change the timer in this [line](https://github.com/woocommerce/woocommerce/blob/2a319440fd3fab8a7a6d5a0b3fee3601d0c0e7d7/plugins/woocommerce-admin/client/core-profiler/services/installAndActivatePlugins.ts#L177) to 5000. (in milliseconds)
3. Go to the plugins page and click `Continue`
4. After 5 seconds, you should see a request to `{site}/wp-json/wc-admin/onboarding/plugins/install-and-activate-async` and redirected to Woo Home. 
5. Confirm `storeprofiler_store_extensions_installed_and_activated` tracks

**Installation completed with errors**

1. Go to your WP plugins directory and make `mailpoet` directory. 
2. Create an empty `test.txt` file in the `mailpoet` directory. This will make the installation fail. 
3. Go to the plugins page and click `Continue`
4. You should see the plugins page with an error.
6. Click `Please try again`
7. It should fail again.
8. Remove `mailpoet` directory from your plugins directory.
9. Click `Please try again` again.

![Screen Shot 2023-05-22 at 4 32 02 PM](https://github.com/woocommerce/woocommerce/assets/4723145/095f8035-11d2-4edd-9da3-29370d9010f3)

**User clicks on skip this page**

1. Go to the plugins page.
2. Click `Skip this step`
3. You should be redirected to Woo Home
4. `woocommerce_onboarding_profile` option should have `plugins_page_skipped` set to true

<!-- End testing instructions -->