### PR TITLE
Do not show "Adding new attribute failed" error message when loading of product screens is interrupted by page unload

### DIFF
--- a/plugins/woocommerce/changelog/fix-adding-new-attribute-failed-error
+++ b/plugins/woocommerce/changelog/fix-adding-new-attribute-failed-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Do not enqueue product meta boxes scripts on edit-product screen.

--- a/plugins/woocommerce/changelog/fix-adding-new-attribute-failed-error
+++ b/plugins/woocommerce/changelog/fix-adding-new-attribute-failed-error
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Do not enqueue product meta boxes scripts on edit-product screen.
+Do not show "Adding new attribute failed" error message when loading of product screens is interrupted by page unload.

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -438,28 +438,27 @@ jQuery( function ( $ ) {
 			} );
 	} );
 
-	// Attribute Tables.
+	// Set up attributes, if current page has the attributes list.
+	const $product_attributes = $( '.product_attributes' );
+	if ( $product_attributes.length === 1 ) {
+		var woocommerce_attribute_items = $product_attributes.find( '.woocommerce_attribute' ).get();
 
-	// Initial order.
-	var woocommerce_attribute_items = $( '.product_attributes' )
-		.find( '.woocommerce_attribute' )
-		.get();
-
-	// If the product has no attributes, add an empty attribute to be filled out by the user.
-	$( function add_blank_custom_attribute_if_no_attributes() {
-		if ( woocommerce_attribute_items.length === 0 ) {
+		// If the product has no attributes, add an empty attribute to be filled out by the user.
+		if ( woocommerce_attribute_items.length === 0  ) {
 			add_custom_attribute_to_list();
 		}
-	} );
 
-	woocommerce_attribute_items.sort( function ( a, b ) {
-		var compA = parseInt( $( a ).attr( 'rel' ), 10 );
-		var compB = parseInt( $( b ).attr( 'rel' ), 10 );
-		return compA < compB ? -1 : compA > compB ? 1 : 0;
-	} );
-	$( woocommerce_attribute_items ).each( function ( index, el ) {
-		$( '.product_attributes' ).append( el );
-	} );
+		// Sort the attributes by their position.
+		woocommerce_attribute_items.sort( function ( a, b ) {
+			var compA = parseInt( $( a ).attr( 'rel' ), 10 );
+			var compB = parseInt( $( b ).attr( 'rel' ), 10 );
+			return compA < compB ? -1 : compA > compB ? 1 : 0;
+		} );
+
+		$( woocommerce_attribute_items ).each( function ( index, el ) {
+			$product_attributes.append( el );
+		} );
+	}
 
 	function update_attribute_row_indexes() {
 		$( '.product_attributes .woocommerce_attribute' ).each( function (

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -1,5 +1,11 @@
 /*global woocommerce_admin_meta_boxes */
 jQuery( function ( $ ) {
+	let isPageUnloading = false;
+
+	$( window ).on( 'beforeunload', function () {
+		isPageUnloading = true;
+	} );
+
 	// Scroll to first checked category
 	// https://github.com/scribu/wp-category-checklist-tree/blob/d1c3c1f449e1144542efa17dde84a9f52ade1739/category-checklist-tree.php
 	$( function () {
@@ -571,9 +577,13 @@ jQuery( function ( $ ) {
 			disable_or_enable_fields();
 			jQuery.maybe_disable_save_button();
 		} catch ( error ) {
-			alert(
-				woocommerce_admin_meta_boxes.i18n_add_attribute_error_notice
-			);
+			if ( isPageUnloading ) {
+				// If the page is unloading, the outstanding ajax fetch may fail in Firefox (and possible other browsers, too).
+				// We don't want to show an error message in this case, because it was caused by the user leaving the page.
+				return;
+			}
+
+			alert( woocommerce_admin_meta_boxes.i18n_add_attribute_error_notice );
 			throw error;
 		} finally {
 			unblock_attributes_tab_container();


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

#### Why did this happen

In WooCommerce 7.8 the empty state handling for the attributes tab on the product editor updated (#38126) and then  refactored to add an alert when the background request to get the empty attribute form failed (#38354).

Unfortunately, in Firefox (and possibly other browsers), these background requests fail (and the error handling associated with them are executed) when they are canceled due to the entire page being unloaded (Chrome appears to handle this differently, not executing the error handling for these canceled/failed background requests).

To make matters worse, the request to get the empty attribute form was being made when on the product edit/list screen ("All Products": `/wp-admin/edit.php?post_type=product`), when it really only is useful on the product screen ("Add New": `/wp-admin/post-new.php?post_type=product` and "Edit": `/wp-admin/post.php?post=0000&action=edit`).

The page can get unloaded while these background requests are in-progress in normal circumstances when the connection between the browser and the server is slow.

#### How to reproduce the issue in #38755

A few scenarios where this can be seen:

* Load "All Products" and quickly click a product to edit it, or sort the list by clicking one of the column headers
* Load a product to edit it and quickly navigate to a different page

These can be difficult to reproduce if the timing isn't right. I found that setting my network throttling to "Wi-Fi" in the Network tab of the browser developer tools made it more likely that this occurred.

**Also, as mentioned, I have only seen this happen in Firefox.**

#### What is changed in this PR

This PR fixes this error by:

* Only attempting to load the empty attribute form when editing a product (do not attempt to load it when viewing "All Products")
* Suppressing the "Adding new attribute failed" alert if the page is being unloaded

_This PR does not stop the `meta-boxes-product.js` and `meta-boxes-product-variation.js` files from being enqueued for the `edit-product` screen ("All Products"). While I believe it to be unnecessary in that scenario, those files have been loaded for 5-10 years in that scenario and I want to dig into things a bit further to verify that changing that will introduce no issues that aren't immediately apparent. I will create a follow-up issue to handle this._

Also, note that in Firefox there still may be circumstances where messages such as the following still appear in the console:

```
Uncaught (in promise) Object { code: "fetch_error", message: "You are probably offline." }
```

These messages appeared prior to WooCommerce 7.8. Ideally they would suppressed, but that would be a more involved fix and should be handled separately in the future if desired.

Closes #38755.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

With **Firefox**:

1. Load "All Products" and quickly click a product to edit it, or sort the list by clicking one of the column headers
2. Do this a number of times and verify that you *never* see the "Adding new attribute failed" alert
3. Load a product to edit it and quickly navigate to a different page
4. Do this a number of times and verify that you *never* see the "Adding new attribute failed" alert
5. Repeat everything in Chrome to verify no issues exist there either
6. Verify that the empty state for the attributes tab is correct as detailed in #38126.

Empty state for attributes tab:

<img width="809" alt="Screenshot 2023-05-05 at 15 08 08" src="https://user-images.githubusercontent.com/2098816/236548525-35471f39-db35-45bc-9b82-11bf3e457f7a.png">

<!-- End testing instructions -->
