### PR TITLE
Keep showing product editor feedback bar after feedback modal shown

### DIFF
--- a/packages/js/product-editor/changelog/update-keep-showing-feedback-bar-after-feedback
+++ b/packages/js/product-editor/changelog/update-keep-showing-feedback-bar-after-feedback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Show feedback bar even after feedback is given.

--- a/packages/js/product-editor/src/hooks/use-feedback-bar/use-feedback-bar.ts
+++ b/packages/js/product-editor/src/hooks/use-feedback-bar/use-feedback-bar.ts
@@ -2,49 +2,35 @@
  * External dependencies
  */
 import { resolveSelect, useDispatch, useSelect } from '@wordpress/data';
-import { useCustomerEffortScoreModal } from '@woocommerce/customer-effort-score';
 import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 
 /**
  * Internal dependencies
  */
-import {
-	PRODUCT_EDITOR_SHOW_FEEDBACK_BAR_OPTION_NAME,
-	PRODUCT_EDITOR_FEEDBACK_CES_ACTION,
-} from '../../constants';
+import { PRODUCT_EDITOR_SHOW_FEEDBACK_BAR_OPTION_NAME } from '../../constants';
 
 export const useFeedbackBar = () => {
 	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
 
-	const { wasPreviouslyShown, isLoading: isCesModalOptionsLoading } =
-		useCustomerEffortScoreModal();
+	const { shouldShowFeedbackBar } = useSelect( ( select ) => {
+		const { getOption, hasFinishedResolution } =
+			select( OPTIONS_STORE_NAME );
 
-	const { shouldShowFeedbackBar } = useSelect(
-		( select ) => {
-			const { getOption, hasFinishedResolution } =
-				select( OPTIONS_STORE_NAME );
+		const showFeedbackBarOption = getOption(
+			PRODUCT_EDITOR_SHOW_FEEDBACK_BAR_OPTION_NAME
+		) as string;
 
-			const showFeedbackBarOption = getOption(
-				PRODUCT_EDITOR_SHOW_FEEDBACK_BAR_OPTION_NAME
-			) as string;
+		const resolving = ! hasFinishedResolution( 'getOption', [
+			PRODUCT_EDITOR_SHOW_FEEDBACK_BAR_OPTION_NAME,
+		] );
 
-			const resolving = ! hasFinishedResolution( 'getOption', [
-				PRODUCT_EDITOR_SHOW_FEEDBACK_BAR_OPTION_NAME,
-			] );
-
-			return {
-				shouldShowFeedbackBar:
-					! resolving &&
-					window.wcTracks?.isEnabled &&
-					! isCesModalOptionsLoading &&
-					! wasPreviouslyShown(
-						PRODUCT_EDITOR_FEEDBACK_CES_ACTION
-					) &&
-					showFeedbackBarOption === 'yes',
-			};
-		},
-		[ isCesModalOptionsLoading, wasPreviouslyShown ]
-	);
+		return {
+			shouldShowFeedbackBar:
+				! resolving &&
+				window.wcTracks?.isEnabled &&
+				showFeedbackBarOption === 'yes',
+		};
+	}, [] );
 
 	const showFeedbackBar = () => {
 		updateOptions( {
@@ -67,11 +53,7 @@ export const useFeedbackBar = () => {
 	const maybeShowFeedbackBar = async () => {
 		const { showFeedbackBarOption } = await getOptions();
 
-		if (
-			window.wcTracks?.isEnabled &&
-			! wasPreviouslyShown( PRODUCT_EDITOR_FEEDBACK_CES_ACTION ) &&
-			showFeedbackBarOption !== 'no'
-		) {
+		if ( window.wcTracks?.isEnabled && showFeedbackBarOption !== 'no' ) {
 			showFeedbackBar();
 		}
 	};


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR keeps the product editor feedback bar visible even if the user clicks the "Share feedback" link in the feedback bar. This allows the customer to provide further feedback or turn off the product editor in the future.

Closes #38733. Follow up to #38599.

#### Feedback modal with feedback bar visible in background:

<img width="1097" alt="Screenshot 2023-06-16 at 11 34 43" src="https://github.com/woocommerce/woocommerce/assets/2098816/fdeeaf88-fbcd-487e-90b2-235dcfc8ab05">

#### Feedback bar still visible after closing feedback modal by any means:

<img width="1097" alt="Screenshot 2023-06-16 at 11 34 51" src="https://github.com/woocommerce/woocommerce/assets/2098816/45c94690-fd68-4988-85e5-68a4a0171eaf">

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Note: To reset the state of the system so that the feedback footer will be shown, delete the following options:
* `woocommerce_product_editor_show_feedback_bar`
* `woocommerce_block_product_tour_shown`


1. Enable experimental "new product editor" (beta) in WooCommerce > Settings > Advanced > Features
2. Go to Products > Add New
3. You should see the tour kit step in the bottom left of the editor.
4. Click the X button.
5. The feedback footer should be shown.
6. Refresh the page.
7. Verify feedback footer is still shown.

Note: For the following, you will want to reset the state of the system between verifications to get the feedback footer to show (see above).

8. Verify that if the "X" button is clicked:
    - the feedback footer is hidden permanently
    - the `wcadmin_product_editor_feedback_bar_dismiss_click` Tracks event is logged
9. Verify that if the "Share feedback" link is clicked:
    - the standard CES feedback modal is shown (exact style will be handled in #38502 and #38521)
    - the feedback footer remains shown
    - the `wcadmin_product_editor_feedback_bar_share_feedback_click` Tracks event is logged
10. Verify that if the "turn if off" link is clicked:
    - a custom feedback modal is shown (exact style will be handled in #38592 and #38521)
    - the feedback footer is hidden permanently
    - the `wcadmin_product_editor_feedback_bar_turnoff_editor_click` Tracks event is logged


<!-- End testing instructions -->
