### PR TITLE
Add activation option workaround to trigger `woocommerce_newly_installed` action

### DIFF
--- a/plugins/woocommerce/changelog/fix-38682-newly-installed-hook
+++ b/plugins/woocommerce/changelog/fix-38682-newly-installed-hook
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Trigger "woocommerce_newly_installed" hook for new installations

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -273,7 +273,7 @@ class WC_Install {
 			 * @since 6.5.0
 			 */
 			do_action( 'woocommerce_newly_installed' );
-			do_action_deprecated( 'woocommerce_admin_newly_installed', array(), '6.5.1', 'woocommerce_newly_installed' );
+			do_action_deprecated( 'woocommerce_admin_newly_installed', array(), '6.5.0', 'woocommerce_newly_installed' );
 
 			update_option( self::NEWLY_INSTALLED_OPTION, 'no' );
 		}

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -13,6 +13,7 @@ use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Registe
 use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Synchronize as Download_Directories_Sync;
 use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
 use Automattic\WooCommerce\Internal\WCCom\ConnectionHelper as WCConnectionHelper;
+use Automattic\WooCommerce\Internal\Traits\AccessiblePrivateMethods;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -20,6 +21,7 @@ defined( 'ABSPATH' ) || exit;
  * WC_Install Class.
  */
 class WC_Install {
+	use AccessiblePrivateMethods;
 
 	/**
 	 * DB updates and callbacks that need to be run per version.
@@ -247,7 +249,6 @@ class WC_Install {
 	public static function init() {
 		add_action( 'init', array( __CLASS__, 'check_version' ), 5 );
 		add_action( 'init', array( __CLASS__, 'manual_database_update' ), 20 );
-		add_action( 'admin_init', array( __CLASS__, 'newly_installed' ) );
 		add_action( 'admin_init', array( __CLASS__, 'wc_admin_db_update_notice' ) );
 		add_action( 'admin_init', array( __CLASS__, 'add_admin_note_after_page_created' ) );
 		add_action( 'woocommerce_run_update_callback', array( __CLASS__, 'run_update_callback' ) );
@@ -258,6 +259,9 @@ class WC_Install {
 		add_filter( 'plugin_row_meta', array( __CLASS__, 'plugin_row_meta' ), 10, 2 );
 		add_filter( 'wpmu_drop_tables', array( __CLASS__, 'wpmu_drop_tables' ) );
 		add_filter( 'cron_schedules', array( __CLASS__, 'cron_schedules' ) );
+
+		// Register the `woocommerce_newly_installed` action using AccessiblePrivateMethods::add_action().
+		self::add_action( 'admin_init', array( __CLASS__, 'newly_installed' ) );
 	}
 
 	/**
@@ -265,7 +269,7 @@ class WC_Install {
 	 *
 	 * @since x.x.x
 	 */
-	public static function newly_installed() {
+	private static function newly_installed() {
 		if ( 'yes' === get_option( self::NEWLY_INSTALLED_OPTION, false ) ) {
 			/**
 			 * Run when WooCommerce has been installed for the first time.

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -259,15 +259,13 @@ class WC_Install {
 		add_filter( 'plugin_row_meta', array( __CLASS__, 'plugin_row_meta' ), 10, 2 );
 		add_filter( 'wpmu_drop_tables', array( __CLASS__, 'wpmu_drop_tables' ) );
 		add_filter( 'cron_schedules', array( __CLASS__, 'cron_schedules' ) );
-
-		// Register the `woocommerce_newly_installed` action using AccessiblePrivateMethods::add_action().
 		self::add_action( 'admin_init', array( __CLASS__, 'newly_installed' ) );
 	}
 
 	/**
 	 * Trigger `woocommerce_newly_installed` action for new installations.
 	 *
-	 * @since x.x.x
+	 * @since 8.0.0
 	 */
 	private static function newly_installed() {
 		if ( 'yes' === get_option( self::NEWLY_INSTALLED_OPTION, false ) ) {

--- a/plugins/woocommerce/src/Internal/Admin/Notes/CouponPageMoved.php
+++ b/plugins/woocommerce/src/Internal/Admin/Notes/CouponPageMoved.php
@@ -35,7 +35,7 @@ class CouponPageMoved {
 
 		add_action( 'admin_init', [ $this, 'possibly_add_note' ] );
 		add_action( 'admin_init', [ $this, 'redirect_to_coupons' ] );
-		add_action( 'woocommerce_admin_newly_installed', [ $this, 'disable_legacy_menu_for_new_install' ] );
+		add_action( 'woocommerce_newly_installed', [ $this, 'disable_legacy_menu_for_new_install' ] );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/install.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/install.php
@@ -132,13 +132,19 @@ class WC_Admin_Tests_Install extends WP_UnitTestCase {
 	 * Test the following options are created.
 	 *
 	 * - woocommerce_admin_install_timestamp
+	 * - WC_Install::NEWLY_INSTALLED_OPTION
 	 *
 	 * @return void
 	 */
 	public function test_options_are_set() {
 		delete_transient( 'wc_installing' );
 		WC_Install::install();
-		$options = array( 'woocommerce_admin_install_timestamp' );
+
+		$options = array(
+			'woocommerce_admin_install_timestamp',
+			WC_Install::NEWLY_INSTALLED_OPTION,
+		);
+
 		foreach ( $options as $option ) {
 			$this->assertNotFalse( get_option( $option ) );
 		}
@@ -168,13 +174,19 @@ class WC_Admin_Tests_Install extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test woocommerce_newly_installed action gets fired.
+	 * Test woocommerce_newly_installed action gets fired and the option is set to 'no'.
+	 *
 	 * @return void
 	 */
 	public function test_woocommerce_newly_installed_action() {
-		delete_option( 'woocommerce_version' );
-		WC_Install::check_version();
-		$this->assertTrue( did_action( 'woocommerce_newly_installed' ) > 0 );
+		update_option( WC_Install::NEWLY_INSTALLED_OPTION, 'yes' );
+
+		// Call twice to ensure `woocommerce_newly_installed` is only triggered once.
+		WC_Install::newly_installed();
+		WC_Install::newly_installed();
+
+		$this->assertTrue( 1 === did_action( 'woocommerce_newly_installed' ) );
+		$this->assertEquals( get_option( WC_Install::NEWLY_INSTALLED_OPTION ), 'no' );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds an [option workaround](https://developer.wordpress.org/reference/functions/register_activation_hook/#process-flow) for new installations of WooCommerce so that the `woocommerce_newly_installed` hook is triggered the first time `admin_init` runs after activation.

Additionally, the action name used in `CouponPageMoved.php` is updated to the newer `woocommerce_newly_installed`.

Closes #38682

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Setup a new environment that WooCommerce has not previously been installed on
2. Activate WooCommerce
3. Confirm that the legacy menu `WooCommerce > Coupons` is not added
4. Go to `wp-admin/options.php`, search for `woocommerce_newly_installed`, and confirm the value is `no`

<!-- End testing instructions -->
