### PR TITLE
Monorepo Setup: Pin phpcs-changed version

### DIFF
--- a/.github/actions/setup-woocommerce-monorepo/action.yml
+++ b/.github/actions/setup-woocommerce-monorepo/action.yml
@@ -43,7 +43,7 @@ runs:
           with:
               php-version: ${{ inputs.php-version }}
               coverage: none
-              tools: phpcs, sirbrillig/phpcs-changed
+              tools: phpcs, sirbrillig/phpcs-changed:2.10.2
 
         - name: Cache Composer Dependencies
           uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

PHPCS-changed is already pinned in composer.json

https://github.com/woocommerce/woocommerce/blob/adb8058b9620971da263845d042682814a46c68d/plugins/woocommerce/bin/composer/phpcs/composer.json#L4

This PR also pins the version in `shivammathur/setup-php` usage when setting up the Monorepo.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. See the Code Sniff action pass in CI

<!-- End testing instructions -->
