### PR TITLE
Add meta boxes for custom taxonomies in order edit screens

### DIFF
--- a/plugins/woocommerce/changelog/fix-38560
+++ b/plugins/woocommerce/changelog/fix-38560
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add support for taxonomy meta boxes in HPOS order edit screen.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/TaxonomiesMetaBox.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/TaxonomiesMetaBox.php
@@ -31,6 +31,10 @@ class TaxonomiesMetaBox {
 				$taxonomy->meta_box_cb = array( $this, 'order_categories_meta_box' );
 			}
 
+			if ( 'post_tags_meta_box' === $taxonomy->meta_box_cb ) {
+				$taxonomy->meta_box_cb = array( $this, 'order_tags_meta_box' );
+			}
+
 			$label = $taxonomy->labels->name;
 
 			if ( ! is_taxonomy_hierarchical( $tax_name ) ) {
@@ -181,5 +185,18 @@ class TaxonomiesMetaBox {
 	public function order_categories_meta_box( $order, $box ) {
 		$post = get_post( $order->get_id() );
 		post_categories_meta_box( $post, $box );
+	}
+
+	/**
+	 * Add the tags meta box to the order screen. This is just a wrapper around the post_tags_meta_box.
+	 *
+	 * @param \WC_Abstract_Order $order Order object.
+	 * @param array              $box   Meta box args.
+	 *
+	 * @return void
+	 */
+	public function order_tags_meta_box( $order, $box ) {
+		$post = get_post( $order->get_id() );
+		post_tags_meta_box( $post, $box );
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/TaxonomiesMetaBox.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/TaxonomiesMetaBox.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace Automattic\WooCommerce\Internal\Admin\Orders\MetaBoxes;
+
+/**
+ * TaxonomiesMetaBox class, renders taxonomy sidebar widget on order edit screen.
+ */
+class TaxonomiesMetaBox {
+
+	/**
+	 * Registers meta boxes to be rendered in order edit screen for taxonomies.
+	 *
+	 * Note: This is re-implementation of part of WP core's `register_and_do_post_meta_boxes` function. Since the code block that add meta box for taxonomies is not filterable, we have to re-implement it.
+	 *
+	 * @param string $screen_id Screen ID.
+	 * @param string $order_type Order type to register meta boxes for.
+	 *
+	 * @return void
+	 */
+	public function add_taxonomies_meta_boxes( string $screen_id, string $order_type ) {
+		include_once ABSPATH . 'wp-admin/includes/meta-boxes.php';
+		$taxonomies = get_object_taxonomies( $order_type );
+		// All taxonomies.
+		foreach ( $taxonomies as $tax_name ) {
+			$taxonomy = get_taxonomy( $tax_name );
+			if ( ! $taxonomy->show_ui || false === $taxonomy->meta_box_cb ) {
+				continue;
+			}
+
+			if ( 'post_categories_meta_box' === $taxonomy->meta_box_cb ) {
+				$taxonomy->meta_box_cb = array( $this, 'order_categories_meta_box' );
+			}
+
+			$label = $taxonomy->labels->name;
+
+			if ( ! is_taxonomy_hierarchical( $tax_name ) ) {
+				$tax_meta_box_id = 'tagsdiv-' . $tax_name;
+			} else {
+				$tax_meta_box_id = $tax_name . 'div';
+			}
+
+			add_meta_box(
+				$tax_meta_box_id,
+				$label,
+				$taxonomy->meta_box_cb,
+				$screen_id,
+				'side',
+				'core',
+				array(
+					'taxonomy'               => $tax_name,
+					'__back_compat_meta_box' => true,
+				)
+			);
+		}
+	}
+
+	/**
+	 * Save handler for taxonomy data.
+	 *
+	 * @param \WC_Abstract_Order $order Order object.
+	 * @param array|null         $taxonomy_input Taxonomy input passed from input.
+	 */
+	public function save_taxonomies( \WC_Abstract_Order $order, $taxonomy_input ) {
+		if ( ! isset( $taxonomy_input ) ) {
+			return;
+		}
+
+		$sanitized_tax_input = $this->sanitize_tax_input( $taxonomy_input );
+
+		$this->set_default_taxonomies( $order, $sanitized_tax_input );
+		$this->set_custom_taxonomies( $order, $sanitized_tax_input );
+	}
+
+	/**
+	 * Sanitize taxonomy input by calling sanitize callbacks for each registered taxonomy.
+	 *
+	 * @param array|null $taxonomy_data Nonce verified taxonomy input.
+	 *
+	 * @return array Sanitized taxonomy input.
+	 */
+	private function sanitize_tax_input( $taxonomy_data ) : array {
+		$sanitized_tax_input = array();
+		if ( ! is_array( $taxonomy_data ) ) {
+			return $sanitized_tax_input;
+		}
+
+		// Convert taxonomy input to term IDs, to avoid ambiguity.
+		foreach ( $taxonomy_data as $taxonomy => $terms ) {
+			$tax_object = get_taxonomy( $taxonomy );
+			if ( $tax_object && isset( $tax_object->meta_box_sanitize_cb ) ) {
+				$sanitized_tax_input[ $taxonomy ] = call_user_func_array( $tax_object->meta_box_sanitize_cb, array( $taxonomy, $terms ) );
+			}
+		}
+
+		return $sanitized_tax_input;
+	}
+
+	/**
+	 * Set default taxonomies for the order.
+	 *
+	 * Note: This is re-implementation of part of WP core's `wp_insert_post` function. Since the code block that set default taxonomies is not filterable, we have to re-implement it.
+	 *
+	 * @param \WC_Abstract_Order $order               Order object.
+	 * @param array              $sanitized_tax_input Sanitized taxonomy input.
+	 *
+	 * @return void
+	 */
+	private function set_default_taxonomies( \WC_Abstract_Order $order, array $sanitized_tax_input ) {
+		if ( 'auto-draft' === $order->get_status() ) {
+			return;
+		}
+
+		foreach ( get_object_taxonomies( $order->get_type(), 'object' ) as $taxonomy => $tax_object ) {
+			if ( empty( $tax_object->default_term ) ) {
+				return;
+			}
+
+			// Filter out empty terms.
+			if ( isset( $sanitized_tax_input[ $taxonomy ] ) && is_array( $sanitized_tax_input[ $taxonomy ] ) ) {
+				$sanitized_tax_input[ $taxonomy ] = array_filter( $sanitized_tax_input[ $taxonomy ] );
+			}
+
+			// Passed custom taxonomy list overwrites the existing list if not empty.
+			$terms = wp_get_object_terms( $order->get_id(), $taxonomy, array( 'fields' => 'ids' ) );
+			if ( ! empty( $terms ) && empty( $sanitized_tax_input[ $taxonomy ] ) ) {
+				$sanitized_tax_input[ $taxonomy ] = $terms;
+			}
+
+			if ( empty( $sanitized_tax_input[ $taxonomy ] ) ) {
+				$default_term_id = get_option( 'default_term_' . $taxonomy );
+				if ( ! empty( $default_term_id ) ) {
+					$sanitized_tax_input[ $taxonomy ] = array( (int) $default_term_id );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Set custom taxonomies for the order.
+	 *
+	 * Note: This is re-implementation of part of WP core's `wp_insert_post` function. Since the code block that set custom taxonomies is not filterable, we have to re-implement it.
+	 *
+	 * @param \WC_Abstract_Order $order               Order object.
+	 * @param array              $sanitized_tax_input Sanitized taxonomy input.
+	 *
+	 * @return void
+	 */
+	private function set_custom_taxonomies( \WC_Abstract_Order $order, array $sanitized_tax_input ) {
+		if ( empty( $sanitized_tax_input ) ) {
+			return;
+		}
+
+		foreach ( $sanitized_tax_input as $taxonomy => $tags ) {
+			$taxonomy_obj = get_taxonomy( $taxonomy );
+
+			if ( ! $taxonomy_obj ) {
+				/* translators: %s: Taxonomy name. */
+				_doing_it_wrong( __FUNCTION__, esc_html( sprintf( __( 'Invalid taxonomy: %s.', 'woocommerce' ), $taxonomy ) ), '7.9.0' );
+				continue;
+			}
+
+			// array = hierarchical, string = non-hierarchical.
+			if ( is_array( $tags ) ) {
+				$tags = array_filter( $tags );
+			}
+
+			if ( current_user_can( $taxonomy_obj->cap->assign_terms ) ) {
+				wp_set_post_terms( $order->get_id(), $tags, $taxonomy );
+			}
+		}
+	}
+
+	/**
+	 * Add the categories meta box to the order screen. This is just a wrapper around the post_categories_meta_box.
+	 *
+	 * @param \WC_Abstract_Order $order Order object.
+	 * @param array              $box   Meta box args.
+	 *
+	 * @return void
+	 */
+	public function order_categories_meta_box( $order, $box ) {
+		$post = get_post( $order->get_id() );
+		post_categories_meta_box( $post, $box );
+	}
+}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1641,6 +1641,84 @@ FROM $order_meta_table
 
 		$changes = $order->get_changes();
 		$this->update_address_index_meta( $order, $changes );
+		$default_taxonomies = $this->init_default_taxonomies( $order, array() );
+		$this->set_custom_taxonomies( $order, $default_taxonomies );
+	}
+
+	/**
+	 * Set default taxonomies for the order.
+	 *
+	 * Note: This is re-implementation of part of WP core's `wp_insert_post` function. Since the code block that set default taxonomies is not filterable, we have to re-implement it.
+	 *
+	 * @param \WC_Abstract_Order $order               Order object.
+	 * @param array              $sanitized_tax_input Sanitized taxonomy input.
+	 *
+	 * @return array Sanitized tax input with default taxonomies.
+	 */
+	public function init_default_taxonomies( \WC_Abstract_Order $order, array $sanitized_tax_input ) {
+		if ( 'auto-draft' === $order->get_status() ) {
+			return $sanitized_tax_input;
+		}
+
+		foreach ( get_object_taxonomies( $order->get_type(), 'object' ) as $taxonomy => $tax_object ) {
+			if ( empty( $tax_object->default_term ) ) {
+				return $sanitized_tax_input;
+			}
+
+			// Filter out empty terms.
+			if ( isset( $sanitized_tax_input[ $taxonomy ] ) && is_array( $sanitized_tax_input[ $taxonomy ] ) ) {
+				$sanitized_tax_input[ $taxonomy ] = array_filter( $sanitized_tax_input[ $taxonomy ] );
+			}
+
+			// Passed custom taxonomy list overwrites the existing list if not empty.
+			$terms = wp_get_object_terms( $order->get_id(), $taxonomy, array( 'fields' => 'ids' ) );
+			if ( ! empty( $terms ) && empty( $sanitized_tax_input[ $taxonomy ] ) ) {
+				$sanitized_tax_input[ $taxonomy ] = $terms;
+			}
+
+			if ( empty( $sanitized_tax_input[ $taxonomy ] ) ) {
+				$default_term_id = get_option( 'default_term_' . $taxonomy );
+				if ( ! empty( $default_term_id ) ) {
+					$sanitized_tax_input[ $taxonomy ] = array( (int) $default_term_id );
+				}
+			}
+		}
+		return $sanitized_tax_input;
+	}
+
+	/**
+	 * Set custom taxonomies for the order.
+	 *
+	 * Note: This is re-implementation of part of WP core's `wp_insert_post` function. Since the code block that set custom taxonomies is not filterable, we have to re-implement it.
+	 *
+	 * @param \WC_Abstract_Order $order               Order object.
+	 * @param array              $sanitized_tax_input Sanitized taxonomy input.
+	 *
+	 * @return void
+	 */
+	public function set_custom_taxonomies( \WC_Abstract_Order $order, array $sanitized_tax_input ) {
+		if ( empty( $sanitized_tax_input ) ) {
+			return;
+		}
+
+		foreach ( $sanitized_tax_input as $taxonomy => $tags ) {
+			$taxonomy_obj = get_taxonomy( $taxonomy );
+
+			if ( ! $taxonomy_obj ) {
+				/* translators: %s: Taxonomy name. */
+				_doing_it_wrong( __FUNCTION__, esc_html( sprintf( __( 'Invalid taxonomy: %s.', 'woocommerce' ), $taxonomy ) ), '7.9.0' );
+				continue;
+			}
+
+			// array = hierarchical, string = non-hierarchical.
+			if ( is_array( $tags ) ) {
+				$tags = array_filter( $tags );
+			}
+
+			if ( current_user_can( $taxonomy_obj->cap->assign_terms ) ) {
+				wp_set_post_terms( $order->get_id(), $tags, $taxonomy );
+			}
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/OrderAdminServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/OrderAdminServiceProvider.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\Internal\Admin\Orders\COTRedirectionController;
 use Automattic\WooCommerce\Internal\Admin\Orders\Edit;
 use Automattic\WooCommerce\Internal\Admin\Orders\EditLock;
 use Automattic\WooCommerce\Internal\Admin\Orders\ListTable;
+use Automattic\WooCommerce\Internal\Admin\Orders\MetaBoxes\TaxonomiesMetaBox;
 use Automattic\WooCommerce\Internal\Admin\Orders\PageController;
 use Automattic\WooCommerce\Internal\DependencyManagement\AbstractServiceProvider;
 
@@ -28,6 +29,7 @@ class OrderAdminServiceProvider extends AbstractServiceProvider {
 		Edit::class,
 		ListTable::class,
 		EditLock::class,
+		TaxonomiesMetaBox::class,
 	);
 
 	/**
@@ -41,5 +43,6 @@ class OrderAdminServiceProvider extends AbstractServiceProvider {
 		$this->share( Edit::class )->addArgument( PageController::class );
 		$this->share( ListTable::class )->addArgument( PageController::class );
 		$this->share( EditLock::class );
+		$this->share( TaxonomiesMetaBox::class );
 	}
 }

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/OrderAdminServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/OrderAdminServiceProvider.php
@@ -11,6 +11,7 @@ use Automattic\WooCommerce\Internal\Admin\Orders\EditLock;
 use Automattic\WooCommerce\Internal\Admin\Orders\ListTable;
 use Automattic\WooCommerce\Internal\Admin\Orders\MetaBoxes\TaxonomiesMetaBox;
 use Automattic\WooCommerce\Internal\Admin\Orders\PageController;
+use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
 use Automattic\WooCommerce\Internal\DependencyManagement\AbstractServiceProvider;
 
 /**
@@ -43,6 +44,6 @@ class OrderAdminServiceProvider extends AbstractServiceProvider {
 		$this->share( Edit::class )->addArgument( PageController::class );
 		$this->share( ListTable::class )->addArgument( PageController::class );
 		$this->share( EditLock::class );
-		$this->share( TaxonomiesMetaBox::class );
+		$this->share( TaxonomiesMetaBox::class )->addArgument( OrdersTableDataStore::class );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
+++ b/plugins/woocommerce/tests/php/includes/abstracts/class-wc-abstract-order-test.php
@@ -190,7 +190,7 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 	 */
 	public function test_apply_coupon_across_status() {
 		$coupon_code = 'coupon_test_count_across_status';
-		$coupon = WC_Helper_Coupon::create_coupon( $coupon_code );
+		$coupon      = WC_Helper_Coupon::create_coupon( $coupon_code );
 		$this->assertEquals( 0, $coupon->get_usage_count() );
 
 		$order = WC_Helper_Order::create_order();
@@ -253,8 +253,8 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 	 */
 	public function test_apply_coupon_stores_meta_data() {
 		$coupon_code = 'coupon_test_meta_data';
-		$coupon = WC_Helper_Coupon::create_coupon( $coupon_code );
-		$order  = WC_Helper_Order::create_order();
+		$coupon      = WC_Helper_Coupon::create_coupon( $coupon_code );
+		$order       = WC_Helper_Order::create_order();
 		$order->set_status( 'processing' );
 		$order->save();
 		$order->apply_coupon( $coupon_code );
@@ -323,5 +323,30 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 
 		$order = wc_get_order( $order->get_id() );
 		$this->assertInstanceOf( Automattic\WooCommerce\Admin\Overrides\Order::class, $order );
+	}
+
+	/**
+	 * @testDox When a taxonomy with a default term is set on the order, it's inserted when a new order is created.
+	 */
+	public function test_default_term_for_custom_taxonomy() {
+		$custom_taxonomy = register_taxonomy(
+			'custom_taxonomy',
+			'shop_order',
+			array(
+				'default_term' => 'new_term',
+			),
+		);
+
+		// Set user who has access to create term.
+		$current_user_id = get_current_user_id();
+		$user            = new WP_User( wp_create_user( 'test', '' ) );
+		$user->set_role( 'administrator' );
+		wp_set_current_user( $user->ID );
+
+		$order = wc_create_order();
+
+		wp_set_current_user( $current_user_id );
+		$order_terms = wp_list_pluck( wp_get_object_terms( $order->get_id(), $custom_taxonomy->name ), 'name' );
+		$this->assertContains( 'new_term', $order_terms );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds support to display taxonomy widgets on the order edit screen for HPOS, when a taxonomy is registered for the `shop_order` post type. This is already done by WP core for post edit screens, so we add similar functionality for HPOS as well.

Additionally, this also fixes a bug when a taxonomy with a default term is registered for order, but it does not get automatically added to the new orders.

Closes #38560 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

First, we are going to register a custom taxonomy for orders, by adding the following code snippet:

```php
function register_custom_taxonomy_gh_38676() {
	register_taxonomy(
		'custom_tag',
		'shop_order',
		array(
			'labels' => array(
				'name' => 'Custom Tag',
			),
			'default_term' => 'new_tag',
		),
	);
	register_taxonomy(
		'custom_category',
		'shop_order',
		array(
			'labels' => array(
				'name' => 'Custom Category',
			),
			'default_term' => 'new_category',
			'hierarchical' => true,
		),
	);
}
add_action( 'init', 'register_custom_taxonomy_gh_38676' );
```




1. Switch to HPOS as an authoritative data table.
2. In the sidebar, you should see the following two widgets for custom taxonomies we registered, like so:

<img width="339" alt="Screenshot 2023-06-12 at 6 31 19 PM" src="https://github.com/woocommerce/woocommerce/assets/7571618/3df3c7d6-a666-4ed3-a57a-b2d6120f6da9">

3. Add and remove categories and tags and click on update to make sure that changes persists, similar to how it works when posts are authoritative. By default, the tag `new_tag` and category `new_category` will already be applied to new order.

<!-- End testing instructions -->
