### PR TITLE
Make e2e test `can discard industry changes when navigating back to "Store Details"` independent from previous tests

### DIFF
--- a/plugins/woocommerce/changelog/e2e-make-tests-independant-from-previous-tests
+++ b/plugins/woocommerce/changelog/e2e-make-tests-independant-from-previous-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Ensure `can discard industry changes when navigating back to "Store Details"'` can run independent from previous tests

--- a/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/complete-onboarding-wizard.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/complete-onboarding-wizard.spec.js
@@ -60,6 +60,23 @@ test.describe( 'Store owner can complete onboarding wizard', () => {
 	test( 'can discard industry changes when navigating back to "Store Details"', async ( {
 		page,
 	} ) => {
+
+		// set up pre-condition to ensure Industries stored in 
+		// storeDetails.us.industries2 have been set 
+		await onboarding.completeIndustrySection(
+			page,
+			storeDetails.us.industries2,
+			storeDetails.us.expectedNumberOfIndustries
+		);
+
+		// Navigate to "Store Details" section to show Save Changes modal prompt
+		await page.click( 'button >> text=Store Details' );
+
+		// Save the changes to ensure the test is now in the correct state
+		// independent of the previous test results
+		await onboarding.handleSaveChangesModal( page, { saveChanges: true } );
+
+		// // test proper begins
 		await onboarding.completeIndustrySection(
 			page,
 			storeDetails.us.industries,

--- a/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/complete-onboarding-wizard.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/complete-onboarding-wizard.spec.js
@@ -72,11 +72,17 @@ test.describe( 'Store owner can complete onboarding wizard', () => {
 		// Navigate to "Store Details" section to show Save Changes modal prompt
 		await page.click( 'button >> text=Store Details' );
 
-		// Save the changes to ensure the test is now in the correct state
-		// independent of the previous test results
-		await onboarding.handleSaveChangesModal( page, { saveChanges: true } );
+		// handle save changes modal if displayed
+		const saveChangesModalVisible = await page
+			.locator( '.components-modal__header-heading' )
+			.isVisible();
+		if ( saveChangesModalVisible ) {
+			// Save the changes to ensure the test is now in the correct state
+			// independent of the previous test results
+			await onboarding.handleSaveChangesModal( page, { saveChanges: true } );
+		}
 
-		// // test proper begins
+		// test proper begins
 		await onboarding.completeIndustrySection(
 			page,
 			storeDetails.us.industries,

--- a/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/complete-onboarding-wizard.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/complete-onboarding-wizard.spec.js
@@ -70,7 +70,7 @@ test.describe( 'Store owner can complete onboarding wizard', () => {
 		);
 
 		// Navigate to "Store Details" section to show Save Changes modal prompt
-		await page.click( 'button >> text=Store Details' );
+		await page.locator( 'button >> text=Store Details' ).click();
 
 		// handle save changes modal if displayed
 		const saveChangesModalVisible = await page


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Ensures the e2e test `can discard industry changes when navigating back to "Store Details"` is not dependant on previous tests being successfully executed
Closes https://github.com/woocommerce/woocommerce/issues/38714.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout `trunk` (we will test against this branch later) to view current issue
2. Setup the test environment with `pnpm env:test`
3. Run the test with the following command in order to view the progress in debug mode:
5. `pnpm test:e2e-pw ./tests/e2e-pw/tests/activate-and-setup/complete-onboarding-wizard.spec.js:60 --debug`
6. Test will fail as the Industry button is not available (previous changes have not been saved) - this is one indicator this test is not standalone - you can kill the test at this point
7. Now, we want to setup the data to mimic a previous test fails where not all of the 3 industries have been selected:
8. Launch http://localhost:8086/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=industry
9. Select 1 checkbox such as the following:
<img width="845" alt="image" src="https://github.com/woocommerce/woocommerce/assets/105309450/acda8584-9a90-4fc6-9cab-07de03edc1d7">

10. Click Store Details
11. Click Save on `Save changes?` modal
13. Run the test again with the following command in order to view the progress in debug mode:
14. `pnpm test:e2e-pw ./tests/e2e-pw/tests/activate-and-setup/complete-onboarding-wizard.spec.js:60 --debug` 
15. Test will now fail as Health and beauty was not selected as would be expected from 'previous passed tests'
16. Checkout this branch 
17.  Restart the environment with pnpm env:restart (or Install woocommerce-admin-test-helper and reset  woocommerce_onboarding_profile)
19. Run `pnpm test:e2e-pw ./tests/e2e-pw/tests/activate-and-setup/complete-onboarding-wizard.spec.js:60 --debug`
20. Test should pass in isolation
21. Repeat steps 7 to 13
22. Test should pass as appropriate checkboxes have been selected and saved
23. All tests in the folder should pass `pnpm test:e2e-pw ./tests/e2e-pw/tests/activate-and-setup/complete-onboarding-wizard.spec.js`

<!-- End testing instructions -->
