### PR TITLE
Redirect to the old editor when attempting to edit a non-supported product type

### DIFF
--- a/plugins/woocommerce/changelog/update-38695
+++ b/plugins/woocommerce/changelog/update-38695
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Redirect to the old editor when attempting to edit a non-supported product type

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -21,9 +21,21 @@ class Init {
 	const EDITOR_CONTEXT_NAME = 'woocommerce/edit-product';
 
 	/**
+	 * Supported post types.
+	 */
+	private $supported_post_types = array( 'simple' );
+
+	/**
+	 * Redirection controller.
+	 */
+	private $redirection_controller;
+
+	/**
 	 * Constructor
 	 */
 	public function __construct() {
+		$this->redirection_controller = new RedirectionController( $this->supported_post_types );
+
 		if ( \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_block_editor' ) ) {
 			if ( ! Features::is_enabled( 'new-product-management-experience' ) ) {
 				add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_styles' ) );
@@ -36,56 +48,6 @@ class Init {
 
 			$block_registry = new BlockRegistry();
 			$block_registry->init();
-		}
-
-		add_action( 'current_screen', array( $this, 'maybe_redirect_to_new_editor' ), 30, 0 );
-		add_action( 'current_screen', array( $this, 'maybe_redirect_to_old_editor' ), 30, 0 );
-	}
-
-	/**
-	 * Redirects from old product form to the new product form if the
-	 * feature `product_block_editor` is enabled.
-	 */
-	public function maybe_redirect_to_new_editor(): void {
-		if ( \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_block_editor' ) ) {
-			$screen = get_current_screen();
-
-			if ( 'post' === $screen->base && 'product' === $screen->post_type ) {
-				if ( 'add' === $screen->action ) {
-					wp_safe_redirect( admin_url( 'admin.php?page=wc-admin&path=/add-product' ) );
-					exit();
-				}
-
-				if ( isset( $_GET['post'] ) && isset( $_GET['action'] ) && 'edit' === $_GET['action'] ) {
-					$product_id = absint( $_GET['post'] );
-					wp_safe_redirect( admin_url( 'admin.php?page=wc-admin&path=/product/' . $product_id ) );
-					exit();
-				}
-			}
-		}
-	}
-
-	/**
-	 * Redirects from new product form to the old product form if the
-	 * feature `product_block_editor` is enabled.
-	 */
-	public function maybe_redirect_to_old_editor(): void {
-		if ( ! \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_block_editor' ) ) {
-			if ( \Automattic\WooCommerce\Admin\PageController::is_admin_page() && isset( $_GET['path'] ) ) {
-				$path        = esc_url_raw( wp_unslash( $_GET['path'] ) );
-				$parsed_path = explode( '/', wp_parse_url( $path, PHP_URL_PATH ) );
-
-				if ( 'add-product' === $parsed_path[1] ) {
-					wp_safe_redirect( admin_url( 'post-new.php?post_type=product' ) );
-					exit();
-				}
-
-				if ( 'product' === $parsed_path[1] ) {
-					$product_id = absint( $parsed_path[2] );
-					wp_safe_redirect( admin_url( 'post.php?post=' . $product_id . '&action=edit' ) );
-					exit();
-				}
-			}
 		}
 	}
 

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -22,11 +22,15 @@ class Init {
 
 	/**
 	 * Supported post types.
+	 *
+	 * @var array
 	 */
 	private $supported_post_types = array( 'simple' );
 
 	/**
 	 * Redirection controller.
+	 *
+	 * @var RedirectionController
 	 */
 	private $redirection_controller;
 

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/RedirectionController.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/RedirectionController.php
@@ -14,6 +14,8 @@ class RedirectionController {
 
 	/**
 	 * Supported post types.
+	 *
+	 * @var array
 	 */
 	private $supported_post_types;
 
@@ -74,7 +76,7 @@ class RedirectionController {
 		}
 
 		if ( $this->is_legacy_edit_screen() ) {
-			$product_id = absint( $_GET['post'] );
+			$product_id = isset( $_GET['post'] ) ? absint( $_GET['post'] ) : null;
 			if ( ! $this->is_product_supported( $product_id ) ) {
 				return;
 			}
@@ -90,12 +92,12 @@ class RedirectionController {
 	public function maybe_redirect_to_old_editor(): void {
 		$route = $this->get_parsed_route();
 
-		if ( $route['page'] === 'add-product' ) {
+		if ( 'add-product' === $route['page'] ) {
 			wp_safe_redirect( admin_url( 'post-new.php?post_type=product' ) );
 			exit();
 		}
 
-		if ( $route['page'] === 'product' ) {
+		if ( 'product' === $route['page'] ) {
 			wp_safe_redirect( admin_url( 'post.php?post=' . $route['product_id'] . '&action=edit' ) );
 			exit();
 		}
@@ -117,7 +119,7 @@ class RedirectionController {
 
 		return array(
 			'page'       => $path_pieces[1],
-			'product_id' => $path_pieces[1] === 'product' ? absint( $path_pieces[2] ) : null,
+			'product_id' => 'product' === $path_pieces[1] ? absint( $path_pieces[2] ) : null,
 		);
 	}
 
@@ -128,7 +130,7 @@ class RedirectionController {
 		$route      = $this->get_parsed_route();
 		$product_id = $route['product_id'];
 
-		if ( $route['page'] === 'product' && ! $this->is_product_supported( $product_id ) ) {
+		if ( 'product' === $route['page'] && ! $this->is_product_supported( $product_id ) ) {
 			wp_safe_redirect( admin_url( 'post.php?post=' . $route['product_id'] . '&action=edit' ) );
 			exit();
 		}

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/RedirectionController.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/RedirectionController.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * WooCommerce Product Editor Redirection Controller
+ */
+
+namespace Automattic\WooCommerce\Admin\Features\ProductBlockEditor;
+
+use Automattic\WooCommerce\Internal\Admin\WCAdminAssets;
+
+/**
+ * Handle redirecting to the old or new editor based on features and support.
+ */
+class RedirectionController {
+
+	/**
+	 * Supported post types.
+	 */
+	private $supported_post_types;
+
+	/**
+	 * Set up the hooks used for redirection.
+	 *
+	 * @param array $supported_post_types Array of supported post types.
+	 */
+	public function __construct( $supported_post_types ) {
+		$this->supported_post_types = $supported_post_types;
+
+		if ( \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_block_editor' ) ) {
+			add_action( 'current_screen', array( $this, 'maybe_redirect_to_new_editor' ), 30, 0 );
+			add_action( 'current_screen', array( $this, 'redirect_non_supported_product_types' ), 30, 0 );
+		} else {
+			add_action( 'current_screen', array( $this, 'maybe_redirect_to_old_editor' ), 30, 0 );
+		}
+	}
+
+	/**
+	 * Check if the current screen is the legacy add product screen.
+	 */
+	protected function is_legacy_add_new_screen(): bool {
+		$screen = get_current_screen();
+		return 'post' === $screen->base && 'product' === $screen->post_type && 'add' === $screen->action;
+	}
+
+	/**
+	 * Check if the current screen is the legacy edit product screen.
+	 */
+	protected function is_legacy_edit_screen(): bool {
+		$screen = get_current_screen();
+		return 'post' === $screen->base
+			&& 'product' === $screen->post_type
+			&& isset( $_GET['post'] )
+			&& isset( $_GET['action'] )
+			&& 'edit' === $_GET['action'];
+	}
+
+	/**
+	 * Check if a product is supported by the new experience.
+	 *
+	 * @param integer $product_id Product ID.
+	 */
+	protected function is_product_supported( $product_id ): bool {
+		$product = $product_id ? wc_get_product( $product_id ) : null;
+		return $product && in_array( $product->get_type(), $this->supported_post_types, true );
+	}
+
+	/**
+	 * Redirects from old product form to the new product form if the
+	 * feature `product_block_editor` is enabled.
+	 */
+	public function maybe_redirect_to_new_editor(): void {
+		if ( $this->is_legacy_add_new_screen() ) {
+			wp_safe_redirect( admin_url( 'admin.php?page=wc-admin&path=/add-product' ) );
+			exit();
+		}
+
+		if ( $this->is_legacy_edit_screen() ) {
+			$product_id = absint( $_GET['post'] );
+			if ( ! $this->is_product_supported( $product_id ) ) {
+				return;
+			}
+			wp_safe_redirect( admin_url( 'admin.php?page=wc-admin&path=/product/' . $product_id ) );
+			exit();
+		}
+	}
+
+	/**
+	 * Redirects from new product form to the old product form if the
+	 * feature `product_block_editor` is enabled.
+	 */
+	public function maybe_redirect_to_old_editor(): void {
+		$route = $this->get_parsed_route();
+
+		if ( $route['page'] === 'add-product' ) {
+			wp_safe_redirect( admin_url( 'post-new.php?post_type=product' ) );
+			exit();
+		}
+
+		if ( $route['page'] === 'product' ) {
+			wp_safe_redirect( admin_url( 'post.php?post=' . $route['product_id'] . '&action=edit' ) );
+			exit();
+		}
+	}
+
+	/**
+	 * Get the parsed WooCommerce Admin path.
+	 */
+	protected function get_parsed_route(): array {
+		if ( ! \Automattic\WooCommerce\Admin\PageController::is_admin_page() || ! isset( $_GET['path'] ) ) {
+			return array(
+				'page'       => null,
+				'product_id' => null,
+			);
+		}
+
+		$path        = esc_url_raw( wp_unslash( $_GET['path'] ) );
+		$path_pieces = explode( '/', wp_parse_url( $path, PHP_URL_PATH ) );
+
+		return array(
+			'page'       => $path_pieces[1],
+			'product_id' => $path_pieces[1] === 'product' ? absint( $path_pieces[2] ) : null,
+		);
+	}
+
+	/**
+	 * Redirect non supported product types to legacy editor.
+	 */
+	public function redirect_non_supported_product_types(): void {
+		$route      = $this->get_parsed_route();
+		$product_id = $route['product_id'];
+
+		if ( $route['page'] === 'product' && ! $this->is_product_supported( $product_id ) ) {
+			wp_safe_redirect( admin_url( 'post.php?post=' . $route['product_id'] . '&action=edit' ) );
+			exit();
+		}
+	}
+
+}


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #38695 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a variable product in the old experience and copy the ID
2. Go to WooCommerce -> Settings -> Advanced -> Features and enable the product blocks editor
3. Navigate to `/wp-admin/admin.php?page=wc-admin&path=/product/{product_id}&tab=general` replacing `{product_id}` with the copied variable product ID
4. Make sure that you are redirected to the old product editor

<!-- End testing instructions -->
