### PR TITLE
Add missing spacing in WCPay welcome incentive page cards

### DIFF
--- a/plugins/woocommerce-admin/client/payments-welcome/style.scss
+++ b/plugins/woocommerce-admin/client/payments-welcome/style.scss
@@ -2,6 +2,10 @@
 	max-width: 680px;
 	margin: 0 auto;
 
+	.components-card {
+		margin-bottom: $gap-large;
+	}
+
 	.components-notice.is-error {
 		margin: 0 0 $gap-large 0;
 	}

--- a/plugins/woocommerce/changelog/fix-wcpay-incentive-cards-spacing
+++ b/plugins/woocommerce/changelog/fix-wcpay-incentive-cards-spacing
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Add a mising spacing in WCPay welcome incentve page cards.
+
+


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:
 Add missing space between `<Card>` in WCPay welcome incentive page.


### How to test the changes in this Pull Request:
- Ensure the incentive page is visible following the testing instructions on #38689.
- There should be a space of `24px` between every `<Card>` component.

### Screenshots
| Before | After |
| - | - |
|<img width="694" alt="Screenshot 2023-06-20 at 10 36 55" src="https://github.com/woocommerce/woocommerce/assets/7670276/9dcdc903-b2b6-459d-b189-930bee9b8976">|<img width="696" alt="image" src="https://github.com/woocommerce/woocommerce/assets/7670276/acb66492-b632-4669-b3e5-8d28dd78f227">|