### PR TITLE
Add Core Profiler loading spinner

### DIFF
--- a/plugins/woocommerce-admin/client/core-profiler/components/profile-spinner/profile-spinner.scss
+++ b/plugins/woocommerce-admin/client/core-profiler/components/profile-spinner/profile-spinner.scss
@@ -1,0 +1,12 @@
+.woocommerce-profile-wizard__spinner {
+	align-items: center;
+	display: flex;
+	margin: 0 auto;
+	height: 100vh;
+	justify-content: center;
+
+	.components-spinner {
+		width: 48px;
+		height: 48px;
+	}
+}

--- a/plugins/woocommerce-admin/client/core-profiler/components/profile-spinner/profile-spinner.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/components/profile-spinner/profile-spinner.tsx
@@ -11,12 +11,12 @@ import './profile-spinner.scss';
 export const ProfileSpinner = () => {
 	return (
 		<>
-            <div 
-                className={ `woocommerce-profile-wizard__spinner` }
-                data-testid="core-profiler-loading-screen"
-            >
-                <Spinner />
-            </div>
+			<div
+				className={ `woocommerce-profile-wizard__spinner` }
+				data-testid="core-profiler-loading-screen"
+			>
+				<Spinner />
+			</div>
 		</>
 	);
 };

--- a/plugins/woocommerce-admin/client/core-profiler/components/profile-spinner/profile-spinner.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/components/profile-spinner/profile-spinner.tsx
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import { Spinner } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import './profile-spinner.scss';
+
+export const ProfileSpinner = () => {
+	return (
+		<>
+            <div 
+                className={ `woocommerce-profile-wizard__spinner` }
+                data-testid="core-profiler-loading-screen"
+            >
+                <Spinner />
+            </div>
+		</>
+	);
+};

--- a/plugins/woocommerce-admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/index.tsx
@@ -1206,8 +1206,7 @@ export const CoreProfilerController = ( {
 		: undefined;
 	const navigationProgress = currentNodeMeta?.progress; // This value is defined in each state node's meta tag, we can assume it is 0-100
 	const CurrentComponent =
-		currentNodeMeta?.component ??
-		( () => ( <ProfileSpinner /> ) ); // If no component is defined for the state then its a loading state
+		currentNodeMeta?.component ?? ( () => <ProfileSpinner /> ); // If no component is defined for the state then its a loading state
 
 	useEffect( () => {
 		document.body.classList.remove( 'woocommerce-admin-is-loading' );

--- a/plugins/woocommerce-admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/index.tsx
@@ -47,6 +47,7 @@ import {
 	InstalledPlugin,
 	PluginInstallError,
 } from './services/installAndActivatePlugins';
+import { ProfileSpinner } from './components/profile-spinner/profile-spinner';
 
 export type InitializationCompleteEvent = {
 	type: 'INITIALIZATION_COMPLETE';
@@ -1206,9 +1207,7 @@ export const CoreProfilerController = ( {
 	const navigationProgress = currentNodeMeta?.progress; // This value is defined in each state node's meta tag, we can assume it is 0-100
 	const CurrentComponent =
 		currentNodeMeta?.component ??
-		( () => (
-			<div data-testid="core-profiler-loading-screen">Insert Spinner</div>
-		) ); // If no component is defined for the state then its a loading state
+		( () => ( <ProfileSpinner /> ) ); // If no component is defined for the state then its a loading state
 
 	useEffect( () => {
 		document.body.classList.remove( 'woocommerce-admin-is-loading' );

--- a/plugins/woocommerce/changelog/add-core-profiler-spinner
+++ b/plugins/woocommerce/changelog/add-core-profiler-spinner
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add an animated spinner to the Core Profiler to be displayed when assets are loading.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #37994

In this PR, we're adding a spinner animation that shows when Core Profiler components are being loaded. Previously, there was some "Insert Spinner" placeholder text.

### How to test the changes in this Pull Request:

**Locally**
1. Check out this branch and [build the plugin](https://github.com/woocommerce/woocommerce/blob/trunk/DEVELOPMENT.md).
2. Download and install the [WooCommerce Beta Tester](https://wordpress.org/plugins/woocommerce-beta-tester/) plugin.
3. In `wp-admin`, under **Tools > WCA Test Helper**, click the Features link in the top menu.
4. Find the `core-profiler` feature flag and enable it via the toggle.
5. Open this URL in your WP install: /wp-admin/admin.php?page=wc-admin&path=%2Fprofiler
6. As the new Core Profiler page is loading, you should see a spinner animation in the center of the page instead of the text "Insert Spinner"

**JN Sites**
1. Go to https://jurassic.ninja/ and click "Want more options?" at the bottom
2. Check both WooCommerce and WooCommerce Beta Tester in the right column.
3. After checking the Beta Tester option, enter `add/core-profiler-spinner` in the "Select Branch to Enable" field.
4. Click _Launch Single Site_ at the top of the page and wait until your WP site is ready.
5. Follow steps 3-6 above to test.