### PR TITLE
Fix flakiness in `can set variation defaults` test.

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-variation-defaults
+++ b/plugins/woocommerce/changelog/e2e-fix-variation-defaults
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix flakiness in `can set variation defaults` test.

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/add-variable-product/update-variations.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/add-variable-product/update-variations.spec.js
@@ -541,6 +541,10 @@ test.describe( 'Update variations', () => {
 			await page.locator( 'a[href="#variable_product_options"]' ).click();
 		} );
 
+		await test.step( 'Wait for block overlay to disappear.', async () => {
+			await expect( page.locator( '.blockOverlay' ) ).not.toBeVisible();
+		} );
+
 		await test.step( 'Select variation defaults', async () => {
 			for ( const attribute of defaultVariation ) {
 				const defaultAttributeMenu = page.locator( 'select', {


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Recently, the `merchant/products/add-variable-product/update-variations.spec.js:443:2 › Update variations › can set variation defaults` E2E test had been flaky because it attempts to prematurely save the changes made to variation defaults while an overlay is still present, therefore blocking the "Save changes" button. This PR waits for the overlay to disappear first before hitting the save button.

More context: p1685589968946829/1685536035.485139-slack-C01BWDDTGKX

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Flakiness is not apparent on a local wp-env environment, so you'll have to test this fix on an external site like JN. Create a new JN site.
2. In your local machine, checkout this branch:
   ```
   git pull
   git checkout e2e/fix-variation-defaults
   ```
3. Run the commands for installing dependencies (no need to run the build commands):
   ```
   nvm use
   pnpm install
   ```
4. Build the woocommerce zip file from this branch by running the commands:
   ```
   cd plugins/woocommerce
   bash bin/build-zip.sh
   ```
5. You should see a woocommerce.zip file in `plugins/woocommerce/woocommerce.zip`. Install this zip to the JN site you created earlier.
6. On the JN site, create a customer with username `customer`, email `customer@woocommercecoree2etestsuite.com`, and a secure password.
7. Run the `can set variation defaults` test against the JN site through these variables and commands, assuming that you're in the `plugins/woocommerce` directory:
   ```
   export BASE_URL="https://your-jn-site"
   export ADMIN_USER="your-jn-admin"
   export ADMIN_PASSWORD="your-admin-password"
   export ADMIN_USER_EMAIL="your-admin-email"
   export CUSTOMER_USER='customer'
   export CUSTOMER_PASSWORD="your-customer-password"
   export CUSTOMER_USER_EMAIL='customer@woocommercecoree2etestsuite.com'
   pnpm test:e2e-pw -g "can set variation defaults" --retries=0
   ```
8. Make sure that the test passed.
9. To check for flakiness, run the test a few more times on the same JN site while keeping the `--retries=0` option to ensure it always passes on the first run, except for the occasional 500 errors in JN.

<!-- End testing instructions -->
