### PR TITLE
Fix Duplicate Jetpack Contact Form buttons

### DIFF
--- a/plugins/woo-ai/changelog/fix-jetpack-form-buttons
+++ b/plugins/woo-ai/changelog/fix-jetpack-form-buttons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Unhook a duplicate Jetpack Contact Form button hook.

--- a/plugins/woo-ai/woo-ai.php
+++ b/plugins/woo-ai/woo-ai.php
@@ -52,8 +52,10 @@ function _woo_ai_bootstrap(): void {
 			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
 		}
 	} );
-
-	remove_action( 'media_buttons', array( Automattic\Jetpack\Forms\ContactForm\Admin::init(), 'grunion_media_button' ), 999 );
+	
+	if ( class_exists( 'Automattic\Jetpack\Forms\ContactForm\Admin' ) ) {
+		remove_action( 'media_buttons', array( Automattic\Jetpack\Forms\ContactForm\Admin::init(), 'grunion_media_button' ), 999 );
+	}
 
 	// Check if Jetpack is enabled.
 	if ( ! class_exists( 'Jetpack' ) ) {

--- a/plugins/woo-ai/woo-ai.php
+++ b/plugins/woo-ai/woo-ai.php
@@ -53,6 +53,8 @@ function _woo_ai_bootstrap(): void {
 		}
 	} );
 
+	remove_action( 'media_buttons', array( Automattic\Jetpack\Forms\ContactForm\Admin::init(), 'grunion_media_button' ), 999 );
+
 	// Check if Jetpack is enabled.
 	if ( ! class_exists( 'Jetpack' ) ) {
 		include dirname( __FILE__ ) . '/includes/class-woo-ai-admin-notices.php';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Remove a hook named `grunion_media_button` which is supposed to be removed using `remove_action()` but the [parameters are incorrect](https://github.com/Automattic/jetpack/blob/f6577280d83e987ce53553b47d7bdb4a60b5773a/projects/plugins/jetpack/modules/contact-form/grunion-editor-view.php#L33) as it's not referencing [the correct method](https://github.com/Automattic/jetpack/blob/f6577280d83e987ce53553b47d7bdb4a60b5773a/projects/packages/forms/src/contact-form/class-admin.php#L414).

Here's where Jetpack tries to remove it:
https://github.com/Automattic/jetpack/blob/f6577280d83e987ce53553b47d7bdb4a60b5773a/projects/plugins/jetpack/modules/contact-form/grunion-editor-view.php#L33

This is a stopgap until a fix is applied to Jetpack.

### How to test the changes in this Pull Request:

1. Open up a Woo Express site, go to the product editor and notice the duplicate Add Contact Form button.
2. With this patch applied, refresh the product editor, note that one is missing.
3. Check that the remaining button indeed works by focusing on the product description field and clicking "Add Contact Form".