### PR TITLE
Remove feature related query args after enabling/disabling it

### DIFF
--- a/plugins/woocommerce/changelog/fix-remove-feature-queryargs
+++ b/plugins/woocommerce/changelog/fix-remove-feature-queryargs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove feature related query args after enabling/disabling it

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -1114,6 +1114,8 @@ class FeaturesController {
 
 		$is_feature_nonce_invalid = ( ! isset( $_GET['_feature_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_feature_nonce'] ) ), 'change_feature_enable' ) );
 
+		$query_params_to_remove = array( '_feature_nonce' );
+
 		foreach ( array_keys( $this->features ) as $feature_id ) {
 			if ( isset( $_GET[ $feature_id ] ) && is_numeric( $_GET[ $feature_id ] ) ) {
 				$value = absint( $_GET[ $feature_id ] );
@@ -1128,8 +1130,11 @@ class FeaturesController {
 				} elseif ( 0 === $value ) {
 					$this->change_feature_enable( $feature_id, false );
 				}
-				wp_safe_redirect( remove_query_arg( array( $feature_id, '_feature_nonce' ), wp_get_referer() ) );
+				$query_params_to_remove[] = $feature_id;
 			}
+		}
+		if ( count( $query_params_to_remove ) > 1 ) {
+			wp_safe_redirect( remove_query_arg( $query_params_to_remove, wp_get_referer() ) );
 		}
 	}
 }

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -1128,6 +1128,7 @@ class FeaturesController {
 				} elseif ( 0 === $value ) {
 					$this->change_feature_enable( $feature_id, false );
 				}
+				wp_safe_redirect( remove_query_arg( array( $feature_id, '_feature_nonce' ), wp_get_referer() ) );
 			}
 		}
 	}

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -1128,7 +1128,7 @@ class FeaturesController {
 				} elseif ( 0 === $value ) {
 					$this->change_feature_enable( $feature_id, false );
 				}
-				// wp_safe_redirect( remove_query_arg( array( $feature_id, '_feature_nonce' ), wp_get_referer() ) );
+				wp_safe_redirect( remove_query_arg( array( $feature_id, '_feature_nonce' ), wp_get_referer() ) );
 			}
 		}
 	}

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -1128,7 +1128,7 @@ class FeaturesController {
 				} elseif ( 0 === $value ) {
 					$this->change_feature_enable( $feature_id, false );
 				}
-				wp_safe_redirect( remove_query_arg( array( $feature_id, '_feature_nonce' ), wp_get_referer() ) );
+				// wp_safe_redirect( remove_query_arg( array( $feature_id, '_feature_nonce' ), wp_get_referer() ) );
 			}
 		}
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

Remove feature related query args after enabling/disabling it

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #38832 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure you delete the options `woocommerce_product_editor_show_feedback_bar` and `woocommerce_block_product_tour_shown`.
2. Enable the new product editor in `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
3. Go to Product > Add.
4. Close the tour popover.
5. On the feedback footer, click 'Turn it off' and 'Skip' on the modal that opens.
6. Check that the application redirects to the old editor without the `_feature_nonce` and `product_block_editor` query params.

<!-- End testing instructions -->
