### PR TITLE
Fix transient notices overlapping product editor footer (take 2)

### DIFF
--- a/packages/js/product-editor/changelog/fix-notices-overlapping-footer-2
+++ b/packages/js/product-editor/changelog/fix-notices-overlapping-footer-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix overlapping TransientNotices with product editor footer

--- a/packages/js/product-editor/src/components/editor/editor.tsx
+++ b/packages/js/product-editor/src/components/editor/editor.tsx
@@ -86,13 +86,17 @@ export function Editor( { product, settings }: EditorProps ) {
 											<PluginArea scope="woocommerce-product-block-editor" />
 										</>
 									}
-									footer={ <Footer product={ product } /> }
 								/>
 
 								<Popover.Slot />
 							</ValidationProvider>
 						</SlotFillProvider>
 					</ShortcutProvider>
+					{ /* We put Footer here instead of in InterfaceSkeleton because Footer uses
+					WooFooterItem to actually render in the WooFooterItem.Slot defined by
+					WooCommerce Admin. And, we need to put it outside of the SlotFillProvider
+					we create in this component. */ }
+					<Footer product={ product } />
 				</EntityProvider>
 			</StrictMode>
 		</LayoutContextProvider>

--- a/packages/js/product-editor/src/components/feedback-bar/feedback-bar.tsx
+++ b/packages/js/product-editor/src/components/feedback-bar/feedback-bar.tsx
@@ -9,7 +9,6 @@ import {
 	Fragment,
 } from '@wordpress/element';
 import { closeSmall } from '@wordpress/icons';
-import { WooFooterItem } from '@woocommerce/admin-layout';
 import { Pill } from '@woocommerce/components';
 import { useCustomerEffortScoreModal } from '@woocommerce/customer-effort-score';
 import { Product } from '@woocommerce/data';
