### PR TITLE
E2E: Set up HPOS through `wp option` cli command

### DIFF
--- a/plugins/woocommerce/changelog/e2e-enable-hpos-wp-option
+++ b/plugins/woocommerce/changelog/e2e-enable-hpos-wp-option
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Enable HPOS through the `wp option` command.

--- a/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
+++ b/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
@@ -26,7 +26,8 @@ wp-env run tests-cli sudo cp /var/www/html/wp-content/plugins/woocommerce/tests/
 
 if [ $ENABLE_HPOS == 1 ]; then
 	echo -e 'Enable High-Performance Order Tables\n'
-	wp-env run tests-cli wp plugin install https://gist.github.com/vedanshujain/564afec8f5e9235a1257994ed39b1449/archive/b031465052fc3e04b17624acbeeb2569ef4d5301.zip --activate
+	wp-env run tests-cli wp option update woocommerce_feature_custom_order_tables_enabled 'yes'
+	wp-env run tests-cli wp option update woocommerce_custom_orders_table_enabled 'yes'
 fi
 
 if [ $ENABLE_NEW_PRODUCT_EDITOR == 1 ]; then


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #39098.

This PR changes the way `test-env-setup.sh` enables HPOS. In `trunk`, HPOS is enabled using the `woocommerce-experimental-enable-new-product-editor.zip` plugin. But this PR changes that by using the `wp option` CLI command instead.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Clone this branch.
    ```bash
    git checkout e2e/enable-hpos-wp-cli
    ```
2. Run the usual scripts to launch the local environment, but with the `ENABLE_HPOS` environment variable:
    ```bash
    export ENABLE_HPOS=1
    pnpm install
    pnpm run build --filter=woocommerce
    cd plugins/woocommerce
    pnpm env:test
    ```
3. Go to http://localhost:8086/wp-admin/admin.php?page=wc-settings&tab=advanced&section=custom_data_stores and verify that the _"Use the WooCommerce orders tables"_ checkbox is checked.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
