### PR TITLE
Enqueue `wc-cart-fragments` globally if filtering on `woocommerce_add_to_cart_fragments`

### DIFF
--- a/plugins/woocommerce/changelog/fix-38735-fragment-compatibility
+++ b/plugins/woocommerce/changelog/fix-38735-fragment-compatibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Load the wc-cart-fragments script globally if a theme uses the woocommerce_add_to_cart_fragments filter for custom functionality.

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -224,14 +224,18 @@ class WC_AJAX {
 		woocommerce_mini_cart();
 
 		$mini_cart = ob_get_clean();
+		$fragments = array(
+			'div.widget_shopping_cart_content' => '<div class="widget_shopping_cart_content">' . $mini_cart . '</div>',
+		);
+
+		// Handle deprecated add_to_cart_fragment hook.
+		if ( has_filter( 'add_to_cart_fragments' ) ) {
+			wc_deprecated_hook( 'add_to_cart_fragments', '3.0.0', 'woocommerce_add_to_cart_fragments' );
+			$fragments = apply_filters( 'add_to_cart_fragments', $fragments );
+		}
 
 		$data = array(
-			'fragments' => apply_filters(
-				'woocommerce_add_to_cart_fragments',
-				array(
-					'div.widget_shopping_cart_content' => '<div class="widget_shopping_cart_content">' . $mini_cart . '</div>',
-				)
-			),
+			'fragments' => apply_filters( 'woocommerce_add_to_cart_fragments', $fragments ),
 			'cart_hash' => WC()->cart->get_cart_hash(),
 		);
 

--- a/plugins/woocommerce/includes/class-wc-deprecated-filter-hooks.php
+++ b/plugins/woocommerce/includes/class-wc-deprecated-filter-hooks.php
@@ -23,7 +23,6 @@ class WC_Deprecated_Filter_Hooks extends WC_Deprecated_Hooks {
 	protected $deprecated_hooks = array(
 		'woocommerce_account_orders_columns'              => 'woocommerce_my_account_my_orders_columns',
 		'woocommerce_structured_data_order'               => 'woocommerce_email_order_schema_markup',
-		'woocommerce_add_to_cart_fragments'               => 'add_to_cart_fragments',
 		'woocommerce_add_to_cart_redirect'                => 'add_to_cart_redirect',
 		'woocommerce_product_get_width'                   => 'woocommerce_product_width',
 		'woocommerce_product_get_height'                  => 'woocommerce_product_height',
@@ -70,7 +69,6 @@ class WC_Deprecated_Filter_Hooks extends WC_Deprecated_Hooks {
 	protected $deprecated_version = array(
 		'woocommerce_my_account_my_orders_columns'   => '2.6.0',
 		'woocommerce_email_order_schema_markup'      => '3.0.0',
-		'add_to_cart_fragments'                      => '3.0.0',
 		'add_to_cart_redirect'                       => '3.0.0',
 		'woocommerce_product_width'                  => '3.0.0',
 		'woocommerce_product_height'                 => '3.0.0',

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -431,6 +431,12 @@ class WC_Frontend_Scripts {
 		// Global frontend scripts.
 		self::enqueue_script( 'woocommerce' );
 
+		// Only enqueue the cart fragment script if a theme/plugin is using it to update custom fragments.
+		// The cart widget handles the enqueue internally when needed, so no global enqueue is needed by default.
+		if ( has_filter( 'woocommerce_add_to_cart_fragments' ) || has_filter( 'add_to_cart_fragments' ) ) {
+			wp_enqueue_script( 'wc-cart-fragments' );
+		}
+
 		// CSS Styles.
 		$enqueue_styles = self::get_styles();
 		if ( $enqueue_styles ) {


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

This is a follow up to #35530 that potentially addresses #38735 by enqueueing the `wc-cart-fragments` script globally if a theme uses the `woocommerce_add_to_cart_fragments` filter for custom functionality. This is the case with Elementor which uses it for the menu cart.

`woocommerce_add_to_cart_fragments` by default only has a fragment for the mini-cart widget. This is the only consumer of that functionality by default. That is why the cart fragments script was removed globally in #35530 for performance reasons.

Themes that do not use these filters will continue to not load `wc-cart-fragments` unless the mini cart _widget_ is used. This is to prevent the unnecessary loading of the script which causes performance issues.

The alternative to this patch is for themes to enqueue the script manually if making use of the functionality:

```php
wp_enqueue_script( 'wc-cart-fragments' );
```

This PR can be disregarded and closed if we choose to make that the requirement.

Closes #38735

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Activate a default WP theme such as Twenty Twenty
2. On the frontend, view source and confirm a script with the handle `wc-cart-fragments` is not loaded
3. Go to Appearance > Widgets and add the mini cart widget to a sidebar.
4. On the frontend, view source and confirm a script with the handle `wc-cart-fragments` is loaded
5. Remove the widget
6. Add some custom code (theme functions.php would suffice) which uses the filter:

```php
add_filter( 'woocommerce_add_to_cart_fragments', function( $fragments ) {
     return $fragments;
} );
```

7. On the frontend, view source and confirm a script with the handle `wc-cart-fragments` is loaded

If you have the Elementor theme + pro plugin installed you can also test their menu cart widget. After adding items to the cart, refresh the page and click the menu cart. Before this patch the cart sidebar will open blank. After this patch, the cart sidebar will have items listed.

<!-- End testing instructions -->
