### PR TITLE
Redirect to Jetpack connect page on plugins page skip

### DIFF
--- a/plugins/woocommerce-admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/index.tsx
@@ -1174,9 +1174,13 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 							} );
 							return promiseDelay( 3000 );
 						},
-						onDone: {
-							actions: [ 'redirectToWooHome' ],
-						},
+						onDone: [
+							{
+								target: 'isJetpackConnected',
+								cond: 'hasJetpackSelected',
+							},
+							{ actions: [ 'redirectToWooHome' ] },
+						],
 					},
 					meta: {
 						component: Loader,

--- a/plugins/woocommerce/changelog/fix-39039-jetpack-redirect-issue
+++ b/plugins/woocommerce/changelog/fix-39039-jetpack-redirect-issue
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+When all plugins are deselected, but Jetpack is already installed and not connected, redirect users to the Jetpack Connect page.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #39039 

This PR updates Jetpack Connect redirection logic.

When all plugins are deselected, but Jetpack is already installed and not connected, redirect users to the Jetpack Connect page.



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout this branch
2. Install & activate Jetpack
3. Start the core profiler
4. Go to plugins page
5. Confirm Jetpack is labeled as installed
6. Deselect all plugins
7. Click `Continue`
8. You should be redirected to Jetpack Connect page

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
