### PR TITLE
Declare HPOS compatibility.

### DIFF
--- a/plugins/woo-ai/changelog/add-hpos-support
+++ b/plugins/woo-ai/changelog/add-hpos-support
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Declare HPOS compatibility.

--- a/plugins/woo-ai/woo-ai.php
+++ b/plugins/woo-ai/woo-ai.php
@@ -47,6 +47,12 @@ function _woo_ai_bootstrap(): void {
 		return;
 	}
 
+	add_action( 'before_woocommerce_init', function() {
+		if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
+			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
+		}
+	} );
+
 	// Check if Jetpack is enabled.
 	if ( ! class_exists( 'Jetpack' ) ) {
 		include dirname( __FILE__ ) . '/includes/class-woo-ai-admin-notices.php';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Declare WooCommerce HPOS support.
Closes #38584 

### How to test the changes in this Pull Request:

Simple!

Without this change applied, if you were to go to WooCommerce->Settings->Advanced->Features, you wouldn't be able to enable HPOS:

![Screen Shot 2023-06-02 at 14 51 54](https://github.com/woocommerce/woocommerce/assets/6723003/9b3221b5-ba6f-4967-83c4-d9cd4cb2cbd9)

With this applied, you should be able to enable it:
![Screen Shot 2023-06-02 at 14 51 26](https://github.com/woocommerce/woocommerce/assets/6723003/3cb8b2b2-43f6-45e9-b6e3-13aba11edef2)

To be ultra-sure, you can:
- Enable the orders Table usage
- Perform a checkout 
- View the order at WooCommerce->Orders