### PR TITLE
Address some more wc-admin PHP 8.1+ deprecation warnings

### DIFF
--- a/plugins/woocommerce/changelog/fix-php-dynamic-prop-warnings
+++ b/plugins/woocommerce/changelog/fix-php-dynamic-prop-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Address more PHP 8.1+ deprecation warnings in wc-admin code.

--- a/plugins/woocommerce/src/Admin/API/OnboardingTasks.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingTasks.php
@@ -39,7 +39,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	/**
 	 * Duration to milisecond mapping.
 	 *
-	 * @var string
+	 * @var array
 	 */
 	protected $duration_to_ms = array(
 		'day'  => DAY_IN_SECONDS * 1000,
@@ -762,6 +762,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 
 		if ( ! $task && $id ) {
 			$task = new DeprecatedExtendedTask(
+				null,
 				array(
 					'id'             => $id,
 					'is_dismissable' => true,
@@ -795,6 +796,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 
 		if ( ! $task && $id ) {
 			$task = new DeprecatedExtendedTask(
+				null,
 				array(
 					'id'             => $id,
 					'is_dismissable' => true,
@@ -837,6 +839,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 
 		if ( ! $task && $task_id ) {
 			$task = new DeprecatedExtendedTask(
+				null,
 				array(
 					'id'            => $task_id,
 					'is_snoozeable' => true,
@@ -874,6 +877,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 
 		if ( ! $task && $id ) {
 			$task = new DeprecatedExtendedTask(
+				null,
 				array(
 					'id'            => $id,
 					'is_snoozeable' => true,
@@ -961,6 +965,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 
 		if ( ! $task && $id ) {
 			$task = new DeprecatedExtendedTask(
+				null,
 				array(
 					'id' => $id,
 				)

--- a/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/DataStore.php
@@ -31,6 +31,13 @@ class DataStore extends SqlQuery {
 	protected $cache_timeout = 3600;
 
 	/**
+	 * Cache identifier.
+	 *
+	 * @var string
+	 */
+	protected $cache_key = '';
+
+	/**
 	 * Table used as a data store for this report.
 	 *
 	 * @var string

--- a/plugins/woocommerce/src/Admin/API/Reports/Segmenter.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Segmenter.php
@@ -543,6 +543,87 @@ class Segmenter {
 	}
 
 	/**
+	 * Calculate segments for totals where the segmenting property is bound to product (e.g. category, product_id, variation_id).
+	 *
+	 * @param array  $segmenting_selections SELECT part of segmenting SQL query--one for 'product_level' and one for 'order_level'.
+	 * @param string $segmenting_from FROM part of segmenting SQL query.
+	 * @param string $segmenting_where WHERE part of segmenting SQL query.
+	 * @param string $segmenting_groupby GROUP BY part of segmenting SQL query.
+	 * @param string $segmenting_dimension_name Name of the segmenting dimension.
+	 * @param string $table_name Name of SQL table which is the stats table for orders.
+	 * @param array  $totals_query Array of SQL clauses for totals query.
+	 * @param string $unique_orders_table Name of temporary SQL table that holds unique orders.
+	 *
+	 * @return array
+	 */
+	protected function get_product_related_totals_segments( $segmenting_selections, $segmenting_from, $segmenting_where, $segmenting_groupby, $segmenting_dimension_name, $table_name, $totals_query, $unique_orders_table ) {
+		return array();
+	}
+
+	/**
+	 * Calculate segments for intervals where the segmenting property is bound to product (e.g. category, product_id, variation_id).
+	 *
+	 * @param array  $segmenting_selections SELECT part of segmenting SQL query--one for 'product_level' and one for 'order_level'.
+	 * @param string $segmenting_from FROM part of segmenting SQL query.
+	 * @param string $segmenting_where WHERE part of segmenting SQL query.
+	 * @param string $segmenting_groupby GROUP BY part of segmenting SQL query.
+	 * @param string $segmenting_dimension_name Name of the segmenting dimension.
+	 * @param string $table_name Name of SQL table which is the stats table for orders.
+	 * @param array  $intervals_query Array of SQL clauses for intervals query.
+	 * @param string $unique_orders_table Name of temporary SQL table that holds unique orders.
+	 *
+	 * @return array
+	 */
+	protected function get_product_related_intervals_segments( $segmenting_selections, $segmenting_from, $segmenting_where, $segmenting_groupby, $segmenting_dimension_name, $table_name, $intervals_query, $unique_orders_table ) {
+		return array();
+	}
+
+	/**
+	 * Calculate segments for totals query where the segmenting property is bound to order (e.g. coupon or customer type).
+	 *
+	 * @param string $segmenting_select SELECT part of segmenting SQL query.
+	 * @param string $segmenting_from FROM part of segmenting SQL query.
+	 * @param string $segmenting_where WHERE part of segmenting SQL query.
+	 * @param string $segmenting_groupby GROUP BY part of segmenting SQL query.
+	 * @param string $table_name Name of SQL table which is the stats table for orders.
+	 * @param array  $totals_query Array of SQL clauses for intervals query.
+	 *
+	 * @return array
+	 */
+	protected function get_order_related_totals_segments( $segmenting_select, $segmenting_from, $segmenting_where, $segmenting_groupby, $table_name, $totals_query ) {
+		return array();
+	}
+
+	/**
+	 * Calculate segments for intervals query where the segmenting property is bound to order (e.g. coupon or customer type).
+	 *
+	 * @param string $segmenting_select SELECT part of segmenting SQL query.
+	 * @param string $segmenting_from FROM part of segmenting SQL query.
+	 * @param string $segmenting_where WHERE part of segmenting SQL query.
+	 * @param string $segmenting_groupby GROUP BY part of segmenting SQL query.
+	 * @param string $table_name Name of SQL table which is the stats table for orders.
+	 * @param array  $intervals_query Array of SQL clauses for intervals query.
+	 *
+	 * @return array
+	 */
+	protected function get_order_related_intervals_segments( $segmenting_select, $segmenting_from, $segmenting_where, $segmenting_groupby, $table_name, $intervals_query ) {
+		return array();
+	}
+
+	/**
+	 * Return array of segments formatted for REST response.
+	 *
+	 * @param string $type Type of segments to return--'totals' or 'intervals'.
+	 * @param array  $query_params SQL query parameter array.
+	 * @param string $table_name Name of main SQL table for the data store (used as basis for JOINS).
+	 *
+	 * @return array
+	 */
+	protected function get_segments( $type, $query_params, $table_name ) {
+		return array();
+	}
+
+	/**
 	 * Calculate segments for segmenting property bound to product (e.g. category, product_id, variation_id).
 	 *
 	 * @param string $type Type of segments to return--'totals' or 'intervals'.

--- a/plugins/woocommerce/src/Admin/DeprecatedClassFacade.php
+++ b/plugins/woocommerce/src/Admin/DeprecatedClassFacade.php
@@ -25,12 +25,28 @@ defined( 'ABSPATH' ) || exit;
  * A facade to allow deprecating an entire class.
  */
 class DeprecatedClassFacade {
+
 	/**
 	 * The instance that this facade covers over.
 	 *
 	 * @var object
 	 */
 	protected $instance;
+
+	/**
+	 * The name of the non-deprecated class that this facade covers.
+	 *
+	 * @var string
+	 */
+	protected static $facade_over_classname;
+
+	/**
+	 * The version that this class was deprecated in.
+	 *
+	 * @var string
+	 */
+	protected static $deprecated_in_version = '';
+
 
 	/**
 	 * Constructor.

--- a/plugins/woocommerce/src/Admin/Features/Navigation/Favorites.php
+++ b/plugins/woocommerce/src/Admin/Features/Navigation/Favorites.php
@@ -22,6 +22,13 @@ class Favorites {
 	const META_NAME = 'navigation_favorites';
 
 	/**
+	 * Favorites instance.
+	 *
+	 * @var Favorites|null
+	 */
+	protected static $instance = null;
+
+	/**
 	 * Get class instance.
 	 */
 	final public static function instance() {

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/DeprecatedExtendedTask.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/DeprecatedExtendedTask.php
@@ -17,6 +17,27 @@ class DeprecatedExtendedTask extends Task {
 	public $id = '';
 
 	/**
+	 * Additional info.
+	 *
+	 * @var string|null
+	 */
+	public $additional_info = '';
+
+	/**
+	 * Content.
+	 *
+	 * @var string
+	 */
+	public $content = '';
+
+	/**
+	 * Whether the task is complete or not.
+	 *
+	 * @var boolean
+	 */
+	public $is_complete = false;
+
+	/**
 	 * Snoozeable.
 	 *
 	 * @var boolean
@@ -29,6 +50,35 @@ class DeprecatedExtendedTask extends Task {
 	 * @var boolean
 	 */
 	public $is_dismissable = false;
+
+	/**
+	 * Whether the store is capable of viewing the task.
+	 *
+	 * @var bool
+	 */
+	public $can_view = true;
+
+	/**
+	 * Level.
+	 *
+	 * @var int
+	 */
+	public $level = 3;
+
+	/**
+	 * Time.
+	 *
+	 * @var string|null
+	 */
+	public $time;
+
+	/**
+	 * Title.
+	 *
+	 * @var string
+	 */
+	public $title = '';
+
 
 	/**
 	 * Constructor.

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/NotRuleProcessor.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/NotRuleProcessor.php
@@ -11,6 +11,14 @@ defined( 'ABSPATH' ) || exit;
  * Rule processor that negates the rules in the rule's operand.
  */
 class NotRuleProcessor implements RuleProcessorInterface {
+
+	/**
+	 * The rule evaluator to use.
+	 *
+	 * @var RuleEvaluator
+	 */
+	protected $rule_evaluator;
+
 	/**
 	 * Constructor.
 	 *

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/OrderCountRuleProcessor.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/OrderCountRuleProcessor.php
@@ -11,6 +11,14 @@ defined( 'ABSPATH' ) || exit;
  * Rule processor for publishing based on the number of orders.
  */
 class OrderCountRuleProcessor implements RuleProcessorInterface {
+
+	/**
+	 * The orders provider.
+	 *
+	 * @var OrdersProvider
+	 */
+	protected $orders_provider;
+
 	/**
 	 * Constructor.
 	 *

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/PluginsActivatedRuleProcessor.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/PluginsActivatedRuleProcessor.php
@@ -13,6 +13,14 @@ use Automattic\WooCommerce\Admin\PluginsProvider\PluginsProvider;
  * Rule processor for sending when the provided plugins are activated.
  */
 class PluginsActivatedRuleProcessor implements RuleProcessorInterface {
+
+	/**
+	 * The plugins provider.
+	 *
+	 * @var PluginsProviderInterface
+	 */
+	protected $plugins_provider;
+
 	/**
 	 * Constructor.
 	 *

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/ProductCountRuleProcessor.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/ProductCountRuleProcessor.php
@@ -13,6 +13,14 @@ defined( 'ABSPATH' ) || exit;
  * products.
  */
 class ProductCountRuleProcessor implements RuleProcessorInterface {
+
+	/**
+	 * The product query.
+	 *
+	 * @var WC_Product_Query
+	 */
+	protected $product_query;
+
 	/**
 	 * Constructor.
 	 *

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/PublishAfterTimeRuleProcessor.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/PublishAfterTimeRuleProcessor.php
@@ -13,6 +13,14 @@ use Automattic\WooCommerce\Admin\DateTimeProvider\CurrentDateTimeProvider;
  * Rule processor for sending after a specified date/time.
  */
 class PublishAfterTimeRuleProcessor implements RuleProcessorInterface {
+
+	/**
+	 * The DateTime provider.
+	 *
+	 * @var DateTimeProviderInterface
+	 */
+	protected $date_time_provider;
+
 	/**
 	 * Constructor.
 	 *

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/PublishBeforeTimeRuleProcessor.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/PublishBeforeTimeRuleProcessor.php
@@ -13,6 +13,14 @@ use Automattic\WooCommerce\Admin\DateTimeProvider\CurrentDateTimeProvider;
  * Rule processor for sending before a specified date/time.
  */
 class PublishBeforeTimeRuleProcessor implements RuleProcessorInterface {
+
+	/**
+	 * The DateTime provider.
+	 *
+	 * @var DateTimeProviderInterface
+	 */
+	protected $date_time_provider;
+
 	/**
 	 * Constructor.
 	 *

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/WCAdminActiveForRuleProcessor.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/WCAdminActiveForRuleProcessor.php
@@ -13,6 +13,14 @@ defined( 'ABSPATH' ) || exit;
  * given number of seconds.
  */
 class WCAdminActiveForRuleProcessor implements RuleProcessorInterface {
+
+	/**
+	 * Provides the amount of time wcadmin has been active for.
+	 *
+	 * @var WCAdminActiveForProvider
+	 */
+	protected $wcadmin_active_for_provider;
+
 	/**
 	 * Constructor
 	 *

--- a/plugins/woocommerce/src/Admin/ReportCSVEmail.php
+++ b/plugins/woocommerce/src/Admin/ReportCSVEmail.php
@@ -20,6 +20,28 @@ if ( ! class_exists( 'WC_Email', false ) ) {
  * ReportCSVEmail Class.
  */
 class ReportCSVEmail extends \WC_Email {
+
+	/**
+	 * Report labels.
+	 *
+	 * @var array
+	 */
+	protected $report_labels;
+
+	/**
+	 * Report type (e.g. 'customers').
+	 *
+	 * @var string
+	 */
+	protected $report_type;
+
+	/**
+	 * Download URL.
+	 *
+	 * @var string
+	 */
+	protected $download_url;
+
 	/**
 	 * Constructor.
 	 */


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds another batch of fixes related to PHP 8.1+ compatibility, in a similar vein to #38587.

Some of the warnings that this PR addresses should be appearing on most pages (at least on the backend) but some I detected with some static code analysis and I'm not entirely sure how to repro.

I added some comments to the code with additional context.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

The following tests warnings related to Remote Inbox Notifications (which are almost all).

1. Make sure you're on PHP 8.2 and with logging enabled.
2. Even though some of the warnings should probably occur naturally after using the backend for a while, but I suggest triggering the `wc_admin_daily` cron job manually. For example, by using [WP Crontrol](https://wordpress.org/plugins/wp-crontrol/).
3.
   - On `trunk`, your log file should be full with warnings such as the following:
   ```
      PHP Deprecated:  Creation of dynamic property Automattic\WooCommerce\Admin\RemoteInboxNotifications\PublishAfterTimeRuleProcessor::$date_time_provider is deprecated in [...]/woocommerce/plugins/woocommerce/src/Admin/RemoteInboxNotifications/PublishAfterTimeRuleProcessor.php on line 22
      PHP Deprecated:  Creation of dynamic property Automattic\WooCommerce\Admin\RemoteInboxNotifications\PublishBeforeTimeRuleProcessor::$date_time_provider is deprecated in [...]/woocommerce/plugins/woocommerce/src/Admin/RemoteInboxNotifications/PublishBeforeTimeRuleProcessor.php on line 22
      PHP Deprecated:  Creation of dynamic property Automattic\WooCommerce\Admin\RemoteInboxNotifications\PluginsActivatedRuleProcessor::$plugins_provider is deprecated in [...]/woocommerce/plugins/woocommerce/src/Admin/RemoteInboxNotifications/PluginsActivatedRuleProcessor.php on line 22
      PHP Deprecated:  Creation of dynamic property Automattic\WooCommerce\Admin\RemoteInboxNotifications\NotRuleProcessor::$rule_evaluator is deprecated in [...]/woocommerce/plugins/woocommerce/src/Admin/RemoteInboxNotifications/NotRuleProcessor.php on line 20
   ```
   - On this branch, no warnings should be logged.

<!-- End testing instructions -->
