### PR TITLE
Update status only when its changed.

### DIFF
--- a/plugins/woocommerce/changelog/fix-35951
+++ b/plugins/woocommerce/changelog/fix-35951
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update status only when it's changed.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1738,8 +1738,8 @@ FROM $order_meta_table
 
 		$changes['type'] = $order->get_type();
 
-		// Make sure 'status' is correct.
-		if ( array_key_exists( 'status', $column_mapping ) ) {
+		// Make sure 'status' is correctly prefixed.
+		if ( array_key_exists( 'status', $column_mapping ) && array_key_exists( 'status', $changes ) ) {
 			$changes['status'] = $this->get_post_status( $order );
 		}
 

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -2132,4 +2132,20 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 
 		$this->assertEquals( 1, $result );
 	}
+
+	/**
+	 * @testDox When saving an order, status is automatically prefixed even if it was not earlier.
+	 */
+	public function test_get_db_row_from_order_only_prefixed_status_is_written_to_db() {
+		$order = wc_create_order();
+
+		$order->set_status( 'completed' );
+		$db_row_callback = function ( $order, $only_changes ) {
+			return $this->get_db_row_from_order( $order, $this->order_column_mapping, $only_changes );
+		};
+
+		$db_row = $db_row_callback->call( $this->sut, $order, false );
+
+		$this->assertEquals( 'wc-completed', $db_row['data']['status'] );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We were earlier saving status anytime the `save` method was called, this PR updates the logic to only save status when it's actually being changed to prevent unnecessary inserts.

Closes #35951

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

This is mostly a performance improvement, and does not impact functionality directly so no specific instructions are needed. Besides, changing and saving order status is very well captured by E2E tests, so as long as E2E tests with HPOS enabled are passing, this change should be covered.

<!-- End testing instructions -->
