### PR TITLE
fix: check whether WC_ADMIN_APP is defined before using

### DIFF
--- a/plugins/woocommerce-beta-tester/changelog/fix-beta-tester-wcapp-constant
+++ b/plugins/woocommerce-beta-tester/changelog/fix-beta-tester-wcapp-constant
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+check for WC_ADMIN_APP constant before using it

--- a/plugins/woocommerce-beta-tester/woocommerce-beta-tester.php
+++ b/plugins/woocommerce-beta-tester/woocommerce-beta-tester.php
@@ -78,6 +78,9 @@ add_action( 'plugins_loaded', '_wc_beta_tester_bootstrap' );
  * Register the JS.
  */
 function add_extension_register_script() {
+	if ( ! defined( 'WC_ADMIN_APP' ) ) {
+		return;
+	}
 	$script_path       = '/build/index.js';
 	$script_asset_path = dirname( __FILE__ ) . '/build/index.asset.php';
 	$script_asset      = file_exists( $script_asset_path )


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Check for the existence of the WC_ADMIN_APP constant before using it. Fixes an issue where backend would become inaccessible when installing Beta Tester without WooCommerce. 

Closes #38578.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. checkout trunk, cd to `plugins/woocommerce-beta-tester` and run `wp-env start`
2. visit the env site and deactivate WooCommerce
3. observe that wp-admin isn't accessible anymore
4. switch to this branch
5. note that an error message is now shown instead of the backend becoming inaccessible:

![Screenshot 2023-06-19 at 16 35 30](https://github.com/woocommerce/woocommerce/assets/23619/b75ab339-6899-4a33-b2f7-e04ec2cabf5b)


<!-- End testing instructions -→
