### PR TITLE
Fix various 'dynamic property declaration' warnings (PHP 8.2+)

### DIFF
--- a/plugins/woocommerce/changelog/fix-php8-dynamic-prop-etc
+++ b/plugins/woocommerce/changelog/fix-php8-dynamic-prop-etc
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix various 'dynamic property declaration' warnings on PHP 8.2+.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -319,8 +319,8 @@ class WC_Admin_Menus {
 	 */
 	public function orders_menu(): void {
 		if ( wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled() ) {
-			$this->orders_page_controller = wc_get_container()->get( Custom_Orders_PageController::class );
-			$this->orders_page_controller->setup();
+			$orders_page_controller = wc_get_container()->get( Custom_Orders_PageController::class );
+			$orders_page_controller->setup();
 		} else {
 			wc_get_container()->get( COTRedirectionController::class )->setup();
 		}

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -319,8 +319,7 @@ class WC_Admin_Menus {
 	 */
 	public function orders_menu(): void {
 		if ( wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled() ) {
-			$orders_page_controller = wc_get_container()->get( Custom_Orders_PageController::class );
-			$orders_page_controller->setup();
+			wc_get_container()->get( Custom_Orders_PageController::class )->setup();
 		} else {
 			wc_get_container()->get( COTRedirectionController::class )->setup();
 		}

--- a/plugins/woocommerce/includes/class-wc-cart-totals.php
+++ b/plugins/woocommerce/includes/class-wc-cart-totals.php
@@ -118,6 +118,13 @@ final class WC_Cart_Totals {
 	);
 
 	/**
+	 * Cache of tax rates for a given tax class.
+	 *
+	 * @var array
+	 */
+	protected $item_tax_rates;
+
+	/**
 	 * Sets up the items provided, and calculate totals.
 	 *
 	 * @since 3.2.0

--- a/plugins/woocommerce/includes/class-wc-order.php
+++ b/plugins/woocommerce/includes/class-wc-order.php
@@ -109,6 +109,14 @@ class WC_Order extends WC_Abstract_Order {
 	);
 
 	/**
+	 * Refunds for an order. Use {@see get_refunds()} instead.
+	 *
+	 * @deprecated 2.2.0
+	 * @var stdClass|WC_Order[]
+	 */
+	public $refunds;
+
+	/**
 	 * When a payment is complete this function is called.
 	 *
 	 * Most of the time this should mark an order as 'processing' so that admin can process/post the items.

--- a/plugins/woocommerce/includes/emails/class-wc-email.php
+++ b/plugins/woocommerce/includes/emails/class-wc-email.php
@@ -229,6 +229,13 @@ class WC_Email extends WC_Settings_API {
 	public $replace = array();
 
 	/**
+	 * E-mail type: plain, html or multipart.
+	 *
+	 * @var string
+	 */
+	public $email_type;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {

--- a/plugins/woocommerce/includes/legacy/class-wc-legacy-cart.php
+++ b/plugins/woocommerce/includes/legacy/class-wc-legacy-cart.php
@@ -18,6 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Legacy cart class.
  */
+#[AllowDynamicProperties]
 abstract class WC_Legacy_Cart {
 
 	/**

--- a/plugins/woocommerce/includes/tracks/class-wc-tracks-event.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-tracks-event.php
@@ -12,6 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * WC_Tracks_Event class.
  */
+#[AllowDynamicProperties]
 class WC_Tracks_Event {
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR addresses a few misc. `dynamic property declaration` warnings found around the codebase, and not addressed by the other subject-specific PRs.

In particular, it covers the following deprecation warnings:

- `Creation of dynamic property WC_Admin_Menus::$orders_page_controller` triggered when visiting any admin screen.
- `Creation of dynamic property WC_Email_New_Order::$email_type` (repeated for all WC e-mails) triggered on almost all pages.
- `Creation of dynamic property WC_Cart::$coupon_discount_totals` triggered  on almost all pages.
- `Creation of dynamic property WC_Cart::$coupon_discount_tax_totals` triggered on almost all pages.
- `Creation of dynamic property WC_Tracks_Event::$PROPERTY` triggered when creating tracks events, for example, when visiting a specific order on the admin.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure you're on PHP 8.2+ and your environment has logging enabled (and/or use Query Monitor).
2. Navigate through the admin/frontend using the list above as a guide, with deprecation warnings and when they are triggered.
3.
   - On `trunk` you should see those warnings in the log file or in Query Monitor.
   - On this branch, those warnings are no longer triggered.


<!-- End testing instructions -->
