### PR TITLE
Update the product's permalink (slug) when an AI suggestion is selected

### DIFF
--- a/plugins/woo-ai/changelog/update-product-slug-ai
+++ b/plugins/woo-ai/changelog/update-product-slug-ai
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Update the product's permalink (slug) when an AI suggested title is selected.

--- a/plugins/woo-ai/src/hooks/index.ts
+++ b/plugins/woo-ai/src/hooks/index.ts
@@ -1,3 +1,5 @@
 export * from './useTinyEditor';
 export * from './useCompletion';
 export * from './useFeedbackSnackbar';
+export * from './useProductSlug';
+export * from './useProductDataSuggestions';

--- a/plugins/woo-ai/src/hooks/useProductSlug.ts
+++ b/plugins/woo-ai/src/hooks/useProductSlug.ts
@@ -1,0 +1,77 @@
+/**
+ * External dependencies
+ */
+import { useRef } from '@wordpress/element';
+
+type UseProductSlugHook = {
+	updateProductSlug: ( title: string, postId: number ) => Promise< void >;
+};
+
+declare global {
+	interface Window {
+		ajaxurl?: string;
+	}
+}
+
+export const useProductSlug = (): UseProductSlugHook => {
+	const slugInputRef = useRef< HTMLInputElement >(
+		document.querySelector( '#post_name' )
+	);
+
+	const updateSlugInDOM = ( responseData: string ) => {
+		const editSlugBox = document.getElementById( 'edit-slug-box' );
+		if ( editSlugBox ) {
+			editSlugBox.innerHTML = responseData;
+
+			const newSlug = document.getElementById(
+				'editable-post-name-full'
+			)?.innerText;
+			if ( newSlug && slugInputRef.current ) {
+				slugInputRef.current.value = newSlug;
+				slugInputRef.current.setAttribute( 'value', newSlug );
+			}
+		}
+	};
+
+	const updateProductSlug = async (
+		title: string,
+		postId: number
+	): Promise< void > => {
+		const ajaxUrl: string = window?.ajaxurl || '/wp-admin/admin-ajax.php';
+		const samplePermalinkNonce = document
+			.getElementById( 'samplepermalinknonce' )
+			?.getAttribute( 'value' );
+
+		if ( ! samplePermalinkNonce ) {
+			throw new Error( 'Nonce could not be found in the DOM' );
+		}
+
+		const formData = new FormData();
+		formData.append( 'action', 'sample-permalink' );
+		formData.append( 'post_id', postId.toString() );
+		formData.append( 'new_title', title );
+		formData.append( 'new_slug', title );
+		formData.append( 'samplepermalinknonce', samplePermalinkNonce );
+
+		try {
+			const response = await fetch( ajaxUrl, {
+				method: 'POST',
+				body: formData,
+			} );
+
+			const responseData = await response.text();
+
+			if ( responseData !== '-1' ) {
+				updateSlugInDOM( responseData );
+			} else {
+				throw new Error( 'Invalid response!' );
+			}
+		} catch ( e ) {
+			throw new Error( "Couldn't update the slug!" );
+		}
+	};
+
+	return {
+		updateProductSlug,
+	};
+};

--- a/plugins/woo-ai/src/product-name/name-utils.ts
+++ b/plugins/woo-ai/src/product-name/name-utils.ts
@@ -5,7 +5,7 @@ import { recordTracksFactory, getPostId } from '../utils';
 
 type TracksData = Record<
 	string,
