### PR TITLE
Prevent possible duplication in `woocommerce_cart_item_name` filter

### DIFF
--- a/plugins/woocommerce/changelog/fix-item-name-filtered-twice
+++ b/plugins/woocommerce/changelog/fix-item-name-filtered-twice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent possible duplication of product name in 'woocommerce_item_name' filter.

--- a/plugins/woocommerce/templates/cart/cart.php
+++ b/plugins/woocommerce/templates/cart/cart.php
@@ -38,15 +38,19 @@ do_action( 'woocommerce_before_cart' ); ?>
 
 			<?php
 			foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
-				$_product   = apply_filters( 'woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key );
-				$product_id = apply_filters( 'woocommerce_cart_item_product_id', $cart_item['product_id'], $cart_item, $cart_item_key );
+				$_product     = apply_filters( 'woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key );
+				$product_id   = apply_filters( 'woocommerce_cart_item_product_id', $cart_item['product_id'], $cart_item, $cart_item_key );
+				$product_name = $_product->get_name();
+
 				/**
 				 * Filter the product name.
 				 *
 				 * @since 7.8.0
 				 * @param string $product_name Name of the product in the cart.
+				 * @param array $cart_item The product in the cart.
+				 * @param string $cart_item_key Key for the product in the cart.
 				 */
-				$product_name = apply_filters( 'woocommerce_cart_item_name', $_product->get_name(), $cart_item, $cart_item_key );
+				$plain_product_name = wp_strip_all_tags( apply_filters( 'woocommerce_cart_item_name', $product_name, $cart_item, $cart_item_key ) );
 
 				if ( $_product && $_product->exists() && $cart_item['quantity'] > 0 && apply_filters( 'woocommerce_cart_item_visible', true, $cart_item, $cart_item_key ) ) {
 					$product_permalink = apply_filters( 'woocommerce_cart_item_permalink', $_product->is_visible() ? $_product->get_permalink( $cart_item ) : '', $cart_item, $cart_item_key );
@@ -61,7 +65,7 @@ do_action( 'woocommerce_before_cart' ); ?>
 										'<a href="%s" class="remove" aria-label="%s" data-product_id="%s" data-product_sku="%s">&times;</a>',
 										esc_url( wc_get_cart_remove_url( $cart_item_key ) ),
 										/* translators: %s is the product name */
-										esc_attr( sprintf( __( 'Remove %s from cart', 'woocommerce' ), $product_name ) ),
+										esc_attr( sprintf( __( 'Remove %s from cart', 'woocommerce' ), $plain_product_name ) ),
 										esc_attr( $product_id ),
 										esc_attr( $_product->get_sku() )
 									),
@@ -100,6 +104,8 @@ do_action( 'woocommerce_before_cart' ); ?>
 							 *
 							 * @since 7.8.0
 							 * @param string $product_url URL the product in the cart.
+							 * @param array $cart_item The product in the cart.
+							 * @param string $cart_item_key Key for the product in the cart.
 							 */
 							echo wp_kses_post( apply_filters( 'woocommerce_cart_item_name', sprintf( '<a href="%s">%s</a>', esc_url( $product_permalink ), $product_name ), $cart_item, $cart_item_key ) );
 						}
@@ -138,7 +144,7 @@ do_action( 'woocommerce_before_cart' ); ?>
 								'input_value'  => $cart_item['quantity'],
 								'max_value'    => $max_quantity,
 								'min_value'    => $min_quantity,
-								'product_name' => $product_name,
+								'product_name' => $plain_product_name,
 							),
 							$_product,
 							false

--- a/plugins/woocommerce/templates/cart/mini-cart.php
+++ b/plugins/woocommerce/templates/cart/mini-cart.php
@@ -50,7 +50,7 @@ do_action( 'woocommerce_before_mini_cart' ); ?>
 							'<a href="%s" class="remove remove_from_cart_button" aria-label="%s" data-product_id="%s" data-cart_item_key="%s" data-product_sku="%s">&times;</a>',
 							esc_url( wc_get_cart_remove_url( $cart_item_key ) ),
 							/* translators: %s is the product name */
-							esc_attr( sprintf( __( 'Remove %s from cart', 'woocommerce' ), $product_name ) ),
+							esc_attr( sprintf( __( 'Remove %s from cart', 'woocommerce' ), wp_strip_all_tags( $product_name ) ) ),
 							esc_attr( $product_id ),
 							esc_attr( $cart_item_key ),
 							esc_attr( $_product->get_sku() )


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

After #37830, in the cart template, [the product name is filtered and stored in `$product_name`](https://github.com/woocommerce/woocommerce/blob/f8c6c437212a3b17706a1f2011f4be6ca0b0338c/plugins/woocommerce/templates/cart/cart.php#L49), but then the filter is applied again to this (already) filtered name before [it is output](https://github.com/woocommerce/woocommerce/blob/f8c6c437212a3b17706a1f2011f4be6ca0b0338c/plugins/woocommerce/templates/cart/cart.php#L96).

This double filtering can produce the wrong result in various contexts (such as when 3rd party code uses the filter to append something to the name of the product).

This PR tries to keep the functionality added in #37830 while preventing duplication in the filter.

Props to @jimjasson for the analysis leading to this PR 🎩 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check out `trunk`.
1. Add the following code as a snippet or directly as a PHP file in `wp-content/mu-plugins/`. This snippet should result in "suffix" appearing after the product name in the cart.

   ```php
   <?php
   add_filter(
	   'woocommerce_cart_item_name',
	   function( $content, $cart_item, $cart_item_key ) {
		   return $content . ' suffix';
	   }
	   10,
	   3
   );
   ````
1. Add a product to the cart.
1. Go to the cart page.
1. Confirm that you see "<Product Name> suffix suffix" as product name, indicating that "suffix" has been appended twice.
1. Check out this branch.
1. Refresh the cart page.
1. Confirm that you see "<Product Name> suffix" as product name. No duplication should occur.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
