### PR TITLE
POC Consume product editor templates from REST API

### DIFF
--- a/packages/js/product-editor/src/components/block-editor/block-editor.tsx
+++ b/packages/js/product-editor/src/components/block-editor/block-editor.tsx
@@ -1,8 +1,10 @@
 /**
  * External dependencies
  */
-import { Template } from '@wordpress/blocks';
-import { createElement, useMemo } from '@wordpress/element';
+import {
+	Template,
+} from '@wordpress/blocks';
+import { createElement, useMemo, useLayoutEffect } from '@wordpress/element';
 import { Product } from '@woocommerce/data';
 import { useSelect, select as WPSelect } from '@wordpress/data';
 import { uploadMedia } from '@wordpress/media-utils';
@@ -19,9 +21,6 @@ import {
 	EditorSettings,
 	EditorBlockListSettings,
 	ObserveTyping,
-	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-	// @ts-ignore No types for this exist yet.
-	__unstableEditorStyles as EditorStyles,
 } from '@wordpress/block-editor';
 // It doesn't seem to notice the External dependency block whn @ts-ignore is added.
 // eslint-disable-next-line @woocommerce/dependency-group
@@ -95,24 +94,21 @@ export function BlockEditor( {
 	return (
 		<div className="woocommerce-product-block-editor">
 			<BlockContextProvider value={ context }>
+				<BlocksTemplate />
 				<BlockEditorProvider
 					value={ blocks }
 					onInput={ onInput }
 					onChange={ onChange }
 					settings={ settings }
 				>
-					<BlocksTemplate />
-					<EditorStyles styles={ settings?.styles } />
-					<div className="editor-styles-wrapper">
-						{ /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */ }
-						{ /* @ts-ignore No types for this exist yet. */ }
-						<BlockEditorKeyboardShortcuts.Register />
-						<BlockTools>
-							<ObserveTyping>
-								<BlockList className="woocommerce-product-block-editor__block-list" />
-							</ObserveTyping>
-						</BlockTools>
-					</div>
+					{ /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */ }
+					{ /* @ts-ignore No types for this exist yet. */ }
+					<BlockEditorKeyboardShortcuts.Register />
+					<BlockTools>
+						<ObserveTyping>
+							<BlockList className="woocommerce-product-block-editor__block-list" />
+						</ObserveTyping>
+					</BlockTools>
 				</BlockEditorProvider>
 			</BlockContextProvider>
 		</div>

--- a/packages/js/product-editor/src/components/blocks-template/blocks-template.tsx
+++ b/packages/js/product-editor/src/components/blocks-template/blocks-template.tsx
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import { useSelect } from '@wordpress/data';
+import { parse, synchronizeBlocksWithTemplate } from '@wordpress/blocks';
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { synchronizeBlocksWithTemplate } from '@wordpress/blocks';
 import { useLayoutEffect } from '@wordpress/element';
 import {
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -12,6 +12,9 @@ import {
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore
 	useEntityId,
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore store should be included.
+	useEntityRecords,
 } from '@wordpress/core-data';
 
 export function BlocksTemplate() {
@@ -27,12 +30,30 @@ export function BlocksTemplate() {
 		id: productId,
 	} );
 
+
+	const { records: templates, isResolving: isLoading } = useEntityRecords(
+		'postType',
+		'wp_template',
+		{
+			post_type: 'woocommerce_product_editor_template',
+			per_page: -1,
+		}
+	);
+
 	useLayoutEffect( () => {
+		if ( isLoading || ! templates ) {
+			return;
+		}
+		const template = templates.find(
+			// @ts-ignore
+			( t ) => t.id === 'woocommerce/woocommerce//product-editor_simple'
+		);
+		const parsed = parse( template.content.raw );
 		onChange(
-			synchronizeBlocksWithTemplate( [], blockEditorSettings?.template ),
+			synchronizeBlocksWithTemplate( parsed ),
 			{}
 		);
-	}, [ blockEditorSettings?.template ] );
+	}, [ templates, isLoading ] );
 
 	return null;
 }

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -41,6 +41,7 @@ class Init {
 			$block_registry->init();
 			$this->template_registry = ProductTemplateRegistry::get_instance();
 			$this->template_registry->register_core_templates();
+			add_filter( 'get_block_templates', array( $this->template_registry, 'add_block_templates' ), 10, 3 );
 		}
 	}
 

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/BaseProductTemplate.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/BaseProductTemplate.php
@@ -38,8 +38,8 @@ trait BaseProductTemplate {
             array(
                 'parent' => self::GENERAL_GROUP,
                 'block'  => array(
-                    'woocommerce/product-name-field',
-                    array(
+                    'blockName' => 'woocommerce/product-name-field',
+                    'attrs'     => array(
                         'name' => 'Product name',
                     ),
                 ),
@@ -49,7 +49,7 @@ trait BaseProductTemplate {
             array(
                 'parent' => self::GENERAL_GROUP,
                 'block'  => array(
-                    'woocommerce/product-summary-field',
+                    'blockName' => 'woocommerce/product-summary-field',
                 ),
             ),
         );

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/ProductTemplateInterface.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/ProductTemplateInterface.php
@@ -36,11 +36,25 @@ interface ProductTemplateInterface {
 	public function __construct();
 
 	/**
-	 * Get the name of the template.
+	 * Get the slug of the template.
 	 *
-	 * @return string Template name
+	 * @return string Template slug
 	 */
-	public function get_name();
+	public function get_slug();
+
+	/**
+	 * Get the title of the template.
+	 *
+	 * @return string Template title
+	 */
+	public function get_title();
+
+	/**
+	 * Get the description for the template.
+	 *
+	 * @return string Template description
+	 */
+	public function get_description();
 
 	/**
 	 * Get the template layout.

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -17,12 +17,30 @@ class SimpleProductTemplate extends AbstractProductTemplate implements ProductTe
     }
 
 	/**
-	 * Get the name of the template.
+	 * Get the slug of the template.
 	 *
-	 * @return string Template name
+	 * @return string Template slug
 	 */
-    public function get_name() {
+    public function get_slug() {
         return 'simple';
+    }
+
+    /**
+	 * Get the title of the template.
+	 *
+	 * @return string Template title
+	 */
+    public function get_title() {
+        return __( 'Simple product editor template.', 'woocommerce' );
+    }
+
+    /**
+	 * Get the description for the template.
+	 *
+	 * @return string Template description
+	 */
+    public function get_description() {
+        return __( 'Product template for editing simple product types.', 'woocommerce' );
     }
 
 }

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/VariableProductTemplate.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/VariableProductTemplate.php
@@ -13,12 +13,30 @@ class VariableProductTemplate implements ProductTemplateInterface {
     public function __construct() {}
 
 	/**
-	 * Get the name of the template.
+	 * Get the slug of the template.
 	 *
-	 * @return string Template name
+	 * @return string Template slug
 	 */
-    public function get_name() {
+    public function get_slug() {
         return 'variable';
+    }
+
+    /**
+	 * Get the title of the template.
+	 *
+	 * @return string Template title
+	 */
+    public function get_title() {
+        return __( 'Variable product editor template.', 'woocommerce' );
+    }
+
+    /**
+	 * Get the description for the template.
+	 *
+	 * @return string Template description
+	 */
+    public function get_description() {
+        return __( 'Product template for editing variable product types.', 'woocommerce' );
     }
 
     /**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR is a POC that looks into registering product editor templates in the templates REST API.  Consuming templates via the REST API brings us several benefits:

* Reduces the need to pre-hydrate this data on all WCA pages.
* Allows templates to be filtered by native WordPress template filters. (needed for some extensibility being experimented with in Gutenberg)
* Asynchronous fetching of templates could allow templates to respond to client-side changes of products.

Things that this POC does not handle:

* Performance concerns around parsing data back and forth between various template formats
* Including all product type templates and fields
* Possible clean-up and duplication around the product templates and the `WP_Block_Template` class

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1.
2.
3.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
