### PR TITLE
feat: Hooks added to the "OrdersTableQuery::build_query()" function

### DIFF
--- a/plugins/woocommerce/changelog/feat-orders-table-query-hooks
+++ b/plugins/woocommerce/changelog/feat-orders-table-query-hooks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Adds hooks for modifying custom orders tables SQL statements.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -679,14 +679,41 @@ class OrdersTableQuery {
 		// JOIN.
 		$join = implode( ' ', array_unique( array_filter( array_map( 'trim', $this->join ) ) ) );
 
+		/**
+		 * Filters the JOIN clause of the query.
+		 *
+		 * @param string $join The JOIN clause of the query.
+		 * @param array  $args The query arguments.
+		 * @param object $query The `OrdersTableQuery` instance.
+		 */
+		$join = apply_filters( 'woocommerce_cot_query_join', $join, $this->args, $this );
+
 		// WHERE.
 		$where = '1=1';
 		foreach ( $this->where as $_where ) {
 			$where .= " AND ({$_where})";
 		}
 
+		/**
+		 * Filters the WHERE clause of the query.
+		 *
+		 * @param string $where The WHERE clause of the query.
+		 * @param array  $args  The query arguments.
+		 * @param object $query The `OrdersTableQuery` instance.
+		 */
+		$where = apply_filters( 'woocommerce_cot_query_where', $where, $this->args, $this );
+
 		// ORDER BY.
 		$orderby = $this->orderby ? ( 'ORDER BY ' . implode( ', ', $this->orderby ) ) : '';
+
+		/**
+		 * Filters the ORDER BY clause of the query.
+		 *
+		 * @param string $orderby The ORDER BY clause of the query.
+		 * @param array  $args    The query arguments.
+		 * @param object $query   The `OrdersTableQuery` instance.
+		 */
+		$orderby = apply_filters( 'woocommerce_cot_query_orderby', $orderby, $this->args, $this );
 
 		// LIMITS.
 		$limits = '';
@@ -699,6 +726,15 @@ class OrdersTableQuery {
 
 		// GROUP BY.
 		$groupby = $this->groupby ? 'GROUP BY ' . implode( ', ', (array) $this->groupby ) : '';
+
+		/**
+		 * Filters the GROUP BY clause of the query.
+		 *
+		 * @param string $groupby The GROUP BY clause of the query.
+		 * @param array  $args    The query arguments.
+		 * @param object $query   The `OrdersTableQuery` instance.
+		 */
+		$groupby = apply_filters( 'woocommerce_cot_query_groupby', $groupby, $this->args, $this );
 
 		$this->sql = "SELECT $fields FROM $orders_table $join WHERE $where $groupby $orderby $limits";
 		$this->build_count_query( $fields, $join, $where, $groupby );

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -682,6 +682,8 @@ class OrdersTableQuery {
 		/**
 		 * Filters the JOIN clause of the query.
 		 *
+		 * @since 7.9.0
+		 *
 		 * @param string $join The JOIN clause of the query.
 		 * @param array  $args The query arguments.
 		 * @param object $query The `OrdersTableQuery` instance.
@@ -697,6 +699,8 @@ class OrdersTableQuery {
 		/**
 		 * Filters the WHERE clause of the query.
 		 *
+		 * @since 7.9.0
+		 *
 		 * @param string $where The WHERE clause of the query.
 		 * @param array  $args  The query arguments.
 		 * @param object $query The `OrdersTableQuery` instance.
@@ -708,6 +712,8 @@ class OrdersTableQuery {
 
 		/**
 		 * Filters the ORDER BY clause of the query.
+		 *
+		 * @since 7.9.0
 		 *
 		 * @param string $orderby The ORDER BY clause of the query.
 		 * @param array  $args    The query arguments.
@@ -729,6 +735,8 @@ class OrdersTableQuery {
 
 		/**
 		 * Filters the GROUP BY clause of the query.
+		 *
+		 * @since 7.9.0
 		 *
 		 * @param string $groupby The GROUP BY clause of the query.
 		 * @param array  $args    The query arguments.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 overrides:
   '@types/react': ^17.0.2
@@ -5069,7 +5073,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-create-class-features-plugin': 7.19.0(@babel/core@7.12.9)
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
 
@@ -5081,7 +5085,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-create-class-features-plugin': 7.19.0(@babel/core@7.17.8)
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8097,7 +8101,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-module-transforms': 7.21.2
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-simple-access': 7.20.2
     transitivePeerDependencies:
       - supports-color
@@ -8111,7 +8115,7 @@ packages:
     dependencies:
       '@babel/core': 7.21.3
       '@babel/helper-module-transforms': 7.21.2
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-simple-access': 7.20.2
     transitivePeerDependencies:
       - supports-color
@@ -17935,7 +17939,7 @@ packages:
       '@wordpress/style-engine': 0.15.0
       '@wordpress/token-list': 2.19.0
       '@wordpress/url': 3.29.0
-      '@wordpress/warning': 2.34.0
+      '@wordpress/warning': 2.19.0
       '@wordpress/wordcount': 3.19.0
       change-case: 4.1.2
       classnames: 2.3.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,8 +1,4 @@
-lockfileVersion: '6.1'
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
+lockfileVersion: '6.0'
 
 overrides:
   '@types/react': ^17.0.2
@@ -5073,7 +5069,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-create-class-features-plugin': 7.19.0(@babel/core@7.12.9)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.21.5
     transitivePeerDependencies:
       - supports-color
 
@@ -5085,7 +5081,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-create-class-features-plugin': 7.19.0(@babel/core@7.17.8)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.21.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8101,7 +8097,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-module-transforms': 7.21.2
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.21.5
       '@babel/helper-simple-access': 7.20.2
     transitivePeerDependencies:
       - supports-color
@@ -8115,7 +8111,7 @@ packages:
     dependencies:
       '@babel/core': 7.21.3
       '@babel/helper-module-transforms': 7.21.2
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.21.5
       '@babel/helper-simple-access': 7.20.2
     transitivePeerDependencies:
       - supports-color
@@ -17939,7 +17935,7 @@ packages:
       '@wordpress/style-engine': 0.15.0
       '@wordpress/token-list': 2.19.0
       '@wordpress/url': 3.29.0
-      '@wordpress/warning': 2.19.0
+      '@wordpress/warning': 2.34.0
       '@wordpress/wordcount': 3.19.0
       change-case: 4.1.2
       classnames: 2.3.1


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

- Recreation of #38595 
Adds the following hooks to the **Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableQuery** class.
- `woocommerce_cot_query_join`: Meant to work like the `posts_join` hook but for the orders table.
- `woocommerce_cot_query_where`: Meant to work like the `posts_where` hook but for the orders table.
- `woocommerce_cot_query_orderby`: Meant to work like the `posts_orderby` hook but for the orders table.
- `woocommerce_cot_query_groupby`: Meant to work like the `posts_groupby` hook but for the orders table.

No none issues related to this. I personally just need this functionality to fully support HPOS is [WPGraphQL WooCommerce](https://github.com/wp-graphql/wp-graphql-woocommerce)

### How to test the changes in this Pull Request:

Testing these hooks effectively can get a complicated so below is a test plugin.

```php
<?php
/**
 * Test plugin
 */

/**
 * Edit the WHERE clause of the query.
 *
 * @param string $where The WHERE clause of the query.
 * @param array  $args  The arguments passed to the query.
 * @param string $query The query being filtered.
 *
 * @return string
 */
function edit_where( $where, $args, $query ) {
    error_log( $where );

    return $where;
}
add_filter( 'woocommerce_cot_query_where', 'edit_where', 10, 3 );
        

/**
 * Edit the ORDER BY clause of the query.
 *
 * @param string $orderby The orderby clause of the query.
 * @param array  $args    The arguments passed to the query.
 * @param string $query   The query being filtered.
 *
 * @return string
 */
function edit_orderby( $orderby, $args, $query ) {
    error_log( $orderby );

    return $orderby;
}
add_filter( 'woocommerce_cot_query_orderby', 'edit_orderby', 10, 3 );
```
1. Set WP_DEBUG_LOG flag.
2. Install and activate WooCommerce and the provided test plugin
3. Activate HPOS from the WC settings.
4. Navigate to `Orders` page on the admin.
5. Check debug log of output of "where" and "orderby"
