### PR TITLE
When removing customer accounts, their content should be preserved.

### DIFF
--- a/plugins/woocommerce/changelog/fix-24432-account-cleanup
+++ b/plugins/woocommerce/changelog/fix-24432-account-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+When dormant customer accounts are removed, their content should be preserved.

--- a/plugins/woocommerce/includes/class-wc-privacy.php
+++ b/plugins/woocommerce/includes/class-wc-privacy.php
@@ -381,7 +381,14 @@ class WC_Privacy extends WC_Abstract_Privacy {
 			}
 
 			foreach ( $user_ids as $user_id ) {
-				wp_delete_user( $user_id );
+				wp_delete_user( $user_id, 0 );
+				wc_get_logger()->info(
+					sprintf(
+						/* translators: %d user ID. */
+						__( "User #%d was deleted by WooCommerce in accordance with the site's personal data retention settings. Any content belonging to that user has been retained but unassigned.", 'woocommerce' ),
+						$user_id
+					)
+				);
 				$count ++;
 			}
 		}

--- a/plugins/woocommerce/tests/php/includes/class-wc-privacy-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-privacy-test.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Tests relating to the WC_Privacy class.
+ */
+class WC_Privacy_Test extends WC_Unit_Test_Case {
+	/**
+	 * @testdox When user accounts are deleted, their content should be preserved.
+	 *
+	 * @return void
+	 */
+	public function test_delete_inactive_accounts(): void {
+		$customer = WC_Helper_Customer::create_customer();
+		update_user_meta( $customer->get_id(), 'wc_last_active', time() - YEAR_IN_SECONDS );
+		$post_id = wp_insert_post( array() );
+
+		update_option(
+			'woocommerce_delete_inactive_accounts',
+			array(
+				'number' => 1,
+				'unit'   => 'months',
+			)
+		);
+
+		$this->assertEquals( 1, WC_Privacy::delete_inactive_accounts(), 'Dormant customer accounts are removed in accordance with configured privacy settings.' );
+		$this->assertFalse( get_user_by( 'id', $customer->get_id() ), 'The deleted user account no longer exists.' );
+		$this->assertEquals( 0, get_post_field( 'post_author', $post_id ), 'Posts belonging to the removed user still exist, but do not have an author.' );
+	}
+}

--- a/plugins/woocommerce/tests/php/includes/class-wc-privacy-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-privacy-test.php
@@ -11,8 +11,8 @@ class WC_Privacy_Test extends WC_Unit_Test_Case {
 	 */
 	public function test_delete_inactive_accounts(): void {
 		$customer = WC_Helper_Customer::create_customer();
+		$post_id  = $this->factory->post->create( array( 'post_author' => $customer->get_id() ) );
 		update_user_meta( $customer->get_id(), 'wc_last_active', time() - YEAR_IN_SECONDS );
-		$post_id = wp_insert_post( array() );
 
 		update_option(
 			'woocommerce_delete_inactive_accounts',
@@ -22,8 +22,9 @@ class WC_Privacy_Test extends WC_Unit_Test_Case {
 			)
 		);
 
+		$this->assertEquals( $customer->get_id(), get_post_field( 'post_author', $post_id ), 'The test post was successfully assigned to the customer.' );
 		$this->assertEquals( 1, WC_Privacy::delete_inactive_accounts(), 'Dormant customer accounts are removed in accordance with configured privacy settings.' );
 		$this->assertFalse( get_user_by( 'id', $customer->get_id() ), 'The deleted user account no longer exists.' );
-		$this->assertEquals( 0, get_post_field( 'post_author', $post_id ), 'Posts belonging to the removed user still exist, but do not have an author.' );
+		$this->assertEquals( '0', get_post_field( 'post_author', $post_id ), 'Posts belonging to the removed user still exist, but do not have an author.' );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

When WooCommerce is configured to remove inactive (subscriber or customer) user accounts, it also removes any pages or posts that the user created.

<div align="center"><img width="800" alt="Screenshot 2023-06-20 at 16 21 22" src="https://github.com/woocommerce/woocommerce/assets/3594411/b4984ce1-4db4-408f-b6c2-2864bc5975d7"></div>

It is likely that most stores are unaffected, as customers generally do not author pages or posts. However, as described in the linked issue, it is possible an editor or author might be 'demoted' to subscriber. In such a case, we probably do not want to remove their content *automatically*.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #24432.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

It is probably easiest to use WP CLI to test this change, but first you should navigate to **WooCommerce ▸ Settings ▸ Accounts & Privacy** and set **retain inactive accounts** to **1 month**. Then, using WP CLI, start by creating a new user (you will be given the ID of the newly created user):

```
wp user create testuser test@user.local --role=subscriber
```

Simulate a situation in which this user has not been active for 1 year (replace `<user_id>` with the actual numeric ID from the last step):

```
wp user meta update <user_id> wc_last_active $(wp eval "print time() - YEAR_IN_SECONDS;")
```

Now create a post for this user (again, replace `<user_id>` as needed):

```
wp post create --post_title="Hello" --post_content="Hi, world." --post_author=<user_id>
```

Let's force WooCommerce to clean-up inactive user accounts:

```
wp eval "WC_Privacy::delete_inactive_accounts();"
```

Now, confirm everything worked as expected by trying to list details about the (now deleted) user account ... this should result in an *invalid user ID, email or login* error:

```
wp user get <user_id>
```

Let's check that their content still exists using the post ID you would have been supplied with a few steps back:

```
wp post get <post_id>
```

Look through the output for the `post_author` field, it should be `0` (zero). Finally, navigate to **WooCommerce ▸ Status ▸ Logs** and you should find this event was logged:

<div align="center"><img width="800" alt="Screenshot 2023-06-20 at 16 33 59" src="https://github.com/woocommerce/woocommerce/assets/3594411/915975c8-0d05-4eff-82a5-9466dd7592b9"></div>

<!-- End testing instructions -->

### Notes:

- This is a simpler version of [an earlier proposal](https://github.com/woocommerce/woocommerce/pull/25980), but should still satisfy the requirements of https://github.com/woocommerce/woocommerce/issues/24432.
- If we want, we can still add email notifications, as suggested in the earlier PR, but I propose doing so as a possible future change (I don't think we strictly need it, and it comes with complications of its own).
- I chose to "unassigning" the post author for each affected post (this basically means, setting the relevant post author fields to zero). This is a bit of a trade-off:
    - Some parts of the WP UI (like the post list table) are better at reflecting this than others (like the post editor, which will *appear* to list the first availabe user with writing capabilities as the author). That's a little sub-optimal, but I felt most comfortable with this.
    - An alternative is picking an admin user and assigning the content over to them; we can certainly do this, but it could cause a different type of confusion.