### PR TITLE
fix deprecated warning in dashboard setup

### DIFF
--- a/plugins/woocommerce/changelog/fix-dashboard-setup-warning
+++ b/plugins/woocommerce/changelog/fix-dashboard-setup-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix deprecated warning in dashboard setup

--- a/plugins/woocommerce/includes/admin/class-wc-admin-dashboard-setup.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-dashboard-setup.php
@@ -91,7 +91,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard_Setup', false ) ) :
 		 * @return string
 		 */
 		public function get_button_link( $task ) {
-			$url = $task->get_json()['actionUrl'];
+			$url = (string) $task->get_json()['actionUrl'];
 
 			if ( substr( $url, 0, 4 ) === 'http' ) {
 				return $url;


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR converts the task `actionUrl` to a string before it's used as a parameter to string handling functions.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Update to PHP 8.1
2. Load the WP dashboard in `trunk`
3. See the following warning in the debug log
```
[16-Jun-2023 17:06:47 UTC] PHP Deprecated:  substr(): Passing null to parameter #1 ($string) of type string is deprecated in /Users/ronrennick/Sites/wc/wp-content/woocommerce/plugins/woocommerce/includes/admin/class-wc-admin-dashboard-setup.php on line 97
```
4. Switch to this branch & refresh the page
5. No warning should be logged.

<!-- End testing instructions -->
