### PR TITLE
Load the Cart Fragments script on specific pages

### DIFF
--- a/plugins/woocommerce/changelog/load-cart-fragments-script-selectively
+++ b/plugins/woocommerce/changelog/load-cart-fragments-script-selectively
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Load the "cart-fragments" JS script only on pages that would update the cart

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-cart.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-cart.php
@@ -44,11 +44,12 @@ class WC_Widget_Cart extends WC_Widget {
 	}
 
 	/**
-	 * Get list of Woo blocks that update the cart.
+	 * Get the list of Woo blocks that update the cart.
+	 * The cart widget isn't loaded on the Cart and Checkout Blocks, so they don't need to be included here.
 	 *
 	 * @return array;
 	 */
-	public static function get_blocks() {
+	public static function get_blocks_that_update_the_cart() {
 		return array(
 			'woocommerce/handpicked-products',
 			'woocommerce/single-product',
@@ -118,7 +119,7 @@ class WC_Widget_Cart extends WC_Widget {
 		}
 
 		global $post;
-		$is_cart_related_block = $this->has_block_from_list( self::get_blocks(), $post );
+		$is_cart_related_block = $this->has_block_from_list( self::get_blocks_that_update_the_cart(), $post );
 
 		if ( $is_cart_related_block || is_shop() || is_product() || is_product_category() ) {
 			wp_enqueue_script( 'wc-cart-fragments' );

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-cart.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-cart.php
@@ -82,25 +82,10 @@ class WC_Widget_Cart extends WC_Widget {
 	}
 
 	/**
-	 * Output widget.
-	 *
-	 * @see WP_Widget
-	 *
-	 * @param array $args     Arguments.
-	 * @param array $instance Widget instance.
+	 * Get refreshed cart fragment on page load.
 	 */
-	public function widget( $args, $instance ) {
-		if ( apply_filters( 'woocommerce_widget_cart_is_hidden', is_cart() || is_checkout() ) ) {
-			return;
-		}
-
-		global $post;
-		$is_cart_related_block = $this->array_contains( $post->post_content, self::get_blocks() );
-
-		if ( $is_cart_related_block || is_shop() || is_product() || is_product_category() ) {
-			wp_enqueue_script( 'wc-cart-fragments' );
-		} elseif ( ! wp_script_is( 'wc-cart-fragments-data', 'registered' ) ) {
-			ob_start();
+	public static function get_refreshed_cart_fragment_on_page_load() {
+		ob_start();
 
 			woocommerce_mini_cart();
 
@@ -127,6 +112,28 @@ class WC_Widget_Cart extends WC_Widget {
 				 } )
 				'
 			);
+	}
+
+	/**
+	 * Output widget.
+	 *
+	 * @see WP_Widget
+	 *
+	 * @param array $args     Arguments.
+	 * @param array $instance Widget instance.
+	 */
+	public function widget( $args, $instance ) {
+		if ( apply_filters( 'woocommerce_widget_cart_is_hidden', is_cart() || is_checkout() ) ) {
+			return;
+		}
+
+		global $post;
+		$is_cart_related_block = $this->array_contains( $post->post_content, self::get_blocks() );
+
+		if ( $is_cart_related_block || is_shop() || is_product() || is_product_category() ) {
+			wp_enqueue_script( 'wc-cart-fragments' );
+		} elseif ( ! wp_script_is( 'wc-cart-fragments-data', 'registered' ) ) {
+			self::get_refreshed_cart_fragment_on_page_load();
 		}
 
 		$hide_if_empty = empty( $instance['hide_if_empty'] ) ? 0 : 1;

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-cart.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-cart.php
@@ -66,18 +66,34 @@ class WC_Widget_Cart extends WC_Widget {
 	}
 
 	/**
-	 * array_contains
-	 * Check if string contains word from array.
+	 * Check if post has a block from the provided list of blocks.
+	 *
+	 * @param string[]                $blocks     Blocks to check for.
+	 * @param int|string|WP_Post|null $post       Post to check.
 	 *
 	 * @since 1.0.0
 	 * @version 1.0.0
 	 **/
-	function array_contains( $str, array $arr ) {
-		foreach ( $arr as $a ) {
-			if ( stripos( $str, $a ) !== false ) {
-				return true;
-			}
+	function has_block_from_list( $blocks, $post = null ) {
+		if ( ! $post ) {
+			$post = get_post();
 		}
+
+		if ( ! $post ) {
+			return false;
+		}
+
+		if ( ! function_exists( 'parse_blocks' ) ) {
+			return false;
+		}
+
+		$block_from_page = parse_blocks( $post->post_content );
+		$block_name      = $block_from_page[0]['blockName'];
+
+		if ( in_array( $block_name, $blocks, true ) ) {
+			return true;
+		}
+
 		return false;
 	}
 
@@ -107,7 +123,7 @@ class WC_Widget_Cart extends WC_Widget {
 		}
 
 		global $post;
-		$is_cart_related_block = $this->array_contains( $post->post_content, self::get_blocks() );
+		$is_cart_related_block = $this->has_block_from_list( self::get_blocks(), $post );
 
 		if ( $is_cart_related_block || is_shop() || is_product() || is_product_category() ) {
 			wp_enqueue_script( 'wc-cart-fragments' );

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-cart.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-cart.php
@@ -131,7 +131,7 @@ class WC_Widget_Cart extends WC_Widget {
 			echo '<div class="widget_shopping_cart_content"></div>';
 		} else {
 			// Insert cart widget with the Mini-cart content.
-			echo '<div class="widget_shopping_cart_content">' . woocommerce_mini_cart() . '</div>';
+			echo '<div class="widget_shopping_cart_content">' . esc_html( woocommerce_mini_cart() ) . '</div>';
 		}
 
 		if ( $hide_if_empty ) {

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-cart.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-cart.php
@@ -99,6 +99,34 @@ class WC_Widget_Cart extends WC_Widget {
 
 		if ( $is_cart_related_block || is_shop() || is_product() || is_product_category() ) {
 			wp_enqueue_script( 'wc-cart-fragments' );
+		} elseif ( ! wp_script_is( 'wc-cart-fragments-data', 'registered' ) ) {
+			ob_start();
+
+			woocommerce_mini_cart();
+
+			$mini_cart = ob_get_clean();
+
+			$data = array(
+				'fragments' => apply_filters(
+					'woocommerce_add_to_cart_fragments',
+					array(
+						'div.widget_shopping_cart_content' => '<div class="widget_shopping_cart_content">' . $mini_cart . '</div>',
+					)
+				),
+				'cart_hash' => WC()->cart->get_cart_hash(),
+			);
+
+			wp_register_script( 'wc-cart-fragments-data', false );
+			wp_enqueue_script( 'wc-cart-fragments-data' );
+			wp_add_inline_script(
+				'wc-cart-fragments-data',
+				'jQuery( function( $ ) {
+					$.each( ' . wp_json_encode( $data['fragments'] ) . ', function( key, value ) {
+						$( key ).replaceWith( value );
+					});
+				 } )
+				'
+			);
 		}
 
 		$hide_if_empty = empty( $instance['hide_if_empty'] ) ? 0 : 1;

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-cart.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-cart.php
@@ -74,7 +74,7 @@ class WC_Widget_Cart extends WC_Widget {
 	 * @since 1.0.0
 	 * @version 1.0.0
 	 **/
-	function has_block_from_list( $blocks, $post = null ) {
+	private function has_block_from_list( $blocks, $post = null ) {
 		if ( ! $post ) {
 			$post = get_post();
 		}

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-cart.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-cart.php
@@ -83,15 +83,10 @@ class WC_Widget_Cart extends WC_Widget {
 			return false;
 		}
 
-		if ( ! function_exists( 'parse_blocks' ) ) {
-			return false;
-		}
-
-		$block_from_page = parse_blocks( $post->post_content );
-		$block_name      = $block_from_page[0]['blockName'];
-
-		if ( in_array( $block_name, $blocks, true ) ) {
-			return true;
+		foreach ( $blocks as $block_name ) {
+			if ( stripos( $post->post_content, $block_name ) !== false ) {
+				return true;
+			}
 		}
 
 		return false;

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-cart.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-cart.php
@@ -44,6 +44,44 @@ class WC_Widget_Cart extends WC_Widget {
 	}
 
 	/**
+	 * Get list of Woo blocks that update the cart.
+	 *
+	 * @return array;
+	 */
+	public static function get_blocks() {
+		return array(
+			'woocommerce/handpicked-products',
+			'woocommerce/single-product',
+			'woocommerce/product-collection',
+			'woocommerce/add-to-cart-form',
+			'woocommerce/product-top-rated',
+			'woocommerce/product-tag',
+			'woocommerce/products-by-attribute',
+			'woocommerce/product-on-sale',
+			'woocommerce/product-new',
+			'woocommerce/product-category',
+			'woocommerce/product-best-sellers',
+			'woocommerce/all-products',
+		);
+	}
+
+	/**
+	 * array_contains
+	 * Check if string contains word from array.
+	 *
+	 * @since 1.0.0
+	 * @version 1.0.0
+	 **/
+	function array_contains( $str, array $arr ) {
+		foreach ( $arr as $a ) {
+			if ( stripos( $str, $a ) !== false ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
 	 * Output widget.
 	 *
 	 * @see WP_Widget
@@ -56,7 +94,12 @@ class WC_Widget_Cart extends WC_Widget {
 			return;
 		}
 
-		wp_enqueue_script( 'wc-cart-fragments' );
+		global $post;
+		$is_cart_related_block = $this->array_contains( $post->post_content, self::get_blocks() );
+
+		if ( $is_cart_related_block || is_shop() || is_product() || is_product_category() ) {
+			wp_enqueue_script( 'wc-cart-fragments' );
+		}
 
 		$hide_if_empty = empty( $instance['hide_if_empty'] ) ? 0 : 1;
 


### PR DESCRIPTION
In an effort to improve the JS performance for the Cart Fragments (see P2: pdFofs-162-p2), we want to load the `cart-fragments` JS script selectively:

- **What we already do:** The `cart-fragments` is only loaded when the Legacy Cart Widget is used. But it's loaded on all pages of the site. Even on pages that would not update the cart (e.g., Home). See [line](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/widgets/class-wc-widget-cart.php#L59).
- **What the PR is changing:** We want to load the `cart-fragments` script only on pages that would update the cart (see P2's suggestion: pdFofs-162-p2#comment-1330):
  - So, in this [line](https://github.com/woocommerce/woocommerce/blob/try/load-cart-fragments-script-on-specific-pages/plugins/woocommerce/includes/widgets/class-wc-widget-cart.php#L112-L113), we are loading the script only for specific pages and blocks that allow updating the cart.
  - Since the cart-fragments script isn’t loaded on other pages (e.g., home), an empty Cart Widget is displayed (i.e., we don’t get the cart data). To fix this bug, we send the cart content from the back-end on page load (see [line](https://github.com/woocommerce/woocommerce/blob/try/load-cart-fragments-script-on-specific-pages/plugins/woocommerce/includes/widgets/class-wc-widget-cart.php#L116-L119))

### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add the Legacy Cart Widget to the sidebar
2. Go to the shop page.
3. Add one or more products to the cart. Ensure the Cart Widget is updated accordingly
4. Go to the home page. Ensure the Cart Widget is correctly displayed

<!-- End testing instructions -->