### PR TITLE
do not use image size cache while in customizer

### DIFF
--- a/plugins/woocommerce/changelog/fix-28480
+++ b/plugins/woocommerce/changelog/fix-28480
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+do not use image size cache while in customizer

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -927,7 +927,7 @@ function wc_get_theme_support( $prop = '', $default = null ) {
  */
 function wc_get_image_size( $image_size ) {
 	$cache_key = 'size-' . ( is_array( $image_size ) ? implode( '-', $image_size ) : $image_size );
-	$size      = wp_cache_get( $cache_key, 'woocommerce' );
+	$size      = ! is_customize_preview() ? wp_cache_get( $cache_key, 'woocommerce' ) : false;
 
 	if ( $size ) {
 		return $size;
@@ -983,8 +983,11 @@ function wc_get_image_size( $image_size ) {
 
 	$size = apply_filters( 'woocommerce_get_image_size_' . $image_size, $size );
 
-	wp_cache_set( $cache_key, $size, 'woocommerce' );
-
+	if ( is_customize_preview() ) {
+		wp_cache_delete( $cache_key, 'woocommerce' );
+	} else {
+		wp_cache_set( $cache_key, $size, 'woocommerce' );
+	}
 	return $size;
 }
 


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR updates `wc_get_image_size()` to bypass the object cache when in the customizer. It also removes the cached setting so that it can be refreshed after the customizations are published. 

The customizer uses `pre_option_*` filters to dynamically reflect the settings changes made by the user. Currently, if the site has a persistent object cache, the function returns early without getting the options with the pre_option_ filters. 

Closes #28480 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Use a test site with a persistent object cache
2. Install and activate Twenty Twenty-One
3. Ensure you have products with featured images
4. Go to Appearance -> Customize -> WooCommerce -> Product Images
5. Test all three options to verify the product thumbnails are updated according to the selected setting in the customizer preview

<!-- End testing instructions -->
