### PR TITLE
improve get_children transient validation

### DIFF
--- a/plugins/woocommerce/changelog/fix-38642-read-children
+++ b/plugins/woocommerce/changelog/fix-38642-read-children
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+improve get_children transient validation

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -119,11 +119,11 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 	public function read_children( &$product, $force_read = false ) {
 		$children_transient_name = 'wc_product_children_' . $product->get_id();
 		$children                = get_transient( $children_transient_name );
-		if ( false === $children ) {
+		if ( empty( $children ) || ! is_array( $children ) ) {
 			$children = array();
 		}
 
-		if ( empty( $children ) || ! is_array( $children ) || ! isset( $children['all'] ) || ! isset( $children['visible'] ) || $force_read ) {
+		if ( ! isset( $children['all'] ) || ! isset( $children['visible'] ) || $force_read ) {
 			$all_args = array(
 				'post_parent' => $product->get_id(),
 				'post_type'   => 'product_variation',


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR improves the transient validation in `read_children()`. The current code assumes that the transient isn't set or is an array. While there is an `is_array` check, it doesn't get initialzed to an array.

Closes #38642 .

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Switch to PHP 8.1 or 8.2
2. Create a variable product with children or use an existing one
3. Add this test snippet
```
add_filter( 'pre_transient_wc_product_children_{VARIABLE_PRODUCT_ID}', function() {
	return 'not-an-array';
} );
```
4. Load the single product page for the variable product
5. In `trunk` this generates a fatal error
6. The product page loads properly in this branch
7. No errors are logged in this branch

<!-- End testing instructions -->
