### PR TITLE
Override Jetpack connection data endpoint when Jetpack is not installed

### DIFF
--- a/plugins/woocommerce/changelog/update-38979-override-jetpack-data-endpont
+++ b/plugins/woocommerce/changelog/update-38979-override-jetpack-data-endpont
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Override /jetpack/v4/connection/data to return 404 to fix conflict with Android app flow

--- a/plugins/woocommerce/src/Admin/API/OnboardingPlugins.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingPlugins.php
@@ -132,7 +132,7 @@ class OnboardingPlugins extends WC_REST_Data_Controller {
 		 *
 		 * For more details, see https://github.com/woocommerce/woocommerce/issues/38979
 		 */
-		if ( Constants::get_constant( 'JETPACK__VERSION' ) === null ) {
+		if ( Constants::get_constant( 'JETPACK__VERSION' ) === null && wp_is_mobile() ) {
 			register_rest_route(
 				'jetpack/v4',
 				'/connection/data',

--- a/plugins/woocommerce/src/Admin/API/OnboardingPlugins.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingPlugins.php
@@ -11,6 +11,7 @@ defined( 'ABSPATH' ) || exit;
 
 use ActionScheduler;
 use Automattic\Jetpack\Connection\Manager;
+use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Admin\PluginsHelper;
 use Automattic\WooCommerce\Admin\PluginsInstallLoggers\AsynPluginsInstallLogger;
 use WC_REST_Data_Controller;
@@ -124,6 +125,29 @@ class OnboardingPlugins extends WC_REST_Data_Controller {
 				),
 			)
 		);
+
+		/*
+		 * This is a temporary solution to override /jetpack/v4/connection/data endpoint
+		 * registered by Jetpack Connection when Jetpack is not installed.
+		 *
+		 * For more details, see https://github.com/woocommerce/woocommerce/issues/38979
+		 */
+		if ( Constants::get_constant( 'JETPACK__VERSION' ) === null ) {
+			register_rest_route(
+				'jetpack/v4',
+				'/connection/data',
+				array(
+					array(
+						'methods'             => 'GET',
+						'permission_callback' => '__return_true',
+						'callback'            => function() {
+							return new WP_REST_Response( null, 404 );
+						},
+					),
+				),
+				true
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #38979 

This PR overrides `/jetpack/v4/connection/data` endpoint to return 404 when Jetpack is not installed to fix conflict with Android app Jetpack installation flow.



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout the branch.
2. Try to access `http://YOUR-SITE/wp-json/jetpack/v4/connection/data` with wget `wget -U "Android" http://YOUR-SITE/wp-json/jetpack/v4/connection/data`
3. Confirm the endpoint returns 404 not found.
4. Install and activate Jetpack.
5. Try to access the endpoint again.
6. You should get a permission error.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
