### PR TITLE
[Enhancement]: Add Tracks event recording to Emails settings

### DIFF
--- a/plugins/woocommerce/changelog/add-track-email-settings
+++ b/plugins/woocommerce/changelog/add-track-email-settings
@@ -1,0 +1,5 @@
+Significance: patch
+Type: add
+Comment: Track checkboxes and selects in Settings > Emails settings
+
+

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-settings-api.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-settings-api.php
@@ -213,6 +213,11 @@ abstract class WC_Settings_API {
 				try {
 					$this->settings[ $key ] = $this->get_field_value( $key, $field, $post_data );
 					if ( 'select' === $field['type'] || 'checkbox' === $field['type'] ) {
+						/**
+						 * Notify that a non-option setting has been updated.
+						 *
+						 * @since 7.8.0
+						 */
 						do_action(
 							'woocommerce_update_non_option_setting',
 							array(
@@ -229,8 +234,8 @@ abstract class WC_Settings_API {
 		}
 
 		$option_key = $this->get_option_key();
-		do_action( 'woocommerce_update_option', array( 'id' => $option_key ) );
-		return update_option( $option_key, apply_filters( 'woocommerce_settings_api_sanitized_fields_' . $this->id, $this->settings ), 'yes' );
+		do_action( 'woocommerce_update_option', array( 'id' => $option_key ) ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+		return update_option( $option_key, apply_filters( 'woocommerce_settings_api_sanitized_fields_' . $this->id, $this->settings ), 'yes' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 	}
 
 	/**

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-settings-api.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-settings-api.php
@@ -212,6 +212,16 @@ abstract class WC_Settings_API {
 			if ( 'title' !== $this->get_field_type( $field ) ) {
 				try {
 					$this->settings[ $key ] = $this->get_field_value( $key, $field, $post_data );
+					if ( 'select' === $field['type'] || 'checkbox' === $field['type'] ) {
+						do_action(
+							'woocommerce_update_non_option_setting',
+							array(
+								'id'    => $key,
+								'type'  => $field['type'],
+								'value' => $this->settings[ $key ],
+							)
+						);
+					}
 				} catch ( Exception $e ) {
 					$this->add_error( $e->getMessage() );
 				}
@@ -219,8 +229,8 @@ abstract class WC_Settings_API {
 		}
 
 		$option_key = $this->get_option_key();
-        do_action( 'woocommerce_update_option', array( 'id' => $option_key ) );
-        return update_option( $option_key, apply_filters( 'woocommerce_settings_api_sanitized_fields_' . $this->id, $this->settings ), 'yes' );
+		do_action( 'woocommerce_update_option', array( 'id' => $option_key ) );
+		return update_option( $option_key, apply_filters( 'woocommerce_settings_api_sanitized_fields_' . $this->id, $this->settings ), 'yes' );
 	}
 
 	/**
@@ -729,7 +739,7 @@ abstract class WC_Settings_API {
 			'options'           => array(),
 		);
 
-		$data = wp_parse_args( $data, $defaults );
+		$data  = wp_parse_args( $data, $defaults );
 		$value = $this->get_option( $key );
 
 		ob_start();

--- a/plugins/woocommerce/includes/tracks/events/class-wc-settings-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-settings-tracking.php
@@ -89,13 +89,25 @@ class WC_Settings_Tracking {
 		if ( ! in_array( $option['id'], $this->allowed_options, true ) ) {
 			$this->allowed_options[] = $option['id'];
 		}
-		if ( 'add' === $option['action'] ) {
-			$this->added_options[] = $option['id'];
-		} elseif ( 'delete' === $option['action'] ) {
-			$this->deleted_options[] = $option['id'];
-		} elseif ( ! in_array( $option['id'], $this->updated_options, true ) ) {
+		if ( isset( $option['action'] ) ) {
+			if ( 'add' === $option['action'] ) {
+				$this->added_options[] = $option['id'];
+			} elseif ( 'delete' === $option['action'] ) {
+				$this->deleted_options[] = $option['id'];
+			} elseif ( ! in_array( $option['id'], $this->updated_options, true ) ) {
+				$this->updated_options[] = $option['id'];
+			}
+		} elseif ( isset( $option['value'] ) ) {
+			if ( 'select' === $option['type'] ) {
+				$this->modified_options[ $option['id'] ] = $option['value'];
+
+			} elseif ( 'checkbox' === $option['type'] ) {
+				$option_state                             = 'yes' === $option['value'] ? 'enabled' : 'disabled';
+				$this->toggled_options[ $option_state ][] = $option['id'];
+			}
 			$this->updated_options[] = $option['id'];
 		}
+
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add Tracks event recording to Emails settings

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #38015 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure tracking is enabled in WooCommerce > Settings > Advanced > WooCommerce.com.
2. Go to WooCommerce > Settings > Emails.
3. Click 'Manage' on any Email type.
4. Change the value of a checkbox (Enable/disable) and a dropdown (Email type).
5. Save changes.
6. Go to WooCommerce > Status > Logs.
7. Search for 'tracks' and open the last updated entry.
8. Search for the latest 'wcadmin_settings_change' event fired and check the parameters. It should look similar to:

```
2023-06-20T19:10:29+00:00 DEBUG wcadmin_settings_change
2023-06-20T19:10:29+00:00 DEBUG   - error: 
2023-06-20T19:10:29+00:00 DEBUG   - settings: enabled,email_type,woocommerce_customer_on_hold_order_settings
2023-06-20T19:10:29+00:00 DEBUG   - enabled: enabled
2023-06-20T19:10:29+00:00 DEBUG   - email_type: plain
2023-06-20T19:10:29+00:00 DEBUG   - tab: email
```

<!-- End testing instructions -->
