### PR TITLE
Refresh UX to enable HPOS tables

### DIFF
--- a/plugins/woocommerce/changelog/fix-34975
+++ b/plugins/woocommerce/changelog/fix-34975
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Refresh UX to enable HPOS to make it user friendly.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
@@ -431,6 +431,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 					case 'radio':
 						$option_value = $value['value'];
 						$disabled_values = $value['disabled'] ?? array();
+						$show_desc_at_end = $value['desc_at_end'] ?? false;
 
 						?>
 						<tr valign="top">
@@ -439,7 +440,11 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 							</th>
 							<td class="forminp forminp-<?php echo esc_attr( sanitize_title( $value['type'] ) ); ?>">
 								<fieldset>
-									<?php echo $description; // WPCS: XSS ok. ?>
+									<?php
+									if ( ! $show_desc_at_end ) {
+										echo wp_kses_post( $description );
+									}
+									?>
 									<ul>
 									<?php
 									foreach ( $value['options'] as $key => $val ) {
@@ -457,6 +462,9 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 												/> <?php echo esc_html( $val ); ?></label>
 										</li>
 										<?php
+									}
+									if ( $show_desc_at_end ) {
+										echo wp_kses_post( "<p class='description description-thin'>{$value['desc']}</p>" );
 									}
 									?>
 									</ul>

--- a/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
@@ -429,8 +429,8 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 
 					// Radio inputs.
 					case 'radio':
-						$option_value = $value['value'];
-						$disabled_values = $value['disabled'] ?? array();
+						$option_value     = $value['value'];
+						$disabled_values  = $value['disabled'] ?? array();
 						$show_desc_at_end = $value['desc_at_end'] ?? false;
 
 						?>

--- a/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
@@ -464,7 +464,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 										<?php
 									}
 									if ( $show_desc_at_end ) {
-										echo wp_kses_post( "<p class='description description-thin'>{$value['desc']}</p>" );
+										echo wp_kses_post( "<p class='description description-thin'>{$description}</p>" );
 									}
 									?>
 									</ul>

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostMetaToOrderMetaMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostMetaToOrderMetaMigrator.php
@@ -6,6 +6,7 @@
 namespace Automattic\WooCommerce\Database\Migrations\CustomOrderTable;
 
 use Automattic\WooCommerce\Database\Migrations\MetaToMetaTableMigrator;
