### PR TITLE
Add re-migrate support to HPOS CLI.

### DIFF
--- a/plugins/woocommerce/changelog/fix-38660
+++ b/plugins/woocommerce/changelog/fix-38660
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add re-migrate support to HPOS CLI.

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -304,6 +304,11 @@ class CLIRunner {
 	 * ---
 	 * default: Output of function `wc_get_order_types( 'cot-migration' )`
 	 *
+	 * [--re-migrate]
+	 * : Attempt to re-migrate orders that failed verification. You should only use this option when you have never run the site with HPOS as authoritative source of order data yet, otherwise, you risk stale data overwriting the more recent data.
+	 * This option can only be enabled when --verbose flag is also set.
+	 * default: false
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     # Verify migrated order data, 500 orders at a time.
@@ -327,6 +332,7 @@ class CLIRunner {
 				'end-at'      => - 1,
 				'verbose'     => false,
 				'order-types' => '',
+				're-migrate'  => false,
 			)
 		);
 
@@ -340,6 +346,7 @@ class CLIRunner {
 		$batch_size     = ( (int) $assoc_args['batch-size'] ) === 0 ? 500 : (int) $assoc_args['batch-size'];
 		$verbose        = (bool) $assoc_args['verbose'];
 		$order_types    = wc_get_order_types( 'cot-migration' );
+		$remigrate      = (bool) $assoc_args['re-migrate'];
 		if ( ! empty( $assoc_args['order-types'] ) ) {
 			$passed_order_types = array_map( 'trim', explode( ',', $assoc_args['order-types'] ) );
 			$order_types        = array_intersect( $order_types, $passed_order_types );
@@ -415,6 +422,36 @@ class CLIRunner {
 						$errors
 					)
 				);
+				if ( $remigrate ) {
+					WP_CLI::warning(
+						sprintf(
+							__( 'Attempting to remigrate...', 'woocommerce')
+						)
+					);
+					$failed_ids = array_keys( $failed_ids_in_current_batch );
+					$this->synchronizer->process_batch( $failed_ids );
+					$errors_in_remigrate_batch = $this->post_to_cot_migrator->verify_migrated_orders( $failed_ids );
+					$errors_in_remigrate_batch = $this->verify_meta_data( $failed_ids, $errors_in_remigrate_batch );
+					if ( count( $errors_in_remigrate_batch ) > 0 ) {
+						// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r -- This is a CLI command and debugging code is intended.
+						$formatted_errors = print_r( $errors_in_remigrate_batch, true );
+						WP_CLI::warning(
+							sprintf(
+							/* Translators: %1$d is number of errors and %2$s is the formatted array of order IDs. */
+								_n(
+									'%1$d error found: %2$s when re-migrating order. Please review the error above.',
+									'%1$d errors found: %2$s when re-migrating orders. Please review the errors above.',
+									count( $errors_in_remigrate_batch ),
+									'woocommerce'
+								),
+								count( $errors_in_remigrate_batch ),
+								$formatted_errors
+							)
+						);
+					} else {
+						WP_CLI::warning( 'Re-migration successful.', 'woocommerce' );
+					}
+				}
 			}
 
 			$progress->tick();

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -305,7 +305,7 @@ class CLIRunner {
 	 * default: Output of function `wc_get_order_types( 'cot-migration' )`
 	 *
 	 * [--re-migrate]
-	 * : Attempt to re-migrate orders that failed verification. You should only use this option when you have never run the site with HPOS as authoritative source of order data yet, otherwise, you risk stale data overwriting the more recent data.
+	 * : Attempt to re-migrate orders that failed verification. You should only use this option when you have never run the site with HPOS as authoritative source of order data yet, or you have manually checked the reported errors, otherwise, you risk stale data overwriting the more recent data.
 	 * This option can only be enabled when --verbose flag is also set.
 	 * default: false
 	 *
@@ -425,7 +425,7 @@ class CLIRunner {
 				if ( $remigrate ) {
 					WP_CLI::warning(
 						sprintf(
-							__( 'Attempting to remigrate...', 'woocommerce')
+							__( 'Attempting to remigrate...', 'woocommerce' )
 						)
 					);
 					$failed_ids = array_keys( $failed_ids_in_current_batch );

--- a/plugins/woocommerce/src/Database/Migrations/MetaToCustomTableMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/MetaToCustomTableMigrator.php
@@ -243,13 +243,7 @@ abstract class MetaToCustomTableMigrator extends TableMigrator {
 		$to_insert = array_diff_key( $data['data'], $existing_records );
 		$this->process_insert_batch( $to_insert );
 
-		$existing_records = array_filter(
-			$existing_records,
-			function( $record_data ) {
-				return '1' === $record_data->modified;
-			}
-		);
-		$to_update        = array_intersect_key( $data['data'], $existing_records );
+		$to_update = array_intersect_key( $data['data'], $existing_records );
 		$this->process_update_batch( $to_update, $existing_records );
 	}
 
@@ -357,38 +351,13 @@ abstract class MetaToCustomTableMigrator extends TableMigrator {
 
 		$entity_id_placeholder = implode( ',', array_fill( 0, count( $entity_ids ), '%d' ) );
 
-		// Additional SQL to check if the row needs update according to the column mapping.
-		// The IFNULL and CHAR(0) "hack" is needed because NULLs can't be directly compared in SQL.
-		$modified_selector   = array();
-		$core_column_mapping = array_filter(
-			$this->core_column_mapping,
-			function( $mapping ) {
-				return ! isset( $mapping['select_clause'] );
-			}
-		);
-		foreach ( $core_column_mapping as $column_name => $mapping ) {
-			if ( $column_name === $source_primary_key_column ) {
-				continue;
-			}
-			$modified_selector[] =
-				"IFNULL(source.$column_name,CHAR(0)) != IFNULL(destination.{$mapping['destination']},CHAR(0))"
-				. ( 'string' === $mapping['type'] ? ' COLLATE ' . $wpdb->collate : '' );
-		}
-
-		if ( empty( $modified_selector ) ) {
-			$modified_selector = ', 1 AS modified';
-		} else {
-			$modified_selector = trim( implode( ' OR ', $modified_selector ) );
-			$modified_selector = ", if( $modified_selector, 1, 0 ) AS modified";
-		}
-
 		$additional_where = $this->get_additional_where_clause_for_get_data_to_insert_or_update( $entity_ids );
 
 		$already_migrated_entity_ids = $this->db_get_results(
 			$wpdb->prepare(
 			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- All columns and table names are hardcoded.
 				"
-SELECT source.`$source_primary_key_column` as source_id, destination.`$destination_primary_key_column` as destination_id $modified_selector
+SELECT source.`$source_primary_key_column` as source_id, destination.`$destination_primary_key_column` as destination_id
 FROM `$destination_table` destination
 JOIN `$source_table` source ON source.`$source_destination_join_column` = destination.`$destination_source_join_column`
 WHERE source.`$source_primary_key_column` IN ( $entity_id_placeholder ) $additional_where


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds support to re-migrate orders on the fly for orders that failed verification. This enhancement is specially helpful for large sites that does not have the sync on all the time, but have run migrate CLI periodically.

Closes #38660 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. With posts authoritative, enable sync.
2. Turn off the sync when both HPOS and posts tables are in sync.
3. Edit any existing order, or add a new order so that the out of sync condition can be simulated.
4. Run the CLI command like so: `wp wc cot verify_cot_data --verbose --re-migrate`. In the output, you will first see the order that you have edited shown as error and out of sync. This will be followed by message: `Warning: Attempting to remigrate` and then order will be re-migrated.

<!-- End testing instructions -->
