### PR TITLE
Fix assertion in HPOS unit test

### DIFF
--- a/plugins/woocommerce/changelog/fix-hpos-test
+++ b/plugins/woocommerce/changelog/fix-hpos-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Minor fix in assertion in unit tests.
+
+

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -1718,7 +1718,7 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 			),
 		);
 		$query       = new OrdersTableQuery( array( 'field_query' => $field_query ) );
-		$this->assertCount( 0, $query->posts );
+		$this->assertCount( 3, $query->posts );
 
 		// Test combinations of field_query with regular query args.
 		$args  = array(


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

I realized that unit tests were failing on this assertion: https://github.com/woocommerce/woocommerce/blob/45025a9ad056122439b9fea0c1a55b83580ac7e1/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php#L1720-L1721.

Not sure since when this is happening, but the correct value to check here is actually `3` not `0`.
The part of the test immediately preceding the assertion is meant to obtain orders with `total NOT IN BETWEEN '1' AND '1'` which is the same as `total != 1.0`, but that's precisely all 3 test orders (not 0), since [those are created with totals `15.0`, `16.0` and `9.99`](https://github.com/woocommerce/woocommerce/blob/45025a9ad056122439b9fea0c1a55b83580ac7e1/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php#L1570-L1574).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Run this specific unit test (`phpunit --filter 'test_cot_query_field_query'`). Alternatively, check that unit tests pass on this PR.
2. Confirm no failures occur.

<!-- End testing instructions -->
