### PR TITLE
Prepare create product editor block package

### DIFF
--- a/packages/js/create-product-editor-block/CHANGELOG.md
+++ b/packages/js/create-product-editor-block/CHANGELOG.md
@@ -10,5 +10,3 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 -   Minor - Initial version of @woocommerce/create-product-editor-block [#38263]
 -   Minor - Do not add script prop to generated block.json [#38496]
-
-[See legacy changelogs for previous versions](https://github.com/woocommerce/woocommerce/blob/68581955106947918d2b17607a01bdfdf22288a9/packages/js/create-product-editor-block/CHANGELOG.md).

--- a/packages/js/create-product-editor-block/CHANGELOG.md
+++ b/packages/js/create-product-editor-block/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0](https://www.npmjs.com/package/@woocommerce/create-product-editor-block/v/1.1.0) - 2023-06-29 
+
+-   Minor - Update pnpm monorepo-wide to 8.6.5 [#38990]
+
 ## [1.0.0](https://www.npmjs.com/package/@woocommerce/create-product-editor-block/v/1.0.0) - 2023-06-28 
 
 -   Minor - Initial version of @woocommerce/create-product-editor-block [#38263]
 -   Minor - Do not add script prop to generated block.json [#38496]
+
+[See legacy changelogs for previous versions](https://github.com/woocommerce/woocommerce/blob/68581955106947918d2b17607a01bdfdf22288a9/packages/js/create-product-editor-block/CHANGELOG.md).

--- a/packages/js/create-product-editor-block/changelog/dev-update-pnpm-8.6.5
+++ b/packages/js/create-product-editor-block/changelog/dev-update-pnpm-8.6.5
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Update pnpm monorepo-wide to 8.6.5

--- a/packages/js/create-product-editor-block/changelog/update-add_gitignore_to_package
+++ b/packages/js/create-product-editor-block/changelog/update-add_gitignore_to_package
@@ -1,5 +1,0 @@
-Significance: patch
-Type: tweak
-Comment: Minimal change that was missed during bootstrap, no changelog necessary.
-
-

--- a/packages/js/create-product-editor-block/package.json
+++ b/packages/js/create-product-editor-block/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/create-product-editor-block",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"description": "A template to be used with `@wordpress/create-block` to create a Product Editor block.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Auto generated changes ran with the `./tools/package-release/bin/dev prepare @woocommerce/create-product-editor-block` script, duplicate of https://github.com/woocommerce/woocommerce/pull/39019, but actions are stuck there.



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check if things look ok

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
