### PR TITLE
Set skipped flag when guided setup is skipped

### DIFF
--- a/plugins/woocommerce-admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/index.tsx
@@ -999,9 +999,20 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 							} ),
 							invoke: {
 								src: ( context ) => {
-									return updateBusinessLocation(
-										context.businessInfo.location as string
-									);
+									const skipped = dispatch(
+										ONBOARDING_STORE_NAME
+									).updateProfileItems( {
+										skipped: true,
+									} );
+									const businessLocation =
+										updateBusinessLocation(
+											context.businessInfo
+												.location as string
+										);
+									return Promise.all( [
+										skipped,
+										businessLocation,
+									] );
 								},
 								onDone: {
 									target: 'progress20',

--- a/plugins/woocommerce/changelog/update-skipped-should-be-set
+++ b/plugins/woocommerce/changelog/update-skipped-should-be-set
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Set woocommerce_onboarding_profile.skipped when guided set is skipped


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR sets `woocommerce_onboarding_profile.skipped` when the user skips the guided setup.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:


1. Start the core profiler
2. Click `Skip guided setup`
3. Choose a country and click continue.
4. Confirm `woocommerce_onboarding_profile.skipped` is set
5. 
<!-- End testing instructions -->
