### PR TITLE
Refresh onboarding profile values on the Homescreen

### DIFF
--- a/plugins/woocommerce-admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/index.tsx
@@ -20,7 +20,6 @@ import {
 	updateQueryString,
 	getQuery,
 	getNewPath,
-	navigateTo,
 } from '@woocommerce/navigation';
 import {
 	ExtensionList,

--- a/plugins/woocommerce-admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/index.tsx
@@ -332,9 +332,7 @@ const handleGeolocation = assign( {
 } );
 
 const redirectToWooHome = () => {
-	navigateTo( {
-		url: getNewPath( {}, '/', {} ),
-	} );
+	window.location.href = getNewPath( {}, '/', {} );
 };
 
 const redirectToJetpackAuthPage = (

--- a/plugins/woocommerce/changelog/fix-38859-use-hard-redirection-from-core-profiler
+++ b/plugins/woocommerce/changelog/fix-38859-use-hard-redirection-from-core-profiler
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Use window.location.href for page redirection to get the latest onboarding profile values on the Homescreen


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #38843  .

This PR replaces the `navigateTo` React redirection function with `window.location.href` to perform a hard refresh. This change is made to ensure that the latest onboarding profile values are fetched on the Homescreen, enabling accurate detection of onboarding completion.

This change also fixes other redirection issues mentioned in pdibGW-26P-p2 thread.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Delete `woocommerce_onboarding_profile` option.
2. Navigate to `WooCommerce -> Home`
3. You should be redirected to the core profiler.
4. Proceed as usual until the plugins page.
5. Click `Skip this step`
6. You should be redirected to WooCommerce Home



<!-- End testing instructions -->