### PR TITLE
Remove StoreDetails task when core-profiler flag is on

### DIFF
--- a/plugins/woocommerce/changelog/update-38687-update-storedetails-for-coreprofiler
+++ b/plugins/woocommerce/changelog/update-38687-update-storedetails-for-coreprofiler
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Remove StoreDetails task when core-profiler flag is on

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
@@ -108,21 +108,27 @@ class TaskLists {
 	 * Initialize default lists.
 	 */
 	public static function init_default_lists() {
+		$tasks = array(
+			'StoreDetails',
+			'Purchase',
+			'Products',
+			'WooCommercePayments',
+			'Payments',
+			'Tax',
+			'Shipping',
+			'Marketing',
+			'Appearance',
+		);
+
+		if ( Features::is_enabled( 'core-profiler' ) ) {
+			array_shift( $tasks );
+		}
+
 		self::add_list(
 			array(
 				'id'                      => 'setup',
 				'title'                   => __( 'Get ready to start selling', 'woocommerce' ),
-				'tasks'                   => array(
-					'StoreDetails',
-					'Purchase',
-					'Products',
-					'WooCommercePayments',
-					'Payments',
-					'Tax',
-					'Shipping',
-					'Marketing',
-					'Appearance',
-				),
+				'tasks'                   => $tasks,
 				'display_progress_header' => true,
 				'event_prefix'            => 'tasklist_',
 				'options'                 => array(


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #38687 

This PR removes StoreDetails task when `core-profiler` flag is on. See the original issue for details.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Turn on `core-profiler` flag.
2. Go to `WooCommerce -> Home`
3. Confirm `Add Store details` is not rendered.

<!-- End testing instructions -->
