### PR TITLE
Fix email report download link

### DIFF
--- a/plugins/woocommerce/changelog/fix-36755-email-report-download-link
+++ b/plugins/woocommerce/changelog/fix-36755-email-report-download-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Reschedule jobs blocked by other delayed jobs

--- a/plugins/woocommerce/src/Admin/Schedulers/SchedulerTraits.php
+++ b/plugins/woocommerce/src/Admin/Schedulers/SchedulerTraits.php
@@ -21,7 +21,7 @@ trait SchedulerTraits {
 	/**
 	 * Queue instance.
 	 *
-	 * @var WC_Queue_Interface
+	 * @var \WC_Queue_Interface
 	 */
 	protected static $queue = null;
 
@@ -38,7 +38,7 @@ trait SchedulerTraits {
 	/**
 	 * Get queue instance.
 	 *
-	 * @return WC_Queue_Interface
+	 * @return \WC_Queue_Interface
 	 */
 	public static function queue() {
 		if ( is_null( self::$queue ) ) {
@@ -51,7 +51,7 @@ trait SchedulerTraits {
 	/**
 	 * Set queue instance.
 	 *
-	 * @param WC_Queue_Interface $queue Queue instance.
+	 * @param \WC_Queue_Interface $queue Queue instance.
 	 */
 	public static function set_queue( $queue ) {
 		self::$queue = $queue;
@@ -163,8 +163,7 @@ trait SchedulerTraits {
 			}
 		}
 
-		$string = '[' . implode( ',', $flattened ) . ']';
-		return $string;
+		return '[' . implode( ',', $flattened ) . ']';
 	}
 
 	/**
@@ -208,7 +207,7 @@ trait SchedulerTraits {
 	 * Get the next blocking job for an action.
 	 *
 	 * @param string $action_name Action name.
-	 * @return false|ActionScheduler_Action
+	 * @return false|\ActionScheduler_Action
 	 */
 	public static function get_next_blocking_job( $action_name ) {
 		$dependency = self::get_dependency( $action_name );
@@ -265,7 +264,7 @@ trait SchedulerTraits {
 	 * This function allows backwards compatibility with Action Scheduler < v3.0.
 	 *
 	 * @param \ActionScheduler_Action $action Action.
-	 * @return DateTime|null
+	 * @return \DateTime|null
 	 */
 	public static function get_next_action_time( $action ) {
 		if ( method_exists( $action->get_schedule(), 'get_next' ) ) {
@@ -318,9 +317,8 @@ trait SchedulerTraits {
 	 * @return void
 	 */
 	public static function queue_batches( $range_start, $range_end, $single_batch_action, $action_args = array() ) {
-		$batch_size       = static::get_batch_size( 'queue_batches' );
-		$range_size       = 1 + ( $range_end - $range_start );
-		$action_timestamp = time() + 5;
+		$batch_size = static::get_batch_size( 'queue_batches' );
+		$range_size = 1 + ( $range_end - $range_start );
 
 		if ( $range_size > $batch_size ) {
 			// If the current batch range is larger than a single batch,

--- a/plugins/woocommerce/src/Admin/Schedulers/SchedulerTraits.php
+++ b/plugins/woocommerce/src/Admin/Schedulers/SchedulerTraits.php
@@ -228,20 +228,7 @@ trait SchedulerTraits {
 			)
 		);
 
-		$next_job_schedule = null;
-
-		if ( is_array( $blocking_jobs ) ) {
-			foreach ( $blocking_jobs as $blocking_job ) {
-				$next_job_schedule = self::get_next_action_time( $blocking_job );
-
-				// Ensure that the next schedule is a DateTime (it can be null).
-				if ( is_a( $next_job_schedule, 'DateTime' ) ) {
-					return $blocking_job;
-				}
-			}
-		}
-
-		return false;
+		return reset( $blocking_jobs );
 	}
 
 	/**
@@ -256,9 +243,14 @@ trait SchedulerTraits {
 		// or schedule to run now if no blocking jobs exist.
 		$blocking_job = static::get_next_blocking_job( $action_name );
 		if ( $blocking_job ) {
-			$after = new \DateTime();
+			$next_action_time = self::get_next_action_time( $blocking_job );
+
+			if ( ! is_a( $next_action_time, 'DateTime' ) ) {
+				$next_action_time = new \DateTime();
+			}
+
 			self::queue()->schedule_single(
-				self::get_next_action_time( $blocking_job )->getTimestamp() + 5,
+				$next_action_time->getTimestamp() + 5,
 				$action_hook,
 				$args,
 				static::$group


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #36755 

The report exporter uses two types of actions: `export_report` to generate a report and `email_report_download_link` to mail it to the user. `email_report_download_link` is dependent on the completion of all instances of `export_report` because the report needs to be generated before mailing a link to it.

Although `email_report_download_link` is defined after `export_report`, it's not guaranteed that that's the case when reading the actions from database later on. Woocommerce currently orders the actions by scheduled date when reading them from DB. The different actions can have the same date and time though.

For example, running `select hook, status, scheduled_date_gmt from wp_actionscheduler_actions where status = 'pending' order by scheduled_date_gmt;` gives me this:

![Example](https://i.imgur.com/8fAtS5b.png)

This was replicated in mysql "5.7.40-google-log".

From the SQL spec (http://www.contrib.andrew.cmu.edu/~shadow/sql/sql1992.txt):
If an order by clause is specified ... The relative order of two rows that are not distinct is implementation-dependent.

So sometimes we can get `email_report_download_link` before `export_report`.

Normally this is not a problem because the method responsible for firing actions; `SchedulerTraits::do_action_or_reschedule` will reschedule actions that are dependent on other pending actions. In some cases that doesn't work though.

This is because the method used for finding blocking actions; `SchedulerTraits::get_next_blocking_job` only returns a blocking action/job when it's scheduled to be run in the future. This means that actions can't depend on other actions that have their scheduled time in the past. `export_report` actions can have their scheduled time in the past, because they're scheduled 5 seconds into the future and the action queue is processed much more infrequently.

This results in the `email_report_download_link` action not being rescheduled and being run immediately, while the report is still being generated, and the email will be completely discarded due to its completion being less than 100%.

https://github.com/woocommerce/woocommerce/blob/ac85cc2c59802f090db27ee8667c7c4b0aff2c2f/plugins/woocommerce/src/Admin/ReportExporter.php#L199-L213

My fix just allows actions to depend on other actions that are past their schedule. There are many other possible fixes too:
- Don't check if a report is completed before sending a link to it (it will complete during the following seconds anyways)
- Create a hook for completion percentage and send the email when 100% is reached
- Schedule the hooks to more than 5 seconds into the future
- Schedule the hooks at shutdown so that execution is unlikely to take a lot of time after that

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

This is kind of difficult to test.

You can simulate the SQL behaviour by scheduling `email_report_download_link` action before `export_report` actions in `ReportExporter::queue_report_export` and waiting after it. This will guarantee that `email_report_download_link` is called before `export_report` (and hopefully rescheduled).

Like this:
```php
if ( 0 < $num_batches ) {
	if ( $send_email ) {
		$email_action_args = array( get_current_user_id(), $export_id, $report_type );
		self::schedule_action( 'email_report_download_link', $email_action_args );
	}

        sleep(0.01);

	self::queue_batches( 1, $num_batches, 'export_report', $report_batch_args );
}
```

1. Simulate as described or make sure that SQL will return the actions in an order that causes the bug to appear
2. Go to stock analytics in wp admin (Analytics > Stock)
3. Download a CSV report and wait for it to be mailed to you. If `email_report_download_link` was called prematurely, no email should be sent. (Analytics > Stock > Download)
4. Make sure that the actions are listed as "Past-due" in (WooCommerce > Status > Scheduled Actions). This is a requirement for the bug to appear
5. Checkout this branch and repeat steps 1-4. All else being equal, you should now receive the email.

<!-- End testing instructions -->
