### PR TITLE
Product Editor Onboarding: Add About the editor... option the more menu in product block editor

### DIFF
--- a/plugins/woocommerce-admin/client/products/fills/more-menu-items/about-the-editor-menu-item.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/more-menu-items/about-the-editor-menu-item.tsx
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { MenuItem } from '@wordpress/components';
+import { info, Icon } from '@wordpress/icons';
+
+export const AboutTheEditorMenuItem = () => {
+	return (
+		<MenuItem
+			onClick={ () => {} }
+			icon={ <Icon icon={ info } /> }
+			iconPosition="right"
+		>
+			{ __( 'About the editor…', 'woocommerce' ) }
+		</MenuItem>
+	);
+};

--- a/plugins/woocommerce-admin/client/products/fills/more-menu-items/about-the-editor-menu-item.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/more-menu-items/about-the-editor-menu-item.tsx
@@ -4,15 +4,38 @@
 import { __ } from '@wordpress/i18n';
 import { MenuItem } from '@wordpress/components';
 import { info, Icon } from '@wordpress/icons';
+import { useState } from '@wordpress/element';
 
-export const AboutTheEditorMenuItem = () => {
+/**
+ * Internal dependencies
+ */
+import BlockEditorGuide from '~/products/tour/block-editor/block-editor-guide';
+
+export const AboutTheEditorMenuItem = ( {
+	onClose,
+}: {
+	onClose: () => void;
+} ) => {
+	const [ isGuideOpen, setIsGuideOpen ] = useState( false );
 	return (
-		<MenuItem
-			onClick={ () => {} }
-			icon={ <Icon icon={ info } /> }
-			iconPosition="right"
-		>
-			{ __( 'About the editor…', 'woocommerce' ) }
-		</MenuItem>
+		<>
+			<MenuItem
+				onClick={ () => {
+					setIsGuideOpen( true );
+				} }
+				icon={ <Icon icon={ info } /> }
+				iconPosition="right"
+			>
+				{ __( 'About the editor…', 'woocommerce' ) }
+			</MenuItem>
+			{ isGuideOpen && (
+				<BlockEditorGuide
+					onCloseGuide={ () => {
+						setIsGuideOpen( false );
+						onClose();
+					} }
+				/>
+			) }
+		</>
 	);
 };

--- a/plugins/woocommerce-admin/client/products/fills/more-menu-items/about-the-editor-menu-item.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/more-menu-items/about-the-editor-menu-item.tsx
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { MenuItem } from '@wordpress/components';
 import { info, Icon } from '@wordpress/icons';
 import { useState } from '@wordpress/element';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -21,6 +22,9 @@ export const AboutTheEditorMenuItem = ( {
 		<>
 			<MenuItem
 				onClick={ () => {
+					recordEvent(
+						'block_product_editor_about_the_editor_menu_item_clicked'
+					);
 					setIsGuideOpen( true );
 				} }
 				icon={ <Icon icon={ info } /> }

--- a/plugins/woocommerce-admin/client/products/fills/more-menu-items/index.ts
+++ b/plugins/woocommerce-admin/client/products/fills/more-menu-items/index.ts
@@ -1,2 +1,3 @@
 export * from './feedback-menu-item';
 export * from './classic-editor-menu-item';
+export * from './about-the-editor-menu-item';

--- a/plugins/woocommerce-admin/client/products/fills/product-block-editor-fills.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/product-block-editor-fills.tsx
@@ -19,6 +19,7 @@ import { useEntityProp } from '@wordpress/core-data';
 import {
 	FeedbackMenuItem,
 	ClassicEditorMenuItem,
+	AboutTheEditorMenuItem,
 } from '../fills/more-menu-items';
 
 const MoreMenuFill = ( { onClose }: { onClose: () => void } ) => {
@@ -28,6 +29,7 @@ const MoreMenuFill = ( { onClose }: { onClose: () => void } ) => {
 		<>
 			<FeedbackMenuItem onClose={ onClose } />
 			<ClassicEditorMenuItem productId={ id } onClose={ onClose } />
+			<AboutTheEditorMenuItem onClose={ onClose } />
 		</>
 	);
 };

--- a/plugins/woocommerce-admin/client/products/product-more-menu.tsx
+++ b/plugins/woocommerce-admin/client/products/product-more-menu.tsx
@@ -17,7 +17,6 @@ import { ALLOW_TRACKING_OPTION_NAME } from '@woocommerce/customer-effort-score';
 import {
 	FeedbackMenuItem,
 	ClassicEditorMenuItem,
-	AboutTheEditorMenuItem,
 } from './fills/more-menu-items';
 
 import './product-more-menu.scss';
@@ -55,7 +54,6 @@ export const ProductMoreMenu = () => {
 							productId={ values.id }
 							onClose={ onClose }
 						/>
-						<AboutTheEditorMenuItem />
 					</>
 				) }
 			</DropdownMenu>

--- a/plugins/woocommerce-admin/client/products/product-more-menu.tsx
+++ b/plugins/woocommerce-admin/client/products/product-more-menu.tsx
@@ -17,6 +17,7 @@ import { ALLOW_TRACKING_OPTION_NAME } from '@woocommerce/customer-effort-score';
 import {
 	FeedbackMenuItem,
 	ClassicEditorMenuItem,
+	AboutTheEditorMenuItem,
 } from './fills/more-menu-items';
 
 import './product-more-menu.scss';
@@ -54,6 +55,7 @@ export const ProductMoreMenu = () => {
 							productId={ values.id }
 							onClose={ onClose }
 						/>
+						<AboutTheEditorMenuItem />
 					</>
 				) }
 			</DropdownMenu>

--- a/plugins/woocommerce/changelog/add-about-the-form
+++ b/plugins/woocommerce/changelog/add-about-the-form
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Product Editor Onboarding: Add About the editor... option the more menu in product block editor


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Add a new menu item to the "More" menu in the block product editor, which (re) opens the onboarding guide.

Closes #38522.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Open the block product editor;
2. On the top right of the editor, click on the three dots button, and click on "About the editor...";
3. The tracks event `wcadmin_block_product_editor_about_the_editor_menu_item_clicked` should have been fired;
4. The Guide should be shown correctly.
5. You should be able to navigate between the steps and close it.

<!-- End testing instructions -->
