### PR TITLE
Fix the monorepo utils lint job

### DIFF
--- a/.github/workflows/pr-lint-test-js.yml
+++ b/.github/workflows/pr-lint-test-js.yml
@@ -23,7 +23,7 @@ jobs:
               uses: ./.github/actions/setup-woocommerce-monorepo
 
             - name: Lint
-              run: pnpm run -r --filter='release-posts' --filter='woocommerce/client/admin...' --filter='!@woocommerce/e2e*' --filter='!@woocommerce/api' --color lint
+              run: pnpm run -r --filter='release-posts' --filter='woocommerce/client/admin...' --filter='@woocommerce/monorepo-utils' --filter='!@woocommerce/e2e*' --filter='!@woocommerce/api' --color lint
 
             - name: Test
               run: pnpm run test --filter='woocommerce/client/admin...' --filter='!@woocommerce/e2e*' --filter='!@woocommerce/api' --color

--- a/tools/monorepo-utils/src/changefile/lib/__tests__/github.ts
+++ b/tools/monorepo-utils/src/changefile/lib/__tests__/github.ts
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import path from 'path';
-
-/**
  * Internal dependencies
  */
 import {

--- a/tools/monorepo-utils/src/code-freeze/commands/version-bump/lib/update.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/version-bump/lib/update.ts
@@ -13,8 +13,8 @@ import { Logger } from '../../../../core/logger';
 /**
  * Update plugin readme changelog.
  *
- * @param  tmpRepoPath cloned repo path
- * @param  nextVersion version to bump to
+ * @param tmpRepoPath cloned repo path
+ * @param nextVersion version to bump to
  */
 export const updateReadmeChangelog = async (
 	tmpRepoPath: string,
@@ -38,8 +38,8 @@ export const updateReadmeChangelog = async (
 /**
  * Update plugin class file.
  *
- * @param  tmpRepoPath cloned repo path
- * @param  nextVersion version to bump to
+ * @param tmpRepoPath cloned repo path
+ * @param nextVersion version to bump to
  */
 export const updateClassPluginFile = async (
 	tmpRepoPath: string,
@@ -96,8 +96,8 @@ export const updateJSON = async (
 /**
  * Update plugin main file.
  *
- * @param  tmpRepoPath cloned repo path
- * @param  nextVersion version to bump to
+ * @param tmpRepoPath cloned repo path
+ * @param nextVersion version to bump to
  */
 export const updatePluginFile = async (
 	tmpRepoPath: string,

--- a/tools/monorepo-utils/src/code-freeze/commands/version-bump/lib/validate.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/version-bump/lib/validate.ts
@@ -12,7 +12,7 @@ import { Logger } from '../../../../core/logger';
 /**
  * Get a plugin's current version.
  *
- * @param  tmpRepoPath cloned repo path
+ * @param tmpRepoPath cloned repo path
  */
 export const getCurrentVersion = async (
 	tmpRepoPath: string
@@ -44,11 +44,10 @@ export const stripPrereleaseParameters = (
 };
 
 /**
- * Validate inputs.
+ * Validate the arguments passed to the version bump command.
  *
- * @param  plugin          plugin
- * @param  options         options
- * @param  options.version version
+ * @param tmpRepoPath cloned repo path
+ * @param version     version to bump to
  */
 export const validateArgs = async (
 	tmpRepoPath: string,

--- a/tools/monorepo-utils/src/core/git.ts
+++ b/tools/monorepo-utils/src/core/git.ts
@@ -156,7 +156,7 @@ export const cloneAuthenticatedRepo = async (
 /**
  * Do a minimal sparse checkout of a github repo.
  *
- * @param {string}        githubRepoUrl -     the URL to the repo to checkout.
+ * @param {string}        githubRepoUrl - the URL to the repo to checkout.
  * @param {string}        path          - the path to checkout to.
  * @param {Array<string>} directories   - the files or directories to checkout.
  * @param {string}        base          - the base branch to checkout from. Defaults to trunk.
@@ -193,7 +193,7 @@ export const sparseCheckoutRepo = async (
 /**
  * Do a minimal sparse checkout of a github repo without history.
  *
- * @param {string}        githubRepoUrl -     the URL to the repo to checkout.
+ * @param {string}        githubRepoUrl - the URL to the repo to checkout.
  * @param {string}        path          - the path to checkout to.
  * @param {Array<string>} directories   - the files or directories to checkout.
  * @return {Promise<string>}  the path to the cloned repo.
@@ -268,7 +268,7 @@ const refIsHash = ( ref: string ) => {
  * formed hash is provided it is returned unmodified.
  *
  * @param {string} baseDir - the dir of the git repo to get the hash from.
- * @param {string} ref     -    Either a commit hash or a branch name.
+ * @param {string} ref     - Either a commit hash or a branch name.
  * @return {string} - the commit hash of the ref.
  */
 export const getCommitHash = async ( baseDir: string, ref: string ) => {

--- a/tools/monorepo-utils/src/core/github/repo.ts
+++ b/tools/monorepo-utils/src/core/github/repo.ts
@@ -95,7 +95,7 @@ export const getRefFromGithubBranch = async (
 			}
 		` );
 
-	// @ts-ignore: The graphql query is typed, but the response is not.
+	// @ts-expect-error: The graphql query is typed, but the response is not.
 	return repository.ref.target.history.edges.shift().node.oid;
 };
 
@@ -167,7 +167,7 @@ export const createPullRequest = async ( options: {
 		}
 	);
 
-	//@ts-ignore There is a type mismatch between the graphql schema and the response. pullRequest.data.head.repo.has_discussions is a boolean, but the graphql schema doesn't have that field.
+	//@ts-expect-error There is a type mismatch between the graphql schema and the response. pullRequest.data.head.repo.has_discussions is a boolean, but the graphql schema doesn't have that field.
 	return pullRequest.data;
 };
 
@@ -175,9 +175,9 @@ export const createPullRequest = async ( options: {
  * Get a pull request from GitHub.
  *
  * @param {Object} options
- * @param {string} options.owner repository owner.
- * @param {string} options.name  repository name.
- * @param          prNumber      pull request number.
+ * @param {string} options.owner    repository owner.
+ * @param {string} options.name     repository name.
+ * @param {string} options.prNumber pull request number.
  * @return {Promise<object>}     pull request data.
  */
 export const getPullRequest = async ( options: {
@@ -195,7 +195,7 @@ export const getPullRequest = async ( options: {
 		}
 	);
 
-	//@ts-ignore Not sure why this error comes up. All versions are up to date and the schema is correct.
+	//@ts-expect-error Not sure why this error comes up. All versions are up to date and the schema is correct.
 	return pr.data;
 };
 

--- a/tools/monorepo-utils/src/core/wpenv.ts
+++ b/tools/monorepo-utils/src/core/wpenv.ts
@@ -35,7 +35,7 @@ export const isWPEnvPortTaken = () => {
  * Start wp-env.
  *
  * @param {string}   tmpRepoPath - path to the temporary repo to start wp-env from.
- * @param {Function} error       -  error print method.
+ * @param {Function} error       - error print method.
  * @return {boolean} if starting the container succeeded.
  */
 export const startWPEnv = async (


### PR DESCRIPTION
### Changes proposed in this Pull Request:

As part of a larger goal to get `pnpm lint` working across the monorepo this fixes the lint issues in monorepo utils and also adds it to the lint job to ensure we keep the standards correct before merging future PRs.

Most of the fixes here were autoformatting.Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. The CI job should lint and pass
2. You can test this locally by checking out this PR
3. Then navigate to `tools/monorepo-utils`
4. Run a lint `pnpm lint`. It should pass.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
