### PR TITLE
add: core profiler url routing

### DIFF
--- a/plugins/woocommerce-admin/client/core-profiler/test/core-profiler-machine.test.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/test/core-profiler-machine.test.tsx
@@ -30,6 +30,7 @@ const recordTracksActionsMocks = Object.fromEntries(
 const actionOverrides = {
 	...preFetchActionsMocks,
 	...recordTracksActionsMocks,
+	updateQueryStep: jest.fn(),
 	updateTrackingOption: jest.fn(),
 	updateOnboardingProfileOption: jest.fn(),
 	redirectToWooHome: jest.fn(),
@@ -52,6 +53,9 @@ const servicesOverrides = {
  *  We can insert other states to test the pre and post-conditions as well.
  */
 describe( 'All states in CoreProfilerMachine should be reachable', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
 	const testMachine = createMachine( {
 		id: 'coreProfilerTestMachine',
 		initial: 'initializing',

--- a/plugins/woocommerce/changelog/add-core-profiler-url-routing
+++ b/plugins/woocommerce/changelog/add-core-profiler-url-routing
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Added ability for the core profiler state machine to navigate by using the 'step' URL query param


### PR DESCRIPTION
- dev: refactor core-profiler - modularise each page
- moved initializing into introOptIn so it's not a special case by itself
- added url routing

### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR introduces the ability for the Core Profiler pages to be directly navigated to when the `&step=` URL query parameter is specified. 

This parameter currently can take the values of `intro-opt-in` , `user-profile` , `business-info` , `plugins` , and `skip-guided-setup`.

Closes #37993.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

There are 5 navigable pages in the Core Profiler, and each of them should still work like before, and in sequence. 
They are: `intro-opt-in` , `user-profile` , `business-info` , `plugins` , and `skip-guided-setup`

In addition to this, they should also be directly navigated to when the URL is entered in the browser URL bar. When navigated to directly, they should load previously saved profile data.

The back/forward browser button should also work as expected.

1. Install and activate WooCommerce on a brand new site
1. Install the WooCommerce Beta Tester plugin
1. Go to /wp-admin/tools.php?page=woocommerce-admin-test-helper
1. Enable the 'core-profiler' feature flag
1. Open your browser developer console and run localStorage.setItem( 'debug', 'wc-admin:*' ); to set debug for tracks
1. Visit http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard
1. Navigate throughout, and also directly go to steps by using the URLs. e.g http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=plugins

<!-- End testing instructions -->
