### PR TITLE
Add tool selector option to iframe editor

### DIFF
--- a/packages/js/product-editor/changelog/add-38487
+++ b/packages/js/product-editor/changelog/add-38487
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add tool selector option to iframe editor

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
@@ -7,6 +7,9 @@ import { __ } from '@wordpress/i18n';
 import {
 	NavigableToolbar,
 	store as blockEditorStore,
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore ToolSelector exists in WordPress components.
+	ToolSelector,
 } from '@wordpress/block-editor';
 import { plus } from '@wordpress/icons';
 import {
@@ -33,8 +36,9 @@ export function HeaderToolbar() {
 	const { isInserterOpened, setIsInserterOpened } =
 		useContext( EditorContext );
 	const isWideViewport = useViewportMatch( 'wide' );
+	const isLargeViewport = useViewportMatch( 'medium' );
 	const inserterButton = useRef< HTMLButtonElement | null >( null );
-	const { isInserterEnabled } = useSelect( ( select ) => {
+	const { isInserterEnabled, isTextModeEnabled } = useSelect( ( select ) => {
 		const {
 			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 			// @ts-ignore These selectors are available in the block data store.
@@ -45,9 +49,13 @@ export function HeaderToolbar() {
 			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 			// @ts-ignore These selectors are available in the block data store.
 			getBlockSelectionEnd,
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore These selectors are available in the block data store.
+			__unstableGetEditorMode: getEditorMode,
 		} = select( blockEditorStore );
 
 		return {
+			isTextModeEnabled: getEditorMode() === 'text',
 			isInserterEnabled: hasInserterItems(
 				getBlockRootClientId( getBlockSelectionEnd() )
 			),
@@ -98,6 +106,12 @@ export function HeaderToolbar() {
 				/>
 				{ isWideViewport && (
 					<>
+						{ isLargeViewport && (
+							<ToolbarItem
+								as={ ToolSelector }
+								disabled={ isTextModeEnabled }
+							/>
+						) }
 						<ToolbarItem as={ EditorHistoryUndo } />
 						<ToolbarItem as={ EditorHistoryRedo } />
 					</>

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
@@ -4,13 +4,6 @@
 import { useSelect } from '@wordpress/data';
 import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
-import {
-	NavigableToolbar,
-	store as blockEditorStore,
-	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-	// @ts-ignore ToolSelector exists in WordPress components.
-	ToolSelector,
-} from '@wordpress/block-editor';
 import { plus } from '@wordpress/icons';
 import {
 	createElement,
@@ -20,6 +13,13 @@ import {
 	useContext,
 } from '@wordpress/element';
 import { MouseEvent } from 'react';
+import {
+	NavigableToolbar,
+	store as blockEditorStore,
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore ToolSelector exists in WordPress components.
+	ToolSelector,
+} from '@wordpress/block-editor';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore ToolbarItem exists in WordPress components.
 // eslint-disable-next-line @woocommerce/dependency-group


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<img width="391" alt="Screen Shot 2023-06-12 at 3 23 11 PM" src="https://github.com/woocommerce/woocommerce/assets/10561050/d7526374-8d07-4dc5-b59b-4b4968873817">

Closes #38487 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to WooCommerce -> Settings -> Advanced -> Features and enable the Product Blocks Editor.
2. Navigate to the Add Product page
3. Click on "Add description"
4. Make sure your viewport is "wide" (laptop size or up)
5. Click on the tool selector and check that you can toggle between "Select" and "Edit" mode
6. Clicking on a block a couple of times should toggle back to "Edit" mode and be reflected in the toolbar

<!-- End testing instructions -->
