### PR TITLE
Various UI fixes in Core profiler steps

### DIFF
--- a/plugins/woocommerce-admin/client/core-profiler/components/heading/style.scss
+++ b/plugins/woocommerce-admin/client/core-profiler/components/heading/style.scss
@@ -10,7 +10,7 @@
 	.woocommerce-profiler-heading__title {
 		font-style: normal;
 		font-weight: 400;
-		letter-spacing: .75px;
+		letter-spacing: 0.75px;
 		font-size: 40px;
 		line-height: 46px;
 		text-align: center;

--- a/plugins/woocommerce-admin/client/core-profiler/components/heading/style.scss
+++ b/plugins/woocommerce-admin/client/core-profiler/components/heading/style.scss
@@ -4,14 +4,15 @@
 	justify-content: center;
 	align-items: center;
 	margin-bottom: 48px;
-	max-width: 550px;
+	max-width: 610px;
 	width: 100%;
 
 	.woocommerce-profiler-heading__title {
 		font-style: normal;
-		font-weight: 500;
+		font-weight: 400;
+		letter-spacing: .75px;
 		font-size: 40px;
-		line-height: 40px;
+		line-height: 46px;
 		text-align: center;
 		color: $gray-900;
 		margin-bottom: 12px;
@@ -29,10 +30,11 @@
 		font-size: 16px;
 		line-height: 24px;
 		text-align: center;
-		color: $gray-800;
+		color: $gray-700;
+		letter-spacing: 0.25px;
 
 		@include breakpoint( '<782px' ) {
-			color: $gray-800;
+			color: $gray-700;
 		}
 	}
 

--- a/plugins/woocommerce-admin/client/core-profiler/components/heading/style.scss
+++ b/plugins/woocommerce-admin/client/core-profiler/components/heading/style.scss
@@ -11,8 +11,8 @@
 		font-style: normal;
 		font-weight: 400;
 		letter-spacing: 0.75px;
-		font-size: 40px;
-		line-height: 46px;
+		font-size: 32px;
+		line-height: 40px;
 		text-align: center;
 		color: $gray-900;
 		margin-bottom: 12px;

--- a/plugins/woocommerce-admin/client/core-profiler/components/multiple-selector/multiple-selector.scss
+++ b/plugins/woocommerce-admin/client/core-profiler/components/multiple-selector/multiple-selector.scss
@@ -1,4 +1,4 @@
-@import '../../shared';
+@import '../../shared.scss';
 
 .woocommerce-experimental-select-control {
 	&:hover,

--- a/plugins/woocommerce-admin/client/core-profiler/components/multiple-selector/multiple-selector.scss
+++ b/plugins/woocommerce-admin/client/core-profiler/components/multiple-selector/multiple-selector.scss
@@ -1,3 +1,4 @@
+@import '../../shared';
 
 .woocommerce-experimental-select-control {
 	&:hover,
@@ -67,47 +68,6 @@
 			box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
 			border-radius: 2px;
 			overflow-x: hidden !important;
-
-			ul li {
-				&:hover {
-					background-color: #eff2fd !important;
-					cursor: pointer;
-				}
-
-				.components-base-control__field {
-					margin-bottom: 0 !important;
-				}
-
-				.components-checkbox-control__label {
-					cursor: pointer;
-					font-size: 13px;
-					font-weight: normal !important;
-					pointer-events: none;
-				}
-
-				.components-checkbox-control__input-container {
-					border: 1px solid #757575;
-					border-radius: 2px;
-					height: 20px !important;
-					padding: 1px;
-					width: 20px !important;
-
-					.components-checkbox-control__input[type='checkbox'] {
-						border: none;
-						height: 16px !important;
-						width: 16px !important;
-						&:checked {
-							border-radius: 2px;
-						}
-					}
-
-					svg {
-						height: 20px;
-						top: -1px;
-						width: 22px;
-					}
-				}
-			}
 		}
 	}
 }

--- a/plugins/woocommerce-admin/client/core-profiler/components/multiple-selector/render-menu.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/components/multiple-selector/render-menu.tsx
@@ -50,6 +50,7 @@ export const renderMenu =
 							} }
 						>
 							<CheckboxControl
