### PR TITLE
Fix base location remote inbox rule

### DIFF
--- a/plugins/woocommerce/changelog/fix-38793-base-location-rule
+++ b/plugins/woocommerce/changelog/fix-38793-base-location-rule
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add another check in base location rule to fix OBW extensions bug

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/BaseLocationCountryRuleProcessor.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/BaseLocationCountryRuleProcessor.php
@@ -36,7 +36,7 @@ class BaseLocationCountryRuleProcessor implements RuleProcessorInterface {
 			'CA' === $base_location['state'] &&
 			empty( get_option( 'woocommerce_store_address', '' ) ) &&
 			OnboardingProfile::needs_completion() &&
-			! $onboarding_profile['is_store_country_set']
+			isset( $onboarding_profile['is_store_country_set'] ) && ! $onboarding_profile['is_store_country_set']
 			) {
 			return false;
 		}

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/BaseLocationCountryRuleProcessor.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/BaseLocationCountryRuleProcessor.php
@@ -30,14 +30,11 @@ class BaseLocationCountryRuleProcessor implements RuleProcessorInterface {
 		}
 
 		$onboarding_profile = get_option( 'woocommerce_onboarding_profile', array() );
+		$is_address_default = 'US' === $base_location['country'] && 'CA' === $base_location['state'] && empty( get_option( 'woocommerce_store_address', '' ) );
+		$is_store_country_set = isset( $onboarding_profile['is_store_country_set'] ) && $onboarding_profile['is_store_country_set'];
+
 		// Return false if the location is the default country and if onboarding hasn't been finished or the store address not been updated.
-		if (
-			'US' === $base_location['country'] &&
-			'CA' === $base_location['state'] &&
-			empty( get_option( 'woocommerce_store_address', '' ) ) &&
-			OnboardingProfile::needs_completion() &&
-			isset( $onboarding_profile['is_store_country_set'] ) && ! $onboarding_profile['is_store_country_set']
-			) {
+		if ( $is_address_default && OnboardingProfile::needs_completion() && ! $is_store_country_set ) {
 			return false;
 		}
 

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/BaseLocationCountryRuleProcessor.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/BaseLocationCountryRuleProcessor.php
@@ -29,8 +29,15 @@ class BaseLocationCountryRuleProcessor implements RuleProcessorInterface {
 			return false;
 		}
 
+		$onboarding_profile = get_option( 'woocommerce_onboarding_profile', array() );
 		// Return false if the location is the default country and if onboarding hasn't been finished or the store address not been updated.
-		if ( 'US' === $base_location['country'] && 'CA' === $base_location['state'] && empty( get_option( 'woocommerce_store_address', '' ) ) && OnboardingProfile::needs_completion() ) {
+		if (
+			'US' === $base_location['country'] &&
+			'CA' === $base_location['state'] &&
+			empty( get_option( 'woocommerce_store_address', '' ) ) &&
+			OnboardingProfile::needs_completion() &&
+			! $onboarding_profile[ 'is_store_country_set' ]
+			) {
 			return false;
 		}
 

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/BaseLocationCountryRuleProcessor.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/BaseLocationCountryRuleProcessor.php
@@ -36,7 +36,7 @@ class BaseLocationCountryRuleProcessor implements RuleProcessorInterface {
 			'CA' === $base_location['state'] &&
 			empty( get_option( 'woocommerce_store_address', '' ) ) &&
 			OnboardingProfile::needs_completion() &&
-			! $onboarding_profile[ 'is_store_country_set' ]
+			! $onboarding_profile['is_store_country_set']
 			) {
 			return false;
 		}

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/BaseLocationCountryRuleProcessor.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/BaseLocationCountryRuleProcessor.php
@@ -29,8 +29,8 @@ class BaseLocationCountryRuleProcessor implements RuleProcessorInterface {
 			return false;
 		}
 
-		$onboarding_profile = get_option( 'woocommerce_onboarding_profile', array() );
-		$is_address_default = 'US' === $base_location['country'] && 'CA' === $base_location['state'] && empty( get_option( 'woocommerce_store_address', '' ) );
+		$onboarding_profile   = get_option( 'woocommerce_onboarding_profile', array() );
+		$is_address_default   = 'US' === $base_location['country'] && 'CA' === $base_location['state'] && empty( get_option( 'woocommerce_store_address', '' ) );
 		$is_store_country_set = isset( $onboarding_profile['is_store_country_set'] ) && $onboarding_profile['is_store_country_set'];
 
 		// Return false if the location is the default country and if onboarding hasn't been finished or the store address not been updated.

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-inbox-notifications/base-location-country-rule-processor.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-inbox-notifications/base-location-country-rule-processor.php
@@ -117,6 +117,22 @@ class WC_Admin_Tests_RemoteInboxNotifications_BaseLocationCountryRuleProcessor e
 	}
 
 	/**
+	 * Tests that the processor returns true if profiler option's `is_store_country_set` is true.
+	 *
+	 * @group fast
+	 */
+	public function test_spec_succeeds_if_base_location_is_default_and_is_store_country_set_is_true() {
+		update_option( 'woocommerce_default_country', 'US:CA' );
+		update_option( OnboardingProfile::DATA_OPTION, array( 'is_store_country_set' => true ) );
+
+		$processor = new BaseLocationCountryRuleProcessor();
+
+		$result = $processor->process( $this->get_rule(), new stdClass() );
+
+		$this->assertEquals( true, $result );
+	}
+
+	/**
 	 * Tests that the processor returns true if country is default but address is updated.
 	 *
 	 * @group fast


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #38793.

Fixes base location rule not covering when a user is in California, US, and doesn't set street address in Onboarding Wizard. This is applicable to both the old OBW and core profiler.

### How to test the changes in this Pull Request:

**Delete existing options**

1. Install the `WooCommerce Beta Tester` plugin
1. Go to Tools > WCA Test Helper `/wp-admin/tools.php?page=woocommerce-admin-test-helper`
1. Delete the options `woocommerce_onboarding_profile` and `woocommerce_store_address`

**Testing**

1. Go to `/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard`
1. Select `United States (US) — California` as the country
1. Do not set a street address if you're using the old OBW
1. Continue until the extensions step, observe that `WooCommerce Payments` extension is displayed

<!-- End testing instructions -->
