### PR TITLE
Core profiler -- fix the gap at the top on iPad and iPad Mini

### DIFF
--- a/plugins/woocommerce-admin/client/core-profiler/style.scss
+++ b/plugins/woocommerce-admin/client/core-profiler/style.scss
@@ -606,7 +606,7 @@
 
 // Override WP Core style where it applies padding-top: 46px
 // This style fixes devices with width between 601px and 782px (iPad and iPad Mini)
-@media screen and (min-width: 601px) and (max-width: 782px)  {
+@media screen and (min-width: 601px) and (max-width: 782px) {
 	html.wp-toolbar {
 		padding-top: 32px !important;
 	}

--- a/plugins/woocommerce-admin/client/core-profiler/style.scss
+++ b/plugins/woocommerce-admin/client/core-profiler/style.scss
@@ -603,3 +603,11 @@
 		}
 	}
 }
+
+// Override WP Core style where it applies padding-top: 46px
+// This style fixes devices with width between 601px and 782px (iPad and iPad Mini)
+@media screen and (min-width: 601px) and (max-width: 782px)  {
+	html.wp-toolbar {
+		padding-top: 32px !important;
+	}
+}

--- a/plugins/woocommerce/changelog/fix-38948-unexpected-gap-on-ipad
+++ b/plugins/woocommerce/changelog/fix-38948-unexpected-gap-on-ipad
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix unexpected gap on ipad and ipad mini


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #38948 

This PR fixes unexpected gap on iPad and iPad Mii

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Checkout this branch
2. Start the core profiler
3. Change to mobile view
4. Select iPad and iPad Mini
5. Confirm there is no gap at the top

<!-- End testing instructions -->


### Screenshots

Before:
![Screen Shot 2023-07-05 at 2 18 29 PM](https://github.com/woocommerce/woocommerce/assets/4723145/80c48325-891f-45d5-9558-5a5619a86900)

After:
![Screen Shot 2023-07-05 at 2 18 42 PM](https://github.com/woocommerce/woocommerce/assets/4723145/229a1f45-a5a3-42c6-b1e6-c117a7ffc633)

