### PR TITLE
Address possible PHP deprecation warning in `/wc-admin/options` endpoint

### DIFF
--- a/plugins/woocommerce/changelog/fix-wc-admin-rest-options-error
+++ b/plugins/woocommerce/changelog/fix-wc-admin-rest-options-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Address possible PHP warning in wc-admin/options REST endpoint.

--- a/plugins/woocommerce/src/Admin/API/Options.php
+++ b/plugins/woocommerce/src/Admin/API/Options.php
@@ -233,9 +233,13 @@ class Options extends \WC_REST_Data_Controller {
 	 * @return array Options object with option values.
 	 */
 	public function get_options( $request ) {
-		$params  = ( isset( $request['options'] ) && is_string( $request['options'] ) ) ? explode( ',', $request['options'] ) : array();
 		$options = array();
 
+		if ( empty( $request['options'] ) || ! is_string( $request['options'] ) ) {
+			return $options;
+		}
+
+		$params = explode( ',', $request['options'] );
 		foreach ( $params as $option ) {
 			$options[ $option ] = get_option( $option );
 		}

--- a/plugins/woocommerce/src/Admin/API/Options.php
+++ b/plugins/woocommerce/src/Admin/API/Options.php
@@ -69,7 +69,7 @@ class Options extends \WC_REST_Data_Controller {
 	 * @return WP_Error|boolean
 	 */
 	public function get_item_permissions_check( $request ) {
-		$params  = ( isset( $request['options'] ) && is_string( $request['options'] ) ) ? explode( ',', $request['options'] ) : array();
+		$params = ( isset( $request['options'] ) && is_string( $request['options'] ) ) ? explode( ',', $request['options'] ) : array();
 
 		if ( ! $params ) {
 			return new \WP_Error( 'woocommerce_rest_cannot_view', __( 'You must supply an array of options.', 'woocommerce' ), 500 );

--- a/plugins/woocommerce/src/Admin/API/Options.php
+++ b/plugins/woocommerce/src/Admin/API/Options.php
@@ -69,9 +69,9 @@ class Options extends \WC_REST_Data_Controller {
 	 * @return WP_Error|boolean
 	 */
 	public function get_item_permissions_check( $request ) {
-		$params = explode( ',', $request['options'] );
+		$params  = ( isset( $request['options'] ) && is_string( $request['options'] ) ) ? explode( ',', $request['options'] ) : array();
 
-		if ( ! isset( $request['options'] ) || ! is_array( $params ) ) {
+		if ( ! $params ) {
 			return new \WP_Error( 'woocommerce_rest_cannot_view', __( 'You must supply an array of options.', 'woocommerce' ), 500 );
 		}
 
@@ -233,12 +233,8 @@ class Options extends \WC_REST_Data_Controller {
 	 * @return array Options object with option values.
 	 */
 	public function get_options( $request ) {
-		$params  = explode( ',', $request['options'] );
+		$params  = ( isset( $request['options'] ) && is_string( $request['options'] ) ) ? explode( ',', $request['options'] ) : array();
 		$options = array();
-
-		if ( ! is_array( $params ) ) {
-			return array();
-		}
 
 		foreach ( $params as $option ) {
 			$options[ $option ] = get_option( $option );


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

While working on the admin I noticed the following warning in my logs:

```
PHP Deprecated:  explode(): Passing null to parameter #2 ($string) of type string is deprecated in [...]/woocommerce/src/Admin/API/Options.php on line 72
```

I'm not sure exactly what part of WC is calling this (deprecated?) endpoint and either not passing or passing an empty set of "options" to it, but I could reliably reproduce by making direct requests to `/wp-json/wc-admin/options`.

This PR addresses the PHP deprecation warning.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Switch to PHP 8.1 or 8.2.
1. Check out `trunk`.
1. Using RapidAPI, Insomnia or a similar tool, make a request to `/wp-json/wc-admin/options` with no query params.
1. Make sure your logs show the warning indicated above.
1. Check out this branch.
1. Repeat step 2 and confirm the warning no longer appears.

<!-- End testing instructions -->