+use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
 
 /**
  * Helper class to migrate records from the WordPress post meta table
@@ -39,13 +40,6 @@ class PostMetaToOrderMetaMigrator extends MetaToMetaTableMigrator {
 	 */
 	protected function get_meta_config(): array {
 		global $wpdb;
-		// TODO: Remove hardcoding.
-		$table_names = array(
-			'orders'    => $wpdb->prefix . 'wc_orders',
-			'addresses' => $wpdb->prefix . 'wc_order_addresses',
-			'op_data'   => $wpdb->prefix . 'wc_order_operational_data',
-			'meta'      => $wpdb->prefix . 'wc_orders_meta',
-		);
 
 		return array(
 			'source'      => array(
@@ -57,15 +51,15 @@ class PostMetaToOrderMetaMigrator extends MetaToMetaTableMigrator {
 					'meta_value_column' => 'meta_value',
 				),
 				'entity'        => array(
-					'table_name'       => $table_names['orders'],
-					'source_id_column' => 'id',
-					'id_column'        => 'id',
+					'table_name'       => $wpdb->posts,
+					'source_id_column' => 'ID',
+					'id_column'        => 'ID',
 				),
 				'excluded_keys' => $this->excluded_columns,
 			),
 			'destination' => array(
 				'meta' => array(
-					'table_name'        => $table_names['meta'],
+					'table_name'        => OrdersTableDataStore::get_meta_table_name(),
 					'entity_id_column'  => 'order_id',
 					'meta_key_column'   => 'meta_key',
 					'meta_value_column' => 'meta_value',

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostToOrderAddressTableMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostToOrderAddressTableMigrator.php
@@ -6,6 +6,7 @@
 namespace Automattic\WooCommerce\Database\Migrations\CustomOrderTable;
 
 use Automattic\WooCommerce\Database\Migrations\MetaToCustomTableMigrator;
+use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
 
 /**
  * Helper class to migrate records from the WordPress post table
@@ -38,21 +39,14 @@ class PostToOrderAddressTableMigrator extends MetaToCustomTableMigrator {
 	 */
 	protected function get_schema_config(): array {
 		global $wpdb;
-		// TODO: Remove hardcoding.
-		$table_names = array(
-			'orders'    => $wpdb->prefix . 'wc_orders',
-			'addresses' => $wpdb->prefix . 'wc_order_addresses',
-			'op_data'   => $wpdb->prefix . 'wc_order_operational_data',
-			'meta'      => $wpdb->prefix . 'wc_orders_meta',
-		);
 
 		return array(
 			'source'      => array(
 				'entity' => array(
-					'table_name'             => $table_names['orders'],
-					'meta_rel_column'        => 'id',
-					'destination_rel_column' => 'id',
-					'primary_key'            => 'id',
+					'table_name'             => $wpdb->posts,
+					'meta_rel_column'        => 'ID',
+					'destination_rel_column' => 'ID',
+					'primary_key'            => 'ID',
 				),
 				'meta'   => array(
 					'table_name'        => $wpdb->postmeta,
@@ -63,7 +57,7 @@ class PostToOrderAddressTableMigrator extends MetaToCustomTableMigrator {
 				),
 			),
 			'destination' => array(
-				'table_name'        => $table_names['addresses'],
+				'table_name'        => OrdersTableDataStore::get_addresses_table_name(),
 				'source_rel_column' => 'order_id',
 				'primary_key'       => 'id',
 				'primary_key_type'  => 'int',
@@ -80,7 +74,7 @@ class PostToOrderAddressTableMigrator extends MetaToCustomTableMigrator {
 		$type = $this->type;
 
 		return array(
-			'id'   => array(
+			'ID'   => array(
 				'type'        => 'int',
 				'destination' => 'order_id',
 			),

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostToOrderOpTableMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostToOrderOpTableMigrator.php
@@ -6,6 +6,7 @@
 namespace Automattic\WooCommerce\Database\Migrations\CustomOrderTable;
 
 use Automattic\WooCommerce\Database\Migrations\MetaToCustomTableMigrator;
+use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
 
 /**
  * Helper class to migrate records from the WordPress post table
@@ -22,21 +23,14 @@ class PostToOrderOpTableMigrator extends MetaToCustomTableMigrator {
 	 */
 	protected function get_schema_config(): array {
 		global $wpdb;
-		// TODO: Remove hardcoding.
-		$table_names = array(
-			'orders'    => $wpdb->prefix . 'wc_orders',
-			'addresses' => $wpdb->prefix . 'wc_order_addresses',
-			'op_data'   => $wpdb->prefix . 'wc_order_operational_data',
-			'meta'      => $wpdb->prefix . 'wc_orders_meta',
-		);
 
 		return array(
 			'source'      => array(
 				'entity' => array(
-					'table_name'             => $table_names['orders'],
-					'meta_rel_column'        => 'id',
-					'destination_rel_column' => 'id',
-					'primary_key'            => 'id',
+					'table_name'             => $wpdb->posts,
+					'meta_rel_column'        => 'ID',
+					'destination_rel_column' => 'ID',
+					'primary_key'            => 'ID',
 				),
 				'meta'   => array(
 					'table_name'        => $wpdb->postmeta,
@@ -47,7 +41,7 @@ class PostToOrderOpTableMigrator extends MetaToCustomTableMigrator {
 				),
 			),
 			'destination' => array(
-				'table_name'        => $table_names['op_data'],
+				'table_name'        => OrdersTableDataStore::get_operational_data_table_name(),
 				'source_rel_column' => 'order_id',
 				'primary_key'       => 'id',
 				'primary_key_type'  => 'int',
@@ -63,7 +57,7 @@ class PostToOrderOpTableMigrator extends MetaToCustomTableMigrator {
 	 */
 	protected function get_core_column_mapping(): array {
 		return array(
-			'id' => array(
+			'ID' => array(
 				'type'        => 'int',
 				'destination' => 'order_id',
 			),

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostsToOrdersMigrationController.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostsToOrdersMigrationController.php
@@ -98,12 +98,6 @@ class PostsToOrdersMigrationController {
 	 * @return bool|null True if transaction started, false if transactions won't be used, null if transaction failed to start.
 	 */
 	private function maybe_start_transaction(): ?bool {
-		global $wpdb;
-		$transaction_isolation_level = get_option( CustomOrdersTableController::DB_TRANSACTIONS_ISOLATION_LEVEL_OPTION );
-		if ( ! $transaction_isolation_level ) {
-			$table = $this->get_custom_orders_table_name();
-		}
-
 		$transaction_isolation_level = get_option( CustomOrdersTableController::DB_TRANSACTIONS_ISOLATION_LEVEL_OPTION, CustomOrdersTableController::DEFAULT_DB_TRANSACTIONS_ISOLATION_LEVEL );
 		$set_transaction_isolation_level_command = "SET TRANSACTION ISOLATION LEVEL $transaction_isolation_level";
 

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostsToOrdersMigrationController.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostsToOrdersMigrationController.php
@@ -26,7 +26,7 @@ class PostsToOrdersMigrationController {
 	/**
 	 * Array of objects used to perform the migration.
 	 *
-	 * @var array
+	 * @var array[TableMigrator]
 	 */
 	private $all_migrators;
 
@@ -40,13 +40,13 @@ class PostsToOrdersMigrationController {
 	 */
 	public function __construct() {
 
-		$this->all_migrators   = array();
-		$this->all_migrators[] = new PostToOrderTableMigrator();
-		$this->all_migrators[] = new PostToOrderAddressTableMigrator( 'billing' );
-		$this->all_migrators[] = new PostToOrderAddressTableMigrator( 'shipping' );
-		$this->all_migrators[] = new PostToOrderOpTableMigrator();
-		$this->all_migrators[] = new PostMetaToOrderMetaMigrator( $this->get_migrated_meta_keys() );
-		$this->error_logger    = wc_get_logger();
+		$this->all_migrators                           = array();
+		$this->all_migrators['order']                  = new PostToOrderTableMigrator();
+		$this->all_migrators['order_address_billing']  = new PostToOrderAddressTableMigrator( 'billing' );
+		$this->all_migrators['order_address_shipping'] = new PostToOrderAddressTableMigrator( 'shipping' );
+		$this->all_migrators['order_operational_data'] = new PostToOrderOpTableMigrator();
+		$this->all_migrators['order_meta']             = new PostMetaToOrderMetaMigrator( $this->get_migrated_meta_keys() );
+		$this->error_logger                            = wc_get_logger();
 	}
 
 	/**
@@ -56,7 +56,7 @@ class PostsToOrdersMigrationController {
 	 */
 	public function get_migrated_meta_keys() {
 		$migrated_meta_keys = array();
-		foreach ( $this->all_migrators as $migrator ) {
+		foreach ( $this->all_migrators as $name => $migrator ) {
 			if ( method_exists( $migrator, 'get_meta_column_config' ) ) {
 				$migrated_meta_keys = array_merge( $migrated_meta_keys, $migrator->get_meta_column_config() );
 			}
@@ -72,23 +72,71 @@ class PostsToOrdersMigrationController {
 	public function migrate_orders( array $order_post_ids ): void {
 		$this->error_logger = WC()->call_function( 'wc_get_logger' );
 
-		$using_transactions = $this->maybe_start_transaction();
-		if ( null === $using_transactions ) {
-			return;
-		}
-
-		$errors_were_logged = false;
-
-		foreach ( $this->all_migrators as $migrator ) {
-			$errors_were_logged = $this->do_orders_migration_step( $migrator, $order_post_ids );
-			if ( $errors_were_logged && $using_transactions ) {
-				$this->rollback_transaction();
-				break;
+		$data = array();
+		foreach ( $this->all_migrators as $name => $migrator ) {
+			$data[ $name ] = $migrator->fetch_sanitized_migration_data( $order_post_ids );
+			if ( ! empty( $data['errors'] ) ) {
+				$this->handle_migration_error( $order_post_ids, $data['errors'], null, null, $name );
+				return;
 			}
 		}
 
-		if ( ! $errors_were_logged && $using_transactions ) {
-			$this->commit_transaction();
+		$using_transactions = $this->maybe_start_transaction();
+
+		foreach ( $this->all_migrators as $name => $migrator ) {
+			$results   = $migrator->process_migration_data( $data[ $name ] );
+			$errors    = array_unique( $results['errors'] );
+			$exception = $results['exception'];
+
+			if ( null === $exception && empty( $errors ) ) {
+				continue;
+			}
+
+			$this->handle_migration_error( $order_post_ids, $errors, $exception, $using_transactions, $name );
+			break;
+		}
+
+		$this->commit_transaction();
+
+	}
+
+	/**
+	 * Log migration errors if any.
+	 *
+	 * @param array           $order_post_ids List of post IDs of the orders to migrate.
+	 * @param array           $errors List of errors to log.
+	 * @param \Exception|null $exception Exception to log.
+	 * @param bool|null       $using_transactions Whether transactions were used.
+	 * @param string          $name Name of the migrator.
+	 */
+	private function handle_migration_error( array $order_post_ids, array $errors, ?\Exception $exception, ?bool $using_transactions, string $name ) {
+		$batch = ArrayUtil::to_ranges_string( $order_post_ids );
+
+		if ( null !== $exception ) {
+			$exception_class = get_class( $exception );
+			$this->error_logger->error(
+				"$name: when processing ids $batch: ($exception_class) {$exception->getMessage()}, {$exception->getTraceAsString()}",
+				array(
+					'source'    => self::LOGS_SOURCE_NAME,
+					'ids'       => $order_post_ids,
+					'exception' => $exception,
+				)
+			);
+		}
+
+		foreach ( $errors as $error ) {
+			$this->error_logger->error(
+				"$name: when processing ids $batch: $error",
+				array(
+					'source' => self::LOGS_SOURCE_NAME,
+					'ids'    => $order_post_ids,
+					'error'  => $error,
+				)
+			);
+		}
+
+		if ( $using_transactions ) {
+			$this->rollback_transaction();
 		}
 	}
 
@@ -98,10 +146,11 @@ class PostsToOrdersMigrationController {
 	 * @return bool|null True if transaction started, false if transactions won't be used, null if transaction failed to start.
 	 */
 	private function maybe_start_transaction(): ?bool {
-		$transaction_isolation_level = get_option( CustomOrdersTableController::DB_TRANSACTIONS_ISOLATION_LEVEL_OPTION, CustomOrdersTableController::DEFAULT_DB_TRANSACTIONS_ISOLATION_LEVEL );
+		$transaction_isolation_level             = get_option( CustomOrdersTableController::DB_TRANSACTIONS_ISOLATION_LEVEL_OPTION, CustomOrdersTableController::DEFAULT_DB_TRANSACTIONS_ISOLATION_LEVEL );
 		$set_transaction_isolation_level_command = "SET TRANSACTION ISOLATION LEVEL $transaction_isolation_level";
 
-		if ( ! $this->db_query( $set_transaction_isolation_level_command ) ) {
+		// We suppress errors in transaction isolation level setting because it's not supported by all DB engines, additionally, this might be executing in context of another transaction with a different isolation level.
+		if ( ! $this->db_query( $set_transaction_isolation_level_command, true ) ) {
 			return null;
 		}
 
@@ -129,15 +178,23 @@ class PostsToOrdersMigrationController {
 	/**
 	 * Execute a database query and log any errors.
 	 *
-	 * @param string $query The SQL query to execute.
+	 * @param string $query          The SQL query to execute.
+	 * @param bool   $supress_errors Whether to suppress errors.
+	 *
 	 * @return bool True if the query succeeded, false if there were errors.
 	 */
-	private function db_query( string $query ): bool {
+	private function db_query( string $query, bool $supress_errors = false ): bool {
 		$wpdb = WC()->get_global( 'wpdb' );
 
 		try {
+			if ( $supress_errors ) {
+				$suppress = $wpdb->suppress_errors( true );
+			}
 			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 			$wpdb->query( $query );
+			if ( $supress_errors ) {
+				$wpdb->suppress_errors( $suppress );
+			}
 		} catch ( \Exception $exception ) {
 			$exception_class = get_class( $exception );
 			$this->error_logger->error(
@@ -160,52 +217,6 @@ class PostsToOrdersMigrationController {
 				)
 			);
 			return false;
-		}
-
-		return true;
-	}
-
-	/**
-	 * Performs one step of the migration for a set of order posts using one given migration class.
-	 * All database errors and exceptions are logged.
-	 *
-	 * @param object $migration_class The migration class to use, must have a `process_migration_batch_for_ids(array of ids)` method.
-	 * @param array  $order_post_ids List of post IDs of the orders to migrate.
-	 * @return bool True if errors were logged, false otherwise.
-	 */
-	private function do_orders_migration_step( object $migration_class, array $order_post_ids ): bool {
-		$result = $migration_class->process_migration_batch_for_ids( $order_post_ids );
-
-		$errors    = array_unique( $result['errors'] );
-		$exception = $result['exception'];
-		if ( null === $exception && empty( $errors ) ) {
-			return false;
-		}
-
-		$migration_class_name = ( new \ReflectionClass( $migration_class ) )->getShortName();
-		$batch                = ArrayUtil::to_ranges_string( $order_post_ids );
-
-		if ( null !== $exception ) {
-			$exception_class = get_class( $exception );
-			$this->error_logger->error(
-				"$migration_class_name: when processing ids $batch: ($exception_class) {$exception->getMessage()}, {$exception->getTraceAsString()}",
-				array(
-					'source'    => self::LOGS_SOURCE_NAME,
-					'ids'       => $order_post_ids,
-					'exception' => $exception,
-				)
-			);
-		}
-
-		foreach ( $errors as $error ) {
-			$this->error_logger->error(
-				"$migration_class_name: when processing ids $batch: $error",
-				array(
-					'source' => self::LOGS_SOURCE_NAME,
-					'ids'    => $order_post_ids,
-					'error'  => $error,
-				)
-			);
 		}
 
 		return true;

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostsToOrdersMigrationController.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/PostsToOrdersMigrationController.php
@@ -26,7 +26,7 @@ class PostsToOrdersMigrationController {
 	/**
 	 * Array of objects used to perform the migration.
 	 *
-	 * @var array[TableMigrator]
+	 * @var TableMigrator[]
 	 */
 	private $all_migrators;
 

--- a/plugins/woocommerce/src/Database/Migrations/MetaToCustomTableMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/MetaToCustomTableMigrator.php
@@ -225,6 +225,7 @@ abstract class MetaToCustomTableMigrator extends TableMigrator {
 	 * @return array[] Data to be migrated. Would be of the form: array( 'data' => array( ... ), 'errors' => array( ... ) ).
 	 */
 	public function fetch_sanitized_migration_data( $entity_ids ) {
+		$this->clear_errors();
 		$data = $this->fetch_data_for_migration_for_ids( $entity_ids );
 
 		foreach ( $data['errors'] as $entity_id => $errors ) {
@@ -232,7 +233,10 @@ abstract class MetaToCustomTableMigrator extends TableMigrator {
 				$this->add_error( "Error importing data for post with id $entity_id: column $column_name: $error_message" );
 			}
 		}
-		return $data;
+		return array(
+			'data'   => $data['data'],
+			'errors' => $this->get_errors(),
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Database/Migrations/MetaToCustomTableMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/MetaToCustomTableMigrator.php
@@ -218,13 +218,13 @@ abstract class MetaToCustomTableMigrator extends TableMigrator {
 	}
 
 	/**
-	 * Migrate a batch of entities from the posts table to the corresponding table.
+	 * Return data to be migrated for a batch of entities.
 	 *
 	 * @param array $entity_ids Ids of entities to migrate.
 	 *
-	 * @return void
+	 * @return array[] Data to be migrated. Would be of the form: array( 'data' => array( ... ), 'errors' => array( ... ) ).
 	 */
-	protected function process_migration_batch_for_ids_core( array $entity_ids ): void {
+	public function fetch_sanitized_migration_data( $entity_ids ) {
 		$data = $this->fetch_data_for_migration_for_ids( $entity_ids );
 
 		foreach ( $data['errors'] as $entity_id => $errors ) {
@@ -232,19 +232,56 @@ abstract class MetaToCustomTableMigrator extends TableMigrator {
 				$this->add_error( "Error importing data for post with id $entity_id: column $column_name: $error_message" );
 			}
 		}
+		return $data;
+	}
+
+	/**
+	 * Migrate a batch of entities from the posts table to the corresponding table.
+	 *
+	 * @param array $entity_ids Ids of entities to migrate.
+	 *
+	 * @return void
+	 */
+	protected function process_migration_batch_for_ids_core( array $entity_ids ): void {
+		$data = $this->fetch_sanitized_migration_data( $entity_ids );
+		$this->process_migration_data( $data );
+	}
+
+	/**
+	 * Process migration data for a batch of entities.
+	 *
+	 * @param array $data Data to be migrated. Should be of the form: array( 'data' => array( ... ) ) as returned by the `fetch_sanitized_migration_data` method.
+	 *
+	 * @return array Array of errors and exception if any.
+	 */
+	public function process_migration_data( array $data ) {
+		$this->clear_errors();
+		$exception = null;
 
 		if ( count( $data['data'] ) === 0 ) {
-			return;
+			return array(
+				'errors'    => $this->get_errors(),
+				'exception' => null,
+			);
 		}
 
-		$entity_ids       = array_keys( $data['data'] );
-		$existing_records = $this->get_already_existing_records( $entity_ids );
+		try {
+			$entity_ids       = array_keys( $data['data'] );
+			$existing_records = $this->get_already_existing_records( $entity_ids );
 
-		$to_insert = array_diff_key( $data['data'], $existing_records );
-		$this->process_insert_batch( $to_insert );
+			$to_insert = array_diff_key( $data['data'], $existing_records );
+			$this->process_insert_batch( $to_insert );
 
-		$to_update = array_intersect_key( $data['data'], $existing_records );
-		$this->process_update_batch( $to_update, $existing_records );
+			$to_update = array_intersect_key( $data['data'], $existing_records );
+			$this->process_update_batch( $to_update, $existing_records );
+		} catch ( \Exception $e ) {
+			$exception = $e;
+		}
+
+		return array(
+			'errors'    => $this->get_errors(),
+			'exception' => $exception,
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Database/Migrations/MetaToMetaTableMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/MetaToMetaTableMigrator.php
@@ -68,6 +68,7 @@ abstract class MetaToMetaTableMigrator extends TableMigrator {
 	 * @return array[] Data to be migrated. Would be of the form: array( 'data' => array( ... ), 'errors' => array( ... ) ).
 	 */
 	public function fetch_sanitized_migration_data( $entity_ids ) {
+		$this->clear_errors();
 		$to_migrate = $this->fetch_data_for_migration_for_ids( $entity_ids );
 		if ( empty( $to_migrate ) ) {
 			return array(
@@ -78,7 +79,10 @@ abstract class MetaToMetaTableMigrator extends TableMigrator {
 
 		$already_migrated = $this->get_already_migrated_records( array_keys( $to_migrate ) );
 
-		return $this->classify_update_insert_records( $to_migrate, $already_migrated );
+		return array(
+			'data'   => $this->classify_update_insert_records( $to_migrate, $already_migrated ),
+			'errors' => $this->get_errors(),
+		);
 	}
 
 	/**
@@ -99,6 +103,9 @@ abstract class MetaToMetaTableMigrator extends TableMigrator {
 	 * @return array Array of errors and exception if any.
 	 */
 	public function process_migration_data( array $data ) {
+		if ( isset( $data['data'] ) ) {
+			$data = $data['data'];
+		}
 		$this->clear_errors();
 		$exception = null;
 

--- a/plugins/woocommerce/src/Database/Migrations/MetaToMetaTableMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/MetaToMetaTableMigrator.php
@@ -61,33 +61,70 @@ abstract class MetaToMetaTableMigrator extends TableMigrator {
 	}
 
 	/**
+	 * Return data to be migrated for a batch of entities.
+	 *
+	 * @param array $entity_ids Ids of entities to migrate.
+	 *
+	 * @return array[] Data to be migrated. Would be of the form: array( 'data' => array( ... ), 'errors' => array( ... ) ).
+	 */
+	public function fetch_sanitized_migration_data( $entity_ids ) {
+		$to_migrate = $this->fetch_data_for_migration_for_ids( $entity_ids );
+		if ( empty( $to_migrate ) ) {
+			return array(
+				array(),
+				array(),
+			);
+		}
+
+		$already_migrated = $this->get_already_migrated_records( array_keys( $to_migrate ) );
+
+		return $this->classify_update_insert_records( $to_migrate, $already_migrated );
+	}
+
+	/**
 	 * Migrate a batch of entities from the posts table to the corresponding table.
 	 *
 	 * @param array $entity_ids Ids of entities ro migrate.
 	 */
 	protected function process_migration_batch_for_ids_core( array $entity_ids ): void {
-		$to_migrate = $this->fetch_data_for_migration_for_ids( $entity_ids );
-		if ( empty( $to_migrate ) ) {
-			return;
-		}
+		$sanitized_data = $this->fetch_sanitized_migration_data( $entity_ids );
+		$this->process_migration_data( $sanitized_data );
+	}
 
-		$already_migrated = $this->get_already_migrated_records( array_keys( $to_migrate ) );
+	/**
+	 * Process migration data for a batch of entities.
+	 *
+	 * @param array $data Data to be migrated. Should be of the form: array( 'data' => array( ... ) ) as returned by the `fetch_sanitized_migration_data` method.
+	 *
+	 * @return array Array of errors and exception if any.
+	 */
+	public function process_migration_data( array $data ) {
+		$this->clear_errors();
+		$exception = null;
 
-		$data      = $this->classify_update_insert_records( $to_migrate, $already_migrated );
 		$to_insert = $data[0];
 		$to_update = $data[1];
 
-		if ( ! empty( $to_insert ) ) {
-			$insert_queries       = $this->generate_insert_sql_for_batch( $to_insert );
-			$processed_rows_count = $this->db_query( $insert_queries );
-			$this->maybe_add_insert_or_update_error( 'insert', $processed_rows_count );
+		try {
+			if ( ! empty( $to_insert ) ) {
+				$insert_queries       = $this->generate_insert_sql_for_batch( $to_insert );
+				$processed_rows_count = $this->db_query( $insert_queries );
+				$this->maybe_add_insert_or_update_error( 'insert', $processed_rows_count );
+			}
+
+			if ( ! empty( $to_update ) ) {
+				$update_queries       = $this->generate_update_sql_for_batch( $to_update );
+				$processed_rows_count = $this->db_query( $update_queries );
+				$this->maybe_add_insert_or_update_error( 'update', $processed_rows_count );
+			}
+		} catch ( \Exception $e ) {
+			$exception = $e;
 		}
 
-		if ( ! empty( $to_update ) ) {
-			$update_queries       = $this->generate_update_sql_for_batch( $to_update );
-			$processed_rows_count = $this->db_query( $update_queries );
-			$this->maybe_add_insert_or_update_error( 'update', $processed_rows_count );
-		}
+		return array(
+			'errors'    => $this->get_errors(),
+			'exception' => $exception,
+		);
 	}
 
 	/**
@@ -179,7 +216,7 @@ abstract class MetaToMetaTableMigrator extends TableMigrator {
 	 *   ...,
 	 * )
 	 */
-	private function fetch_data_for_migration_for_ids( array $entity_ids ): array {
+	public function fetch_data_for_migration_for_ids( array $entity_ids ): array {
 		if ( empty( $entity_ids ) ) {
 			return array();
 		}

--- a/plugins/woocommerce/src/Database/Migrations/MetaToMetaTableMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/MetaToMetaTableMigrator.php
@@ -72,8 +72,8 @@ abstract class MetaToMetaTableMigrator extends TableMigrator {
 		$to_migrate = $this->fetch_data_for_migration_for_ids( $entity_ids );
 		if ( empty( $to_migrate ) ) {
 			return array(
-				array(),
-				array(),
+				'data'   => array(),
+				'errors' => array(),
 			);
 		}
 

--- a/plugins/woocommerce/src/Database/Migrations/TableMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/TableMigrator.php
@@ -36,6 +36,10 @@ abstract class TableMigrator {
 	 * @return void
 	 */
 	protected function add_error( string $error ): void {
+		if ( is_null( $this->errors ) ) {
+			$this->errors = array();
+		}
+
 		if ( ! in_array( $error, $this->errors, true ) ) {
 			$this->errors[] = $error;
 		}

--- a/plugins/woocommerce/src/Database/Migrations/TableMigrator.php
+++ b/plugins/woocommerce/src/Database/Migrations/TableMigrator.php
@@ -94,6 +94,8 @@ abstract class TableMigrator {
 	 *
 	 * @param array $entity_ids Order ids to migrate.
 	 * @return array An array containing the keys 'errors' (array of strings) and 'exception' (exception object or null).
+	 *
+	 * @deprecated 8.0.0 Use `fetch_sanitized_migration_data` and `process_migration_data` instead.
 	 */
 	public function process_migration_batch_for_ids( array $entity_ids ): array {
 		$this->clear_errors();
@@ -111,12 +113,38 @@ abstract class TableMigrator {
 		);
 	}
 
+	// phpcs:disable Squiz.Commenting.FunctionComment.InvalidNoReturn, Squiz.Commenting.FunctionCommentThrowTag.Missing -- Methods are not marked abstract for back compat.
+	/**
+	 * Return data to be migrated for a batch of entities.
+	 *
+	 * @param array $entity_ids Ids of entities to migrate.
+	 *
+	 * @return array[] Data to be migrated. Would be of the form: array( 'data' => array( ... ), 'errors' => array( ... ) ).
+	 */
+	public function fetch_sanitized_migration_data( array $entity_ids ) {
+		throw new \Exception( 'Not implemented' );
+	}
+
+	/**
+	 * Process migration data for a batch of entities.
+	 *
+	 * @param array $data Data to be migrated. Should be of the form: array( 'data' => array( ... ) ) as returned by the `fetch_sanitized_migration_data` method.
+	 *
+	 * @return array Array of errors and exception if any.
+	 */
+	public function process_migration_data( array $data ) {
+		throw new \Exception( 'Not implemented' );
+	}
+	// phpcs:enable
+
 	/**
 	 * The core method that actually performs the migration for the supplied batch of order ids.
 	 * It doesn't need to deal with database errors nor with exceptions.
 	 *
 	 * @param array $entity_ids Order ids to migrate.
 	 * @return void
+	 *
+	 * @deprecated 8.0.0 Use `fetch_sanitized_migration_data` and `process_migration_data` instead.
 	 */
 	abstract protected function process_migration_batch_for_ids_core( array $entity_ids ): void;
 

--- a/plugins/woocommerce/src/Internal/Admin/Settings.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings.php
@@ -251,7 +251,7 @@ class Settings {
 		foreach ( array_keys( $features ) as $feature_id ) {
 			$new_features[ $feature_id ] = array(
 				'is_enabled'      => $features[ $feature_id ]['is_enabled'],
-				'is_experimental' => $features[ $feature_id ]['is_experimental'],
+				'is_experimental' => $features[ $feature_id ]['is_experimental'] ?? false,
 			);
 		}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -633,7 +633,6 @@ class CustomOrdersTableController {
 		$plugin_info             = $this->features_controller->get_compatible_plugins_for_feature( 'custom_order_tables' );
 		$plugin_incompat_warning = $this->plugin_util->generate_incompatible_plugin_feature_warning( 'custom_order_tables', $plugin_info );
 		$can_hpos_enabled        = count( array_merge( $plugin_info['compatible'], $plugin_info['incompatible'] ) ) === 0;
-
 		?>
 		<fieldset>
 			<tr>
@@ -683,8 +682,20 @@ class CustomOrdersTableController {
 							type="checkbox"
 							value="yes"
 							<?php checked( 'yes', $sync_enabled ); ?>
-						><?php echo esc_html( __( 'Keep posts and orders table in sync', 'woocommerce' ) ); ?>
+						><?php echo esc_html( __( 'Keep posts and orders table in sync (Compatibility mode).', 'woocommerce' ) ); ?>
 					</label>
+					<p class="description description-thin">
+					<?php
+					if ( $sync_in_progress ) {
+						echo esc_html(
+							sprintf(
+								__( 'Sync in progress... %d orders pending. ', 'woocommerce' ),
+								$sync_status['current_pending_count']
+							)
+						);
+					}
+					?>
+					</p>
 				</td>
 			</tr>
 			<tr>

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -117,7 +117,7 @@ class CustomOrdersTableController {
 		self::add_filter( 'woocommerce_debug_tools', array( $this, 'add_initiate_regeneration_entry_to_tools_array' ), 999, 1 );
 		self::add_filter( 'updated_option', array( $this, 'process_updated_option' ), 999, 3 );
 		self::add_filter( 'pre_update_option', array( $this, 'process_pre_update_option' ), 999, 3 );
-		self::add_action( FeaturesController::FEATURE_ENABLED_CHANGED_ACTION, array( $this, 'process_options_updated' ), 10, 1 );
+		self::add_action( FeaturesController::FEATURE_ENABLED_CHANGED_ACTION, array( $this, 'handle_data_sync_option_changed' ), 10, 1 );
 		self::add_action( 'woocommerce_after_register_post_type', array( $this, 'register_post_type_for_order_placeholders' ), 10, 0 );
 		self::add_action( FeaturesController::FEATURE_ENABLED_CHANGED_ACTION, array( $this, 'handle_feature_enabled_changed' ), 10, 2 );
 		self::add_action( 'woocommerce_feature_setting', array( $this, 'get_hpos_feature_setting' ), 10, 2 );
@@ -358,7 +358,7 @@ class CustomOrdersTableController {
 	 *
 	 * @param string $feature_id Feature ID.
 	 */
-	private function process_options_updated( string $feature_id ) {
+	private function handle_data_sync_option_changed( string $feature_id ) {
 		if ( DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION !== $feature_id ) {
 			return;
 		}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -456,15 +456,15 @@ class CustomOrdersTableController {
 		$can_hpos_enabled        = count( array_merge( $plugin_info['compatible'], $plugin_info['incompatible'] ) ) === 0;
 
 		return array(
-			'id'          => 'woocommerce_feature_custom_order_tables_enabled',
+			'id'          => self::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION,
 			'title'       => __( 'Data storage for orders', 'woocommerce' ),
 			'type'        => 'radio',
 			'options'     => array(
-				'post' => __( 'WordPress Post tables', 'woocommerce' ),
-				'hpos' => __( 'High performance order storage (new)', 'woocommerce' ),
+				'no' => __( 'WordPress Post tables', 'woocommerce' ),
+				'yes' => __( 'High performance order storage (new)', 'woocommerce' ),
 			),
-			'value'       => $hpos_enabled ? 'hpos' : 'post',
-			'disabled'    => $can_hpos_enabled && $sync_complete ? array() : array( 'hpos' ),
+			'value'       => $hpos_enabled ? 'yes' : 'no',
+			'disabled'    => $can_hpos_enabled && $sync_complete ? array() : array( 'yes' ),
 			'desc'        => $plugin_incompat_warning,
 			'desc_at_end' => true,
 		);

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -36,8 +36,6 @@ class CustomOrdersTableController {
 
 	/**
 	 * The name of the option that tells whether database transactions are to be used or not for data synchronization.
-	 *
-	 * @deprecated We only use READ UNCOMMITTED isolation level, which provides us with correctness guarantee in new table, without locking post tables.
 	 */
 	public const USE_DB_TRANSACTIONS_OPTION = 'woocommerce_use_db_transactions_for_custom_orders_table_data_sync';
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -124,7 +124,6 @@ class CustomOrdersTableController {
 		self::add_filter( 'woocommerce_debug_tools', array( $this, 'add_initiate_regeneration_entry_to_tools_array' ), 999, 1 );
 		self::add_filter( 'updated_option', array( $this, 'process_updated_option' ), 999, 3 );
 		self::add_filter( 'pre_update_option', array( $this, 'process_pre_update_option' ), 999, 3 );
-		self::add_filter( DataSynchronizer::PENDING_SYNCHRONIZATION_FINISHED_ACTION, array( $this, 'process_sync_finished' ), 10, 0 );
 		self::add_action( 'woocommerce_update_options_advanced_custom_data_stores', array( $this, 'process_options_updated' ), 10, 0 );
 		self::add_action( 'woocommerce_after_register_post_type', array( $this, 'register_post_type_for_order_placeholders' ), 10, 0 );
 		self::add_action( FeaturesController::FEATURE_ENABLED_CHANGED_ACTION, array( $this, 'handle_feature_enabled_changed' ), 10, 2 );
@@ -170,7 +169,7 @@ class CustomOrdersTableController {
 	 * @return bool True if the feature is visible.
 	 */
 	public function is_feature_visible(): bool {
-		return $this->features_controller->feature_is_enabled( 'custom_order_tables' );
+		return true;
 	}
 
 	/**
@@ -179,24 +178,6 @@ class CustomOrdersTableController {
 	 * This method shouldn't be used anymore, see the FeaturesController class.
 	 */
 	public function show_feature() {
-		$class_and_method = ( new \ReflectionClass( $this ) )->getShortName() . '::' . __FUNCTION__;
-		wc_doing_it_wrong(
-			$class_and_method,
-			sprintf(
-				// translators: %1$s the name of the class and method used.
-				__( '%1$s: The visibility of the custom orders table feature is now handled by the WooCommerce features engine. See the FeaturesController class, or go to WooCommerce - Settings - Advanced - Features.', 'woocommerce' ),
-				$class_and_method
-			),
-			'7.0'
-		);
-	}
-
-	/**
-	 * Hides the feature, so that no entries will be added to the debug tools page.
-	 *
-	 * This method shouldn't be used anymore, see the FeaturesController class.
-	 */
-	public function hide_feature() {
 		$class_and_method = ( new \ReflectionClass( $this ) )->getShortName() . '::' . __FUNCTION__;
 		wc_doing_it_wrong(
 			$class_and_method,
@@ -326,7 +307,7 @@ class CustomOrdersTableController {
 	 */
 	private function delete_custom_orders_tables() {
 		if ( $this->custom_orders_table_usage_is_enabled() ) {
-			throw new \Exception( "Can't delete the custom orders tables: they are currently in use (via Settings > Advanced > Custom data stores)." );
+			throw new \Exception( "Can't delete the custom orders tables: they are currently in use (via Settings > Advanced > Features)." );
 		}
 
 		delete_option( self::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION );

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -5,6 +5,7 @@
 
 namespace Automattic\WooCommerce\Internal\DataStores\Orders;
 
+use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Caches\OrderCache;
 use Automattic\WooCommerce\Caches\OrderCacheController;
 use Automattic\WooCommerce\Internal\BatchProcessing\BatchProcessingController;
@@ -434,6 +435,11 @@ class CustomOrdersTableController {
 		if ( ! in_array( $feature_id, array( 'custom_order_tables', DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION ), true ) ) {
 			return $feature_setting;
 		}
+
+		if ( Constants::get_constant( 'WC_INSTALLING', false ) ) {
+			return $feature_setting;
+		}
+
 		$sync_status = $this->data_synchronizer->get_sync_status();
 		if ( 'custom_order_tables' === $feature_id ) {
 			return $this->get_hpos_setting_for_feature( $sync_status );
@@ -485,6 +491,12 @@ class CustomOrdersTableController {
 			$sync_message = sprintf(
 				// translators: %d: number of pending orders.
 				__( 'Currently syncing orders... %d pending', 'woocommerce' ),
+				$sync_status['current_pending_count']
+			);
+		} elseif ( $sync_status['current_pending_count'] > 0 ) {
+			$sync_message = sprintf(
+				// translators: %d: number of pending orders.
+				__( 'Sync %d pending orders. You can switch data storage for orders only when posts and orders table are in sync.', 'woocommerce' ),
 				$sync_status['current_pending_count']
 			);
 		}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -436,9 +436,9 @@ class CustomOrdersTableController {
 		}
 		$sync_status = $this->data_synchronizer->get_sync_status();
 		if ( 'custom_order_tables' === $feature_id ) {
-			return $this->get_hpos_enable_feature_setting( $sync_status );
+			return $this->get_hpos_setting_for_feature( $sync_status );
 		}
-		return $this->get_hpos_sync_enable_feature_setting( $sync_status );
+		return $this->get_hpos_setting_for_sync( $sync_status );
 	}
 
 	/**
@@ -448,7 +448,7 @@ class CustomOrdersTableController {
 	 *
 	 * @return array Feature setting object.
 	 */
-	private function get_hpos_enable_feature_setting( $sync_status ) {
+	private function get_hpos_setting_for_feature( $sync_status ) {
 		$hpos_enabled            = $this->custom_orders_table_usage_is_enabled();
 		$plugin_info             = $this->features_controller->get_compatible_plugins_for_feature( 'custom_order_tables' );
 		$plugin_incompat_warning = $this->plugin_util->generate_incompatible_plugin_feature_warning( 'custom_order_tables', $plugin_info );
@@ -477,7 +477,7 @@ class CustomOrdersTableController {
 	 *
 	 * @return array Feature setting object.
 	 */
-	private function get_hpos_sync_enable_feature_setting( $sync_status ) {
+	private function get_hpos_setting_for_sync( $sync_status ) {
 		$sync_in_progress = $this->batch_processing_controller->is_enqueued( get_class( $this->data_synchronizer ) );
 		$sync_enabled     = get_option( DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION );
 		$sync_message     = '';

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -34,11 +34,6 @@ class CustomOrdersTableController {
 	public const CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION = 'woocommerce_custom_orders_table_enabled';
 
 	/**
-	 * The name of the option that tells that the authoritative table must be flipped once sync finishes.
-	 */
-	private const AUTO_FLIP_AUTHORITATIVE_TABLE_ROLES_OPTION = 'woocommerce_auto_flip_authoritative_table_roles';
-
-	/**
 	 * The name of the option that tells whether database transactions are to be used or not for data synchronization.
 	 *
 	 * @deprecated We only use READ UNCOMMITTED isolation level, which provides us with correctness guarantee in new table, without locking post tables.
@@ -361,42 +356,10 @@ class CustomOrdersTableController {
 	}
 
 	/**
-	 * Handler for the synchronization finished hook.
-	 * Here we switch the authoritative table if needed.
-	 */
-	private function process_sync_finished() {
-		if ( ! $this->auto_flip_authoritative_table_enabled() ) {
-			return;
-		}
-
-		update_option( self::AUTO_FLIP_AUTHORITATIVE_TABLE_ROLES_OPTION, 'no' );
-
-		if ( $this->custom_orders_table_usage_is_enabled() ) {
-			update_option( self::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, 'no' );
-		} else {
-			update_option( self::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, 'yes' );
-		}
-	}
-
-	/**
-	 * Is the automatic authoritative table switch setting set?
-	 *
-	 * @return bool
-	 */
-	private function auto_flip_authoritative_table_enabled(): bool {
-		return get_option( self::AUTO_FLIP_AUTHORITATIVE_TABLE_ROLES_OPTION ) === 'yes';
-	}
-
-	/**
 	 * Handler for the all settings updated hook.
 	 */
 	private function process_options_updated() {
 		$data_sync_is_enabled = $this->data_synchronizer->data_sync_is_enabled();
-
-		// Disabling the sync implies disabling the automatic authoritative table switch too.
-		if ( ! $data_sync_is_enabled && $this->auto_flip_authoritative_table_enabled() ) {
-			update_option( self::AUTO_FLIP_AUTHORITATIVE_TABLE_ROLES_OPTION, 'no' );
-		}
 
 		// Enabling/disabling the sync implies starting/stopping it too, if needed.
 		// We do this check here, and not in process_pre_update_option, so that if for some reason

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -466,7 +466,7 @@ class CustomOrdersTableController {
 			'title'       => __( 'Data storage for orders', 'woocommerce' ),
 			'type'        => 'radio',
 			'options'     => array(
-				'no' => __( 'WordPress Post tables', 'woocommerce' ),
+				'no'  => __( 'WordPress Post tables', 'woocommerce' ),
 				'yes' => __( 'High performance order storage (new)', 'woocommerce' ),
 			),
 			'value'       => $hpos_enabled ? 'yes' : 'no',

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -248,9 +248,9 @@ class CustomOrdersTableController {
 			return $tools_array;
 		}
 
-		if ( $this->is_feature_visible() ) {
+		if ( $this->custom_orders_table_usage_is_enabled() || $this->data_synchronizer->data_sync_is_enabled() ) {
 			$disabled = true;
-			$message  = __( 'This will delete the custom orders tables. The tables can be deleted only if the "High-Performance order storage" feature is disabled (via Settings > Advanced > Features).', 'woocommerce' );
+			$message  = __( 'This will delete the custom orders tables. The tables can be deleted only if the "High-Performance order storage" is not authoritative and sync is disabled (via Settings > Advanced > Features).', 'woocommerce' );
 		} else {
 			$disabled = false;
 			$message  = __( 'This will delete the custom orders tables. To create them again enable the "High-Performance order storage" feature (via Settings > Advanced > Features).', 'woocommerce' );

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -514,10 +514,10 @@ class CustomOrdersTableController {
 				_n(
 					'Sync %d pending order. You can switch data storage for orders only when posts and orders table are in sync.',
 					'Sync %d pending orders. You can switch data storage for orders only when posts and orders table are in sync.',
+					$sync_status['current_pending_count'],
 					'woocommerce'
 				),
 				$sync_status['current_pending_count'],
-				'woocommerce'
 			);
 		}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -511,13 +511,13 @@ class CustomOrdersTableController {
 		} elseif ( $sync_status['current_pending_count'] > 0 ) {
 			$sync_message = sprintf(
 				// translators: %d: number of pending orders.
-				_n( 
-					'Sync %d pending order. You can switch data storage for orders only when posts and orders table are in sync.', 'woocommerce' ),
-					'Sync %d pending orders. You can switch data storage for orders only when posts and orders table are in sync.', 'woocommerce' ),
-					$sync_status['current_pending_count'],
+				_n(
+					'Sync %d pending order. You can switch data storage for orders only when posts and orders table are in sync.',
+					'Sync %d pending orders. You can switch data storage for orders only when posts and orders table are in sync.',
 					'woocommerce'
 				),
-				$sync_status['current_pending_count']
+				$sync_status['current_pending_count'],
+				'woocommerce'
 			);
 		}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -525,7 +525,7 @@ class CustomOrdersTableController {
 			'id'       => DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION,
 			'title'    => '',
 			'type'     => 'checkbox',
-			'desc'     => __( 'Keep posts and orders table in sync. (Compatibility mode)', 'woocommerce' ),
+			'desc'     => __( 'Keep the posts and orders tables in sync (compatibility mode).', 'woocommerce' ),
 			'value'    => $sync_enabled,
 			'desc_tip' => $sync_message,
 		);

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -481,7 +481,7 @@ class CustomOrdersTableController {
 			'title'       => __( 'Data storage for orders', 'woocommerce' ),
 			'type'        => 'radio',
 			'options'     => array(
-				'no'  => __( 'WordPress Post tables', 'woocommerce' ),
+				'no'  => __( 'WordPress post tables', 'woocommerce' ),
 				'yes' => __( 'High performance order storage (new)', 'woocommerce' ),
 			),
 			'value'       => $hpos_enabled ? 'yes' : 'no',

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -511,7 +511,12 @@ class CustomOrdersTableController {
 		} elseif ( $sync_status['current_pending_count'] > 0 ) {
 			$sync_message = sprintf(
 				// translators: %d: number of pending orders.
-				__( 'Sync %d pending orders. You can switch data storage for orders only when posts and orders table are in sync.', 'woocommerce' ),
+				_n( 
+					'Sync %d pending order. You can switch data storage for orders only when posts and orders table are in sync.', 'woocommerce' ),
+					'Sync %d pending orders. You can switch data storage for orders only when posts and orders table are in sync.', 'woocommerce' ),
+					$sync_status['current_pending_count'],
+					'woocommerce'
+				),
 				$sync_status['current_pending_count']
 			);
 		}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -28,7 +28,6 @@ class DataSynchronizer implements BatchProcessorInterface {
 
 	public const ORDERS_DATA_SYNC_ENABLED_OPTION           = 'woocommerce_custom_orders_table_data_sync_enabled';
 	private const INITIAL_ORDERS_PENDING_SYNC_COUNT_OPTION = 'woocommerce_initial_orders_pending_sync_count';
-	public const PENDING_SYNCHRONIZATION_FINISHED_ACTION   = 'woocommerce_orders_sync_finished';
 	public const PLACEHOLDER_ORDER_POST_TYPE               = 'shop_order_placehold';
 
 	public const DELETED_RECORD_META_KEY        = '_deleted_from';

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -34,6 +34,8 @@ class DataSynchronizer implements BatchProcessorInterface {
 	public const DELETED_FROM_POSTS_META_VALUE  = 'posts_table';
 	public const DELETED_FROM_ORDERS_META_VALUE = 'orders_table';
 
+	public const ORDERS_TABLE_CREATED = 'no';
+
 	private const ORDERS_SYNC_BATCH_SIZE = 250;
 
 	// Allowed values for $type in get_ids_of_orders_pending_sync method.
@@ -131,6 +133,7 @@ class DataSynchronizer implements BatchProcessorInterface {
 	 */
 	public function create_database_tables() {
 		$this->database_util->dbdelta( $this->data_store->get_database_schema() );
+		update_option( self::ORDERS_TABLE_CREATED, 'yes' );
 	}
 
 	/**
@@ -142,6 +145,7 @@ class DataSynchronizer implements BatchProcessorInterface {
 		foreach ( $table_names as $table_name ) {
 			$this->database_util->drop_database_table( $table_name );
 		}
+		delete_option( self::ORDERS_TABLE_CREATED );
 	}
 
 	/**
@@ -627,9 +631,7 @@ ORDER BY orders.id ASC
 			return;
 		}
 
-		$features_controller = wc_get_container()->get( FeaturesController::class );
-		$feature_is_enabled  = $features_controller->feature_is_enabled( 'custom_order_tables' );
-		if ( ! $feature_is_enabled ) {
+		if ( 'yes' !== get_option( self::ORDERS_TABLE_CREATED ) ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1050,7 +1050,7 @@ WHERE
 			return;
 		}
 
-		$data_sync_enabled = $data_synchronizer->data_sync_is_enabled() && 0 === $data_synchronizer->get_current_orders_pending_sync_count_cached();
+		$data_sync_enabled = $data_synchronizer->data_sync_is_enabled();
 		$load_posts_for    = array_diff( $order_ids, self::$reading_order_ids );
 		$post_orders       = $data_sync_enabled ? $this->get_post_orders_for_ids( array_intersect_key( $orders, array_flip( $load_posts_for ) ) ) : array();
 

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/OrdersDataStoreServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/OrdersDataStoreServiceProvider.php
@@ -21,6 +21,7 @@ use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStoreMeta;
 use Automattic\WooCommerce\Internal\Features\FeaturesController;
 use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
+use Automattic\WooCommerce\Utilities\PluginUtil;
 
 /**
  * Service provider for the classes in the Internal\DataStores\Orders namespace.
@@ -69,6 +70,7 @@ class OrdersDataStoreServiceProvider extends AbstractServiceProvider {
 				FeaturesController::class,
 				OrderCache::class,
 				OrderCacheController::class,
+				PluginUtil::class,
 			)
 		);
 		$this->share( OrderCache::class );

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -9,6 +9,7 @@ use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Internal\Admin\Analytics;
 use Automattic\WooCommerce\Admin\Features\Navigation\Init;
 use Automattic\WooCommerce\Admin\Features\NewProductManagementExperience;
+use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
 use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer;
 use Automattic\WooCommerce\Internal\Traits\AccessiblePrivateMethods;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
@@ -472,7 +473,15 @@ class FeaturesController {
 		$matches = array();
 		$success = preg_match( '/^woocommerce_feature_([a-zA-Z0-9_]+)_enabled$/', $option, $matches );
 
-		if ( ! $success && Analytics::TOGGLE_OPTION_NAME !== $option && Init::TOGGLE_OPTION_NAME !== $option && NewProductManagementExperience::TOGGLE_OPTION_NAME !== $option ) {
+		$known_features = array(
+			Analytics::TOGGLE_OPTION_NAME,
+			Init::TOGGLE_OPTION_NAME,
+			NewProductManagementExperience::TOGGLE_OPTION_NAME,
+			DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION,
+			CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION,
+		);
+
+		if ( ! $success && ! in_array( $option, $known_features, true ) ) {
 			return;
 		}
 
@@ -484,6 +493,8 @@ class FeaturesController {
 			$feature_id = 'analytics';
 		} elseif ( Init::TOGGLE_OPTION_NAME === $option ) {
 			$feature_id = 'new_navigation';
+		} elseif ( in_array( $option, $known_features, true ) ) {
+			$feature_id = $option;
 		} else {
 			$feature_id = $matches[1];
 		}

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -112,7 +112,9 @@ class FeaturesController {
 				'disable_ui'      => false,
 			),
 			// Options HPOS features are added in CustomOrdersTableController to keep the logic in same place.
-			'custom_order_tables'  => array(),
+			'custom_order_tables'  => array(
+				'name' => __( 'High performance order storage', 'woocommerce' ),
+			),
 			$hpos_enable_sync      => array(),
 			'cart_checkout_blocks' => array(
 				'name'            => __( 'Cart & Checkout Blocks', 'woocommerce' ),

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -115,7 +115,9 @@ class FeaturesController {
 			'custom_order_tables'  => array(
 				'name' => __( 'High performance order storage', 'woocommerce' ),
 			),
-			$hpos_enable_sync      => array(),
+			$hpos_enable_sync      => array(
+				'name' => '',
+			),
 			'cart_checkout_blocks' => array(
 				'name'            => __( 'Cart & Checkout Blocks', 'woocommerce' ),
 				'description'     => __( 'Optimize for faster checkout', 'woocommerce' ),
@@ -552,7 +554,7 @@ class FeaturesController {
 		$experimental_feature_ids = array_filter(
 			$feature_ids,
 			function( $feature_id ) use ( $features ) {
-				return $features[ $feature_id ]['is_experimental'];
+				return $features[ $feature_id ]['is_experimental'] ?? false;
 			}
 		);
 		$mature_feature_ids       = array_diff( $feature_ids, $experimental_feature_ids );

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -565,10 +565,8 @@ class FeaturesController {
 				 *
 				 * @param bool $disabled False.
 				 */
-				$additional_features = apply_filters( 'woocommerce_settings_features', $features );
+				$feature_settings = apply_filters( 'woocommerce_settings_features', $feature_settings );
 				// phpcs:enable WooCommerce.Commenting.CommentHooks.MissingSinceComment
-
-				$feature_settings = array_merge( $feature_settings, $additional_features );
 
 				if ( ! empty( $experimental_feature_ids ) ) {
 					$feature_settings[] = array(

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -717,6 +717,16 @@ class FeaturesController {
 		/**
 		 * Allows to modify feature setting that will be used to render in the feature page.
 		 *
+		 * @param array $feature_setting The feature setting. Describes the feature:
+		 * 		- title: The title of the feature.
+		 * 		- desc: The description of the feature. Will be displayed under the title.
+		 * 		- type: The type of the feature. Could be any of supported settings types from `WC_Admin_Settings::output_fields`, but if it's anything other than checkbox or radio, it will need custom handling.
+		 * 		- id: The id of the feature. Will be used as the name of the setting.
+		 * 		- disabled: Whether the feature is disabled or not.
+		 * 		- desc_tip: The description tip of the feature. Will be displayed as a tooltip next to the description.
+		 * 		- tooltip: The tooltip of the feature. Will be displayed as a tooltip next to the name.
+		 * 		- default: The default value of the feature.
+		 * @param string $feature_id The id of the feature.
 		 * @since 8.0.0
 		 */
 		return apply_filters( 'woocommerce_feature_setting', $feature_setting, $feature_id );

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -115,7 +115,7 @@ class FeaturesController {
 			),
 			// Options for HPOS features are added in CustomOrdersTableController to keep the logic in same place.
 			'custom_order_tables'  => array( // This exists for back-compat, otherwise is always enabled and hidden from WC 8.0.
-				'name'               => '',
+				'name'               => __( 'High-Performance order storage (COT)', 'woocommerce' ),
 				'enabled_by_default' => true,
 			),
 			$hpos_authoritative    => array(

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -417,13 +417,16 @@ class FeaturesController {
 	 * @return string The option that enables or disables the feature.
 	 */
 	public function feature_enable_option_name( string $feature_id ): string {
-		if ( 'analytics' === $feature_id ) {
-			return Analytics::TOGGLE_OPTION_NAME;
-		} elseif ( 'new_navigation' === $feature_id ) {
-			return Init::TOGGLE_OPTION_NAME;
+		switch ( $feature_id ) {
+			case 'analytics':
+				return Analytics::TOGGLE_OPTION_NAME;
+			case 'new_navigation':
+				return Init::TOGGLE_OPTION_NAME;
+			case 'custom_order_tables':
+				return CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION;
+			default:
+				return "woocommerce_feature_{$feature_id}_enabled";
 		}
-
-		return "woocommerce_feature_{$feature_id}_enabled";
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -718,14 +718,14 @@ class FeaturesController {
 		 * Allows to modify feature setting that will be used to render in the feature page.
 		 *
 		 * @param array $feature_setting The feature setting. Describes the feature:
-		 * 		- title: The title of the feature.
-		 * 		- desc: The description of the feature. Will be displayed under the title.
-		 * 		- type: The type of the feature. Could be any of supported settings types from `WC_Admin_Settings::output_fields`, but if it's anything other than checkbox or radio, it will need custom handling.
-		 * 		- id: The id of the feature. Will be used as the name of the setting.
-		 * 		- disabled: Whether the feature is disabled or not.
-		 * 		- desc_tip: The description tip of the feature. Will be displayed as a tooltip next to the description.
-		 * 		- tooltip: The tooltip of the feature. Will be displayed as a tooltip next to the name.
-		 * 		- default: The default value of the feature.
+		 *      - title: The title of the feature.
+		 *      - desc: The description of the feature. Will be displayed under the title.
+		 *      - type: The type of the feature. Could be any of supported settings types from `WC_Admin_Settings::output_fields`, but if it's anything other than checkbox or radio, it will need custom handling.
+		 *      - id: The id of the feature. Will be used as the name of the setting.
+		 *      - disabled: Whether the feature is disabled or not.
+		 *      - desc_tip: The description tip of the feature. Will be displayed as a tooltip next to the description.
+		 *      - tooltip: The tooltip of the feature. Will be displayed as a tooltip next to the name.
+		 *      - default: The default value of the feature.
 		 * @param string $feature_id The id of the feature.
 		 * @since 8.0.0
 		 */

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -91,7 +91,8 @@ class FeaturesController {
 	 * Creates a new instance of the class.
 	 */
 	public function __construct() {
-		$hpos_enable_sync = DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION;
+		$hpos_enable_sync   = DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION;
+		$hpos_authoritative = CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION;
 		$features         = array(
 			'analytics'            => array(
 				'name'               => __( 'Analytics', 'woocommerce' ),
@@ -112,8 +113,12 @@ class FeaturesController {
 				'is_experimental' => true,
 				'disable_ui'      => false,
 			),
-			// Options HPOS features are added in CustomOrdersTableController to keep the logic in same place.
-			'custom_order_tables'  => array(
+			// Options for HPOS features are added in CustomOrdersTableController to keep the logic in same place.
+			'custom_order_tables'  => array( // This exists for back-compat, otherwise is always enabled and hidden from WC 8.0.
+				'name'               => '',
+				'enabled_by_default' => true,
+			),
+			$hpos_authoritative    => array(
 				'name' => __( 'High performance order storage', 'woocommerce' ),
 			),
 			$hpos_enable_sync      => array(

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -93,7 +93,7 @@ class FeaturesController {
 	public function __construct() {
 		$hpos_enable_sync   = DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION;
 		$hpos_authoritative = CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION;
-		$features         = array(
+		$features           = array(
 			'analytics'            => array(
 				'name'               => __( 'Analytics', 'woocommerce' ),
 				'description'        => __( 'Enables WooCommerce Analytics', 'woocommerce' ),

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -114,9 +114,9 @@ class FeaturesController {
 				'disable_ui'      => false,
 			),
 			// Options for HPOS features are added in CustomOrdersTableController to keep the logic in same place.
-			'custom_order_tables'  => array( // This exists for back-compat, otherwise is always enabled and hidden from WC 8.0.
+			'custom_order_tables'  => array( // This exists for back-compat only, otherwise it's value is superseded by $hpos_authoritative option.
 				'name'               => __( 'High-Performance order storage (COT)', 'woocommerce' ),
-				'enabled_by_default' => true,
+				'enabled_by_default' => false,
 			),
 			$hpos_authoritative    => array(
 				'name' => __( 'High performance order storage', 'woocommerce' ),
@@ -232,7 +232,8 @@ class FeaturesController {
 		}
 
 		$default_value = $this->feature_is_enabled_by_default( $feature_id ) ? 'yes' : 'no';
-		return 'yes' === get_option( $this->feature_enable_option_name( $feature_id ), $default_value );
+		$value         = 'yes' === get_option( $this->feature_enable_option_name( $feature_id ), $default_value );
+		return $value;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Utilities/DatabaseUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/DatabaseUtil.php
@@ -33,8 +33,11 @@ class DatabaseUtil {
 	 * @return array An array containing the names of the tables that currently don't exist in the database.
 	 */
 	public function get_missing_tables( string $creation_queries ): array {
-		$dbdelta_output = $this->dbdelta( $creation_queries, false );
-		$parsed_output  = $this->parse_dbdelta_output( $dbdelta_output );
+		global $wpdb;
+		$suppress_errors = $wpdb->suppress_errors( true );
+		$dbdelta_output  = $this->dbdelta( $creation_queries, false );
+		$wpdb->suppress_errors( $suppress_errors );
+		$parsed_output = $this->parse_dbdelta_output( $dbdelta_output );
 		return $parsed_output['created_tables'];
 	}
 

--- a/plugins/woocommerce/src/Utilities/PluginUtil.php
+++ b/plugins/woocommerce/src/Utilities/PluginUtil.php
@@ -219,8 +219,12 @@ class PluginUtil {
 				),
 				admin_url( 'plugins.php' )
 			);
-			/* translators: %s = URL of the plugins page */
-			$extra_desc_tip = sprintf( __( "<br><a href='%s'>View and manage</a>", 'woocommerce' ), $incompatible_plugins_url );
+			/* translators: %1$s opening link tag %2$s closing link tag. */
+			$extra_desc_tip = '<br>' . sprintf( 
+				__( '%1$sView and manage%2$s', 'woocommerce' ), 
+				'<a href="' . esc_url( $incompatible_plugins_url ) . '">',
+				'</a>'
+			);
 
 			$feature_warning .= $extra_desc_tip;
 

--- a/plugins/woocommerce/src/Utilities/PluginUtil.php
+++ b/plugins/woocommerce/src/Utilities/PluginUtil.php
@@ -219,9 +219,9 @@ class PluginUtil {
 				),
 				admin_url( 'plugins.php' )
 			);
-			/* translators: %1$s opening link tag %2$s closing link tag. */
-			$extra_desc_tip = '<br>' . sprintf( 
-				__( '%1$sView and manage%2$s', 'woocommerce' ), 
+			$extra_desc_tip           = '<br>' . sprintf(
+				/* translators: %1$s opening link tag %2$s closing link tag. */
+				__( '%1$sView and manage%2$s', 'woocommerce' ),
 				'<a href="' . esc_url( $incompatible_plugins_url ) . '">',
 				'</a>'
 			);

--- a/plugins/woocommerce/src/Utilities/PluginUtil.php
+++ b/plugins/woocommerce/src/Utilities/PluginUtil.php
@@ -199,7 +199,7 @@ class PluginUtil {
 			} else {
 
 				$feature_warning = sprintf(
-				/* translators: %1\$s, %2\$s = printable plugin names, %3\$d = plugins count */
+					/* translators: %1\$s, %2\$s = printable plugin names, %3\$d = plugins count */
 					_n(
 						'⚠ Incompatible plugins detected (%1$s, %2$s and %3$d other).',
 						'⚠ Incompatible plugins detected (%1$s and %2$s plugins and %3$d others).',

--- a/plugins/woocommerce/src/Utilities/PluginUtil.php
+++ b/plugins/woocommerce/src/Utilities/PluginUtil.php
@@ -191,7 +191,7 @@ class PluginUtil {
 				$feature_warning = sprintf( __( '⚠ 1 Incompatible plugin detected (%s).', 'woocommerce' ), $this->get_plugin_name( $incompatibles[0] ) );
 			} elseif ( 2 === $incompatible_count ) {
 				$feature_warning = sprintf(
-				/* translators: %1\$s, %2\$s = printable plugin names */
+					/* translators: %1\$s, %2\$s = printable plugin names */
 					__( '⚠ 2 Incompatible plugins detected (%1$s and %2$s).', 'woocommerce' ),
 					$this->get_plugin_name( $incompatibles[0] ),
 					$this->get_plugin_name( $incompatibles[1] )

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Helpers/OrderHelper.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Helpers/OrderHelper.php
@@ -164,6 +164,7 @@ class OrderHelper {
 		$features_controller->change_feature_enable( 'custom_order_tables', $enabled );
 
 		update_option( CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, wc_bool_to_string( $enabled ) );
+		wp_cache_flush();
 
 		// Confirm things are really correct.
 		$wc_data_store = WC_Data_Store::load( 'order' );

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Helpers/OrderHelper.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Helpers/OrderHelper.php
@@ -168,7 +168,6 @@ class OrderHelper {
 		// Confirm things are really correct.
 		$wc_data_store = WC_Data_Store::load( 'order' );
 		assert( is_a( $wc_data_store->get_current_class_name(), OrdersTableDataStore::class, true ) === $enabled );
-		$wpdb->query( 'commit' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Helpers/OrderHelper.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Helpers/OrderHelper.php
@@ -159,6 +159,7 @@ class OrderHelper {
 	 * @return void
 	 */
 	public static function toggle_cot_feature_and_usage( bool $enabled ) {
+		global $wpdb;
 		$features_controller = wc_get_container()->get( Featurescontroller::class );
 		$features_controller->change_feature_enable( 'custom_order_tables', $enabled );
 
@@ -167,6 +168,7 @@ class OrderHelper {
 		// Confirm things are really correct.
 		$wc_data_store = WC_Data_Store::load( 'order' );
 		assert( is_a( $wc_data_store->get_current_class_name(), OrdersTableDataStore::class, true ) === $enabled );
+		$wpdb->query( 'commit' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Helpers/OrderHelper.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Helpers/OrderHelper.php
@@ -143,8 +143,6 @@ class OrderHelper {
 	 * Helper method to drop custom tables if present.
 	 */
 	public static function delete_order_custom_tables() {
-		$features_controller = wc_get_container()->get( Featurescontroller::class );
-		$features_controller->change_feature_enable( 'custom_order_tables', true );
 		$synchronizer = wc_get_container()
 			->get( DataSynchronizer::class );
 		if ( $synchronizer->check_orders_table_exists() ) {
@@ -175,9 +173,6 @@ class OrderHelper {
 	 * Helper method to create custom tables if not present.
 	 */
 	public static function create_order_custom_table_if_not_exist() {
-		$features_controller = wc_get_container()->get( Featurescontroller::class );
-		$features_controller->change_feature_enable( 'custom_order_tables', true );
-
 		$synchronizer = wc_get_container()->get( DataSynchronizer::class );
 		if ( ! $synchronizer->check_orders_table_exists() ) {
 			$synchronizer->create_database_tables();

--- a/plugins/woocommerce/tests/php/helpers/HPOSToggleTrait.php
+++ b/plugins/woocommerce/tests/php/helpers/HPOSToggleTrait.php
@@ -54,7 +54,7 @@ trait HPOSToggleTrait {
 	 * @param bool $cot_authoritative True to set the orders table as authoritative, false to set the posts table as authoritative.
 	 */
 	protected function toggle_cot_authoritative( bool $cot_authoritative ) {
-		update_option( CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, wc_bool_to_string( $cot_authoritative ) );
+		OrderHelper::toggle_cot_feature_and_usage( $cot_authoritative );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-advanced-test.php
+++ b/plugins/woocommerce/tests/php/includes/settings/class-wc-settings-advanced-test.php
@@ -33,10 +33,6 @@ class WC_Settings_Advanced_Test extends WC_Settings_Unit_Test_Case {
 			'features',
 		);
 
-		if ( wc_get_container()->get( CustomOrdersTableController::class )->is_feature_visible() ) {
-			$expected[] = 'custom_data_stores';
-		}
-
 		$this->assertEquals( $expected, $section_names );
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
@@ -33,9 +33,7 @@ class DataSynchronizerTests extends HposTestCase {
 		OrderHelper::delete_order_custom_tables(); // We need this since non-temporary tables won't drop automatically.
 		OrderHelper::create_order_custom_table_if_not_exist();
 		OrderHelper::toggle_cot_feature_and_usage( false );
-		$this->sut           = wc_get_container()->get( DataSynchronizer::class );
-		$features_controller = wc_get_container()->get( Featurescontroller::class );
-		$features_controller->change_feature_enable( 'custom_order_tables', true );
+		$this->sut = wc_get_container()->get( DataSynchronizer::class );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR makes the following changes to the feature-enabling flow for HPOS:

### Setting for specifying transactions is removed

Since many merchants would not be able to take an informed decision about which transaction setting to use (and whether to use transactions in the first place), this PR

1. Removes the setting to select the transaction and enabled it for everyone by default in `READ UNCOMMITTED` mode.
2. Reduces the scope of the transaction so that only insert and update statements of the batch are enclosed in a transaction. Currently, select statements (on the posts table) were also enclosed and therefore locks the post table for the duration of the transaction, which is something that is now avoided.

### Dedicated feature setting page is now folded into the feature controller page itself.

Currently, we have a dedicated feature setting page, which is now removed and folded into the features setting page itself so that merchant won't have to navigate to yet another screen to enable disable the feature.

### HPOS feature is elevated to stable and reduced the severity of warning messages

Currently, we have marked HPOS as experimental, however with this PR we have marked it as stable, and also reduced the severity of warning messages that we are showing.

So with this PR, the feature page will look like this:

When HPOS tables are authoritative

![Screenshot 2023-07-07 at 6 59 12 PM](https://github.com/woocommerce/woocommerce/assets/7571618/a9d0872b-3897-4967-8f54-d89e4a9152ba)

When post tables are authoritative (and incompatible plugins + un-synced orders are present)

![Screenshot 2023-07-07 at 6 57 32 PM](https://github.com/woocommerce/woocommerce/assets/7571618/41cc8941-9789-4102-827d-9792901c7564)




Closes #34975 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Pre-testing**
1. Start with a new show as this flow will be best tested when we start with a new shop on this branch. Alternatively, to start with the existing shop, switch to post tables, disable the sync, and drop the tables created for HPOS.
2. Create some products and some orders.
3. Add a dummy incompatible plugin. To do this create a new file called incompatible.php with the following contents and upload it to the site and activate the plugin
```php
<?php
/**
 * Plugin Name: Incompatible
 * WC requires at least: 5.0.0
 * WC tested up to: 7.4.0
 */

/**
 * Declare HPOS (in)compatibility.
 */
add_action( 'before_woocommerce_init', function() {
	if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
		\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, false );
	}
} );

```


**Actual testing**
1. After completing pre-testing, let's go to WooCommerce > Settings> Advanced > Features. You should see the HPOS setting right on this screen.
2. Check that option to enable HPOS is disabled with the warning about incompatible plugins and unsynced order.
3. Start the sync, and test that it completes after some time.
4. Once sync is complete, go to the screen now, the warning about unsynced orders should go away.
5. Go the plugins screen and disable the test plugin that we uploaded.
6. Come back to the WooCommerce > Settings> Advanced > Features, option to enable HPOS should now be available.
7. Test that you can enable HPOS, go to the orders page and check that orders are listed as expected.

Please also refer to additional scenarios covered [in this comment](https://github.com/woocommerce/woocommerce/pull/38993#issuecomment-1630964276).

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement

#### Message <!-- Add a changelog message here -->

Refresh the HPOS enable UX flow for better clarity.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
