### PR TITLE
Adding tracks events indicating visibility for ai features

### DIFF
--- a/plugins/woo-ai/changelog/add-view-tracks-events-39004
+++ b/plugins/woo-ai/changelog/add-view-tracks-events-39004
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Adding tracks events to indicate view for ai features.

--- a/plugins/woo-ai/src/product-description/product-description-button-container.tsx
+++ b/plugins/woo-ai/src/product-description/product-description-button-container.tsx
@@ -113,6 +113,10 @@ export function WriteItForMeButtonContainer() {
 		};
 	}, [ titleEl ] );
 
+	useEffect( () => {
+		recordDescriptionTracks( 'view_button' );
+	}, [] );
+
 	const writeItForMeEnabled =
 		! fetching && productTitle.length >= MIN_TITLE_LENGTH_FOR_DESCRIPTION;
 

--- a/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
+++ b/plugins/woo-ai/src/product-name/product-name-suggestions.tsx
@@ -52,6 +52,7 @@ export const ProductNameSuggestions = () => {
 		useState< SuggestionsState >( SuggestionsState.None );
 	const [ isFirstLoad, setIsFirstLoad ] = useState< boolean >( true );
 	const [ visible, setVisible ] = useState< boolean >( false );
+	const [ viewed, setViewed ] = useState< boolean >( false );
 	const [ suggestions, setSuggestions ] = useState< ProductDataSuggestion[] >(
 		[]
 	);
@@ -63,6 +64,13 @@ export const ProductNameSuggestions = () => {
 	const [ productName, setProductName ] = useState< string >(
 		nameInputRef.current?.value || ''
 	);
+
+	useEffect( () => {
+		if ( visible === true && viewed === false ) {
+			setViewed( true );
+			recordNameTracks( 'view_ui' );
+		}
+	}, [ visible, viewed ] );
 
 	useEffect( () => {
 		const nameInput = nameInputRef.current;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

To better capture usage percentages in terms of our AI features, we're adding a couple tracks events to indicate when the associated UI for the title suggestions or the "Write with AI" button for the description is displayed.

For the title suggestions, this is fired only once per page view, when the ui below the title field is displayed.

For the description, it's fired when the "Write with AI" button is displayed, which is normally on page load.

Closes #[39004](https://github.com/woocommerce/woocommerce/issues/39004) .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout branch.
2.  Open console and enter `localStorage.setItem( 'debug', '*tracks*' );` to view tracks events.
3. Navigate to Products -> Add new.
4. You should see that the "Write with AI button" is displayed, and the `wcadmin_woo_ai_product_description_completion_view_button` event is fired.
5. Focus the product title field.
6. You should see the box appear below the field, and the `wcadmin_woo_ai_product_name_completion_view_ui` tracks event fired.

<!-- End testing instructions -->
