### PR TITLE
E2E: Fix skipping of core profiler in `page-loads.spec.js`

### DIFF
--- a/plugins/woocommerce/changelog/e2e-skip-core-profiler
+++ b/plugins/woocommerce/changelog/e2e-skip-core-profiler
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix skipping of core profiler in page-loads.spec.js.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #39056.

Currently, the E2E tests in `page-loads.spec.js` fail when it's run while the default admin user has not skipped OBW yet. This is because the if condition [here](https://github.com/woocommerce/woocommerce/blob/ad8b121e2198e0daf98d32c88a586b408249887d/plugins/woocommerce/tests/e2e-pw/tests/merchant/page-loads.spec.js#L54), which was meant to skip the guided setup, doesn't execute -- `currentPage.name` will never be equal to `Home`.

This PR fixes this by:
- moving these [lines](https://github.com/woocommerce/woocommerce/blob/ad8b121e2198e0daf98d32c88a586b408249887d/plugins/woocommerce/tests/e2e-pw/tests/merchant/page-loads.spec.js#L55-L62) onto a `beforeAll` hook so that the skipping will happen only once, rather than leaving it in the `beforeEach` block where it runs before each test unnecessarily.
- simplifying the if condition to rely only on whether `coreProfilerEnabled` is `true` or not.

This PR also removes these [lines](https://github.com/woocommerce/woocommerce/blob/ad8b121e2198e0daf98d32c88a586b408249887d/plugins/woocommerce/tests/e2e-pw/tests/merchant/page-loads.spec.js#L71-L86), as I think we no longer have a use case where the old onboarding wizard will be shown to the user.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Testing locally

1. Run the usual setup scripts for launching `wp-env`. But don't run any tests yet.
1. As expected, when you navigate to WooCommerce > Home, you'll be taken to the core profiler Welcome page. Do not click "Skip guided setup". But if you happen to have skipped it by accident, you can send a POST request to `http://localhost:8086/wp-json/wc-admin/onboarding/profile` with the following payload in order to reset the skipped state:
   ```json
    {
    "skipped": false
    }
   ```
1. Run only the `page-loads.spec.js` file. All tests in it should pass.
    ```bash
    pnpm --filter=woocommerce test:e2e-pw page-loads.spec.js
    ```

#### Testing on the permanent sites for daily and release tests

Assuming you don't have a running `wp-env` local environment, and you're on the `woocommerce` monorepo root dir:
1. Run only `pnpm install` to install dependencies. No need to run the `build` and `env:test` PNPM commands.
1. Make sure that the daily and release test sites do not skip the core profiler. As mentioned earlier, do this by sending a POST request to `/wp-json/wc-admin/onboarding/profile` with this payload:
    ```json
    {
    "skipped": false
    }
    ```
1. Run the `page-loads.spec.js` E2E spec against the daily and release smoke test sites using the following environment variables. Get their values from the secret store if you haven't saved them yet.
    ```bash
    export BASE_URL='...'
    export ADMIN_USER='...'
    export ADMIN_USER_EMAIL='...'
    export ADMIN_PASSWORD='...'
    export CUSTOMER_USER='...'
    export CUSTOMER_PASSWORD='...'
    export CUSTOMER_USER_EMAIL='...'
    export RESET_SITE=true
    pnpm --filter=woocommerce test:e2e-pw page-loads.spec.js
    ```
1. All tests should pass.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
