### PR TITLE
In-App Marketplace: use `useQuery` instead of `getQuery` for tab URLs, so browser history works

### DIFF
--- a/plugins/woocommerce-admin/client/layout/controller.js
+++ b/plugins/woocommerce-admin/client/layout/controller.js
@@ -182,10 +182,10 @@ export const getPages = () => {
 			layout: {
 				header: false,
 			},
-			path: '/marketplace',
+			path: '/extensions',
 			breadcrumbs: [
-				[ '/marketplace', __( 'Marketplace', 'woocommerce' ) ],
-				__( 'Marketplace', 'woocommerce' ),
+				[ '/extensions', __( 'Extensions', 'woocommerce' ) ],
+				__( 'Extensions', 'woocommerce' ),
 			],
 			wpOpenMenu: 'toplevel_page_woocommerce',
 			capability: 'manage_woocommerce',

--- a/plugins/woocommerce-admin/client/marketplace/components/constants.ts
+++ b/plugins/woocommerce-admin/client/marketplace/components/constants.ts
@@ -1,2 +1,2 @@
 export const DEFAULT_TAB_KEY = 'discover';
-export const MARKETPLACE_PATH = '/marketplace';
+export const MARKETPLACE_PATH = '/extensions';

--- a/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { useEffect } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import classNames from 'classnames';
-import { getQuery, getNewPath, navigateTo } from '@woocommerce/navigation';
+import { getNewPath, navigateTo, useQuery } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -80,16 +80,15 @@ const Tabs = ( props: TabsProps ): JSX.Element => {
 		tab?: string;
 	}
 
-	useEffect( () => {
-		const query: Query = getQuery();
+	const query: Query = useQuery();
 
+	useEffect( () => {
 		if ( query?.tab && tabs[ query.tab ] ) {
 			setSelectedTab( query.tab );
-			return;
+		} else {
+			setSelectedTab( DEFAULT_TAB_KEY );
 		}
-
-		setSelectedTab( DEFAULT_TAB_KEY );
-	}, [ setSelectedTab ] );
+	}, [ query, setSelectedTab ] );
 
 	return (
 		<nav className="woocommerce-marketplace__tabs">

--- a/plugins/woocommerce/src/Internal/Admin/Marketplace.php
+++ b/plugins/woocommerce/src/Internal/Admin/Marketplace.php
@@ -16,7 +16,7 @@ class Marketplace {
 	 * Class initialization, to be executed when the class is resolved by the container.
 	 */
 	final public function init() {
-		add_action( 'admin_menu', array( $this, 'register_pages' ), 45 );
+		add_action( 'admin_menu', array( $this, 'register_pages' ), 70 );
 	}
 
 	/**
@@ -39,8 +39,8 @@ class Marketplace {
 			array(
 				'id'     => 'woocommerce-marketplace',
 				'parent' => 'woocommerce',
-				'title'  => __( 'Marketplace', 'woocommerce' ),
-				'path'   => '/marketplace',
+				'title'  => __( 'Extensions', 'woocommerce' ),
+				'path'   => '/extensions',
 			),
 		);
 


### PR DESCRIPTION
This is a small update to the changes in https://github.com/woocommerce/woocommerce/pull/38885. We're using `useQuery` instead of `getQuery` from `@woocommerce/navigation` to ensure going back and forward in browser history works with the new marketplace page and tabs.

### Submission Review Guidelines:

- I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/). 
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- Changes URL query handler in `Tabs` component to use `useQuery` instead of `getQuery`.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://href.li/?17315-gh-Automattic/woocommerce.com
Related: https://github.com/woocommerce/woocommerce/pull/38885

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Enable the right Node version:

```
nvm use
```

3. From the WooCommerce plugin folder, update the Composer autoload class maps:

```
cd plugins/woocommerce
composer dump-autoload
```

4.  Then run the build:

```
pnpm run --filter=woocommerce build
```

5. Go to WooCommerce in your local environment, and confirm that you see the new menu item `Marketplace` in the WooCommerce menu above `Settings`. (If you're using wp-env the URL is http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fmarketplace.)
6. Check that you can navigate from there to the `Extensions` tab and back again. The `Marketplace` menu item should be highlighted as the current item while you're on each of these tabs, and the URL should correctly reflect the page and tab. If you visit one of the URLs, the correct tab should load.
7. Check that navigation works as expected when you use the browser Back and Forward buttons.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message

Tweaks the method we use to get the current query string, to ensure browser history works when you navigate to the marketplace.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>

### Screenshots

<img width="500" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1647564/008c2a3d-c102-4847-86a7-893aaae5023f">