-	string | number | Array< Record< string, string | number > >
+	string | number | null | Array< Record< string, string | number | null > >
 >;
 
 export const recordNameTracks = recordTracksFactory< TracksData >(

--- a/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
+++ b/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
@@ -10,7 +10,7 @@ import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
  */
 import MagicIcon from '../../assets/images/icons/magic.svg';
 import AlertIcon from '../../assets/images/icons/alert.svg';
-import { productData } from '../utils';
+import { productData, getPostId } from '../utils';
 import { useProductDataSuggestions, useProductSlug } from '../hooks';
 import {
 	ProductDataSuggestion,
@@ -151,16 +151,15 @@ export const ProductNameSuggestions = () => {
 		setSuggestions( [] );
 
 		// Update product slug.
-		const currentProductData = productData();
-		try {
-			updateProductSlug(
-				suggestion.content,
-				currentProductData.product_id
-			);
-		} catch ( e ) {
-			// Log silently if slug update fails.
-			/* eslint-disable-next-line no-console */
-			console.error( e );
+		const productId = getPostId();
+		if ( productId !== null ) {
+			try {
+				updateProductSlug( suggestion.content, productId );
+			} catch ( e ) {
+				// Log silently if slug update fails.
+				/* eslint-disable-next-line no-console */
+				console.error( e );
+			}
 		}
 	};
 

--- a/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
+++ b/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
@@ -20,6 +20,7 @@ import { SuggestionItem, PoweredByLink, recordNameTracks } from './index';
 import { RandomLoadingMessage } from '../components';
 
 const MIN_TITLE_LENGTH = 10;
+import { useProductSlug } from '../hooks/useProductSlug';
 
 enum SuggestionsState {
 	Fetching = 'fetching',
@@ -56,6 +57,7 @@ export const ProductNameSuggestions = () => {
 		[]
 	);
 	const { fetchSuggestions } = useProductDataSuggestions();
+	const { updateProductSlug } = useProductSlug();
 	const nameInputRef = useRef< HTMLInputElement >(
 		document.querySelector( '#title' )
 	);
@@ -148,6 +150,19 @@ export const ProductNameSuggestions = () => {
 
 		updateProductName( suggestion.content );
 		setSuggestions( [] );
+
+		// Update product slug.
+		const currentProductData = productData();
+		try {
+			updateProductSlug(
+				suggestion.content,
+				currentProductData.product_id
+			);
+		} catch ( e ) {
+			// Log silently if slug update fails.
+			/* eslint-disable-next-line no-console */
+			console.error( e );
+		}
 	};
 
 	const fetchProductSuggestions = async (

--- a/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
+++ b/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
@@ -10,7 +10,7 @@ import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
  */
 import MagicIcon from '../../assets/images/icons/magic.svg';
 import AlertIcon from '../../assets/images/icons/alert.svg';
-import { productData, getPostId } from '../utils';
+import { productData } from '../utils';
 import { useProductDataSuggestions, useProductSlug } from '../hooks';
 import {
 	ProductDataSuggestion,
@@ -150,11 +150,17 @@ export const ProductNameSuggestions = () => {
 		updateProductName( suggestion.content );
 		setSuggestions( [] );
 
-		// Update product slug.
-		const productId = getPostId();
-		if ( productId !== null ) {
+		// Update product slug if product is a draft.
+		const currentProductData = productData();
+		if (
+			currentProductData.product_id !== null &&
+			currentProductData.publishing_status === 'draft'
+		) {
 			try {
-				updateProductSlug( suggestion.content, productId );
+				updateProductSlug(
+					suggestion.content,
+					currentProductData.product_id
+				);
 			} catch ( e ) {
 				// Log silently if slug update fails.
 				/* eslint-disable-next-line no-console */

--- a/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
+++ b/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
@@ -11,7 +11,7 @@ import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import MagicIcon from '../../assets/images/icons/magic.svg';
 import AlertIcon from '../../assets/images/icons/alert.svg';
 import { productData } from '../utils';
-import { useProductDataSuggestions } from '../hooks/useProductDataSuggestions';
+import { useProductDataSuggestions, useProductSlug } from '../hooks';
 import {
 	ProductDataSuggestion,
 	ProductDataSuggestionRequest,
@@ -20,7 +20,6 @@ import { SuggestionItem, PoweredByLink, recordNameTracks } from './index';
 import { RandomLoadingMessage } from '../components';
 
 const MIN_TITLE_LENGTH = 10;
-import { useProductSlug } from '../hooks/useProductSlug';
 
 enum SuggestionsState {
 	Fetching = 'fetching',

--- a/plugins/woo-ai/src/utils/get-post-id.ts
+++ b/plugins/woo-ai/src/utils/get-post-id.ts
@@ -1,4 +1,6 @@
-export const getPostId = () =>
-	Number(
-		( document.querySelector( '#post_ID' ) as HTMLInputElement )?.value
-	);
+export const getPostId = (): number | null => {
+	const postIdEl: HTMLInputElement | null =
+		document.querySelector( '#post_ID' );
+
+	return postIdEl ? Number( postIdEl.value ) : null;
+};

--- a/plugins/woo-ai/src/utils/productData.ts
+++ b/plugins/woo-ai/src/utils/productData.ts
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { Attribute, ProductData } from './types';
-import { getTinyContent } from '../utils/tiny-tools';
+import { getTinyContent } from './tiny-tools';
 
 const isElementVisible = ( element: HTMLElement ) =>
 	! ( window.getComputedStyle( element ).display === 'none' );
@@ -102,8 +102,16 @@ const getProductType = () => {
 	return productTypeEl ? productTypeEl.value : '';
 };
 
+const getProductId = (): number => {
+	const productIdEl: HTMLInputElement | null =
+		document.querySelector( '#post_ID' );
+
+	return productIdEl ? parseInt( productIdEl.value, 10 ) : 0;
+};
+
 export const productData = (): ProductData => {
 	return {
+		product_id: getProductId(),
 		name: getProductName(),
 		categories: getCategories(),
 		tags: getTags(),
@@ -112,13 +120,9 @@ export const productData = (): ProductData => {
 		product_type: getProductType(),
 		is_downloadable: (
 			document.querySelector( '#_downloadable' ) as HTMLInputElement
-		 )?.checked
-			? 'Yes'
-			: 'No',
+		 )?.checked,
 		is_virtual: (
 			document.querySelector( '#_virtual' ) as HTMLInputElement
-		 )?.checked
-			? 'Yes'
-			: 'No',
+		 )?.checked,
 	};
 };

--- a/plugins/woo-ai/src/utils/productData.ts
+++ b/plugins/woo-ai/src/utils/productData.ts
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { Attribute, ProductData } from './types';
-import { getTinyContent } from './tiny-tools';
+import { getTinyContent, getPostId } from '.';
 
 const isElementVisible = ( element: HTMLElement ) =>
 	! ( window.getComputedStyle( element ).display === 'none' );
@@ -102,16 +102,9 @@ const getProductType = () => {
 	return productTypeEl ? productTypeEl.value : '';
 };
 
-const getProductId = (): number => {
-	const productIdEl: HTMLInputElement | null =
-		document.querySelector( '#post_ID' );
-
-	return productIdEl ? parseInt( productIdEl.value, 10 ) : 0;
-};
-
 export const productData = (): ProductData => {
 	return {
-		product_id: getProductId(),
+		product_id: getPostId(),
 		name: getProductName(),
 		categories: getCategories(),
 		tags: getTags(),

--- a/plugins/woo-ai/src/utils/productData.ts
+++ b/plugins/woo-ai/src/utils/productData.ts
@@ -117,5 +117,8 @@ export const productData = (): ProductData => {
 		is_virtual: (
 			document.querySelector( '#_virtual' ) as HTMLInputElement
 		 )?.checked,
+		publishing_status: (
+			document.querySelector( '#post_status' ) as HTMLInputElement
+		 )?.value,
 	};
 };

--- a/plugins/woo-ai/src/utils/recordTracksFactory.ts
+++ b/plugins/woo-ai/src/utils/recordTracksFactory.ts
@@ -3,9 +3,11 @@
  */
 import { recordEvent } from '@woocommerce/tracks';
 
-export const recordTracksFactory = < T = Record< string, string | number > >(
+export const recordTracksFactory = <
+	T = Record< string, string | number | null >
+>(
 	feature: string,
-	propertiesCallback: () => Record< string, string | number >
+	propertiesCallback: () => Record< string, string | number | null >
 ) => {
 	return ( name: string, properties?: T ) =>
 		recordEvent( `woo_ai_product_${ feature }_${ name }`, {

--- a/plugins/woo-ai/src/utils/types.ts
+++ b/plugins/woo-ai/src/utils/types.ts
@@ -4,14 +4,15 @@ export type Attribute = {
 };
 
 export type ProductData = {
+	product_id: number;
 	name: string;
 	description: string;
 	categories: string[];
 	tags: string[];
 	attributes: Attribute[];
 	product_type: string;
-	is_downloadable: string;
-	is_virtual: string;
+	is_downloadable: boolean;
+	is_virtual: boolean;
 };
 
 export type ProductDataSuggestion = {

--- a/plugins/woo-ai/src/utils/types.ts
+++ b/plugins/woo-ai/src/utils/types.ts
@@ -13,6 +13,7 @@ export type ProductData = {
 	product_type: string;
 	is_downloadable: boolean;
 	is_virtual: boolean;
+	publishing_status: string;
 };
 
 export type ProductDataSuggestion = {

--- a/plugins/woo-ai/src/utils/types.ts
+++ b/plugins/woo-ai/src/utils/types.ts
@@ -4,7 +4,7 @@ export type Attribute = {
 };
 
 export type ProductData = {
-	product_id: number;
+	product_id: number | null;
 	name: string;
 	description: string;
 	categories: string[];


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

This PR implements a new React hook that will update the product's permalink (i.e., slug) whenever a suggested product title is selected for a product. 

Previously (as indicated in #38483), the plan was only to update the slug for new and draft products; however, since WordPress automatically redirects the pages when their permalink is modified (https://github.com/woocommerce/woocommerce/issues/38483#issuecomment-1600566503), we can update the slug for existing products as well so that they match the new product title.

cc: @jarekmorawski would love your comment here because I'm concerned automatically updating the product's permalink on existing products might catch some people off guard since they expect only the title to be updated. We could add a message notifying them of this change and letting them know that the old URL will redirect to the new one.

Closes #38483

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new product or edit an existing one
2. On the product edit page, click on the title input and generate a title using AI
3. Click on any of the suggested titles and confirm that the product's permalink is updated
4. Generate another title and again confirm that the permalink is updated
5. Save the product and confirm you can open the product view page using the permalink
6. Make a note of the current product URL
7. Go back to the product edit page and update the product title again
8. Save the product and confirm the previous URL still redirects to the newly generated permalink

<!-- End testing instructions -->