@@ -93,42 +92,40 @@ export function FeedbackBar( { product }: FeedbackBarProps ) {
 	return (
 		<>
 			{ shouldShowFeedbackBar && (
-				<WooFooterItem>
-					<div className="woocommerce-product-mvp-ces-footer">
-						<Pill>Beta</Pill>
-						<div className="woocommerce-product-mvp-ces-footer__message">
-							{ createInterpolateElement(
-								__(
-									'How is your experience with the new product form? <span><shareButton>Share feedback</shareButton> or <turnOffButton>turn it off</turnOffButton></span>',
-									'woocommerce'
+				<div className="woocommerce-product-mvp-ces-footer">
+					<Pill>Beta</Pill>
+					<div className="woocommerce-product-mvp-ces-footer__message">
+						{ createInterpolateElement(
+							__(
+								'How is your experience with the new product form? <span><shareButton>Share feedback</shareButton> or <turnOffButton>turn it off</turnOffButton></span>',
+								'woocommerce'
+							),
+							{
+								span: (
+									<span className="woocommerce-product-mvp-ces-footer__message-buttons" />
 								),
-								{
-									span: (
-										<span className="woocommerce-product-mvp-ces-footer__message-buttons" />
-									),
-									shareButton: (
-										<Button
-											variant="link"
-											onClick={ onShareFeedbackClick }
-										/>
-									),
-									turnOffButton: (
-										<Button
-											onClick={ onTurnOffEditorClick }
-											variant="link"
-										/>
-									),
-								}
-							) }
-						</div>
-						<Button
-							className="woocommerce-product-mvp-ces-footer__close-button"
-							icon={ closeSmall }
-							label={ __( 'Hide this message', 'woocommerce' ) }
-							onClick={ onHideFeedbackBarClick }
-						></Button>
+								shareButton: (
+									<Button
+										variant="link"
+										onClick={ onShareFeedbackClick }
+									/>
+								),
+								turnOffButton: (
+									<Button
+										onClick={ onTurnOffEditorClick }
+										variant="link"
+									/>
+								),
+							}
+						) }
 					</div>
-				</WooFooterItem>
+					<Button
+						className="woocommerce-product-mvp-ces-footer__close-button"
+						icon={ closeSmall }
+						label={ __( 'Hide this message', 'woocommerce' ) }
+						onClick={ onHideFeedbackBarClick }
+					></Button>
+				</div>
 			) }
 		</>
 	);

--- a/packages/js/product-editor/src/components/footer/footer.tsx
+++ b/packages/js/product-editor/src/components/footer/footer.tsx
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import { createElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { createElement, Fragment } from '@wordpress/element';
 import { WooFooterItem } from '@woocommerce/admin-layout';
 import { Product } from '@woocommerce/data';
 
@@ -18,16 +17,11 @@ export type FooterProps = {
 
 export function Footer( { product }: FooterProps ) {
 	return (
-		<div
-			className="woocommerce-product-footer"
-			role="region"
-			aria-label={ __( 'Product Editor bottom bar.', 'woocommerce' ) }
-			tabIndex={ -1 }
-		>
-			<WooFooterItem.Slot name="product" />
-
-			<FeedbackBar product={ product } />
-			<ProductMVPFeedbackModalContainer productId={ product.id } />
-		</div>
+		<WooFooterItem>
+			<>
+				<FeedbackBar product={ product } />
+				<ProductMVPFeedbackModalContainer productId={ product.id } />
+			</>
+		</WooFooterItem>
 	);
 }

--- a/plugins/woocommerce-admin/client/layout/footer/footer.scss
+++ b/plugins/woocommerce-admin/client/layout/footer/footer.scss
@@ -1,12 +1,12 @@
 .woocommerce-layout__footer {
 	background: $studio-white;
+	border-top: 1px solid $gray-200;
 	box-sizing: border-box;
 	padding: 0;
 	position: fixed;
 	width: calc(100% - 160px);
-	bottom: 0;
-	z-index: 1001;
-	/* on top of #wp-content-editor-tools */
+	bottom: -1px; /* to hide the border when no visible children */
+	z-index: 1001; /* on top of #wp-content-editor-tools */
 
 	.woocommerce-profile-wizard__body & {
 		width: 100%;

--- a/plugins/woocommerce-admin/client/layout/footer/footer.scss
+++ b/plugins/woocommerce-admin/client/layout/footer/footer.scss
@@ -8,6 +8,10 @@
 	z-index: 1001;
 	/* on top of #wp-content-editor-tools */
 
+	.woocommerce-profile-wizard__body & {
+		width: 100%;
+	}
+
 	@include breakpoint('782px-960px') {
 		width: calc(100% - 36px);
 	}

--- a/plugins/woocommerce-admin/client/layout/index.js
+++ b/plugins/woocommerce-admin/client/layout/index.js
@@ -43,7 +43,7 @@ import { Controller, getPages } from './controller';
 import { Header } from '../header';
 import { Footer } from './footer';
 import Notices from './notices';
-import TransientNotices from './transient-notices';
+import { TransientNotices } from './transient-notices';
 import { getAdminSetting } from '~/utils/admin-settings';
 import { usePageClasses } from './hooks/use-page-classes';
 import '~/activity-panel';

--- a/plugins/woocommerce-admin/client/layout/transient-notices/index.js
+++ b/plugins/woocommerce-admin/client/layout/transient-notices/index.js
@@ -18,7 +18,7 @@ import './style.scss';
 const QUEUE_OPTION = 'woocommerce_admin_transient_notices_queue';
 const QUEUED_NOTICE_FILTER = 'woocommerce_admin_queued_notice_filter';
 
-function TransientNotices( props ) {
+export function TransientNotices( props ) {
 	const { removeNotice: onRemove } = useDispatch( 'core/notices' );
 	const { createNotice: createNotice2, removeNotice: onRemove2 } =
 		useDispatch( 'core/notices2' );
@@ -111,5 +111,3 @@ TransientNotices.propTypes = {
 	 */
 	notices: PropTypes.array,
 };
-
-export default TransientNotices;

--- a/plugins/woocommerce-admin/client/layout/transient-notices/index.js
+++ b/plugins/woocommerce-admin/client/layout/transient-notices/index.js
@@ -3,6 +3,7 @@
  */
 import { applyFilters } from '@wordpress/hooks';
 import classnames from 'classnames';
+import { WooFooterItem } from '@woocommerce/admin-layout';
 import { OPTIONS_STORE_NAME, USER_STORE_NAME } from '@woocommerce/data';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -89,12 +90,14 @@ function TransientNotices( props ) {
 	const combinedNotices = getNotices();
 
 	return (
-		<SnackbarList
-			notices={ combinedNotices }
-			className={ classes }
-			onRemove={ onRemove }
-			onRemove2={ onRemove2 }
-		/>
+		<WooFooterItem>
+			<SnackbarList
+				notices={ combinedNotices }
+				className={ classes }
+				onRemove={ onRemove }
+				onRemove2={ onRemove2 }
+			/>
+		</WooFooterItem>
 	);
 }
 

--- a/plugins/woocommerce-admin/client/layout/transient-notices/style.scss
+++ b/plugins/woocommerce-admin/client/layout/transient-notices/style.scss
@@ -1,31 +1,21 @@
 @import '../../navigation/stylesheets/variables.scss';
 
 .woocommerce-transient-notices {
-	position: fixed;
-	bottom: $gap-small;
-	left: $admin-menu-width + $gap;
+	position: absolute;
+	left: $gap;
+	bottom: 100%;
+	margin-bottom: $gap-small;
 	z-index: calc(z-index('.components-snackbar-list') + 1);
 	width: auto;
 
-	@media ( max-width: 960px ) {
-		left: 50px;
-	}
-
-	@media ( max-width: 782px ) {
-		left: $gap;
-	}
-
 	.woocommerce-profile-wizard__body & {
 		left: unset;
+		width: 100%;
 
 		.components-snackbar {
 			margin-left: auto;
 			margin-right: auto;
 		}
-	}
-
-	.has-woocommerce-navigation & {
-		left: $navigation-width + $gap;
 	}
 }
 

--- a/plugins/woocommerce-admin/client/layout/transient-notices/test/index.js
+++ b/plugins/woocommerce-admin/client/layout/transient-notices/test/index.js
@@ -3,7 +3,6 @@
  */
 import { render } from '@testing-library/react';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { WooFooterItem } from '@woocommerce/admin-layout';
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce-admin/client/layout/transient-notices/test/index.js
+++ b/plugins/woocommerce-admin/client/layout/transient-notices/test/index.js
@@ -7,7 +7,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import TransientNotices from '..';
+import { TransientNotices } from '..';
 
 jest.mock( '@wordpress/data', () => {
 	// Require the original module to not be mocked...

--- a/plugins/woocommerce-admin/client/layout/transient-notices/test/index.js
+++ b/plugins/woocommerce-admin/client/layout/transient-notices/test/index.js
@@ -3,6 +3,7 @@
  */
 import { render } from '@testing-library/react';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { WooFooterItem } from '@woocommerce/admin-layout';
 
 /**
  * Internal dependencies
@@ -24,6 +25,18 @@ jest.mock( '@wordpress/data', () => {
 useDispatch.mockReturnValue( {
 	removeNotice: jest.fn(),
 	createNotice: jest.fn(),
+} );
+
+jest.mock( '@woocommerce/admin-layout', () => {
+	const originalModule = jest.requireActual( '@woocommerce/admin-layout' );
+
+	return {
+		__esModule: true, // Use it when dealing with esModules
+		...originalModule,
+		WooFooterItem: jest.fn( ( { children } ) => {
+			return <div>{ children }</div>;
+		} ),
+	};
 } );
 
 jest.mock( '../snackbar/list', () =>

--- a/plugins/woocommerce/changelog/fix-notices-overlapping-footer-2
+++ b/plugins/woocommerce/changelog/fix-notices-overlapping-footer-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix overlapping TransientNotices with footer


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In #38599, the product editor footer was introduced.

Transient notices overlapped this new footer.

This PR updates the the transient notices to not overlap the WooCommerce Admin footer.

To support this change, the `TransientNotices` component was changed to use the `WooFooterItem` fill. The CSS was updated to account for this change. No visible changes should be introduced to the use of `TransientNotices` anywhere in WooCommerce except for the case this PR is addressing (not overlapping the footer).

Closes #38651.

#### Before (overlapping transient notices)

<img width="1115" alt="Screenshot 2023-06-05 at 19 36 54" src="https://github.com/woocommerce/woocommerce/assets/2098816/6421a525-fd8a-4299-936d-2f9a1a26d063">

#### After (transient notices above footer)

<img width="1097" alt="Screenshot 2023-06-09 at 15 11 31" src="https://github.com/woocommerce/woocommerce/assets/2098816/e9fa3f6e-78ac-4305-a7d2-118df08f9aa3">

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Note: To reset the state of the system so that the feedback footer will be shown, delete the following options:
* `woocommerce_product_editor_show_feedback_bar`
* `woocommerce_ces_shown_for_actions`

1. Enable experimental "new product editor" (beta) in WooCommerce > Settings > Advanced > Features
2. Go to Products > Add New
3. Verify no feedback footer is shown.
4. Fill out some fields and save draft (or publish).
5. Verify feedback footer is shown and transient notice is shown correctly above it.
6. Dismiss the footer.
7. Make a change to the product and save draft.
8. Verify the transient notice is shown correct at the bottom of the screen.

<!-- End testing instructions -->
