### PR TITLE
Decode HTML entities from store name

### DIFF
--- a/plugins/woocommerce-admin/client/core-profiler/pages/BusinessInfo.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/pages/BusinessInfo.tsx
@@ -11,6 +11,8 @@ import {
 	useState,
 } from '@wordpress/element';
 import { findCountryOption, getCountry } from '@woocommerce/onboarding';
+import { decodeEntities } from '@wordpress/html-entities';
+
 /**
  * Internal dependencies
  */
@@ -189,7 +191,7 @@ export const BusinessInfo = ( {
 						onChange={ ( value ) => {
 							setStoreName( value );
 						} }
-						value={ storeName }
+						value={ decodeEntities( storeName ) }
 						label={
 							<>
 								{ __(

--- a/plugins/woocommerce/changelog/update-38790-fix-blogname-with-html-entities
+++ b/plugins/woocommerce/changelog/update-38790-fix-blogname-with-html-entities
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Decode HTML entities for the store name


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #38790 .

This PR decodes HTML entities from store name value to display it correctly. 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:



1. Start the core profiler
2. Enter a store name with `'`.
3. Click continue
4. Go back to the business info page and refresh the page
5. Confirm the store name is displayed without any HTML entities 

<!-- End testing instructions -->
