### PR TITLE
HPOS: Add descriptive document titles to HPOS order admin screens

### DIFF
--- a/plugins/woocommerce/changelog/update-order-admin-page-titles
+++ b/plugins/woocommerce/changelog/update-order-admin-page-titles
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Add descriptive document titles to HPOS order admin screens

--- a/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
@@ -178,22 +178,22 @@ class PageController {
 
 		if ( $this->is_order_screen( $this->order_type, 'list' ) ) {
 			$admin_title = sprintf(
-				// translators: 1. The label for an order type; 2. The name of the website;
+				// translators: 1: The label for an order type 2: The name of the website
 				esc_html__( '%1$s &lsaquo; %2$s &#8212; WordPress', 'woocommerce' ),
 				esc_html( $labels->name ),
 				esc_html( get_bloginfo( 'name' ) )
 			);
 		} else if ( $this->is_order_screen( $this->order_type, 'edit' ) ) {
 			$admin_title = sprintf(
-				// translators: 1. The label for an order type; 2. The title of the order; 3. The name of the website;
-				esc_html__( '%1$s &#8220;%2$s&#8221; &lsaquo; %3$s &#8212; WordPress', 'woocommerce' ),
+				// translators: 1: The label for an order type 2: The title of the order 3: The name of the website
+				esc_html__( '%1$s #%2$s &lsaquo; %3$s &#8212; WordPress', 'woocommerce' ),
 				esc_html( $labels->edit_item ),
-				esc_html( $this->order->get_title() ),
+				absint( $this->order->get_id() ),
 				esc_html( get_bloginfo( 'name' ) )
 			);
 		} else if ( $this->is_order_screen( $this->order_type, 'new' ) ) {
 			$admin_title = sprintf(
-				// translators: 1. The label for an order type; 2. The name of the website;
+				// translators: 1: The label for an order type 2: The name of the website
 				esc_html__( '%1$s &lsaquo; %2$s &#8212; WordPress', 'woocommerce' ),
 				esc_html( $labels->add_new_item ),
 				esc_html( get_bloginfo( 'name' ) )

--- a/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
@@ -164,9 +164,9 @@ class PageController {
 	/**
 	 * Set the document title for Orders screens to match what it would be with the shop_order CPT.
 	 *
-	 * @param string $admin_title
+	 * @param string $admin_title The admin screen title before it's filtered.
 	 *
-	 * @return string
+	 * @return string The filtered admin title.
 	 */
 	private function set_page_title( $admin_title ) {
 		if ( ! $this->is_order_screen( $this->order_type ) ) {
@@ -178,22 +178,22 @@ class PageController {
 
 		if ( $this->is_order_screen( $this->order_type, 'list' ) ) {
 			$admin_title = sprintf(
-				// translators: 1: The label for an order type 2: The name of the website
+				// translators: 1: The label for an order type 2: The name of the website.
 				esc_html__( '%1$s &lsaquo; %2$s &#8212; WordPress', 'woocommerce' ),
 				esc_html( $labels->name ),
 				esc_html( get_bloginfo( 'name' ) )
 			);
-		} else if ( $this->is_order_screen( $this->order_type, 'edit' ) ) {
+		} elseif ( $this->is_order_screen( $this->order_type, 'edit' ) ) {
 			$admin_title = sprintf(
-				// translators: 1: The label for an order type 2: The title of the order 3: The name of the website
+				// translators: 1: The label for an order type 2: The title of the order 3: The name of the website.
 				esc_html__( '%1$s #%2$s &lsaquo; %3$s &#8212; WordPress', 'woocommerce' ),
 				esc_html( $labels->edit_item ),
 				absint( $this->order->get_id() ),
 				esc_html( get_bloginfo( 'name' ) )
 			);
-		} else if ( $this->is_order_screen( $this->order_type, 'new' ) ) {
+		} elseif ( $this->is_order_screen( $this->order_type, 'new' ) ) {
 			$admin_title = sprintf(
-				// translators: 1: The label for an order type 2: The name of the website
+				// translators: 1: The label for an order type 2: The name of the website.
 				esc_html__( '%1$s &lsaquo; %2$s &#8212; WordPress', 'woocommerce' ),
 				esc_html( $labels->add_new_item ),
 				esc_html( get_bloginfo( 'name' ) )

--- a/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
@@ -146,6 +146,7 @@ class PageController {
 		$page_suffix = ( 'shop_order' === $this->order_type ? '' : '--' . $this->order_type );
 
 		self::add_action( 'load-woocommerce_page_wc-orders' . $page_suffix, array( $this, 'handle_load_page_action' ) );
+		self::add_action( 'admin_title', array( $this, 'set_page_title' ) );
 	}
 
 	/**
@@ -158,6 +159,48 @@ class PageController {
 		if ( method_exists( $this, 'setup_action_' . $this->current_action ) ) {
 			$this->{"setup_action_{$this->current_action}"}();
 		}
+	}
+
+	/**
+	 * Set the document title for Orders screens to match what it would be with the shop_order CPT.
+	 *
+	 * @param string $admin_title
+	 *
+	 * @return string
+	 */
+	private function set_page_title( $admin_title ) {
+		if ( ! $this->is_order_screen( $this->order_type ) ) {
+			return $admin_title;
+		}
+
+		$wp_order_type = get_post_type_object( $this->order_type );
+		$labels        = get_post_type_labels( $wp_order_type );
+
+		if ( $this->is_order_screen( $this->order_type, 'list' ) ) {
+			$admin_title = sprintf(
+				// translators: 1. The label for an order type; 2. The name of the website;
+				esc_html__( '%1$s &lsaquo; %2$s &#8212; WordPress', 'woocommerce' ),
+				esc_html( $labels->name ),
+				esc_html( get_bloginfo( 'name' ) )
+			);
+		} else if ( $this->is_order_screen( $this->order_type, 'edit' ) ) {
+			$admin_title = sprintf(
+				// translators: 1. The label for an order type; 2. The title of the order; 3. The name of the website;
+				esc_html__( '%1$s &#8220;%2$s&#8221; &lsaquo; %3$s &#8212; WordPress', 'woocommerce' ),
+				esc_html( $labels->edit_item ),
+				esc_html( $this->order->get_title() ),
+				esc_html( get_bloginfo( 'name' ) )
+			);
+		} else if ( $this->is_order_screen( $this->order_type, 'new' ) ) {
+			$admin_title = sprintf(
+				// translators: 1. The label for an order type; 2. The name of the website;
+				esc_html__( '%1$s &lsaquo; %2$s &#8212; WordPress', 'woocommerce' ),
+				esc_html( $labels->add_new_item ),
+				esc_html( get_bloginfo( 'name' ) )
+			);
+		}
+
+		return $admin_title;
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Updates the `<title>` tag on Orders admin screens to more closely match what is used for CPT order screens. One slight difference is that on the Edit order screen, the HPOS title will show the order ID number instead of the order date.

### How to test the changes in this Pull Request:

1. Check the behavior on trunk before checking out this branch.
2. Ensure that the HPOS feature is turned on (WooCommerce > Settings > Features) but have the posts table set as authoritative.
3. View the orders list table screen and note the title of the document (usually shown in the "tab" part of a browser tab).
4. Do the same for the Edit order screen and the Add new order screen.
5. Now change the HPOS settings to make the customer order tables authoritative.
6. View the same orders screens and note that all of them show the same thing instead of being relevant to the current screen.
7. Now check out this branch and repeat the process. The document titles on the Edit and Add new screens show now be similar regardless of which HPOS mode is used.

