### PR TITLE
WC Tracker: Add info about features and plugin compatibility

### DIFF
--- a/plugins/woocommerce/changelog/try-wc-tracker-feature-compat
+++ b/plugins/woocommerce/changelog/try-wc-tracker-feature-compat
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Adds info about features and plugin compatibility to the data collected by WC Tracker

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -176,7 +176,7 @@ class WC_Tracker {
 		// Shipping method info.
 		$data['shipping_methods'] = self::get_active_shipping_methods();
 
-		// Features
+		// Features.
 		$data['enabled_features'] = self::get_enabled_features();
 
 		// Get all WooCommerce options info.

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -331,9 +331,9 @@ class WC_Tracker {
 			if ( isset( $v['PluginURI'] ) ) {
 				$formatted['plugin_uri'] = wp_strip_all_tags( $v['PluginURI'] );
 			}
-			$formatted['feature_compat'] = array();
+			$formatted['feature_compatibility'] = array();
 			if ( wc_get_container()->get( PluginUtil::class )->is_woocommerce_aware_plugin( $k ) ) {
-				$formatted['feature_compat'] = array_filter( FeaturesUtil::get_compatible_features_for_plugin( $k ) );
+				$formatted['feature_compatibility'] = array_filter( FeaturesUtil::get_compatible_features_for_plugin( $k ) );
 			}
 			if ( in_array( $k, $active_plugins_keys, true ) ) {
 				// Remove active plugins from list so we can show active and inactive separately.

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -12,8 +12,8 @@
 
 use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
+use Automattic\WooCommerce\Utilities\{ FeaturesUtil, OrderUtil, PluginUtil };
 use Automattic\WooCommerce\Internal\Utilities\BlocksUtil;
-use Automattic\WooCommerce\Utilities\OrderUtil;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -153,7 +153,6 @@ class WC_Tracker {
 		$data['inactive_plugins'] = $all_plugins['inactive_plugins'];
 
 		// Jetpack & WooCommerce Connect.
-
 		$data['jetpack_version']    = Constants::is_defined( 'JETPACK__VERSION' ) ? Constants::get_constant( 'JETPACK__VERSION' ) : 'none';
 		$data['jetpack_connected']  = ( class_exists( 'Jetpack' ) && is_callable( 'Jetpack::is_active' ) && Jetpack::is_active() ) ? 'yes' : 'no';
 		$data['jetpack_is_staging'] = self::is_jetpack_staging_site() ? 'yes' : 'no';
@@ -176,6 +175,9 @@ class WC_Tracker {
 
 		// Shipping method info.
 		$data['shipping_methods'] = self::get_active_shipping_methods();
+
+		// Features
+		$data['enabled_features'] = self::get_enabled_features();
 
 		// Get all WooCommerce options info.
 		$data['settings'] = self::get_all_woocommerce_options_values();
@@ -328,6 +330,10 @@ class WC_Tracker {
 			}
 			if ( isset( $v['PluginURI'] ) ) {
 				$formatted['plugin_uri'] = wp_strip_all_tags( $v['PluginURI'] );
+			}
+			$formatted['feature_compat'] = array();
+			if ( wc_get_container()->get( PluginUtil::class )->is_woocommerce_aware_plugin( $k ) ) {
+				$formatted['feature_compat'] = array_filter( FeaturesUtil::get_compatible_features_for_plugin( $k ) );
 			}
 			if ( in_array( $k, $active_plugins_keys, true ) ) {
 				// Remove active plugins from list so we can show active and inactive separately.
@@ -902,6 +908,23 @@ class WC_Tracker {
 		}
 
 		return $active_methods;
+	}
+
+	/**
+	 * Get an array of slugs for WC features that are enabled on the site.
+	 *
+	 * @return string[]
+	 */
+	private static function get_enabled_features() {
+		$all_features     = FeaturesUtil::get_features( true, true );
+		$enabled_features = array_filter(
+			$all_features,
+			function( $feature ) {
+				return $feature['is_enabled'];
+			}
+		);
+
+		return array_keys( $enabled_features );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/mockable-functions.php
+++ b/plugins/woocommerce/tests/legacy/mockable-functions.php
@@ -10,6 +10,7 @@
 return array(
 	'current_user_can',
 	'get_bloginfo',
+	'get_plugins',
 	'get_woocommerce_currencies',
 	'get_woocommerce_currency_symbol',
 	'wc_get_price_excluding_tax',

--- a/plugins/woocommerce/tests/legacy/mockable-functions.php
+++ b/plugins/woocommerce/tests/legacy/mockable-functions.php
@@ -10,7 +10,6 @@
 return array(
 	'current_user_can',
 	'get_bloginfo',
-	'get_plugins',
 	'get_woocommerce_currencies',
 	'get_woocommerce_currency_symbol',
 	'wc_get_price_excluding_tax',

--- a/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
@@ -132,7 +132,7 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 		};
 
 		$container = wc_get_container();
-		$container->get( PluginUtil::class );
+		$container->get( PluginUtil::class ); // Ensure that the class is loaded.
 		$container->reset_all_resolved();
 		$container->replace( PluginUtil::class, $pluginutil_mock );
 		$container->replace( FeaturesController::class, $featurescontroller_mock );
@@ -158,6 +158,10 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 			),
 			$tracking_data['inactive_plugins']['plugin3']['feature_compatibility']
 		);
+
+		// Reset the mocked classes so they don't affect other tests.
+		$container->replace( PluginUtil::class, PluginUtil::class );
+		$container->replace( FeaturesController::class, FeaturesController::class );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
@@ -5,10 +5,6 @@
  * @package WooCommerce\Tests\WC_Tracker.
  */
 
-use Automattic\WooCommerce\Internal\Features\FeaturesController;
-use Automattic\WooCommerce\Utilities\PluginUtil;
-use Automattic\WooCommerce\Testing\Tools\CodeHacking\Hacks\FunctionsMockerHack;
-
 // phpcs:disable Squiz.Classes.ClassFileName.NoMatch, Squiz.Classes.ValidClassName.NotCamelCaps -- Backward compatibility.
 /**
  * Class WC_Tracker_Test
@@ -70,102 +66,6 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 		// Test the default case of no filter for set for woocommerce_admin_disabled.
 		$this->assertArrayHasKey( 'wc_admin_disabled', $tracking_data );
 		$this->assertEquals( 'no', $tracking_data['wc_admin_disabled'] );
-	}
-
-	/**
-	 * @testDox Test the features compatibility data for plugin tracking data.
-	 */
-	public function test_get_tracking_data_plugin_feature_compatibility() {
-		$legacy_mocks = array(
-			'get_plugins' => function() {
-				return array(
-					'plugin1' => array(
-						'Name' => 'Plugin 1',
-					),
-					'plugin2' => array(
-						'Name' => 'Plugin 2',
-					),
-					'plugin3' => array(
-						'Name' => 'Plugin 3',
-					),
-				);
-			},
-		);
-		FunctionsMockerHack::add_function_mocks( $legacy_mocks );
-		$this->register_legacy_proxy_function_mocks( $legacy_mocks );
-
-		update_option( 'active_plugins', array( 'plugin1', 'plugin2' ) );
-
-		$pluginutil_mock = new class() extends PluginUtil {
-			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
-			public function is_woocommerce_aware_plugin( $plugin ): bool {
-				if ( 'plugin1' === $plugin ) {
-					return false;
-				}
-
-				return true;
-			}
-		};
-
-		$featurescontroller_mock = new class() extends FeaturesController {
-			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
-			public function get_compatible_features_for_plugin( string $plugin_name, bool $enabled_features_only = false ): array {
-				$compat = array();
-				switch ( $plugin_name ) {
-					case 'plugin2':
-						$compat = array(
-							'compatible'   => array( 'feature1' ),
-							'incompatible' => array( 'feature2' ),
-							'uncertain'    => array( 'feature3' ),
-						);
-						break;
-					case 'plugin3':
-						$compat = array(
-							'compatible'   => array( 'feature2' ),
-							'incompatible' => array(),
-							'uncertain'    => array( 'feature1', 'feature3' ),
-						);
-						break;
-				}
-
-				return $compat;
-			}
-		};
-
-		$container = wc_get_container();
-		$container->get( PluginUtil::class ); // Ensure that the class is loaded.
-		$container->reset_all_resolved();
-		$container->replace( PluginUtil::class, $pluginutil_mock );
-		$container->replace( FeaturesController::class, $featurescontroller_mock );
-
-		$tracking_data = WC_Tracker::get_tracking_data();
-
-		$this->assertEquals(
-			array(),
-			$tracking_data['active_plugins']['plugin1']['feature_compatibility']
-		);
-		$this->assertEquals(
-			array(
-				'compatible'   => array( 'feature1' ),
-				'incompatible' => array( 'feature2' ),
-				'uncertain'    => array( 'feature3' ),
-			),
-			$tracking_data['active_plugins']['plugin2']['feature_compatibility']
-		);
-		$this->assertEquals(
-			array(
-				'compatible' => array( 'feature2' ),
-				'uncertain'  => array( 'feature1', 'feature3' ),
-			),
-			$tracking_data['inactive_plugins']['plugin3']['feature_compatibility']
-		);
-
-		// Reset the mocked classes so they don't affect other tests.
-		$container->replace( PluginUtil::class, PluginUtil::class );
-		$container->get( PluginUtil::class );
-		$container->replace( FeaturesController::class, FeaturesController::class );
-
-		$this->reset_legacy_proxy_mocks();
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
@@ -92,6 +92,7 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 			},
 		);
 		FunctionsMockerHack::add_function_mocks( $legacy_mocks );
+		$this->register_legacy_proxy_function_mocks( $legacy_mocks );
 
 		update_option( 'active_plugins', array( 'plugin1', 'plugin2' ) );
 
@@ -161,7 +162,10 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 
 		// Reset the mocked classes so they don't affect other tests.
 		$container->replace( PluginUtil::class, PluginUtil::class );
+		$container->get( PluginUtil::class );
 		$container->replace( FeaturesController::class, FeaturesController::class );
+
+		$this->reset_legacy_proxy_mocks();
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
@@ -80,7 +80,7 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 			'get_plugins' => function() {
 				return array(
 					'plugin1' => array(
-						'Name' => 'Plugin 1'
+						'Name' => 'Plugin 1',
 					),
 					'plugin2' => array(
 						'Name' => 'Plugin 2',
@@ -89,13 +89,14 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 						'Name' => 'Plugin 3',
 					),
 				);
-			}
+			},
 		);
 		FunctionsMockerHack::add_function_mocks( $legacy_mocks );
 
 		update_option( 'active_plugins', array( 'plugin1', 'plugin2' ) );
 
 		$pluginutil_mock = new class() extends PluginUtil {
+			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
 			public function is_woocommerce_aware_plugin( $plugin ): bool {
 				if ( 'plugin1' === $plugin ) {
 					return false;
@@ -106,9 +107,10 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 		};
 
 		$featurescontroller_mock = new class() extends FeaturesController {
+			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
 			public function get_compatible_features_for_plugin( string $plugin_name, bool $enabled_features_only = false ): array {
 				$compat = array();
-				switch( $plugin_name ) {
+				switch ( $plugin_name ) {
 					case 'plugin2':
 						$compat = array(
 							'compatible'   => array( 'feature1' ),
@@ -151,8 +153,8 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 		);
 		$this->assertEquals(
 			array(
-				'compatible'   => array( 'feature2' ),
-				'uncertain'    => array( 'feature1', 'feature3' ),
+				'compatible' => array( 'feature2' ),
+				'uncertain'  => array( 'feature1', 'feature3' ),
 			),
 			$tracking_data['inactive_plugins']['plugin3']['feature_compatibility']
 		);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

* Adds a data key with the list of WC features that are currently enabled on the site.
* Adds a `feature_compat` key to each plugin that shows its compatibility with each feature (compatible, incompatible, or uncertain) if the plugin is "WooCommerce aware", otherwise just an empty array.

### How to test the changes in this Pull Request:

1. Add this snippet to a new file in your test site's `wp-content/mu-plugins` directory:

```php
<?php

add_action(
	'admin_notices',
	function() {
		echo '<div class="notice notice-info"><pre>';
		print_r( \WC_Tracker::get_tracking_data() );
		echo '</pre></div>';
	}
);
```

2. Then view any admin page that will display admin notices (i.e. not block editor screens). You should see an admin notice at the top that outputs all the data collected by WC Tracker.
3. Check for a key called `enabled_features` and see what's listed there. By default it will probably show `analytics` and if you have HPOS enabled, it will also list `custom_order_tables`.
4. Look through the lists of active and inactive plugins. Each should now have an additional `feature_compat` property that lists that plugin's compatibility status with each WooCommerce feature, or, if the plugin is unrelated to WooCommerce, it should just be an empty array.