### PR TITLE
Allow `plugins_page_skipped` parameter in Onboarding API endpoint

### DIFF
--- a/packages/js/data/changelog/fix-38659-core-profiler-skipped-option-plugins-step
+++ b/packages/js/data/changelog/fix-38659-core-profiler-skipped-option-plugins-step
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add is_plugins_page_skipped parameter to onboarding API

--- a/packages/js/data/src/onboarding/types.ts
+++ b/packages/js/data/src/onboarding/types.ts
@@ -136,7 +136,7 @@ export type ProfileItems = {
 	selling_venues?: string | null;
 	setup_client?: boolean | null;
 	skipped?: boolean | null;
-	plugins_page_skipped?: boolean | null;
+	is_plugins_page_skipped?: boolean | null;
 	/** @deprecated This is always null, the theme step has been removed since WC 7.7. */
 	theme?: string | null;
 	wccom_connected?: boolean | null;

--- a/plugins/woocommerce-admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/index.tsx
@@ -1126,7 +1126,7 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 							dispatch(
 								ONBOARDING_STORE_NAME
 							).updateProfileItems( {
-								plugins_page_skipped: true,
+								is_plugins_page_skipped: true,
 								completed: true,
 							} );
 							return promiseDelay( 3000 );

--- a/plugins/woocommerce/changelog/fix-38659-core-profiler-skipped-option-plugins-step
+++ b/plugins/woocommerce/changelog/fix-38659-core-profiler-skipped-option-plugins-step
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Allow plugins_page_skipped parameter in Onboarding API endpoint

--- a/plugins/woocommerce/src/Admin/API/OnboardingProfile.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingProfile.php
@@ -449,6 +449,13 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
 			),
+			'plugins_page_skipped' => array(
+				'type'              => 'boolean',
+				'description'       => __( 'Whether or not plugins step in core profiler was skipped.', 'woocommerce' ),
+				'context'           => array( 'view' ),
+				'readonly'          => true,
+				'validate_callback' => 'rest_validate_request_arg',
+			),
 		);
 
 		return apply_filters( 'woocommerce_rest_onboarding_profile_properties', $properties );

--- a/plugins/woocommerce/src/Admin/API/OnboardingProfile.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingProfile.php
@@ -449,7 +449,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
 			),
