### PR TITLE
Update track name prefix for core profiler

### DIFF
--- a/plugins/woocommerce-admin/client/core-profiler/actions/tracks.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/actions/tracks.tsx
@@ -21,7 +21,7 @@ const recordTracksStepViewed = (
 	{ action }: { action: unknown }
 ) => {
 	const { step } = action as { step: string };
-	recordEvent( 'storeprofiler_step_view', {
+	recordEvent( 'coreprofiler_step_view', {
 		step,
 		wc_version: getSetting( 'wcVersion' ),
 	} );
@@ -33,12 +33,12 @@ const recordTracksStepSkipped = (
 	{ action }: { action: unknown }
 ) => {
 	const { step } = action as { step: string };
-	recordEvent( `storeprofiler_${ step }_skip` );
+	recordEvent( `coreprofiler_${ step }_skip` );
 };
 
 const recordTracksIntroCompleted = () => {
-	recordEvent( 'storeprofiler_step_complete', {
-		step: 'store_details',
+	recordEvent( 'coreprofiler_step_complete', {
+		step: 'intro_optin',
 		wc_version: getSetting( 'wcVersion' ),
 	} );
 };
@@ -47,12 +47,12 @@ const recordTracksUserProfileCompleted = (
 	_context: CoreProfilerStateMachineContext,
 	event: Extract< UserProfileEvent, { type: 'USER_PROFILE_COMPLETED' } >
 ) => {
-	recordEvent( 'storeprofiler_step_complete', {
+	recordEvent( 'coreprofiler_step_complete', {
 		step: 'user_profile',
 		wc_version: getSetting( 'wcVersion' ),
 	} );
 
-	recordEvent( 'storeprofiler_user_profile', {
+	recordEvent( 'coreprofiler_user_profile', {
 		business_choice: event.payload.userProfile.businessChoice,
 		selling_online_answer: event.payload.userProfile.sellingOnlineAnswer,
 		selling_platforms: event.payload.userProfile.sellingPlatforms
@@ -62,7 +62,7 @@ const recordTracksUserProfileCompleted = (
 };
 
 const recordTracksSkipBusinessLocationCompleted = () => {
-	recordEvent( 'storeprofiler_step_complete', {
+	recordEvent( 'coreprofiler_step_complete', {
 		step: 'skip_business_location',
 		wc_version: getSetting( 'wcVersion' ),
 	} );
@@ -72,12 +72,12 @@ const recordTracksBusinessInfoCompleted = (
 	_context: CoreProfilerStateMachineContext,
 	event: Extract< BusinessInfoEvent, { type: 'BUSINESS_INFO_COMPLETED' } >
 ) => {
-	recordEvent( 'storeprofiler_step_complete', {
+	recordEvent( 'coreprofiler_step_complete', {
 		step: 'business_info',
 		wc_version: getSetting( 'wcVersion' ),
 	} );
 
-	recordEvent( 'storeprofiler_business_info', {
+	recordEvent( 'coreprofiler_business_info', {
 		business_name_filled:
 			POSSIBLY_DEFAULT_STORE_NAMES.findIndex(
 				( name ) => name === event.payload.storeName
@@ -96,7 +96,7 @@ const recordTracksPluginsLearnMoreLinkClicked = (
 	{ action }: { action: unknown }
 ) => {
 	const { step } = action as { step: string };
-	recordEvent( `storeprofiler_${ step }_learn_more_link_clicked`, {
+	recordEvent( `coreprofiler_${ step }_learn_more_link_clicked`, {
 		plugin: _event.payload.plugin,
 		link: _event.payload.learnMoreLink,
 	} );

--- a/plugins/woocommerce-admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/index.tsx
@@ -681,7 +681,7 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 					entry: [
 						{
 							type: 'recordTracksStepViewed',
-							step: 'store_details',
+							step: 'intro_opt_in',
 						},
 						{ type: 'updateQueryStep', step: 'intro-opt-in' },
 					],
@@ -697,7 +697,7 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 							actions: [
 								{
 									type: 'recordTracksStepSkipped',
-									step: 'store_details',
+									step: 'intro_opt_in',
 								},
 							],
 						},
@@ -1198,73 +1198,16 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 										event
 									) => event.payload.errors,
 								} ),
-								( _context, event ) => {
-									recordEvent(
-										'storeprofiler_store_extensions_installed_and_activated',
-										{
-											success: false,
-											failed_extensions:
-												event.payload.errors.map(
-													(
-														error: PluginInstallError
-													) =>
-														getPluginTrackKey(
-															error.plugin
-														)
-												),
-										}
-									);
+								{
+									type: 'recordFailedPluginInstallations',
 								},
 							],
 						},
 						PLUGINS_INSTALLATION_COMPLETED: {
 							target: 'postPluginInstallation',
 							actions: [
-								( _context, event ) => {
-									const installationCompletedResult =
-										event.payload
-											.installationCompletedResult;
-
-									const trackData: {
-										success: boolean;
-										installed_extensions: string[];
-										total_time: string;
-										[ key: string ]:
-											| number
-											| boolean
-											| string
-											| string[];
-									} = {
-										success: true,
-										installed_extensions:
-											installationCompletedResult.installedPlugins.map(
-												(
-													installedPlugin: InstalledPlugin
-												) =>
-													getPluginTrackKey(
-														installedPlugin.plugin
-													)
-											),
-										total_time: getTimeFrame(
-											installationCompletedResult.totalTime
-										),
-									};
-
-									for ( const installedPlugin of installationCompletedResult.installedPlugins ) {
-										trackData[
-											'install_time_' +
-												getPluginTrackKey(
-													installedPlugin.plugin
-												)
-										] = getTimeFrame(
-											installedPlugin.installTime
-										);
-									}
-
-									recordEvent(
-										'storeprofiler_store_extensions_installed_and_activated',
-										trackData
-									);
+								{
+									type: 'recordSuccessfulPluginInstallation',
 								},
 							],
 						},

--- a/plugins/woocommerce-admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/index.tsx
@@ -26,7 +26,6 @@ import {
 	Extension,
 	GeolocationResponse,
 } from '@woocommerce/data';
-import { recordEvent } from '@woocommerce/tracks';
 import { initializeExPlat } from '@woocommerce/explat';
 import { CountryStateOption } from '@woocommerce/onboarding';
 
@@ -49,7 +48,7 @@ import { BusinessLocation } from './pages/BusinessLocation';
 import { getCountryStateOptions } from './services/country';
 import { Loader } from './pages/Loader';
 import { Plugins } from './pages/Plugins';
-import { getPluginSlug, getPluginTrackKey, getTimeFrame } from '~/utils';
+import { getPluginSlug } from '~/utils';
 import './style.scss';
 import {
 	InstallationCompletedResult,

--- a/plugins/woocommerce/changelog/update-38627-update-track-prefix-for-core-profiler
+++ b/plugins/woocommerce/changelog/update-38627-update-track-prefix-for-core-profiler
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Use coreprofiler_ prefix for core profiler track names


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/38627.

This PR replaces `storeprofiler_` prefix with `coreprofiler_`.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Enable tracking 
2. Open your browser inspector and set log level to verbose.
3. Go through the core profiler and confirm tracks have `coreprofiler_` prefix

<!-- End testing instructions -->
