### PR TITLE
WC Tracker: Add unit test for plugin feature compatibility data

### DIFF
--- a/plugins/woocommerce/changelog/fix-38720-wc-tracker-unit-test
+++ b/plugins/woocommerce/changelog/fix-38720-wc-tracker-unit-test
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Added a unit test for plugin feature compatibility data in WC Tracker

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -14,6 +14,7 @@ use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
 use Automattic\WooCommerce\Utilities\{ FeaturesUtil, OrderUtil, PluginUtil };
 use Automattic\WooCommerce\Internal\Utilities\BlocksUtil;
+use Automattic\WooCommerce\Proxies\LegacyProxy;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -311,7 +312,7 @@ class WC_Tracker {
 			include ABSPATH . '/wp-admin/includes/plugin.php';
 		}
 
-		$plugins             = get_plugins();
+		$plugins             = wc_get_container()->get( LegacyProxy::class )->call_function( 'get_plugins' );
 		$active_plugins_keys = get_option( 'active_plugins', array() );
 		$active_plugins      = array();
 

--- a/plugins/woocommerce/tests/legacy/mockable-functions.php
+++ b/plugins/woocommerce/tests/legacy/mockable-functions.php
@@ -10,6 +10,7 @@
 return array(
 	'current_user_can',
 	'get_bloginfo',
+	'get_plugins',
 	'get_woocommerce_currencies',
 	'get_woocommerce_currency_symbol',
 	'wc_get_price_excluding_tax',

--- a/plugins/woocommerce/tests/legacy/mockable-functions.php
+++ b/plugins/woocommerce/tests/legacy/mockable-functions.php
@@ -10,7 +10,6 @@
 return array(
 	'current_user_can',
 	'get_bloginfo',
-	'get_plugins',
 	'get_woocommerce_currencies',
 	'get_woocommerce_currency_symbol',
 	'wc_get_price_excluding_tax',

--- a/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
@@ -5,6 +5,10 @@
  * @package WooCommerce\Tests\WC_Tracker.
  */
 
+use Automattic\WooCommerce\Internal\Features\FeaturesController;
+use Automattic\WooCommerce\Utilities\PluginUtil;
+use Automattic\WooCommerce\Testing\Tools\CodeHacking\Hacks\FunctionsMockerHack;
+
 // phpcs:disable Squiz.Classes.ClassFileName.NoMatch, Squiz.Classes.ValidClassName.NotCamelCaps -- Backward compatibility.
 /**
  * Class WC_Tracker_Test
@@ -66,6 +70,96 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 		// Test the default case of no filter for set for woocommerce_admin_disabled.
 		$this->assertArrayHasKey( 'wc_admin_disabled', $tracking_data );
 		$this->assertEquals( 'no', $tracking_data['wc_admin_disabled'] );
+	}
+
+	/**
+	 * @testDox Test the features compatibility data for plugin tracking data.
+	 */
+	public function test_get_tracking_data_plugin_feature_compatibility() {
+		$legacy_mocks = array(
+			'get_plugins' => function() {
+				return array(
+					'plugin1' => array(
+						'Name' => 'Plugin 1',
+					),
+					'plugin2' => array(
+						'Name' => 'Plugin 2',
+					),
+					'plugin3' => array(
+						'Name' => 'Plugin 3',
+					),
+				);
+			},
+		);
+		FunctionsMockerHack::add_function_mocks( $legacy_mocks );
+
+		update_option( 'active_plugins', array( 'plugin1', 'plugin2' ) );
+
+		$pluginutil_mock = new class() extends PluginUtil {
+			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+			public function is_woocommerce_aware_plugin( $plugin ): bool {
+				if ( 'plugin1' === $plugin ) {
+					return false;
+				}
+
+				return true;
+			}
+		};
+
+		$featurescontroller_mock = new class() extends FeaturesController {
+			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+			public function get_compatible_features_for_plugin( string $plugin_name, bool $enabled_features_only = false ): array {
+				$compat = array();
+				switch ( $plugin_name ) {
+					case 'plugin2':
+						$compat = array(
+							'compatible'   => array( 'feature1' ),
+							'incompatible' => array( 'feature2' ),
+							'uncertain'    => array( 'feature3' ),
+						);
+						break;
+					case 'plugin3':
+						$compat = array(
+							'compatible'   => array( 'feature2' ),
+							'incompatible' => array(),
+							'uncertain'    => array( 'feature1', 'feature3' ),
+						);
+						break;
+				}
+
+				return $compat;
+			}
+		};
+
+		$container = wc_get_container();
+		$container->get( PluginUtil::class ); // Ensure that the class is loaded.
+		$container->replace( PluginUtil::class, $pluginutil_mock );
+		$container->replace( FeaturesController::class, $featurescontroller_mock );
+
+		$tracking_data = WC_Tracker::get_tracking_data();
+
+		$this->assertEquals(
+			array(),
+			$tracking_data['active_plugins']['plugin1']['feature_compatibility']
+		);
+		$this->assertEquals(
+			array(
+				'compatible'   => array( 'feature1' ),
+				'incompatible' => array( 'feature2' ),
+				'uncertain'    => array( 'feature3' ),
+			),
+			$tracking_data['active_plugins']['plugin2']['feature_compatibility']
+		);
+		$this->assertEquals(
+			array(
+				'compatible' => array( 'feature2' ),
+				'uncertain'  => array( 'feature1', 'feature3' ),
+			),
+			$tracking_data['inactive_plugins']['plugin3']['feature_compatibility']
+		);
+
+		$this->reset_container_replacements();
+		$container->reset_all_resolved();
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
@@ -7,7 +7,6 @@
 
 use Automattic\WooCommerce\Internal\Features\FeaturesController;
 use Automattic\WooCommerce\Utilities\PluginUtil;
-use Automattic\WooCommerce\Testing\Tools\CodeHacking\Hacks\FunctionsMockerHack;
 
 // phpcs:disable Squiz.Classes.ClassFileName.NoMatch, Squiz.Classes.ValidClassName.NotCamelCaps -- Backward compatibility.
 /**
@@ -91,7 +90,7 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 				);
 			},
 		);
-		FunctionsMockerHack::add_function_mocks( $legacy_mocks );
+		$this->register_legacy_proxy_function_mocks( $legacy_mocks );
 
 		update_option( 'active_plugins', array( 'plugin1', 'plugin2' ) );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Per the linked issue, it previously wasn't possible to add this unit test because of some shortcomings in the dependency injection system. Those shortcomings were resolved in #38849, so now we're adding the test!

Fixes #38720

### How to test the changes in this Pull Request:

Since GitHub will run the new test as part of its checks, no manual testing is really necessary. But if you want to run it manually, make sure you run both the WC Tracker tests and the PluginUtil tests together, as the latter is where the interference was happening. If you are using the wp-env dev environment, you can run something like this:

```
pnpm run test:unit:env --filter="WC_Tracker|PluginUtil"
```
