### PR TITLE
Fix failing tests in create shipping zones

### DIFF
--- a/plugins/woocommerce/changelog/fix-failing-shipping-tests
+++ b/plugins/woocommerce/changelog/fix-failing-shipping-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed failing shipping zones tests and cleaned up locators

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-shipping-zones.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-shipping-zones.spec.js
@@ -91,6 +91,8 @@ test.describe( 'WooCommerce Shipping Settings - Add new shipping zone', () => {
 					.filter( { hasText: 'Local pickup' } )
 			).toBeVisible();
 
+			await page.getByRole( 'button', { name: 'Save changes'} ).click();
+
 			await page.goto(
 				'wp-admin/admin.php?page=wc-settings&tab=shipping'
 			);
@@ -146,6 +148,8 @@ test.describe( 'WooCommerce Shipping Settings - Add new shipping zone', () => {
 					.filter( { hasText: 'Free shipping' } )
 			).toBeVisible();
 
+			await page.getByRole( 'button', { name: 'Save changes'} ).click();
+
 			await page.goto(
 				'wp-admin/admin.php?page=wc-settings&tab=shipping'
 			);
@@ -175,22 +179,20 @@ test.describe( 'WooCommerce Shipping Settings - Add new shipping zone', () => {
 				'wp-admin/admin.php?page=wc-settings&tab=shipping&zone_id=new',
 				{ waitUntil: 'networkidle' }
 			);
-			await page.locator( '#zone_name' ).fill( shippingZoneNameFlatRate );
+			await page.getByPlaceholder( 'Zone name' ).fill( shippingZoneNameFlatRate );
 
-			await page.locator( '.select2-search__field' ).click();
-			await page.locator( '.select2-search__field' ).type( 'Canada' );
+			await page.getByPlaceholder( 'Select regions within this zone' ).click();
+			await page.getByPlaceholder( 'Select regions within this zone' ).type( 'Canada' );
 			await page
-				.locator(
-					'.select2-results__option.select2-results__option--highlighted'
-				)
+				.getByText('Canada').last()
 				.click();
 
-			await page.locator( 'text=Add shipping method' ).click();
+			await page.getByRole( 'button', { name: 'Add shipping method' } ).click();
 
 			await page
-				.locator( 'select[name=add_method_id]' )
-				.selectOption( 'flat_rate' );
-			await page.locator( '#btn-ok' ).click();
+				.getByRole( 'combobox' )
+				.selectOption( { label: 'Flat rate' } );
+			await page.getByRole('button', { name: 'Add shipping method' } ).last().click();
 			await page.waitForLoadState( 'networkidle' );
 			await expect(
 				page
@@ -199,8 +201,8 @@ test.describe( 'WooCommerce Shipping Settings - Add new shipping zone', () => {
 			).toBeVisible();
 
 			await page.getByRole( 'link', { name: 'Flat rate' } ).click();
-			await page.locator( '#woocommerce_flat_rate_cost' ).fill( '10' );
-			await page.locator( '#btn-ok' ).click();
+			await page.getByLabel( 'Cost', { exact: true } ).fill( '10' );
+			await page.getByRole( 'button', { name: 'Save changes' } ).last().click();
 			await page.waitForLoadState( 'networkidle' );
 
 			await page.goto(

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-shipping-zones.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-shipping-zones.spec.js
@@ -64,40 +64,32 @@ test.describe( 'WooCommerce Shipping Settings - Add new shipping zone', () => {
 				{ waitUntil: 'networkidle' }
 			);
 			await page
-				.locator( '#zone_name' )
+				.getByPlaceholder( 'Zone name' )
 				.fill( shippingZoneNameLocalPickup );
 
-			await page.locator( '.select2-search__field' ).click();
+			await page.getByPlaceholder( 'Select regions within this zone' ).click();
 			await page
-				.locator( '.select2-search__field' )
+				.getByPlaceholder( 'Select regions within this zone' )
 				.type( 'British Columbia, Canada' );
 			await page
-				.locator(
-					'.select2-results__option.select2-results__option--highlighted'
-				)
+				.getByText( 'British Columbia, Canada' ).last()
 				.click();
 
-			await page.locator( '.wc-shipping-zone-postcodes-toggle' ).click();
-			await page.locator( '#zone_postcodes' ).fill( maynePostal );
+			await page.getByRole( 'link', { name: 'Limit to specific ZIP/postcodes' } ).click();
+			await page.getByPlaceholder( 'List 1 postcode per line' ).fill( maynePostal );
 
-			await page.locator( 'text=Add shipping method' ).click();
+			await page.getByRole( 'button', { name: 'Add shipping method' } ).click();
 
 			await page
-				.locator( 'select[name=add_method_id]' )
-				.selectOption( 'local_pickup' );
-			await page.locator( '#btn-ok' ).click();
+				.getByRole( 'combobox' )
+				.selectOption( { label: 'Local pickup' } );
+			await page.getByRole('button', { name: 'Add shipping method' } ).last().click();
 			await page.waitForLoadState( 'networkidle' );
 			await expect(
 				page
 					.locator( '.wc-shipping-zone-method-title' )
 					.filter( { hasText: 'Local pickup' } )
 			).toBeVisible();
-
-			await page.locator( '#submit' ).click();
-			await page.waitForFunction( () => {
-				const button = document.querySelector( '#submit' );
-				return button && button.disabled;
-			} );
 
 			await page.goto(
 				'wp-admin/admin.php?page=wc-settings&tab=shipping'
@@ -131,24 +123,22 @@ test.describe( 'WooCommerce Shipping Settings - Add new shipping zone', () => {
 				'wp-admin/admin.php?page=wc-settings&tab=shipping&zone_id=new',
 				{ waitUntil: 'networkidle' }
 			);
-			await page.locator( '#zone_name' ).fill( shippingZoneNameFreeShip );
+			await page.getByPlaceholder( 'Zone name' ).fill( shippingZoneNameFreeShip );
 
-			await page.locator( '.select2-search__field' ).click();
+			await page.getByPlaceholder( 'Select regions within this zone' ).click();
 			await page
-				.locator( '.select2-search__field' )
+				.getByPlaceholder( 'Select regions within this zone' )
 				.type( 'British Columbia, Canada' );
 			await page
-				.locator(
-					'.select2-results__option.select2-results__option--highlighted'
-				)
+				.getByText( 'British Columbia, Canada' ).last()
 				.click();
 
-			await page.locator( 'text=Add shipping method' ).click();
+			await page.getByRole( 'button', { name: 'Add shipping method' } ).click();
 
 			await page
-				.locator( 'select[name=add_method_id]' )
-				.selectOption( 'free_shipping' );
-			await page.locator( '#btn-ok' ).click();
+				.getByRole( 'combobox' )
+				.selectOption( { label: 'Free shipping' } );
+			await page.getByRole('button', { name: 'Add shipping method' } ).last().click();
 			await page.waitForLoadState( 'networkidle' );
 			await expect(
 				page
@@ -156,11 +146,6 @@ test.describe( 'WooCommerce Shipping Settings - Add new shipping zone', () => {
 					.filter( { hasText: 'Free shipping' } )
 			).toBeVisible();
 
-			await page.locator( '#submit' ).click();
-			await page.waitForFunction( () => {
-				const button = document.querySelector( '#submit' );
-				return button && button.disabled;
-			} );
 			await page.goto(
 				'wp-admin/admin.php?page=wc-settings&tab=shipping'
 			);


### PR DESCRIPTION
### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Two tests in `merchant/create-shipping-zones.spec.js` were failing because functionality changed.  This fixes that, and while I was working with them, I updated the locators used in the test to modernize them.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Pull this branch
2. `pnpm env:start`
3. `pnpm test:e2e-pw tests/e2e-pw/tests/merchant/create-shipping-zones.spec.js`
4. All tests should pass

<!-- End testing instructions -->
