### PR TITLE
Add header buttons to the description editor modal

### DIFF
--- a/packages/js/product-editor/changelog/add-38831_header_buttons_to_description_modal
+++ b/packages/js/product-editor/changelog/add-38831_header_buttons_to_description_modal
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add header buttons to the description editor modal #39156

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.scss
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.scss
@@ -32,9 +32,11 @@
     }
 	&-right {
 		margin-left: auto;
-        padding-right: $gap-small;
-		button {
+		button.woocommerce-modal-actions__done-button,
+		button.woocommerce-modal-actions__cancel-button {
 			margin-left: $gap-small;
+			bottom: calc($gap-small / 2);
+			height: $gap-larger - $gap-smallest;
 		}
     }
 }

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.scss
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.scss
@@ -31,6 +31,10 @@
         padding-left: $gap-small;
     }
 	&-right {
+		margin-left: auto;
         padding-right: $gap-small;
+		button {
+			margin-left: $gap-small;
+		}
     }
 }

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.scss
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.scss
@@ -31,11 +31,20 @@
         padding-left: $gap-small;
     }
 	&-right {
-		margin-left: auto;
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		> .components-dropdown-menu {
+			margin-right: $gap-small;
+			> button.components-dropdown-menu__toggle {
+				min-width: 32px !important;
+				padding-left: 0 !important;
+				padding-right: 0 !important;
+			}
+		}
 		button.woocommerce-modal-actions__done-button,
 		button.woocommerce-modal-actions__cancel-button {
-			margin-left: $gap-small;
-			bottom: calc($gap-small / 2);
+			margin-left: $gap-smaller;
 			height: $gap-larger - $gap-smallest;
 		}
     }

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.scss
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.scss
@@ -36,11 +36,14 @@
 		align-items: center;
 		> .components-dropdown-menu {
 			margin-right: $gap-small;
+			width: 48px;
 			> button.components-dropdown-menu__toggle {
-				min-width: 32px !important;
-				padding-left: 0 !important;
-				padding-right: 0 !important;
+				padding: $gap-smaller !important;
+				margin-right: -8px;
 			}
+		}
+		> .woocommerce-show-block-inspector-panel {
+			margin-right: -$gap-smaller;
 		}
 		button.woocommerce-modal-actions__done-button,
 		button.woocommerce-modal-actions__cancel-button {

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
@@ -146,7 +146,10 @@ export function HeaderToolbar( {
 				>
 					{ __( 'Done', 'woocommerce' ) }
 				</ToolbarItem>
-				<ToolbarItem as={ ShowBlockInspectorPanel } />
+				<ToolbarItem
+					as={ ShowBlockInspectorPanel }
+					className="woocommerce-show-block-inspector-panel"
+				/>
 				<ToolbarItem as={ MoreMenu } />
 			</div>
 		</NavigableToolbar>

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
@@ -35,7 +35,17 @@ import { DocumentOverview } from './document-overview';
 import { ShowBlockInspectorPanel } from './show-block-inspector-panel';
 import { MoreMenu } from './more-menu';
 
-export function HeaderToolbar() {
+type HeaderToolbarProps = {
+	isModalActionsBarVisible?: boolean;
+	onSave?: () => void;
+	onCancel?: () => void;
+};
+
+export function HeaderToolbar( {
+	isModalActionsBarVisible = false,
+	onSave = () => {},
+	onCancel = () => {},
+}: HeaderToolbarProps ) {
 	const { isInserterOpened, setIsInserterOpened } =
 		useContext( EditorContext );
 	const isWideViewport = useViewportMatch( 'wide' );
@@ -121,10 +131,28 @@ export function HeaderToolbar() {
 					</>
 				) }
 			</div>
-			<div className="woocommerce-iframe-editor__header-toolbar-right">
-				<ToolbarItem as={ ShowBlockInspectorPanel } />
-				<ToolbarItem as={ MoreMenu } />
-			</div>
+			{ isModalActionsBarVisible && (
+				<div className="woocommerce-iframe-editor__header-toolbar-right">
+					<div className="woocommerce-modal-actions">
+						<Button
+							variant="tertiary"
+							className="woocommerce-modal-actions__cancel-button"
+							onClick={ onCancel }
+						>
+							{ __( 'Cancel', 'woocommerce' ) }
+						</Button>
+						<Button
+							variant="primary"
+							className="woocommerce-modal-actions__done-button"
+							onClick={ onSave }
+						>
+							{ __( 'Done', 'woocommerce' ) }
+						</Button>
+					</div>
+					<ToolbarItem as={ ShowBlockInspectorPanel } />
+					<ToolbarItem as={ MoreMenu } />
+				</div>
+			) }
 		</NavigableToolbar>
 	);
 }

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
@@ -36,13 +36,11 @@ import { ShowBlockInspectorPanel } from './show-block-inspector-panel';
 import { MoreMenu } from './more-menu';
 
 type HeaderToolbarProps = {
-	isModalActionsBarVisible?: boolean;
 	onSave?: () => void;
 	onCancel?: () => void;
 };
 
 export function HeaderToolbar( {
-	isModalActionsBarVisible = false,
 	onSave = () => {},
 	onCancel = () => {},
 }: HeaderToolbarProps ) {
@@ -131,28 +129,26 @@ export function HeaderToolbar( {
 					</>
 				) }
 			</div>
-			{ isModalActionsBarVisible && (
-				<div className="woocommerce-iframe-editor__header-toolbar-right">
-					<div className="woocommerce-modal-actions">
-						<Button
-							variant="tertiary"
-							className="woocommerce-modal-actions__cancel-button"
-							onClick={ onCancel }
-						>
-							{ __( 'Cancel', 'woocommerce' ) }
-						</Button>
-						<Button
-							variant="primary"
-							className="woocommerce-modal-actions__done-button"
-							onClick={ onSave }
-						>
-							{ __( 'Done', 'woocommerce' ) }
-						</Button>
-					</div>
-					<ToolbarItem as={ ShowBlockInspectorPanel } />
-					<ToolbarItem as={ MoreMenu } />
-				</div>
-			) }
+			<div className="woocommerce-iframe-editor__header-toolbar-right">
+				<ToolbarItem
+					as={ Button }
+					variant="tertiary"
+					className="woocommerce-modal-actions__cancel-button"
+					onClick={ onCancel }
+				>
+					{ __( 'Cancel', 'woocommerce' ) }
+				</ToolbarItem>
+				<ToolbarItem
+					as={ Button }
+					variant="primary"
+					className="woocommerce-modal-actions__done-button"
+					onClick={ onSave }
+				>
+					{ __( 'Done', 'woocommerce' ) }
+				</ToolbarItem>
+				<ToolbarItem as={ ShowBlockInspectorPanel } />
+				<ToolbarItem as={ MoreMenu } />
+			</div>
 		</NavigableToolbar>
 	);
 }

--- a/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
@@ -124,7 +124,6 @@ export function IframeEditor( {
 					useSubRegistry={ true }
 				>
 					<HeaderToolbar
-						isModalActionsBarVisible={ true }
 						onSave={ () => {
 							appendEdit( temporalBlocks );
 							setBlocks( temporalBlocks );

--- a/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
@@ -33,6 +33,7 @@ import { SecondarySidebar } from './secondary-sidebar/secondary-sidebar';
 import { useEditorHistory } from './hooks/use-editor-history';
 
 type IframeEditorProps = {
+	closeModal?: () => void;
 	initialBlocks?: BlockInstance[];
 	onChange?: ( blocks: BlockInstance[] ) => void;
 	onClose?: () => void;
@@ -41,16 +42,28 @@ type IframeEditorProps = {
 };
 
 export function IframeEditor( {
+	closeModal = () => {},
 	initialBlocks = [],
 	onChange = () => {},
 	onClose,
-	onInput,
+	onInput = () => {},
 	settings: __settings,
 }: IframeEditorProps ) {
 	const [ resizeObserver ] = useResizeObserver();
 	const [ blocks, setBlocks ] = useState< BlockInstance[] >( initialBlocks );
-	const { appendEdit, hasRedo, hasUndo, redo, undo } = useEditorHistory( {
+	const [ temporalBlocks, setTemporalBlocks ] =
+		useState< BlockInstance[] >( initialBlocks );
+	const { appendEdit } = useEditorHistory( {
 		setBlocks,
+	} );
+	const {
+		appendEdit: tempAppendEdit,
+		hasRedo,
+		hasUndo,
+		redo,
+		undo,
+	} = useEditorHistory( {
+		setBlocks: setTemporalBlocks,
 	} );
 	const [ isInserterOpened, setIsInserterOpened ] = useState( false );
 	const [ isListViewOpened, setIsListViewOpened ] = useState( false );
@@ -99,14 +112,33 @@ export function IframeEditor( {
 					} }
 					value={ blocks }
 					onChange={ ( updatedBlocks: BlockInstance[] ) => {
-						appendEdit( updatedBlocks );
-						setBlocks( updatedBlocks );
+						tempAppendEdit( updatedBlocks );
+						setTemporalBlocks( updatedBlocks );
 						onChange( updatedBlocks );
 					} }
-					onInput={ onInput }
+					onInput={ ( updatedBlocks: BlockInstance[] ) => {
+						tempAppendEdit( updatedBlocks );
+						setTemporalBlocks( updatedBlocks );
+						onInput( updatedBlocks );
+					} }
 					useSubRegistry={ true }
 				>
-					<HeaderToolbar />
+					<HeaderToolbar
+						isModalActionsBarVisible={ true }
+						onSave={ () => {
+							appendEdit( temporalBlocks );
+							setBlocks( temporalBlocks );
+							onChange( temporalBlocks );
+							closeModal();
+						} }
+						onCancel={ () => {
+							appendEdit( blocks );
+							setBlocks( blocks );
+							onChange( blocks );
+							setTemporalBlocks( blocks );
+							closeModal();
+						} }
+					/>
 					<div className="woocommerce-iframe-editor__main">
 						<SecondarySidebar />
 						<BlockTools

--- a/packages/js/product-editor/src/components/modal-editor/modal-editor.tsx
+++ b/packages/js/product-editor/src/components/modal-editor/modal-editor.tsx
@@ -52,6 +52,7 @@ export function ModalEditor( {
 				initialBlocks={ initialBlocks }
 				onInput={ debouncedOnChange }
 				onChange={ debouncedOnChange }
+				closeModal={ handleClose }
 			/>
 		</Modal>
 	);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR adds the `Done` and `Cancel` actions to the `Description` modal.

<img width="1234" alt="Screenshot 2023-07-10 at 18 18 38" src="https://github.com/woocommerce/woocommerce/assets/1314156/3a2d717a-fe69-4e4a-8b56-398700087533">


Closes #38831.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable "Try the new product editor (Beta)" in WooCommerce > Advanced > Features.
2. Go to Product > Add New.
3. Click "Add Description".
4. Verify that there is a `Cancel` and a `Done` buttons on the top right of the modal.
5. Add a text and confirm that the text is not being shown after pressing `Cancel`.
6. Click "Add Description" again.
7. Add a text and confirm that the text is shown after pressing `Done`.

<img width="758" alt="Screenshot 2023-07-10 at 18 29 06" src="https://github.com/woocommerce/woocommerce/assets/1314156/55261569-3ec8-4c7d-84ee-e9a0dff82a75">


_The `X` on the top right of the modal will be removed. I leave the current behavior until it gets removed._


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
