### PR TITLE
fix: core profiler plugins list race condition

### DIFF
--- a/plugins/woocommerce-admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/index.tsx
@@ -364,6 +364,16 @@ const updateOnboardingProfileOption = (
 	} );
 };
 
+const spawnUpdateOnboardingProfileOption = assign( {
+	spawnUpdateOnboardingProfileOptionRef: (
+		context: CoreProfilerStateMachineContext
+	) =>
+		spawn(
+			() => updateOnboardingProfileOption( context ),
+			'update-onboarding-profile'
+		),
+} );
+
 const updateBusinessLocation = ( countryAndState: string ) => {
 	return dispatch( OPTIONS_STORE_NAME ).updateOptions( {
 		woocommerce_default_country: countryAndState,
@@ -389,7 +399,7 @@ const assignUserProfile = assign( {
 
 const updateBusinessInfo = async (
 	_context: CoreProfilerStateMachineContext,
-	event: BusinessInfoEvent
+	event: AnyEventObject
 ) => {
 	const refreshedOnboardingProfile = ( await resolveSelect(
 		OPTIONS_STORE_NAME
@@ -518,6 +528,7 @@ const coreProfilerMachineActions = {
 	handleOnboardingProfileOption,
 	assignOnboardingProfile,
 	persistBusinessInfo,
+	spawnUpdateOnboardingProfileOption,
 	redirectToWooHome,
 };
 
@@ -530,6 +541,7 @@ const coreProfilerMachineServices = {
 	getOnboardingProfileOption,
 	getPlugins,
 	browserPopstateHandler,
+	updateBusinessInfo,
 };
 export const coreProfilerStateMachineDefinition = createMachine( {
 	id: 'coreProfiler',
@@ -772,16 +784,9 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 					] ),
 				},
 				postUserProfile: {
-					invoke: {
-						src: ( context ) => {
-							return updateOnboardingProfileOption( context );
-						},
-						onDone: {
-							target: '#businessInfo',
-						},
-						onError: {
-							target: '#businessInfo',
-						},
+					entry: [ 'spawnUpdateOnboardingProfileOption' ],
+					always: {
+						target: '#businessInfo',
 					},
 				},
 			},
@@ -938,11 +943,19 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 					],
 					on: {
 						BUSINESS_INFO_COMPLETED: {
+							target: 'postBusinessInfo',
+							actions: [ 'recordTracksBusinessInfoCompleted' ],
+						},
+					},
+				},
+				postBusinessInfo: {
+					invoke: {
+						src: 'updateBusinessInfo',
+						onDone: {
 							target: '#plugins',
-							actions: [
-								'persistBusinessInfo',
-								'recordTracksBusinessInfoCompleted',
-							],
+						},
+						onError: {
+							target: '#plugins',
 						},
 					},
 				},
@@ -1337,8 +1350,8 @@ export const CoreProfilerController = ( {
 	);
 
 	const navigationProgress = currentNodeMeta?.progress;
-	const CurrentComponent =
-		currentNodeMeta?.component ?? ( () => <ProfileSpinner /> ); // If no component is defined for the state then its a loading state
+
+	const CurrentComponent = currentNodeMeta?.component;
 
 	const currentNodeCssLabel =
 		state.value instanceof Object
@@ -1364,13 +1377,15 @@ export const CoreProfilerController = ( {
 			<div
 				className={ `woocommerce-profile-wizard__container woocommerce-profile-wizard__step-${ currentNodeCssLabel }` }
 			>
-				{
+				{ CurrentComponent ? (
 					<CurrentComponent
 						navigationProgress={ navigationProgress }
 						sendEvent={ send }
 						context={ state.context }
 					/>
-				}
+				) : (
+					<ProfileSpinner />
+				) }
 			</div>
 		</>
 	);

--- a/plugins/woocommerce-admin/client/core-profiler/pages/BusinessInfo.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/pages/BusinessInfo.tsx
@@ -91,6 +91,7 @@ export const BusinessInfo = ( {
 		onboardingProfile: {
 			is_store_country_set: isStoreCountrySet,
 			industry: industryFromOnboardingProfile,
+			business_choice: businessChoiceFromOnboardingProfile,
 		},
 	} = context;
 
@@ -152,7 +153,9 @@ export const BusinessInfo = ( {
 	const selectCountryLabel = __( 'Select country/region', 'woocommerce' );
 	const selectIndustryQuestionLabel =
 		selectIndustryMapping[
-			businessChoice || 'im_just_starting_my_business'
+			businessChoice ||
+				businessChoiceFromOnboardingProfile ||
+				'im_just_starting_my_business'
 		];
 
 	const [ dismissedGeolocationNotice, setDismissedGeolocationNotice ] =

--- a/plugins/woocommerce/changelog/fix-core-profiler-plugins-race-condition
+++ b/plugins/woocommerce/changelog/fix-core-profiler-plugins-race-condition
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Fixed race condition in core profiler's plugin list fetching and also minor spinner fixes


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixed these bugs:
- Plugins list was not reflecting the user's updated country selection from Business Info page due to a race condition
- Spinner was janky due to unnecessary re-render between different child loading states
- Post User Profile page spinner was removed by making the update run in the background instead of blocking the state
- Business Info page was not using the saved onboarding profile industry choice if it was navigated to directly


Closes 238-gh-woocommerce/team-ghidorah.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

### Jank Reduced flows

1. Install and activate WooCommerce on a brand new site
1. Install the WooCommerce Beta Tester plugin
1. Go to /wp-admin/tools.php?page=woocommerce-admin-test-helper
1. Enable the 'core-profiler' feature flag
1. Visit /wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard
1. Step through the various pages
1. Observe that the spinners don't reset while in progress
1. Observe that there is no longer a spinner after the User Profile page (the one with the selection of whether you're starting a new business or not)

### Plugins race condition
1. Previously, if you switched from a country with a different set of plugins (e.g US:CA -> Afghanistan), you would see the wrong set of plugins since it would not reflect the new selection
1. You would then see a different set of plugins if you refreshed the Plugins page
1. Observe that this does not happen anymore, and the plugins page always shows the correct plugins now

### Business Info Industry Label
1. Previously, if you navigated to the Business Info page directly (http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=business-info), it would always show the label 'What type of products or services do you plan to sell?'
1. Observe that it reflects your saved onboarding choice now and should show the correct one.

<!-- End testing instructions -->