### PR TITLE
Ensure order ordering in order filter unit test

### DIFF
--- a/plugins/woocommerce/changelog/fix-unit-test-test_query_filters
+++ b/plugins/woocommerce/changelog/fix-unit-test-test_query_filters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure order ordering in order filter unit test

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
@@ -181,6 +181,7 @@ class OrdersTableQueryTests extends WC_Unit_Test_Case {
 	 */
 	public function test_query_filters() {
 		$order1 = new \WC_Order();
+		$order1->set_date_created( time() - HOUR_IN_SECONDS );
 		$order1->save();
 
 		$order2 = new \WC_Order();
@@ -198,10 +199,10 @@ class OrdersTableQueryTests extends WC_Unit_Test_Case {
 		$this->assertCount( 0, wc_get_orders( array() ) );
 		remove_all_filters( 'woocommerce_orders_table_query_clauses' );
 
-		// Force a query that sorts orders by id DESC (as opposed to the default date ASC) if a query arg is present.
+		// Force a query that sorts orders by id ASC (as opposed to the default date DESC) if a query arg is present.
 		$filter_callback = function( $clauses, $query, $query_args ) use ( $order1 ) {
 			if ( ! empty( $query_args['my_custom_arg'] ) ) {
-				$clauses['orderby'] = $query->get_table_name( 'orders' ) . '.id DESC';
+				$clauses['orderby'] = $query->get_table_name( 'orders' ) . '.id ASC';
 			}
 
 			return $clauses;
@@ -212,6 +213,7 @@ class OrdersTableQueryTests extends WC_Unit_Test_Case {
 			wc_get_orders(
 				array(
 					'return' => 'ids',
+					'my_custom_arg' => true,
 				)
 			),
 			array(
@@ -223,7 +225,6 @@ class OrdersTableQueryTests extends WC_Unit_Test_Case {
 			wc_get_orders(
 				array(
 					'return'        => 'ids',
-					'my_custom_arg' => true,
 				)
 			),
 			array(

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
@@ -200,7 +200,7 @@ class OrdersTableQueryTests extends WC_Unit_Test_Case {
 		remove_all_filters( 'woocommerce_orders_table_query_clauses' );
 
 		// Force a query that sorts orders by id ASC (as opposed to the default date DESC) if a query arg is present.
-		$filter_callback = function( $clauses, $query, $query_args ) use ( $order1 ) {
+		$filter_callback = function( $clauses, $query, $query_args ) {
 			if ( ! empty( $query_args['my_custom_arg'] ) ) {
 				$clauses['orderby'] = $query->get_table_name( 'orders' ) . '.id ASC';
 			}
@@ -212,7 +212,7 @@ class OrdersTableQueryTests extends WC_Unit_Test_Case {
 		$this->assertEquals(
 			wc_get_orders(
 				array(
-					'return' => 'ids',
+					'return'        => 'ids',
 					'my_custom_arg' => true,
 				)
 			),
@@ -224,7 +224,7 @@ class OrdersTableQueryTests extends WC_Unit_Test_Case {
 		$this->assertEquals(
 			wc_get_orders(
 				array(
-					'return'        => 'ids',
+					'return' => 'ids',
 				)
 			),
 			array(


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

The `test_query_filters()` function was passing most of the time because the creation date of `$order1` and `$order2` would round to the same time stamp. Per the change I made to the comment, `wc_get_orders()` default to returning the 10 most recent orders by order creation date (ie. what we see when we open the list table or the `wc/v3/orders` endpoint). 

This PR updates the test to ensure the correct default ordering by explicitly setting the creation date of `$order1`.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Code review
2. Unit tests pass in CI
