### PR TITLE
Fix infinite redirect from homescreen to core profiler

### DIFF
--- a/plugins/woocommerce-admin/client/homescreen/index.tsx
+++ b/plugins/woocommerce-admin/client/homescreen/index.tsx
@@ -3,12 +3,14 @@
  */
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
 import {
 	ONBOARDING_STORE_NAME,
 	withOnboardingHydration,
 	WCDataSelector,
 } from '@woocommerce/data';
 import { getHistory, getNewPath, useQuery } from '@woocommerce/navigation';
+
 /**
  * Internal dependencies
  */
@@ -26,9 +28,15 @@ const Homescreen = ( {
 	} = {},
 	hasFinishedResolution,
 }: HomescreenProps ) => {
-	if ( hasFinishedResolution && ! profilerCompleted && ! profilerSkipped ) {
-		getHistory().push( getNewPath( {}, '/setup-wizard', {} ) );
-	}
+	useEffect( () => {
+		if (
+			hasFinishedResolution &&
+			! profilerCompleted &&
+			! profilerSkipped
+		) {
+			getHistory().push( getNewPath( {}, '/setup-wizard', {} ) );
+		}
+	}, [ hasFinishedResolution, profilerCompleted, profilerSkipped ] );
 
 	const query = useQuery();
 	// @ts-expect-error Layout is a pure JS component

--- a/plugins/woocommerce/changelog/fix-infinite-redirect-to-core-profiler
+++ b/plugins/woocommerce/changelog/fix-infinite-redirect-to-core-profiler
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix infinite redirect from homescreen when onboarding isn't completed using useEffect to remove unintentional rerendering


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Resolves an infinite redirect in react router which causes a crash.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Use a fresh site or delete `woocommerce_onboarding_profile` option
2. Go to WooCommerce > Analytics and refresh the page to remove state from memory
3. Go to WooCommerce > Home
4. Observe that you're redirected to Core profiler successfully

