### PR TITLE
Fix grey background when menu collapsed

### DIFF
--- a/plugins/woocommerce-admin/client/layout/footer/footer.scss
+++ b/plugins/woocommerce-admin/client/layout/footer/footer.scss
@@ -1,28 +1,26 @@
-.woocommerce-admin-page__add-product {
-	.woocommerce-layout__footer {
-		background: $studio-white;
-		border-top: 1px solid $gray-200;
-		box-sizing: border-box;
-		padding: 0;
-		position: fixed;
-		width: calc(100% - 160px);
-		bottom: -1px; /* to hide the border when no visible children */
-		z-index: 1001; /* on top of #wp-content-editor-tools */
+.woocommerce-layout__footer {
+	background: $studio-white;
+	border-top: 1px solid $gray-200;
+	box-sizing: border-box;
+	padding: 0;
+	position: fixed;
+	width: calc(100% - 160px);
+	bottom: -1px; /* to hide the border when no visible children */
+	z-index: 1001; /* on top of #wp-content-editor-tools */
 
-		.woocommerce-profile-wizard__body & {
-			width: 100%;
-		}
-
-		@include breakpoint('782px-960px') {
-			width: calc(100% - 36px);
-		}
-
-		@include breakpoint('<782px') {
-			flex-flow: row wrap;
-			width: 100%;
-		}
+	.woocommerce-profile-wizard__body & {
+		width: 100%;
 	}
-	&.folded .woocommerce-layout__footer {
-		width: calc(100% - $admin-menu-width-collapsed);
+
+	@include breakpoint('782px-960px') {
+		width: calc(100% - 36px);
 	}
+
+	@include breakpoint('<782px') {
+		flex-flow: row wrap;
+		width: 100%;
+	}
+}
+.folded .woocommerce-layout__footer {
+	width: calc(100% - $admin-menu-width-collapsed);
 }

--- a/plugins/woocommerce-admin/client/layout/footer/footer.scss
+++ b/plugins/woocommerce-admin/client/layout/footer/footer.scss
@@ -1,23 +1,28 @@
-.woocommerce-layout__footer {
-	background: $studio-white;
-	border-top: 1px solid $gray-200;
-	box-sizing: border-box;
-	padding: 0;
-	position: fixed;
-	width: calc(100% - 160px);
-	bottom: -1px; /* to hide the border when no visible children */
-	z-index: 1001; /* on top of #wp-content-editor-tools */
+.woocommerce-admin-page__add-product {
+	.woocommerce-layout__footer {
+		background: $studio-white;
+		border-top: 1px solid $gray-200;
+		box-sizing: border-box;
+		padding: 0;
+		position: fixed;
+		width: calc(100% - 160px);
+		bottom: -1px; /* to hide the border when no visible children */
+		z-index: 1001; /* on top of #wp-content-editor-tools */
 
-	.woocommerce-profile-wizard__body & {
-		width: 100%;
+		.woocommerce-profile-wizard__body & {
+			width: 100%;
+		}
+
+		@include breakpoint('782px-960px') {
+			width: calc(100% - 36px);
+		}
+
+		@include breakpoint('<782px') {
+			flex-flow: row wrap;
+			width: 100%;
+		}
 	}
-
-	@include breakpoint('782px-960px') {
-		width: calc(100% - 36px);
-	}
-
-	@include breakpoint('<782px') {
-		flex-flow: row wrap;
-		width: 100%;
+	&.folded .woocommerce-layout__footer {
+		width: calc(100% - $admin-menu-width-collapsed);
 	}
 }

--- a/plugins/woocommerce-admin/client/products/product-page.scss
+++ b/plugins/woocommerce-admin/client/products/product-page.scss
@@ -26,8 +26,8 @@
 	.interface-interface-skeleton__header,
 	.interface-interface-skeleton__footer {
 		background-color: $white;
-		width: calc(100% - $admin-menu-width);
-		left: $admin-menu-width;
+		width: calc(100% - $admin-menu-width-collapsed);
+		left: $admin-menu-width-collapsed;
 		position: fixed;
 		@include breakpoint( '<960px' ) {
 			left: $admin-menu-width-collapsed;
@@ -59,4 +59,8 @@ html.interface-interface-skeleton__html-container {
 	@include breakpoint( '<782px' ) {
 		position: inherit;
 	}
+}
+
+div#wpwrap {
+	background-color: $white;
 }

--- a/plugins/woocommerce-admin/client/products/product-page.scss
+++ b/plugins/woocommerce-admin/client/products/product-page.scss
@@ -64,3 +64,7 @@ html.interface-interface-skeleton__html-container {
 div#wpwrap {
 	background-color: $white;
 }
+
+div#adminmenuback {
+	z-index: 101;
+}

--- a/plugins/woocommerce-admin/client/products/product-page.scss
+++ b/plugins/woocommerce-admin/client/products/product-page.scss
@@ -37,8 +37,8 @@
 			left: 0;
 			width: 100%;
 		}
-		// Higher than the sidebar which has a z-index of 90.
-		z-index: 100;
+		// Lower than the sidebar which has a z-index of 90.
+		z-index: 80;
 	}
 
 	&.folded .interface-interface-skeleton__header, &.folded .interface-interface-skeleton__footer  {
@@ -68,8 +68,4 @@ html.interface-interface-skeleton__html-container {
 
 div#wpwrap {
 	background-color: $white;
-}
-
-div#adminmenuback {
-	z-index: 101;
 }

--- a/plugins/woocommerce-admin/client/products/product-page.scss
+++ b/plugins/woocommerce-admin/client/products/product-page.scss
@@ -26,9 +26,9 @@
 	.interface-interface-skeleton__header,
 	.interface-interface-skeleton__footer {
 		background-color: $white;
-		width: calc(100% - $admin-menu-width-collapsed);
-		left: $admin-menu-width-collapsed;
 		position: fixed;
+		width: calc(100% - $admin-menu-width);
+		left: $admin-menu-width;
 		@include breakpoint( '<960px' ) {
 			left: $admin-menu-width-collapsed;
 			width: calc(100% - $admin-menu-width-collapsed);
@@ -39,6 +39,11 @@
 		}
 		// Higher than the sidebar which has a z-index of 90.
 		z-index: 100;
+	}
+
+	&.folded .interface-interface-skeleton__header, &.folded .interface-interface-skeleton__footer  {
+		width: calc(100% - $admin-menu-width-collapsed);
+		left: $admin-menu-width-collapsed;
 	}
 
 	.interface-interface-skeleton__header {

--- a/plugins/woocommerce-admin/client/products/product-page.scss
+++ b/plugins/woocommerce-admin/client/products/product-page.scss
@@ -68,5 +68,7 @@ html.interface-interface-skeleton__html-container {
 }
 
 div#wpwrap {
-	background-color: $white;
+	.woocommerce-product-block-editor {
+		background-color: $white;
+	}
 }

--- a/plugins/woocommerce-admin/client/products/product-page.scss
+++ b/plugins/woocommerce-admin/client/products/product-page.scss
@@ -41,7 +41,8 @@
 		z-index: 80;
 	}
 
-	&.folded .interface-interface-skeleton__header, &.folded .interface-interface-skeleton__footer  {
+	&.folded .interface-interface-skeleton__header,
+	&.folded .interface-interface-skeleton__footer {
 		width: calc(100% - $admin-menu-width-collapsed);
 		left: $admin-menu-width-collapsed;
 	}

--- a/plugins/woocommerce/changelog/fix-38887_grey_background_when_menu_collapsed
+++ b/plugins/woocommerce/changelog/fix-38887_grey_background_when_menu_collapsed
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix grey background when menu is collapsed #38887


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Error 1 - When collapsing the WordPress menu, a grey box appears in the top left corner.

Error 2 - When navigating to the Inventory field, the same grey background is displayed at the bottom of the form.

<img width="1441" alt="Screenshot 2023-06-22 at 3 19 31 PM" src="https://github.com/woocommerce/woocommerce/assets/2240960/f3f520fb-1a66-42d1-abc3-e3852e35bcc4">

Closes #38887.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Navigate to `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features` and ensure that `New product editor` is enabled.
2. Go to `Products > Add New` using a window with a height shorter than the admin menu, and scroll down.
3. Verify that the product header is always positioned behind the admin bar.
4. Click the `Collapse menu` button located at the bottom of the admin bar.
5. The product header should now cover the full width of the page.
6. Go to the `Inventory` tab.
7. Confirm that the white background extends to the bottom of the page.

![Screen Capture on 2023-06-26 at 11-19-25](https://github.com/woocommerce/woocommerce/assets/1314156/431692ca-100f-4181-bec5-65380104c253)


<!-- End testing instructions -->
