### PR TITLE
Implement experiment within code for new users

### DIFF
--- a/plugins/woocommerce-admin/client/task-lists/fills/products/use-create-product-by-type.ts
+++ b/plugins/woocommerce-admin/client/task-lists/fills/products/use-create-product-by-type.ts
@@ -2,11 +2,10 @@
  * External dependencies
  */
 import { useDispatch } from '@wordpress/data';
-import { ITEMS_STORE_NAME, OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { ITEMS_STORE_NAME } from '@woocommerce/data';
 import { getNewPath, navigateTo } from '@woocommerce/navigation';
 import { getAdminLink } from '@woocommerce/settings';
 import { loadExperimentAssignment } from '@woocommerce/explat';
-import moment from 'moment';
 import { useState } from '@wordpress/element';
 
 /**
@@ -14,13 +13,11 @@ import { useState } from '@wordpress/element';
  */
 import { ProductTypeKey } from './constants';
 import { createNoticesFromResponse } from '../../../lib/notices';
-
-const NEW_PRODUCT_MANAGEMENT = 'woocommerce_new_product_management_enabled';
+import { getAdminSetting } from '~/utils/admin-settings';
 
 export const useCreateProductByType = () => {
 	const { createProductFromTemplate } = useDispatch( ITEMS_STORE_NAME );
 	const [ isRequesting, setIsRequesting ] = useState< boolean >( false );
-	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
 	const isNewExperienceEnabled =
 		window.wcAdminFeatures[ 'new-product-management-experience' ];
 
@@ -35,23 +32,19 @@ export const useCreateProductByType = () => {
 		setIsRequesting( true );
 
 		if ( type === 'physical' ) {
-			const momentDate = moment().utc();
-			const year = momentDate.format( 'YYYY' );
-			const month = momentDate.format( 'MM' );
-			const assignment = await loadExperimentAssignment(
-				`woocommerce_product_creation_experience_${ year }${ month }_v1`
-			);
-
 			if ( isNewExperienceEnabled ) {
 				navigateTo( { url: getNewPath( {}, '/add-product', {} ) } );
 				return;
 			}
+
+			const assignment = await loadExperimentAssignment(
+				'woocommerce_product_creation_experience_202305_v2'
+			);
+
 			if ( assignment.variationName === 'treatment' ) {
-				await updateOptions( {
-					[ NEW_PRODUCT_MANAGEMENT ]: 'yes',
-				} );
+				const _feature_nonce = getAdminSetting( '_feature_nonce' );
 				window.location.href = getAdminLink(
-					'admin.php?page=wc-admin&path=/add-product'
+					`post-new.php?post_type=product&product_block_editor=1&_feature_nonce=${ _feature_nonce }`
 				);
 				return;
 			}

--- a/plugins/woocommerce-admin/client/task-lists/fills/products/use-create-product-by-type.ts
+++ b/plugins/woocommerce-admin/client/task-lists/fills/products/use-create-product-by-type.ts
@@ -38,7 +38,7 @@ export const useCreateProductByType = () => {
 			}
 
 			const assignment = await loadExperimentAssignment(
-				'woocommerce_product_creation_experience_202305_v2'
+				'woocommerce_product_creation_experience_202306_v2'
 			);
 
 			if ( assignment.variationName === 'treatment' ) {

--- a/plugins/woocommerce/changelog/add-85
+++ b/plugins/woocommerce/changelog/add-85
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Implement experiment within code for new users#85

--- a/plugins/woocommerce/changelog/add-85
+++ b/plugins/woocommerce/changelog/add-85
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-Implement experiment within code for new users#85
+Implement the product blocks experiment within code for new users


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/mothra-private/issues/85

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Note: Before testing this make sure `Try the new product editor (Beta)` under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features` and `new-product-management-experience` under `/wp-admin/tools.php?page=woocommerce-admin-test-helper` are both turned off.

1. Go to the ExPlat experiment called `woocommerce_product_creation_experience_202306_v2` and pick the variation you want to test.
2. When hovering any `Bookmarklet` link of control or treatment variation a popover should be shown with the instructions to try one variation or the other.
3. Make sure you save the suggested link into your browser bookmarks.
4. Go to `/wp-admin/admin.php?page=wc-admin` and click on the second item to add new products
5. While on this page click on the bookmark saved on point 3, make sure you do not are viewing a different page
6. After clicking the saved bookmark a modal with this title should be shown `ExPlat: Successful Assignment`
7. Close the modal
8. Then click on `Physical product` item.
9. If the variation name chosen was `control` then you should see the old/legacy product form
10. If the variation was `treatment` then you should see the new product blocks editor and anytime from now you should not longer see the old one anymore unless you disable the `Try the new product editor (Beta)` feature.

<!-- End testing instructions -->