### PR TITLE
Update deprecated method call in `tools/create-extension`

### DIFF
--- a/tools/create-extension/_main.php
+++ b/tools/create-extension/_main.php
@@ -9,9 +9,9 @@
  * Register the JS and CSS.
  */
 function add_extension_register_script() {
-	if ( 
+	if (
 		! method_exists( 'Automattic\WooCommerce\Admin\Loader', 'is_admin_or_embed_page' ) ||
-		! \Automattic\WooCommerce\Admin\Loader::is_admin_or_embed_page()
+		! \Automattic\WooCommerce\Admin\PageController::is_admin_or_embed_page()
 	) {
 		return;
 	}

--- a/tools/create-extension/_main.php
+++ b/tools/create-extension/_main.php
@@ -10,7 +10,7 @@
  */
 function add_extension_register_script() {
 	if (
-		! method_exists( 'Automattic\WooCommerce\Admin\Loader', 'is_admin_or_embed_page' ) ||
+		! method_exists( 'Automattic\WooCommerce\Admin\PageController', 'is_admin_or_embed_page' ) ||
 		! \Automattic\WooCommerce\Admin\PageController::is_admin_or_embed_page()
 	) {
 		return;


### PR DESCRIPTION
Replaces a call to a deprecated method with updated code. I came across this problem via a [Community Slack thread](https://woocommercecommunity.slack.com/archives/C4TNYTR28/p1686663349193249):

> While enabling wp_debug, I discovered this error in the dashboard: `Deprecated: Function is_admin_or_embed_page is deprecated since version 6.3! Use \Automattic\WooCommerce\Admin\PageController::is_admin_or_embed_page() instead. in /data/7/3/73955e7d-281c-483a-8c3e-f1d87a9f775e/[redacted]/web/wp-includes/functions.php on line 5413` 
> Is this something to be concerned about?

This specific report may be unrelated to our `create-extension` tool, but I see the same thing is possible if we generate an extension using this tool.

### How to test the changes in this Pull Request:

1. Setup the WooCommerce monorepo per all the usual steps ([here](https://github.com/woocommerce/woocommerce/blob/7.8.0/README.md) and [here](https://github.com/woocommerce/woocommerce/blob/7.8.0/DEVELOPMENT.md)).
2. Please also install and activate [Query Monitor](https://wordpress.org/plugins/query-monitor/) (or use some other tool to monitor for errors).
3. Scaffold a new extension: `pnpm run create-extension`
4. Move the generated extension to the plugins directory and activate.
5. Notice that, if you generate the extension from trunk, the generated extension emits a deprecated function notice similar to the one in the description.
6. Whereas, if you generate the extension using this branch, there is no deprecation notice.

<!-- End testing instructions -->
