### PR TITLE
Fix task list header overlap

### DIFF
--- a/plugins/woocommerce-admin/client/task-lists/setup-task-list/style.scss
+++ b/plugins/woocommerce-admin/client/task-lists/setup-task-list/style.scss
@@ -240,7 +240,7 @@
 
 		position: absolute;
 		z-index: 0;
-		right: 6%;
+		right: 24px;
 		max-width: 25%;
 		max-height: 150px;
 		width: auto;
@@ -264,7 +264,7 @@
 			max-width: 380px;
 		}
 
-		max-width: 75%;
+		max-width: 70%;
 		p,
 		span {
 			color: $gray-600;

--- a/plugins/woocommerce/changelog/fix-38645-checklist-overlap
+++ b/plugins/woocommerce/changelog/fix-38645-checklist-overlap
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed a visual bug where text overlapped the image in the task list header.


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR is a follow-up to #38585 which _partially_ fixed an issue with text overlapping a background image in the Task List header. In this PR, we've changed the text width and moved the background image further to the right which addresses the problem:

**Before**
![image](https://github.com/woocommerce/woocommerce/assets/4297811/a8e77b48-8034-4798-b2c0-ec41eac8aaf5)

**After**
![image](https://github.com/woocommerce/woocommerce/assets/4297811/ff376706-da14-4fb2-9170-a73d52e2c964)

Closes #38645

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Build this branch
2. On a fresh install, skip the onboarding wizard to land at the home screen.
3. Ensure that the Single Column layout is selected on the Display menu in the Woo toolbar.
4. See that Task List header text does not overlap the image.
5. Change the layout type to Two Columns with the Display menu.
6. See that Task List header does not overlap the image.