### PR TITLE
Fix The Task Header Width in 2-Col Layout

### DIFF
--- a/plugins/woocommerce-admin/client/task-lists/setup-task-list/style.scss
+++ b/plugins/woocommerce-admin/client/task-lists/setup-task-list/style.scss
@@ -264,7 +264,7 @@
 			max-width: 380px;
 		}
 
-		max-width: 500px;
+		max-width: 75%;
 		p,
 		span {
 			color: $gray-600;

--- a/plugins/woocommerce/changelog/fix-task-header-width
+++ b/plugins/woocommerce/changelog/fix-task-header-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix a bug where text overlapped the image in the task list header.


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes a bug where text overlaps an image on the Task List header in the Two Column layout. 

It changes the `max-width` to 75% to ensure it resizes relatively the same for both Single and Two Column layouts.

### Before

<img width="495" alt="Screen Shot 2023-06-02 at 10 47 19 pm" src="https://github.com/woocommerce/woocommerce/assets/9312929/543db3af-cafb-4b29-8af1-05c546d3f6e2">


### After

<img width="522" alt="Screen Shot 2023-06-02 at 10 46 29 pm" src="https://github.com/woocommerce/woocommerce/assets/9312929/94eddacc-ccc6-4af4-9edc-107b208ce1fd">



Closes #38537 . 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Build this branch
2. On a fresh install, skip the onboarding wizard to land at the home screen.
3. Ensure that the Single Column layout is selected on the Display menu in the Woo toolbar.
4. See that Task List header does not overlap the image.
5. Change the layout type to Two Columns with the Display menu.
6.  See that Task List header does not overlap the image.

<!-- End testing instructions -->
