### PR TITLE
Fixes possible fatal error in legacy report code

### DIFF
--- a/plugins/woocommerce/changelog/fix-34118
+++ b/plugins/woocommerce/changelog/fix-34118
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Handle possibly empty refund value in reports (PHP 8.1+).

--- a/plugins/woocommerce/includes/admin/reports/class-wc-admin-report.php
+++ b/plugins/woocommerce/includes/admin/reports/class-wc-admin-report.php
@@ -512,7 +512,7 @@ class WC_Admin_Report {
 			}
 
 			if ( $data_key ) {
-				$prepared_data[ $time ][1] += $d->$data_key;
+				$prepared_data[ $time ][1] += is_numeric( $d->$data_key ) ? $d->$data_key : 0;
 			} else {
 				$prepared_data[ $time ][1] ++;
 			}

--- a/plugins/woocommerce/includes/admin/reports/class-wc-report-sales-by-date.php
+++ b/plugins/woocommerce/includes/admin/reports/class-wc-report-sales-by-date.php
@@ -326,7 +326,7 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 		);
 
 		foreach ( $this->report_data->partial_refunds as $key => $order ) {
-			$this->report_data->partial_refunds[ $key ]->net_refund = $order->total_refund - ( $order->total_shipping + $order->total_tax + $order->total_shipping_tax );
+			$this->report_data->partial_refunds[ $key ]->net_refund = (float) $order->total_refund - ( (float) $order->total_shipping + (float) $order->total_tax + (float) $order->total_shipping_tax );
 		}
 
 		/**


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR adds some typecasts to certain operations in the "Sales by date" legacy report that deal with partial refunds. This, to prevent a possible PHP error.

This is similar to what was added in #28403 but for full refunds.

Closes #34118.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

The instructions are a bit artificial as apparently the error occurs when a refund amount in the db is an empty string, which shouldn't happen under normal circumstances.

Also, the legacy report code assumes the datastore is set to posts (no HPOS tables), so there's also that 😅.

1. Either disable HPOS or make sure "WordPress posts table" is set as data store for orders in WC > Settings > Custom data stores.
2. Either create a new order with a few items (on the admin or by completing the checkout workflow) or choose an existing one.
3. Open the order from step 2 and add a partial refund to it:
   1. Click the "Refund" button.
   2. Enter a quantity less than the line's total in the checkbox next to any product line.
   3. Click "Refund <X> manually".
   4. Click OK.
4. Use phpMyAdmin (or similar) to set the refund amount for the order that was just created to an empty string. The following query should work:
   ```sql
   UPDATE wp_postmeta SET meta_value = '' WHERE meta_key = '_refund_amount' ORDER BY post_id DESC LIMIT 1
   ```
5. To make the report pick up the new value, you'll first have to clear transients: to do so, go to WC > Status > Tools and click "Clear transients".
6. Go to WC > Reports and in the date selector, make sure to make a selection that includes the order you created/chose in step 2.
7. On `trunk` a fatal error should be triggered. On this branch, no error occurs.

<!-- End testing instructions -->
