### PR TITLE
Product Editor Onboarding: Show spotlight for first time visitors

### DIFF
--- a/packages/js/components/changelog/add-block-tour
+++ b/packages/js/components/changelog/add-block-tour
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Allow passing react elements to heading in TourKit
+
+

--- a/packages/js/components/src/tour-kit/types.ts
+++ b/packages/js/components/src/tour-kit/types.ts
@@ -12,7 +12,7 @@ export interface WooStep extends Step {
 	meta: {
 		/** Unique name for step, mainly used for tracking. */
 		name: string | null;
-		heading: string | null;
+		heading: string | React.ReactElement | null;
 		descriptions: {
 			desktop: string | React.ReactElement | null;
 			mobile?: string | React.ReactElement | null;

--- a/plugins/woocommerce-admin/client/products/product-page.tsx
+++ b/plugins/woocommerce-admin/client/products/product-page.tsx
@@ -10,7 +10,6 @@ import {
 import { Spinner } from '@wordpress/components';
 import { useEffect } from '@wordpress/element';
 import { useParams } from 'react-router-dom';
-import { TourKit } from '@woocommerce/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -19,6 +18,7 @@ import { __ } from '@wordpress/i18n';
 import { useProductEntityRecord } from './hooks/use-product-entity-record';
 import './fills/product-block-editor-fills';
 import './product-page.scss';
+import BlockEditorTour from './tour/block-editor/block-editor-tour';
 
 declare const productBlockEditorSettings: ProductEditorSettings;
 
@@ -43,18 +43,7 @@ export default function ProductPage() {
 				product={ product }
 				settings={ productBlockEditorSettings || {} }
 			/>
-			<TourKit config={ { steps: [{
-				meta: {
-					name: 'todo',
-					primaryButton: {
-						text: __( 'View highlights' , 'woocommerce' ),
-					},
-					descriptions: {
-						desktop: __( 'We designed a brand new product editing experience to let you focus on what\'s important.' , 'woocommerce' ),
-					},
-					heading: __( 'Meet a streamlined product form' , 'woocommerce' ),
-				},
-			}], closeHandler: () => {}} } />
+			<BlockEditorTour />
 		</>
 	);
 }

--- a/plugins/woocommerce-admin/client/products/product-page.tsx
+++ b/plugins/woocommerce-admin/client/products/product-page.tsx
@@ -10,7 +10,6 @@ import {
 import { Spinner } from '@wordpress/components';
 import { useEffect } from '@wordpress/element';
 import { useParams } from 'react-router-dom';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce-admin/client/products/product-page.tsx
+++ b/plugins/woocommerce-admin/client/products/product-page.tsx
@@ -10,6 +10,8 @@ import {
 import { Spinner } from '@wordpress/components';
 import { useEffect } from '@wordpress/element';
 import { useParams } from 'react-router-dom';
+import { TourKit } from '@woocommerce/components';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -36,9 +38,23 @@ export default function ProductPage() {
 	}
 
 	return (
-		<Editor
-			product={ product }
-			settings={ productBlockEditorSettings || {} }
-		/>
+		<>
+			<Editor
+				product={ product }
+				settings={ productBlockEditorSettings || {} }
+			/>
+			<TourKit config={ { steps: [{
+				meta: {
+					name: 'todo',
+					primaryButton: {
+						text: __( 'View highlights' , 'woocommerce' ),
+					},
+					descriptions: {
+						desktop: __( 'We designed a brand new product editing experience to let you focus on what\'s important.' , 'woocommerce' ),
+					},
+					heading: __( 'Meet a streamlined product form' , 'woocommerce' ),
+				},
+			}], closeHandler: () => {}} } />
+		</>
 	);
 }

--- a/plugins/woocommerce-admin/client/products/product-page.tsx
+++ b/plugins/woocommerce-admin/client/products/product-page.tsx
@@ -18,7 +18,7 @@ import { __ } from '@wordpress/i18n';
 import { useProductEntityRecord } from './hooks/use-product-entity-record';
 import './fills/product-block-editor-fills';
 import './product-page.scss';
-import BlockEditorTour from './tour/block-editor/block-editor-tour';
+import BlockEditorTourWrapper from './tour/block-editor/block-editor-tour-wrapper';
 
 declare const productBlockEditorSettings: ProductEditorSettings;
 
@@ -43,7 +43,7 @@ export default function ProductPage() {
 				product={ product }
 				settings={ productBlockEditorSettings || {} }
 			/>
-			<BlockEditorTour />
+			<BlockEditorTourWrapper />
 		</>
 	);
 }

--- a/plugins/woocommerce-admin/client/products/tour/block-editor/block-editor-guide.tsx
+++ b/plugins/woocommerce-admin/client/products/tour/block-editor/block-editor-guide.tsx
@@ -5,6 +5,9 @@
 import { Guide } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
 import './style.scss';
 
 interface Props {

--- a/plugins/woocommerce-admin/client/products/tour/block-editor/block-editor-guide.tsx
+++ b/plugins/woocommerce-admin/client/products/tour/block-editor/block-editor-guide.tsx
@@ -1,0 +1,110 @@
+/**
+ * External dependencies
+ */
+
+import { Guide } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+import './style.scss';
+
+interface Props {
+	onCloseGuide: () => void;
+}
+
+const BlockEditorGuide = ( { onCloseGuide }: Props ) => {
+	return (
+		<Guide
+			className="woocommerce-block-editor-guide"
+			finishButtonText={ __( 'Close', 'woocommerce' ) }
+			onFinish={ onCloseGuide }
+			pages={ [
+				{
+					content: (
+						<>
+							<h1 className="woocommerce-block-editor-guide__heading">
+								{ __(
+									'Refreshed, streamlined interface',
+									'woocommerce'
+								) }
+							</h1>
+							<p className="woocommerce-block-editor-guide__text">
+								{ __(
+									'Experience a simpler, more focused interface with a modern design that enhances usability.',
+									'woocommerce'
+								) }
+							</p>
+						</>
+					),
+					image: (
+						<div className="woocommerce-block-editor-guide__background1"></div>
+					),
+				},
+				{
+					content: (
+						<>
+							<h1 className="woocommerce-block-editor-guide__heading">
+								{ __(
+									'Content-rich product descriptions',
+									'woocommerce'
+								) }
+							</h1>
+							<p className="woocommerce-block-editor-guide__text">
+								{ __(
+									'Create compelling product pages with blocks, media, images, videos, and any content you desire to engage customers.',
+									'woocommerce'
+								) }
+							</p>
+						</>
+					),
+					image: (
+						<div className="woocommerce-block-editor-guide__background2"></div>
+					),
+				},
+				{
+					content: (
+						<>
+							<h1 className="woocommerce-block-editor-guide__heading">
+								{ __(
+									'Improved speed & performance',
+									'woocommerce'
+								) }
+							</h1>
+							<p className="woocommerce-block-editor-guide__text">
+								{ __(
+									'Enjoy a seamless experience without page reloads. Our modern technology ensures reliability and lightning-fast performance.',
+									'woocommerce'
+								) }
+							</p>
+						</>
+					),
+					image: (
+						<div className="woocommerce-block-editor-guide__background3"></div>
+					),
+				},
+				{
+					content: (
+						<>
+							<h1 className="woocommerce-block-editor-guide__heading">
+								{ __(
+									'More features are on the way',
+									'woocommerce'
+								) }
+							</h1>
+							<p className="woocommerce-block-editor-guide__text">
+								{ __(
+									'While we currently support physical products, exciting updates are coming to accommodate more types, like digital products, variations, and more. Stay tuned!',
+									'woocommerce'
+								) }
+							</p>
+						</>
+					),
+					image: (
+						<div className="woocommerce-block-editor-guide__background4"></div>
+					),
+				},
+			] }
+		/>
+	);
+};
+
+export default BlockEditorGuide;

--- a/plugins/woocommerce-admin/client/products/tour/block-editor/block-editor-tour-wrapper.tsx
+++ b/plugins/woocommerce-admin/client/products/tour/block-editor/block-editor-tour-wrapper.tsx
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import BlockEditorTour from './block-editor-tour';
 import { useBlockEditorTourOptions } from './use-block-editor-tour-options';
 

--- a/plugins/woocommerce-admin/client/products/tour/block-editor/block-editor-tour-wrapper.tsx
+++ b/plugins/woocommerce-admin/client/products/tour/block-editor/block-editor-tour-wrapper.tsx
@@ -1,0 +1,9 @@
+import BlockEditorTour from './block-editor-tour';
+import { useBlockEditorTourOptions } from './use-block-editor-tour-options';
+
+const BlockEditorTourWrapper = () => {
+	const blockEditorTourProps = useBlockEditorTourOptions();
+	return <BlockEditorTour { ...blockEditorTourProps } />;
+};
+
+export default BlockEditorTourWrapper;

--- a/plugins/woocommerce-admin/client/products/tour/block-editor/block-editor-tour.tsx
+++ b/plugins/woocommerce-admin/client/products/tour/block-editor/block-editor-tour.tsx
@@ -99,9 +99,8 @@ const BlockEditorTour = ( { shouldTourBeShown, dismissModal }: Props ) => {
 								resize: true,
 							},
 						},
-						portalParentElement: document.getElementById(
-							'wpbody'
-						),
+						portalParentElement:
+							document.getElementById( 'wpbody' ),
 						popperModifiers: [
 							{
 								name: 'bottom-left',

--- a/plugins/woocommerce-admin/client/products/tour/block-editor/block-editor-tour.tsx
+++ b/plugins/woocommerce-admin/client/products/tour/block-editor/block-editor-tour.tsx
@@ -1,40 +1,45 @@
 /**
  * External dependencies
  */
-import { TourKit } from '@woocommerce/components';
+import { Pill, TourKit } from '@woocommerce/components';
 import { Guide } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { recordEvent } from '@woocommerce/tracks';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 
 import './style.scss';
+import BlockEditorGuide from './block-editor-guide';
 
 interface Props {
-	isTourOpen: boolean;
+	shouldTourBeShown: boolean;
 	dismissModal: () => void;
-	openGuide: () => void;
-	closeGuide: () => void;
-	isGuideOpen: boolean;
 }
 
-const BlockEditorTour = ( {
-	isTourOpen,
-	dismissModal,
-	openGuide,
-	isGuideOpen,
-	closeGuide,
-}: Props ) => {
+const BlockEditorTour = ( { shouldTourBeShown, dismissModal }: Props ) => {
 	useEffect( () => {
-		if ( isTourOpen ) {
+		if ( shouldTourBeShown ) {
 			recordEvent( 'block_product_editor_spotlight_view' );
 		}
-	}, [ isTourOpen ] );
+	}, [ shouldTourBeShown ] );
 
-	if ( isTourOpen ) {
+	const [ isGuideOpen, setIsGuideOpen ] = useState( false );
+
+	const openGuide = () => {
+		setIsGuideOpen( true );
+	};
+
+	const closeGuide = () => {
+		recordEvent( 'block_product_editor_spotlight_completed' );
+		setIsGuideOpen( false );
+	};
+
+	if ( isGuideOpen ) {
+		return <BlockEditorGuide onCloseGuide={ closeGuide } />;
+	} else if ( shouldTourBeShown ) {
 		return (
 			<TourKit
 				config={ {
@@ -54,9 +59,18 @@ const BlockEditorTour = ( {
 										'woocommerce'
 									),
 								},
-								heading: __(
-									'Meet a streamlined product form',
-									'woocommerce'
+								heading: (
+									<>
+										<span>
+											{ __(
+												'Meet a streamlined product form',
+												'woocommerce'
+											) }
+										</span>{ ' ' }
+										<Pill className="woocommerce-block-editor-guide__pill">
+											{ __( 'Beta', 'woocommerce' ) }
+										</Pill>
+									</>
 								),
 							},
 							referenceElements: {
@@ -86,8 +100,9 @@ const BlockEditorTour = ( {
 								resize: true,
 							},
 						},
-						portalParentElement:
-							document.getElementById( 'wpbody' ),
+						portalParentElement: document.getElementById(
+							'wpbody'
+						),
 						popperModifiers: [
 							{
 								name: 'bottom-left',
@@ -105,103 +120,6 @@ const BlockEditorTour = ( {
 						],
 					},
 				} }
-			/>
-		);
-	} else if ( isGuideOpen ) {
-		return (
-			<Guide
-				className="woocommerce-block-editor-guide"
-				finishButtonText={ __( 'Close', 'woocommerce' ) }
-				onFinish={ () => {
-					recordEvent( 'block_product_editor_spotlight_completed' );
-					closeGuide();
-				} }
-				pages={ [
-					{
-						content: (
-							<>
-								<h1 className="woocommerce-block-editor-guide__heading">
-									{ __(
-										'Refreshed, streamlined interface',
-										'woocommerce'
-									) }
-								</h1>
-								<p className="woocommerce-block-editor-guide__text">
-									{ __(
-										'Experience a simpler, more focused interface with a modern design that enhances usability.',
-										'woocommerce'
-									) }
-								</p>
-							</>
-						),
-						image: (
-							<div className="woocommerce-block-editor-guide__background1"></div>
-						),
-					},
-					{
-						content: (
-							<>
-								<h1 className="woocommerce-block-editor-guide__heading">
-									{ __(
-										'Content-rich product descriptions',
-										'woocommerce'
-									) }
-								</h1>
-								<p className="woocommerce-block-editor-guide__text">
-									{ __(
-										'Create compelling product pages with blocks, media, images, videos, and any content you desire to engage customers.',
-										'woocommerce'
-									) }
-								</p>
-							</>
-						),
-						image: (
-							<div className="woocommerce-block-editor-guide__background2"></div>
-						),
-					},
-					{
-						content: (
-							<>
-								<h1 className="woocommerce-block-editor-guide__heading">
-									{ __(
-										'Improved speed & performance',
-										'woocommerce'
-									) }
-								</h1>
-								<p className="woocommerce-block-editor-guide__text">
-									{ __(
-										'Enjoy a seamless experience without page reloads. Our modern technology ensures reliability and lightning-fast performance.',
-										'woocommerce'
-									) }
-								</p>
-							</>
-						),
-						image: (
-							<div className="woocommerce-block-editor-guide__background3"></div>
-						),
-					},
-					{
-						content: (
-							<>
-								<h1 className="woocommerce-block-editor-guide__heading">
-									{ __(
-										'More features are on the way',
-										'woocommerce'
-									) }
-								</h1>
-								<p className="woocommerce-block-editor-guide__text">
-									{ __(
-										'While we currently support physical products, exciting updates are coming to accommodate more types, like digital products, variations, and more. Stay tuned!',
-										'woocommerce'
-									) }
-								</p>
-							</>
-						),
-						image: (
-							<div className="woocommerce-block-editor-guide__background4"></div>
-						),
-					},
-				] }
 			/>
 		);
 	}

--- a/plugins/woocommerce-admin/client/products/tour/block-editor/block-editor-tour.tsx
+++ b/plugins/woocommerce-admin/client/products/tour/block-editor/block-editor-tour.tsx
@@ -3,81 +3,173 @@
  */
 
 import { TourKit } from '@woocommerce/components';
-import { useEffect, useState } from '@wordpress/element';
+import { Guide } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useBlockEditorTour } from './use-block-editor-tour';
 
+/*
+ * Internal dependencies
+ */
+
+import './style.scss';
+
 const BlockEditorTour = () => {
-	const { isClosed, dismissModal } = useBlockEditorTour();
+	const {
+		isTourOpen,
+		dismissModal,
+		openGuide,
+		isGuideOpen,
+	} = useBlockEditorTour();
 
-	const [ height, setHeight ] = useState( window.innerHeight );
-	useEffect( () => {
-		function handleResize() {
-			setHeight( window.innerHeight );
-		}
-		window.addEventListener('resize', handleResize);
-		return () => {
-			window.removeEventListener('resize', handleResize);
-		}
-	}, []);
-
-	if ( isClosed ) {
-		return null;
-	}
-
-	return (
-		<TourKit
-			config={ {
-				steps: [
+	if ( isGuideOpen ) {
+		return (
+			<Guide
+				className='woocommerce-block-editor-guide'
+				pages={ [
 					{
-						meta: {
-							name: 'woocommerce-block-editor-tour',
-							primaryButton: {
-								text: __( 'View highlights', 'woocommerce' ),
-							},
-							descriptions: {
-								desktop: __(
-									"We designed a brand new product editing experience to let you focus on what's important.",
+						content: (
+							<>
+								<h1>
+									{ __(
+										'Refreshed, streamlined interface',
+										'woocommerce'
+									) }
+								</h1>
+								<p>
+									{ __(
+										'Experience a simpler, more focused interface with a modern design that enhances usability.',
+										'woocommerce'
+									) }
+								</p>
+							</>
+						),
+					},
+					{
+						content: (
+							<>
+								<h1>
+									{ __(
+										'Content-rich product descriptions',
+										'woocommerce'
+									) }
+								</h1>
+								<p>
+									{ __(
+										'Create compelling product pages with blocks, media, images, videos, and any content you desire to engage customers.',
+										'woocommerce'
+									) }
+								</p>
+							</>
+						),
+					},
+					{
+						content: (
+							<>
+								<h1>
+									{ __(
+										'Improved speed & performance',
+										'woocommerce'
+									) }
+								</h1>
+								<p>
+									{ __(
+										'Enjoy a seamless experience without page reloads. Our modern technology ensures reliability and lightning-fast performance.',
+										'woocommerce'
+									) }
+								</p>
+							</>
+						),
+					},
+					{
+						content: (
+							<>
+								<h1>
+									{ __(
+										'More features are on the way',
+										'woocommerce'
+									) }
+								</h1>
+								<p>
+									{ __(
+										'While we currently support physical products, exciting updates are coming to accommodate more types, like digital products, variations, and more. Stay tuned!',
+										'woocommerce'
+									) }
+								</p>
+							</>
+						),
+					},
+				] }
+			/>
+		);
+	} else if ( isTourOpen ) {
+		return (
+			<TourKit
+				config={ {
+					steps: [
+						{
+							meta: {
+								name: 'woocommerce-block-editor-tour',
+								primaryButton: {
+									text: __(
+										'View highlights',
+										'woocommerce'
+									),
+								},
+								descriptions: {
+									desktop: __(
+										"We designed a brand new product editing experience to let you focus on what's important.",
+										'woocommerce'
+									),
+								},
+								heading: __(
+									'Meet a streamlined product form',
 									'woocommerce'
 								),
 							},
-							heading: __(
-								'Meet a streamlined product form',
-								'woocommerce'
-							),
-						},
-						referenceElements: {
-							desktop: '#adminmenuback',
-						},
-					},
-				],
-				closeHandler: dismissModal,
-				options: {
-					effects: {
-						arrowIndicator: false,
-						overlay: false,
-						liveResize: {
-							rootElementSelector: '#adminmenuback',
-							resize: true,
-						},
-					},
-					popperModifiers: [
-						{
-							name: 'offset',
-							options: {
-								offset: [
-									// 180 is the TourKitStep's height.
-									height / 2 - 180,
-									10,
-								],
+							referenceElements: {
+								desktop: '#adminmenuback',
 							},
 						},
 					],
-				},
-				placement: 'bottom-end',
-			} }
-		/>
-	);
+					closeHandler: ( _, __, source ) => {
+						dismissModal();
+						if ( source === 'done-btn' ) {
+							openGuide();
+						}
+					},
+					options: {
+						effects: {
+							arrowIndicator: false,
+							overlay: false,
+							liveResize: {
+								rootElementSelector: '#adminmenuback',
+								resize: true,
+							},
+						},
+						portalParentElement: document.getElementById(
+							'wpbody'
+						),
+						popperModifiers: [
+							{
+								name: 'bottom-left',
+								enabled: true,
+								phase: 'beforeWrite',
+								requires: [ 'computeStyles' ],
+								fn: ( { state } ) => {
+									state.styles.popper.top = 'auto';
+									state.styles.popper.left = 'auto';
+									state.styles.popper.bottom = '10px';
+									state.styles.popper.transform =
+										'translate3d(10px, 0px, 0px)';
+								},
+							},
+						],
+					},
+				} }
+			/>
+		);
+	}
+	return null;
 };
 
 export default BlockEditorTour;

--- a/plugins/woocommerce-admin/client/products/tour/block-editor/block-editor-tour.tsx
+++ b/plugins/woocommerce-admin/client/products/tour/block-editor/block-editor-tour.tsx
@@ -5,7 +5,7 @@
 import { TourKit } from '@woocommerce/components';
 import { Guide } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useBlockEditorTour } from './use-block-editor-tour';
+import { useBlockEditorTourOptions } from './use-block-editor-tour-options';
 
 /*
  * Internal dependencies
@@ -13,18 +13,24 @@ import { useBlockEditorTour } from './use-block-editor-tour';
 
 import './style.scss';
 
-const BlockEditorTour = () => {
-	const {
-		isTourOpen,
-		dismissModal,
-		openGuide,
-		isGuideOpen,
-	} = useBlockEditorTour();
+interface Props {
+	isTourOpen: boolean;
+	dismissModal: () => void;
+	openGuide: () => void;
+	isGuideOpen: boolean;
+}
 
+const BlockEditorTour = ( {
+	isTourOpen,
+	dismissModal,
+	openGuide,
+	isGuideOpen,
+}: Props ) => {
 	if ( isGuideOpen ) {
 		return (
 			<Guide
-				className='woocommerce-block-editor-guide'
+				className="woocommerce-block-editor-guide"
+				finishButtonText={ __( 'Close', 'woocommerce' ) }
 				pages={ [
 					{
 						content: (
@@ -43,7 +49,9 @@ const BlockEditorTour = () => {
 								</p>
 							</>
 						),
-						image: <div className="woocommerce-block-editor-guide__background1"></div>
+						image: (
+							<div className="woocommerce-block-editor-guide__background1"></div>
+						),
 					},
 					{
 						content: (
@@ -62,7 +70,9 @@ const BlockEditorTour = () => {
 								</p>
 							</>
 						),
-						image: <div className="woocommerce-block-editor-guide__background2"></div>
+						image: (
+							<div className="woocommerce-block-editor-guide__background2"></div>
+						),
 					},
 					{
 						content: (
@@ -81,7 +91,9 @@ const BlockEditorTour = () => {
 								</p>
 							</>
 						),
-						image: <div className="woocommerce-block-editor-guide__background3"></div>
+						image: (
+							<div className="woocommerce-block-editor-guide__background3"></div>
+						),
 					},
 					{
 						content: (
@@ -100,7 +112,9 @@ const BlockEditorTour = () => {
 								</p>
 							</>
 						),
-						image: <div className="woocommerce-block-editor-guide__background4"></div>
+						image: (
+							<div className="woocommerce-block-editor-guide__background4"></div>
+						),
 					},
 				] }
 			/>

--- a/plugins/woocommerce-admin/client/products/tour/block-editor/block-editor-tour.tsx
+++ b/plugins/woocommerce-admin/client/products/tour/block-editor/block-editor-tour.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { Pill, TourKit } from '@woocommerce/components';
-import { Guide } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { recordEvent } from '@woocommerce/tracks';
 import { useEffect, useState } from '@wordpress/element';

--- a/plugins/woocommerce-admin/client/products/tour/block-editor/block-editor-tour.tsx
+++ b/plugins/woocommerce-admin/client/products/tour/block-editor/block-editor-tour.tsx
@@ -1,0 +1,83 @@
+/**
+ * External dependencies
+ */
+
+import { TourKit } from '@woocommerce/components';
+import { useEffect, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useBlockEditorTour } from './use-block-editor-tour';
+
+const BlockEditorTour = () => {
+	const { isClosed, dismissModal } = useBlockEditorTour();
+
+	const [ height, setHeight ] = useState( window.innerHeight );
+	useEffect( () => {
+		function handleResize() {
+			setHeight( window.innerHeight );
+		}
+		window.addEventListener('resize', handleResize);
+		return () => {
+			window.removeEventListener('resize', handleResize);
+		}
+	}, []);
+
+	if ( isClosed ) {
+		return null;
+	}
+
+	return (
+		<TourKit
+			config={ {
+				steps: [
+					{
+						meta: {
+							name: 'woocommerce-block-editor-tour',
+							primaryButton: {
+								text: __( 'View highlights', 'woocommerce' ),
+							},
+							descriptions: {
+								desktop: __(
+									"We designed a brand new product editing experience to let you focus on what's important.",
+									'woocommerce'
+								),
+							},
+							heading: __(
+								'Meet a streamlined product form',
+								'woocommerce'
+							),
+						},
+						referenceElements: {
+							desktop: '#adminmenuback',
+						},
+					},
+				],
+				closeHandler: dismissModal,
+				options: {
+					effects: {
+						arrowIndicator: false,
+						overlay: false,
+						liveResize: {
+							rootElementSelector: '#adminmenuback',
+							resize: true,
+						},
+					},
+					popperModifiers: [
+						{
+							name: 'offset',
+							options: {
+								offset: [
+									// 180 is the TourKitStep's height.
+									height / 2 - 180,
+									10,
+								],
+							},
+						},
+					],
+				},
+				placement: 'bottom-end',
+			} }
+		/>
+	);
+};
+
+export default BlockEditorTour;

--- a/plugins/woocommerce-admin/client/products/tour/block-editor/block-editor-tour.tsx
+++ b/plugins/woocommerce-admin/client/products/tour/block-editor/block-editor-tour.tsx
@@ -1,14 +1,13 @@
 /**
  * External dependencies
  */
-
 import { TourKit } from '@woocommerce/components';
 import { Guide } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { recordEvent } from '@woocommerce/tracks';
 import { useEffect } from '@wordpress/element';
 
-/*
+/**
  * Internal dependencies
  */
 
@@ -65,7 +64,7 @@ const BlockEditorTour = ( {
 							},
 						},
 					],
-					closeHandler: ( _, __, source ) => {
+					closeHandler: ( _steps, _currentStepIndex, source ) => {
 						dismissModal();
 						if ( source === 'done-btn' ) {
 							recordEvent(
@@ -87,9 +86,8 @@ const BlockEditorTour = ( {
 								resize: true,
 							},
 						},
-						portalParentElement: document.getElementById(
-							'wpbody'
-						),
+						portalParentElement:
+							document.getElementById( 'wpbody' ),
 						popperModifiers: [
 							{
 								name: 'bottom-left',

--- a/plugins/woocommerce-admin/client/products/tour/block-editor/block-editor-tour.tsx
+++ b/plugins/woocommerce-admin/client/products/tour/block-editor/block-editor-tour.tsx
@@ -5,7 +5,8 @@
 import { TourKit } from '@woocommerce/components';
 import { Guide } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useBlockEditorTourOptions } from './use-block-editor-tour-options';
+import { recordEvent } from '@woocommerce/tracks';
+import { useEffect } from '@wordpress/element';
 
 /*
  * Internal dependencies
@@ -17,6 +18,7 @@ interface Props {
 	isTourOpen: boolean;
 	dismissModal: () => void;
 	openGuide: () => void;
+	closeGuide: () => void;
 	isGuideOpen: boolean;
 }
 
@@ -25,12 +27,97 @@ const BlockEditorTour = ( {
 	dismissModal,
 	openGuide,
 	isGuideOpen,
+	closeGuide,
 }: Props ) => {
-	if ( isGuideOpen ) {
+	useEffect( () => {
+		if ( isTourOpen ) {
+			recordEvent( 'block_product_editor_spotlight_view' );
+		}
+	}, [ isTourOpen ] );
+
+	if ( isTourOpen ) {
+		return (
+			<TourKit
+				config={ {
+					steps: [
+						{
+							meta: {
+								name: 'woocommerce-block-editor-tour',
+								primaryButton: {
+									text: __(
+										'View highlights',
+										'woocommerce'
+									),
+								},
+								descriptions: {
+									desktop: __(
+										"We designed a brand new product editing experience to let you focus on what's important.",
+										'woocommerce'
+									),
+								},
+								heading: __(
+									'Meet a streamlined product form',
+									'woocommerce'
+								),
+							},
+							referenceElements: {
+								desktop: '#adminmenuback',
+							},
+						},
+					],
+					closeHandler: ( _, __, source ) => {
+						dismissModal();
+						if ( source === 'done-btn' ) {
+							recordEvent(
+								'block_product_editor_spotlight_view_highlights'
+							);
+							openGuide();
+						} else {
+							recordEvent(
+								'block_product_editor_spotlight_dismissed'
+							);
+						}
+					},
+					options: {
+						effects: {
+							arrowIndicator: false,
+							overlay: false,
+							liveResize: {
+								rootElementSelector: '#adminmenuback',
+								resize: true,
+							},
+						},
+						portalParentElement: document.getElementById(
+							'wpbody'
+						),
+						popperModifiers: [
+							{
+								name: 'bottom-left',
+								enabled: true,
+								phase: 'beforeWrite',
+								requires: [ 'computeStyles' ],
+								fn: ( { state } ) => {
+									state.styles.popper.top = 'auto';
+									state.styles.popper.left = 'auto';
+									state.styles.popper.bottom = '10px';
+									state.styles.popper.transform =
+										'translate3d(10px, 0px, 0px)';
+								},
+							},
+						],
+					},
+				} }
+			/>
+		);
+	} else if ( isGuideOpen ) {
 		return (
 			<Guide
 				className="woocommerce-block-editor-guide"
 				finishButtonText={ __( 'Close', 'woocommerce' ) }
+				onFinish={ () => {
+					recordEvent( 'block_product_editor_spotlight_completed' );
+					closeGuide();
+				} }
 				pages={ [
 					{
 						content: (
@@ -117,73 +204,6 @@ const BlockEditorTour = ( {
 						),
 					},
 				] }
-			/>
-		);
-	} else if ( isTourOpen ) {
-		return (
-			<TourKit
-				config={ {
-					steps: [
-						{
-							meta: {
-								name: 'woocommerce-block-editor-tour',
-								primaryButton: {
-									text: __(
-										'View highlights',
-										'woocommerce'
-									),
-								},
-								descriptions: {
-									desktop: __(
-										"We designed a brand new product editing experience to let you focus on what's important.",
-										'woocommerce'
-									),
-								},
-								heading: __(
-									'Meet a streamlined product form',
-									'woocommerce'
-								),
-							},
-							referenceElements: {
-								desktop: '#adminmenuback',
-							},
-						},
-					],
-					closeHandler: ( _, __, source ) => {
-						dismissModal();
-						if ( source === 'done-btn' ) {
-							openGuide();
-						}
-					},
-					options: {
-						effects: {
-							arrowIndicator: false,
-							overlay: false,
-							liveResize: {
-								rootElementSelector: '#adminmenuback',
-								resize: true,
-							},
-						},
-						portalParentElement: document.getElementById(
-							'wpbody'
-						),
-						popperModifiers: [
-							{
-								name: 'bottom-left',
-								enabled: true,
-								phase: 'beforeWrite',
-								requires: [ 'computeStyles' ],
-								fn: ( { state } ) => {
-									state.styles.popper.top = 'auto';
-									state.styles.popper.left = 'auto';
-									state.styles.popper.bottom = '10px';
-									state.styles.popper.transform =
-										'translate3d(10px, 0px, 0px)';
-								},
-							},
-						],
-					},
-				} }
 			/>
 		);
 	}

--- a/plugins/woocommerce-admin/client/products/tour/block-editor/block-editor-tour.tsx
+++ b/plugins/woocommerce-admin/client/products/tour/block-editor/block-editor-tour.tsx
@@ -29,13 +29,13 @@ const BlockEditorTour = () => {
 					{
 						content: (
 							<>
-								<h1>
+								<h1 className="woocommerce-block-editor-guide__heading">
 									{ __(
 										'Refreshed, streamlined interface',
 										'woocommerce'
 									) }
 								</h1>
-								<p>
+								<p className="woocommerce-block-editor-guide__text">
 									{ __(
 										'Experience a simpler, more focused interface with a modern design that enhances usability.',
 										'woocommerce'
@@ -43,17 +43,18 @@ const BlockEditorTour = () => {
 								</p>
 							</>
 						),
+						image: <div className="woocommerce-block-editor-guide__background1"></div>
 					},
 					{
 						content: (
 							<>
-								<h1>
+								<h1 className="woocommerce-block-editor-guide__heading">
 									{ __(
 										'Content-rich product descriptions',
 										'woocommerce'
 									) }
 								</h1>
-								<p>
+								<p className="woocommerce-block-editor-guide__text">
 									{ __(
 										'Create compelling product pages with blocks, media, images, videos, and any content you desire to engage customers.',
 										'woocommerce'
@@ -61,17 +62,18 @@ const BlockEditorTour = () => {
 								</p>
 							</>
 						),
+						image: <div className="woocommerce-block-editor-guide__background2"></div>
 					},
 					{
 						content: (
 							<>
-								<h1>
+								<h1 className="woocommerce-block-editor-guide__heading">
 									{ __(
 										'Improved speed & performance',
 										'woocommerce'
 									) }
 								</h1>
-								<p>
+								<p className="woocommerce-block-editor-guide__text">
 									{ __(
 										'Enjoy a seamless experience without page reloads. Our modern technology ensures reliability and lightning-fast performance.',
 										'woocommerce'
@@ -79,17 +81,18 @@ const BlockEditorTour = () => {
 								</p>
 							</>
 						),
+						image: <div className="woocommerce-block-editor-guide__background3"></div>
 					},
 					{
 						content: (
 							<>
-								<h1>
+								<h1 className="woocommerce-block-editor-guide__heading">
 									{ __(
 										'More features are on the way',
 										'woocommerce'
 									) }
 								</h1>
-								<p>
+								<p className="woocommerce-block-editor-guide__text">
 									{ __(
 										'While we currently support physical products, exciting updates are coming to accommodate more types, like digital products, variations, and more. Stay tuned!',
 										'woocommerce'
@@ -97,6 +100,7 @@ const BlockEditorTour = () => {
 								</p>
 							</>
 						),
+						image: <div className="woocommerce-block-editor-guide__background4"></div>
 					},
 				] }
 			/>

--- a/plugins/woocommerce-admin/client/products/tour/block-editor/style.scss
+++ b/plugins/woocommerce-admin/client/products/tour/block-editor/style.scss
@@ -1,24 +1,25 @@
 .woocommerce-block-editor-guide {
 	&__background1 {
 		height: 220px;
-		background-color: #F2EDFF;
+		background-color: #f2edff;
 	}
 	&__background2 {
 		height: 220px;
-		background-color: #DFD1FB;
+		background-color: #dfd1fb;
 	}
 	&__background3 {
 		height: 220px;
-		background-color: #CFB9F6;
+		background-color: #cfb9f6;
 	}
 	&__background4 {
 		height: 220px;
-		background-color: #BEA0F2;
+		background-color: #bea0f2;
 	}
 	&.components-modal__frame {
 		width: 320px;
 	}
-	&__heading, &__text {
+	&__heading,
+	&__text {
 		margin: 12px 24px;
 	}
 
@@ -34,24 +35,20 @@
 		&__page-control {
 			margin-top: 12px;
 		}
-	}
-	.components-guide__footer {
-		width: unset;
-		margin: 32px 24px;
-		.components-button {
-
+		&__footer {
+			width: unset;
+			margin: 32px 24px;
+			.components-guide__back-button {
+				left: 0;
+				padding: 6px 12px;
+			}
+			.components-guide__forward-button {
+				right: 0;
+				padding: 6px 12px;
+			}
+			.components-guide__finish-button {
+				right: 0;
+			}
 		}
-		.components-guide__back-button {
-			left: 0px;
-			padding: 6px 12px;
-		}
-		.components-guide__forward-button {
-			right: 0px;
-			padding: 6px 12px;
-		}
-		.components-guide__finish-button {
-			right: 0px;
-		}
-
 	}
 }

--- a/plugins/woocommerce-admin/client/products/tour/block-editor/style.scss
+++ b/plugins/woocommerce-admin/client/products/tour/block-editor/style.scss
@@ -1,26 +1,33 @@
+$background-height: 220px;
+$yellow: #f5e6ab;
+
 .woocommerce-block-editor-guide {
 	&__background1 {
-		height: 220px;
+		height: $background-height;
 		background-color: #f2edff;
 	}
 	&__background2 {
-		height: 220px;
+		height: $background-height;
 		background-color: #dfd1fb;
 	}
 	&__background3 {
-		height: 220px;
+		height: $background-height;
 		background-color: #cfb9f6;
 	}
 	&__background4 {
-		height: 220px;
+		height: $background-height;
 		background-color: #bea0f2;
 	}
+	&__pill {
+		border: 1px solid $yellow;
+		background-color: $yellow;
+	}
 	&.components-modal__frame {
-		width: 320px;
+		max-width: 320px;
 	}
 	&__heading,
 	&__text {
-		margin: 12px 24px;
+		margin: $gap-small $gap-large;
 	}
 
 	&__heading {
@@ -28,23 +35,20 @@
 		line-height: 30px;
 	}
 
-	&__text {
-		height: 80px;
-	}
 	.components-guide {
 		&__page-control {
-			margin-top: 12px;
+			margin-top: $gap-small;
 		}
 		&__footer {
 			width: unset;
-			margin: 32px 24px;
+			margin: $gap-large $gap-large;
 			.components-guide__back-button {
 				left: 0;
-				padding: 6px 12px;
+				padding: $gap-smaller $gap-small;
 			}
 			.components-guide__forward-button {
 				right: 0;
-				padding: 6px 12px;
+				padding: $gap-smaller $gap-small;
 			}
 			.components-guide__finish-button {
 				right: 0;

--- a/plugins/woocommerce-admin/client/products/tour/block-editor/style.scss
+++ b/plugins/woocommerce-admin/client/products/tour/block-editor/style.scss
@@ -1,0 +1,36 @@
+.woocommerce-block-editor-guide {
+	&.components-modal__frame {
+		width: 320px;
+		max-height: 480px;
+	}
+	h1, p {
+		margin: 24px;
+	}
+	h1 {
+		line-height: 30px;
+		font-size: 24px;
+	}
+	p {
+
+		height: 60px; // testing a fixed height
+	}
+	.components-guide__footer {
+		width: unset;
+		margin: 32px 24px;
+		.components-button {
+
+		}
+		.components-guide__back-button {
+			left: 0px;
+			padding: 6px 12px;
+		}
+		.components-guide__forward-button {
+			right: 0px;
+			padding: 6px 12px;
+		}
+		.components-guide__finish-button {
+			right: 0px;
+		}
+
+	}
+}

--- a/plugins/woocommerce-admin/client/products/tour/block-editor/style.scss
+++ b/plugins/woocommerce-admin/client/products/tour/block-editor/style.scss
@@ -1,18 +1,39 @@
 .woocommerce-block-editor-guide {
+	&__background1 {
+		height: 220px;
+		background-color: #F2EDFF;
+	}
+	&__background2 {
+		height: 220px;
+		background-color: #DFD1FB;
+	}
+	&__background3 {
+		height: 220px;
+		background-color: #CFB9F6;
+	}
+	&__background4 {
+		height: 220px;
+		background-color: #BEA0F2;
+	}
 	&.components-modal__frame {
 		width: 320px;
-		max-height: 480px;
 	}
-	h1, p {
-		margin: 24px;
+	&__heading, &__text {
+		margin: 12px 24px;
 	}
-	h1 {
-		line-height: 30px;
-		font-size: 24px;
-	}
-	p {
 
-		height: 60px; // testing a fixed height
+	&__heading {
+		font-size: 24px;
+		line-height: 30px;
+	}
+
+	&__text {
+		height: 80px;
+	}
+	.components-guide {
+		&__page-control {
+			margin-top: 12px;
+		}
 	}
 	.components-guide__footer {
 		width: unset;

--- a/plugins/woocommerce-admin/client/products/tour/block-editor/use-block-editor-tour-options.ts
+++ b/plugins/woocommerce-admin/client/products/tour/block-editor/use-block-editor-tour-options.ts
@@ -37,6 +37,7 @@ export const useBlockEditorTourOptions = () => {
 		isTourOpen,
 		isTourClosed,
 		openGuide: () => setIsGuideOpen( true ),
+		closeGuide: () => setIsGuideOpen( false ),
 		isGuideOpen,
 	};
 };

--- a/plugins/woocommerce-admin/client/products/tour/block-editor/use-block-editor-tour-options.ts
+++ b/plugins/woocommerce-admin/client/products/tour/block-editor/use-block-editor-tour-options.ts
@@ -8,7 +8,7 @@ import { useState } from '@wordpress/element';
 export const BLOCK_EDITOR_TOUR_SHOWN_OPTION =
 	'woocommerce_block_product_tour_shown';
 
-export const useBlockEditorTour = () => {
+export const useBlockEditorTourOptions = () => {
 	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
 	const [ isGuideOpen, setIsGuideOpen ] = useState( false );
 	const { isTourOpen, isTourClosed } = useSelect( ( select ) => {

--- a/plugins/woocommerce-admin/client/products/tour/block-editor/use-block-editor-tour-options.ts
+++ b/plugins/woocommerce-admin/client/products/tour/block-editor/use-block-editor-tour-options.ts
@@ -15,14 +15,15 @@ export const useBlockEditorTourOptions = () => {
 		const { getOption, hasFinishedResolution } =
 			select( OPTIONS_STORE_NAME );
 
-		const isTourClosed = getOption( BLOCK_EDITOR_TOUR_SHOWN_OPTION ) === 'yes' ||
-		! hasFinishedResolution( 'getOption', [
-			BLOCK_EDITOR_TOUR_SHOWN_OPTION,
-		] );
+		const tourClosed =
+			getOption( BLOCK_EDITOR_TOUR_SHOWN_OPTION ) === 'yes' ||
+			! hasFinishedResolution( 'getOption', [
+				BLOCK_EDITOR_TOUR_SHOWN_OPTION,
+			] );
 
 		return {
-			isTourClosed,
-			isTourOpen: !isTourClosed,
+			isTourClosed: tourClosed,
+			isTourOpen: ! tourClosed,
 		};
 	} );
 

--- a/plugins/woocommerce-admin/client/products/tour/block-editor/use-block-editor-tour-options.ts
+++ b/plugins/woocommerce-admin/client/products/tour/block-editor/use-block-editor-tour-options.ts
@@ -3,27 +3,24 @@
  */
 import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useState } from '@wordpress/element';
 
 export const BLOCK_EDITOR_TOUR_SHOWN_OPTION =
 	'woocommerce_block_product_tour_shown';
 
 export const useBlockEditorTourOptions = () => {
 	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
-	const [ isGuideOpen, setIsGuideOpen ] = useState( false );
-	const { isTourOpen, isTourClosed } = useSelect( ( select ) => {
+	const { shouldTourBeShown } = useSelect( ( select ) => {
 		const { getOption, hasFinishedResolution } =
 			select( OPTIONS_STORE_NAME );
 
-		const tourClosed =
+		const wasTourShown =
 			getOption( BLOCK_EDITOR_TOUR_SHOWN_OPTION ) === 'yes' ||
 			! hasFinishedResolution( 'getOption', [
 				BLOCK_EDITOR_TOUR_SHOWN_OPTION,
 			] );
 
 		return {
-			isTourClosed: tourClosed,
-			isTourOpen: ! tourClosed,
+			shouldTourBeShown: ! wasTourShown,
 		};
 	} );
 
@@ -35,10 +32,6 @@ export const useBlockEditorTourOptions = () => {
 
 	return {
 		dismissModal,
-		isTourOpen,
-		isTourClosed,
-		openGuide: () => setIsGuideOpen( true ),
-		closeGuide: () => setIsGuideOpen( false ),
-		isGuideOpen,
+		shouldTourBeShown,
 	};
 };

--- a/plugins/woocommerce-admin/client/products/tour/block-editor/use-block-editor-tour.ts
+++ b/plugins/woocommerce-admin/client/products/tour/block-editor/use-block-editor-tour.ts
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { useSelect, useDispatch } from '@wordpress/data';
+
+export const TODO_RENAME =
+	'woocommerce_block_product_tour_shown';
+
+export const useBlockEditorTour = () => {
+	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
+	const { isClosed } = useSelect( ( select ) => {
+		const { getOption, hasFinishedResolution } =
+			select( OPTIONS_STORE_NAME );
+
+		return {
+			isClosed:
+				getOption( TODO_RENAME ) === 'yes' ||
+				! hasFinishedResolution( 'getOption', [
+					TODO_RENAME,
+				] ),
+		};
+	} );
+
+	const dismissModal = () => {
+		updateOptions( {
+			[ TODO_RENAME ]: 'yes',
+		} );
+	};
+
+	return {
+		dismissModal,
+		isClosed,
+	};
+};

--- a/plugins/woocommerce-admin/client/products/tour/block-editor/use-block-editor-tour.ts
+++ b/plugins/woocommerce-admin/client/products/tour/block-editor/use-block-editor-tour.ts
@@ -5,7 +5,7 @@ import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 
-export const TODO_RENAME =
+export const BLOCK_EDITOR_TOUR_SHOWN_OPTION =
 	'woocommerce_block_product_tour_shown';
 
 export const useBlockEditorTour = () => {
@@ -15,9 +15,9 @@ export const useBlockEditorTour = () => {
 		const { getOption, hasFinishedResolution } =
 			select( OPTIONS_STORE_NAME );
 
-		const isTourClosed = getOption( TODO_RENAME ) === 'yes' ||
+		const isTourClosed = getOption( BLOCK_EDITOR_TOUR_SHOWN_OPTION ) === 'yes' ||
 		! hasFinishedResolution( 'getOption', [
-			TODO_RENAME,
+			BLOCK_EDITOR_TOUR_SHOWN_OPTION,
 		] );
 
 		return {
@@ -28,7 +28,7 @@ export const useBlockEditorTour = () => {
 
 	const dismissModal = () => {
 		updateOptions( {
-			[ TODO_RENAME ]: 'yes',
+			[ BLOCK_EDITOR_TOUR_SHOWN_OPTION ]: 'yes',
 		} );
 	};
 

--- a/plugins/woocommerce-admin/client/products/tour/block-editor/use-block-editor-tour.ts
+++ b/plugins/woocommerce-admin/client/products/tour/block-editor/use-block-editor-tour.ts
@@ -3,22 +3,26 @@
  */
 import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { useState } from '@wordpress/element';
 
 export const TODO_RENAME =
 	'woocommerce_block_product_tour_shown';
 
 export const useBlockEditorTour = () => {
 	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
-	const { isClosed } = useSelect( ( select ) => {
+	const [ isGuideOpen, setIsGuideOpen ] = useState( false );
+	const { isTourOpen, isTourClosed } = useSelect( ( select ) => {
 		const { getOption, hasFinishedResolution } =
 			select( OPTIONS_STORE_NAME );
 
+		const isTourClosed = getOption( TODO_RENAME ) === 'yes' ||
+		! hasFinishedResolution( 'getOption', [
+			TODO_RENAME,
+		] );
+
 		return {
-			isClosed:
-				getOption( TODO_RENAME ) === 'yes' ||
-				! hasFinishedResolution( 'getOption', [
-					TODO_RENAME,
-				] ),
+			isTourClosed,
+			isTourOpen: !isTourClosed,
 		};
 	} );
 
@@ -30,6 +34,9 @@ export const useBlockEditorTour = () => {
 
 	return {
 		dismissModal,
-		isClosed,
+		isTourOpen,
+		isTourClosed,
+		openGuide: () => setIsGuideOpen( true ),
+		isGuideOpen,
 	};
 };

--- a/plugins/woocommerce/changelog/add-block-tour
+++ b/plugins/woocommerce/changelog/add-block-tour
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Show spotlight for first time visitors of block product editor

--- a/plugins/woocommerce/src/Admin/API/Options.php
+++ b/plugins/woocommerce/src/Admin/API/Options.php
@@ -202,6 +202,7 @@ class Options extends \WC_REST_Data_Controller {
 			'woocommerce_weight_unit',
 			'woocommerce_ces_product_mvp_ces_action',
 			'woocommerce_product_tour_modal_hidden',
+			'woocommerce_block_product_tour_shown',
 			'woocommerce_revenue_report_date_tour_shown',
 			'woocommerce_date_type',
 			'date_format',


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Show a spotlight and a guided tour for first time visitors, using TourKit and Guide components.


Bug with Guide component: the 'X' button from the modal keeps focusing when navigating between pages.
Limitation with Guide component: it's not possible to know if the Guide was closed or finished, because the same callback is called for both, with no parameters.


Closes #38516 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the block product editor in WooCommerce > Settings > Advanced > Features.
2. Go to Product > Add New.
3. You should see the tour kit step in the bottom left of the editor.
4. The `wcadmin_block_product_editor_spotlight_view` tracks event should be fired.
5. Click the X button.
6. The `wcadmin_block_product_editor_spotlight_dismissed` tracks event should be fired.
7. Refresh the page.
8. You should not see the tour kit step anymore.
9. Delete the option `woocommerce_block_product_tour_shown` using WCA test helper.
10. Refresh the page.
11. The tour kit step should show up again.
12. Click 'View highlights'.
13. You should see the Guide component and be able to navigate between the pages.
14. Navigate until the last page and press 'Close'
15. The `wcadmin_block_product_editor_spotlight_completed` tracks event should be fired.

<!-- End testing instructions -->
