### PR TITLE
Show "Save draft" instead of "Saved" on initial product page

### DIFF
--- a/packages/js/product-editor/changelog/fix-38608
+++ b/packages/js/product-editor/changelog/fix-38608
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Show "Save draft" instead of "Saved" on initial product page

--- a/packages/js/product-editor/src/components/header/hooks/use-save-draft/use-save-draft.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-save-draft/use-save-draft.tsx
@@ -103,7 +103,7 @@ export function useSaveDraft( {
 	let children: ReactNode;
 	if ( productStatus === 'publish' ) {
 		children = __( 'Switch to draft', 'woocommerce' );
-	} else if ( hasEdits ) {
+	} else if ( hasEdits || productStatus === 'auto-draft' ) {
 		children = __( 'Save draft', 'woocommerce' );
 	} else {
 		children = (


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

Previously, the "Saved" button was shown indicating a new product had already been saved prior to saving.  This PR shows "Save draft" instead for new products.

#### Before

<img width="306" alt="Screen Shot 2023-06-05 at 9 43 40 AM" src="https://github.com/woocommerce/woocommerce/assets/10561050/ba0ec727-f6ee-483d-99d4-f087da63de1b">


#### After

<img width="346" alt="Screen Shot 2023-06-05 at 9 42 52 AM" src="https://github.com/woocommerce/woocommerce/assets/10561050/b0f42691-3353-463e-aebe-739b053a9093">


Closes #38608 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the product blocks editor under WooCommerce->Settings->Advanced->Features.
2. Navigate to WooCommerce -> Add product.
3. Note that the button in the top right initially says "Save draft"
4. Make some changes and save the product
5. Note that the button now says "Saved"

<!-- End testing instructions -->
