### PR TITLE
Add/order model trash untrash

### DIFF
--- a/plugins/woocommerce/changelog/add-order-model-trash-untrash
+++ b/plugins/woocommerce/changelog/add-order-model-trash-untrash
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Provide a data-store agnostic way of untrashing orders.

--- a/plugins/woocommerce/includes/class-wc-order.php
+++ b/plugins/woocommerce/includes/class-wc-order.php
@@ -2290,8 +2290,6 @@ class WC_Order extends WC_Abstract_Order {
 	/**
 	 * Attempts to restore the specified order back to its original status (after having been trashed).
 	 *
-	 * @param WC_Order $order The order to be untrashed.
-	 *
 	 * @return bool If the operation was successful.
 	 */
 	public function untrash(): bool {

--- a/plugins/woocommerce/includes/class-wc-order.php
+++ b/plugins/woocommerce/includes/class-wc-order.php
@@ -2286,4 +2286,15 @@ class WC_Order extends WC_Abstract_Order {
 	public function is_created_via( $modus ) {
 		return apply_filters( 'woocommerce_order_is_created_via', $modus === $this->get_created_via(), $this, $modus );
 	}
+
+	/**
+	 * Attempts to restore the specified order back to its original status (after having been trashed).
+	 *
+	 * @param WC_Order $order The order to be untrashed.
+	 *
+	 * @return bool If the operation was successful.
+	 */
+	public function untrash(): bool {
+		return $this->data_store->untrash_order( $this );
+	}
 }

--- a/plugins/woocommerce/includes/class-wc-order.php
+++ b/plugins/woocommerce/includes/class-wc-order.php
@@ -2295,6 +2295,6 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return bool If the operation was successful.
 	 */
 	public function untrash(): bool {
-		return $this->data_store->untrash_order( $this );
+		return (bool) $this->data_store->untrash_order( $this );
 	}
 }

--- a/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -1181,4 +1181,20 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 		);
 		WC_Order::prime_raw_meta_data_cache( $raw_meta_data_collection, 'orders' );
 	}
+
+	/**
+	 * Attempts to restore the specified order back to its original status (after having been trashed).
+	 *
+	 * @param WC_Order $order The order to be untrashed.
+	 *
+	 * @return bool If the operation was successful.
+	 */
+	public function untrash_order( WC_Order $order ): bool {
+		if ( ! wp_untrash_post( $order->get_id() ) ) {
+			return false;
+		}
+
+		$order->set_status( get_post_field( 'post_status', $order->get_id() ) );
+		return (bool) $order->save();
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
+++ b/plugins/woocommerce/tests/php/includes/data-stores/class-wc-order-data-store-cpt-test.php
@@ -275,4 +275,22 @@ class WC_Order_Data_Store_CPT_Test extends WC_Unit_Test_Case {
 		}
 	}
 
+	/**
+	 * Test the untrashing an order works as expected when done in an agnostic way (ie, not depending directly on
+	 * functions such as `wp_untrash_post()`.
+	 *
+	 * @return void
+	 */
+	public function test_untrash(): void {
+		$order           = WC_Helper_Order::create_order();
+		$order_id        = $order->get_id();
+		$original_status = $order->get_status();
+
+		$order->delete();
+		$this->assertEquals( 'trash', $order->get_status(), 'The order was successfully trashed.' );
+
+		$order = wc_get_order( $order_id );
+		$this->assertTrue( $order->untrash(), 'The order was restored from the trash.' );
+		$this->assertEquals( $original_status, $order->get_status(), 'The original order status is restored following untrash.' );
+	}
 }


### PR DESCRIPTION
It is possible to trash orders, regardless of data-store, by calling `$order->delete()`. However, there is not currently a uniform way of recovering orders from the trash:

- For CPT orders, one should use `wp_untrash_post()`
- For HPOS orders, one should use `$order->get_data_store->untrash_order()`

It therefore makes sense to have a single path for untrashing, as an analog of `$order->delete()`. Additionally, this will make it easier to test scenarios [where orders move in and out of the trash](https://github.com/woocommerce/woocommerce/pull/37842) across data-stores. With those things in mind, this PR introduces `$order->untrash()`.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

This change does not impact any user-facing functionality. To compliment code review, though, you may wish to do some testing via WP Shell or similar:

```
>>> $order_id = 12345;
>>> $order = wc_get_order( $order_id )
=> Automattic\WooCommerce\Admin\Overrides\Order {#6136
     +refunds: null,
     +customer_id: null,
   }

>>> $order->get_status()
=> "pending"

>>> $order->delete()
=> true

>>> $order->get_status()
=> "trash"

>>> $order = wc_get_order( $order_id )
=> Automattic\WooCommerce\Admin\Overrides\Order {#6141
     +refunds: null,
     +customer_id: null,
   }

>>> $order->untrash()
=> true

>>> $order->get_status()
=> "pending"
```

☝🏼 As you may observe, it is necessary to obtain a fresh instance of the order object after trashing it, before it can be untrashed. This is because, after calling `$order->delete()`, the order ID is set to `(int) 0` (an existing behavior).

<!-- End testing instructions -->
