### PR TITLE
Update product editor CES modal to match new designs

### DIFF
--- a/packages/js/customer-effort-score/changelog/update-38576
+++ b/packages/js/customer-effort-score/changelog/update-38576
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add props to allow passing a classname to the feedback modal

--- a/packages/js/customer-effort-score/src/components/feedback-modal/feedback-modal.tsx
+++ b/packages/js/customer-effort-score/src/components/feedback-modal/feedback-modal.tsx
@@ -21,6 +21,7 @@ import classnames from 'classnames';
  * @param {string}   props.cancelButtonLabel      Label for the cancel button.
  * @param {Function} props.onModalClose           Callback for when user closes modal by clicking cancel.
  * @param {Function} props.children               Children to be rendered.
+ * @param {string}   props.className              Class name to addd to the modal.
  */
 function FeedbackModal( {
 	onSubmit,

--- a/packages/js/customer-effort-score/src/components/feedback-modal/feedback-modal.tsx
+++ b/packages/js/customer-effort-score/src/components/feedback-modal/feedback-modal.tsx
@@ -42,7 +42,7 @@ function FeedbackModal( {
 	isSubmitButtonDisabled?: boolean;
 	submitButtonLabel?: string;
 	cancelButtonLabel?: string;
-	className: string;
+	className?: string;
 } ): JSX.Element | null {
 	const [ isOpen, setOpen ] = useState( true );
 

--- a/packages/js/customer-effort-score/src/components/feedback-modal/feedback-modal.tsx
+++ b/packages/js/customer-effort-score/src/components/feedback-modal/feedback-modal.tsx
@@ -5,6 +5,7 @@ import { createElement, useState } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import { Button, Modal } from '@wordpress/components';
 import { Text } from '@woocommerce/experimental';
+import classnames from 'classnames';
 
 /**
  * Provides a modal requesting customer feedback.
@@ -30,6 +31,7 @@ function FeedbackModal( {
 	isSubmitButtonDisabled,
 	submitButtonLabel,
 	cancelButtonLabel,
+	className,
 }: {
 	onSubmit: () => void;
 	title: string;
@@ -39,6 +41,7 @@ function FeedbackModal( {
 	isSubmitButtonDisabled?: boolean;
 	submitButtonLabel?: string;
 	cancelButtonLabel?: string;
+	className: string;
 } ): JSX.Element | null {
 	const [ isOpen, setOpen ] = useState( true );
 
@@ -55,21 +58,23 @@ function FeedbackModal( {
 
 	return (
 		<Modal
-			className="woocommerce-feedback-modal"
+			className={ classnames( 'woocommerce-feedback-modal', className ) }
 			title={ title }
 			onRequestClose={ closeModal }
 			shouldCloseOnClickOutside={ false }
 		>
-			<Text
-				variant="body"
-				as="p"
-				className="woocommerce-feedback-modal__description"
-				size={ 14 }
-				lineHeight="20px"
-				marginBottom="1.5em"
-			>
-				{ description }
-			</Text>
+			{ description && (
+				<Text
+					variant="body"
+					as="p"
+					className="woocommerce-feedback-modal__description"
+					size={ 14 }
+					lineHeight="20px"
+					marginBottom="1.5em"
+				>
+					{ description }
+				</Text>
+			) }
 			{ children }
 			<div className="woocommerce-feedback-modal__buttons">
 				<Button isTertiary onClick={ closeModal } name="cancel">

--- a/packages/js/product-editor/changelog/update-38576
+++ b/packages/js/product-editor/changelog/update-38576
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update product CES modal design and fields

--- a/packages/js/product-editor/src/components/product-mvp-feedback-modal-container/product-mvp-feedback-modal-container.tsx
+++ b/packages/js/product-editor/src/components/product-mvp-feedback-modal-container/product-mvp-feedback-modal-container.tsx
@@ -32,11 +32,16 @@ export const ProductMVPFeedbackModalContainer: React.FC< {
 		? getAdminLink( `post.php?post=${ productId }&action=edit` )
 		: getAdminLink( 'post-new.php?post_type=product' );
 
-	const recordScore = ( checked: string[], comments: string ) => {
+	const recordScore = (
+		checked: string[],
+		comments: string,
+		email: string
+	) => {
 		recordEvent( 'product_mvp_feedback', {
 			action: 'disable',
 			checked,
 			comments: comments || '',
+			email,
 		} );
 		hideProductMVPFeedbackModal();
 		window.location.href = `${ classicEditorUrl }&new-product-experience-disabled=true`;

--- a/packages/js/product-editor/src/components/product-mvp-feedback-modal/product-mvp-feedback-modal.tsx
+++ b/packages/js/product-editor/src/components/product-mvp-feedback-modal/product-mvp-feedback-modal.tsx
@@ -3,7 +3,11 @@
  */
 import { createElement, Fragment, useState } from '@wordpress/element';
 import PropTypes from 'prop-types';
-import { CheckboxControl, TextareaControl } from '@wordpress/components';
+import {
+	CheckboxControl,
+	TextareaControl,
+	TextControl,
+} from '@wordpress/components';
 import { FeedbackModal } from '@woocommerce/customer-effort-score';
 import { Text } from '@woocommerce/experimental';
 import { __ } from '@wordpress/i18n';
@@ -61,11 +65,12 @@ function ProductMVPFeedbackModal( {
 		},
 	];
 	const [ comments, setComments ] = useState( '' );
+	const [ email, setEmail ] = useState( '' );
+	const checked = checkboxes
+		.filter( ( checkbox ) => checkbox.checked )
+		.map( ( checkbox ) => checkbox.key );
 
 	const onSendFeedback = () => {
-		const checked = checkboxes
-			.filter( ( checkbox ) => checkbox.checked )
-			.map( ( checkbox ) => checkbox.key );
 		recordScoreCallback( checked, comments );
 	};
 
@@ -80,11 +85,7 @@ function ProductMVPFeedbackModal( {
 	return (
 		<FeedbackModal
 			title={ __(
-				'Thanks for trying out the new product editor!',
-				'woocommerce'
-			) }
-			description={ __(
-				'We’re working on making it better, and your feedback will help improve the experience for thousands of merchants like you.',
+				'Thanks for trying out the new product form!',
 				'woocommerce'
 			) }
 			onSubmit={ onSendFeedback }
@@ -92,6 +93,7 @@ function ProductMVPFeedbackModal( {
 			isSubmitButtonDisabled={ isSendButtonDisabled }
 			submitButtonLabel={ __( 'Send feedback', 'woocommerce' ) }
 			cancelButtonLabel={ __( 'Skip', 'woocommerce' ) }
+			className="woocommerce-product-mvp-feedback-modal"
 		>
 			<>
 				<Text
@@ -100,43 +102,51 @@ function ProductMVPFeedbackModal( {
 					weight="600"
 					size="14"
 					lineHeight="20px"
-				>
-					{ __(
-						'What made you switch back to the classic product editor?',
-						'woocommerce'
-					) }
-				</Text>
-				<Text
-					weight="400"
-					size="12"
-					as="p"
-					lineHeight="16px"
-					color="#757575"
-					className="woocommerce-product-mvp-feedback-modal__subtitle"
-				>
-					{ __( '(Check all that apply)', 'woocommerce' ) }
-				</Text>
-				<div className="woocommerce-product-mvp-feedback-modal__checkboxes">
-					{ checkboxes.map( ( checkbox, index ) => (
-						<CheckboxControl
-							key={ index }
-							label={ checkbox.label }
-							name={ checkbox.key }
-							checked={ checkbox.checked }
-							onChange={ checkbox.onChange }
-						/>
-					) ) }
-				</div>
-				<div className="woocommerce-product-mvp-feedback-modal__comments">
-					<TextareaControl
-						label={ __( 'Additional comments', 'woocommerce' ) }
-						value={ comments }
-						placeholder={ __(
-							'Optional, but much apprecated. We love reading your feedback!',
+				></Text>
+				<fieldset className="woocommerce-product-mvp-feedback-modal__reason">
+					<legend>
+						{ __(
+							'What made you turn off the new product form?',
 							'woocommerce'
 						) }
+					</legend>
+					<div className="woocommerce-product-mvp-feedback-modal__checkboxes">
+						{ checkboxes.map( ( checkbox, index ) => (
+							<CheckboxControl
+								key={ index }
+								label={ checkbox.label }
+								name={ checkbox.key }
+								checked={ checkbox.checked }
+								onChange={ checkbox.onChange }
+							/>
+						) ) }
+					</div>
+				</fieldset>
+
+				<div className="woocommerce-product-mvp-feedback-modal__comments">
+					<TextareaControl
+						label={ __(
+							'Additional thoughts (optional)',
+							'woocommerce'
+						) }
+						value={ comments }
 						onChange={ ( value: string ) => setComments( value ) }
 						rows={ 5 }
+					/>
+				</div>
+				<div className="woocommerce-product-mvp-feedback-modal__email">
+					<TextControl
+						label={ __(
+							'Your email address (optional)',
+							'woocommerce'
+						) }
+						value={ email }
+						onChange={ ( value: string ) => setEmail( value ) }
+						rows={ 5 }
+						help={ __(
+							'In case you want to participate in further discussion and future user research.',
+							'woocommerce'
+						) }
 					/>
 				</div>
 			</>

--- a/packages/js/product-editor/src/components/product-mvp-feedback-modal/product-mvp-feedback-modal.tsx
+++ b/packages/js/product-editor/src/components/product-mvp-feedback-modal/product-mvp-feedback-modal.tsx
@@ -1,7 +1,12 @@
 /**
  * External dependencies
  */
-import { createElement, Fragment, useState } from '@wordpress/element';
+import {
+	createElement,
+	createInterpolateElement,
+	Fragment,
+	useState,
+} from '@wordpress/element';
 import PropTypes from 'prop-types';
 import {
 	CheckboxControl,
@@ -86,6 +91,12 @@ function ProductMVPFeedbackModal( {
 		! slowBuggyOrBroken &&
 		! other;
 
+	const optionalElement = (
+		<span className="woocommerce-product-mvp-feedback-modal__optional">
+			{ __( '(optional)', 'woocommerce' ) }
+		</span>
+	);
+
 	return (
 		<FeedbackModal
 			title={ __(
@@ -129,9 +140,14 @@ function ProductMVPFeedbackModal( {
 
 				<div className="woocommerce-product-mvp-feedback-modal__comments">
 					<TextareaControl
-						label={ __(
-							'Additional thoughts (optional)',
-							'woocommerce'
+						label={ createInterpolateElement(
+							__(
+								'Additional thoughts <optional/>',
+								'woocommerce'
+							),
+							{
+								optional: optionalElement,
+							}
 						) }
 						value={ comments }
 						onChange={ ( value: string ) => setComments( value ) }
@@ -140,9 +156,14 @@ function ProductMVPFeedbackModal( {
 				</div>
 				<div className="woocommerce-product-mvp-feedback-modal__email">
 					<TextControl
-						label={ __(
-							'Your email address (optional)',
-							'woocommerce'
+						label={ createInterpolateElement(
+							__(
+								'Your email address <optional/>',
+								'woocommerce'
+							),
+							{
+								optional: optionalElement,
+							}
 						) }
 						value={ email }
 						onChange={ ( value: string ) => setEmail( value ) }

--- a/packages/js/product-editor/src/components/product-mvp-feedback-modal/product-mvp-feedback-modal.tsx
+++ b/packages/js/product-editor/src/components/product-mvp-feedback-modal/product-mvp-feedback-modal.tsx
@@ -71,7 +71,7 @@ function ProductMVPFeedbackModal( {
 		.map( ( checkbox ) => checkbox.key );
 
 	const onSendFeedback = () => {
-		recordScoreCallback( checked, comments );
+		recordScoreCallback( checked, comments, email );
 	};
 
 	const isSendButtonDisabled =

--- a/packages/js/product-editor/src/components/product-mvp-feedback-modal/product-mvp-feedback-modal.tsx
+++ b/packages/js/product-editor/src/components/product-mvp-feedback-modal/product-mvp-feedback-modal.tsx
@@ -83,14 +83,6 @@ function ProductMVPFeedbackModal( {
 		recordScoreCallback( checked, comments, email );
 	};
 
-	const isSendButtonDisabled =
-		! comments &&
-		! missingFeatures &&
-		! missingPlugins &&
-		! difficultToUse &&
-		! slowBuggyOrBroken &&
-		! other;
-
 	const optionalElement = (
 		<span className="woocommerce-product-mvp-feedback-modal__optional">
 			{ __( '(optional)', 'woocommerce' ) }
@@ -105,7 +97,7 @@ function ProductMVPFeedbackModal( {
 			) }
 			onSubmit={ onSendFeedback }
 			onModalClose={ onCloseModal }
-			isSubmitButtonDisabled={ isSendButtonDisabled }
+			isSubmitButtonDisabled={ ! checked.length }
 			submitButtonLabel={ __( 'Send feedback', 'woocommerce' ) }
 			cancelButtonLabel={ __( 'Skip', 'woocommerce' ) }
 			className="woocommerce-product-mvp-feedback-modal"

--- a/packages/js/product-editor/src/components/product-mvp-feedback-modal/product-mvp-feedback-modal.tsx
+++ b/packages/js/product-editor/src/components/product-mvp-feedback-modal/product-mvp-feedback-modal.tsx
@@ -24,7 +24,11 @@ function ProductMVPFeedbackModal( {
 	recordScoreCallback,
 	onCloseModal,
 }: {
-	recordScoreCallback: ( checked: string[], comments: string ) => void;
+	recordScoreCallback: (
+		checked: string[],
+		comments: string,
+		email: string
+	) => void;
 	onCloseModal?: () => void;
 } ): JSX.Element | null {
 	const [ missingFeatures, setMissingFeatures ] = useState( false );

--- a/packages/js/product-editor/src/components/product-mvp-feedback-modal/style.scss
+++ b/packages/js/product-editor/src/components/product-mvp-feedback-modal/style.scss
@@ -32,7 +32,7 @@ $modal-header-height: 84px;
 		line-height: 1.4;
 		text-transform: uppercase;
 		display: inline-block;
-		margin-bottom: $gap-smaller;
+		margin-bottom: $gap-small;
 		padding: 0;
 	}
 

--- a/packages/js/product-editor/src/components/product-mvp-feedback-modal/style.scss
+++ b/packages/js/product-editor/src/components/product-mvp-feedback-modal/style.scss
@@ -1,23 +1,44 @@
 .woocommerce-product-mvp-feedback-modal {
+	.components-modal__header {
+		height: 84px;
+
+		&-heading {
+			font-weight: 500;
+			font-size: 20px;
+		}
+	}
+
+	legend {
+		font-size: 11px;
+		font-weight: 500;
+		line-height: 1.4;
+		text-transform: uppercase;
+		display: inline-block;
+		margin-bottom: $gap-smaller;
+		padding: 0;
+	}
+
 	&__subtitle {
 		margin-top: $gap-smaller !important;
 	}
+
 	&__checkboxes {
-		margin: $gap-small 0;
+		display: grid;
+		grid-template-columns: 1fr 1fr;
 	}
+
 	&__comments {
 		margin-top: 2em;
 		margin-bottom: 1.5em;
 
-		label {
-			display: block;
-			font-weight: bold;
-			text-transform: none;
-			font-size: 14px;
-		}
-
 		textarea {
 			width: 100%;
 		}
+	}
+
+	&__reason,
+	&__comments,
+	&__email {
+		margin-bottom: $gap-large;
 	}
 }

--- a/packages/js/product-editor/src/components/product-mvp-feedback-modal/style.scss
+++ b/packages/js/product-editor/src/components/product-mvp-feedback-modal/style.scss
@@ -1,6 +1,8 @@
 $modal-header-height: 84px;
 
 .woocommerce-product-mvp-feedback-modal {
+	width: 600px;
+
 	.components-modal__header {
 		height: $modal-header-height;
 

--- a/packages/js/product-editor/src/components/product-mvp-feedback-modal/style.scss
+++ b/packages/js/product-editor/src/components/product-mvp-feedback-modal/style.scss
@@ -8,6 +8,10 @@
 		}
 	}
 
+	.components-modal__content {
+		margin-top: 108px;
+	}
+
 	legend {
 		font-size: 11px;
 		font-weight: 500;

--- a/packages/js/product-editor/src/components/product-mvp-feedback-modal/style.scss
+++ b/packages/js/product-editor/src/components/product-mvp-feedback-modal/style.scss
@@ -1,6 +1,8 @@
+$modal-header-height: 84px;
+
 .woocommerce-product-mvp-feedback-modal {
 	.components-modal__header {
-		height: 84px;
+		height: $modal-header-height;
 
 		&-heading {
 			font-weight: 500;
@@ -9,7 +11,16 @@
 	}
 
 	.components-modal__content {
-		margin-top: 108px;
+		margin-top: $modal-header-height;
+	}
+
+	legend,
+	label {
+		color: $gray-900;
+	}
+
+	.woocommerce-product-mvp-feedback-modal__optional {
+		color: $gray-700;
 	}
 
 	legend {

--- a/packages/js/product-editor/src/components/product-mvp-feedback-modal/style.scss
+++ b/packages/js/product-editor/src/components/product-mvp-feedback-modal/style.scss
@@ -12,6 +12,7 @@ $modal-header-height: 84px;
 
 	.components-modal__content {
 		margin-top: $modal-header-height;
+		padding-bottom: 32px;
 	}
 
 	legend,

--- a/packages/js/product-editor/src/components/product-mvp-feedback-modal/test/index.tsx
+++ b/packages/js/product-editor/src/components/product-mvp-feedback-modal/test/index.tsx
@@ -48,6 +48,7 @@ describe( 'ProductMVPFeedbackModal', () => {
 		fireEvent.click( screen.getByRole( 'checkbox', { name: /other/i } ) );
 		expect( mockRecordScoreCallback ).toHaveBeenCalledWith(
 			[ 'other' ],
+			'',
 			''
 		);
 	} );


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Updates the fields and designs of the CES modal.

<img width="630" alt="Screen Shot 2023-06-02 at 1 52 57 PM" src="https://github.com/woocommerce/woocommerce/assets/10561050/2d225b37-1a49-46b8-9bd0-57f4effd3245">


Closes #38576  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Open your console and enter `localStorage.setItem( 'debug', '*tracks*' );` and also check "Preserve log"
2. Navigate to WooCommerce -> Settings -> Advanced -> Features and enable the product block editor
3. Navigate to the Add Product page
4. Click the "more" icon (three vertical dots in the upper right) and click "Use the classic editor"
5. Note the design matches those in the Figma designs in the issue
6. Make sure that the submit is disabled until at least one checkbox is selected
7. Note that an event is shown in your console `wcadmin_product_mvp_feedback` containing the email, comments, and checked reasons

<!-- End testing instructions -->
