### PR TITLE
Update WooPayments welcome page incentive logic

### DIFF
--- a/plugins/woocommerce-admin/client/payments-welcome/banner.tsx
+++ b/plugins/woocommerce-admin/client/payments-welcome/banner.tsx
@@ -21,7 +21,7 @@ interface Props {
 
 const Banner: React.FC< Props > = ( { isSubmitted, handleSetup } ) => {
 	const { first_name } = getAdminSetting( 'currentUserData', {} );
-	const { description, cta_label, tos_url } = getAdminSetting(
+	const { description, cta_label, tc_url } = getAdminSetting(
 		'wcpayWelcomePageIncentive'
 	);
 
@@ -65,7 +65,7 @@ const Banner: React.FC< Props > = ( { isSubmitted, handleSetup } ) => {
 					{ strings.noThanks }
 				</Button>
 				<p>{ strings.TosAndPp }</p>
-				<p>{ strings.termsAndConditions( tos_url ) }</p>
+				<p>{ strings.termsAndConditions( tc_url ) }</p>
 			</CardBody>
 			<CardDivider />
 			<CardBody className="woopayments-welcome-page__payments">

--- a/plugins/woocommerce-admin/client/payments-welcome/exit-survey-modal.tsx
+++ b/plugins/woocommerce-admin/client/payments-welcome/exit-survey-modal.tsx
@@ -63,7 +63,8 @@ function ExitSurveyModal( {}: {
 
 	const exitSurvey = () => {
 		recordEvent( 'wcpay_exit_survey', {
-			just_remove: true /* eslint-disable-line camelcase */,
+			just_remove: true,
+			incentive_id: incentive.id,
 		} );
 
 		closeModal();
@@ -71,14 +72,13 @@ function ExitSurveyModal( {}: {
 
 	const sendFeedback = () => {
 		recordEvent( 'wcpay_exit_survey', {
-			/* eslint-disable camelcase */
 			happy: isHappyChecked ? 'Yes' : 'No',
 			install: isInstallChecked ? 'Yes' : 'No',
 			more_info: isMoreInfoChecked ? 'Yes' : 'No',
 			another_time: isAnotherTimeChecked ? 'Yes' : 'No',
 			something_else: isSomethingElseChecked ? 'Yes' : 'No',
 			comments,
-			/* eslint-enable camelcase */
+			incentive_id: incentive.id,
 		} );
 
 		if ( isMoreInfoChecked ) {

--- a/plugins/woocommerce-admin/client/payments-welcome/index.tsx
+++ b/plugins/woocommerce-admin/client/payments-welcome/index.tsx
@@ -31,7 +31,7 @@ declare global {
 					id: string;
 					description: string;
 					cta_label: string;
-					tos_url: string;
+					tc_url: string;
 				};
 			};
 		};

--- a/plugins/woocommerce-admin/client/payments-welcome/index.tsx
+++ b/plugins/woocommerce-admin/client/payments-welcome/index.tsx
@@ -90,8 +90,8 @@ const ConnectAccountPage = () => {
 	const handleSetup = async () => {
 		setSubmitted( true );
 		recordEvent( 'wcpay_connect_account_clicked', {
-			// eslint-disable-next-line camelcase
 			wpcom_connection: isJetpackConnected ? 'Yes' : 'No',
+			incentive_id: incentive.id,
 		} );
 
 		const pluginsToInstall = [ ...enabledApms ].map(
@@ -107,6 +107,7 @@ const ConnectAccountPage = () => {
 					extensions: [ ...enabledApms ]
 						.map( ( apm ) => apm.id )
 						.join( ', ' ),
+					incentive_id: incentive.id,
 				} );
 				await activatePromo();
 			} else {

--- a/plugins/woocommerce-admin/client/payments-welcome/style.scss
+++ b/plugins/woocommerce-admin/client/payments-welcome/style.scss
@@ -160,14 +160,6 @@
 	}
 
 	&__survey {
-		.components-modal__content {
-			padding: 0 $gap-larger $gap-larger;
-
-			p {
-				text-transform: none;
-			}
-		}
-
 		p {
 			margin-bottom: 1em;
 		}

--- a/plugins/woocommerce/changelog/update-3531-incentive-logic
+++ b/plugins/woocommerce/changelog/update-3531-incentive-logic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+WCPay welcome incentive logic

--- a/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
+++ b/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
@@ -267,7 +267,7 @@ class WcPayWelcomePage {
 				'has_orders'   => ! empty(
 					wc_get_orders(
 						[
-							'status'       => ['wc-completed', 'wc-processing'],
+							'status'       => [ 'wc-completed', 'wc-processing' ],
 							'date_created' => '>=' . strtotime( '-90 days' ),
 							'return'       => 'ids',
 							'limit'        => 1,

--- a/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
+++ b/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
@@ -267,7 +267,7 @@ class WcPayWelcomePage {
 				'has_orders'   => ! empty(
 					wc_get_orders(
 						[
-							'status'       => array_map( 'wc_get_order_status_name', wc_get_is_paid_statuses() ),
+							'status'       => ['wc-completed', 'wc-processing'],
 							'date_created' => '>=' . strtotime( '-90 days' ),
 							'return'       => 'ids',
 							'limit'        => 1,


### PR DESCRIPTION
Closes https://github.com/Automattic/woocommerce-payments-server/issues/3531

### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:
- Update orders status query to ensure it excludes trash.
- Add the incentive ID to every track on the welcome page and exit survey.
- Remove unnecessary SCSS after #38775 fix.
- Rename `tos_url` to `tc_url` for naming clarity since it refers to "Terms and Conditions", not "Terms of Service"

### How to test the changes in this Pull Request:
#### Trash orders
- Meet Switch incentive eligibility, more details in #38689.
- Move to trash any order created ≤ 90 days ago.
- Remove `_transient_wcpay_welcome_page_incentive` option.
- Incentive page should not be visible after refresh.

#### Incentive ID on Tracks
- With the incentive page visible, click on **No thanks**.
- Choose either **Just dismiss WooPayments** or **Dismiss and send feedback**.
- `wcpay_exit_survey` event should be tracked with `incentive_id: [ID of the eligible incentive]`.
- To easily check it you can run `localStorage.setItem( 'debug', 'wc-admin:tracks' )` on the browser console.

#### Unnecessary SCSS
- The exit survey modal:
  - Should have common `padding-bottom`, not 100px.
  - `<p>` text must not be uppercase.

