### PR TITLE
Ignore cached plugin data when checking if plugins are WooCommerce-aware

### DIFF
--- a/plugins/woocommerce/changelog/fix-37343-incompatible-plugins-list
+++ b/plugins/woocommerce/changelog/fix-37343-incompatible-plugins-list
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+When detecting which plugins are WooCommerce-aware, improve accuracy by ignoring cached plugin data.

--- a/plugins/woocommerce/src/Utilities/PluginUtil.php
+++ b/plugins/woocommerce/src/Utilities/PluginUtil.php
@@ -65,6 +65,9 @@ class PluginUtil {
 	 */
 	public function get_woocommerce_aware_plugins( bool $active_only = false ): array {
 		if ( is_null( $this->woocommerce_aware_plugins ) ) {
+			// In case `get_plugins` was called much earlier in the request (before our headers could be injected), we
+			// invalidate the plugin cache list.
+			wp_cache_delete( 'plugins', 'plugins' );
 			$all_plugins = $this->proxy->call_function( 'get_plugins' );
 
 			$this->woocommerce_aware_plugins =


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

If WooCommerce detects that one or more plugins are not compatible with an enabled feature, it tries to warn the merchant and provide a list of the relevant plugins. In some cases, though, the list may be empty (even if incompatible plugins are present):

<table><tr><td><img alt="Screenshot 2023-06-20 at 13 28 53" src="https://github.com/woocommerce/woocommerce/assets/3594411/fc6ae7e8-246d-4c86-9155-edee462f39d7"></td><td><img  alt="Screenshot 2023-06-20 at 13 29 37" src="https://github.com/woocommerce/woocommerce/assets/3594411/afcc6dc5-497b-4062-8d58-72b2a61b7ab1"></td></tr></table>

This can happen if another plugin calls `get_plugins()` early in the request (before WooCommerce can filter it, and add WooCommerce header information to each plugin).

Closes #37343.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Please install, but do not activate, the following plugins (the zip file contains two single-file plugins):

💾 [Download Test Plugins](https://github.com/woocommerce/woocommerce/files/11806335/test-plugins-37343.zip)

- `Issue #37343 ▸ Plugin A` (test plugin A) is the plugin that causes the problem, by making a very early call to `get_plugins()`. 
- `Issue #37343 ▸ Plugin B` (test plugin B) is a WooCommerce-aware plugin that declares incompatibility with HPOS. 

Once you've set things up, proceed as follows:

1. Enable HPOS via **WooCommerce ▸ Settings ▸ Advanced ▸ Features**.
2. Visit the main plugin screen and activate test plugins A and B.
3. Return to (and refresh if needed) the feature admin page. You should find a link to manage incompatible plugins:

<div align="center"><img width="800" alt="Screenshot 2023-06-20 at 13 40 56" src="https://github.com/woocommerce/woocommerce/assets/3594411/beaaf127-9d92-4d96-b8d8-32527afec302"></div>

4. Follow the link, and you should be brought to a filtered version of the plugin list table. Without this change, the list will be empty. With this change, it should include at least test plugin B:

<div align="center"><img width="900" alt="Screenshot 2023-06-20 at 14 26 18" src="https://github.com/woocommerce/woocommerce/assets/3594411/0420edb4-9656-410b-a493-e038a730c8c4"></div>

:point_up: Note the presence of the inline notification, below plugin B, further calling attention to the fact that the incompatibility is with HPOS. This should also be present when the fix branch is applied.

<!-- End testing instructions -->
