### PR TITLE
Add an admin notice about the upcoming change in PHP requirements (PHP 7.4)

### DIFF
--- a/plugins/woocommerce/changelog/add-php-74-version-bump-notice
+++ b/plugins/woocommerce/changelog/add-php-74-version-bump-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add an admin notice about the upcoming PHP version requirement change for PHP 7.3 users

--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -57,6 +57,7 @@ class WC_Admin_Notices {
 		add_action( 'woocommerce_installed', array( __CLASS__, 'reset_admin_notices' ) );
 		add_action( 'wp_loaded', array( __CLASS__, 'add_redirect_download_method_notice' ) );
 		add_action( 'admin_init', array( __CLASS__, 'hide_notices' ), 20 );
+		self::add_action( 'admin_init', array( __CLASS__, 'maybe_remove_php74_required_notice' ) );
 
 		// @TODO: This prevents Action Scheduler async jobs from storing empty list of notices during WC installation.
 		// That could lead to OBW not starting and 'Run setup wizard' notice not appearing in WP admin, which we want
@@ -119,7 +120,52 @@ class WC_Admin_Notices {
 		self::add_notice( 'template_files' );
 		self::add_min_version_notice();
 		self::add_maxmind_missing_license_key_notice();
+		self::maybe_add_php74_required_notice();
 	}
+
+	// phpcs:disable Generic.Commenting.Todo.TaskFound
+
+	/**
+	 * Add an admin notice about the bump of the required PHP version in WooCommerce 8.2
+	 * if the current PHP version is too old.
+	 *
+	 * TODO: Remove this method in WooCommerce 8.2.
+	 */
+	private static function maybe_add_php74_required_notice() {
+		if ( version_compare( phpversion(), '7.4', '>=' ) ) {
+			return;
+		}
+
+		self::add_custom_notice(
+			'php74_required_in_woo_82',
+			sprintf(
+				'%s%s',
+				sprintf(
+					'<h4>%s</h4>',
+					esc_html__( 'PHP version requirements will change soon', 'woocommerce' )
+				),
+				sprintf(
+				// translators: Placeholder is a URL.
+					wpautop( wp_kses_data( __( 'WooCommerce 8.2, scheduled for <b>October 2023</b>, will require PHP 7.4 or newer to work. Your server is currently running an older version of PHP, so this change will impact your store. Upgrading to at least PHP 8.0 is recommended. <b><a href="%s">Learn more about this change.</a></b>', 'woocommerce' ) ) ),
+					'https://developer.woocommerce.com/2023/06/05/new-requirement-for-woocommerce-8-2-php-7-4/'
+				)
+			)
+		);
+	}
+
+	/**
+	 * Remove the admin notice about the bump of the required PHP version in WooCommerce 8.2
+	 * if the current PHP version is good.
+	 *
+	 * TODO: Remove this method in WooCommerce 8.2.
+	 */
+	private static function maybe_remove_php74_required_notice() {
+		if ( version_compare( phpversion(), '7.4', '>=' ) && self::has_notice( 'php74_required_in_woo_82' ) ) {
+			self::remove_notice( 'php74_required_in_woo_82' );
+		}
+	}
+
+	// phpcs:enable Generic.Commenting.Todo.TaskFound
 
 	/**
 	 * Show a notice.


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The minimum required PHP version will be 7.4 as of WooCommerce 8.2. This pull request adds a dismissable admin notice visible when PHP 7.3 is used:

![image](https://github.com/woocommerce/woocommerce/assets/937723/f8ac731b-c349-4cc5-8f4e-905e9a217423)

The notice is created (if needed) when the theme is switched or a new version of WooCommerce is installed.

This pull request is a re-edition of https://github.com/woocommerce/woocommerce/pull/36444.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Run the following in command line to simulate a new WooCommerce version installed, this will also attempt to clear some user meta that doesn't exist yet:

```
wp eval 'WC_Admin_Notices::reset_admin_notices(); delete_user_meta(get_current_user_id(), "dismissed_php74_required_in_woo_88_notice");' --user=<your WP user name or id>
```

2. Switch to PHP 7.4 and load any admin page, e.g. orders. You shouldn't see any notice.

3. Switch to PHP 7.3, repeat step 1, and load the admin page again. You should see the notice.

4. Switch to PHP 7.4, reload the admin page (DON'T repeat step 1 this time), and you should see that the notice has disappeared.

5. Switch to PHP 7.3, repeat step 1, reload the admin page, and click the "Dismiss" button. The notice shouldn't appear anymore unless you repeat step 1.

1+2 simulates a user that was already on PHP 7.4+ at the time of upgrading to the WooCommerce release that includes this pull request, nothing will happen for these users; 3+4 simulates a user that upgrades his PHP without dismissing the notice; and 3+5 simulates a user that dismisses the notice without (or before) upgrading his PHP. 