### PR TITLE
Disable 'Used for variations' checkbox when product type is not variable

### DIFF
--- a/plugins/woocommerce/changelog/update-used-for-var
+++ b/plugins/woocommerce/changelog/update-used-for-var
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Disable 'Used for variations' checkbox when product type is not variable

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -873,6 +873,8 @@ jQuery( function ( $ ) {
 				// Hide the 'Used for variations' checkbox if not viewing a variable product
 				show_and_hide_panels();
 
+				disable_or_enable_fields();
+
 				// Make sure the dropdown is not disabled for empty value attributes.
 				$( 'select.attribute_taxonomy' )
 					.find( 'option' )

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -553,6 +553,7 @@ jQuery( function ( $ ) {
 
 			toggle_expansion_of_attribute_list_item( $attributeListItem );
 
+			disable_or_enable_fields();
 			jQuery.maybe_disable_save_button();
 		} catch ( error ) {
 			alert( woocommerce_admin_meta_boxes.i18n_add_attribute_error_notice );

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute-inner.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute-inner.php
@@ -93,28 +93,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<tr>
 		<td>
 			<div class="enable_variation show_if_variable">
-				<label><input type="checkbox" class="woocommerce_attribute_used_for_variations checkbox" <?php checked( $attribute->get_variation(), true ); ?> <?php echo esc_attr( isset( $is_variations_screen ) ? 'disabled' : '' ); ?> name="attribute_variation[<?php echo esc_attr( $i ); ?>]" value="1" /> <?php esc_html_e( 'Used for variations', 'woocommerce' ); ?></label>
-				<?php
-				if ( isset( $is_variations_screen ) ) {
-					?>
-					<input type="hidden" name="attribute_variation[<?php echo esc_attr( $i ); ?>]" value="1" />
-					<?php
-				}
-				?>
+				<label><input type="checkbox" disabled class="woocommerce_attribute_used_for_variations checkbox enable_if_variable" <?php checked( $attribute->get_variation(), true ); ?> name="attribute_variation[<?php echo esc_attr( $i ); ?>]" value="1" /> <?php esc_html_e( 'Used for variations', 'woocommerce' ); ?></label>
 			</div>
 		</td>
 	</tr>
 	<?php
-	if ( ! isset( $is_variations_screen ) ) {
-		/**
-		 * Hook to display custom attribute terms.
-		 *
-		 * @since 3.4.0
-		 * @param WC_Product_Attribute $attribute Attribute object.
-		 * @param number $i Attribute index.
-		 */
-		do_action( 'woocommerce_after_product_attribute_settings', $attribute, $i );
-	}
+	/**
+	 * Hook to display custom attribute terms.
+	 *
+	 * @since 3.4.0
+	 * @param WC_Product_Attribute $attribute Attribute object.
+	 * @param number $i Attribute index.
+	 */
+	do_action( 'woocommerce_after_product_attribute_settings', $attribute, $i );
 	?>
 	</tbody>
 </table>


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Disable 'Used for variations' checkbox when product type is not variable

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #38778.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Open the legacy product editor at Product > Add New.
2. Leave product type as 'Simple' for now.
3. Go to Attributes tab.
4. Add a new Attribute, fill the mandatory values, and click 'Save attributes'.
5. Switch product type to 'Variable'.
6. Verify that the previously added attribute does not have 'Used for variations' checked, since it was not persisted with that value.
7. Add a new attribute.
8. Verify that 'Used for variations' is checked as default.
9. Fill all mandatory values and click 'Save attributes'. 
10. Refresh and check if the information was persisted successfully.

<!-- End testing instructions -->
