### PR TITLE
Update to WooCommerce blocks 10.4.3

### DIFF
--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-10.4.3
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-10.4.3
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update WooCommerce Blocks to 10.4.3

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -23,7 +23,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.6.1",
-		"woocommerce/woocommerce-blocks": "10.4.2"
+		"woocommerce/woocommerce-blocks": "10.4.3"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.3.0",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "79382fd9f5521821b18242e0214c91a1",
+    "content-hash": "53bb11983621ded24e2eae39b9baf6c2",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1004,16 +1004,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "10.4.2",
+            "version": "10.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "7b462a775d4148d9f0d13b5072756e5cdd9a4b23"
+                "reference": "c5019d7d0347787d0d9eabbbe41c41e3ff8fe1cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/7b462a775d4148d9f0d13b5072756e5cdd9a4b23",
-                "reference": "7b462a775d4148d9f0d13b5072756e5cdd9a4b23",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/c5019d7d0347787d0d9eabbbe41c41e3ff8fe1cf",
+                "reference": "c5019d7d0347787d0d9eabbbe41c41e3ff8fe1cf",
                 "shasum": ""
             },
             "require": {
@@ -1059,9 +1059,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v10.4.2"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v10.4.3"
             },
-            "time": "2023-06-13T08:33:16+00:00"
+            "time": "2023-06-21T06:28:19+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 10.4.3.

## Blocks 10.4.3

* [Release PR](https://github.com/woocommerce/woocommerce-blocks/pull/9919)
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/1043.md)

### Changelog entry

```

#### Bug Fixes

- Products block: fix compatibility with Gutenberg 16. ([9878](https://github.com/woocommerce/woocommerce-blocks/pull/9878))
```




