### PR TITLE
E2e: fix order emails

### DIFF
--- a/plugins/woocommerce/.wp-env.json
+++ b/plugins/woocommerce/.wp-env.json
@@ -24,7 +24,7 @@
                 ".",
                 "https://downloads.wordpress.org/plugin/akismet.zip",
                 "https://github.com/WP-API/Basic-Auth/archive/master.zip",
-                "https://downloads.wordpress.org/plugin/wp-mail-logging.1.11.2.zip"
+                "https://downloads.wordpress.org/plugin/wp-mail-logging.zip"
             ],
             "themes": [
                 "https://downloads.wordpress.org/theme/twentynineteen.zip"

--- a/plugins/woocommerce/changelog/e2e-fix-order-emails-tests
+++ b/plugins/woocommerce/changelog/e2e-fix-order-emails-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update locators in `order-emails` spec, and use the latest version of WP Mail Logging.

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-emails.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-emails.spec.js
@@ -104,12 +104,16 @@ test.describe( 'Merchant > Order Action emails received', () => {
 				customerBilling.email
 			) }`
 		);
-		await expect( page.locator( 'td.column-receiver' ) ).toContainText(
-			admin.email
-		);
-		await expect( page.locator( 'td.column-subject' ) ).toContainText(
-			`[${ storeName }]: New order #${ orderId }`
-		);
+
+		// Expect row containing the admin email and the correct subject to be listed.
+		await expect(
+			page
+				.getByRole( 'row' )
+				.filter( { hasText: admin.email } )
+				.filter( {
+					hasText: `[${ storeName }]: New order #${ orderId }`,
+				} )
+		).toBeVisible();
 	} );
 
 	test( 'can email invoice/order details to customer', async ( { page } ) => {
@@ -127,11 +131,15 @@ test.describe( 'Merchant > Order Action emails received', () => {
 				customerBilling.email
 			) }`
 		);
-		await expect( page.locator( 'td.column-receiver' ) ).toContainText(
-			customerBilling.email
-		);
-		await expect( page.locator( 'td.column-subject' ) ).toContainText(
-			`Invoice for order #${ orderId } on ${ storeName }`
-		);
+
+		// Expect row containing the billing email and the correct subject to be listed.
+		await expect(
+			page
+				.getByRole( 'row' )
+				.filter( { hasText: customerBilling.email } )
+				.filter( {
+					hasText: `Invoice for order #${ orderId } on ${ storeName }`,
+				} )
+		).toBeVisible();
 	} );
 } );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-emails.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-emails.spec.js
@@ -54,8 +54,8 @@ test.describe( 'Merchant > Order Action emails received', () => {
 			consumerSecret: process.env.CONSUMER_SECRET,
 			version: 'wc/v3',
 		} );
-		await api.delete( `orders/${ orderId }`, { force: true } );
-		await api.delete( `orders/${ newOrderId }`, { force: true } );
+
+		await api.post( `orders/batch`, { delete: [ orderId, newOrderId ] } );
 	} );
 
 	test( 'can receive new order email', async ( { page, baseURL } ) => {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/39012.

This PR does three things:
1. Start using the latest version of WP Mail Logging plugin.
2. Address the failures in `order-emails.spec.js` originally discovered in https://github.com/woocommerce/woocommerce/issues/38856
3. Fix an issue in `order-emails.spec.js` where the afterAll hook fails when trying to delete a test order from a test that wasn't run.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Assuming you already have your local wp-env set up:

1. Make sure your local site doesn't have any test orders. Delete them if it happened to have some lying around.
2. Run `order-emails.spec.js` about three times to ensure it isn't flaky. You can do this through the command
    ```bash
    pnpm test:e2e-pw order-emails.spec.js --repeat-each=3 --workers=1
    ```
    It's important to set `--workers=1` to prevent a single test block, say `can receive new order email` from being run in parallel with its duplicate.
1. Make sure that no test orders were left. This ensures that the [batch deleting](https://github.com/woocommerce/woocommerce/pull/39013/commits/a946f642392ef85724c67e4ecadf445c2c0885f2) of test orders worked.
2. Run each test in `order-emails.spec.js` by using these commands:
   ```bash
   pnpm test:e2e-pw -g "can receive new order email"
   pnpm test:e2e-pw -g "can resend new order notification"
   pnpm test:e2e-pw -g "can email invoice/order details to customer"
   ```
   This ensures that the recent changes would allow them to run independently of one another.
4. Run all the `merchant` E2E tests to ensure that `order-emails.spec.js` doesn't interfere with other tests, or is not interfered by them. You can use this command: `pnpm test:e2e-pw merchant`.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
