### PR TITLE
Remove editor-styles-wrapper class from product editor

### DIFF
--- a/packages/js/product-editor/changelog/update-remove-editor-styles-wrapper
+++ b/packages/js/product-editor/changelog/update-remove-editor-styles-wrapper
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove editor-styles-wrapper from product editor

--- a/packages/js/product-editor/src/components/block-editor/block-editor.tsx
+++ b/packages/js/product-editor/src/components/block-editor/block-editor.tsx
@@ -107,16 +107,14 @@ export function BlockEditor( {
 					onChange={ onChange }
 					settings={ settings }
 				>
-					<div className="editor-styles-wrapper">
-						{ /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */ }
-						{ /* @ts-ignore No types for this exist yet. */ }
-						<BlockEditorKeyboardShortcuts.Register />
-						<BlockTools>
-							<ObserveTyping>
-								<BlockList className="woocommerce-product-block-editor__block-list" />
-							</ObserveTyping>
-						</BlockTools>
-					</div>
+					{ /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */ }
+					{ /* @ts-ignore No types for this exist yet. */ }
+					<BlockEditorKeyboardShortcuts.Register />
+					<BlockTools>
+						<ObserveTyping>
+							<BlockList className="woocommerce-product-block-editor__block-list" />
+						</ObserveTyping>
+					</BlockTools>
 				</BlockEditorProvider>
 			</BlockContextProvider>
 		</div>

--- a/packages/js/product-editor/src/components/block-editor/style.scss
+++ b/packages/js/product-editor/src/components/block-editor/style.scss
@@ -14,6 +14,10 @@
 		font-family: var(--wp--preset--font-family--system-font);
 	}
 
+	h4 {
+		font-size: 16px;
+	}
+
 	label {
 		color: $gray-900;
 	}
@@ -64,26 +68,6 @@
 		margin-top: calc(2 * $gap);
 	}
 
-	.editor-styles-wrapper {
-		h4 {
-			font-size: 16px;
-		}
-
-		.block-editor-block-list__layout.is-root-container {
-			padding-left: calc(2 * $gap);
-			padding-right: calc(2 * $gap);
-			padding-bottom: 128px;
-
-			@include breakpoint(">782px") {
-				padding-left: 0;
-				padding-right: 0;
-				max-width: 650px;
-				margin-left: auto;
-				margin-right: auto;
-			}
-		}
-	}
-
 	.components-input-control {
 		&__input::placeholder {
 			color: $gray-700;
@@ -126,9 +110,24 @@
 		font-weight: 500;
 	}
 
-	.block-editor-block-list__layout
+	.block-editor-block-list__layout {
+		&.is-root-container {
+			padding-left: calc(2 * $gap);
+			padding-right: calc(2 * $gap);
+			padding-bottom: 128px;
+
+			@include breakpoint(">782px") {
+				padding-left: 0;
+				padding-right: 0;
+				max-width: 650px;
+				margin-left: auto;
+				margin-right: auto;
+			}
+		}
+
 		.block-editor-block-list__block:not([contenteditable]):focus:after {
-		display: none; // use important or increase specificity.
+			display: none; // use important or increase specificity.
+		}
 	}
 }
 

--- a/packages/js/product-editor/src/components/block-editor/style.scss
+++ b/packages/js/product-editor/src/components/block-editor/style.scss
@@ -26,6 +26,20 @@
 		text-decoration: none;
 	}
 