+								className="core-profiler__checkbox"
 								onChange={ () => {} }
 								checked={ isSelected }
 								label={ item.label }

--- a/plugins/woocommerce-admin/client/core-profiler/components/plugin-card/plugin-card.scss
+++ b/plugins/woocommerce-admin/client/core-profiler/components/plugin-card/plugin-card.scss
@@ -128,6 +128,7 @@
 				color: #00450c;
 				font-size: 11px;
 				font-weight: 500;
+				line-height: 20px;
 				@include breakpoint( '<782px' ) {
 					display: none;
 				}

--- a/plugins/woocommerce-admin/client/core-profiler/components/plugin-card/plugin-card.scss
+++ b/plugins/woocommerce-admin/client/core-profiler/components/plugin-card/plugin-card.scss
@@ -76,14 +76,10 @@
 			width: 16px;
 			height: 16px;
 			&:focus {
-				box-shadow: none;
 				border-color: #1e1e1e;
 			}
 		}
 		.components-checkbox-control__input[type='checkbox']:checked {
-			box-shadow: 0 0 0 1px #fff,
-				0 0 0 2px
-				var(--wp-components-color-accent, var(--wp-admin-theme-color, #007cba));
 			outline: 1px solid transparent;
 		}
 		.components-checkbox-control__checked {

--- a/plugins/woocommerce-admin/client/core-profiler/components/plugin-card/plugin-card.scss
+++ b/plugins/woocommerce-admin/client/core-profiler/components/plugin-card/plugin-card.scss
@@ -1,4 +1,4 @@
-@import '../../shared';
+@import '../../shared.scss';
 
 .woocommerce-profiler-plugins-plugin-card {
 	max-width: 492px;
@@ -72,7 +72,7 @@
 		}
 	}
 
-  .components-checkbox-control__input-container {
+	.components-checkbox-control__input-container {
 		margin-right: 24px;
 
 		@include breakpoint( '<782px' ) {

--- a/plugins/woocommerce-admin/client/core-profiler/components/plugin-card/plugin-card.scss
+++ b/plugins/woocommerce-admin/client/core-profiler/components/plugin-card/plugin-card.scss
@@ -1,3 +1,5 @@
+@import '../../shared';
+
 .woocommerce-profiler-plugins-plugin-card {
 	max-width: 492px;
 	display: flex;
@@ -70,23 +72,11 @@
 		}
 	}
 
-	.components-checkbox-control {
-		.components-checkbox-control__input,
-		components-checkbox-control__input-container {
-			width: 16px;
-			height: 16px;
-			&:focus {
-				border-color: #1e1e1e;
-			}
-		}
-		.components-checkbox-control__input[type='checkbox']:checked {
-			outline: 1px solid transparent;
-		}
-		.components-checkbox-control__checked {
-			left: -1px;
-			top: -1px;
-			width: 18px;
-			height: 18px;
+  .components-checkbox-control__input-container {
+		margin-right: 24px;
+
+		@include breakpoint( '<782px' ) {
+			margin-right: 16px;
 		}
 	}
 

--- a/plugins/woocommerce-admin/client/core-profiler/components/plugin-card/plugin-card.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/components/plugin-card/plugin-card.tsx
@@ -35,7 +35,7 @@ export const PluginCard = ( {
 		<div className="woocommerce-profiler-plugins-plugin-card">
 			{ ! installed && (
 				<CheckboxControl
-					className='core-profiler__checkbox'
+					className="core-profiler__checkbox"
 					checked={ checked }
 					onChange={ onChange ? onChange : () => {} }
 				/>

--- a/plugins/woocommerce-admin/client/core-profiler/components/plugin-card/plugin-card.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/components/plugin-card/plugin-card.tsx
@@ -35,6 +35,7 @@ export const PluginCard = ( {
 		<div className="woocommerce-profiler-plugins-plugin-card">
 			{ ! installed && (
 				<CheckboxControl
+					className='core-profiler__checkbox'
 					checked={ checked }
 					onChange={ onChange ? onChange : () => {} }
 				/>

--- a/plugins/woocommerce-admin/client/core-profiler/pages/IntroOptIn.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/pages/IntroOptIn.tsx
@@ -69,7 +69,7 @@ export const IntroOptIn = ( {
 
 				<div className="woocommerce-profiler-intro-opt-in__footer">
 					<CheckboxControl
-						className="woocommerce-profiler-intro-opt-in__checkbox"
+						className="core-profiler__checkbox"
 						label={ interpolateComponents( {
 							mixedString: __(
 								'I agree to share my data to tailor my store setup experience and get more relevant content. WooCommerce never rent or sell your data and you can opt out at any time in WooCommerce settings. {{link}}Learn more about usage tracking{{/link}}.',

--- a/plugins/woocommerce-admin/client/core-profiler/shared.scss
+++ b/plugins/woocommerce-admin/client/core-profiler/shared.scss
@@ -1,0 +1,39 @@
+.core-profiler__checkbox {
+  input {
+    outline: 2px solid transparent;
+    width: 16px;
+    height: 16px;
+    border-radius: 2px;
+  }
+
+  .components-checkbox-control__input-container {
+    width: 16px;
+    height: 16px;
+  }
+
+  .components-checkbox-control__input[type=checkbox] {
+    width: 16px !important;
+    height: 16px !important;
+  }
+
+  svg.components-checkbox-control__checked {
+    width: 20px;
+    height: 20px;
+
+    @include breakpoint( '<600px' ) {
+      width: 16px;
+      height: 16px;
+    }
+  }
+
+  .components-base-control__field {
+    margin-bottom: 0;
+    display: flex;
+    align-items: center;
+  }
+
+  .woocommerce-select-control__control-input {
+    font-size: 13px;
+    line-height: 16px;
+  }
+}

--- a/plugins/woocommerce-admin/client/core-profiler/shared.scss
+++ b/plugins/woocommerce-admin/client/core-profiler/shared.scss
@@ -1,39 +1,39 @@
 .core-profiler__checkbox {
-  input {
-    outline: 2px solid transparent;
-    width: 16px;
-    height: 16px;
-    border-radius: 2px;
-  }
+	input {
+		outline: 2px solid transparent;
+		width: 16px;
+		height: 16px;
+		border-radius: 2px;
+	}
 
-  .components-checkbox-control__input-container {
-    width: 16px;
-    height: 16px;
-  }
+	.components-checkbox-control__input-container {
+		width: 16px;
+		height: 16px;
+	}
 
-  .components-checkbox-control__input[type=checkbox] {
-    width: 16px !important;
-    height: 16px !important;
-  }
+	.components-checkbox-control__input[type='checkbox'] {
+		width: 16px !important;
+		height: 16px !important;
+	}
 
-  svg.components-checkbox-control__checked {
-    width: 20px;
-    height: 20px;
+	svg.components-checkbox-control__checked {
+		width: 20px;
+		height: 20px;
 
-    @include breakpoint( '<600px' ) {
-      width: 16px;
-      height: 16px;
-    }
-  }
+		@include breakpoint( '<600px' ) {
+			width: 16px;
+			height: 16px;
+		}
+	}
 
-  .components-base-control__field {
-    margin-bottom: 0;
-    display: flex;
-    align-items: center;
-  }
+	.components-base-control__field {
+		margin-bottom: 0;
+		display: flex;
+		align-items: center;
+	}
 
-  .woocommerce-select-control__control-input {
-    font-size: 13px;
-    line-height: 16px;
-  }
+	.woocommerce-select-control__control-input {
+		font-size: 13px;
+		line-height: 16px;
+	}
 }

--- a/plugins/woocommerce-admin/client/core-profiler/style.scss
+++ b/plugins/woocommerce-admin/client/core-profiler/style.scss
@@ -596,7 +596,6 @@
 				margin: 0;
 
 				.geolocation-notice-geolocated-country {
-					color: #3858e9;
 					text-decoration: none;
 				}
 			}

--- a/plugins/woocommerce-admin/client/core-profiler/style.scss
+++ b/plugins/woocommerce-admin/client/core-profiler/style.scss
@@ -169,7 +169,6 @@
 
 		.woocommerce-profiler-intro-opt-in__checkbox {
 			input {
-				box-shadow: 0 0 0 2px #fff, 0 0 0 4px $gray-700;
 				outline: 2px solid transparent;
 				width: 16px;
 				height: 16px;

--- a/plugins/woocommerce-admin/client/core-profiler/style.scss
+++ b/plugins/woocommerce-admin/client/core-profiler/style.scss
@@ -116,6 +116,15 @@
 	flex-direction: column;
 }
 
+.core-profiler-intro-opt-in-screen {
+	.woocommerce-profiler-heading {
+		.woocommerce-profiler-heading__title {
+			font-size: 40px;
+			line-height: 46px;
+		}
+	}
+}
+
 .woocommerce-profiler-intro-opt-in__content {
 	padding-top: 110px;
 	flex: 1;

--- a/plugins/woocommerce-admin/client/core-profiler/style.scss
+++ b/plugins/woocommerce-admin/client/core-profiler/style.scss
@@ -1,3 +1,5 @@
+@import './shared.scss';
+
 .woocommerce-layout .woocommerce-layout__main {
 	@include breakpoint( '<782px' ) {
 		padding-top: 0 !important;
@@ -167,49 +169,17 @@
 			margin: 16px auto 20px;
 		}
 
-		.woocommerce-profiler-intro-opt-in__checkbox {
-			input {
-				outline: 2px solid transparent;
-				width: 16px;
-				height: 16px;
-				border-radius: 2px;
-			}
+		.components-checkbox-control__input-container {
+			margin-left: 5px;
+		}
 
-			.components-checkbox-control__input-container {
-				width: 16px;
-				height: 16px;
-				margin-left: 5px;
-			}
-
-			svg.components-checkbox-control__checked {
-				width: 20px;
-				height: 20px;
-
-				@include breakpoint( '<782px' ) {
-					width: 16px;
-					height: 16px;
-				}
-			}
-
-			.components-base-control__field {
-				margin-bottom: 0;
-				display: flex;
-				align-items: center;
-			}
-
-			.components-checkbox-control__label {
-				display: inline-block;
-				color: $gray-700;
-				font-size: 13px;
-				line-height: 16px;
-				max-width: 514px;
-				margin-left: 10px;
-			}
-
-			.woocommerce-select-control__control-input {
-				font-size: 13px;
-				line-height: 16px;
-			}
+		.components-checkbox-control__label {
+			display: inline-block;
+			color: $gray-700;
+			font-size: 13px;
+			line-height: 16px;
+			max-width: 514px;
+			margin-left: 10px;
 		}
 
 		a {

--- a/plugins/woocommerce-admin/client/core-profiler/style.scss
+++ b/plugins/woocommerce-admin/client/core-profiler/style.scss
@@ -114,9 +114,7 @@
 	min-height: 100vh;
 	display: flex;
 	flex-direction: column;
-}
 
-.core-profiler-intro-opt-in-screen {
 	.woocommerce-profiler-heading {
 		.woocommerce-profiler-heading__title {
 			font-size: 40px;

--- a/plugins/woocommerce-admin/client/core-profiler/test/__snapshots__/core-profiler-machine.test.tsx.snap
+++ b/plugins/woocommerce-admin/client/core-profiler/test/__snapshots__/core-profiler-machine.test.tsx.snap
@@ -123,7 +123,7 @@ Object {
               class="woocommerce-profiler-intro-opt-in__footer"
             >
               <div
-                class="components-base-control components-checkbox-control woocommerce-profiler-intro-opt-in__checkbox css-wdf2ti-Wrapper ej5x27r4"
+                class="components-base-control components-checkbox-control core-profiler__checkbox css-wdf2ti-Wrapper ej5x27r4"
               >
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
@@ -268,7 +268,7 @@ Object {
             class="woocommerce-profiler-intro-opt-in__footer"
           >
             <div
-              class="components-base-control components-checkbox-control woocommerce-profiler-intro-opt-in__checkbox css-wdf2ti-Wrapper ej5x27r4"
+              class="components-base-control components-checkbox-control core-profiler__checkbox css-wdf2ti-Wrapper ej5x27r4"
             >
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
@@ -496,7 +496,7 @@ Object {
               class="woocommerce-profiler-intro-opt-in__footer"
             >
               <div
-                class="components-base-control components-checkbox-control woocommerce-profiler-intro-opt-in__checkbox css-wdf2ti-Wrapper ej5x27r4"
+                class="components-base-control components-checkbox-control core-profiler__checkbox css-wdf2ti-Wrapper ej5x27r4"
               >
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
@@ -641,7 +641,7 @@ Object {
             class="woocommerce-profiler-intro-opt-in__footer"
           >
             <div
-              class="components-base-control components-checkbox-control woocommerce-profiler-intro-opt-in__checkbox css-wdf2ti-Wrapper ej5x27r4"
+              class="components-base-control components-checkbox-control core-profiler__checkbox css-wdf2ti-Wrapper ej5x27r4"
             >
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
@@ -869,7 +869,7 @@ Object {
               class="woocommerce-profiler-intro-opt-in__footer"
             >
               <div
-                class="components-base-control components-checkbox-control woocommerce-profiler-intro-opt-in__checkbox css-wdf2ti-Wrapper ej5x27r4"
+                class="components-base-control components-checkbox-control core-profiler__checkbox css-wdf2ti-Wrapper ej5x27r4"
               >
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
@@ -1014,7 +1014,7 @@ Object {
             class="woocommerce-profiler-intro-opt-in__footer"
           >
             <div
-              class="components-base-control components-checkbox-control woocommerce-profiler-intro-opt-in__checkbox css-wdf2ti-Wrapper ej5x27r4"
+              class="components-base-control components-checkbox-control core-profiler__checkbox css-wdf2ti-Wrapper ej5x27r4"
             >
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
@@ -1242,7 +1242,7 @@ Object {
               class="woocommerce-profiler-intro-opt-in__footer"
             >
               <div
-                class="components-base-control components-checkbox-control woocommerce-profiler-intro-opt-in__checkbox css-wdf2ti-Wrapper ej5x27r4"
+                class="components-base-control components-checkbox-control core-profiler__checkbox css-wdf2ti-Wrapper ej5x27r4"
               >
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
@@ -1387,7 +1387,7 @@ Object {
             class="woocommerce-profiler-intro-opt-in__footer"
           >
             <div
-              class="components-base-control components-checkbox-control woocommerce-profiler-intro-opt-in__checkbox css-wdf2ti-Wrapper ej5x27r4"
+              class="components-base-control components-checkbox-control core-profiler__checkbox css-wdf2ti-Wrapper ej5x27r4"
             >
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
@@ -1615,7 +1615,7 @@ Object {
               class="woocommerce-profiler-intro-opt-in__footer"
             >
               <div
-                class="components-base-control components-checkbox-control woocommerce-profiler-intro-opt-in__checkbox css-wdf2ti-Wrapper ej5x27r4"
+                class="components-base-control components-checkbox-control core-profiler__checkbox css-wdf2ti-Wrapper ej5x27r4"
               >
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
@@ -1760,7 +1760,7 @@ Object {
             class="woocommerce-profiler-intro-opt-in__footer"
           >
             <div
-              class="components-base-control components-checkbox-control woocommerce-profiler-intro-opt-in__checkbox css-wdf2ti-Wrapper ej5x27r4"
+              class="components-base-control components-checkbox-control core-profiler__checkbox css-wdf2ti-Wrapper ej5x27r4"
             >
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
@@ -2375,7 +2375,7 @@ Object {
               class="woocommerce-profiler-intro-opt-in__footer"
             >
               <div
-                class="components-base-control components-checkbox-control woocommerce-profiler-intro-opt-in__checkbox css-wdf2ti-Wrapper ej5x27r4"
+                class="components-base-control components-checkbox-control core-profiler__checkbox css-wdf2ti-Wrapper ej5x27r4"
               >
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
@@ -2520,7 +2520,7 @@ Object {
             class="woocommerce-profiler-intro-opt-in__footer"
           >
             <div
-              class="components-base-control components-checkbox-control woocommerce-profiler-intro-opt-in__checkbox css-wdf2ti-Wrapper ej5x27r4"
+              class="components-base-control components-checkbox-control core-profiler__checkbox css-wdf2ti-Wrapper ej5x27r4"
             >
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
@@ -2748,7 +2748,7 @@ Object {
               class="woocommerce-profiler-intro-opt-in__footer"
             >
               <div
-                class="components-base-control components-checkbox-control woocommerce-profiler-intro-opt-in__checkbox css-wdf2ti-Wrapper ej5x27r4"
+                class="components-base-control components-checkbox-control core-profiler__checkbox css-wdf2ti-Wrapper ej5x27r4"
               >
                 <div
                   class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"
@@ -2893,7 +2893,7 @@ Object {
             class="woocommerce-profiler-intro-opt-in__footer"
           >
             <div
-              class="components-base-control components-checkbox-control woocommerce-profiler-intro-opt-in__checkbox css-wdf2ti-Wrapper ej5x27r4"
+              class="components-base-control components-checkbox-control core-profiler__checkbox css-wdf2ti-Wrapper ej5x27r4"
             >
               <div
                 class="components-base-control__field css-10urnh1-StyledField-deprecatedMarginField ej5x27r3"

--- a/plugins/woocommerce-admin/client/core-profiler/utils/get-loader-stage-meta.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/utils/get-loader-stage-meta.tsx
@@ -32,7 +32,7 @@ const LayoutStage = {
 		{
 			label: __( '#FunWooFact: ', 'woocommerce' ),
 			text: __(
-				'#FunWooFact: Did you know that Woo powers almost 4 million stores worldwide? You’re in good company.',
+				'Did you know that Woo powers almost 4 million stores worldwide? You’re in good company.',
 				'woocommerce'
 			),
 		},

--- a/plugins/woocommerce/changelog/fix-38731-core-profiler-ui-fixes
+++ b/plugins/woocommerce/changelog/fix-38731-core-profiler-ui-fixes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Minor UI fixes in Core profiler steps


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #38731.

Fixes the following:

1. Heading letters spacing
1. Subheading color to the proper grey
1. Removed duplicated `#FunWooFact` during `Extending your store's capabilities` loading message
1. Vertically center the "Installed" label in the extensions screen
2. Button color in the geolocation message

Additional changes:

1. Standardize checkbox styling
2. Fixed heading size for Woo


Note:
- I wasn't able to fully match the font for the heading and subheading fonts since it uses SF Pro font, which we have no web license for. Instead, I adjusted the font weight, line height, and letter spacing.

### How to test the changes in this Pull Request:

1. Install and activate WooCommerce on a brand new site
1. Install the WooCommerce Beta Tester plugin
1. Go to /wp-admin/tools.php?page=woocommerce-admin-test-helper
1. Enable the 'core-profiler' feature flag
1. Visit your public URL /wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard
4. Go through the new core profiler flow.
5. Observe the heading letter spacing is similar to design
6. Have at least one extension of the plugins step already installed and activated 
7. Observe the `Installed` label is now vertically centered

Before:
<img width="560" alt="image" src="https://github.com/woocommerce/woocommerce/assets/3747241/ced07b56-75bf-4276-ba2e-9727bfb65746">

After:
<img width="614" alt="image" src="https://github.com/woocommerce/woocommerce/assets/3747241/d937effa-62c6-4c2c-896c-c7c89e1bec59">


Before:
<img width="489" alt="image" src="https://github.com/woocommerce/woocommerce/assets/3747241/75cc3e76-7326-4744-9433-749c66b369ee">
After:
<img width="491" alt="image" src="https://github.com/woocommerce/woocommerce/assets/3747241/b06e56cb-e7bf-4673-915d-41bd5d243ab0">

Before:
<img width="421" alt="image" src="https://github.com/woocommerce/woocommerce/assets/3747241/7adcf785-2a6b-4ee4-a3eb-ec747b030a94">
After:
<img width="432" alt="image" src="https://github.com/woocommerce/woocommerce/assets/3747241/c911328a-40e4-4d09-8479-6d528455c54c">

Before:
<img width="644" alt="image" src="https://github.com/woocommerce/woocommerce/assets/3747241/ff619636-a262-41cb-a1cd-440e35e09b0f">
After:
<img width="691" alt="image" src="https://github.com/woocommerce/woocommerce/assets/3747241/dcae19ad-0142-48a5-a747-d2acac800d51">

<!-- End testing instructions -->
