### PR TITLE
E2E: Add update button click, and more assertions to `can add custom product attributes` test

### DIFF
--- a/plugins/woocommerce/changelog/e2e-attributes-more-assertions
+++ b/plugins/woocommerce/changelog/e2e-attributes-more-assertions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Add more assertions to `can add custom product attributes` E2E test.

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/add-variable-product/create-product-attributes.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/add-variable-product/create-product-attributes.spec.js
@@ -68,11 +68,11 @@ test.describe( 'Add product attributes', () => {
 						.getByRole( 'button', { name: 'Add new' } )
 						.click();
 
-					await page
-						.getByRole( 'heading', {
+					await expect(
+						page.getByRole( 'heading', {
 							name: 'New attribute',
 						} )
-						.waitFor();
+					).toBeVisible();
 				} );
 			}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #39119.

This pull request:
- Adds [these assertions](https://github.com/woocommerce/woocommerce/pull/39139/files#diff-43fbdc7512061c5149014b364f067055990b2b8b29083dc42facf15de24f6a79R154-R164) to check for correctness of the added attributes
- Adds [this step](https://github.com/woocommerce/woocommerce/pull/39139/files#diff-43fbdc7512061c5149014b364f067055990b2b8b29083dc42facf15de24f6a79R122-R135) to click on the "Update" button in the Edit Product page.
    - Clicking "Update" will introduce flakiness to succeeding steps because it triggers a lot of requests. To eliminate the flakiness, I added [this line](https://github.com/woocommerce/woocommerce/pull/39139/files#diff-43fbdc7512061c5149014b364f067055990b2b8b29083dc42facf15de24f6a79R134) to wait for the final request to be resolved before proceeding further. Playwright discourages using `networkidle` so I went with this approach instead.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. I reorganized most of the steps in `create-product-attributes.spec.js` so please review if this new flow makes sense.
1. Checkout this branch.
2. Run our usual commands for launching the local E2E environment.
3. Run the `create-product-attributes.spec.js` spec and make sure it's not flaky by running multiple instances of it repeatedly. You can do so through this command:
    ```bash
    cd plugins/woocommerce
    pnpm test:e2e-pw create-product-attributes.spec.js --retries=0 --workers=4 --repeat-each=8
    ```
4. All instances of this test should pass, which indicates it isn't flaky.
1. Run this spec together with the rest of the `merchant` tests:
    ```bash
    cd plugins/woocommerce
    pnpm test:e2e-pw merchant
    ```
    They should all pass.

<!-- End testing instructions -->


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
