### PR TITLE
Replace 'use classic editor' with 'Turn off the new product editor' in options menu

### DIFF
--- a/plugins/woocommerce-admin/client/products/fills/more-menu-items/classic-editor-menu-item.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/more-menu-items/classic-editor-menu-item.tsx
@@ -14,7 +14,6 @@ import {
 /**
  * Internal dependencies
  */
-import { ClassicEditorIcon } from '../../images/classic-editor-icon';
 import { getAdminSetting } from '~/utils/admin-settings';
 
 export const ClassicEditorMenuItem = ( {
@@ -67,10 +66,12 @@ export const ClassicEditorMenuItem = ( {
 				}
 				onClose();
 			} }
-			icon={ <ClassicEditorIcon /> }
-			iconPosition="right"
+			info={ __(
+				'Save changes and go back to the classic product editing screen.',
+				'woocommerce'
+			) }
 		>
-			{ __( 'Use the classic editor', 'woocommerce' ) }
+			{ __( 'Turn off the new product form', 'woocommerce' ) }
 		</MenuItem>
 	);
 };

--- a/plugins/woocommerce/changelog/add-38575
+++ b/plugins/woocommerce/changelog/add-38575
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Replace 'use classic editor' with 'Turn off the new product editor' in options menu#38575


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #38575

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure the `Try the new product editor` checkbox is checked.
3. Go to `/wp-admin/admin.php?page=wc-admin&path=/add-product`
4. Click the `Options` menu
5. Check that all requirements described in #38575 are working as defined there.

<!-- End testing instructions -->
