### PR TITLE
Update WooCommerce Blocks to 10.2.3

### DIFF
--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-10.2.3
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-10.2.3
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update WooCommerce Blocks to 10.2.3

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -21,7 +21,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.5.4",
-		"woocommerce/woocommerce-blocks": "10.2.2"
+		"woocommerce/woocommerce-blocks": "10.2.3"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.3.0",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -628,16 +628,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "10.2.2",
+            "version": "10.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "8676dbf33efb2b0702e7ac22510e378ee37c370c"
+                "reference": "1682631f0b14accc15b9c3a6207f36484d4f9050"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/8676dbf33efb2b0702e7ac22510e378ee37c370c",
-                "reference": "8676dbf33efb2b0702e7ac22510e378ee37c370c",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/1682631f0b14accc15b9c3a6207f36484d4f9050",
+                "reference": "1682631f0b14accc15b9c3a6207f36484d4f9050",
                 "shasum": ""
             },
             "require": {
@@ -683,9 +683,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v10.2.2"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v10.2.3"
             },
-            "time": "2023-05-31T15:04:23+00:00"
+            "time": "2023-06-09T14:13:09+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 10.2.3. This is intended to be merged into WooCommerce 7.8.

## Blocks 10.2.3

* [Release PR](https://github.com/woocommerce/woocommerce-blocks/pull/9779)
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/1023.md)

### Changelog entry

#### Bug Fixes

- Update the Featured Category patterns to replace the Unsplash image with a CCO licensed image from Pxhere. ([9765](https://github.com/woocommerce/woocommerce-blocks/pull/9765))
- Update the Hero Product Split pattern to replace the Unsplash image with a CCO licensed image from Pxhere. ([9762](https://github.com/woocommerce/woocommerce-blocks/pull/9762))
****