### PR TITLE
Clean up after testing `wc_load_cart()`

### DIFF
--- a/plugins/woocommerce/changelog/fix-test-wc-load-cart
+++ b/plugins/woocommerce/changelog/fix-test-wc-load-cart
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Cleanup global state after testing `wc_load_cart()`.

--- a/plugins/woocommerce/tests/legacy/unit-tests/util/class-wc-tests-core-functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/util/class-wc-tests-core-functions.php
@@ -1049,6 +1049,10 @@ class WC_Tests_Core_Functions extends WC_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_wc_load_cart() {
+		$original_cart     = $this->wc->cart;
+		$original_customer = $this->wc->customer;
+		$original_session  = $this->wc->session;
+
 		$this->assertInstanceOf( 'WC_Cart', $this->wc->cart );
 		$this->assertInstanceOf( 'WC_Customer', $this->wc->customer );
 		$this->assertInstanceOf( 'WC_Session', $this->wc->session );
@@ -1065,6 +1069,12 @@ class WC_Tests_Core_Functions extends WC_Unit_Test_Case {
 		$this->assertInstanceOf( 'WC_Customer', $this->wc->customer );
 		$this->assertInstanceOf( 'WC_Session', $this->wc->session );
 
+		// Restore original cart, customer and session instances. Important since global state (including filters and
+		// actions) is reset between tests, and we want to avoid a scenario in which wc()->cart and cart-related
+		// callbacks are separate instances of the same class - which can lead to strange effects.
+		$this->wc->cart     = $original_cart;
+		$this->wc->customer = $original_customer;
+		$this->wc->session  = $original_session;
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Adds some cleanup at the end of `test_wc_load_cart`. This should unblock https://github.com/woocommerce/woocommerce/pull/37847 (and *possibly* also https://github.com/woocommerce/woocommerce/pull/37842), for which tests are failing under PHP 8.0. here's an outline of the problem:

- Before `test_wc_load_cart` runs, `wc()->cart` (the global cart object) is already established, and it will already have [registered callbacks](https://github.com/woocommerce/woocommerce/blob/7.8.2/plugins/woocommerce/includes/class-wc-cart.php#L106-L112) for various actions and filters (this happens via the cart's constructor).
- Within `test_wc_load_cart`, `wc()->cart` reference is basically replaced (the old objects are not destroyed, however). At this point, we now have two instances of the cart.
- After `test_wc_load_cart` has executed, we still have two cart objects but, because (most) global state is restored between tests, cart-related callbacks reference the 'old' cart instance, and not the new one.

This potentially leads to some strange effects (please see test fails in the above PR), which this PR corrects.

A possible alternative is moving this cleanup to the setup and teardown methods in `WC_Unit_Test_Case`, but this approach felt like the better fit.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

In this case, I don't think manual testing is applicable and code review should be sufficient.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
