### PR TITLE
Add Variations tab to Product Block Editor

### DIFF
--- a/plugins/woocommerce/changelog/add-38880_add_variations_tab_to_product_block_editor
+++ b/plugins/woocommerce/changelog/add-38880_add_variations_tab_to_product_block_editor
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add Variations tab to Product block editor

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -689,6 +689,17 @@ class Init {
 					),
 				),
 			);
+			if ( Features::is_enabled( 'product-variation-management' ) ) {
+				array_push( $args['template'], array(
+					'woocommerce/product-tab',
+					array(
+						'id'    => 'variations',
+						'title' => __( 'Variations', 'woocommerce' ),
+						'order' => 40,
+					),
+					array(),
+				) );
+			}
 		}
 		return $args;
 	}

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -690,15 +690,18 @@ class Init {
 				),
 			);
 			if ( Features::is_enabled( 'product-variation-management' ) ) {
-				array_push( $args['template'], array(
-					'woocommerce/product-tab',
+				array_push(
+					$args['template'],
 					array(
-						'id'    => 'variations',
-						'title' => __( 'Variations', 'woocommerce' ),
-						'order' => 40,
-					),
-					array(),
-				) );
+						'woocommerce/product-tab',
+						array(
+							'id'    => 'variations',
+							'title' => __( 'Variations', 'woocommerce' ),
+							'order' => 40,
+						),
+						array(),
+					)
+				);
 			}
 		}
 		return $args;


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR introduces the addition of a `Variations` tab to the Product Block Editor.

![Screenshot 2023-06-23 at 15 23 09](https://github.com/woocommerce/woocommerce/assets/1314156/f17eda8f-dbd9-4112-9f6b-72f3598eaedf)


Closes #38880 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to WooCommerce > Settings > Advanced > Features and enable the `New product editor`.
2. Navigate to Products > Add New and verify that the `Variations` tab is not visible.
3. Install the WooCommerce Beta Tester plugin and access Tools > WCA Test Helper > Features.
4. Enable the feature `product-variation-management`.
5. Return to Products > Add New and verify that the `Variations` tab is now visible.

<!-- End testing instructions -->