-			'plugins_page_skipped' => array(
+			'is_plugins_page_skipped' => array(
 				'type'              => 'boolean',
 				'description'       => __( 'Whether or not plugins step in core profiler was skipped.', 'woocommerce' ),
 				'context'           => array( 'view' ),

--- a/plugins/woocommerce/src/Admin/API/OnboardingProfile.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingProfile.php
@@ -261,21 +261,21 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 	 */
 	public static function get_profile_properties() {
 		$properties = array(
-			'completed'            => array(
+			'completed'               => array(
 				'type'              => 'boolean',
 				'description'       => __( 'Whether or not the profile was completed.', 'woocommerce' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
 			),
-			'skipped'              => array(
+			'skipped'                 => array(
 				'type'              => 'boolean',
 				'description'       => __( 'Whether or not the profile was skipped.', 'woocommerce' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
 			),
-			'industry'             => array(
+			'industry'                => array(
 				'type'              => 'array',
 				'description'       => __( 'Industry.', 'woocommerce' ),
 				'context'           => array( 'view' ),
@@ -285,7 +285,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 					'type' => 'object',
 				),
 			),
-			'product_types'        => array(
+			'product_types'           => array(
 				'type'              => 'array',
 				'description'       => __( 'Types of products sold.', 'woocommerce' ),
 				'context'           => array( 'view' ),
@@ -297,7 +297,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 					'type' => 'string',
 				),
 			),
-			'product_count'        => array(
+			'product_count'           => array(
 				'type'              => 'string',
 				'description'       => __( 'Number of products to be added.', 'woocommerce' ),
 				'context'           => array( 'view' ),
@@ -311,7 +311,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 					'1000+',
 				),
 			),
-			'selling_venues'       => array(
+			'selling_venues'          => array(
 				'type'              => 'string',
 				'description'       => __( 'Other places the store is selling products.', 'woocommerce' ),
 				'context'           => array( 'view' ),
@@ -325,7 +325,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 					'other-woocommerce',
 				),
 			),
-			'number_employees'     => array(
+			'number_employees'        => array(
 				'type'              => 'string',
 				'description'       => __( 'Number of employees of the store.', 'woocommerce' ),
 				'context'           => array( 'view' ),
@@ -340,7 +340,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 					'not specified',
 				),
 			),
-			'revenue'              => array(
+			'revenue'                 => array(
 				'type'              => 'string',
 				'description'       => __( 'Current annual revenue of the store.', 'woocommerce' ),
 				'context'           => array( 'view' ),
@@ -356,7 +356,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 					'rather-not-say',
 				),
 			),
-			'other_platform'       => array(
+			'other_platform'          => array(
 				'type'              => 'string',
 				'description'       => __( 'Name of other platform used to sell.', 'woocommerce' ),
 				'context'           => array( 'view' ),
@@ -374,14 +374,14 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 					'other',
 				),
 			),
-			'other_platform_name'  => array(
+			'other_platform_name'     => array(
 				'type'              => 'string',
 				'description'       => __( 'Name of other platform used to sell (not listed).', 'woocommerce' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
 			),
-			'business_extensions'  => array(
+			'business_extensions'     => array(
 				'type'              => 'array',
 				'description'       => __( 'Extra business extensions to install.', 'woocommerce' ),
 				'context'           => array( 'view' ),
@@ -401,12 +401,12 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 						'mailpoet',
 						'codistoconnect',
 						'tiktok-for-business',
-						'tiktok-for-business:alt'
+						'tiktok-for-business:alt',
 					),
 					'type' => 'string',
 				),
 			),
-			'theme'                => array(
+			'theme'                   => array(
 				'type'              => 'string',
 				'description'       => __( 'Selected store theme.', 'woocommerce' ),
 				'context'           => array( 'view' ),
@@ -414,35 +414,35 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 				'sanitize_callback' => 'sanitize_title_with_dashes',
 				'validate_callback' => 'rest_validate_request_arg',
 			),
-			'setup_client'         => array(
+			'setup_client'            => array(
 				'type'              => 'boolean',
 				'description'       => __( 'Whether or not this store was setup for a client.', 'woocommerce' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
 			),
-			'wccom_connected'      => array(
+			'wccom_connected'         => array(
 				'type'              => 'boolean',
 				'description'       => __( 'Whether or not the store was connected to WooCommerce.com during the extension flow.', 'woocommerce' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
 			),
-			'is_agree_marketing'   => array(
+			'is_agree_marketing'      => array(
 				'type'              => 'boolean',
 				'description'       => __( 'Whether or not this store agreed to receiving marketing contents from WooCommerce.com.', 'woocommerce' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
 			),
-			'store_email'          => array(
+			'store_email'             => array(
 				'type'              => 'string',
 				'description'       => __( 'Store email address.', 'woocommerce' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'validate_callback' => array( __CLASS__, 'rest_validate_marketing_email' ),
 			),
-			'is_store_country_set' => array(
+			'is_store_country_set'    => array(
 				'type'              => 'boolean',
 				'description'       => __( 'Whether or not this store country is set via onboarding profiler.', 'woocommerce' ),
 				'context'           => array( 'view' ),

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/onboarding-profile.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/api/onboarding-profile.php
@@ -131,7 +131,7 @@ class WC_Admin_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertCount( 17, $properties );
+		$this->assertCount( 18, $properties );
 		$this->assertArrayHasKey( 'completed', $properties );
 		$this->assertArrayHasKey( 'skipped', $properties );
 		$this->assertArrayHasKey( 'industry', $properties );
@@ -149,6 +149,7 @@ class WC_Admin_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'is_agree_marketing', $properties );
 		$this->assertArrayHasKey( 'store_email', $properties );
 		$this->assertArrayHasKey( 'is_store_country_set', $properties );
+		$this->assertArrayHasKey( 'is_plugins_page_skipped', $properties );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #38659.

### How to test the changes in this Pull Request:

1. Install and activate WooCommerce on a brand new site
1. Install the WooCommerce Beta Tester plugin
1. Go to /wp-admin/tools.php?page=woocommerce-admin-test-helper
1. Enable the 'core-profiler' feature flag
1. Visit your public URL /wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard
4. Go through the new core profiler flow until the plugins step
5. Skip the plugins step by clicking on `Skip this step`
6. Go to `Tools > WCA Test Helper`
7. In the Options tab, search for `woocommerce_onboarding_profile`
8. Click on `Edit`
9. Observe the value `plugins_page_skipped`: `true` exists

<!-- End testing instructions -->
