### PR TITLE
Always pass defaults to product_type_options filter

### DIFF
--- a/plugins/woocommerce/changelog/update-product_type_options_param
+++ b/plugins/woocommerce/changelog/update-product_type_options_param
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Always pass default product type options to product_type_options filter

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -56,22 +56,7 @@ class WC_Meta_Box_Product_Data {
 		/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
 		return apply_filters(
 			'product_type_options',
-			array(
-				'virtual'      => array(
-					'id'            => '_virtual',
-					'wrapper_class' => 'show_if_simple',
-					'label'         => __( 'Virtual', 'woocommerce' ),
-					'description'   => __( 'Virtual products are intangible and are not shipped.', 'woocommerce' ),
-					'default'       => 'no',
-				),
-				'downloadable' => array(
-					'id'            => '_downloadable',
-					'wrapper_class' => 'show_if_simple',
-					'label'         => __( 'Downloadable', 'woocommerce' ),
-					'description'   => __( 'Downloadable products give access to a file upon purchase.', 'woocommerce' ),
-					'default'       => 'no',
-				),
-			)
+			wc_get_default_product_type_options(),
 		);
 		/* phpcs: enable */
 	}

--- a/plugins/woocommerce/includes/admin/wc-admin-functions.php
+++ b/plugins/woocommerce/includes/admin/wc-admin-functions.php
@@ -563,3 +563,29 @@ function wc_get_current_admin_url() {
 
 	return remove_query_arg( array( '_wpnonce', '_wc_notice_nonce', 'wc_db_update', 'wc_db_update_nonce', 'wc-hide-notice' ), admin_url( $uri ) );
 }
+
+/**
+ * Get default product type options.
+ *
+ * @internal
+ * @since 7.9.0
+ * @return array
+ */
+function wc_get_default_product_type_options() {
+	return array(
+		'virtual'      => array(
+			'id'            => '_virtual',
+			'wrapper_class' => 'show_if_simple',
+			'label'         => __( 'Virtual', 'woocommerce' ),
+			'description'   => __( 'Virtual products are intangible and are not shipped.', 'woocommerce' ),
+			'default'       => 'no',
+		),
+		'downloadable' => array(
+			'id'            => '_downloadable',
+			'wrapper_class' => 'show_if_simple',
+			'label'         => __( 'Downloadable', 'woocommerce' ),
+			'description'   => __( 'Downloadable products give access to a file upon purchase.', 'woocommerce' ),
+			'default'       => 'no',
+		),
+	);
+}

--- a/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
+++ b/plugins/woocommerce/includes/tracks/events/class-wc-products-tracking.php
@@ -230,18 +230,20 @@ class WC_Products_Tracking {
 	 * @return array
 	 */
 	private static function get_possible_product_type_options_ids() {
-		$product_type_options_ids = array_merge(
+		$product_type_options_ids =
 			array_values(
 				array_map(
 					function ( $product_type_option ) {
 						return $product_type_option['id'];
 					},
 					/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
-					apply_filters( 'product_type_options', array() )
+					apply_filters(
+						'product_type_options',
+						wc_get_default_product_type_options(),
+					)
+					/* phpcs: enable */
 				)
-			),
-			array( '_downloadable', '_virtual' )
-		);
+			);
 
 		return $product_type_options_ids;
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In #38017, the `product_type_options` filter's use was expanded to facilitate the tracking of product type options. Unfortunately, due to the way that it was implemented, some extensions may fail due to this change.

An empty array was passed to the `product_type_options` filter when determining which product type options were configured. Some extensions, such as [Product Bundles](https://woocommerce.com/products/product-bundles/) and [Composite Products](https://woocommerce.com/products/composite-products/), assume that when their hook it called, it will always contain the `virtual` and `downloadable` items in the array.

While an extension should not assumptions as to what specific items are in the array passed to their `product_type_options` hook, there may also be cases where the extension is basing decisions on what items are in the array, and it is confusing to exclude `virtual` and `downloadable` in some circumstances (tracking) while in other circumstances (building the product screen) they are included.

This PR updates the calling of the `product_type_options` filter to always pass the default items `virtual` and `downloadable`.

Again, there is no guarantee that these items will always be present, as another extension could remove them, so extensions should be implemented in a manner to gracefully handle this scenario.

The default product type options are:

- `Virtual`: `_virtual`
- `Downloadable`: `_downloadable`

Extensions can add product type options. Some examples...

The [WooCommerce Gift Cards](https://woocommerce.com/products/gift-cards/) extension adds:

- `Gift Card`: `_gift_card` (also hides and selects `_virtual`)

The [WooCommerce One Page Checkout](https://woocommerce.com/products/woocommerce-one-page-checkout/) extension adds:
- `One Page Checkout`: `_wcopc`

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Notes:
- Install WooCommerce Beta Tester so that the WCA Test Helper is available
- `wcadmin_product_add_publish` can be viewed in `WooCommerce` > `Status` > `Logs`
    - Pick the latest `tracks-` log

Steps:
1. Go to `Product` > `Add New`
2. Fill out product, including settings some product type options, like `Virtual`, `Downloadable`, `Gift Card` (from the _WooCommerce Gift Cards_ extension, see above)
3. Click `Publish`.
4. Verify the `wcadmin_product_add_publish` Tracks event is logged properly, including the `product_type_options` property. (view log as described above)

<!-- End testing instructions -->