### PR TITLE
OrdersTableDataStore: capture+log exceptions when populating order properties

### DIFF
--- a/plugins/woocommerce/changelog/fix-errors-when-setting-order-properties-in-hpos-not-captured
+++ b/plugins/woocommerce/changelog/fix-errors-when-setting-order-properties-in-hpos-not-captured
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+OrdersTableDataStore: capture and log errors when populating order properties

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
@@ -761,7 +761,7 @@ abstract class WC_Data {
 				if ( ! $errors ) {
 					$errors = new WP_Error();
 				}
-				$errors->add( $e->getErrorCode(), $e->getMessage() );
+				$errors->add( $e->getErrorCode(), $e->getMessage(), array( 'property_name' => $prop ) );
 			}
 		}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1346,11 +1346,31 @@ WHERE
 					continue;
 				}
 
-				if ( 'date' === $prop_details['type'] ) {
-					$prop_value = $this->string_to_timestamp( $prop_value );
-				}
+				try {
+					if ( 'date' === $prop_details['type'] ) {
+						$prop_value = $this->string_to_timestamp( $prop_value );
+					}
 
-				$this->set_order_prop( $order, $prop_details['name'], $prop_value );
+					$this->set_order_prop( $order, $prop_details['name'], $prop_value );
+				} catch ( \Exception $e ) {
+					$order_id = $order->get_id();
+					$this->error_logger->warning(
+						sprintf(
+						/* translators: %1$d = peoperty name, %2$d = order ID, %3$s = error message. */
+							__( 'Error when setting property \'%1$s\' for order %2$d: %3$s', 'woocommerce' ),
+							$prop_details['name'],
+							$order_id,
+							$e->getMessage()
+						),
+						array(
+							'exception_code' => $e->getCode(),
+							'exception_msg'  => $e->getMessage(),
+							'origin'         => __METHOD__,
+							'order_id'       => $order_id,
+							'property_name'  => $prop_details['name'],
+						)
+					);
+				}
 			}
 		}
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -2146,4 +2146,70 @@ class OrdersTableDataStoreTests extends WC_Unit_Test_Case {
 
 		$this->assertEquals( 'wc-completed', $db_row['data']['status'] );
 	}
+
+	/**
+	 * @testDox An exception thrown while populating the properties of an order is captured and logged as a warning.
+	 */
+	public function test_error_when_setting_order_property_is_captured_and_logged() {
+		global $wpdb;
+
+		$this->toggle_cot( true );
+		$this->disable_cot_sync();
+
+		// phpcs:disable Squiz.Commenting
+		$fake_logger = new class() {
+			public $warnings = array();
+
+			public function warning( $message, $data ) {
+				$this->warnings[] = array(
+					'message' => $message,
+					'data'    => $data,
+				);
+			}
+		};
+		// phpcs:enable Squiz.Commenting
+
+		$this->register_legacy_proxy_function_mocks(
+			array(
+				'wc_get_logger' => function() use ( $fake_logger ) {
+					return $fake_logger;
+				},
+			)
+		);
+
+		$order = new WC_Order();
+		$order->save();
+		$product_id = $order->add_product( WC_Helper_Product::create_simple_product(), 1 );
+		$order->calculate_totals();
+		$order->save();
+
+		$refund = wc_create_refund(
+			array(
+				'order_id'   => $order->get_id(),
+				'line_items' => array(
+					$product_id => array(
+						'id'           => $product_id,
+						'qty'          => 1,
+						'refund_total' => 1,
+					),
+				),
+			)
+		);
+		$refund->save();
+
+		$this->assertEquals( $order->get_id(), $refund->get_parent_id() );
+
+		$wpdb->update(
+			$this->sut::get_orders_table_name(),
+			array( 'parent_order_id' => 999999 ),
+			array( 'id' => $refund->get_id() ),
+			array( 'parent_order_id' => '%d' ),
+			array( 'id' => '%d' ),
+		);
+
+		$refund = wc_get_order( $refund->get_id() );
+
+		$this->assertEquals( 0, $refund->get_parent_id() );
+		$this->assertEquals( "Error when setting property 'parent_id' for order {$refund->get_id()}: Invalid parent ID", current( $fake_logger->warnings )['message'] );
+	}
 }


### PR DESCRIPTION
- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

In the pre-HPOS era (or with the HPOS feature enabled but the posts table being authoritative) a call to `wc_get_orders` ends up calling the `Abstract_WC_Order_Data_Store_CPT::read` method, which appropriately populates the properties of the order object. If  this process throws errors, these are captured (and nothing is done with them) and the order object is returned anyway.

An example of how this can happen is a refund object whose "parent id" field in the database points to a non-existing order: trying to set its parent id property from the database value will throw an exception.

When HPOS is enabled and the orders table is authoritative, however, the job is done by `OrdersTableDataStore::read` which doesn't capture such errors, thus `wc_get_orders` ends up returning `false` even though the order exists. This is inconsistent with the non-HPOS case, and can also be confusing, especially when trying to retrieve an order whose id has been returned by an orders query.

This pull request makes the HPOS behavior consistent with the non-HPOS case: even if errors are found when populating the order properties, the order object will be returned anyway.

Additionally, these errors will be logged as warnings, both when using the new HPOS-based orders datastore and when using the old CPT based datastore.

### How to test the changes in this Pull Request:

1. HPOS setup: make the orders table authoritative and disable sync (WooCommerce - Settings - Advanced - Custom data stores).
2. Create an order and issue a refund for it. Take note of the refund id.
3. Alter the refund record in the database so it has an invalid parent order id, e.g.:

```
wp db query 'update wp_wc_orders set parent_order_id=999999 where id=<refund id>'
```

4. Just in case, clear the orders cache:

```
wp eval 'wc_get_container()->get("Automattic\WooCommerce\Caches\OrderCache")->flush();'
```

5. Try to retrieve the refund and look at its parent order id:

```
wp eval 'var_dump(wc_get_order(<refund id>)->get_parent_id());'
```

Without the fix you will get an error (_"Call to a member function get_parent_id() on bool"_) because `wc_get_order` will have returned `false`. With the fix you'll get 0 because the property failed to be populated (that's also the case in the non-HPOS world).

6. Look at the logs (WooCommerce - Status - Logs, filter by today's date) and see how a _"Error when setting property 'parent_id' for order &lt;refund id&gt;: Invalid parent ID"_ warning has been logged.

7. Repeat all the steps but with posts authoritative, verify that the same error is logged. Note that this time step 5 would work even without the fix