### PR TITLE
Fix Jetpack redirection issue when the auth endpoint returns an invalid url

### DIFF
--- a/packages/js/data/changelog/fix-38758-jetpack-redirection-fix
+++ b/packages/js/data/changelog/fix-38758-jetpack-redirection-fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Redirect users to WooCommerce Home when Jetpack auth endpoint returns an invalid URL

--- a/packages/js/data/src/onboarding/actions.ts
+++ b/packages/js/data/src/onboarding/actions.ts
@@ -18,6 +18,7 @@ import {
 	TaskType,
 	OnboardingProductTypes,
 	InstallAndActivatePluginsAsyncResponse,
+	GetJetpackAuthUrlResponse,
 } from './types';
 import { Plugin, PluginNames } from '../plugins/types';
 
@@ -489,13 +490,13 @@ export function* installAndActivatePluginsAsync(
 }
 
 export function setJetpackAuthUrl(
-	jetpackAuthUrl: string,
+	results: GetJetpackAuthUrlResponse,
 	redirectUrl: string,
 	from = ''
 ) {
 	return {
 		type: TYPES.SET_JETPACK_AUTH_URL,
-		jetpackAuthUrl,
+		results,
 		redirectUrl,
 		from,
 	};

--- a/packages/js/data/src/onboarding/reducer.ts
+++ b/packages/js/data/src/onboarding/reducer.ts
@@ -434,7 +434,7 @@ const reducer: Reducer< OnboardingState, Action > = (
 				...state,
 				jetpackAuthUrls: {
 					...state.jetpackAuthUrls,
-					[ action.redirectUrl ]: action.jetpackAuthUrl,
+					[ action.redirectUrl ]: action.results,
 				},
 			};
 		default:

--- a/packages/js/data/src/onboarding/resolvers.ts
+++ b/packages/js/data/src/onboarding/resolvers.ts
@@ -159,11 +159,7 @@ export function* getJetpackAuthUrl( query: {
 			method: 'GET',
 		} );
 
-		yield setJetpackAuthUrl(
-			results.url,
-			query.redirectUrl,
-			query.from ?? ''
-		);
+		yield setJetpackAuthUrl( results, query.redirectUrl, query.from ?? '' );
 	} catch ( error ) {
 		yield setError( 'getJetpackAuthUrl', error );
 	}

