### PR TITLE
Fix help panel links

### DIFF
--- a/plugins/woocommerce-admin/client/activity-panel/panels/help.js
+++ b/plugins/woocommerce-admin/client/activity-panel/panels/help.js
@@ -38,15 +38,15 @@ function getHomeItems() {
 		},
 		{
 			title: __( 'Inbox', 'woocommerce' ),
-			link: 'https://woocommerce.com/document/home-screen/?utm_medium=product#section-2',
-		},
-		{
-			title: __( 'Stats Overview', 'woocommerce' ),
 			link: 'https://woocommerce.com/document/home-screen/?utm_medium=product#section-4',
 		},
 		{
-			title: __( 'Store Management', 'woocommerce' ),
+			title: __( 'Stats Overview', 'woocommerce' ),
 			link: 'https://woocommerce.com/document/home-screen/?utm_medium=product#section-5',
+		},
+		{
+			title: __( 'Store Management', 'woocommerce' ),
+			link: 'https://woocommerce.com/document/home-screen/?utm_medium=product#section-10',
 		},
 		{
 			title: __( 'Store Setup Checklist', 'woocommerce' ),

--- a/plugins/woocommerce/changelog/fix-help-panel-links
+++ b/plugins/woocommerce/changelog/fix-help-panel-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix links under "Help" panel on Home screen


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #38539.

This PR fixes "Inbox", "Stats Overview' and "Store management" links under "Help" panel on Home screen redirects to the wrong section.

![Screenshot 2023-06-20 at 15 08 38](https://github.com/woocommerce/woocommerce/assets/4344253/2fc150b4-0127-4266-b2f4-e9eb6ad3632e)


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to `WooCommerce->Home`
2. Click on "Help" panel.
3. Click on **Inbox/Stats overview/Store Management** options.
4. Observe that it redirects to the respective section.

<!-- End testing instructions -->
