### PR TITLE
Support hosts which do not have access to 'DUAL' table

### DIFF
--- a/plugins/woocommerce/changelog/refactor-mysql-dual-table-in-favor-of-real-table
+++ b/plugins/woocommerce/changelog/refactor-mysql-dual-table-in-favor-of-real-table
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Use existing table instead of 'DUAL' to support hosts which do not support 'DUAL'.

--- a/plugins/woocommerce/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -532,16 +532,16 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 		);
 
 		$query_for_tentative_usages = $this->get_tentative_usage_query( $coupon->get_id() );
-		$db_timestamp               = $wpdb->get_var( 'SELECT UNIX_TIMESTAMP() FROM DUAL' );
+		$db_timestamp               = $wpdb->get_var( 'SELECT UNIX_TIMESTAMP() FROM ' . $wpdb->posts . ' LIMIT 1' );
 
 		$coupon_usage_key = '_coupon_held_' . ( (int) $db_timestamp + $held_time ) . '_' . wp_generate_password( 6, false );
 
 		$insert_statement = $wpdb->prepare(
 			"
 			INSERT INTO $wpdb->postmeta ( post_id, meta_key, meta_value )
-			SELECT %d, %s, %s FROM DUAL
+			SELECT %d, %s, %s FROM $wpdb->posts
 			WHERE ( $query_for_usages ) + ( $query_for_tentative_usages ) < %d
-			",
+			LIMIT 1",
 			$coupon->get_id(),
 			$coupon_usage_key,
 			'',
@@ -629,15 +629,15 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 		); // WPCS: unprepared SQL ok.
 
 		$query_for_tentative_usages = $this->get_tentative_usage_query_for_user( $coupon->get_id(), $user_aliases );
-		$db_timestamp               = $wpdb->get_var( 'SELECT UNIX_TIMESTAMP() FROM DUAL' );
+		$db_timestamp               = $wpdb->get_var( 'SELECT UNIX_TIMESTAMP() FROM ' . $wpdb->posts . ' LIMIT 1' );
 
 		$coupon_used_by_meta_key    = '_maybe_used_by_' . ( (int) $db_timestamp + $held_time ) . '_' . wp_generate_password( 6, false );
 		$insert_statement           = $wpdb->prepare(
 			"
 			INSERT INTO $wpdb->postmeta ( post_id, meta_key, meta_value )
-			SELECT %d, %s, %s FROM DUAL
+			SELECT %d, %s, %s FROM $wpdb->posts
 			WHERE ( $query_for_usages ) + ( $query_for_tentative_usages ) < %d
-			",
+			LIMIT 1",
 			$coupon->get_id(),
 			$coupon_used_by_meta_key,
 			$user_alias,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

There isn't a GitHub issue for this, however more details can be found at p6q8Tx-3bj-p2. At a high level, when the `DUAL` table cannot be accessed, the queries which provide a `UNIX_TIMESTAMP()` won't return a correct value, causing coupon usage not to be incremented.

Notes:
- In most cases, the table `posts` was chosen based on the idea that holding a valid coupon would require at least one coupon to exist, meaning at least one row inside `posts` should also exist. This PR method would not work for an empty table.
- `LIMIT 1` also needs to be used to prevent returning more than one row, as this query would normally return same number of rows as there are posts.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Build this plugin and install it into a WordPress instance.
2. Create a product and a coupon on this WooCommerce instance for testing (unless there is an existing coupon and product you'd like to use). If using an existing coupon, take note of the number of usages so far, so that we can assert that this number has incremented.
3. Setup a test payment gateway to allow checkout if a gateway doesn't already exist.
4. Purchase the product using the coupon.
5. Navigate to the coupons list inside WooCommerce and observe that the number of usages for the coupon has incremented.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message <!-- Add a changelog message here -->

Use existing table instead of 'DUAL' to support hosts which do not have access to the 'DUAL' table.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