--- a/packages/js/data/src/onboarding/resolvers.ts
+++ b/packages/js/data/src/onboarding/resolvers.ts
@@ -25,6 +25,7 @@ import {
 import { DeprecatedTasks } from './deprecated-tasks';
 import {
 	ExtensionList,
+	GetJetpackAuthUrlResponse,
 	OnboardingProductTypes,
 	ProfileItems,
 	TaskListType,
@@ -152,9 +153,7 @@ export function* getJetpackAuthUrl( query: {
 			path += '&from=' + query.from;
 		}
 
-		const results: {
-			url: string;
-		} = yield apiFetch( {
+		const results: GetJetpackAuthUrlResponse = yield apiFetch( {
 			path,
 			method: 'GET',
 		} );

--- a/packages/js/data/src/onboarding/selectors.ts
+++ b/packages/js/data/src/onboarding/selectors.ts
@@ -12,6 +12,7 @@ import {
 	OnboardingState,
 	ExtensionList,
 	ProfileItems,
+	GetJetpackAuthUrlResponse,
 } from './types';
 import { WPDataSelectors } from '../types';
 import { Plugin } from '../plugins/types';
@@ -101,7 +102,7 @@ export const getJetpackAuthUrl = (
 		redirectUrl: string;
 		from?: string;
 	}
-): string => {
+): GetJetpackAuthUrlResponse => {
 	return state.jetpackAuthUrls[ query.redirectUrl ] || '';
 };
 

--- a/packages/js/data/src/onboarding/types.ts
+++ b/packages/js/data/src/onboarding/types.ts
@@ -87,6 +87,12 @@ export type Industry = {
 	slug: string;
 };
 
+export type GetJetpackAuthUrlResponse = {
+	url: string;
+	success: boolean;
+	errors: string[];
+};
+
 export type ProductCount = '0' | '1-10' | '11-100' | '101 - 1000' | '1000+';
 
 export type ProductTypeSlug =

--- a/packages/js/data/src/onboarding/types.ts
+++ b/packages/js/data/src/onboarding/types.ts
@@ -80,7 +80,7 @@ export type OnboardingState = {
 	// TODO clarify what the error record's type is
 	errors: Record< string, unknown >;
 	requesting: Record< string, boolean >;
-	jetpackAuthUrls: Record< string, string >;
+	jetpackAuthUrls: Record< string, GetJetpackAuthUrlResponse >;
 };
 
 export type Industry = {

--- a/plugins/woocommerce-admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/index.tsx
@@ -16,7 +16,12 @@ import {
 import { useMachine, useSelector } from '@xstate/react';
 import { useEffect, useMemo } from '@wordpress/element';
 import { resolveSelect, dispatch } from '@wordpress/data';
-import { updateQueryString, getQuery } from '@woocommerce/navigation';
+import {
+	updateQueryString,
+	getQuery,
+	getNewPath,
+	navigateTo,
+} from '@woocommerce/navigation';
 import {
 	ExtensionList,
 	OPTIONS_STORE_NAME,
@@ -322,10 +327,9 @@ const handleGeolocation = assign( {
 } );
 
 const redirectToWooHome = () => {
-	/**
-	 * @todo replace with navigateTo
-	 */
-	window.location.href = '/wp-admin/admin.php?page=wc-admin';
+	navigateTo( {
+		url: getNewPath( {}, '/', {} ),
+	} );
 };
 
 const redirectToJetpackAuthPage = (

--- a/plugins/woocommerce-admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/index.tsx
@@ -328,6 +328,13 @@ const redirectToWooHome = () => {
 	window.location.href = '/wp-admin/admin.php?page=wc-admin';
 };
 
+const redirectToJetpackAuthPage = (
+	_context: CoreProfilerStateMachineContext,
+	event: { data: { url: string } }
+) => {
+	window.location.href = event.data.url;
+};
+
 const updateTrackingOption = (
 	_context: CoreProfilerStateMachineContext,
 	event: IntroOptInEvent
@@ -532,6 +539,7 @@ const coreProfilerMachineActions = {
 	persistBusinessInfo,
 	spawnUpdateOnboardingProfileOption,
 	redirectToWooHome,
+	redirectToJetpackAuthPage,
 };
 
 const coreProfilerMachineServices = {
@@ -1221,12 +1229,18 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 								from: 'woocommerce-core-profiler',
 							} ),
 						onDone: {
-							actions: [
-								( _context, event ) => {
-									window.location.href =
-										event.data + '&installed_ext_success=1';
+							actions: actions.choose( [
+								{
+									cond: ( _context, event ) =>
+										event.data.success === true,
+									actions: 'recordTracksIntroCompleted',
 								},
-							],
+								{
+									cond: ( _context, event ) =>
+										event.data.success === false,
+									actions: 'redirectToWooHome',
+								},
+							] ),
 						},
 					},
 					meta: {

--- a/plugins/woocommerce-admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/index.tsx
@@ -336,7 +336,7 @@ const redirectToJetpackAuthPage = (
 	_context: CoreProfilerStateMachineContext,
 	event: { data: { url: string } }
 ) => {
-	window.location.href = event.data.url;
+	window.location.href = event.data.url + '&installed_ext_success=1';
 };
 
 const updateTrackingOption = (

--- a/plugins/woocommerce-admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/index.tsx
@@ -1233,7 +1233,7 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 								{
 									cond: ( _context, event ) =>
 										event.data.success === true,
-									actions: 'recordTracksIntroCompleted',
+									actions: 'redirectToJetpackAuthPage',
 								},
 								{
 									cond: ( _context, event ) =>

--- a/plugins/woocommerce/changelog/fix-38758-fix-jetpack-redirection-when-endpoint-returns-invalid-url
+++ b/plugins/woocommerce/changelog/fix-38758-fix-jetpack-redirection-when-endpoint-returns-invalid-url
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Redirect users to WooCommerce Home when Jetpack auth endpoint returns an invalid URL.

--- a/plugins/woocommerce/src/Admin/API/OnboardingPlugins.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingPlugins.php
@@ -223,11 +223,13 @@ class OnboardingPlugins extends WC_REST_Data_Controller {
 	 */
 	public function get_jetpack_authorization_url( WP_REST_Request $request ) {
 		$manager = new Manager( 'woocommerce' );
+		$errors  = new WP_Error();
+
 		// Register the site to wp.com.
 		if ( ! $manager->is_connected() ) {
 			$result = $manager->try_registration();
 			if ( is_wp_error( $result ) ) {
-				throw new \Exception( $result->get_error_message() );
+				$errors->add( $result->get_error_code(), $result->get_error_message() );
 			}
 		}
 
@@ -235,7 +237,9 @@ class OnboardingPlugins extends WC_REST_Data_Controller {
 		$calypso_env  = defined( 'WOOCOMMERCE_CALYPSO_ENVIRONMENT' ) && in_array( WOOCOMMERCE_CALYPSO_ENVIRONMENT, [ 'development', 'wpcalypso', 'horizon', 'stage' ], true ) ? WOOCOMMERCE_CALYPSO_ENVIRONMENT : 'production';
 
 		return [
-			'url' => add_query_arg(
+			'success' => ! $errors->has_errors(),
+			'errors'  => $errors->get_error_messages(),
+			'url'     => add_query_arg(
 				[
 					'from'        => $request->get_param( 'from' ),
 					'calypso_env' => $calypso_env,


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #38758 

This PR handles a situation where the getJetpackAuth endpoint returns an invalid URL by redirecting users to WooCommerce Home. It also replaces `window.location.href` from `redirectToWooHome` with `navigateTo`.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

- Make sure your env is not connected to Jetpack. Otherwise, it'll always redirect to Woo Home after the plugins page.

1. Use your local env that is not publicly accessible.
2. Install the `WooCommerce Beta Tester` plugin
3. Go to /wp-admin/tools.php?page=woocommerce-admin-test-helper
4. Enable the 'core-profiler' feature flag
5. Visit http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard
6. Go to the plugins page.
7. Make sure to choose at least one plugin.
8. Open your browser's inspector
9. Click the Continue button.
10. After installation, you should be redirected to Woo Home since your local can't get a valid Jetpack auth URL.

Build a zip file with `pnpm run build:zip` and make a new JN site. Repeat the same steps on the JN site and confirm it redirects you to Jetpack Auth page. 



<!-- End testing instructions -->
