### PR TITLE
Fix `upload-plugin` spec by updating locator from core profiler

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-upload-plugin-spec
+++ b/plugins/woocommerce/changelog/e2e-fix-upload-plugin-spec
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Comment: Update locator in `upload-plugin` spec

--- a/plugins/woocommerce/tests/e2e-pw/tests/smoke-tests/upload-plugin.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/smoke-tests/upload-plugin.spec.js
@@ -115,7 +115,7 @@ test.describe( `${ PLUGIN_NAME } plugin can be uploaded and activated`, () => {
 			async () => {
 				const statsOverviewHeading = page.getByText( 'Stats overview' );
 				const skipSetupStoreLink = page.getByRole( 'button', {
-					name: 'Skip setup store details',
+					name: 'Set up my store',
 				} );
 
 				await page.goto( '/wp-admin/admin.php?page=wc-admin' );


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.


### Changes proposed in this Pull Request:

Closes #38913.

Currently, the plugin tests in the "Smoke test release" workflow are failing because there's one assertion there that checks for the presence of the `Skip setup store details` button from the old onboarding wizard as a means to verify if no crashes would happen, and that WooCommerce > Home would still load after the plugin upload.

<img width="229" alt="2eYtPiui7e" src="https://github.com/woocommerce/woocommerce/assets/4509348/8d4c45d4-637a-4af2-9f02-dcd47beebfc3">


This PR will use a locator from the new core profiler in order to fix this failure.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to the [`Smoke test release`](https://github.com/woocommerce/woocommerce/actions/workflows/smoke-test-release.yml) workflow page.
2. In the `Run workflow` menu, select this branch (`e2e/update-core-profiler-locator-plugin-tests`).
3. In the `WooCommerce Release Tag` textbox, enter `7.9.0-beta.1`
1. Click the green `Run workflow` button.
1. Wait for the _"With {plugin name}"_ tests to finish. 
2. Their _"Run 'Upload plugin' test"_ job should pass.
    <img width="417" alt="O5zWA6sP84" src="https://github.com/woocommerce/woocommerce/assets/4509348/93241954-9f2e-422c-95d1-65c626bc4372">
1. Go to the  [Smoke test daily](https://github.com/woocommerce/woocommerce/actions/workflows/smoke-test-daily.yml) page.
2. In the `Run workflow` menu, select this branch (`e2e/update-core-profiler-locator-plugin-tests`).
3. Click the green `Run workflow` button.
4. Wait for the _"Smoke tests on trunk with {plugin name}"_ tests to finish. 
5. Their _"Run 'Upload plugin' test"_ job should pass.

Other failures in the workflow will be addressed in separate PR's.

@nigeljamesstevenson @jonathansadowski this will need to be cherry-picked into the `release/7.9` branch. Otherwise the "With {Plugin name}" tests in the "Smoke test release" workflow would always fail there.

<!-- End testing instructions -->
