### PR TITLE
Update single-product.js for issue #38711

### DIFF
--- a/plugins/woocommerce/changelog/single-product-tab-open-close
+++ b/plugins/woocommerce/changelog/single-product-tab-open-close
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Improve compatibility between GTM and the single product page.

--- a/plugins/woocommerce/client/legacy/js/frontend/single-product.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/single-product.js
@@ -35,7 +35,7 @@ jQuery( function( $ ) {
 			$tabs_wrapper.find( '.wc-tab, .panel:not(.panel .panel)' ).hide();
 
 			$tab.closest( 'li' ).addClass( 'active' );
-			$tabs_wrapper.find( $tab.attr( 'href' ) ).show();
+			$tabs_wrapper.find( "#"+$tab.attr( 'href').split('#')[1] ).show();
 		} )
 		// Review link
 		.on( 'click', 'a.woocommerce-review-link', function() {

--- a/plugins/woocommerce/client/legacy/js/frontend/single-product.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/single-product.js
@@ -35,7 +35,7 @@ jQuery( function( $ ) {
 			$tabs_wrapper.find( '.wc-tab, .panel:not(.panel .panel)' ).hide();
 
 			$tab.closest( 'li' ).addClass( 'active' );
-			$tabs_wrapper.find( "#"+$tab.attr( 'href').split('#')[1] ).show();
+			$tabs_wrapper.find( '#' + $tab.attr( 'href' ).split( '#' )[1] ).show();
 		} )
 		// Review link
 		.on( 'click', 'a.woocommerce-review-link', function() {


### PR DESCRIPTION
The href attribute will now be splitted by the hash to ensure that the script will work even in case of an absolute link in the tab anchor href.

### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

## How to reproduce the problem:

1. Setup and install Wordpress (6.2.2) + WooCommerce (7.8.0) (You can skip the store details setup) on an Apache/2.4.* (Debian) + PHP 8.1.* + MariaDB (10.6.*) environment;
2. Download the official WooCommerce sample data .csv from here: https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/plugins/woocommerce/sample-data/sample_products.csv`;
3. Go to `WP Admin > Products > All Products > Start Import` and import the sample data downloaded at step 2;
4. Go to the shop and view any product (Ex. "Album $15");
5. Scroll until you find the Description / Reviews tabs;
6. Click on them and see how everything is working as expected;
7. Open the developer tools and simulate what Google Analytics would do to the relative href present on the tabs by pasting this script in your console: `jQuery('#tab-title-description a').attr('href', window.location + jQuery('#tab-title-description a').attr('href'));jQuery('#tab-reviews a').attr('href', window.location + jQuery('#tab-reviews a').attr('href'));`;
8. Now test again the tabs as in step 6 and notice how the tab becomes blank as described in the issue (https://github.com/woocommerce/woocommerce/issues/38711) and check the console for the `Uncaught Error: Syntax error, unrecognized expression` error.

## How to test the fix (https://github.com/woocommerce/woocommerce/pull/38712)

1. Setup and install Wordpress (6.2.2) + WooCommerce (Pulled from https://github.com/woocommerce/woocommerce/pull/38712) (You can skip the store details setup) on an Apache/2.4.* (Debian) + PHP 8.1.* + MariaDB (10.6.*) environment;
2. Repeat every step from the "How to reproduce the issue" section and notice how now everything works as expected.

<!-- End testing instructions -->

Closes #38711 .