### PR TITLE
Restore plugins selection when there is an error

### DIFF
--- a/plugins/woocommerce-admin/client/core-profiler/pages/Plugins.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/pages/Plugins.tsx
@@ -48,7 +48,13 @@ export const Plugins = ( {
 } ) => {
 	const [ selectedPlugins, setSelectedPlugins ] = useState<
 		ExtensionList[ 'plugins' ]
-	>( context.pluginsAvailable.filter( ( plugin ) => ! plugin.is_activated ) );
+	>(
+		context.pluginsAvailable.filter(
+			context.pluginsInstallationErrors.length
+				? ( plugin ) => context.pluginsSelected.includes( plugin.key )
+				: ( plugin ) => ! plugin.is_activated
+		)
+	);
 
 	const setSelectedPlugin = ( plugin: Extension ) => {
 		setSelectedPlugins(

--- a/plugins/woocommerce/changelog/update-38903-core-profiler-plugins-selection-is-not-persisted
+++ b/plugins/woocommerce/changelog/update-38903-core-profiler-plugins-selection-is-not-persisted
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Restore user's plugin selection when there is an installation error


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #38903 

This PR restores user's plugin selection on there is an installation error.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Start with a new JN site and start the core profiler.
2. Proceed to the plugins page.
3. Confirm all the plugins are selected by default.
4. Open your terminal and cd to your WP plugins directory (wp-content/plugins)
5. Run `rm -rf mailpoet && mkdir mailpoet && touch mailpoet/test.txt`. This will cause an installation error.
6. Select `Mailpeot` only.
7. Click `Continue`
8. You should be redirected to the plugins page with an error.
9. Confirm only `Mailpoet` is selected.

<!-- End testing instructions -->
