### PR TITLE
dev: refactor core profiler tracks actions

### DIFF
--- a/plugins/woocommerce-admin/client/core-profiler/actions/tracks.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/actions/tracks.tsx
@@ -11,8 +11,8 @@ import {
 	CoreProfilerStateMachineContext,
 	UserProfileEvent,
 	BusinessInfoEvent,
-} from '../../';
-import { POSSIBLY_DEFAULT_STORE_NAMES } from '../../pages/BusinessInfo';
+} from '..';
+import { POSSIBLY_DEFAULT_STORE_NAMES } from '../pages/BusinessInfo';
 
 const recordTracksStepViewed = (
 	_ctx: unknown,

--- a/plugins/woocommerce-admin/client/core-profiler/actions/tracks.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/actions/tracks.tsx
@@ -15,8 +15,8 @@ import {
 import { POSSIBLY_DEFAULT_STORE_NAMES } from '../pages/BusinessInfo';
 
 const recordTracksStepViewed = (
-	_ctx: unknown,
-	_evt: unknown,
+	_context: unknown,
+	_event: unknown,
 	{ action }: { action: unknown }
 ) => {
 	const { step } = action as { step: string };
@@ -27,8 +27,8 @@ const recordTracksStepViewed = (
 };
 
 const recordTracksStepSkipped = (
-	_ctx: unknown,
-	_evt: unknown,
+	_context: unknown,
+	_event: unknown,
 	{ action }: { action: unknown }
 ) => {
 	const { step } = action as { step: string };

--- a/plugins/woocommerce-admin/client/core-profiler/actions/tracks/index.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/actions/tracks/index.tsx
@@ -1,0 +1,99 @@
+/**
+ * External dependencies
+ */
+import { getSetting } from '@woocommerce/settings';
+import { recordEvent } from '@woocommerce/tracks';
+
+/**
+ * Internal dependencies
+ */
+import {
+	CoreProfilerStateMachineContext,
+	UserProfileEvent,
+	BusinessInfoEvent,
+} from '../../';
+import { POSSIBLY_DEFAULT_STORE_NAMES } from '../../pages/BusinessInfo';
+
+const recordTracksStepViewed = (
+	_ctx: unknown,
+	_evt: unknown,
+	{ action }: { action: unknown }
+) => {
+	const { step } = action as { step: string };
+	recordEvent( 'storeprofiler_step_view', {
+		step,
+		wc_version: getSetting( 'wcVersion' ),
+	} );
+};
+
+const recordTracksStepSkipped = (
+	_ctx: unknown,
+	_evt: unknown,
+	{ action }: { action: unknown }
+) => {
+	const { step } = action as { step: string };
+	recordEvent( `storeprofiler_${ step }_skip` );
+};
+
+const recordTracksIntroCompleted = () => {
+	recordEvent( 'storeprofiler_step_complete', {
+		step: 'store_details',
+		wc_version: getSetting( 'wcVersion' ),
+	} );
+};
+
+const recordTracksUserProfileCompleted = (
+	_context: CoreProfilerStateMachineContext,
+	event: Extract< UserProfileEvent, { type: 'USER_PROFILE_COMPLETED' } >
+) => {
+	recordEvent( 'storeprofiler_step_complete', {
+		step: 'user_profile',
+		wc_version: getSetting( 'wcVersion' ),
+	} );
+
+	recordEvent( 'storeprofiler_user_profile', {
+		business_choice: event.payload.userProfile.businessChoice,
+		selling_online_answer: event.payload.userProfile.sellingOnlineAnswer,
+		selling_platforms: event.payload.userProfile.sellingPlatforms
+			? event.payload.userProfile.sellingPlatforms.join()
+			: null,
+	} );
+};
+
+const recordTracksSkipBusinessLocationCompleted = () => {
+	recordEvent( 'storeprofiler_step_complete', {
+		step: 'skip_business_location',
+		wc_version: getSetting( 'wcVersion' ),
+	} );
+};
+
+const recordTracksBusinessInfoCompleted = (
+	_context: CoreProfilerStateMachineContext,
+	event: Extract< BusinessInfoEvent, { type: 'BUSINESS_INFO_COMPLETED' } >
+) => {
+	recordEvent( 'storeprofiler_step_complete', {
+		step: 'business_info',
+		wc_version: getSetting( 'wcVersion' ),
+	} );
+
+	recordEvent( 'storeprofiler_business_info', {
+		business_name_filled:
+			POSSIBLY_DEFAULT_STORE_NAMES.findIndex(
+				( name ) => name === event.payload.storeName
+			) === -1,
+		industry: event.payload.industry,
+		store_location_previously_set:
+			_context.onboardingProfile.is_store_country_set || false,
+		geolocation_success: _context.geolocatedLocation !== undefined,
+		geolocation_overruled: event.payload.geolocationOverruled,
+	} );
+};
+
+export default {
+	recordTracksStepViewed,
+	recordTracksStepSkipped,
+	recordTracksIntroCompleted,
+	recordTracksUserProfileCompleted,
+	recordTracksSkipBusinessLocationCompleted,
+	recordTracksBusinessInfoCompleted,
+};

--- a/plugins/woocommerce-admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/index.tsx
@@ -16,7 +16,6 @@ import {
 	GeolocationResponse,
 } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
-import { getSetting } from '@woocommerce/settings';
 import { initializeExPlat } from '@woocommerce/explat';
 import { CountryStateOption } from '@woocommerce/onboarding';
 
@@ -48,6 +47,7 @@ import {
 	PluginInstallError,
 } from './services/installAndActivatePlugins';
 import { ProfileSpinner } from './components/profile-spinner/profile-spinner';
+import recordTracksActions from './actions/tracks';
 
 export type InitializationCompleteEvent = {
 	type: 'INITIALIZATION_COMPLETE';
@@ -303,81 +303,6 @@ const redirectToWooHome = () => {
 	window.location.href = '/wp-admin/admin.php?page=wc-admin';
 };
 
-const recordTracksIntroCompleted = () => {
-	recordEvent( 'storeprofiler_step_complete', {
-		step: 'store_details',
-		wc_version: getSetting( 'wcVersion' ),
-	} );
-};
-
-const recordTracksStepViewed = (
-	_ctx: unknown,
-	_evt: unknown,
-	{ action }: { action: unknown }
-) => {
-	const { step } = action as { step: string };
-	recordEvent( 'storeprofiler_step_view', {
-		step,
-		wc_version: getSetting( 'wcVersion' ),
-	} );
-};
-
-const recordTracksStepSkipped = (
-	_ctx: unknown,
-	_evt: unknown,
-	{ action }: { action: unknown }
-) => {
-	const { step } = action as { step: string };
-	recordEvent( `storeprofiler_${ step }_skip` );
-};
-
-const recordTracksUserProfileCompleted = (
-	_context: CoreProfilerStateMachineContext,
-	event: Extract< UserProfileEvent, { type: 'USER_PROFILE_COMPLETED' } >
-) => {
-	recordEvent( 'storeprofiler_step_complete', {
-		step: 'user_profile',
-		wc_version: getSetting( 'wcVersion' ),
-	} );
-
-	recordEvent( 'storeprofiler_user_profile', {
-		business_choice: event.payload.userProfile.businessChoice,
-		selling_online_answer: event.payload.userProfile.sellingOnlineAnswer,
-		selling_platforms: event.payload.userProfile.sellingPlatforms
-			? event.payload.userProfile.sellingPlatforms.join()
-			: null,
-	} );
-};
-
-const recordTracksBusinessInfoCompleted = (
-	_context: CoreProfilerStateMachineContext,
-	event: Extract< BusinessInfoEvent, { type: 'BUSINESS_INFO_COMPLETED' } >
-) => {
-	recordEvent( 'storeprofiler_step_complete', {
-		step: 'business_info',
-		wc_version: getSetting( 'wcVersion' ),
-	} );
-
-	recordEvent( 'storeprofiler_business_info', {
-		business_name_filled:
-			POSSIBLY_DEFAULT_STORE_NAMES.findIndex(
-				( name ) => name === event.payload.storeName
-			) === -1,
-		industry: event.payload.industry,
-		store_location_previously_set:
-			_context.onboardingProfile.is_store_country_set || false,
-		geolocation_success: _context.geolocatedLocation !== undefined,
-		geolocation_overruled: event.payload.geolocationOverruled,
-	} );
-};
-
-const recordTracksSkipBusinessLocationCompleted = () => {
-	recordEvent( 'storeprofiler_step_complete', {
-		step: 'skip_business_location',
-		wc_version: getSetting( 'wcVersion' ),
-	} );
-};
-
 const updateTrackingOption = (
 	_context: CoreProfilerStateMachineContext,
 	event: IntroOptInEvent
@@ -500,15 +425,6 @@ export const preFetchActions = {
 	preFetchGetCountries,
 	preFetchGeolocation,
 	preFetchOptions,
-};
-
-export const recordTracksActions = {
-	recordTracksStepViewed,
-	recordTracksStepSkipped,
-	recordTracksIntroCompleted,
-	recordTracksUserProfileCompleted,
-	recordTracksSkipBusinessLocationCompleted,
-	recordTracksBusinessInfoCompleted,
 };
 
 const coreProfilerMachineActions = {

--- a/plugins/woocommerce-admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/index.tsx
@@ -214,7 +214,7 @@ const preFetchGetCountries = assign( {
 } );
 
 const preFetchOptions = assign( {
-	spawnPrefetchOptionsRef: ( _ctx, _evt, { action } ) => {
+	spawnPrefetchOptionsRef: ( _context, _event, { action } ) => {
 		spawn(
 			() =>
 				Promise.all( [
@@ -351,7 +351,7 @@ const updateBusinessLocation = ( countryAndState: string ) => {
 };
 
 const updateBusinessInfo = async (
-	_ctx: CoreProfilerStateMachineContext,
+	_context: CoreProfilerStateMachineContext,
 	event: BusinessInfoEvent
 ) => {
 	const refreshedOnboardingProfile = ( await resolveSelect(
@@ -370,11 +370,11 @@ const updateBusinessInfo = async (
 
 const persistBusinessInfo = assign( {
 	persistBusinessInfoRef: (
-		_ctx: CoreProfilerStateMachineContext,
+		context: CoreProfilerStateMachineContext,
 		event: BusinessInfoEvent
 	) =>
 		spawn(
-			() => updateBusinessInfo( _ctx, event ),
+			() => updateBusinessInfo( context, event ),
 			'core-profiler-update-business-info'
 		),
 } );
@@ -791,11 +791,11 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 					actions: [
 						assign( {
 							businessInfo: (
-								_context,
+								context,
 								event: BusinessLocationEvent
 							) => {
 								return {
-									..._context.businessInfo,
+									...context.businessInfo,
 									location: event.payload.storeLocation,
 								};
 							},

--- a/plugins/woocommerce-admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/index.tsx
@@ -208,7 +208,7 @@ const handleStoreCountryOption = assign( {
 const preFetchGetCountries = assign( {
 	spawnGetCountriesRef: () =>
 		spawn(
-			resolveSelect( COUNTRIES_STORE_NAME ).getCountries(),
+			() => resolveSelect( COUNTRIES_STORE_NAME ).getCountries(),
 			'core-profiler-prefetch-countries'
 		),
 } );
@@ -216,12 +216,15 @@ const preFetchGetCountries = assign( {
 const preFetchOptions = assign( {
 	spawnPrefetchOptionsRef: ( _ctx, _evt, { action } ) => {
 		spawn(
-			Promise.all( [
-				// @ts-expect-error -- not sure its possible to type this yet, maybe in xstate v5
-				action.options.map( ( optionName: string ) =>
-					resolveSelect( OPTIONS_STORE_NAME ).getOption( optionName )
-				),
-			] ),
+			() =>
+				Promise.all( [
+					// @ts-expect-error -- not sure its possible to type this yet, maybe in xstate v5
+					action.options.map( ( optionName: string ) =>
+						resolveSelect( OPTIONS_STORE_NAME ).getOption(
+							optionName
+						)
+					),
+				] ),
 			'core-profiler-prefetch-options'
 		);
 	},
@@ -282,7 +285,7 @@ const getGeolocation = async ( context: CoreProfilerStateMachineContext ) => {
 const preFetchGeolocation = assign( {
 	spawnGeolocationRef: ( context: CoreProfilerStateMachineContext ) =>
 		spawn(
-			getGeolocation( context ),
+			() => getGeolocation( context ),
 			'core-profiler-prefetch-geolocation'
 		),
 } );
@@ -371,7 +374,7 @@ const persistBusinessInfo = assign( {
 		event: BusinessInfoEvent
 	) =>
 		spawn(
-			updateBusinessInfo( _ctx, event ),
+			() => updateBusinessInfo( _ctx, event ),
 			'core-profiler-update-business-info'
 		),
 } );
@@ -396,7 +399,7 @@ const assignOptInDataSharing = assign( {
 const preFetchGetPlugins = assign( {
 	extensionsRef: () =>
 		spawn(
-			resolveSelect( ONBOARDING_STORE_NAME ).getFreeExtensions(),
+			() => resolveSelect( ONBOARDING_STORE_NAME ).getFreeExtensions(),
 			'core-profiler-prefetch-extensions'
 		),
 } );

--- a/plugins/woocommerce-admin/client/core-profiler/test/core-profiler-machine.test.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/test/core-profiler-machine.test.tsx
@@ -12,11 +12,8 @@ import { createMachine } from 'xstate';
 /**
  * Internal dependencies
  */
-import {
-	preFetchActions,
-	recordTracksActions,
-	CoreProfilerController,
-} from '../';
+import { preFetchActions, CoreProfilerController } from '../';
+import recordTracksActions from '../actions/tracks';
 
 const preFetchActionsMocks = Object.fromEntries(
 	Object.entries( preFetchActions ).map( ( [ key ] ) => [ key, jest.fn() ] )

--- a/plugins/woocommerce/changelog/dev-refactor-core-profiler-tracks
+++ b/plugins/woocommerce/changelog/dev-refactor-core-profiler-tracks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Tidied up core profiler's tracks actions 


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- Consolidated the individual step_viewed tracks actions into a single parameterised action
- Moved the recordTracks actions into their own file to unclutter

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install and activate WooCommerce on a brand new site
2. Install the `WooCommerce Beta Tester` plugin
3. Go to /wp-admin/tools.php?page=woocommerce-admin-test-helper
4. Enable the 'core-profiler' feature flag
5. Visit http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard
6. Check that the tracks events still work for all the core profiler pages

<!-- End testing instructions -->
