### PR TITLE
Set attributes to visible by default

### DIFF
--- a/packages/js/product-editor/changelog/fix-set-attributes-to-visible-by-default
+++ b/packages/js/product-editor/changelog/fix-set-attributes-to-visible-by-default
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Set attributes to visible by default.

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
@@ -8,6 +8,7 @@ import {
 	Form,
 	__experimentalSelectControlMenuSlot as SelectControlMenuSlot,
 } from '@woocommerce/components';
+import { ProductAttributeTerm } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import {
 	Button,
@@ -99,24 +100,52 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 		scrollAttributeIntoView( values.attributes.length );
 	};
 
+	const hasTermsOrOptions = ( attribute: EnhancedProductAttribute ) => {
+		return (
+			( attribute.terms || [] ).length > 0 ||
+			( attribute.options || [] ).length > 0
+		);
+	};
+
+	const isGlobalAttribute = ( attribute: EnhancedProductAttribute ) => {
+		return attribute.id !== 0;
+	};
+
+	const mapTermsToOptions = ( terms: ProductAttributeTerm[] | undefined ) => {
+		if ( ! terms ) {
+			return [];
+		}
+
+		return terms.map( ( term ) => term.name );
+	};
+
+	const getOptions = ( attribute: EnhancedProductAttribute ) => {
+		return isGlobalAttribute( attribute )
+			? mapTermsToOptions( attribute.terms )
+			: attribute.options;
+	};
+
+	const isAttributeFilledOut = (
+		attribute: EnhancedProductAttribute | null
+	): attribute is EnhancedProductAttribute => {
+		return (
+			attribute !== null &&
+			attribute.name.length > 0 &&
+			hasTermsOrOptions( attribute )
+		);
+	};
+
+	const getVisibleOrTrue = ( attribute: EnhancedProductAttribute ) =>
+		attribute.visible !== undefined ? attribute.visible : true;
+
 	const onAddingAttributes = ( values: AttributeForm ) => {
 		const newAttributesToAdd: EnhancedProductAttribute[] = [];
 		values.attributes.forEach( ( attr ) => {
-			if (
-				attr !== null &&
-				attr.name &&
-				( ( attr.terms || [] ).length > 0 ||
-					( attr.options || [] ).length > 0 )
-			) {
-				const options =
-					attr.id !== 0
-						? ( attr.terms || [] ).map( ( term ) => term.name )
-						: attr.options;
+			if ( isAttributeFilledOut( attr ) ) {
 				newAttributesToAdd.push( {
-					...( attr as EnhancedProductAttribute ),
-					// default visible to true if not explicitly set
-					visible: attr.visible !== undefined ? attr.visible : true,
-					options,
+					...attr,
+					visible: getVisibleOrTrue( attr ),
+					options: getOptions( attr ),
 				} );
 			}
 		} );

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
@@ -102,8 +102,8 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 
 	const hasTermsOrOptions = ( attribute: EnhancedProductAttribute ) => {
 		return (
-			( attribute.terms || [] ).length > 0 ||
-			( attribute.options || [] ).length > 0
+			( attribute.terms && attribute.terms.length > 0 ) ||
+			( attribute.options && attribute.options.length > 0 )
 		);
 	};
 

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
@@ -114,6 +114,8 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 						: attr.options;
 				newAttributesToAdd.push( {
 					...( attr as EnhancedProductAttribute ),
+					// default visible to true if not explicitly set
+					visible: attr.visible !== undefined ? attr.visible : true,
 					options,
 				} );
 			}


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR set the "Visible to customers" property to enabled for all attributes added to products with the product editor, by default.

I refactored the related code to increase readability and reduce complexity.

Closes #38772.

#### Add attributes modal

No visible changes

<img width="1257" alt="Screenshot 2023-06-16 at 15 06 46" src="https://github.com/woocommerce/woocommerce/assets/2098816/8d8d9399-ac58-4268-97a5-f7d1550b7177">

#### Edit attribute modal

No visible changes (other than "Visible to customers" will be set properly by default now)

<img width="1257" alt="Screenshot 2023-06-16 at 15 06 59" src="https://github.com/woocommerce/woocommerce/assets/2098816/35d620ea-26b2-4dcd-8072-b44c6951be5d">

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Enable experimental "new product editor" (beta) in WooCommerce > Settings > Advanced > Features
2. Go to Products > Add New
3. Scroll down to Attributes and click "Add attributes"
4. Add both global and custom/local attributes
5. Verify that added attributes have the "Visible to customers" property checked
6. Save the product
7. Refresh
8. Verify the attributes are still set correctly

<!-- End testing instructions -->
