### PR TITLE
Fix selection of multiple orders in HPOS list table

### DIFF
--- a/plugins/woocommerce/changelog/fix-38524
+++ b/plugins/woocommerce/changelog/fix-38524
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix selection of multiple orders in HPOS list table.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -867,7 +867,7 @@ class ListTable extends WP_List_Table {
 	public function column_cb( $item ) {
 		ob_start();
 		?>
-		<input id="cb-select-<?php echo esc_attr( $item->get_id() ); ?>" type="checkbox" name="<?php echo esc_attr( $this->_args['singular'] ); ?>" value="<?php echo esc_attr( $item->get_id() ); ?>" />
+		<input id="cb-select-<?php echo esc_attr( $item->get_id() ); ?>" type="checkbox" name="<?php echo esc_attr( $this->_args['singular'] ); ?>[]" value="<?php echo esc_attr( $item->get_id() ); ?>" />
 
 		<div class="locked-indicator">
 			<span class="locked-indicator-icon" aria-hidden="true"></span>


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
In #38230 I made [an embarrassing mistake](https://github.com/woocommerce/woocommerce/commit/fb5ac94218a086cbe07ae3db5c4bc09e121a49d0) and changed the input name for orders in the HPOS list table from `order[]` to `order`.
This effectively prevents bulk actions from operating on multiple orders at the same time as only one of the orders is sent via POST.

This PR addresses this problem by changing the input's name back to the array format.

Closes #38524.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

(Copy/pasted from the excellent testing instructions in #38524)

1. Enable HPOS by making sure that the "Enable the high performance order storage feature." is enabled in WC > Settings > Advanced > Features. Similarly, ensure that "Use the WooCommerce orders tables" is selected in WC > Settings > Advanced > Custom data stores.
2. Create 2 orders, both with On-Hold status.
3. In orders list table, select both orders.
4. In Bulk actions, choose "Change status to processing" and click Apply.
5.
   - On `trunk`, only one of the orders is changed to "Processing".
   - On this branch, both orders are changed.

<!-- End testing instructions -->
