### PR TITLE
Fix Core Profiler UI issues

### DIFF
--- a/plugins/woocommerce-admin/client/core-profiler/components/multiple-selector/multiple-selector.scss
+++ b/plugins/woocommerce-admin/client/core-profiler/components/multiple-selector/multiple-selector.scss
@@ -106,6 +106,12 @@
 						top: -1px;
 						width: 22px;
 					}
+
+					@include breakpoint( '<782px' ) {
+						svg {
+							width: 18px;
+						}
+					}
 				}
 			}
 		}

--- a/plugins/woocommerce-admin/client/core-profiler/components/multiple-selector/multiple-selector.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/components/multiple-selector/multiple-selector.tsx
@@ -68,6 +68,15 @@ export const MultipleSelector = ( {
 							inputValue: state.inputValue,
 							highlightedIndex: state.highlightedIndex,
 						};
+					case selectControlStateChangeTypes.InputBlur:
+						if ( state.isOpen && actionAndChanges.selectItem ) {
+							// Prevent the menu from closing when clicking on a selected item.
+							return {
+								...changes,
+								isOpen: true,
+							};
+						}
+						return changes;
 					default:
 						return changes;
 				}

--- a/plugins/woocommerce-admin/client/core-profiler/style.scss
+++ b/plugins/woocommerce-admin/client/core-profiler/style.scss
@@ -603,7 +603,7 @@
 	.woocommerce-profiler-user-profile__content {
 		.woocommerce-profiler-button-container {
 			position: inherit;
-			padding: 0px;
+			padding: 0;
 		}
 	}
 }

--- a/plugins/woocommerce-admin/client/core-profiler/style.scss
+++ b/plugins/woocommerce-admin/client/core-profiler/style.scss
@@ -598,3 +598,12 @@
 		}
 	}
 }
+
+@media screen and (max-height: 667px) {
+	.woocommerce-profiler-user-profile__content {
+		.woocommerce-profiler-button-container {
+			position: inherit;
+			padding: 0px;
+		}
+	}
+}

--- a/plugins/woocommerce/changelog/fix-38841-core-profiler-ui-issues
+++ b/plugins/woocommerce/changelog/fix-38841-core-profiler-ui-issues
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix core profiler UI bugs


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/38841.

This PR fixes Core Profiler UI bugs:

1. [Continue button is overlapping](https://github.com/woocommerce/woocommerce/assets/4344253/11dfdc3f-73bb-49a2-ba79-50b8e04e269b) the element on `Which one of these best describes you?` page on mobile (iPhone SE) when selecting `I'm already selling`.
2. [Checkmark icon is not centered](https://github.com/woocommerce/woocommerce/assets/4344253/d75d0f31-76e3-4fbf-ba90-6f60afc7e9b8) in the checkbox
3. When clicking the X button to remove some of the tags, [the dropdown is opened/closed automatically](https://github.com/woocommerce/woocommerce/assets/4344253/9284fbed-f3fb-48b3-b4e0-c8a5332067ea).

I've looked into the dropdown issue, and I don't find a solution to prevent the dropdown from opening when removing items with the current select control component. It is challenging because we cannot differentiate which element the user clicked on from the focus event. So instead, I changed it to prevent the menu from closing when clicking on a selected item.

Before:

https://github.com/woocommerce/woocommerce/assets/4344253/b90d2c5e-f5d4-489d-a769-80fda349af21


After:

https://github.com/woocommerce/woocommerce/assets/4344253/a1a3fbcb-ba68-4825-981e-6896068e7786


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

**Continue button overlapping**

1. Go to  /wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=user-profile
2. Use small mobile view such as iPhone SE
3. Selecting `I'm already selling`.
4. Observe that Continue button is not overlapping

*Checkmark icon*

1. Go to wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=user-profile
2. Use mobile view
3. Select `I'm already selling` > `Yes, I'm selling online`
4. Click on the platform dropdown
5. Select some platform items
6. Observe that checkmark icon is centered.

<img src="https://github.com/woocommerce/woocommerce/assets/4344253/b6b470c5-30e1-446c-b1f7-4949521ca1af" width="300px" />


**Clicking the X button to remove some of the tags**

1. Go to /wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=user-profile
8. Select `I'm already selling` > `Yes, I'm selling online`
9. Select some platform items
10. Close the platform dropdown
11. Click on `x` to remove the selected items 
12. Observe that the dropdown is opened and not closed automatically



<!-- End testing instructions -->
