### PR TITLE
Update WooCommerce Blocks to 10.4.5

### DIFF
--- a/plugins/woocommerce/changelog/2023-06-30-12-49-47-720140
+++ b/plugins/woocommerce/changelog/2023-06-30-12-49-47-720140
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update WooCommerce Blocks to 10.4.5

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -23,7 +23,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.6.1",
-		"woocommerce/woocommerce-blocks": "10.4.4"
+		"woocommerce/woocommerce-blocks": "10.4.5"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.3.0",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2ed1db7f7790007e6772fa4943193e70",
+    "content-hash": "829a099057c5702e82827c5a9598f5c4",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1004,16 +1004,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "10.4.4",
+            "version": "10.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "a9d8f3ed40fe53d0de70bcc8d7e7c9be2eb3b454"
+                "reference": "b0a691b4270d1dae849d869317aaa536c220f8eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/a9d8f3ed40fe53d0de70bcc8d7e7c9be2eb3b454",
-                "reference": "a9d8f3ed40fe53d0de70bcc8d7e7c9be2eb3b454",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/b0a691b4270d1dae849d869317aaa536c220f8eb",
+                "reference": "b0a691b4270d1dae849d869317aaa536c220f8eb",
                 "shasum": ""
             },
             "require": {
@@ -1059,9 +1059,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v10.4.4"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v10.4.5"
             },
-            "time": "2023-06-23T15:19:27+00:00"
+            "time": "2023-06-30T12:46:55+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 10.4.5. This is intended to be merged into WooCommerce 7.9.

## Blocks 10.4.5

* [Release PR](https://github.com/woocommerce/woocommerce-blocks/pull/10038)
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/1045.md)

### Changelog entry

#### Bug Fixes

- Product Rating block > Ensure the customer reviews text links to the relevant user reviews within the Single Product block and Single Product template. ([9998](https://github.com/woocommerce/woocommerce-blocks/pull/9998))
- Fix reviews count not showing for the Product Rating block when inside the Single Product page. ([9995](https://github.com/woocommerce/woocommerce-blocks/pull/9995))
- Single Product template: Fix variation SKU switching in the blockified template. ([9990](https://github.com/woocommerce/woocommerce-blocks/pull/9990))
- Single Product template: Fix variation gallery image switching in the blockified template. ([9986](https://github.com/woocommerce/woocommerce-blocks/pull/9986))

****