### PR TITLE
Marketing: Do not show "Create a campaign" button if there are no campaign types

### DIFF
--- a/plugins/woocommerce-admin/client/marketing/overview-multichannel/Campaigns/Campaigns.test.tsx
+++ b/plugins/woocommerce-admin/client/marketing/overview-multichannel/Campaigns/Campaigns.test.tsx
@@ -158,7 +158,7 @@ describe( 'Campaigns component', () => {
 		expect( screen.getByText( 'Campaign 6' ) ).toBeInTheDocument();
 	} );
 
-	it( 'renders a "Create new campaign" button in the card header, and upon clicking, displays the "Create a new campaign" modal', async () => {
+	it( 'does not render a "Create new campaign" button in the card header when there are no campaign types', async () => {
 		( useCampaigns as jest.Mock ).mockReturnValue( {
 			loading: false,
 			error: undefined,
@@ -169,6 +169,43 @@ describe( 'Campaigns component', () => {
 		} );
 		( useCampaignTypes as jest.Mock ).mockReturnValue( {
 			loading: false,
+			data: [],
+		} );
+
+		render( <Campaigns /> );
+
+		expect(
+			screen.queryByRole( 'button', { name: 'Create new campaign' } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'renders a "Create new campaign" button in the card header when there are campaign types, and upon clicking, displays the "Create a new campaign" modal', async () => {
+		( useCampaigns as jest.Mock ).mockReturnValue( {
+			loading: false,
+			error: undefined,
+			data: [ createTestCampaign( '1' ) ],
+			meta: {
+				total: 1,
+			},
+		} );
+		( useCampaignTypes as jest.Mock ).mockReturnValue( {
+			loading: false,
+			data: [
+				{
+					id: 'google-ads',
+					name: 'Google Ads',
+					description:
+						'Boost your product listings with a campaign that is automatically optimized to meet your goals.',
+					channel: {
+						slug: 'google-listings-and-ads',
+						name: 'Google Listings & Ads',
+					},
+					create_url:
+						'https://wc1.test/wp-admin/admin.php?page=wc-admin&path=/google/dashboard&subpath=/campaigns/create',
+					icon_url:
+						'https://woocommerce.com/wp-content/uploads/2021/06/woo-GoogleListingsAds-jworee.png',
+				},
+			],
 		} );
 
 		render( <Campaigns /> );

--- a/plugins/woocommerce-admin/client/marketing/overview-multichannel/Campaigns/Campaigns.tsx
+++ b/plugins/woocommerce-admin/client/marketing/overview-multichannel/Campaigns/Campaigns.tsx
@@ -28,7 +28,7 @@ import {
 	CardHeaderTitle,
 	CreateNewCampaignModal,
 } from '~/marketing/components';
-import { useCampaigns } from '~/marketing/hooks';
+import { useCampaignTypes, useCampaigns } from '~/marketing/hooks';
 import './Campaigns.scss';
 
 const tableCaption = __( 'Campaigns', 'woocommerce' );
@@ -59,6 +59,7 @@ export const Campaigns = () => {
 	const [ page, setPage ] = useState( 1 );
 	const [ isModalOpen, setModalOpen ] = useState( false );
 	const { loading, data, meta } = useCampaigns( page, perPage );
+	const { data: dataCampaignTypes } = useCampaignTypes();
 	const total = meta?.total;
 
 	const getContent = () => {
@@ -158,6 +159,7 @@ export const Campaigns = () => {
 		);
 	};
 
+	const showCreateCampaignButton = !! dataCampaignTypes?.length;
 	const showFooter = !! ( total && total > perPage );
 
 	return (
@@ -166,12 +168,14 @@ export const Campaigns = () => {
 				<CardHeaderTitle>
 					{ __( 'Campaigns', 'woocommerce' ) }
 				</CardHeaderTitle>
-				<Button
-					variant="secondary"
-					onClick={ () => setModalOpen( true ) }
-				>
-					{ __( 'Create new campaign', 'woocommerce' ) }
-				</Button>
+				{ showCreateCampaignButton && (
+					<Button
+						variant="secondary"
+						onClick={ () => setModalOpen( true ) }
+					>
+						{ __( 'Create new campaign', 'woocommerce' ) }
+					</Button>
+				) }
 				{ isModalOpen && (
 					<CreateNewCampaignModal
 						onRequestClose={ () => setModalOpen( false ) }

--- a/plugins/woocommerce-admin/client/marketing/overview-multichannel/IntroductionBanner/IntroductionBanner.tsx
+++ b/plugins/woocommerce-admin/client/marketing/overview-multichannel/IntroductionBanner/IntroductionBanner.tsx
@@ -33,7 +33,7 @@ export const IntroductionBanner = ( {
 	const { data: dataRecommended } = useRecommendedChannels();
 	const { data: dataCampaignTypes } = useCampaignTypes();
 
-	const showCreateCampaignButton = !! (
+	const showButtons = !! (
 		dataRegistered?.length && dataCampaignTypes?.length
 	);
 
@@ -46,19 +46,13 @@ export const IntroductionBanner = ( {
 	 * and it does not make sense to display the "Add channels" button in this introduction banner
 	 * that will do nothing upon click.
 	 *
-	 * This also depends on the `showCreateCampaignButton` above.
-	 * If "create campaign" button is not shown, then "add channels" button should not be shown either.
-	 * This is to make it look better in the UI.
-	 *
 	 * If there are registered channels and recommended channels,
 	 * the Channels card will display the  "Add channels" toggle button,
 	 * and clicking on the "Add channels" button in this introduction banner
 	 * will scroll to the button in Channels card.
 	 */
 	const showAddChannelsButton = !! (
-		dataRegistered?.length &&
-		dataRecommended?.length &&
-		showCreateCampaignButton
+		dataRegistered?.length && dataRecommended?.length
 	);
 
 	return (
@@ -112,21 +106,19 @@ export const IntroductionBanner = ( {
 						</Flex>
 					</FlexItem>
 				</Flex>
-				{ ( showCreateCampaignButton || showAddChannelsButton ) && (
+				{ showButtons && (
 					<Flex
 						className="woocommerce-marketing-introduction-banner-buttons"
 						justify="flex-start"
 					>
-						{ showCreateCampaignButton && (
-							<Button
-								variant="primary"
-								onClick={ () => {
-									setModalOpen( true );
-								} }
-							>
-								{ __( 'Create a campaign', 'woocommerce' ) }
-							</Button>
-						) }
+						<Button
+							variant="primary"
+							onClick={ () => {
+								setModalOpen( true );
+							} }
+						>
+							{ __( 'Create a campaign', 'woocommerce' ) }
+						</Button>
 						{ showAddChannelsButton && (
 							<Button
 								variant="secondary"

--- a/plugins/woocommerce-admin/client/marketing/overview-multichannel/IntroductionBanner/IntroductionBanner.tsx
+++ b/plugins/woocommerce-admin/client/marketing/overview-multichannel/IntroductionBanner/IntroductionBanner.tsx
@@ -46,13 +46,19 @@ export const IntroductionBanner = ( {
 	 * and it does not make sense to display the "Add channels" button in this introduction banner
 	 * that will do nothing upon click.
 	 *
+	 * This also depends on the `showCreateCampaignButton` above.
+	 * If "create campaign" button is not shown, then "add channels" button should not be shown either.
+	 * This is to make it look better in the UI.
+	 *
 	 * If there are registered channels and recommended channels,
 	 * the Channels card will display the  "Add channels" toggle button,
 	 * and clicking on the "Add channels" button in this introduction banner
 	 * will scroll to the button in Channels card.
 	 */
 	const showAddChannelsButton = !! (
-		dataRegistered?.length && dataRecommended?.length
+		dataRegistered?.length &&
+		dataRecommended?.length &&
+		showCreateCampaignButton
 	);
 
 	return (

--- a/plugins/woocommerce-admin/client/marketing/overview-multichannel/IntroductionBanner/IntroductionBanner.tsx
+++ b/plugins/woocommerce-admin/client/marketing/overview-multichannel/IntroductionBanner/IntroductionBanner.tsx
@@ -13,6 +13,7 @@ import { CreateNewCampaignModal } from '~/marketing/components';
 import {
 	useRegisteredChannels,
 	useRecommendedChannels,
+	useCampaignTypes,
 } from '~/marketing/hooks';
 import './IntroductionBanner.scss';
 import wooIconUrl from './woo.svg';
@@ -30,8 +31,11 @@ export const IntroductionBanner = ( {
 	const [ isModalOpen, setModalOpen ] = useState( false );
 	const { data: dataRegistered } = useRegisteredChannels();
 	const { data: dataRecommended } = useRecommendedChannels();
+	const { data: dataCampaignTypes } = useCampaignTypes();
 
-	const showCreateCampaignButton = !! dataRegistered?.length;
+	const showCreateCampaignButton = !! (
+		dataRegistered?.length && dataCampaignTypes?.length
+	);
 
 	/**
 	 * Boolean to display the "Add channels" button in the introduction banner.

--- a/plugins/woocommerce/changelog/feature-38805-create-campaign-button
+++ b/plugins/woocommerce/changelog/feature-38805-create-campaign-button
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Show create campaign button when there are campaign types in marketing page.


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/38805.

In this PR, we add conditions for rendering the "Create a campaign" button in the Introduction Banner card:

- When there are no supported campaign types, the "Create a campaign" button and "Add channels" button will not be displayed (note that when there are no campaign types, the "Campaigns" card will not be displayed too):

<!--
Introduction banner with "Add channels" button only:
![image](https://github.com/woocommerce/woocommerce/assets/417342/6753f234-db23-4ab4-8495-4c8a0cbbc33e)
-->

![image](https://github.com/woocommerce/woocommerce/assets/417342/8cbd78a3-e20e-4798-8ded-6787ed37c676)

- When there are supported campaign types, the "Create a campaign" button will be displayed (the "Campaigns" card is displayed here, with a "Create new campaign" button in the card header):

![image](https://github.com/woocommerce/woocommerce/assets/417342/ee248edc-ee12-4361-abe7-9596b722f87b)

I also added code for the "Create new campaign" button in the "Campaigns" card, so that "Create new campaign" button will not be shown when there are no campaign types. See the example screenshot below. Note that currently the "Campaigns" card is not displayed when there are no campaign types; this is because there is no match between the supported campaign types and the campaign types in the marketing campaigns, and the `GET /marketing/campaigns` API call returns an error instead of campaigns data. The code added is for "future proofing" just in case.

![image](https://github.com/woocommerce/woocommerce/assets/417342/4ebcb3eb-8189-4167-9466-f7d64e9f0047)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Note: to test the changes, you may need to use some test data in some marketing channel extension. The following is an example of how to do that using Google Listings and Ads:

1. Enable multichannel marketing for Google Listings and Ads using the following script:

```php
add_filter( 'woocommerce_gla_enable_mcm', function( $enabled ) {
	return true;
});
```

2. Modify the `get_campaigns` function in https://github.com/woocommerce/google-listings-and-ads/blob/33243ae88cf0b930d9956903738ececb5069a11e/src/MultichannelMarketing/GLAChannel.php#LL178C42-L178C42, so that it returns some sample marketing campaigns:

```php
	public function get_campaigns(): array {
		return [
			new MarketingCampaign(
				'1',
				$this->campaign_types['google-ads'],
				'Test campaign',
				admin_url( 'admin.php?page=wc-admin&path=/google/settings&subpath=/campaigns/edit' ),
				new Price( '100', 'USD' ),
			),
			new MarketingCampaign(
				'2',
				$this->campaign_types['google-ads'],
				'Test campaign 2',
				admin_url( 'admin.php?page=wc-admin&path=/google/settings&subpath=/campaigns/edit' ),
				new Price( '100', 'USD' ),
			),
		];
	}
```

3. Modify the `generate_campaign_types` function in https://github.com/woocommerce/google-listings-and-ads/blob/33243ae88cf0b930d9956903738ececb5069a11e/src/MultichannelMarketing/GLAChannel.php#L213-L224, so that it returns empty array for campaign types:

```php
	protected function generate_campaign_types(): array {
		return [];
	}
```

Test Steps:

1. Go to the WooCommerce > Marketing page: `/wp-admin/admin.php?page=wc-admin&path=%2Fmarketing`
2. Without modifying `generate_campaign_types`, you should see "Create a campaign" button in the introduction banner, and you should see "Create a campaign" button in the "Campaigns" card.
5. Modify the `generate_campaign_types` function to return empty array. You should NOT see "Create a campaign" button in the introduction banner. The "Campaigns" card should not be shown. In the browser network panel, you should see an error for the `GET /marketing/campaigns` API call. 

<!-- End testing instructions -->
