### PR TITLE
Rename "Install plugin" button text to "Install extension" in Marketing page

### DIFF
--- a/plugins/woocommerce-admin/client/marketing/components/PluginCardBody/SmartPluginCardBody.tsx
+++ b/plugins/woocommerce-admin/client/marketing/components/PluginCardBody/SmartPluginCardBody.tsx
@@ -95,7 +95,7 @@ export const SmartPluginCardBody = ( {
 					disabled={ buttonDisabled }
 					onClick={ installAndActivate }
 				>
-					{ __( 'Install plugin', 'woocommerce' ) }
+					{ __( 'Install extension', 'woocommerce' ) }
 				</Button>
 			);
 		}

--- a/plugins/woocommerce-admin/client/marketing/overview-multichannel/DiscoverTools/DiscoverTools.test.tsx
+++ b/plugins/woocommerce-admin/client/marketing/overview-multichannel/DiscoverTools/DiscoverTools.test.tsx
@@ -58,7 +58,7 @@ describe( 'DiscoverTools component', () => {
 	} );
 
 	describe( 'With plugins loaded', () => {
-		it( 'should render `direct_install: true` plugins with "Install plugin" button', () => {
+		it( 'should render `direct_install: true` plugins with "Install extension" button', () => {
 			(
 				useRecommendedPluginsWithoutChannels as jest.Mock
 			 ).mockReturnValue( {
@@ -92,7 +92,7 @@ describe( 'DiscoverTools component', () => {
 			} );
 			render( <DiscoverTools /> );
 
-			// Assert that we have the "Sales channels" tab, the plugin name, the "Built by WooCommerce" pill, and the "Install plugin" button.
+			// Assert that we have the "Sales channels" tab, the plugin name, the "Built by WooCommerce" pill, and the "Install extension" button.
 			expect( screen.getByText( 'Sales channels' ) ).toBeInTheDocument();
 			expect(
 				screen.getByText( 'Google Listings and Ads' )
@@ -100,7 +100,9 @@ describe( 'DiscoverTools component', () => {
 			expect(
 				screen.getByText( 'Built by WooCommerce' )
 			).toBeInTheDocument();
-			expect( screen.getByText( 'Install plugin' ) ).toBeInTheDocument();
+			expect(
+				screen.getByText( 'Install extension' )
+			).toBeInTheDocument();
 		} );
 
 		it( 'should render `direct_install: false` plugins with "View details" button', () => {

--- a/plugins/woocommerce-admin/client/marketing/overview-multichannel/DiscoverTools/PluginsTabPanel.tsx
+++ b/plugins/woocommerce-admin/client/marketing/overview-multichannel/DiscoverTools/PluginsTabPanel.tsx
@@ -117,7 +117,7 @@ export const PluginsTabPanel = ( {
 									installAndActivate( plugin );
 								} }
 							>
-								{ __( 'Install plugin', 'woocommerce' ) }
+								{ __( 'Install extension', 'woocommerce' ) }
 							</Button>
 						);
 					}

--- a/plugins/woocommerce/changelog/fix-39103-install-extension-button-text
+++ b/plugins/woocommerce/changelog/fix-39103-install-extension-button-text
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Change button text from "Install plugin" to "Install extension" in Marketing page.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/39103.

In Marketing page, there are some button text that says "Install plugin". In the same page, there is another card with the title "Installed extensions". The term "plugin" and "extension" are not consistent.

In this PR, we make them consistent by renaming the button text to "Install extension".

In "Channels" card:

<img width="717" alt="image" src="https://github.com/woocommerce/woocommerce/assets/417342/2ddf9af2-d1fe-436c-b570-874c75e8a52b">

In "Create a new campaign" modal:

<img width="641" alt="image" src="https://github.com/woocommerce/woocommerce/assets/417342/c6a4e8bb-e644-40ab-8daa-0e7891fe1bf7">

In "Discover more marketing tools" card:

<img width="720" alt="image" src="https://github.com/woocommerce/woocommerce/assets/417342/ffe158dd-52e8-4169-b393-e7afe6bbad5b">


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to the Marketing page: `/wp-admin/admin.php?page=wc-admin&path=%2Fmarketing`
2. By referring to the above screenshots, the "Channels" card, "Create a new campaign" modal and "Discover more marketing tools" card should have button text that says "Install extension", instead of "Install plugin".

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
