### PR TITLE
Fix empty state for currency inputs in product editor

### DIFF
--- a/packages/js/product-editor/changelog/fix-38623
+++ b/packages/js/product-editor/changelog/fix-38623
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix empty state for currency inputs in product editor

--- a/packages/js/product-editor/src/hooks/use-currency-input-props.ts
+++ b/packages/js/product-editor/src/hooks/use-currency-input-props.ts
@@ -81,7 +81,7 @@ export const useCurrencyInputProps = ( {
 			}
 		},
 		onChange( newValue: string ) {
-			const sanitizeValue = sanitizePrice( newValue || '0' );
+			const sanitizeValue = sanitizePrice( newValue );
 			if ( onChange ) {
 				onChange( sanitizeValue );
 			}

--- a/packages/js/product-editor/src/hooks/use-product-helper.ts
+++ b/packages/js/product-editor/src/hooks/use-product-helper.ts
@@ -312,6 +312,10 @@ export function useProductHelper() {
 	 */
 	const sanitizePrice = useCallback(
 		( price: string ) => {
+			if ( ! price.length ) {
+				return '';
+			}
+
 			const { getCurrencyConfig } = context;
 			const { decimalSeparator } = getCurrencyConfig();
 			// Build regex to strip out everything except digits, decimal point and minus sign.


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

Previously when adding a number and removing it from a currency input, the input would be reverted to `0.00`.  We should be able to completely clear this field.

Closes #38623  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Navigate to WooCommerce -> Settings -> Advanced -> Features and enable the product editor feature
2. Navigate to Add Product
3. Add a number to the price field
4. Delete the number from the price field
5. The field should remain empty

<!-- End testing instructions -->
