### PR TITLE
Allow registered React-powered page to specify 'parent path'

### DIFF
--- a/changelog/pr-39116
+++ b/changelog/pr-39116
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Allow registered React-powered page to specify 'parent path' in navArgs.

--- a/changelog/pr-39116
+++ b/changelog/pr-39116
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Allow registered React-powered page to specify 'parent path' in navArgs.

--- a/plugins/woocommerce-admin/client/layout/controller.js
+++ b/plugins/woocommerce-admin/client/layout/controller.js
@@ -485,10 +485,20 @@ window.wpNavMenuClassChange = function ( page, url ) {
 		url === '/'
 			? 'admin.php?page=wc-admin'
 			: 'admin.php?page=wc-admin&path=' + encodeURIComponent( url );
-	const currentItemsSelector =
+	let currentItemsSelector =
 		url === '/'
 			? `li > a[href$="${ pageUrl }"], li > a[href*="${ pageUrl }?"]`
 			: `li > a[href*="${ pageUrl }"]`;
+
+	const parentPath = page.navArgs?.parentPath;
+	if ( parentPath ) {
+		const parentPageUrl =
+			parentPath === '/'
+				? 'admin.php?page=wc-admin'
+				: 'admin.php?page=wc-admin&path=' + encodeURIComponent( parentPath );
+		currentItemsSelector += `, li > a[href*="${ parentPageUrl }"]`;
+	}
+
 	const currentItems = wpNavMenu.querySelectorAll( currentItemsSelector );
 
 	Array.from( currentItems ).forEach( function ( item ) {

--- a/plugins/woocommerce-admin/client/layout/controller.js
+++ b/plugins/woocommerce-admin/client/layout/controller.js
@@ -495,7 +495,8 @@ window.wpNavMenuClassChange = function ( page, url ) {
 		const parentPageUrl =
 			parentPath === '/'
 				? 'admin.php?page=wc-admin'
-				: 'admin.php?page=wc-admin&path=' + encodeURIComponent( parentPath );
+				: 'admin.php?page=wc-admin&path=' +
+				  encodeURIComponent( parentPath );
 		currentItemsSelector += `, li > a[href*="${ parentPageUrl }"]`;
 	}
 

--- a/plugins/woocommerce/changelog/add-override-menu-item-highlight
+++ b/plugins/woocommerce/changelog/add-override-menu-item-highlight
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-Allow registered React-powered page to specify 'parent path' in navArgs.
+Allow registered React-powered page to specify 'parent path' in .

--- a/plugins/woocommerce/changelog/add-override-menu-item-highlight
+++ b/plugins/woocommerce/changelog/add-override-menu-item-highlight
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-Allow registered React-powered page to specify 'parent path' in .
+Allow registered React-powered page to specify 'parent path' in navArgs.

--- a/plugins/woocommerce/changelog/add-override-menu-item-highlight
+++ b/plugins/woocommerce/changelog/add-override-menu-item-highlight
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Allow registered React-powered page to specify 'parent path' in .

--- a/plugins/woocommerce/changelog/add-override-menu-item-highlight
+++ b/plugins/woocommerce/changelog/add-override-menu-item-highlight
@@ -1,4 +1,4 @@
 Significance: minor
 Type: add
 
-Allow registered React-powered page to specify 'parent path' in navArgs.
+Allow registered React-powered pages to specify a parent navigation menu item to highlight when active.


### PR DESCRIPTION
This PR tries to solve the problem where [registered React-powered page](https://developer.woocommerce.com/extension-developer-guide/working-with-woocommerce-admin-pages/#registering-a-react-powered-page) whose 'path' does not match with any of the menu item will not have a way to highlight any of the menu item.

Note: I'm trying to solve https://github.com/Automattic/woocommerce-payments/issues/6394.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

By passing `page.navArgs.parentPath`, a page can use that path as a matcher to a menu item.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

ps: I tried to create a simple plugin that utilize this PR change to test but took me quite some time to figure out things, so I'll just use WCPay.

1. Install WooCommerce Payments that is built off [my PR](https://github.com/Automattic/woocommerce-payments/pull/6694). Zip file can be downloaded from [here](https://github.com/Automattic/woocommerce-payments/actions/runs/5501257754).

2. Install [WCPay dev tool](https://github.com/Automattic/woocommerce-payments-dev-tools/archive/refs/heads/trunk.zip).

3. Onboard WCPay by going to wp-admin > Payments. Follow the steps and for ones that are not obvious, I note below.

When asked for a phone number, click this link:
<img width="453" alt="Screenshot 2023-07-10 at 01 05 24" src="https://github.com/woocommerce/woocommerce/assets/73803630/8eb3df3d-9d15-4d5a-a578-8f16d55ff0b9">

When asked for address, fill the form like this per [Stripe's docs](https://stripe.com/docs/connect/testing#test-verification-addresses):
<img width="452" alt="Screenshot 2023-07-10 at 01 07 06" src="https://github.com/woocommerce/woocommerce/assets/73803630/b390b3a7-1562-4d00-9a09-84700b2af743">

When asked for bank account:
<img width="471" alt="Screenshot 2023-07-10 at 01 08 31" src="https://github.com/woocommerce/woocommerce/assets/73803630/d1200d20-cfad-48db-b3f6-3635bcae37ea">
<img width="446" alt="Screenshot 2023-07-10 at 01 08 03" src="https://github.com/woocommerce/woocommerce/assets/73803630/ffba7134-a468-44e0-904a-ed902f840be8">

4. Purchase a product.

5. Open a transaction details page by going to wp-admin > Payments > Transactions > click one of the row in the table.

Notice that with [trunk](https://github.com/woocommerce/woocommerce/tree/trunk), the `Transactions` menu item is not highlighted.
<img width="859" alt="Screenshot 2023-07-10 at 00 08 46" src="https://github.com/woocommerce/woocommerce/assets/73803630/01e565bb-c00a-47b0-8439-47decab791e5">

With this PR's branch, `Transactions` menu item should be highlighted.
<img width="955" alt="Screenshot 2023-07-10 at 00 02 32" src="https://github.com/woocommerce/woocommerce/assets/73803630/235844c2-0f8d-4cdb-9a34-721a79a67126">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message <!-- Add a changelog message here -->

Allow registered React-powered page to specify 'parent path' in `navArgs`.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
