### PR TITLE
Fix character encoding detection in CSV exporter for PHP 8.1

### DIFF
--- a/plugins/woocommerce/changelog/fix-encoding-in-product-exporter-in-php-8.1
+++ b/plugins/woocommerce/changelog/fix-encoding-in-product-exporter-in-php-8.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix character encoding detection in CSV exporter for PHP 8.1

--- a/plugins/woocommerce/includes/export/abstract-wc-csv-exporter.php
+++ b/plugins/woocommerce/includes/export/abstract-wc-csv-exporter.php
@@ -398,8 +398,10 @@ abstract class WC_CSV_Exporter {
 		$use_mb = function_exists( 'mb_convert_encoding' );
 
 		if ( $use_mb ) {
-			$encoding = mb_detect_encoding( $data, 'UTF-8, ISO-8859-1', true );
-			$data     = 'UTF-8' === $encoding ? $data : utf8_encode( $data );
+			$is_valid_utf_8 = mb_check_encoding( $data, 'UTF-8' );
+			if ( ! $is_valid_utf_8 ) {
+				$data = mb_convert_encoding( $data, 'UTF-8', 'ISO-8859-1' );
+			}
 		}
 
 		return $this->escape_data( $data );


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The CSV product exporter (or rather, the abstract exporter it's based on) tries to make sure that the generated data is encoded in UTF-8. To that end it uses a call to `mb_detect_encoding( $data, 'UTF-8, ISO-8859-1' )` which is intended to mean "tell me if $data is encoded in UTF-8 or in ISO-8859-1".

The problem is that [the behavior of mb_detect_encoding has changed in PHP 8.1](https://github.com/php/php-src/issues/8279#issuecomment-1083613035). Long story short, the previous behavior was "return the first valid encoding from the list" (the first encoding for which the supplied data is a valid sequence of bytes) and the new one is "apply heuristics to detect the most probable encoding". But alas, these heuristics can (and often will) fail.

Case in point, from [the original issue](https://github.com/woocommerce/woocommerce/issues/37988): the Turkish word `Yayımlanmış`. This is received by the exporter as an UTF-8 string, whose byte sequence is `0x59, 0x61, 0x79, 0xC4, 0xB1, 0x6D, 0x6C, 0x61, 0x6E, 0x6D, 0xC4, 0xB1, 0xC5, 0x9F`. However this sequence of bytes is also a valid representation for an ISO-8859-1 string, which is `YayÄ±mlanmÄ±Å`. For some reason the new "super-smart" encoding detection algorithm chooses ISO-8859-1 in this case.

The solution is to use [`mb_check_encoding`](https://www.php.net/manual/en/function.mb-check-encoding.php) instead. Only if the received data isn't a valid UTF-8 string we assume that it's ISO-8859-1 and then we convert it to UTF-8. This replicates the previous behavior.

Additionally, if encoding conversion is needed, [`mb_convert_encoding`](https://www.php.net/manual/en/function.mb-convert-encoding.php) is now used instead of [`utf8_encode`](https://www.php.net/manual/en/function.utf8-encode.php), which is deprecated.

Closes #37988.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

First, switch your environment to PHP 8.1, obviously.

Then, create a product whose name is `Yayımlanmış`. If you are testing in an existing store with more products it's recommended to create also a new product category and assign it to the product.

Now add the following snippet to your site, this will change the name of the "Name" column for product exports to `Yayımlanmış` without having to change the language of the entire site. The string is generated directly from the UTF-8 byte sequence to prevent IDE/text editor encoding shenanigans:

```php
add_filter("woocommerce_product_export_product_default_columns", function($columns) {
  $bytes = [0x59, 0x61, 0x79, 0xC4, 0xB1, 0x6D, 0x6C, 0x61, 0x6E, 0x6D, 0xC4, 0xB1, 0xC5, 0x9F];
  $string = implode(array_map("chr", $bytes));
  $columns['name'] = $string;
  return $columns;
}, 10, 1);
```

We're all set now: go to the Products list page, click "Export", select at least the "Name" column (and the product category, if you created and assigned one), and generate the export file.

Without the fix, both the file header and the product name will be `YayÄ±mlanmÄ±Å`. With the fix it will be `Yayımlanmış`, as it should be.

Now, to check the fallback conversion to ISO-8859-1 case, you can repeat the process but changing the definition of `$bytes` in the snippet as follows: `$bytes = [0xE1];`. In this case the generated export file will have `á` as the "Name" column.

### Side note

I created a fix that replicates the previous behavior of the exporter to minimize the chances of breaking things, but I think that we have an architectural problem here. We shouldn't be trying to guess the encoding of the data we send out, we should know beforehand! (and the world is bigger than just UTF-8 and ISO-8859-1, of course).

For the export file header, the strings are translations that come directly from the corresponding POT file, which is already UTF-8; and for the product data, this comes from the database, which (to the best of my knowledge) is already storing everything in UTF-8 unless the database engine is configured differently. So the piece of code that this PR modifies could possibly be removed altogether, but that would require more research.

Also for the record, a similar problem in the opposite direction (product import) was fixed in https://github.com/woocommerce/woocommerce/pull/36819.