### PR TITLE
Add woocommerce_enqueue_product_block_editor_assets action

### DIFF
--- a/plugins/woocommerce/changelog/add-product-block-editor-enqueue-action
+++ b/plugins/woocommerce/changelog/add-product-block-editor-enqueue-action
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add woocommerce_enqueue_product_block_editor_assets action

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -70,6 +70,13 @@ class Init {
 			'before'
 		);
 		wp_tinymce_inline_scripts();
+
+		/**
+		 * Enqueue any product block editor related assets.
+		 *
+		 * @since 7.8.0
+		 */
+		do_action( 'woocommerce_enqueue_product_block_editor_assets' );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -32,8 +32,6 @@ class Init {
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 			add_filter( 'woocommerce_register_post_type_product', array( $this, 'add_product_template' ) );
 
-			add_action( 'current_screen', array( $this, 'set_current_screen_to_block_editor_if_wc_admin' ) );
-
 			$block_registry = new BlockRegistry();
 			$block_registry->init();
 		}
@@ -672,21 +670,5 @@ class Init {
 			);
 		}
 		return $args;
-	}
-
-	/**
-	 * Sets the current screen to the block editor if a wc-admin page.
-	 */
-	public function set_current_screen_to_block_editor_if_wc_admin() {
-		$screen = get_current_screen();
-
-		// phpcs:ignore Squiz.PHP.CommentedOutCode.Found
-		// (no idea why I need that phpcs:ignore above, but I'm tired trying to re-write this comment to get it to pass)
-		// we can't check the 'path' query param because client-side routing is used within wc-admin,
-		// so this action handler is only called on the initial page load from the server, which might
-		// not be the product edit page (it mostly likely isn't).
-		if ( PageController::is_admin_page() ) {
-			$screen->is_block_editor( true );
-		}
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

#### The problem

In #38495 we enabled the loading of custom editor-only blocks in the product block editor by setting the calling `WP_Screen::is_block_editor( true )`

https://github.com/woocommerce/woocommerce/blob/0458dafcb71e97cea8aff73a57e2f154d41004c3/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php#L680

This did enable custom editor-only blocks to properly load.

However, it also had the unfortunate side effect of enabling the enqueuing of assets that are only _really_ intended to be loaded for "the block editor" (the post/FSE editor). This can be easily seen by setting a site to use the [Storefront](https://wordpress.org/themes/storefront/) theme. This results in a gray background and incorrect spacing being applied to the product editor:

<img width="1115" alt="Screenshot 2023-06-05 at 09 25 46" src="https://github.com/woocommerce/woocommerce/assets/2098816/2c6a49a7-4c6d-435d-a3b4-2931d020bea9">

#### Why does this happen?

Storefront is using `enqueue_block_assets` to load custom styles for use in the block editor.

https://github.com/woocommerce/storefront/blob/b12b8368112272fa9bed18473b5514af96163d3d/inc/customizer/class-storefront-customizer.php#L31

```
add_action( 'enqueue_block_assets', array( $this, 'block_editor_customizer_css' ) );
```

The [`enqueue_block_assets`](https://developer.wordpress.org/reference/hooks/enqueue_block_assets/) action:

> Fires after enqueuing block assets for both editor and front-end.
> Call add_action on any hook before ‘wp_enqueue_scripts’.
> 
> In the function call you supply, simply use wp_enqueue_script and wp_enqueue_style to add your functionality to the Gutenberg editor.

Other themes and extensions are likely to use this core action hook as well. And as much as we don't want their code being added to the product editor, they probably don't either!

#### Proposed solution implemented in this PR

We do *not* want the `enqueue_block_assets` action to be called in the context of our product block editor. We want tighter control over what assets get loaded for the product editor, since it is fundamentally a different editor (primarily, it is not wysiwyg).

I have added a `woocommerce_enqueue_product_block_editor_assets` action that can be used by extensions and themes to load assets for the product editor.

There are two primary use cases I see for this:

* Enqueue scripts and styles needed for extensions' blocks
    * If we want to abstract away the enqueuing calls, we could provide a convenience function that extensions could use (pulling the info out of their block.json file... basically, our own `register_block_type` implementation), but...
    * Is there any reason why extensions can't just (be required to) register their product editor blocks client-side in JS via `registerBlockType` from `@wordpress/blocks`? This is how we register all of our core product editor blocks. (see testing instructions below for an example of the code an extension would need to write)
    * In any case, I think we can start with this action hook, and iterate on providing more convenience functions over time to make it even easier for specific use cases.

* Enqueue scripts and styles needed to customize the product editor itself
    * This is likely to be rare, but I think it is important to offer a clear extension point for this, to accommodate any use cases we may not envision.
    * Some possibilities: customizing the look of the product editor through style modifications to further enhance accessibility or theming

I have also removed the call to `WP_Screen::is_block_editor( true )`, since we don't need that anymore.

Closes #38607.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Use the [create-product-editor-block template](https://github.com/woocommerce/woocommerce/blob/trunk/packages/js/create-product-editor-block/README.md) to generate a new custom block extension.
    - Note: since we haven't published `@woocommerce/create-product-editor-block` yet, use the following form of the command to point to a local path:

```
npx @wordpress/create-block --template ./path/to/woocommerce/packages/js/create-product-editor-block
```

2. Make the following changes to the generated extension and rebuild it...
    - Remove the `script` property from the `block.json`
    - Change the initialization in the plugin php file to something similar to this (remove the `add_action( 'init' ) hook`...

```php
function extension_example_product_editor_block_block_init() {
	wp_enqueue_script(
		'extension-example-product-editor-block',
		plugins_url( 'build/index.js', __FILE__ ),
		[ 'wp-blocks', 'wp-element', 'wp-block-editor' ],
		filemtime( plugin_dir_path( __FILE__ ) . 'build/index.js' )
	);

	wp_enqueue_style(
		'extension-example-product-editor-block',
		plugins_url( 'build/index.css', __FILE__ ),
		[],
		filemtime( plugin_dir_path( __FILE__ ) . 'build/index.css' )
	);
}
add_action( 'woocommerce_enqueue_product_block_editor_assets', 'extension_example_product_editor_block_block_init' );

```

3. Load the block-based product editor.
4. Verify no gray background on the form sections.
5. Verify the custom block is rendered correctly (beautiful yellow background).

<!-- End testing instructions -->
