### PR TITLE
Remove hardcoded 'shop order'

### DIFF
--- a/plugins/woocommerce/changelog/remove-hardcoded-shop-order
+++ b/plugins/woocommerce/changelog/remove-hardcoded-shop-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Allow to add custom metabox to custom order edit page by setting the correct screen id.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
@@ -111,7 +111,6 @@ class Edit {
 	 */
 	public function setup( \WC_Order $order ) {
 		$this->order    = $order;
-		$wc_screen_id   = wc_get_page_screen_id( 'shop-order' );
 		$current_screen = get_current_screen();
 		$current_screen->is_block_editor( false );
 		$this->screen_id = $current_screen->id;
@@ -136,7 +135,7 @@ class Edit {
 		 *
 		 * @since 3.8.0.
 		 */
-		do_action( 'add_meta_boxes', $wc_screen_id, $this->order );
+		do_action( 'add_meta_boxes', $this->screen_id, $this->order );
 
 		/**
 		 * Provides an opportunity to inject custom meta boxes into the order editor screen. This
@@ -146,7 +145,7 @@ class Edit {
 		 *
 		 * @oaram WC_Order $order The order being edited.
 		 */
-		do_action( 'add_meta_boxes_' . $wc_screen_id, $this->order );
+		do_action( 'add_meta_boxes_' . $this->screen_id, $this->order );
 
 		$this->enqueue_scripts();
 	}


### PR DESCRIPTION
If HPOS feature is enabled and `wc_orders` is set as authoritative, when we try to add a custom metabox for a custom order like subscription for example, the metabox isn't displayed.

### Why?
If fact subscription `screen_id` is set specifically in the `wc_get_page_screen_id` function https://github.com/woocommerce/woocommerce/blob/7.8.0/plugins/woocommerce/includes/admin/wc-admin-functions.php#L77.
So, if we are in a custom order edit page like subscription the `screen_id` should be `woocommerce_page_wc-orders--shop_subscription`.

However when we edit a subscription
https://github.com/woocommerce/woocommerce/blob/7.8.0/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php#L245-L246 the `screen_id` passed to `add_meta_boxes` action https://github.com/woocommerce/woocommerce/blob/7.8.0/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php#L125
or to create the dynamic action https://github.com/woocommerce/woocommerce/blob/7.8.0/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php#L135 is wrong because `shop_order` is hardcoded in `wc_get_page_screen_id` function call https://github.com/woocommerce/woocommerce/blob/7.8.0/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php#L106  instead of using the order type.

### Changes proposed in this Pull Request:

Use the current `screen_id` instead because it was already assigned https://github.com/woocommerce/woocommerce/blob/7.8.0/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php#L109
and remove the `$wc_screen_id` local variable.

### How to test the changes in this Pull Request:

1. Install WooCommerce and activate it.
2. Enable HPOS feature and set 
3. Install WooCommerce Subscription and activate it
4. Put this code as a mu plugin for adding custom metabox in subscription edit page
```php
<?php
add_action(
	'add_meta_boxes',
	function( $type ) {
		if ( 'woocommerce_page_wc-orders--shop_subscription' === $type ) {
			add_meta_box( 'manooweb_box_1', __( 'My custom metabox', 'manooweb' ), 'manooweb_metabox_display', $type, 'side', 'high' );
		}
	},
	 20
);
add_action(
	'add_meta_boxes_woocommerce_page_wc-orders--shop_subscription',
	function( $type ) {
		$screen = get_current_screen();
		add_meta_box( 'manooweb_box_2', __( 'My custom metabox', 'manooweb' ), 'manooweb_metabox_display', $screen->id, 'side', 'high' );
	},
	 20
);

function manooweb_metabox_display( $order ) {
	 echo 'My custom metabox';
}
```
5. Create a subscription product
6. Order to this subscription product and checkout
7. Edit the subscription and see there is no custom metabox added

With the fix the two metaboxes added by the mu plugin should be displayed.