+	/*
+	 * Override default block margins and layout applied for themes without a theme.json file.
+	 *
+	 * If we no longer call `is_block_editor( true )` in the future for the product editor,
+	 * we can remove this.
+	 *
+	 * See: `wp_add_editor_classic_theme_styles()`
+	 */
+	:where(.wp-block) {
+		margin-bottom: 0;
+		margin-top: 0;
+		max-width: unset;
+	}
+
 	.has-error {
 		.components-base-control {
 			margin-bottom: 0;


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

_Note: This is a more focused (or rather, less ambitious) fix for #38607 than #38634. I still believe that something more along the lines of #38634 will be necessary in order to robustly prevent styles and scripts from being loaded and applied in the context of the product editor. But, the fix in this PR would still ideally be needed as well, for completeness, in case plugins/themes are loading styles with rules with the `.editor-styles-wrapper` selector._

_This PR does not prevent styles from being loaded that shouldn't be, as #38634 does (see below for the wide margins issue). They just aren't applied, since the rules do not match. Any scripts enqueued via `enqueue_block_assets` will still be loaded, which could, in theory result in unexpected behavior._

#### The problem

In #38495 we enabled the loading of custom editor-only blocks in the product block editor by setting the calling `WP_Screen::is_block_editor( true )`

https://github.com/woocommerce/woocommerce/blob/0458dafcb71e97cea8aff73a57e2f154d41004c3/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php#L680

This did enable custom editor-only blocks to properly load.

However, it also had the unfortunate side effect of enabling the enqueuing of assets that are only _really_ intended to be loaded for "the block editor" (the post/FSE editor). This can be easily seen by setting a site to use the [Storefront](https://wordpress.org/themes/storefront/) theme. This results in a gray background and incorrect spacing being applied to the product editor:

<img width="1115" alt="Screenshot 2023-06-05 at 09 25 46" src="https://github.com/woocommerce/woocommerce/assets/2098816/2c6a49a7-4c6d-435d-a3b4-2931d020bea9">

#### Why does this happen?

Storefront is using `enqueue_block_assets` to load custom styles for use in the block editor.

https://github.com/woocommerce/storefront/blob/b12b8368112272fa9bed18473b5514af96163d3d/inc/customizer/class-storefront-customizer.php#L31

```
add_action( 'enqueue_block_assets', array( $this, 'block_editor_customizer_css' ) );
```

The [`enqueue_block_assets`](https://developer.wordpress.org/reference/hooks/enqueue_block_assets/) action:

> Fires after enqueuing block assets for both editor and front-end.
> Call add_action on any hook before ‘wp_enqueue_scripts’.
> 
> In the function call you supply, simply use wp_enqueue_script and wp_enqueue_style to add your functionality to the Gutenberg editor.

These styles have rules with the `.editor-styles-wrapper` selector.

#### What about the wider margins seen with Storefront?

The wider margins seen with Storefront are not from Storefront's styles. They are because themes without a `theme.json` file get default layout and margin styles loaded via the `wp_add_editor_classic_theme_styles()` function.

In particular, there is a rule:

```css
html :where(.wp-block) {
  margin-bottom: 28px;
  margin-top: 28px;
  max-width: 840px;
}
```

This PR includes a commit, [9824140](https://github.com/woocommerce/woocommerce/pull/38681/commits/9824140d0b6b5a4a68958fc95f757f5a957fe72a), that overrides this.

If we update things in the future to not use `is_block_editor( true )` we wouldn't need to reset this, but for now this is an easy and small fix to ensure things look better when using themes such as Storefront.

Closes #38607 (not 100%, but the immediate issue is addressed with Storefront).

### Before and after screenshots

#### Before - Storefront

Note the gray section backgrounds and wider margins.

<img width="1097" alt="Storefront - before" src="https://github.com/woocommerce/woocommerce/assets/2098816/eea9169e-6104-4f4a-986b-3b53a7c7567e">

#### After - Storefront

No issues.

<img width="1097" alt="Storefront - after" src="https://github.com/woocommerce/woocommerce/assets/2098816/cea94906-72f6-463b-b571-928dde851569">

#### Before - Twenty Twenty-Three

No issues.

<img width="1097" alt="Twenty Twenty Three - before" src="https://github.com/woocommerce/woocommerce/assets/2098816/64ba2326-dafd-46f7-8c25-7d442c868fe0">

#### After - Twenty Twenty-Three

Still no issues.

<img width="1097" alt="Twenty Twenty Three - after" src="https://github.com/woocommerce/woocommerce/assets/2098816/4d5555f6-f47f-4745-83f7-29e388e76872">

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Set site theme to _Storefront_.
2. Use the [create-product-editor-block template](https://github.com/woocommerce/woocommerce/blob/trunk/packages/js/create-product-editor-block/README.md) to generate a new custom block extension.
    - Note: since we haven't published `@woocommerce/create-product-editor-block` yet, use the following form of the command to point to a local path:

```
npx @wordpress/create-block --template ./path/to/woocommerce/packages/js/create-product-editor-block
```

3. Make the following changes to the generated extension and rebuild it...
    - Remove the `script` property from the `block.json` (see #38496)

4. Load the block-based product editor.
5. Verify no gray background on the form sections, correct margins, and correct description preview.
6. Verify the custom block is rendered correctly (beautiful yellow background).
7. Repeat steps 4-6 with theme _Twenty Twenty-Three_ (with _Pilgrimage_ style) 

<!-- End testing instructions -->
