### PR TITLE
Visual changes for Intro, guided setup, and skipped guided setup pages

### DIFF
--- a/plugins/woocommerce-admin/client/core-profiler/components/heading/style.scss
+++ b/plugins/woocommerce-admin/client/core-profiler/components/heading/style.scss
@@ -18,8 +18,8 @@
 		padding-top: 0;
 
 		@include breakpoint( '<782px' ) {
-			font-size: 28px !important;
-			line-height: 36px !important;
+			font-size: 28px;
+			line-height: 36px;
 		}
 	}
 
@@ -50,8 +50,6 @@
 			margin: 52px 0 40px;
 
 			.woocommerce-profiler-heading__title {
-				font-size: 32px;
-				line-height: 40px;
 				text-align: left;
 			}
 			.woocommerce-profiler-heading__subtitle {

--- a/plugins/woocommerce-admin/client/core-profiler/components/heading/style.scss
+++ b/plugins/woocommerce-admin/client/core-profiler/components/heading/style.scss
@@ -10,16 +10,16 @@
 	.woocommerce-profiler-heading__title {
 		font-style: normal;
 		font-weight: 500;
-		font-size: 32px;
+		font-size: 40px;
 		line-height: 40px;
 		text-align: center;
-		color: #000;
+		color: $gray-900;
 		margin-bottom: 12px;
 		padding-top: 0;
 
 		@include breakpoint( '<782px' ) {
-			font-size: 28px;
-			line-height: 36px;
+			font-size: 28px !important;
+			line-height: 36px !important;
 		}
 	}
 
@@ -29,7 +29,7 @@
 		font-size: 16px;
 		line-height: 24px;
 		text-align: center;
-		color: $gray-700;
+		color: $gray-800;
 
 		@include breakpoint( '<782px' ) {
 			color: $gray-800;

--- a/plugins/woocommerce-admin/client/core-profiler/pages/IntroOptIn.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/pages/IntroOptIn.tsx
@@ -17,15 +17,13 @@ import { Navigation } from '../components/navigation/navigation';
 export const IntroOptIn = ( {
 	sendEvent,
 	navigationProgress,
-	context,
 }: {
 	sendEvent: ( event: IntroOptInEvent ) => void;
 	navigationProgress: number;
 	context: CoreProfilerStateMachineContext;
 } ) => {
-	const [ iOptInDataSharing, setIsOptInDataSharing ] = useState< boolean >(
-		context.optInDataSharing
-	);
+	const [ iOptInDataSharing, setIsOptInDataSharing ] =
+		useState< boolean >( true );
 
 	return (
 		<div

--- a/plugins/woocommerce-admin/client/core-profiler/pages/UserProfile.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/pages/UserProfile.tsx
@@ -227,7 +227,7 @@ export const UserProfile = ( {
 		>
 			<Navigation
 				percentage={ navigationProgress }
-				skipText={ __( 'Skip this setup', 'woocommerce' ) }
+				skipText={ __( 'Skip this step', 'woocommerce' ) }
 				onSkip={ () =>
 					sendEvent( {
 						type: 'USER_PROFILE_SKIPPED',

--- a/plugins/woocommerce-admin/client/core-profiler/pages/tests/intro-opt-in.test.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/pages/tests/intro-opt-in.test.tsx
@@ -48,20 +48,6 @@ describe( 'IntroOptIn', () => {
 		expect( screen.getByRole( 'checkbox' ) ).toBeChecked();
 	} );
 
-	it( 'should checkbox be unchecked when optInDataSharing is false', () => {
-		const newProps = {
-			...props,
-			context: {
-				optInDataSharing: false,
-			},
-		};
-		render(
-			// @ts-ignore
-			<IntroOptIn { ...newProps } />
-		);
-		expect( screen.getByRole( 'checkbox' ) ).not.toBeChecked();
-	} );
-
 	it( 'should toggle checkbox when checkbox is clicked', () => {
 		render(
 			// @ts-ignore

--- a/plugins/woocommerce-admin/client/core-profiler/pages/tests/user-profile.test.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/pages/tests/user-profile.test.tsx
@@ -114,7 +114,7 @@ describe( 'UserProfile', () => {
 		);
 		screen
 			.getByRole( 'button', {
-				name: /Skip this setup/i,
+				name: /Skip this step/i,
 			} )
 			.click();
 		expect( props.sendEvent ).toHaveBeenCalledWith( {

--- a/plugins/woocommerce-admin/client/core-profiler/style.scss
+++ b/plugins/woocommerce-admin/client/core-profiler/style.scss
@@ -44,7 +44,7 @@
 		padding: 10px 16px;
 		height: 48px;
 		font-size: 14px;
-		font-weight: 500;
+		font-weight: normal;
 	}
 
 	.woocommerce-select-control__option {
@@ -115,7 +115,7 @@
 }
 
 .woocommerce-profiler-intro-opt-in__content {
-	padding-top: 81px;
+	padding-top: 110px;
 	flex: 1;
 
 	@include breakpoint( '<782px' ) {
@@ -127,7 +127,7 @@
 	}
 
 	.woocommerce-profiler-welcome-image {
-		margin-bottom: 48px;
+		margin-bottom: 64px;
 		width: 266px;
 		height: 172px;
 		background: url(./assets/images/welcome-desktop.svg) no-repeat center
@@ -145,10 +145,12 @@
 	.woocommerce-profiler-setup-store__button {
 		padding: 10px 16px;
 		width: 200px;
-		height: 54px;
+		height: 48px;
 		display: flex;
 		justify-content: center;
 		align-items: center;
+		font-size: 14px;
+		font-weight: normal;
 
 		@include breakpoint( '<782px' ) {
 			width: 100%;
@@ -248,43 +250,47 @@
 		top: 40px !important;
 	}
 
-	.woocommerce-profiler-business-location {
+}
+
+
+.woocommerce-profiler-business-location {
+	display: flex;
+	flex-direction: column;
+	.woocommerce-profiler-business-location__content {
+		width: 100%;
 		display: flex;
-		flex-direction: column;
-		.woocommerce-profiler-business-location__content {
-			max-width: 550px;
+		align-self: center;
+		& > div {
 			width: 100%;
-			display: flex;
-			align-self: center;
+		}
 
-			& > div {
-				width: 100%;
-			}
+		.woocommerce-profiler-heading {
+			max-width: 570px;
+		}
 
-			.components-base-control__field {
-				height: 40px;
-			}
+		.components-base-control__field {
+			height: 40px;
+		}
 
-			.woocommerce-select-control__control-icon {
+		.woocommerce-select-control__control-icon {
+			display: none;
+		}
+
+		.woocommerce-select-control__control.is-active {
+			.components-base-control__label {
 				display: none;
 			}
+		}
 
-			.woocommerce-select-control__control.is-active {
-				.components-base-control__label {
-					display: none;
-				}
-			}
+		.woocommerce-select-control.is-searchable
+		.woocommerce-select-control__control-input {
+			margin: 0;
+			padding: 0;
+		}
 
-			.woocommerce-select-control.is-searchable
-			.woocommerce-select-control__control-input {
-				margin: 0;
-				padding: 0;
-			}
-
-			.woocommerce-select-control.is-searchable
-			.components-base-control__label {
-				left: 13px;
-			}
+		.woocommerce-select-control.is-searchable
+		.components-base-control__label {
+			left: 13px;
 		}
 	}
 }
@@ -423,6 +429,7 @@
 		text-align: center;
 		display: block;
 		font-size: 14px;
+		font-weight: normal;
 	}
 
 	.plugin-error {

--- a/plugins/woocommerce-admin/client/core-profiler/style.scss
+++ b/plugins/woocommerce-admin/client/core-profiler/style.scss
@@ -173,6 +173,7 @@
 				outline: 2px solid transparent;
 				width: 16px;
 				height: 16px;
+				border-radius: 2px;
 			}
 
 			.components-checkbox-control__input-container {

--- a/plugins/woocommerce-admin/client/core-profiler/style.scss
+++ b/plugins/woocommerce-admin/client/core-profiler/style.scss
@@ -519,6 +519,7 @@
 			border-color: #bbb;
 			border-radius: 2px;
 			border-width: 1px;
+			font-size: 13px;
 		}
 
 		.woocommerce-profiler-select-control__industry {

--- a/plugins/woocommerce-admin/client/core-profiler/test/__snapshots__/core-profiler-machine.test.tsx.snap
+++ b/plugins/woocommerce-admin/client/core-profiler/test/__snapshots__/core-profiler-machine.test.tsx.snap
@@ -3267,7 +3267,7 @@ Object {
                 class="components-button woocommerce-profiler-navigation-skip-link is-link"
                 type="button"
               >
-                Skip this setup
+                Skip this step
               </button>
             </div>
           </div>

--- a/plugins/woocommerce-admin/client/core-profiler/test/__snapshots__/core-profiler-machine.test.tsx.snap
+++ b/plugins/woocommerce-admin/client/core-profiler/test/__snapshots__/core-profiler-machine.test.tsx.snap
@@ -3086,7 +3086,7 @@ Object {
                   class="components-button woocommerce-profiler-navigation-skip-link is-link"
                   type="button"
                 >
-                  Skip this setup
+                  Skip this step
                 </button>
               </div>
             </div>

--- a/plugins/woocommerce/changelog/update-38626-visual-changes-for-profiler-pages
+++ b/plugins/woocommerce/changelog/update-38626-visual-changes-for-profiler-pages
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Visual changes for the core profiler pages -- intro, guided setup, and skipped guided setup pages


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Partially closes #38626 

This PR included changes from Y5pUYSJPsGEud1vknUZhi8-fi-1440_33442, except hovering color and searchable platform name changes. 

#### Intro (Figma Screenshot)
<img width="1063" alt="Screen Shot 2023-06-22 at 2 36 31 pm" src="https://github.com/woocommerce/woocommerce/assets/9312929/414268cc-f41c-480b-a99c-8e705439da7f">

#### Guided Setup (Figma Screenshot)
<img width="1200" alt="Screen Shot 2023-06-22 at 2 36 56 pm" src="https://github.com/woocommerce/woocommerce/assets/9312929/1b65aabb-2d90-4634-be30-342d23bab782">

#### Skipped Setup (Figma Screenshot)
<img width="1059" alt="Screen Shot 2023-06-22 at 2 37 24 pm" src="https://github.com/woocommerce/woocommerce/assets/9312929/31f00f86-2715-4a6e-836d-c6a4e22d8966">

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Install the `WooCommerce Beta Tester` plugin
2. Go to /wp-admin/tools.php?page=woocommerce-admin-test-helper
3. Enable the 'core-profiler' feature flag
4. Visit http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard
5. Go through the core profiler pages and make sure the changes highlighted in the Figma screenshots have been addressed, except hovering color and searchable platform name changes.


<!-- End testing instructions -->