### PR TITLE
Fix undismissable store alert when using language localization

### DIFF
--- a/plugins/woocommerce-admin/client/layout/store-alerts/index.js
+++ b/plugins/woocommerce-admin/client/layout/store-alerts/index.js
@@ -44,7 +44,7 @@ export class StoreAlerts extends Component {
 	}
 
 	previousAlert( event ) {
-		event.stopPropagation();
+		event?.stopPropagation();
 		const { currentIndex } = this.state;
 
 		if ( currentIndex > 0 ) {
@@ -78,6 +78,10 @@ export class StoreAlerts extends Component {
 					onClick={ async ( event ) => {
 						const url = event.currentTarget.getAttribute( 'href' );
 						event.preventDefault();
+
+						// navigate to previous alert to avoid an out of bounds error in case it's the last alert from the array
+						this.previousAlert();
+
 						await triggerNoteAction( alert.id, action.id );
 						if (
 							url &&

--- a/plugins/woocommerce/changelog/fix-undismissable-notice3
+++ b/plugins/woocommerce/changelog/fix-undismissable-notice3
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix undismissable store alert when using language localization

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
@@ -210,7 +210,7 @@ class RemoteInboxNotificationsEngine {
 			$note_from_db->set_content( $locale->content );
 
 			$localized_actions = SpecRunner::get_actions( $spec );
-			$actions_from_db    = $note_from_db->get_actions();
+			$actions_from_db   = $note_from_db->get_actions();
 			$actions_length    = count( $localized_actions );
 			// Manually copy the action id from the db to the localized action, since they were not being provided.
 			for ( $i = 0; $i < $actions_length; $i++ ) {

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
@@ -206,16 +206,18 @@ class RemoteInboxNotificationsEngine {
 				break;
 			}
 
+			$localized_actions = SpecRunner::get_actions( $spec );
+
+			// Manually copy the action id from the db to the localized action, since they were not being provided.
+			foreach ( $localized_actions as $localized_action ) {
+				$action = $note_from_db->get_action( $localized_action->name );
+				if ( $action ) {
+					$localized_action->id = $action->id;
+				}
+			}
+
 			$note_from_db->set_title( $locale->title );
 			$note_from_db->set_content( $locale->content );
-
-			$localized_actions = SpecRunner::get_actions( $spec );
-			$actions_from_db   = $note_from_db->get_actions();
-			$actions_length    = count( $localized_actions );
-			// Manually copy the action id from the db to the localized action, since they were not being provided.
-			for ( $i = 0; $i < $actions_length; $i++ ) {
-				$localized_actions[ $i ]->id = $actions_from_db[ $i ]->id;
-			}
 			$note_from_db->set_actions( $localized_actions );
 		}
 

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/RemoteInboxNotificationsEngine.php
@@ -208,7 +208,15 @@ class RemoteInboxNotificationsEngine {
 
 			$note_from_db->set_title( $locale->title );
 			$note_from_db->set_content( $locale->content );
-			$note_from_db->set_actions( SpecRunner::get_actions( $spec ) );
+
+			$localized_actions = SpecRunner::get_actions( $spec );
+			$actions_from_db    = $note_from_db->get_actions();
+			$actions_length    = count( $localized_actions );
+			// Manually copy the action id from the db to the localized action, since they were not being provided.
+			for ( $i = 0; $i < $actions_length; $i++ ) {
+				$localized_actions[ $i ]->id = $actions_from_db[ $i ]->id;
+			}
+			$note_from_db->set_actions( $localized_actions );
 		}
 
 		return $note_from_db;

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-inbox-notifications/remote-inbox-notifications-engine.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/remote-inbox-notifications/remote-inbox-notifications-engine.php
@@ -97,7 +97,14 @@ class WC_Admin_Tests_RemoteInboxNotifications_RemoteInboxNotificationsEngine ext
 		$note_from_db = new Note();
 		$note_from_db->set_locale( 'en_US' );
 		$note_from_db->set_name( 'test' );
-
+		$note_from_db->set_actions(
+			array(
+				(object) array(
+					'id'   => 123,
+					'name' => 'test-action',
+				),
+			)
+		);
 		add_filter(
 			'locale',
 			function( $locale ) {
@@ -109,5 +116,7 @@ class WC_Admin_Tests_RemoteInboxNotifications_RemoteInboxNotificationsEngine ext
 		$this->assertEquals( $note->get_title(), '名稱' );
 		$this->assertEquals( $note->get_content(), '內容' );
 		$this->assertEquals( $note->get_actions()[0]->label, '標籤' );
+		$this->assertEquals( $note->get_actions()[0]->id, 123 );
+
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #36913 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to Settings > General.
2. Change your language to a language other than English (United States) (e.g. English (UK)).
3. Using WCA Test Helper, go to Tools > WCA Test Helper > Admin notes and add 2-3 notes of type "update" .
4. Run the following command on your database:
```sql
UPDATE wp_wc_admin_notes SET
`status` = 'unactioned',
WHERE `name` = 'woocommerce-WCstripe-May-2023-updated-needed';
```
5. Go to WooCommerce > Home.
6. Navigate to the last alert and press the Dismiss button for the stripe message, or the action button for the generated messages. (The stripe message should navigate to WordPress home, that's expected)
7. Go back to WooCommerce > Home and refresh the page.
8. All the alerts should be gone.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message <!-- Add a changelog message here -->

Fix undismissable store alert when using language localization

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
