### PR TITLE
Extract usePublishedProductsCount hook and use it in about-the-editor-menu-item

### DIFF
--- a/plugins/woocommerce-admin/client/products/fills/more-menu-items/about-the-editor-menu-item.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/more-menu-items/about-the-editor-menu-item.tsx
@@ -11,6 +11,7 @@ import { recordEvent } from '@woocommerce/tracks';
  * Internal dependencies
  */
 import BlockEditorGuide from '~/products/tour/block-editor/block-editor-guide';
+import { usePublishedProductsCount } from '~/products/tour/block-editor/use-published-products-count';
 
 export const AboutTheEditorMenuItem = ( {
 	onClose,
@@ -18,6 +19,7 @@ export const AboutTheEditorMenuItem = ( {
 	onClose: () => void;
 } ) => {
 	const [ isGuideOpen, setIsGuideOpen ] = useState( false );
+	const { isNewUser } = usePublishedProductsCount();
 	return (
 		<>
 			<MenuItem
@@ -34,6 +36,7 @@ export const AboutTheEditorMenuItem = ( {
 			</MenuItem>
 			{ isGuideOpen && (
 				<BlockEditorGuide
+					isNewUser={ isNewUser }
 					onCloseGuide={ () => {
 						setIsGuideOpen( false );
 						onClose();

--- a/plugins/woocommerce-admin/client/products/tour/block-editor/block-editor-tour.tsx
+++ b/plugins/woocommerce-admin/client/products/tour/block-editor/block-editor-tour.tsx
@@ -1,11 +1,9 @@
 /**
  * External dependencies
  */
-import { useSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Pill, TourKit } from '@woocommerce/components';
-import { PRODUCTS_STORE_NAME } from '@woocommerce/data';
 import { __experimentalUseFeedbackBar as useFeedbackBar } from '@woocommerce/product-editor';
 import { recordEvent } from '@woocommerce/tracks';
 
@@ -15,35 +13,16 @@ import { recordEvent } from '@woocommerce/tracks';
 
 import './style.scss';
 import BlockEditorGuide from './block-editor-guide';
+import { usePublishedProductsCount } from './use-published-products-count';
 
 interface Props {
 	shouldTourBeShown: boolean;
 	dismissModal: () => void;
 }
 
-const PUBLISHED_PRODUCTS_QUERY_PARAMS = {
-	status: 'publish',
-	_fields: [ 'id' ],
-};
-
 const BlockEditorTour = ( { shouldTourBeShown, dismissModal }: Props ) => {
-	const { publishedProductsCount, loadingPublishedProductsCount } = useSelect(
-		( select ) => {
-			const { getProductsTotalCount, hasFinishedResolution } =
-				select( PRODUCTS_STORE_NAME );
-
-			return {
-				publishedProductsCount: getProductsTotalCount(
-					PUBLISHED_PRODUCTS_QUERY_PARAMS,
-					0
-				),
-				loadingPublishedProductsCount: ! hasFinishedResolution(
-					'getProductsTotalCount',
-					[ PUBLISHED_PRODUCTS_QUERY_PARAMS, 0 ]
-				),
-			};
-		}
-	);
+	const { isNewUser, loadingPublishedProductsCount } =
+		usePublishedProductsCount();
 
 	useEffect( () => {
 		if ( shouldTourBeShown ) {
@@ -54,9 +33,6 @@ const BlockEditorTour = ( { shouldTourBeShown, dismissModal }: Props ) => {
 	const [ isGuideOpen, setIsGuideOpen ] = useState( false );
 
 	const { maybeShowFeedbackBar } = useFeedbackBar();
-
-	// we consider a user new if they have no published products
-	const isNewUser = publishedProductsCount < 1;
 
 	const openGuide = () => {
 		setIsGuideOpen( true );

--- a/plugins/woocommerce-admin/client/products/tour/block-editor/use-published-products-count.tsx
+++ b/plugins/woocommerce-admin/client/products/tour/block-editor/use-published-products-count.tsx
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import { PRODUCTS_STORE_NAME } from '@woocommerce/data';
+import { useSelect } from '@wordpress/data';
+
+const PUBLISHED_PRODUCTS_QUERY_PARAMS = {
+	status: 'publish',
+	_fields: [ 'id' ],
+};
+
+export const usePublishedProductsCount = () => {
+	return useSelect( ( select ) => {
+		const { getProductsTotalCount, hasFinishedResolution } =
+			select( PRODUCTS_STORE_NAME );
+
+		const publishedProductsCount = getProductsTotalCount(
+			PUBLISHED_PRODUCTS_QUERY_PARAMS,
+			0
+		) as number;
+
+		const loadingPublishedProductsCount = ! hasFinishedResolution(
+			'getProductsTotalCount',
+			[ PUBLISHED_PRODUCTS_QUERY_PARAMS, 0 ]
+		);
+
+		return {
+			publishedProductsCount,
+			loadingPublishedProductsCount,
+			// we consider a user new if they have no published products
+			isNewUser: publishedProductsCount < 1,
+		};
+	} );
+};

--- a/plugins/woocommerce/changelog/fix-guide-new-user
+++ b/plugins/woocommerce/changelog/fix-guide-new-user
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Consider if user is new or not when clicking in "About the editor"
+
+


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Adjust AboutTheEditorMenuItem props to support `isNewUser` prop.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the block product editor in WooCommerce > Settings > Advanced > Features.
2. Go to Product > Add New.
3. You should see the tour kit step in the bottom left of the editor. (If you have already dismissed it, you can delete the woocommerce_block_product_tour_shown option through WCA Test Helper)
4. The texts should vary depending if you have published products or not.
5. Click 'Tell me more' and check the Guide steps.
6. Close the guide.
7. Click on the three dots icon on the top right corner (tooltip: Options)
8. Click 'About the editor...'
9. Check if the same guide shows up

<!-- End testing instructions -->
