### PR TITLE
Fix backward compatibility for AdvancedFilters 

### DIFF
--- a/packages/js/components/changelog/fix-39021_createInterpolateElement_compatibility
+++ b/packages/js/components/changelog/fix-39021_createInterpolateElement_compatibility
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix AdvancedFilters backward compatibility

--- a/packages/js/components/src/advanced-filters/attribute-filter.js
+++ b/packages/js/components/src/advanced-filters/attribute-filter.js
@@ -19,7 +19,7 @@ import { __ } from '@wordpress/i18n';
  */
 import Search from '../search';
 import SelectControl from '../select-control';
-import { textContent } from './utils';
+import { getInterpolatedString, textContent } from './utils';
 
 const getScreenReaderText = ( {
 	attributeTerms,
@@ -55,9 +55,11 @@ const getScreenReaderText = ( {
 	}
 
 	const filterStr = createInterpolateElement(
-		/* eslint-disable-next-line max-len */
-		/* translators: Sentence fragment describing a product attribute match. Example: "Color Is Not Blue" - attribute = Color, equals = Is Not, value = Blue */
-		__( '<attribute/> <equals/> <value/>', 'woocommerce' ),
+		getInterpolatedString(
+			/* eslint-disable-next-line max-len */
+			/* translators: Sentence fragment describing a product attribute match. Example: "Color Is Not Blue" - attribute = Color, equals = Is Not, value = Blue */
+			__( '<attribute/> <equals/> <value/>', 'woocommerce' )
+		),
 		{
 			attribute: <Fragment>{ attributeName }</Fragment>,
 			equals: <Fragment>{ rule.label }</Fragment>,
@@ -66,11 +68,14 @@ const getScreenReaderText = ( {
 	);
 
 	return textContent(
-		createInterpolateElement( config.labels.title, {
-			filter: <Fragment>{ filterStr }</Fragment>,
-			rule: <Fragment />,
-			title: <Fragment />,
-		} )
+		createInterpolateElement(
+			getInterpolatedString( config.labels.title ),
+			{
+				filter: <Fragment>{ filterStr }</Fragment>,
+				rule: <Fragment />,
+				title: <Fragment />,
+			}
+		)
 	);
 };
 
@@ -148,110 +153,115 @@ const AttributeFilter = ( props ) => {
 					}
 				) }
 			>
-				{ createInterpolateElement( labels.title, {
-					title: <span className={ className } />,
-					rule: (
-						<Select
-							className={ classnames(
-								className,
-								'woocommerce-filters-advanced__rule'
-							) }
-							options={ rules }
-							value={ rule }
-							onChange={ ( selectedValue ) =>
-								onFilterChange( {
-									property: 'rule',
-									value: selectedValue,
-								} )
-							}
-							aria-label={ labels.rule }
-						/>
-					),
-					filter: (
-						<div
-							className={ classnames(
-								className,
-								'woocommerce-filters-advanced__attribute-fieldset'
-							) }
-						>
-							{ ! Array.isArray( value ) ||
-							! value.length ||
-							selectedAttribute.length ? (
-								<Search
-									className="woocommerce-filters-advanced__input woocommerce-search"
-									onChange={ ( [ attr ] ) => {
-										setSelectedAttribute(
-											attr ? [ attr ] : []
-										);
-										setSelectedAttributeTerm( '' );
-										onFilterChange( {
-											property: 'value',
-											value: [ attr && attr.key ].filter(
-												Boolean
-											),
-										} );
-									} }
-									type="attributes"
-									placeholder={ __(
-										'Attribute name',
-										'woocommerce'
-									) }
-									multiple={ false }
-									selected={ selectedAttribute }
-									inlineTags
-									aria-label={ __(
-										'Attribute name',
-										'woocommerce'
-									) }
-								/>
-							) : (
-								<Spinner />
-							) }
-							{ selectedAttribute.length > 0 &&
-								( attributeTerms.length ? (
-									<Fragment>
-										<span className="woocommerce-filters-advanced__attribute-field-separator">
-											=
-										</span>
-										<SelectControl
-											className="woocommerce-filters-advanced__input woocommerce-search"
-											placeholder={ __(
-												'Attribute value',
-												'woocommerce'
-											) }
-											inlineTags
-											isSearchable
-											multiple={ false }
-											showAllOnFocus
-											options={ attributeTerms }
-											selected={ selectedAttributeTerm }
-											onChange={ ( term ) => {
-												// Clearing the input using delete/backspace causes an empty array to be passed here.
-												if (
-													typeof term !== 'string'
-												) {
-													term = '';
-												}
-												setSelectedAttributeTerm(
-													term
-												);
-												onFilterChange( {
-													property: 'value',
-													value: [
-														selectedAttribute[ 0 ]
-															.key,
-														term,
-													].filter( Boolean ),
-												} );
-											} }
-										/>
-									</Fragment>
+				{ createInterpolateElement(
+					getInterpolatedString( labels.title ),
+					{
+						title: <span className={ className } />,
+						rule: (
+							<Select
+								className={ classnames(
+									className,
+									'woocommerce-filters-advanced__rule'
+								) }
+								options={ rules }
+								value={ rule }
+								onChange={ ( selectedValue ) =>
+									onFilterChange( {
+										property: 'rule',
+										value: selectedValue,
+									} )
+								}
+								aria-label={ labels.rule }
+							/>
+						),
+						filter: (
+							<div
+								className={ classnames(
+									className,
+									'woocommerce-filters-advanced__attribute-fieldset'
+								) }
+							>
+								{ ! Array.isArray( value ) ||
+								! value.length ||
+								selectedAttribute.length ? (
+									<Search
+										className="woocommerce-filters-advanced__input woocommerce-search"
+										onChange={ ( [ attr ] ) => {
+											setSelectedAttribute(
+												attr ? [ attr ] : []
+											);
+											setSelectedAttributeTerm( '' );
+											onFilterChange( {
+												property: 'value',
+												value: [
+													attr && attr.key,
+												].filter( Boolean ),
+											} );
+										} }
+										type="attributes"
+										placeholder={ __(
+											'Attribute name',
+											'woocommerce'
+										) }
+										multiple={ false }
+										selected={ selectedAttribute }
+										inlineTags
+										aria-label={ __(
+											'Attribute name',
+											'woocommerce'
+										) }
+									/>
 								) : (
 									<Spinner />
-								) ) }
-						</div>
-					),
-				} ) }
+								) }
+								{ selectedAttribute.length > 0 &&
+									( attributeTerms.length ? (
+										<Fragment>
+											<span className="woocommerce-filters-advanced__attribute-field-separator">
+												=
+											</span>
+											<SelectControl
+												className="woocommerce-filters-advanced__input woocommerce-search"
+												placeholder={ __(
+													'Attribute value',
+													'woocommerce'
+												) }
+												inlineTags
+												isSearchable
+												multiple={ false }
+												showAllOnFocus
+												options={ attributeTerms }
+												selected={
+													selectedAttributeTerm
+												}
+												onChange={ ( term ) => {
+													// Clearing the input using delete/backspace causes an empty array to be passed here.
+													if (
+														typeof term !== 'string'
+													) {
+														term = '';
+													}
+													setSelectedAttributeTerm(
+														term
+													);
+													onFilterChange( {
+														property: 'value',
+														value: [
+															selectedAttribute[ 0 ]
+																.key,
+															term,
+														].filter( Boolean ),
+													} );
+												} }
+											/>
+										</Fragment>
+									) : (
+										<Spinner />
+									) ) }
+							</div>
+						),
+					}
+				) }
 			</div>
 			{ screenReaderText && (
 				<span className="screen-reader-text">{ screenReaderText }</span>

--- a/packages/js/components/src/advanced-filters/attribute-filter.js
+++ b/packages/js/components/src/advanced-filters/attribute-filter.js
@@ -6,7 +6,6 @@ import { SelectControl as Select, Spinner } from '@wordpress/components';
 import classnames from 'classnames';
 import {
 	createElement,
-	createInterpolateElement,
 	Fragment,
 	useEffect,
 	useState,
@@ -19,7 +18,10 @@ import { __ } from '@wordpress/i18n';
  */
 import Search from '../search';
 import SelectControl from '../select-control';
-import { getInterpolatedString, textContent } from './utils';
+import {
+	backwardsCompatibleCreateInterpolateElement as createInterpolateElement,
+	textContent,
+} from './utils';
 
 const getScreenReaderText = ( {
 	attributeTerms,
@@ -55,11 +57,9 @@ const getScreenReaderText = ( {
 	}
 
 	const filterStr = createInterpolateElement(
-		getInterpolatedString(
-			/* eslint-disable-next-line max-len */
-			/* translators: Sentence fragment describing a product attribute match. Example: "Color Is Not Blue" - attribute = Color, equals = Is Not, value = Blue */
-			__( '<attribute/> <equals/> <value/>', 'woocommerce' )
-		),
+		/* eslint-disable-next-line max-len */
+		/* translators: Sentence fragment describing a product attribute match. Example: "Color Is Not Blue" - attribute = Color, equals = Is Not, value = Blue */
+		__( '<attribute/> <equals/> <value/>', 'woocommerce' ),
 		{
 			attribute: <Fragment>{ attributeName }</Fragment>,
 			equals: <Fragment>{ rule.label }</Fragment>,
@@ -68,14 +68,11 @@ const getScreenReaderText = ( {
 	);
 
 	return textContent(
-		createInterpolateElement(
-			getInterpolatedString( config.labels.title ),
-			{
-				filter: <Fragment>{ filterStr }</Fragment>,
-				rule: <Fragment />,
-				title: <Fragment />,
-			}
-		)
+		createInterpolateElement( config.labels.title, {
+			filter: <Fragment>{ filterStr }</Fragment>,
+			rule: <Fragment />,
+			title: <Fragment />,
+		} )
 	);
 };
 
@@ -153,115 +150,110 @@ const AttributeFilter = ( props ) => {
 					}
 				) }
 			>
-				{ createInterpolateElement(
-					getInterpolatedString( labels.title ),
-					{
-						title: <span className={ className } />,
-						rule: (
-							<Select
-								className={ classnames(
-									className,
-									'woocommerce-filters-advanced__rule'
-								) }
-								options={ rules }
-								value={ rule }
-								onChange={ ( selectedValue ) =>
-									onFilterChange( {
-										property: 'rule',
-										value: selectedValue,
-									} )
-								}
-								aria-label={ labels.rule }
-							/>
-						),
-						filter: (
-							<div
-								className={ classnames(
-									className,
-									'woocommerce-filters-advanced__attribute-fieldset'
-								) }
-							>
-								{ ! Array.isArray( value ) ||
-								! value.length ||
-								selectedAttribute.length ? (
-									<Search
-										className="woocommerce-filters-advanced__input woocommerce-search"
-										onChange={ ( [ attr ] ) => {
-											setSelectedAttribute(
-												attr ? [ attr ] : []
-											);
-											setSelectedAttributeTerm( '' );
-											onFilterChange( {
-												property: 'value',
-												value: [
-													attr && attr.key,
-												].filter( Boolean ),
-											} );
-										} }
-										type="attributes"
-										placeholder={ __(
-											'Attribute name',
-											'woocommerce'
-										) }
-										multiple={ false }
-										selected={ selectedAttribute }
-										inlineTags
-										aria-label={ __(
-											'Attribute name',
-											'woocommerce'
-										) }
-									/>
+				{ createInterpolateElement( labels.title, {
+					title: <span className={ className } />,
+					rule: (
+						<Select
+							className={ classnames(
+								className,
+								'woocommerce-filters-advanced__rule'
+							) }
+							options={ rules }
+							value={ rule }
+							onChange={ ( selectedValue ) =>
+								onFilterChange( {
+									property: 'rule',
+									value: selectedValue,
+								} )
+							}
+							aria-label={ labels.rule }
+						/>
+					),
+					filter: (
+						<div
+							className={ classnames(
+								className,
+								'woocommerce-filters-advanced__attribute-fieldset'
+							) }
+						>
+							{ ! Array.isArray( value ) ||
+							! value.length ||
+							selectedAttribute.length ? (
+								<Search
+									className="woocommerce-filters-advanced__input woocommerce-search"
+									onChange={ ( [ attr ] ) => {
+										setSelectedAttribute(
+											attr ? [ attr ] : []
+										);
+										setSelectedAttributeTerm( '' );
+										onFilterChange( {
+											property: 'value',
+											value: [ attr && attr.key ].filter(
+												Boolean
+											),
+										} );
+									} }
+									type="attributes"
+									placeholder={ __(
+										'Attribute name',
+										'woocommerce'
+									) }
+									multiple={ false }
+									selected={ selectedAttribute }
+									inlineTags
+									aria-label={ __(
+										'Attribute name',
+										'woocommerce'
+									) }
+								/>
+							) : (
+								<Spinner />
+							) }
+							{ selectedAttribute.length > 0 &&
+								( attributeTerms.length ? (
+									<Fragment>
+										<span className="woocommerce-filters-advanced__attribute-field-separator">
+											=
+										</span>
+										<SelectControl
+											className="woocommerce-filters-advanced__input woocommerce-search"
+											placeholder={ __(
+												'Attribute value',
+												'woocommerce'
+											) }
+											inlineTags
+											isSearchable
+											multiple={ false }
+											showAllOnFocus
+											options={ attributeTerms }
+											selected={ selectedAttributeTerm }
+											onChange={ ( term ) => {
+												// Clearing the input using delete/backspace causes an empty array to be passed here.
+												if (
+													typeof term !== 'string'
+												) {
+													term = '';
+												}
+												setSelectedAttributeTerm(
+													term
+												);
+												onFilterChange( {
+													property: 'value',
+													value: [
+														selectedAttribute[ 0 ]
+															.key,
+														term,
+													].filter( Boolean ),
+												} );
+											} }
+										/>
+									</Fragment>
 								) : (
 									<Spinner />
-								) }
-								{ selectedAttribute.length > 0 &&
-									( attributeTerms.length ? (
-										<Fragment>
-											<span className="woocommerce-filters-advanced__attribute-field-separator">
-												=
-											</span>
-											<SelectControl
-												className="woocommerce-filters-advanced__input woocommerce-search"
-												placeholder={ __(
-													'Attribute value',
-													'woocommerce'
-												) }
-												inlineTags
-												isSearchable
-												multiple={ false }
-												showAllOnFocus
-												options={ attributeTerms }
-												selected={
-													selectedAttributeTerm
-												}
-												onChange={ ( term ) => {
-													// Clearing the input using delete/backspace causes an empty array to be passed here.
-													if (
-														typeof term !== 'string'
-													) {
-														term = '';
-													}
-													setSelectedAttributeTerm(
-														term
-													);
-													onFilterChange( {
-														property: 'value',
-														value: [
-															selectedAttribute[ 0 ]
-																.key,
-															term,
-														].filter( Boolean ),
-													} );
-												} }
-											/>
-										</Fragment>
-									) : (
-										<Spinner />
-									) ) }
-							</div>
-						),
-					}
-				) }
+								) ) }
+						</div>
+					),
+				} ) }
 			</div>
 			{ screenReaderText && (
 				<span className="screen-reader-text">{ screenReaderText }</span>

--- a/packages/js/components/src/advanced-filters/date-filter.js
+++ b/packages/js/components/src/advanced-filters/date-filter.js
@@ -1,12 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	createElement,
-	createInterpolateElement,
-	Component,
-	Fragment,
-} from '@wordpress/element';
+import { createElement, Component, Fragment } from '@wordpress/element';
 import { SelectControl } from '@wordpress/components';
 import { find, partial } from 'lodash';
 import classnames from 'classnames';
@@ -18,7 +13,10 @@ import moment from 'moment';
  * Internal dependencies
  */
 import DatePicker from '../calendar/date-picker';
-import { getInterpolatedString, textContent } from './utils';
+import {
+	backwardsCompatibleCreateInterpolateElement as createInterpolateElement,
+	textContent,
+} from './utils';
 
 const dateStringFormat = __( 'MMM D, YYYY', 'woocommerce' );
 const dateFormat = __( 'MM/DD/YYYY', 'woocommerce' );
@@ -69,33 +67,23 @@ class DateFilter extends Component {
 		let filterStr = before.format( dateStringFormat );
 
 		if ( rule.value === 'between' ) {
-			filterStr = createInterpolateElement(
-				getInterpolatedString( this.getBetweenString() ),
-				{
-					after: (
-						<Fragment>
-							{ after.format( dateStringFormat ) }
-						</Fragment>
-					),
-					before: (
-						<Fragment>
-							{ before.format( dateStringFormat ) }
-						</Fragment>
-					),
-					span: <Fragment />,
-				}
-			);
+			filterStr = createInterpolateElement( this.getBetweenString(), {
+				after: (
+					<Fragment>{ after.format( dateStringFormat ) }</Fragment>
+				),
+				before: (
+					<Fragment>{ before.format( dateStringFormat ) }</Fragment>
+				),
+				span: <Fragment />,
+			} );
 		}
 
 		return textContent(
-			createInterpolateElement(
-				getInterpolatedString( config.labels.title ),
-				{
-					filter: <Fragment>{ filterStr }</Fragment>,
-					rule: <Fragment>{ rule.label }</Fragment>,
-					title: <Fragment />,
-				}
-			)
+			createInterpolateElement( config.labels.title, {
+				filter: <Fragment>{ filterStr }</Fragment>,
+				rule: <Fragment>{ rule.label }</Fragment>,
+				title: <Fragment />,
+			} )
 		);
 	}
 
@@ -202,24 +190,21 @@ class DateFilter extends Component {
 			afterText,
 			afterError,
 		} = this.state;
-		return createInterpolateElement(
-			getInterpolatedString( this.getBetweenString() ),
-			{
-				after: this.getFormControl( {
-					date: after,
-					error: afterError,
-					onUpdate: partial( this.onRangeDateChange, 'after' ),
-					text: afterText,
-				} ),
-				before: this.getFormControl( {
-					date: before,
-					error: beforeError,
-					onUpdate: partial( this.onRangeDateChange, 'before' ),
-					text: beforeText,
-				} ),
-				span: <span className="separator" />,
-			}
-		);
+		return createInterpolateElement( this.getBetweenString(), {
+			after: this.getFormControl( {
+				date: after,
+				error: afterError,
+				onUpdate: partial( this.onRangeDateChange, 'after' ),
+				text: afterText,
+			} ),
+			before: this.getFormControl( {
+				date: before,
+				error: beforeError,
+				onUpdate: partial( this.onRangeDateChange, 'before' ),
+				text: beforeText,
+			} ),
+			span: <span className="separator" />,
+		} );
 	}
 
 	getFilterInputs() {
@@ -242,37 +227,34 @@ class DateFilter extends Component {
 		const { rule } = this.state;
 		const { labels, rules } = config;
 		const screenReaderText = this.getScreenReaderText( rule, config );
-		const children = createInterpolateElement(
-			getInterpolatedString( labels.title ),
-			{
-				title: <span className={ className } />,
-				rule: (
-					<SelectControl
-						className={ classnames(
-							className,
-							'woocommerce-filters-advanced__rule'
-						) }
-						options={ rules }
-						value={ rule }
-						onChange={ this.onRuleChange }
-						aria-label={ labels.rule }
-					/>
-				),
-				filter: (
-					<div
-						className={ classnames(
-							className,
-							'woocommerce-filters-advanced__input-range',
-							{
-								'is-between': rule === 'between',
-							}
-						) }
-					>
-						{ this.getFilterInputs() }
-					</div>
-				),
-			}
-		);
+		const children = createInterpolateElement( labels.title, {
+			title: <span className={ className } />,
+			rule: (
+				<SelectControl
+					className={ classnames(
+						className,
+						'woocommerce-filters-advanced__rule'
+					) }
+					options={ rules }
+					value={ rule }
+					onChange={ this.onRuleChange }
+					aria-label={ labels.rule }
+				/>
+			),
+			filter: (
+				<div
+					className={ classnames(
+						className,
+						'woocommerce-filters-advanced__input-range',
+						{
+							'is-between': rule === 'between',
+						}
+					) }
+				>
+					{ this.getFilterInputs() }
+				</div>
+			),
+		} );
 		/*eslint-disable jsx-a11y/no-noninteractive-tabindex*/
 		return (
 			<fieldset

--- a/packages/js/components/src/advanced-filters/date-filter.js
+++ b/packages/js/components/src/advanced-filters/date-filter.js
@@ -18,7 +18,7 @@ import moment from 'moment';
  * Internal dependencies
  */
 import DatePicker from '../calendar/date-picker';
-import { textContent } from './utils';
+import { getInterpolatedString, textContent } from './utils';
 
 const dateStringFormat = __( 'MMM D, YYYY', 'woocommerce' );
 const dateFormat = __( 'MM/DD/YYYY', 'woocommerce' );
@@ -69,23 +69,33 @@ class DateFilter extends Component {
 		let filterStr = before.format( dateStringFormat );
 
 		if ( rule.value === 'between' ) {
-			filterStr = createInterpolateElement( this.getBetweenString(), {
-				after: (
-					<Fragment>{ after.format( dateStringFormat ) }</Fragment>
-				),
-				before: (
-					<Fragment>{ before.format( dateStringFormat ) }</Fragment>
-				),
-				span: <Fragment />,
-			} );
+			filterStr = createInterpolateElement(
+				getInterpolatedString( this.getBetweenString() ),
+				{
+					after: (
+						<Fragment>
+							{ after.format( dateStringFormat ) }
+						</Fragment>
+					),
+					before: (
+						<Fragment>
+							{ before.format( dateStringFormat ) }
+						</Fragment>
+					),
+					span: <Fragment />,
+				}
+			);
 		}
 
 		return textContent(
-			createInterpolateElement( config.labels.title, {
-				filter: <Fragment>{ filterStr }</Fragment>,
-				rule: <Fragment>{ rule.label }</Fragment>,
-				title: <Fragment />,
-			} )
+			createInterpolateElement(
+				getInterpolatedString( config.labels.title ),
+				{
+					filter: <Fragment>{ filterStr }</Fragment>,
+					rule: <Fragment>{ rule.label }</Fragment>,
+					title: <Fragment />,
+				}
+			)
 		);
 	}
 
@@ -192,21 +202,24 @@ class DateFilter extends Component {
 			afterText,
 			afterError,
 		} = this.state;
-		return createInterpolateElement( this.getBetweenString(), {
-			after: this.getFormControl( {
-				date: after,
-				error: afterError,
-				onUpdate: partial( this.onRangeDateChange, 'after' ),
-				text: afterText,
-			} ),
-			before: this.getFormControl( {
-				date: before,
-				error: beforeError,
-				onUpdate: partial( this.onRangeDateChange, 'before' ),
-				text: beforeText,
-			} ),
-			span: <span className="separator" />,
-		} );
+		return createInterpolateElement(
+			getInterpolatedString( this.getBetweenString() ),
+			{
+				after: this.getFormControl( {
+					date: after,
+					error: afterError,
+					onUpdate: partial( this.onRangeDateChange, 'after' ),
+					text: afterText,
+				} ),
+				before: this.getFormControl( {
+					date: before,
+					error: beforeError,
+					onUpdate: partial( this.onRangeDateChange, 'before' ),
+					text: beforeText,
+				} ),
+				span: <span className="separator" />,
+			}
+		);
 	}
 
 	getFilterInputs() {
@@ -229,34 +242,37 @@ class DateFilter extends Component {
 		const { rule } = this.state;
 		const { labels, rules } = config;
 		const screenReaderText = this.getScreenReaderText( rule, config );
-		const children = createInterpolateElement( labels.title, {
-			title: <span className={ className } />,
-			rule: (
-				<SelectControl
-					className={ classnames(
-						className,
-						'woocommerce-filters-advanced__rule'
-					) }
-					options={ rules }
-					value={ rule }
-					onChange={ this.onRuleChange }
-					aria-label={ labels.rule }
-				/>
-			),
-			filter: (
-				<div
-					className={ classnames(
-						className,
-						'woocommerce-filters-advanced__input-range',
-						{
-							'is-between': rule === 'between',
-						}
-					) }
-				>
-					{ this.getFilterInputs() }
-				</div>
-			),
-		} );
+		const children = createInterpolateElement(
+			getInterpolatedString( labels.title ),
+			{
+				title: <span className={ className } />,
+				rule: (
+					<SelectControl
+						className={ classnames(
+							className,
+							'woocommerce-filters-advanced__rule'
+						) }
+						options={ rules }
+						value={ rule }
+						onChange={ this.onRuleChange }
+						aria-label={ labels.rule }
+					/>
+				),
+				filter: (
+					<div
+						className={ classnames(
+							className,
+							'woocommerce-filters-advanced__input-range',
+							{
+								'is-between': rule === 'between',
+							}
+						) }
+					>
+						{ this.getFilterInputs() }
+					</div>
+				),
+			}
+		);
 		/*eslint-disable jsx-a11y/no-noninteractive-tabindex*/
 		return (
 			<fieldset

--- a/packages/js/components/src/advanced-filters/index.js
+++ b/packages/js/components/src/advanced-filters/index.js
@@ -34,6 +34,7 @@ import {
 import Link from '../link';
 import AdvancedFilterItem from './item';
 import { Text } from '../experimental';
+import { getInterpolatedString } from './utils';
 
 const matches = [
 	{ value: 'all', label: __( 'All', 'woocommerce' ) },
@@ -147,20 +148,24 @@ class AdvancedFilters extends Component {
 	getTitle() {
 		const { match } = this.state;
 		const { config } = this.props;
-		return createInterpolateElement( config.title, {
-			select: (
-				<SelectControl
-					className="woocommerce-filters-advanced__title-select"
-					options={ matches }
-					value={ match }
-					onChange={ this.onMatchChange }
-					aria-label={ __(
-						'Choose to apply any or all filters',
-						'woocommerce'
-					) }
-				/>
-			),
-		} );
+
+		return createInterpolateElement(
+			getInterpolatedString( config.title ),
+			{
+				select: (
+					<SelectControl
+						className="woocommerce-filters-advanced__title-select"
+						options={ matches }
+						value={ match }
+						onChange={ this.onMatchChange }
+						aria-label={ __(
+							'Choose to apply any or all filters',
+							'woocommerce'
+						) }
+					/>
+				),
+			}
+		);
 	}
 
 	getAvailableFilterKeys() {

--- a/packages/js/components/src/advanced-filters/index.js
+++ b/packages/js/components/src/advanced-filters/index.js
@@ -11,12 +11,7 @@ import {
 	Dropdown,
 	SelectControl,
 } from '@wordpress/components';
-import {
-	createElement,
-	createInterpolateElement,
-	Component,
-	createRef,
-} from '@wordpress/element';
+import { createElement, Component, createRef } from '@wordpress/element';
 import { partial, difference, isEqual } from 'lodash';
 import PropTypes from 'prop-types';
 import AddOutlineIcon from 'gridicons/dist/add-outline';
@@ -34,7 +29,7 @@ import {
 import Link from '../link';
 import AdvancedFilterItem from './item';
 import { Text } from '../experimental';
-import { getInterpolatedString } from './utils';
+import { backwardsCompatibleCreateInterpolateElement as createInterpolateElement } from './utils';
 
 const matches = [
 	{ value: 'all', label: __( 'All', 'woocommerce' ) },
@@ -149,23 +144,20 @@ class AdvancedFilters extends Component {
 		const { match } = this.state;
 		const { config } = this.props;
 
-		return createInterpolateElement(
-			getInterpolatedString( config.title ),
-			{
-				select: (
-					<SelectControl
-						className="woocommerce-filters-advanced__title-select"
-						options={ matches }
-						value={ match }
-						onChange={ this.onMatchChange }
-						aria-label={ __(
-							'Choose to apply any or all filters',
-							'woocommerce'
-						) }
-					/>
-				),
-			}
-		);
+		return createInterpolateElement( config.title, {
+			select: (
+				<SelectControl
+					className="woocommerce-filters-advanced__title-select"
+					options={ matches }
+					value={ match }
+					onChange={ this.onMatchChange }
+					aria-label={ __(
+						'Choose to apply any or all filters',
+						'woocommerce'
+					) }
+				/>
+			),
+		} );
 	}
 
 	getAvailableFilterKeys() {

--- a/packages/js/components/src/advanced-filters/number-filter.js
+++ b/packages/js/components/src/advanced-filters/number-filter.js
@@ -1,12 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	createElement,
-	createInterpolateElement,
-	Component,
-	Fragment,
-} from '@wordpress/element';
+import { createElement, Component, Fragment } from '@wordpress/element';
 import { SelectControl, TextControl } from '@wordpress/components';
 import { get, find, isArray } from 'lodash';
 import classnames from 'classnames';
@@ -17,7 +12,10 @@ import { CurrencyFactory } from '@woocommerce/currency';
  * Internal dependencies
  */
 import TextControlWithAffixes from '../text-control-with-affixes';
-import { getInterpolatedString, textContent } from './utils';
+import {
+	backwardsCompatibleCreateInterpolateElement as createInterpolateElement,
+	textContent,
+} from './utils';
 
 class NumberFilter extends Component {
 	getBetweenString() {
@@ -50,25 +48,19 @@ class NumberFilter extends Component {
 		let filterStr = rangeStart;
 
 		if ( rule.value === 'between' ) {
-			filterStr = createInterpolateElement(
-				getInterpolatedString( this.getBetweenString() ),
-				{
-					rangeStart: <Fragment>{ rangeStart }</Fragment>,
-					rangeEnd: <Fragment>{ rangeEnd }</Fragment>,
-					span: <Fragment />,
-				}
-			);
+			filterStr = createInterpolateElement( this.getBetweenString(), {
+				rangeStart: <Fragment>{ rangeStart }</Fragment>,
+				rangeEnd: <Fragment>{ rangeEnd }</Fragment>,
+				span: <Fragment />,
+			} );
 		}
 
 		return textContent(
-			createInterpolateElement(
-				getInterpolatedString( config.labels.title ),
-				{
-					filter: <Fragment>{ filterStr }</Fragment>,
-					rule: <Fragment>{ rule.label }</Fragment>,
-					title: <Fragment />,
-				}
-			)
+			createInterpolateElement( config.labels.title, {
+				filter: <Fragment>{ filterStr }</Fragment>,
+				rule: <Fragment>{ rule.label }</Fragment>,
+				title: <Fragment />,
+			} )
 		);
 	}
 
@@ -201,38 +193,35 @@ class NumberFilter extends Component {
 			} );
 		};
 
-		return createInterpolateElement(
-			getInterpolatedString( this.getBetweenString() ),
-			{
-				rangeStart: this.getFormControl( {
-					type: inputType,
-					value: rangeStart || '',
-					label: sprintf(
-						/* eslint-disable-next-line max-len */
-						/* translators: Sentence fragment, "range start" refers to the first of two numeric values the field must be between. Screenshot for context: https://cloudup.com/cmv5CLyMPNQ */
-						__( '%(field)s range start', 'woocommerce' ),
-						{ field: get( config, [ 'labels', 'add' ] ) }
-					),
-					onChange: rangeStartOnChange,
-					currencySymbol,
-					symbolPosition,
-				} ),
-				rangeEnd: this.getFormControl( {
-					type: inputType,
-					value: rangeEnd || '',
-					label: sprintf(
-						/* eslint-disable-next-line max-len */
-						/* translators: Sentence fragment, "range end" refers to the second of two numeric values the field must be between. Screenshot for context: https://cloudup.com/cmv5CLyMPNQ */
-						__( '%(field)s range end', 'woocommerce' ),
-						{ field: get( config, [ 'labels', 'add' ] ) }
-					),
-					onChange: rangeEndOnChange,
-					currencySymbol,
-					symbolPosition,
-				} ),
-				span: <span className="separator" />,
-			}
-		);
+		return createInterpolateElement( this.getBetweenString(), {
+			rangeStart: this.getFormControl( {
+				type: inputType,
+				value: rangeStart || '',
+				label: sprintf(
+					/* eslint-disable-next-line max-len */
+					/* translators: Sentence fragment, "range start" refers to the first of two numeric values the field must be between. Screenshot for context: https://cloudup.com/cmv5CLyMPNQ */
+					__( '%(field)s range start', 'woocommerce' ),
+					{ field: get( config, [ 'labels', 'add' ] ) }
+				),
+				onChange: rangeStartOnChange,
+				currencySymbol,
+				symbolPosition,
+			} ),
+			rangeEnd: this.getFormControl( {
+				type: inputType,
+				value: rangeEnd || '',
+				label: sprintf(
+					/* eslint-disable-next-line max-len */
+					/* translators: Sentence fragment, "range end" refers to the second of two numeric values the field must be between. Screenshot for context: https://cloudup.com/cmv5CLyMPNQ */
+					__( '%(field)s range end', 'woocommerce' ),
+					{ field: get( config, [ 'labels', 'add' ] ) }
+				),
+				onChange: rangeEndOnChange,
+				currencySymbol,
+				symbolPosition,
+			} ),
+			span: <span className="separator" />,
+		} );
 	}
 
 	render() {
@@ -241,39 +230,36 @@ class NumberFilter extends Component {
 		const { rule } = filter;
 		const { labels, rules } = config;
 
-		const children = createInterpolateElement(
-			getInterpolatedString( labels.title ),
-			{
-				title: <span className={ className } />,
-				rule: (
-					<SelectControl
-						className={ classnames(
-							className,
-							'woocommerce-filters-advanced__rule'
-						) }
-						options={ rules }
-						value={ rule }
-						onChange={ ( value ) =>
-							onFilterChange( { property: 'rule', value } )
+		const children = createInterpolateElement( labels.title, {
+			title: <span className={ className } />,
+			rule: (
+				<SelectControl
+					className={ classnames(
+						className,
+						'woocommerce-filters-advanced__rule'
+					) }
+					options={ rules }
+					value={ rule }
+					onChange={ ( value ) =>
+						onFilterChange( { property: 'rule', value } )
+					}
+					aria-label={ labels.rule }
+				/>
+			),
+			filter: (
+				<div
+					className={ classnames(
+						className,
+						'woocommerce-filters-advanced__input-range',
+						{
+							'is-between': rule === 'between',
 						}
-						aria-label={ labels.rule }
-					/>
-				),
-				filter: (
-					<div
-						className={ classnames(
-							className,
-							'woocommerce-filters-advanced__input-range',
-							{
-								'is-between': rule === 'between',
-							}
-						) }
-					>
-						{ this.getFilterInputs() }
-					</div>
-				),
-			}
-		);
+					) }
+				>
+					{ this.getFilterInputs() }
+				</div>
+			),
+		} );
 
 		const screenReaderText = this.getScreenReaderText( filter, config );
 

--- a/packages/js/components/src/advanced-filters/number-filter.js
+++ b/packages/js/components/src/advanced-filters/number-filter.js
@@ -17,7 +17,7 @@ import { CurrencyFactory } from '@woocommerce/currency';
  * Internal dependencies
  */
 import TextControlWithAffixes from '../text-control-with-affixes';
-import { textContent } from './utils';
+import { getInterpolatedString, textContent } from './utils';
 
 class NumberFilter extends Component {
 	getBetweenString() {
@@ -50,19 +50,25 @@ class NumberFilter extends Component {
 		let filterStr = rangeStart;
 
 		if ( rule.value === 'between' ) {
-			filterStr = createInterpolateElement( this.getBetweenString(), {
-				rangeStart: <Fragment>{ rangeStart }</Fragment>,
-				rangeEnd: <Fragment>{ rangeEnd }</Fragment>,
-				span: <Fragment />,
-			} );
+			filterStr = createInterpolateElement(
+				getInterpolatedString( this.getBetweenString() ),
+				{
+					rangeStart: <Fragment>{ rangeStart }</Fragment>,
+					rangeEnd: <Fragment>{ rangeEnd }</Fragment>,
+					span: <Fragment />,
+				}
+			);
 		}
 
 		return textContent(
-			createInterpolateElement( config.labels.title, {
-				filter: <Fragment>{ filterStr }</Fragment>,
-				rule: <Fragment>{ rule.label }</Fragment>,
-				title: <Fragment />,
-			} )
+			createInterpolateElement(
+				getInterpolatedString( config.labels.title ),
+				{
+					filter: <Fragment>{ filterStr }</Fragment>,
+					rule: <Fragment>{ rule.label }</Fragment>,
+					title: <Fragment />,
+				}
+			)
 		);
 	}
 
@@ -195,35 +201,38 @@ class NumberFilter extends Component {
 			} );
 		};
 
-		return createInterpolateElement( this.getBetweenString(), {
-			rangeStart: this.getFormControl( {
-				type: inputType,
-				value: rangeStart || '',
-				label: sprintf(
-					/* eslint-disable-next-line max-len */
-					/* translators: Sentence fragment, "range start" refers to the first of two numeric values the field must be between. Screenshot for context: https://cloudup.com/cmv5CLyMPNQ */
-					__( '%(field)s range start', 'woocommerce' ),
-					{ field: get( config, [ 'labels', 'add' ] ) }
-				),
-				onChange: rangeStartOnChange,
-				currencySymbol,
-				symbolPosition,
-			} ),
-			rangeEnd: this.getFormControl( {
-				type: inputType,
-				value: rangeEnd || '',
-				label: sprintf(
-					/* eslint-disable-next-line max-len */
-					/* translators: Sentence fragment, "range end" refers to the second of two numeric values the field must be between. Screenshot for context: https://cloudup.com/cmv5CLyMPNQ */
-					__( '%(field)s range end', 'woocommerce' ),
-					{ field: get( config, [ 'labels', 'add' ] ) }
-				),
-				onChange: rangeEndOnChange,
-				currencySymbol,
-				symbolPosition,
-			} ),
-			span: <span className="separator" />,
-		} );
+		return createInterpolateElement(
+			getInterpolatedString( this.getBetweenString() ),
+			{
+				rangeStart: this.getFormControl( {
+					type: inputType,
+					value: rangeStart || '',
+					label: sprintf(
+						/* eslint-disable-next-line max-len */
+						/* translators: Sentence fragment, "range start" refers to the first of two numeric values the field must be between. Screenshot for context: https://cloudup.com/cmv5CLyMPNQ */
+						__( '%(field)s range start', 'woocommerce' ),
+						{ field: get( config, [ 'labels', 'add' ] ) }
+					),
+					onChange: rangeStartOnChange,
+					currencySymbol,
+					symbolPosition,
+				} ),
+				rangeEnd: this.getFormControl( {
+					type: inputType,
+					value: rangeEnd || '',
+					label: sprintf(
+						/* eslint-disable-next-line max-len */
+						/* translators: Sentence fragment, "range end" refers to the second of two numeric values the field must be between. Screenshot for context: https://cloudup.com/cmv5CLyMPNQ */
+						__( '%(field)s range end', 'woocommerce' ),
+						{ field: get( config, [ 'labels', 'add' ] ) }
+					),
+					onChange: rangeEndOnChange,
+					currencySymbol,
+					symbolPosition,
+				} ),
+				span: <span className="separator" />,
+			}
+		);
 	}
 
 	render() {
@@ -232,36 +241,39 @@ class NumberFilter extends Component {
 		const { rule } = filter;
 		const { labels, rules } = config;
 
-		const children = createInterpolateElement( labels.title, {
-			title: <span className={ className } />,
-			rule: (
-				<SelectControl
-					className={ classnames(
-						className,
-						'woocommerce-filters-advanced__rule'
-					) }
-					options={ rules }
-					value={ rule }
-					onChange={ ( value ) =>
-						onFilterChange( { property: 'rule', value } )
-					}
-					aria-label={ labels.rule }
-				/>
-			),
-			filter: (
-				<div
-					className={ classnames(
-						className,
-						'woocommerce-filters-advanced__input-range',
-						{
-							'is-between': rule === 'between',
+		const children = createInterpolateElement(
+			getInterpolatedString( labels.title ),
+			{
+				title: <span className={ className } />,
+				rule: (
+					<SelectControl
+						className={ classnames(
+							className,
+							'woocommerce-filters-advanced__rule'
+						) }
+						options={ rules }
+						value={ rule }
+						onChange={ ( value ) =>
+							onFilterChange( { property: 'rule', value } )
 						}
-					) }
-				>
-					{ this.getFilterInputs() }
-				</div>
-			),
-		} );
+						aria-label={ labels.rule }
+					/>
+				),
+				filter: (
+					<div
+						className={ classnames(
+							className,
+							'woocommerce-filters-advanced__input-range',
+							{
+								'is-between': rule === 'between',
+							}
+						) }
+					>
+						{ this.getFilterInputs() }
+					</div>
+				),
+			}
+		);
 
 		const screenReaderText = this.getScreenReaderText( filter, config );
 

--- a/packages/js/components/src/advanced-filters/search-filter.js
+++ b/packages/js/components/src/advanced-filters/search-filter.js
@@ -17,7 +17,7 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import Search from '../search';
-import { textContent } from './utils';
+import { getInterpolatedString, textContent } from './utils';
 
 class SearchFilter extends Component {
 	constructor( { filter, config, query } ) {
@@ -90,11 +90,14 @@ class SearchFilter extends Component {
 		const filterStr = selected.map( ( item ) => item.label ).join( ', ' );
 
 		return textContent(
-			createInterpolateElement( config.labels.title, {
-				filter: <Fragment>{ filterStr }</Fragment>,
-				rule: <Fragment>{ rule.label }</Fragment>,
-				title: <Fragment />,
-			} )
+			createInterpolateElement(
+				getInterpolatedString( config.labels.title ),
+				{
+					filter: <Fragment>{ filterStr }</Fragment>,
+					rule: <Fragment>{ rule.label }</Fragment>,
+					title: <Fragment />,
+				}
+			)
 		);
 	}
 
@@ -104,38 +107,41 @@ class SearchFilter extends Component {
 		const { selected } = this.state;
 		const { rule } = filter;
 		const { input, labels, rules } = config;
-		const children = createInterpolateElement( labels.title, {
-			title: <span className={ className } />,
-			rule: (
-				<SelectControl
-					className={ classnames(
-						className,
-						'woocommerce-filters-advanced__rule'
-					) }
-					options={ rules }
-					value={ rule }
-					onChange={ ( value ) =>
-						onFilterChange( { property: 'rule', value } )
-					}
-					aria-label={ labels.rule }
-				/>
-			),
-			filter: (
-				<Search
-					className={ classnames(
-						className,
-						'woocommerce-filters-advanced__input'
-					) }
-					onChange={ this.onSearchChange }
-					type={ input.type }
-					autocompleter={ input.autocompleter }
-					placeholder={ labels.placeholder }
-					selected={ selected }
-					inlineTags
-					aria-label={ labels.filter }
-				/>
-			),
-		} );
+		const children = createInterpolateElement(
+			getInterpolatedString( labels.title ),
+			{
+				title: <span className={ className } />,
+				rule: (
+					<SelectControl
+						className={ classnames(
+							className,
+							'woocommerce-filters-advanced__rule'
+						) }
+						options={ rules }
+						value={ rule }
+						onChange={ ( value ) =>
+							onFilterChange( { property: 'rule', value } )
+						}
+						aria-label={ labels.rule }
+					/>
+				),
+				filter: (
+					<Search
+						className={ classnames(
+							className,
+							'woocommerce-filters-advanced__input'
+						) }
+						onChange={ this.onSearchChange }
+						type={ input.type }
+						autocompleter={ input.autocompleter }
+						placeholder={ labels.placeholder }
+						selected={ selected }
+						inlineTags
+						aria-label={ labels.filter }
+					/>
+				),
+			}
+		);
 
 		const screenReaderText = this.getScreenReaderText( filter, config );
 

--- a/packages/js/components/src/advanced-filters/search-filter.js
+++ b/packages/js/components/src/advanced-filters/search-filter.js
@@ -1,12 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	createElement,
-	createInterpolateElement,
-	Component,
-	Fragment,
-} from '@wordpress/element';
+import { createElement, Component, Fragment } from '@wordpress/element';
 import { SelectControl } from '@wordpress/components';
 import { getIdsFromQuery } from '@woocommerce/navigation';
 import { find, isEqual } from 'lodash';
@@ -17,7 +12,10 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import Search from '../search';
-import { getInterpolatedString, textContent } from './utils';
+import {
+	backwardsCompatibleCreateInterpolateElement as createInterpolateElement,
+	textContent,
+} from './utils';
 
 class SearchFilter extends Component {
 	constructor( { filter, config, query } ) {
@@ -90,14 +88,11 @@ class SearchFilter extends Component {
 		const filterStr = selected.map( ( item ) => item.label ).join( ', ' );
 
 		return textContent(
-			createInterpolateElement(
-				getInterpolatedString( config.labels.title ),
-				{
-					filter: <Fragment>{ filterStr }</Fragment>,
-					rule: <Fragment>{ rule.label }</Fragment>,
-					title: <Fragment />,
-				}
-			)
+			createInterpolateElement( config.labels.title, {
+				filter: <Fragment>{ filterStr }</Fragment>,
+				rule: <Fragment>{ rule.label }</Fragment>,
+				title: <Fragment />,
+			} )
 		);
 	}
 
@@ -107,41 +102,38 @@ class SearchFilter extends Component {
 		const { selected } = this.state;
 		const { rule } = filter;
 		const { input, labels, rules } = config;
-		const children = createInterpolateElement(
-			getInterpolatedString( labels.title ),
-			{
-				title: <span className={ className } />,
-				rule: (
-					<SelectControl
-						className={ classnames(
-							className,
-							'woocommerce-filters-advanced__rule'
-						) }
-						options={ rules }
-						value={ rule }
-						onChange={ ( value ) =>
-							onFilterChange( { property: 'rule', value } )
-						}
-						aria-label={ labels.rule }
-					/>
-				),
-				filter: (
-					<Search
-						className={ classnames(
-							className,
-							'woocommerce-filters-advanced__input'
-						) }
-						onChange={ this.onSearchChange }
-						type={ input.type }
-						autocompleter={ input.autocompleter }
-						placeholder={ labels.placeholder }
-						selected={ selected }
-						inlineTags
-						aria-label={ labels.filter }
-					/>
-				),
-			}
-		);
+		const children = createInterpolateElement( labels.title, {
+			title: <span className={ className } />,
+			rule: (
+				<SelectControl
+					className={ classnames(
+						className,
+						'woocommerce-filters-advanced__rule'
+					) }
+					options={ rules }
+					value={ rule }
+					onChange={ ( value ) =>
+						onFilterChange( { property: 'rule', value } )
+					}
+					aria-label={ labels.rule }
+				/>
+			),
+			filter: (
+				<Search
+					className={ classnames(
+						className,
+						'woocommerce-filters-advanced__input'
+					) }
+					onChange={ this.onSearchChange }
+					type={ input.type }
+					autocompleter={ input.autocompleter }
+					placeholder={ labels.placeholder }
+					selected={ selected }
+					inlineTags
+					aria-label={ labels.filter }
+				/>
+			),
+		} );
 
 		const screenReaderText = this.getScreenReaderText( filter, config );
 

--- a/packages/js/components/src/advanced-filters/select-filter.js
+++ b/packages/js/components/src/advanced-filters/select-filter.js
@@ -16,7 +16,7 @@ import { getDefaultOptionValue } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
-import { textContent } from './utils';
+import { getInterpolatedString, textContent } from './utils';
 
 class SelectFilter extends Component {
 	constructor( { filter, config, onFilterChange } ) {
@@ -58,11 +58,14 @@ class SelectFilter extends Component {
 			find( config.input.options, { value: filter.value } ) || {};
 
 		return textContent(
-			createInterpolateElement( config.labels.title, {
-				filter: <Fragment>{ value.label }</Fragment>,
-				rule: <Fragment>{ rule.label }</Fragment>,
-				title: <Fragment />,
-			} )
+			createInterpolateElement(
+				getInterpolatedString( config.labels.title ),
+				{
+					filter: <Fragment>{ value.label }</Fragment>,
+					rule: <Fragment>{ rule.label }</Fragment>,
+					title: <Fragment />,
+				}
+			)
 		);
 	}
 
@@ -72,45 +75,48 @@ class SelectFilter extends Component {
 		const { options } = this.state;
 		const { rule, value } = filter;
 		const { labels, rules } = config;
-		const children = createInterpolateElement( labels.title, {
-			title: <span className={ className } />,
-			rule: (
-				<SelectControl
-					className={ classnames(
-						className,
-						'woocommerce-filters-advanced__rule'
-					) }
-					options={ rules }
-					value={ rule }
-					onChange={ ( selectedValue ) =>
-						onFilterChange( {
-							property: 'rule',
-							value: selectedValue,
-						} )
-					}
-					aria-label={ labels.rule }
-				/>
-			),
-			filter: options ? (
-				<SelectControl
-					className={ classnames(
-						className,
-						'woocommerce-filters-advanced__input'
-					) }
-					options={ options }
-					value={ value }
-					onChange={ ( selectedValue ) =>
-						onFilterChange( {
-							property: 'value',
-							value: selectedValue,
-						} )
-					}
-					aria-label={ labels.filter }
-				/>
-			) : (
-				<Spinner />
-			),
-		} );
+		const children = createInterpolateElement(
+			getInterpolatedString( labels.title ),
+			{
+				title: <span className={ className } />,
+				rule: (
+					<SelectControl
+						className={ classnames(
+							className,
+							'woocommerce-filters-advanced__rule'
+						) }
+						options={ rules }
+						value={ rule }
+						onChange={ ( selectedValue ) =>
+							onFilterChange( {
+								property: 'rule',
+								value: selectedValue,
+							} )
+						}
+						aria-label={ labels.rule }
+					/>
+				),
+				filter: options ? (
+					<SelectControl
+						className={ classnames(
+							className,
+							'woocommerce-filters-advanced__input'
+						) }
+						options={ options }
+						value={ value }
+						onChange={ ( selectedValue ) =>
+							onFilterChange( {
+								property: 'value',
+								value: selectedValue,
+							} )
+						}
+						aria-label={ labels.filter }
+					/>
+				) : (
+					<Spinner />
+				),
+			}
+		);
 
 		const screenReaderText = this.getScreenReaderText( filter, config );
 

--- a/packages/js/components/src/advanced-filters/select-filter.js
+++ b/packages/js/components/src/advanced-filters/select-filter.js
@@ -1,12 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	createElement,
-	createInterpolateElement,
-	Component,
-	Fragment,
-} from '@wordpress/element';
+import { createElement, Component, Fragment } from '@wordpress/element';
 import { SelectControl, Spinner } from '@wordpress/components';
 import { find } from 'lodash';
 import PropTypes from 'prop-types';
@@ -16,7 +11,10 @@ import { getDefaultOptionValue } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
-import { getInterpolatedString, textContent } from './utils';
+import {
+	backwardsCompatibleCreateInterpolateElement as createInterpolateElement,
+	textContent,
+} from './utils';
 
 class SelectFilter extends Component {
 	constructor( { filter, config, onFilterChange } ) {
@@ -58,14 +56,11 @@ class SelectFilter extends Component {
 			find( config.input.options, { value: filter.value } ) || {};
 
 		return textContent(
-			createInterpolateElement(
-				getInterpolatedString( config.labels.title ),
-				{
-					filter: <Fragment>{ value.label }</Fragment>,
-					rule: <Fragment>{ rule.label }</Fragment>,
-					title: <Fragment />,
-				}
-			)
+			createInterpolateElement( config.labels.title, {
+				filter: <Fragment>{ value.label }</Fragment>,
+				rule: <Fragment>{ rule.label }</Fragment>,
+				title: <Fragment />,
+			} )
 		);
 	}
 
@@ -75,48 +70,45 @@ class SelectFilter extends Component {
 		const { options } = this.state;
 		const { rule, value } = filter;
 		const { labels, rules } = config;
-		const children = createInterpolateElement(
-			getInterpolatedString( labels.title ),
-			{
-				title: <span className={ className } />,
-				rule: (
-					<SelectControl
-						className={ classnames(
-							className,
-							'woocommerce-filters-advanced__rule'
-						) }
-						options={ rules }
-						value={ rule }
-						onChange={ ( selectedValue ) =>
-							onFilterChange( {
-								property: 'rule',
-								value: selectedValue,
-							} )
-						}
-						aria-label={ labels.rule }
-					/>
-				),
-				filter: options ? (
-					<SelectControl
-						className={ classnames(
-							className,
-							'woocommerce-filters-advanced__input'
-						) }
-						options={ options }
-						value={ value }
-						onChange={ ( selectedValue ) =>
-							onFilterChange( {
-								property: 'value',
-								value: selectedValue,
-							} )
-						}
-						aria-label={ labels.filter }
-					/>
-				) : (
-					<Spinner />
-				),
-			}
-		);
+		const children = createInterpolateElement( labels.title, {
+			title: <span className={ className } />,
+			rule: (
+				<SelectControl
+					className={ classnames(
+						className,
+						'woocommerce-filters-advanced__rule'
+					) }
+					options={ rules }
+					value={ rule }
+					onChange={ ( selectedValue ) =>
+						onFilterChange( {
+							property: 'rule',
+							value: selectedValue,
+						} )
+					}
+					aria-label={ labels.rule }
+				/>
+			),
+			filter: options ? (
+				<SelectControl
+					className={ classnames(
+						className,
+						'woocommerce-filters-advanced__input'
+					) }
+					options={ options }
+					value={ value }
+					onChange={ ( selectedValue ) =>
+						onFilterChange( {
+							property: 'value',
+							value: selectedValue,
+						} )
+					}
+					aria-label={ labels.filter }
+				/>
+			) : (
+				<Spinner />
+			),
+		} );
 
 		const screenReaderText = this.getScreenReaderText( filter, config );
 

--- a/packages/js/components/src/advanced-filters/test/advanced-filters.test.js
+++ b/packages/js/components/src/advanced-filters/test/advanced-filters.test.js
@@ -181,6 +181,23 @@ const advancedFiltersConfig = {
 				component: 'Date',
 			},
 		},
+		test: {
+			labels: {
+				add: 'Test',
+				remove: 'Remove test filter',
+				rule: 'Select a test filter match',
+				title: '{{title}}Test title{{/title}} {{filter/}}',
+				filter: 'Select a test type',
+			},
+			input: {
+				component: 'SelectControl',
+				options: [
+					{ value: 'new', label: 'New' },
+					{ value: 'old', label: 'Old' },
+				],
+				defaultOption: 'new',
+			},
+		},
 	},
 };
 
@@ -267,5 +284,20 @@ describe( 'AdvancedFilters', () => {
 		// The previous value should be reset when switching to/from the "Between" rule.
 		expect( dateFields[ 0 ] ).not.toHaveValue();
 		expect( dateFields[ 1 ] ).not.toHaveValue();
+	} );
+
+	test( 'should render the Test option component set in the old way', () => {
+		render( <AdvancedFiltersComponent /> );
+
+		// Add a new filter.
+		userEvent.click(
+			screen.getByRole( 'button', { name: 'Add a Filter' } )
+		);
+
+		// Select Test filter.
+		userEvent.click( screen.getByRole( 'button', { name: 'Test' } ) );
+		expect(
+			screen.getByRole( 'combobox', { name: 'Select a test type' } )
+		).toHaveValue();
 	} );
 } );

--- a/packages/js/components/src/advanced-filters/test/utils.js
+++ b/packages/js/components/src/advanced-filters/test/utils.js
@@ -6,7 +6,7 @@ import { createElement } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { textContent } from '../utils';
+import { getInterpolatedString, textContent } from '../utils';
 
 describe( 'textContent()', () => {
 	test( 'should get text `Hello World`', () => {
@@ -78,5 +78,41 @@ describe( 'textContent()', () => {
 		];
 
 		expect( textContent( component ) ).toBe( 'abcxy' );
+	} );
+} );
+
+describe( 'getInterpolatedString()', () => {
+	test( 'should return string `<h1>my title</h1>`', () => {
+		const interpolatedString = '{{h1}}my title{{/h1}}';
+
+		expect( getInterpolatedString( interpolatedString ) ).toBe(
+			'<h1>my title</h1>'
+		);
+	} );
+
+	test( 'should return string `<tag1>text</tag1> - <tag2>text 2</tag2>`', () => {
+		const interpolatedString =
+			'{{tag1}}text{{/tag1}} - {{tag2}}text 2{{/tag2}}';
+
+		expect( getInterpolatedString( interpolatedString ) ).toBe(
+			'<tag1>text</tag1> - <tag2>text 2</tag2>'
+		);
+	} );
+
+	test( 'should return string `<tag1><tag2> my text </tag2></tag1>`', () => {
+		const interpolatedString =
+			'{{tag1}}{{tag2}} my text {{/tag2}}{{/tag1}}';
+
+		expect( getInterpolatedString( interpolatedString ) ).toBe(
+			'<tag1><tag2> my text </tag2></tag1>'
+		);
+	} );
+
+	test( 'should return string `<tag>my text</tag> <tag2 /> <tag3 />`', () => {
+		const interpolatedString =
+			'{{tag}}my text{{/tag}} {{tag2 /}} {{tag3 /}}';
+		expect( getInterpolatedString( interpolatedString ) ).toBe(
+			'<tag>my text</tag> <tag2 /> <tag3 />'
+		);
 	} );
 } );

--- a/packages/js/components/src/advanced-filters/utils.js
+++ b/packages/js/components/src/advanced-filters/utils.js
@@ -72,9 +72,12 @@ export function getInterpolatedString( interpolatedString ) {
 
 	if ( replacedString !== interpolatedString ) {
 		deprecated(
-			'The interpolation string format `{{element}}...{{/element}}` or `{{element/}}`',
+			'Old interpolation string format `{{element}}...{{/element}}` or `{{element/}}`',
 			{
-				hint: 'Please update your code to use the new format: `<element>...</element>` or `<element/>`.',
+				since: '7.8',
+				alternative:
+					'new interpolation string format `<element>...</element>` or `<element/>`',
+				link: 'https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/components/src/advanced-filters/README.md',
 			}
 		);
 	}

--- a/packages/js/components/src/advanced-filters/utils.js
+++ b/packages/js/components/src/advanced-filters/utils.js
@@ -51,9 +51,8 @@ export function getInterpolatedString( interpolatedString ) {
 
 	if ( regex.exec( interpolatedString ) !== null ) {
 		deprecated(
-			'The interpolation string format `{{element}}...{{/element}}` or `{{element/}}` is deprecated.',
+			'The interpolation string format `{{element}}...{{/element}}` or `{{element/}}`',
 			{
-				version: '7.8.0',
 				hint: 'Please update your code to use the new format: `<element>...</element>` or `<element/>`.',
 			}
 		);

--- a/packages/js/components/src/advanced-filters/utils.js
+++ b/packages/js/components/src/advanced-filters/utils.js
@@ -3,6 +3,7 @@
  */
 import { isArray, isNumber, isString } from 'lodash';
 import deprecated from '@wordpress/deprecated';
+import { createInterpolateElement } from '@wordpress/element';
 
 /**
  * DOM Node.textContent for React components
@@ -79,4 +80,22 @@ export function getInterpolatedString( interpolatedString ) {
 	}
 
 	return replacedString;
+}
+
+/**
+ * This function creates an interpolation element that is backwards compatible.
+ *
+ * @param {string} interpolatedString The interpolation string to be parsed and transformed.
+ * @param {Object} conversionMap      The map used for the conversion to create the interpolate element.
+ *
+ * @return {Element} A React element that is the result of applying the transformation.
+ */
+export function backwardsCompatibleCreateInterpolateElement(
+	interpolatedString,
+	conversionMap
+) {
+	return createInterpolateElement(
+		getInterpolatedString( interpolatedString ),
+		conversionMap
+	);
 }

--- a/packages/js/components/src/advanced-filters/utils.js
+++ b/packages/js/components/src/advanced-filters/utils.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { isArray, isNumber, isString } from 'lodash';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * DOM Node.textContent for React components
@@ -33,4 +34,47 @@ export function textContent( components ) {
 	toText( components );
 
 	return text;
+}
+
+/**
+ * This function processes an input string, checks for deprecated interpolation formatting, and
+ * modifies it to conform to the new standard.
+ * The deprecated interpolation formatting is `{{element}}...{{/element}}`, and the new standard
+ * formatting is `<element>...</element>`.
+ *
+ * @param {string} interpolatedString The interpolation string to be parsed.
+ *
+ * @return {string}  Fixed interpolation string.
+ */
+export function getInterpolatedString( interpolatedString ) {
+	const regex = /(\{\{)(\/?\s*\w+\s*\/?)(\}\})/g;
+
+	if ( regex.exec( interpolatedString ) !== null ) {
+		deprecated(
+			'The interpolation string format `{{element}}...{{/element}}` or `{{element/}}` is deprecated.',
+			{
+				version: '7.8.0',
+				hint: 'Please update your code to use the new format: `<element>...</element>` or `<element/>`.',
+			}
+		);
+
+		return interpolatedString.replaceAll( regex, ( match, p1, p2 ) => {
+			const inner = p2.trim();
+			let replacement;
+			if ( inner.startsWith( '/' ) ) {
+				// Closing tag
+				replacement = `</${ inner.slice( 1 ) }>`;
+			} else if ( inner.endsWith( '/' ) ) {
+				// Self-closing tag
+				replacement = `<${ inner.slice( 0, -1 ) }/>`;
+			} else {
+				// Opening tag
+				replacement = `<${ inner }>`;
+			}
+
+			return replacement;
+		} );
+	}
+
+	return interpolatedString;
 }

--- a/packages/js/components/src/advanced-filters/utils.js
+++ b/packages/js/components/src/advanced-filters/utils.js
@@ -49,15 +49,9 @@ export function textContent( components ) {
 export function getInterpolatedString( interpolatedString ) {
 	const regex = /(\{\{)(\/?\s*\w+\s*\/?)(\}\})/g;
 
-	if ( regex.exec( interpolatedString ) !== null ) {
-		deprecated(
-			'The interpolation string format `{{element}}...{{/element}}` or `{{element/}}`',
-			{
-				hint: 'Please update your code to use the new format: `<element>...</element>` or `<element/>`.',
-			}
-		);
-
-		return interpolatedString.replaceAll( regex, ( match, p1, p2 ) => {
+	const replacedString = interpolatedString.replaceAll(
+		regex,
+		( match, p1, p2 ) => {
 			const inner = p2.trim();
 			let replacement;
 			if ( inner.startsWith( '/' ) ) {
@@ -72,8 +66,17 @@ export function getInterpolatedString( interpolatedString ) {
 			}
 
 			return replacement;
-		} );
+		}
+	);
+
+	if ( replacedString !== interpolatedString ) {
+		deprecated(
+			'The interpolation string format `{{element}}...{{/element}}` or `{{element/}}`',
+			{
+				hint: 'Please update your code to use the new format: `<element>...</element>` or `<element/>`.',
+			}
+		);
 	}
 
-	return interpolatedString;
+	return replacedString;
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR introduces backward compatibility for `AdvancedFilters` and adds a deprecation message. We previously updated the `AdvancedFilters` component to utilize `createInterpolateElement` instead of `interpolateComponents` in [this PR](https://github.com/woocommerce/woocommerce/pull/37967). However, some plugins still send the parameters in the old format to the `AdvancedFilters` component.

With this fix, the `AdvancedFilters` component will handle both cases.

Closes #39021.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install and activate the following plugin [test-advanced-filters-compatibility.zip](https://github.com/woocommerce/woocommerce/files/11926682/test-advanced-filters-compatibility.zip).
2. Go to `WooCommerce` > `Customers` and open the advanced filters.
3. Click on `Add a Filter` and select `Test`.

![Screen Capture on 2023-07-01 at 14-07-43](https://github.com/woocommerce/woocommerce/assets/1314156/7e6e3cc2-8a3b-40b0-9e4b-c825544202b8)

4. The option `Test` is in the old format, but it should still function properly.
5. In the browser console, a deprecation message should appear with the following text:
```
The interpolation string format `{{element}}...{{/element}}` or `{{element/}}` is deprecated. Note: Please update your code to use the new format: `<element>...</element>` or `<element/>`. 
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
