### PR TITLE
Tourkit: focus the step after opening 

### DIFF
--- a/packages/js/components/changelog/fix-isElevated-prop-in-tour-kit
+++ b/packages/js/components/changelog/fix-isElevated-prop-in-tour-kit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Replace isElevated prop with elevation for tour-kit step component

--- a/packages/js/components/changelog/update-tour-kit-auto-focus
+++ b/packages/js/components/changelog/update-tour-kit-auto-focus
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add ability to focus the first step after opening for tourkit

--- a/packages/js/components/src/tour-kit/components/step.tsx
+++ b/packages/js/components/src/tour-kit/components/step.tsx
@@ -3,7 +3,7 @@
  */
 import { withViewportMatch } from '@wordpress/viewport';
 import { Card, CardBody, CardFooter, CardHeader } from '@wordpress/components';
-import { createElement, useEffect } from '@wordpress/element';
+import { createElement, useEffect, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -60,10 +60,13 @@ const Step: React.FunctionComponent<
 		descriptions[ isViewportMobile ? 'mobile' : 'desktop' ] ??
 		descriptions.desktop;
 
+	const stepRef = useRef< HTMLDivElement | undefined >();
+
 	const focusElementSelector =
 		steps[ currentStepIndex ].focusElement?.[
 			isViewportMobile ? 'mobile' : 'desktop'
-		] || null;
+		] ||
+		'.woocommerce-tour-kit .woocommerce-tour-kit-step-navigation__next-bt';
 
 	const iframeSelector =
 		steps[ currentStepIndex ].focusElement?.iframe || null;
@@ -79,11 +82,21 @@ const Step: React.FunctionComponent<
 	useEffect( () => {
 		if ( focusElement ) {
 			setInitialFocusedElement( focusElement );
+		} else {
+			// If no focus element is found, focus the last button in the step so that the user can navigate using keyboard.
+			const buttons = stepRef.current?.querySelectorAll( 'button' );
+			if ( buttons && buttons.length ) {
+				setInitialFocusedElement( buttons[ buttons.length - 1 ] );
+			}
 		}
 	}, [ focusElement, setInitialFocusedElement ] );
 
 	return (
-		<Card className="woocommerce-tour-kit-step" isElevated>
+		<Card
+			ref={ stepRef as React.LegacyRef< HTMLDivElement > }
+			className="woocommerce-tour-kit-step"
+			isElevated
+		>
 			<CardHeader isBorderless={ true } size="small">
 				<StepControls onDismiss={ onDismiss } />
 			</CardHeader>

--- a/packages/js/components/src/tour-kit/components/step.tsx
+++ b/packages/js/components/src/tour-kit/components/step.tsx
@@ -94,7 +94,7 @@ const Step: React.FunctionComponent<
 		<Card
 			ref={ stepRef as React.LegacyRef< HTMLDivElement > }
 			className="woocommerce-tour-kit-step"
-			isElevated
+			elevation={ 2 }
 		>
 			<CardHeader isBorderless={ true } size="small">
 				<StepControls onDismiss={ onDismiss } />

--- a/packages/js/components/src/tour-kit/components/step.tsx
+++ b/packages/js/components/src/tour-kit/components/step.tsx
@@ -65,8 +65,7 @@ const Step: React.FunctionComponent<
 	const focusElementSelector =
 		steps[ currentStepIndex ].focusElement?.[
 			isViewportMobile ? 'mobile' : 'desktop'
-		] ||
-		'.woocommerce-tour-kit .woocommerce-tour-kit-step-navigation__next-bt';
+		] || null;
 
 	const iframeSelector =
 		steps[ currentStepIndex ].focusElement?.iframe || null;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/36512.

Update tour-kit component to automatically focus the step button if the focused element is not provided.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Run `pnpm --filter=storybook run storybook`
2. Go to http://localhost:6007/?path=/story/woocommerce-admin-components-tourkit--auto-scroll
3. Click on `Start Tour` button
4. Observe that the `Next` button is focused.
5. Navigate to next step using keyboard ➡️ 
6. Should see the next step, and the input box is focused.


https://github.com/woocommerce/woocommerce/assets/4344253/a72c94c1-de3e-4e29-8ab7-8fd64145a2fd

1. Go to /wp-admin/admin.php?page=wc-settings&tab=advanced&section=features
2. Enable `Try the new product editor (Beta)` feature
3. Go to /wp-admin/admin.php?page=wc-admin&path=%2Fadd-product
4. Wait a few seconds
5. Observe that `Meet the product editing formBeta` tour is shown.
6. Observe that `View highlights` button is focused.

![Screenshot 2023-06-27 at 20 24 16](https://github.com/woocommerce/woocommerce/assets/4344253/4296ea21-f6d4-44cb-8c02-f62cf724b8f5)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
