### PR TITLE
Fire HPOS bulk action hook for all custom bulk actions

### DIFF
--- a/plugins/woocommerce/changelog/fix-38558
+++ b/plugins/woocommerce/changelog/fix-38558
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fire bulk action orders hook for all custom actions.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -1217,8 +1217,9 @@ class ListTable extends WP_List_Table {
 			exit;
 		}
 
-		$report_action = '';
-		$changed       = 0;
+		$report_action  = '';
+		$changed        = 0;
+		$action_handled = true;
 
 		if ( 'remove_personal_data' === $action ) {
 			$report_action = 'removed_personal_data';
@@ -1239,8 +1240,15 @@ class ListTable extends WP_List_Table {
 
 			if ( isset( $order_statuses[ 'wc-' . $new_status ] ) ) {
 				$changed = $this->do_bulk_action_mark_orders( $ids, $new_status );
+			} else {
+				$action_handled = false;
 			}
 		} else {
+			$action_handled = false;
+		}
+
+		// Custom action.
+		if ( ! $action_handled ) {
 			$screen = get_current_screen()->id;
 
 			/**


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
In HPOS, order bulk actions starting with `mark_` (which include "Mark as Completed", "Mark as Cancelled", etc.) were being handled by our `ListTable` code internally, preventing 3rd parties from implementing similar actions as the bulk action hook wasn't being fired.

This PR makes it so any bulk action that isn't effectively handled by our own code can be implemented by the bulk action hook, even those starting with `mark_` that don't correspond to a change to a known order status.

Closes #38558.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

With some copy/paste from the excellent instructions provided in #38558.

1. Check out `trunk`.
1. Enable HPOS by making sure that the "Enable the high performance order storage feature." is enabled in WC > Settings > Advanced > Features. Similarly, ensure that "Use the WooCommerce orders tables" is selected in WC > Settings > Advanced > Custom data stores.
1. Create a custom plugin or snippet with the following code:
   ```php
   add_filter( "bulk_actions-woocommerce_page_wc-orders", function($actions) {
       return array_merge( $actions, [ 'mark_as_exported' => __( 'Mark as exported' ) ] );
   } );
   
   add_action( "handle_bulk_actions-woocommerce_page_wc-orders", function($redirect_to, $action, $ids) {
       if ($action === 'mark_as_exported') {
           die( 'Handling mark as exported' ); // <-- this never happens
       }
   }, 10, 3 );
   ```
1. Trigger the bulk action from the orders list table - select at least 1 order, then "Mark as exported" from bulk actions, and click Apply.
1. Confirm that nothing happens.
1. Check out this branch and repeat steps 2-4, but this time confirm that the custom hook is triggered and you see a "Handling mark as exported" on the screen.

<!-- End testing instructions -->
