### PR TITLE
Fix "Used for variations" checkbox being disabled on Variable products

### DIFF
--- a/plugins/woocommerce/changelog/fix-disabled-checkbox-variations
+++ b/plugins/woocommerce/changelog/fix-disabled-checkbox-variations
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+
+Comment:
+Fix "Used for variations" checkbox being disabled on Variable products

--- a/plugins/woocommerce/changelog/fix-disabled-checkbox-variations
+++ b/plugins/woocommerce/changelog/fix-disabled-checkbox-variations
@@ -1,5 +1,4 @@
 Significance: patch
 Type: fix
 
-Comment:
-Fix "Used for variations" checkbox being disabled on Variable products
+Comment: Fix "Used for variations" checkbox being disabled on Variable products

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -126,6 +126,34 @@ jQuery( function ( $ ) {
 			return false;
 		} );
 
+	function disable_or_enable_fields() {
+		var product_type = $( 'select#product-type' ).val();
+		$( `.enable_if_simple` ).each( function () {
+			$( this ).addClass( 'disabled' );
+			if ( $( this ).is( 'input' ) ) {
+				$( this ).prop( 'disabled', true );
+			}
+		} );
+		$( `.enable_if_external` ).each( function () {
+			$( this ).addClass( 'disabled' );
+			if ( $( this ).is( 'input' ) ) {
+				$( this ).prop( 'disabled', true );
+			}
+		} );
+		$( `.enable_if_variable` ).each( function () {
+			$( this ).addClass( 'disabled' );
+			if ( $( this ).is( 'input' ) ) {
+				$( this ).prop( 'disabled', true );
+			}
+		} );
+		$( `.enable_if_${ product_type }` ).each( function () {
+			$( this ).removeClass( 'disabled' );
+			if ( $( this ).is( 'input' ) ) {
+				$( this ).prop( 'disabled', false );
+			}
+		} );
+	}
+
 	// Product type specific options.
 	$( 'select#product-type' )
 		.on( 'change', function () {
@@ -267,34 +295,6 @@ jQuery( function ( $ ) {
 					.find( 'li a[href="#' + $id + '"]' )
 					.parent()
 					.hide();
-			}
-		} );
-	}
-
-	function disable_or_enable_fields() {
-		var product_type = $( 'select#product-type' ).val();
-		$( `.enable_if_simple` ).each( function () {
-			$( this ).addClass( 'disabled' );
-			if ( $( this ).is( 'input' ) ) {
-				$( this ).prop( 'disabled', true );
-			}
-		} );
-		$( `.enable_if_external` ).each( function () {
-			$( this ).addClass( 'disabled' );
-			if ( $( this ).is( 'input' ) ) {
-				$( this ).prop( 'disabled', true );
-			}
-		} );
-		$( `.enable_if_variable` ).each( function () {
-			$( this ).addClass( 'disabled' );
-			if ( $( this ).is( 'input' ) ) {
-				$( this ).prop( 'disabled', true );
-			}
-		} );
-		$( `.enable_if_${ product_type }` ).each( function () {
-			$( this ).removeClass( 'disabled' );
-			if ( $( this ).is( 'input' ) ) {
-				$( this ).prop( 'disabled', false );
 			}
 		} );
 	}
@@ -913,6 +913,8 @@ jQuery( function ( $ ) {
 
 					// Hide the 'Used for variations' checkbox if not viewing a variable product
 					show_and_hide_panels();
+
+					disable_or_enable_fields();
 
 					// Make sure the dropdown is not disabled for empty value attributes.
 					$( 'select.attribute_taxonomy' )

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -145,6 +145,7 @@ jQuery( function ( $ ) {
 			}
 
 			show_and_hide_panels();
+			disable_or_enable_fields();
 			change_product_type_tip( get_product_tip_content( select_val ) );
 
 			$( 'ul.wc-tabs li:visible' ).eq( 0 ).find( 'a' ).trigger( 'click' );
@@ -266,6 +267,34 @@ jQuery( function ( $ ) {
 					.find( 'li a[href="#' + $id + '"]' )
 					.parent()
 					.hide();
+			}
+		} );
+	}
+
+	function disable_or_enable_fields() {
+		var product_type = $( 'select#product-type' ).val();
+		$( `.enable_if_simple` ).each( function () {
+			$( this ).addClass( 'disabled' );
+			if ( $( this ).is( 'input' ) ) {
+				$( this ).prop( 'disabled', true );
+			}
+		} );
+		$( `.enable_if_external` ).each( function () {
+			$( this ).addClass( 'disabled' );
+			if ( $( this ).is( 'input' ) ) {
+				$( this ).prop( 'disabled', true );
+			}
+		} );
+		$( `.enable_if_variable` ).each( function () {
+			$( this ).addClass( 'disabled' );
+			if ( $( this ).is( 'input' ) ) {
+				$( this ).prop( 'disabled', true );
+			}
+		} );
+		$( `.enable_if_${ product_type }` ).each( function () {
+			$( this ).removeClass( 'disabled' );
+			if ( $( this ).is( 'input' ) ) {
+				$( this ).prop( 'disabled', false );
 			}
 		} );
 	}
@@ -538,6 +567,8 @@ jQuery( function ( $ ) {
 			update_attribute_row_indexes();
 
 			toggle_expansion_of_attribute_list_item( $attributeListItem );
+
+			disable_or_enable_fields();
 
 			jQuery.maybe_disable_save_button();
 		} catch ( error ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

While reverting [Always show pricing group fields, disable if not available for a product type (#38531)
](https://github.com/woocommerce/woocommerce/pull/38964), unfortunately I removed a function which was necessary for another functionality to work, which caused the issue described in #39105. This reintroduces only the necessary parts for it to work.

Closes #39105 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Open the legacy product editor at Product > Add New.
2. Leave product type as 'Simple' for now.
3. Go to Attributes tab.
4. Add a new Attribute, fill the mandatory values, and click 'Save attributes'.
5. Switch product type to 'Variable'.
6. Verify that the previously added attribute does not have 'Used for variations' checked, since it was not persisted with that value.
7. Add a new attribute.
8. Verify that 'Used for variations' is checked as default.
9. Fill all mandatory values and click 'Save attributes'. 
10. Refresh and check if the information was persisted successfully.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
