### PR TITLE
Enable core-profiler flag 

### DIFF
--- a/plugins/woocommerce/changelog/update-enable-core-profiler-in-prod
+++ b/plugins/woocommerce/changelog/update-enable-core-profiler-in-prod
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Enable core-profiler flag to replace profile wizard with the new core profiler

--- a/plugins/woocommerce/client/admin/config/core.json
+++ b/plugins/woocommerce/client/admin/config/core.json
@@ -4,7 +4,7 @@
 		"analytics": true,
 		"product-block-editor": true,
 		"coupons": true,
-		"core-profiler": false,
+		"core-profiler": true,
 		"customer-effort-score-tracks": true,
 		"import-products-task": true,
 		"experimental-fashion-sample-products": true,

--- a/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/complete-onboarding-wizard.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/complete-onboarding-wizard.spec.js
@@ -3,7 +3,8 @@ const { onboarding } = require( '../../utils' );
 const { storeDetails } = require( '../../test-data/data' );
 const { api } = require( '../../utils' );
 
-test.describe( 'Store owner can complete onboarding wizard', () => {
+// Skipping Onbaording tests as we're replacing StoreDetails with Core Profiler
+test.describe.skip( 'Store owner can complete onboarding wizard', () => {
 	test.use( { storageState: process.env.ADMINSTATE } );
 
 	test.beforeEach( async () => {
@@ -12,7 +13,7 @@ test.describe( 'Store owner can complete onboarding wizard', () => {
 	} );
 
 	// eslint-disable-next-line jest/expect-expect
-	test( 'can complete the "Store Details" section', async ( { page } ) => {
+	test.skip( 'can complete the "Store Details" section', async ( { page } ) => {
 		await onboarding.completeStoreDetailsSection(
 			page,
 			storeDetails.us.store
@@ -133,8 +134,9 @@ test.describe( 'Store owner can complete onboarding wizard', () => {
 	} );
 } );
 
+// Skipping Onbaording tests as we're replacing StoreDetails with Core Profiler
 // !Changed from Japanese to Liberian store, as Japanese Yen does not use decimals
-test.describe(
+test.describe.skip(
 	'A Liberian store can complete the selective bundle install but does not include WCPay.',
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );

--- a/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/complete-onboarding-wizard.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/activate-and-setup/complete-onboarding-wizard.spec.js
@@ -2,9 +2,12 @@ const { test, expect } = require( '@playwright/test' );
 const { onboarding } = require( '../../utils' );
 const { storeDetails } = require( '../../test-data/data' );
 const { api } = require( '../../utils' );
+const { features } = require( '../../utils' );
 
-// Skipping Onbaording tests as we're replacing StoreDetails with Core Profiler
-test.describe.skip( 'Store owner can complete onboarding wizard', () => {
+// Skipping Onbaording tests when the core-profiler is enabled.
+const testRunner = features.is_enabled( 'core-profiler' ) ? test.describe.skip : test.describe;
+
+testRunner( 'Store owner can complete onboarding wizard', () => {
 	test.use( { storageState: process.env.ADMINSTATE } );
 
 	test.beforeEach( async () => {
@@ -13,7 +16,7 @@ test.describe.skip( 'Store owner can complete onboarding wizard', () => {
 	} );
 
 	// eslint-disable-next-line jest/expect-expect
-	test.skip( 'can complete the "Store Details" section', async ( { page } ) => {
+	test( 'can complete the "Store Details" section', async ( { page } ) => {
 		await onboarding.completeStoreDetailsSection(
 			page,
 			storeDetails.us.store
@@ -136,7 +139,7 @@ test.describe.skip( 'Store owner can complete onboarding wizard', () => {
 
 // Skipping Onbaording tests as we're replacing StoreDetails with Core Profiler
 // !Changed from Japanese to Liberian store, as Japanese Yen does not use decimals
-test.describe.skip(
+testRunner(
 	'A Liberian store can complete the selective bundle install but does not include WCPay.',
 	() => {
 		test.use( { storageState: process.env.ADMINSTATE } );
@@ -229,7 +232,7 @@ test.describe.skip(
 );
 
 // Skipping this test because it's very flaky.
-test.describe.skip( 'Store owner can go through setup Task List', () => {
+testRunner( 'Store owner can go through setup Task List', () => {
 	test.use( { storageState: process.env.ADMINSTATE } );
 
 	test.beforeEach( async ( { page } ) => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/admin-tasks/payment.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/admin-tasks/payment.spec.js
@@ -5,16 +5,25 @@ const { features } = require( '../../utils' );
 test.describe( 'Payment setup task', () => {
 	test.use( { storageState: process.env.ADMINSTATE } );
 
-	test.beforeEach( async ( { page } ) => {
+	test.beforeEach( async ( { page, baseURL } ) => {
 		// Skip skipping the setup wizard if the core profiler is enabled.
 		// When the core-profiler is enabled, the following code won't work, causing the tests to fail.
-		if ( !features.is_enabled( 'core-profiler' ) ) {
+		if ( ! features.is_enabled( 'core-profiler' ) ) {
 			await page.goto(
 				'wp-admin/admin.php?page=wc-admin&path=/setup-wizard'
 			);
 			await page.click( 'text=Skip setup store details' );
 			await page.click( 'button >> text=No thanks' );
 			await page.waitForLoadState( 'networkidle' );
+		} else {
+			await new wcApi( {
+				url: baseURL,
+				consumerKey: process.env.CONSUMER_KEY,
+				consumerSecret: process.env.CONSUMER_SECRET,
+				version: 'wc-admin',
+			} ).post( 'onboarding/profile', {
+				'skipped': true,
+			});
 		}
 	} );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/admin-tasks/payment.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/admin-tasks/payment.spec.js
@@ -1,16 +1,21 @@
 const { test, expect } = require( '@playwright/test' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
+const { features } = require( '../../utils' );
 
 test.describe( 'Payment setup task', () => {
 	test.use( { storageState: process.env.ADMINSTATE } );
 
 	test.beforeEach( async ( { page } ) => {
-		await page.goto(
-			'wp-admin/admin.php?page=wc-admin&path=/setup-wizard'
-		);
-		await page.click( 'text=Skip setup store details' );
-		await page.click( 'button >> text=No thanks' );
-		await page.waitForLoadState( 'networkidle' );
+		// Skip skipping the setup wizard if the core profiler is enabled.
+		// When the core-profiler is enabled, the following code won't work, causing the tests to fail.
+		if ( !features.is_enabled( 'core-profiler' ) ) {
+			await page.goto(
+				'wp-admin/admin.php?page=wc-admin&path=/setup-wizard'
+			);
+			await page.click( 'text=Skip setup store details' );
+			await page.click( 'button >> text=No thanks' );
+			await page.waitForLoadState( 'networkidle' );
+		}
 	} );
 
 	test.afterAll( async ( { baseURL } ) => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/page-loads.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/page-loads.spec.js
@@ -8,32 +8,32 @@ const wcPages = [
 		name: 'WooCommerce',
 		subpages: [
 			{ name: 'Home', heading: 'Home' },
-			// { name: 'Orders', heading: 'Orders' },
-			// { name: 'Customers', heading: 'Customers' },
-			// { name: 'Coupons', heading: 'Coupons' },
-			// { name: 'Reports', heading: 'Orders' },
-			// { name: 'Settings', heading: 'General' },
-			// { name: 'Status', heading: 'System status' },
+			{ name: 'Orders', heading: 'Orders' },
+			{ name: 'Customers', heading: 'Customers' },
+			{ name: 'Coupons', heading: 'Coupons' },
+			{ name: 'Reports', heading: 'Orders' },
+			{ name: 'Settings', heading: 'General' },
+			{ name: 'Status', heading: 'System status' },
 		],
 	},
-	// {
-	// 	name: 'Products',
-	// 	subpages: [
-	// 		{ name: 'All Products', heading: 'Products' },
-	// 		{ name: 'Add New', heading: 'Add New' },
-	// 		{ name: 'Categories', heading: 'Product categories' },
-	// 		{ name: 'Tags', heading: 'Product tags' },
-	// 		{ name: 'Attributes', heading: 'Attributes' },
-	// 	],
-	// },
-	// // analytics is handled through a separate test
-	// {
-	// 	name: 'Marketing',
-	// 	subpages: [
-	// 		{ name: 'Overview', heading: 'Overview' },
-	// 		{ name: 'Coupons', heading: 'Coupons' },
-	// 	],
-	// },
+	{
+		name: 'Products',
+		subpages: [
+			{ name: 'All Products', heading: 'Products' },
+			{ name: 'Add New', heading: 'Add New' },
+			{ name: 'Categories', heading: 'Product categories' },
+			{ name: 'Tags', heading: 'Product tags' },
+			{ name: 'Attributes', heading: 'Attributes' },
+		],
+	},
+	// analytics is handled through a separate test
+	{
+		name: 'Marketing',
+		subpages: [
+			{ name: 'Overview', heading: 'Overview' },
+			{ name: 'Coupons', heading: 'Coupons' },
+		],
+	},
 ];
 
 for ( const currentPage of wcPages ) {

--- a/plugins/woocommerce/tests/e2e-pw/utils/features.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/features.js
@@ -1,0 +1,14 @@
+function is_enabled( feature ) {
+	const phase = process.env.WC_ADMIN_PHASE;
+	let config = 'development.json';
+	if ( ![ 'core','developer' ].includes( phase ) ) {
+		config = 'core.json';
+	}
+
+	const features = require( `../../../client/admin/config/${config}` ).features;
+	return features[ feature ] && features[ feature ] === true;
+}
+
+module.exports = {
+	is_enabled
+}

--- a/plugins/woocommerce/tests/e2e-pw/utils/index.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/index.js
@@ -2,10 +2,11 @@ const onboarding = require( './onboarding' );
 const api = require( './api' );
 const site = require( './site' );
 const variableProducts = require( './variable-products' );
-
+const features = require( './features' );
 module.exports = {
 	onboarding,
 	api,
 	site,
 	variableProducts,
+	features
 };


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR enables `core-profiler` flag by default in both dev and prod envs.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Checkout this branch.
2. CD to plugins/woocommerce
3. Run `pnpm run build:zip`
4. Make a new JN site without WooCommerce
5. Upload the test zip to Plugins to install and activate.
6. Confirm you're redirected to the Core Profiler.

<!-- End testing instructions -->
