### PR TITLE
Package release: Handle new package validation

### DIFF
--- a/.github/workflows/prepare-package-release.yml
+++ b/.github/workflows/prepare-package-release.yml
@@ -3,7 +3,7 @@ on:
     workflow_dispatch:
         inputs:
             packages:
-                description: 'Enter a specific package to release, or packages separated by commas, ie @woocommerce/components,@woocommerce/number. Leaving this input to the default "-a" will prepare to release all eligible packages. When releasing a package for the first time, pass the "--initialRelease" flag.'
+                description: 'Enter a specific package to release, or packages separated by commas, ie @woocommerce/components,@woocommerce/number. Leaving this input to the default "-a" will prepare to release all eligible packages.'
                 required: false
                 default: '-a'
 

--- a/tools/package-release/README.md
+++ b/tools/package-release/README.md
@@ -2,6 +2,8 @@
 
 When a package contains sufficient changes to justify a release to [NPM](https://www.npmjs.com/), follow these instructions to create a new release from the monorepo.
 
+Below are instructions for releasing using Github Workflows (recommended) and the command line. When releasing packages for the first time, release from the command line.
+
 ## Release packages using Github Workflows (recommended)
 
 ### Prepare packages
@@ -36,7 +38,7 @@ In order to prepare a package for release, a changelog will need to be compiled 
 ./tools/package-release/bin/dev prepare -a
 ```
 
-When making an initial release for a new package, pass the `--initialRelease` flag to signify a new release for a new package.
+When making an initial release for a new package, pass the `--initial-release` flag to signify a new release for a new package.
 
 2. Create a pull request with the resulting changes and merge it.
 
@@ -47,6 +49,8 @@ See more about the prepare script using `./tools/package-release/bin/dev publish
 1. Pull down the latest commits from Github.
 
 2. Run the release script from monorepo root, first as a dry run.
+
+When making an initial release for a new package, pass the `--initial-release` flag to signify a new release for a new package.
 
 ```
 ./tools/package-release/bin/dev publish -a --dry-run

--- a/tools/package-release/src/commands/prepare/index.ts
+++ b/tools/package-release/src/commands/prepare/index.ts
@@ -49,7 +49,7 @@ export default class PackagePrepare extends Command {
 			default: false,
 			description: 'Perform prepare function on all packages.',
 		} ),
-		initialRelease: Flags.boolean( {
+		'initial-release': Flags.boolean( {
 			default: false,
 			description: "Create a package's first release to NPM",
 		} ),
@@ -72,7 +72,7 @@ export default class PackagePrepare extends Command {
 
 		const packages = args.packages.split( ',' );
 
-		if ( flags.initialRelease && packages.length > 1 ) {
+		if ( flags[ 'initial-release' ] && packages.length > 1 ) {
 			this.error(
 				'Please release only a single package when making an initial release'
 			);
@@ -82,7 +82,7 @@ export default class PackagePrepare extends Command {
 			validatePackage( name, ( e: string ): void => this.error( e ) )
 		);
 
-		await this.preparePackages( packages, flags.initialRelease );
+		await this.preparePackages( packages, flags[ 'initial-release' ] );
 	}
 
 	/**

--- a/tools/package-release/src/commands/publish/index.ts
+++ b/tools/package-release/src/commands/publish/index.ts
@@ -59,6 +59,10 @@ export default class PackageRelease extends Command {
 			description: 'Skip pnpm install',
 			default: false,
 		} ),
+		initialRelease: Flags.boolean( {
+			default: false,
+			description: "Create a package's first release to NPM",
+		} ),
 	};
 
 	/**
@@ -112,13 +116,17 @@ export default class PackageRelease extends Command {
 	 */
 	private publishPackages(
 		packages: Array< string >,
-		{ 'dry-run': dryRun, branch }: { 'dry-run': boolean; branch: string }
+		{
+			'dry-run': dryRun,
+			branch,
+			initialRelease,
+		}: { 'dry-run': boolean; branch: string; initialRelease: boolean }
 	) {
 		packages.forEach( ( name ) => {
 			try {
 				const verb = dryRun ? 'Performing dry run of' : 'Publishing';
 				CliUx.ux.action.start( `${ verb } ${ name }` );
-				if ( isValidUpdate( name ) ) {
+				if ( isValidUpdate( name, initialRelease ) ) {
 					const cwd = getFilepathFromPackageName( name );
 					execSync(
 						`SKIP_TURBO=true pnpm publish ${

--- a/tools/package-release/src/commands/publish/index.ts
+++ b/tools/package-release/src/commands/publish/index.ts
@@ -59,7 +59,7 @@ export default class PackageRelease extends Command {
 			description: 'Skip pnpm install',
 			default: false,
 		} ),
-		initialRelease: Flags.boolean( {
+		'initial-release': Flags.boolean( {
 			default: false,
 			description: "Create a package's first release to NPM",
 		} ),
@@ -119,8 +119,8 @@ export default class PackageRelease extends Command {
 		{
 			'dry-run': dryRun,
 			branch,
-			initialRelease,
-		}: { 'dry-run': boolean; branch: string; initialRelease: boolean }
+			'initial-release': initialRelease,
+		}: { 'dry-run': boolean; branch: string; 'initial-release': boolean }
 	) {
 		packages.forEach( ( name ) => {
 			try {

--- a/tools/package-release/src/validate.ts
+++ b/tools/package-release/src/validate.ts
@@ -130,10 +130,14 @@ export const validatePackage = (
 /**
  * Determine if an update is valid by comparing version numbers.
  *
- * @param {string} name package name.
+ * @param {string}  name           package name.
+ * @param {boolean} initialRelease is package has not been released yet.
  * @return {boolean} If an update is valid.
  */
-export const isValidUpdate = ( name: string ): boolean => {
+export const isValidUpdate = (
+	name: string,
+	initialRelease: boolean
+): boolean => {
 	const packageJson = getPackageJson( name );
 
 	if ( ! packageJson ) {
@@ -144,6 +148,10 @@ export const isValidUpdate = ( name: string ): boolean => {
 
 	if ( ! nextVersion ) {
 		return false;
+	}
+
+	if ( initialRelease ) {
+		return true;
 	}
 
 	const npmVersion = execSync( `pnpm view ${ name } version`, {

--- a/tools/package-release/src/validate.ts
+++ b/tools/package-release/src/validate.ts
@@ -131,7 +131,7 @@ export const validatePackage = (
  * Determine if an update is valid by comparing version numbers.
  *
  * @param {string}  name           package name.
- * @param {boolean} initialRelease is package has not been released yet.
+ * @param {boolean} initialRelease if package has not been released yet.
  * @return {boolean} If an update is valid.
  */
 export const isValidUpdate = (


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Packages are being validated using `pnpm view` before being published. This doesn't work on initial package publish because it doesn't exist in the registry.

This PR adds a flag `--initial-release` to skip this part of validation.

This PR also changes the flag in the `prepare` script from `initialRelease` to `initial-release` to keep consistent casing amongst CLI options.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Pull this branch down (`fix/package-release-initial0-view`)
2. Since `@woocommerce/create-product-editor-block` has already been prepared, but not released, try a dry run to release it using the new `--initial-release` flag.
```
./tools/package-release/bin/dev publish @woocommerce/create-product-editor-block --dry-run --initial-release --branch=fix/package-release-initial0-view
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
