### PR TITLE
Update style of Block product editor TourKit

### DIFF
--- a/plugins/woocommerce-admin/client/products/tour/block-editor/block-editor-tour.tsx
+++ b/plugins/woocommerce-admin/client/products/tour/block-editor/block-editor-tour.tsx
@@ -116,6 +116,7 @@ const BlockEditorTour = ( { shouldTourBeShown, dismissModal }: Props ) => {
 								},
 							},
 						],
+						classNames: 'woocommerce-block-editor-tourkit',
 					},
 				} }
 			/>

--- a/plugins/woocommerce-admin/client/products/tour/block-editor/style.scss
+++ b/plugins/woocommerce-admin/client/products/tour/block-editor/style.scss
@@ -1,10 +1,11 @@
 $background-height: 220px;
 $yellow: #f5e6ab;
+$light-purple: #f2edff;
 
 .woocommerce-block-editor-guide {
 	&__background1 {
 		height: $background-height;
-		background-color: #f2edff;
+		background-color: $light-purple;
 	}
 	&__background2 {
 		height: $background-height;
@@ -54,5 +55,14 @@ $yellow: #f5e6ab;
 				right: 0;
 			}
 		}
+	}
+}
+
+.woocommerce-block-editor-tourkit {
+	.components-card__header {
+		align-items: flex-start;
+		height: 200px;
+		background-color: $light-purple;
+		margin-bottom: $gap;
 	}
 }

--- a/plugins/woocommerce/changelog/update-tourkitdesign
+++ b/plugins/woocommerce/changelog/update-tourkitdesign
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Update styles of block editor tour
+
+


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

Update style of Block product editor TourKit

<img width="1174" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13437655/9b5b54b7-3364-4588-8c5c-202669a09970">


<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the block product editor in WooCommerce > Settings > Advanced > Features.
2. Go to Product > Add New.
3. You should see the tour kit step in the bottom left of the editor. (If you have already dismissed it, you can delete the woocommerce_block_product_tour_shown option through WCA Test Helper)
4. Check the styles against the design in lj4AUMJnpMtUe7XqyvOONq-fi-1335_125302

<!-- End testing instructions -->