### PR TITLE
Bump beta-tester to 2.2.1 to release support for installing trunk live branch

### DIFF
--- a/plugins/woocommerce-beta-tester/changelog/dev-inc-version-beta-tester
+++ b/plugins/woocommerce-beta-tester/changelog/dev-inc-version-beta-tester
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add support for installing WC trunk via live branches.

--- a/plugins/woocommerce-beta-tester/composer.json
+++ b/plugins/woocommerce-beta-tester/composer.json
@@ -6,7 +6,7 @@
 	"license": "GPL-3.0-or-later",
 	"prefer-stable": true,
 	"minimum-stability": "dev",
-	"version": "2.2.0",
+	"version": "2.2.1",
 	"require": {
 		"composer/installers": "~1.7"
 	},

--- a/plugins/woocommerce-beta-tester/package.json
+++ b/plugins/woocommerce-beta-tester/package.json
@@ -7,7 +7,7 @@
 		"url": "git://github.com/woocommerce/woocommerce-beta-tester.git"
 	},
 	"title": "WooCommerce Beta Tester",
-	"version": "2.2.0",
+	"version": "2.2.1",
 	"homepage": "http://github.com/woocommerce/woocommerce-beta-tester",
 	"devDependencies": {
 		"@types/react": "^17.0.2",

--- a/plugins/woocommerce-beta-tester/readme.txt
+++ b/plugins/woocommerce-beta-tester/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, bor0, claudiosanches, claudiulodro, kloon, mikejolley,
 Tags: woocommerce, woo commerce, beta, beta tester, bleeding edge, testing
 Requires at least: 4.7
 Tested up to: 6.0
-Stable tag: 2.2.0
+Stable tag: 2.2.1
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/plugins/woocommerce-beta-tester/woocommerce-beta-tester.php
+++ b/plugins/woocommerce-beta-tester/woocommerce-beta-tester.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Beta Tester
  * Plugin URI: https://github.com/woocommerce/woocommerce-beta-tester
  * Description: Run bleeding edge versions of WooCommerce. This will replace your installed version of WooCommerce with the latest tagged release - use with caution, and not on production sites.
- * Version: 2.2.0
+ * Version: 2.2.1
  * Author: WooCommerce
  * Author URI: http://woocommerce.com/
  * Requires at least: 5.8


### PR DESCRIPTION

### Changes proposed in this Pull Request:

Recently we added support for trunk in beta tester's live branches feature: https://github.com/woocommerce/woocommerce/pull/38536

This bumps the version of beta-tester and adds a changelog entry in prep to release beta tester. Actually the changelog entry is just to satisfy the linter as at least right now the changelogs from beta tester don't seem to be being treated properly, I will explore fixing this as a follow up.

### How to test the changes in this Pull Request:

I don't think anything here needs to be tested.

