### PR TITLE
Prefetch Jetpack connection and auth info 

### DIFF
--- a/plugins/woocommerce-admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/index.tsx
@@ -455,6 +455,26 @@ const assignOptInDataSharing = assign( {
 		event.payload.optInDataSharing,
 } );
 
+const preFetchIsJetpackConnected = assign( {
+	isJetpackConnectedRef: () =>
+		spawn(
+			() => resolveSelect( PLUGINS_STORE_NAME ).isJetpackConnected(),
+			'core-profiler-prefetch-is-jetpack-connected'
+		),
+} );
+
+const preFetchJetpackAuthUrl = assign( {
+	jetpackAuthUrlRef: () =>
+		spawn(
+			() =>
+				resolveSelect( ONBOARDING_STORE_NAME ).getJetpackAuthUrl( {
+					redirectUrl: getAdminLink( 'admin.php?page=wc-admin' ),
+					from: 'woocommerce-core-profiler',
+				} ),
+			'core-profiler-prefetch-jetpack-auth-url'
+		),
+} );
+
 /**
  * Prefetch it so that @wp/data caches it and there won't be a loading delay when its used
  */
@@ -531,6 +551,8 @@ export const preFetchActions = {
 	preFetchGetCountries,
 	preFetchGeolocation,
 	preFetchOptions,
+	preFetchIsJetpackConnected,
+	preFetchJetpackAuthUrl,
 };
 
 const coreProfilerMachineActions = {
@@ -1329,14 +1351,32 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 							],
 						},
 					},
-					entry: [
-						assign( {
-							loader: {
-								progress: 10,
-								useStages: 'plugins',
-							},
-						} ),
-					],
+					entry: actions.choose( [
+						{
+							cond: ( context ) =>
+								context.pluginsSelected.includes( 'jetpack' ),
+							actions: [
+								assign( {
+									loader: {
+										progress: 10,
+										useStages: 'plugins',
+									},
+								} ),
+								'preFetchIsJetpackConnected',
+								'preFetchJetpackAuthUrl',
+							],
+						},
+						{
+							actions: [
+								assign( {
+									loader: {
+										progress: 10,
+										useStages: 'plugins',
+									},
+								} ),
+							],
+						},
+					] ),
 					invoke: {
 						src: pluginInstallerMachine,
 						data: ( context ) => {

--- a/plugins/woocommerce-admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/index.tsx
@@ -1353,8 +1353,7 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 					},
 					entry: actions.choose( [
 						{
-							cond: ( context ) =>
-								context.pluginsSelected.includes( 'jetpack' ),
+							cond: 'hasJetpackSelected',
 							actions: [
 								assign( {
 									loader: {

--- a/plugins/woocommerce/changelog/update-38904-optimize-jetpack-auth-redirection
+++ b/plugins/woocommerce/changelog/update-38904-optimize-jetpack-auth-redirection
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Prefetch Jetpack connection and auth info when Jetpack is selected


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #38904 

This PR prefetches Jetpack connection and auth info when Jetpack is selected for installation to reduce the delay between post-installation and Jetpack auth redirection.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Start a new JN site and start the core profiler.
2. Proceed to the plugins page.
3. Make sure to select Jetpack
4. Open your browser and go to the Network tab.
5. Click `Continue`
6. Confirm a request to `/wp-json/wc-admin/onboarding/plugins/jetpack-authorization-url` 
7. Delete Jetpack if it's already installed
8. Refresh the plugins page
9. Uncheck Jetpack
10. Click `Continue`
11. Confirm a request to  `/wp-json/wc-admin/onboarding/plugins/jetpack-authorization-url` has not been initiated. 

<!-- End testing instructions -->
