### PR TITLE
Show feedback bar after product editor tour/guide

### DIFF
--- a/plugins/woocommerce-admin/client/products/tour/block-editor/block-editor-tour.tsx
+++ b/plugins/woocommerce-admin/client/products/tour/block-editor/block-editor-tour.tsx
@@ -5,6 +5,7 @@ import { Pill, TourKit } from '@woocommerce/components';
 import { __ } from '@wordpress/i18n';
 import { recordEvent } from '@woocommerce/tracks';
 import { useEffect, useState } from '@wordpress/element';
+import { __experimentalUseFeedbackBar as useFeedbackBar } from '@woocommerce/product-editor';
 
 /**
  * Internal dependencies
@@ -27,6 +28,8 @@ const BlockEditorTour = ( { shouldTourBeShown, dismissModal }: Props ) => {
 
 	const [ isGuideOpen, setIsGuideOpen ] = useState( false );
 
+	const { maybeShowFeedbackBar } = useFeedbackBar();
+
 	const openGuide = () => {
 		setIsGuideOpen( true );
 	};
@@ -34,6 +37,7 @@ const BlockEditorTour = ( { shouldTourBeShown, dismissModal }: Props ) => {
 	const closeGuide = () => {
 		recordEvent( 'block_product_editor_spotlight_completed' );
 		setIsGuideOpen( false );
+		maybeShowFeedbackBar();
 	};
 
 	if ( isGuideOpen ) {
@@ -88,6 +92,7 @@ const BlockEditorTour = ( { shouldTourBeShown, dismissModal }: Props ) => {
 							recordEvent(
 								'block_product_editor_spotlight_dismissed'
 							);
+							maybeShowFeedbackBar();
 						}
 					},
 					options: {

--- a/plugins/woocommerce/changelog/update-show-feedback-bar-after-product-editor-tour
+++ b/plugins/woocommerce/changelog/update-show-feedback-bar-after-product-editor-tour
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Show feedback bar after product block editor tour/guide


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR shows the product editor feedback bar at the bottom of the product editor after the product editor tour/guide is closed.

#### Tour shown (no feedback bar)

<img width="1097" alt="Screenshot 2023-06-09 at 16 20 21" src="https://github.com/woocommerce/woocommerce/assets/2098816/7974ba19-1057-45e8-9984-7f59952be942">

#### Guide shown (no feedback bar)

<img width="1097" alt="Screenshot 2023-06-09 at 16 20 35" src="https://github.com/woocommerce/woocommerce/assets/2098816/e6e4e84f-ddaf-4da3-9f55-1160ba7dcd3f">

#### Tour/guide close (feedback bar shown)

<img width="1097" alt="Screenshot 2023-06-09 at 16 20 56" src="https://github.com/woocommerce/woocommerce/assets/2098816/f735bac3-fff9-41e5-b3cc-5f6a7d4fd259">

Closes #38520.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Note: To reset the state of the system so that the product editor tour and feedback footer will be shown, delete the following options:
* `woocommerce_product_editor_show_feedback_bar`
* `woocommerce_ces_shown_for_actions`
* `woocommerce_block_product_tour_shown`

1. Enable experimental "new product editor" (beta) in WooCommerce > Settings > Advanced > Features
2. Go to Products > Add New
3. You should see the tour kit step in the bottom left of the editor.
5. Click the X button.
6. The feedback footer should be shown.
7. Refresh the page.
8. You should not see the tour kit step anymore (you will still see the feedback footer).
9. Delete the option listed above using WCA test helper.
10. Refresh the page.
11. The tour kit step should show up again.
12. Click 'View highlights'.
13. You should see the Guide component and be able to navigate between the pages.
14. At this point, the feedback footer should not be shown.
15. Close the guide at any point.
16. The feedback footer should be shown.
17. Refresh the page.
18. The tour/guide should not be shown, but the feedback footer should be.


<!-- End testing instructions -->
