### PR TITLE
Fix "View Cart" link layout in post/page

### DIFF
--- a/plugins/woocommerce/changelog/fix-blocks-9999-products-grid-layout-in-post
+++ b/plugins/woocommerce/changelog/fix-blocks-9999-products-grid-layout-in-post
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the layout of View Cart link on the posts/pages

--- a/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
@@ -105,13 +105,13 @@
 				display: inline-block;
 				float: none; // Remove float set by WC core.
 				vertical-align: middle;
-	
+
 				// Adjust positioning of quantity selector and button.
 				.qty {
 					margin-right: 0.5rem;
 				}
 			}
-	
+
 			button[name="add-to-cart"],
 			button.single_add_to_cart_button {
 				display: inline-block;
@@ -153,13 +153,6 @@
 		text-decoration: none;
 	}
 
-	a.added_to_cart {
-		// Prevent "View Cart" button from sticking to "Add to Cart" button.
-		// For details see https://github.com/woocommerce/woocommerce-blocks/issues/5285.
-		display: block;
-		margin-top: 1rem;
-	}
-
 	span.onsale {
 		// Style "On Sale" badge in theme colors by default.
 		background-color: var(--wp--preset--color--foreground, $highlight);
@@ -193,6 +186,16 @@
 		// Ensure variation label is vertically centered.
 		line-height: 3.5rem;
 	}
+}
+
+/**
+* Products grid
+*/
+a.added_to_cart {
+	// Prevent "View Cart" button from sticking to "Add to Cart" button.
+	// For details see https://github.com/woocommerce/woocommerce-blocks/issues/5285.
+	display: block;
+	margin-top: 1rem;
 }
 
 /**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Classic Product Grid was limited to use in Product Archive templates. Newer product grid blocks (Products (Beta) or experimental Product Collection from WooCommerce Blocks) can be added outside of the product archive like to a post or a page.

When you add a product to the cart in Products block, there's "View Cart" link appearing below. When Products or Product Collection block is used in another place than an archive template (post/page) then "View Cart" link is off.

This is because some of the styles are not applied, since they require `.woocommerce` class in their ancestor, which is added to the `body` element of product archive, but not on the page or post.

This PR moves the `a.added_to_cart` selector from `.woocommerce`.

Closes https://github.com/woocommerce/woocommerce-blocks/issues/9999.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Activate a block theme (e.g. TT2 or TT3)
2. Create new post
3. Add Products (Beta) block
4. Publish the post and go to the frontend
5. Add a product to cart
6. Expected: "View Cart" link appears BELOW the "Add to Cart" button

<!-- End testing instructions -->
