### PR TITLE
Send the "woo_ai_plugin" feature to the Jetpack AI Query endpoint for usage logging.

### DIFF
--- a/plugins/woo-ai/includes/product-data-suggestion/class-product-data-suggestion-service.php
+++ b/plugins/woo-ai/includes/product-data-suggestion/class-product-data-suggestion-service.php
@@ -58,6 +58,7 @@ class Product_Data_Suggestion_Service {
 		$arguments = array(
 			'content'    => $this->prompt_generator->get_user_prompt( $request ),
 			'skip_cache' => true,
+			'feature'    => 'woo-ai-plugin'
 		);
 
 		try {

--- a/plugins/woo-ai/src/constants.ts
+++ b/plugins/woo-ai/src/constants.ts
@@ -1,2 +1,2 @@
 export const MIN_TITLE_LENGTH = 20;
-export const WOO_AI_PLUGIN_FEATURE_NAME = 'woo-ai-plugin';
+export const WOO_AI_PLUGIN_FEATURE_NAME = 'woo_ai_plugin';

--- a/plugins/woo-ai/src/constants.ts
+++ b/plugins/woo-ai/src/constants.ts
@@ -1,1 +1,2 @@
 export const MIN_TITLE_LENGTH = 20;
+export const WOO_AI_PLUGIN_FEATURE_NAME = 'woo-ai-plugin';

--- a/plugins/woo-ai/src/utils/jetpack-completion.ts
+++ b/plugins/woo-ai/src/utils/jetpack-completion.ts
@@ -3,6 +3,7 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import debugFactory from 'debug';
+import { WOO_AI_PLUGIN_FEATURE_NAME } from '../constants';
 
 const debugToken = debugFactory( 'jetpack-ai-assistant:token' );
 
@@ -88,6 +89,7 @@ export async function askQuestion( question: string, postId = null ) {
 	);
 	url.searchParams.append( 'question', question );
 	url.searchParams.append( 'token', token );
+	url.searchParams.append( 'feature', WOO_AI_PLUGIN_FEATURE_NAME );
 
 	if ( postId ) {
 		url.searchParams.append( 'post_id', postId );


### PR DESCRIPTION
### Changes proposed in this Pull Request:
Pass along a $feature to the Jetpack AI Query endpoint when generating a product description in order to track usage for this specific plugin.

### How to test the changes in this Pull Request:

Closes #38586

See D112723-code for testing instructions. :) 