### PR TITLE
Handling errors from token endpoint

### DIFF
--- a/plugins/woo-ai/changelog/add-wooai-handle-token-failure
+++ b/plugins/woo-ai/changelog/add-wooai-handle-token-failure
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Adding error handling for a bad token request.

--- a/plugins/woo-ai/src/product-description/product-description-button-container.tsx
+++ b/plugins/woo-ai/src/product-description/product-description-button-container.tsx
@@ -18,11 +18,19 @@ import { recordTracksFactory, getPostId } from '../utils';
 
 const DESCRIPTION_MAX_LENGTH = 300;
 
-const getApiError = () => {
-	return __(
-		`❗ We're currently experiencing high demand for our experimental feature. Please check back in shortly.`,
-		'woocommerce'
-	);
+const getApiError = ( error: string ) => {
+	switch ( error ) {
+		case 'connection_error':
+			return __(
+				'❗ We were unable to reach the experimental service. Please check back in shortly.',
+				'woocommerce'
+			);
+		default:
+			return __(
+				`❗ We're currently experiencing high demand for our experimental feature. Please check back in shortly.`,
+				'woocommerce'
+			);
+	}
 };
 
 const recordDescriptionTracks = recordTracksFactory(
@@ -55,7 +63,7 @@ export function WriteItForMeButtonContainer() {
 				// eslint-disable-next-line no-console
 				console.debug( 'Streaming error encountered', error );
 
-				tinyEditor.setContent( getApiError() );
+				tinyEditor.setContent( getApiError( error ) );
 			},
 			onCompletionFinished: ( reason, content ) => {
 				recordDescriptionTracks( 'stop', {


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Adding some basic error handling in the scenario that the token request fails, which results in a generic connection error message to the user.

Closes #38631.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. I've been using this with a WoA dev site ([guide](pb5gDS-1rQ-p2)). Following that guide, but with [this modified script](https://gist.github.com/joelclimbsthings/d0144f525e165d4943650feeec09c9a4).
2. Once you've copied the plugin over, ensure the `Woo AI` plugin is activated.
3. Go to Products -> Add new
4. I'm a little uncertain of the best way to test this since it should only occur if an error is thrown. You can just manually throw an error in [this requestToken function](https://github.com/woocommerce/woocommerce/blob/d278e83140915dcffbb7dcb9c39edd4262c67c61/plugins/woo-ai/src/utils/jetpack-completion.ts#L35), like `throw new Error('test error');`
5. If done, observe that when you click "Write with AI" you see an error within the tiny editor.

<!-- End testing instructions -->