### PR TITLE
Remove accents from country labels to match geo detected country data 

### DIFF
--- a/packages/js/onboarding/changelog/fix-38947-geolocation-compare-issue
+++ b/packages/js/onboarding/changelog/fix-38947-geolocation-compare-issue
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Remove accent from country labels when comparing against geo detected country

--- a/packages/js/onboarding/src/utils/countries/index.ts
+++ b/packages/js/onboarding/src/utils/countries/index.ts
@@ -54,14 +54,21 @@ export const findCountryOption = (
 			// WP GEO API Returns regions without accents.
 			// Remove accents from the region to compare.
 			// Málaga -> Malaga
-			const wcRegion = option.label
-				.split( '—' )[ 1 ]
-				.trim()
-				.normalize( 'NFKD' )
-				.replace( /[\u0300-\u036f]/g, '' );
+			const wcRegion = option.label.split( '—' )[ 1 ].trim();
 
 			// Region matches exactly with mapping.
 			if ( mappingRegion === wcRegion ) {
+				return option;
+			}
+
+			if (
+				wcRegion.localeCompare( location.region || '', 'en', {
+					sensitivity: 'base',
+				} ) === 0 ||
+				wcRegion.localeCompare( location.city || '', 'en', {
+					sensitivity: 'base',
+				} ) === 0
+			) {
 				return option;
 			}
 

--- a/packages/js/onboarding/src/utils/countries/index.ts
+++ b/packages/js/onboarding/src/utils/countries/index.ts
@@ -51,7 +51,14 @@ export const findCountryOption = (
 			countryCode === location.country_short &&
 			option.label.includes( '—' )
 		) {
-			const wcRegion = option.label.split( '—' )[ 1 ].trim();
+			// WP GEO API Returns regions without accents.
+			// Remove accents from the region to compare.
+			// Málaga -> Malaga
+			const wcRegion = option.label
+				.split( '—' )[ 1 ]
+				.trim()
+				.normalize( 'NFKD' )
+				.replace( /[\u0300-\u036f]/g, '' );
 
 			// Region matches exactly with mapping.
 			if ( mappingRegion === wcRegion ) {
@@ -81,7 +88,7 @@ export const findCountryOption = (
 /**
  * Returns just the country portion of a country:state string that is delimited with a colon.
  *
- * @param  countryPossiblyWithState Country string that may or may not have a state. e.g 'US:CA', 'UG:UG312'
+ * @param countryPossiblyWithState Country string that may or may not have a state. e.g 'US:CA', 'UG:UG312'
  * @return Just the country portion of the string, or undefined if input is undefined. e.g 'US', 'UG'
  */
 export const getCountry = ( countryPossiblyWithState: string ) =>

--- a/packages/js/onboarding/src/utils/countries/tests/utils/index.test.ts
+++ b/packages/js/onboarding/src/utils/countries/tests/utils/index.test.ts
@@ -21,6 +21,18 @@ describe( 'findCountryOption', () => {
 		expect( findCountryOption( countryStateOptions, location ) ).toBeNull();
 	} );
 
+	it( 'should ignore accents for comparsion', () => {
+		const location = {
+			city: 'Malaga',
+			region: 'Andalucia',
+			country_short: 'ES',
+		};
+		expect( findCountryOption( countryStateOptions, location ) ).toEqual( {
+			key: 'ES:MA',
+			label: 'Spain — Málaga',
+		} );
+	} );
+
 	it.each( [
 		{
 			location: { country_short: 'TW' },


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #38947  .

 The WP geo API returns regions without accents, while the country labels have accents. This PR removes accents from the country labels when comparing against geo-detected country to match them correctly.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:
This is somewhat tricky to test as you need to somehow make https://public-api.wordpress.com/geo/ endpoint return mock data. I used https://www.charlesproxy.com/ to do so.

If you're using Charles Proxy, 

1. Open Charles Proxy and click Tools -> Rewrite
2. Check `Enable Rewrite` and add a new entry.
3. Add a new location and enter `https://public-api.wordpress.com/geo`
4. Add a new Type and Action
5. Change `Type` to Body
6. Add `{"latitude":"36.720172","longitude":"-4.420112","country_short":"ES","country_long":"Spain","region":"Andalucia","city":"Malaga"}` for `Replace` value

![Screen Shot 2023-07-05 at 5 20 43 PM](https://github.com/woocommerce/woocommerce/assets/4723145/26cbed4e-47eb-4f81-90cd-8dd5d3852504)

1. Checkout this branch in a new store
2. Start the core profiler
8. Proceed to `Tell us a bit about your  store` page
9. `Where is your store located?` should be autofilled and you should not see a warning.
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
