### PR TITLE
Fix issue #38757: CSV importer sales dates

### DIFF
--- a/plugins/woocommerce/changelog/fix-38757-product-csv-importer-sale-dates
+++ b/plugins/woocommerce/changelog/fix-38757-product-csv-importer-sale-dates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix product CSV importer start and end times for sale dates

--- a/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
+++ b/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
@@ -591,6 +591,58 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	}
 
 	/**
+	 * Parse dates from a CSV.
+	 * Dates requires the format YYYY-MM-DD.
+	 * Any time included will be ignored.
+	 * Time will always be set to 00:00:00.
+	 *
+	 * @param string $value Field value.
+	 *
+	 * @return string|null
+	 * 
+	 * @see plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php::save()
+	 */
+	public function parse_date_field_from( $value ) {
+		if ( empty( $value ) ) {
+			return null;
+		}
+
+		if ( preg_match( '/^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])([ 01-9:]*)$/', $value ) ) {
+			// Don't include the time if the field had time in it.
+			$date_field_from_value = current( explode( ' ', $value ) );
+			return date( 'Y-m-d 00:00:00', strtotime( $date_field_from_value ) ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
+		}
+
+		return null;
+	}
+
+	/**
+	 * Parse dates from a CSV.
+	 * Dates requires the format YYYY-MM-DD.
+	 * Any time included will be ignored.
+	 * Time will always be set to 23:59:59.
+	 *
+	 * @param string $value Field value.
+	 *
+	 * @return string|null
+	 * 
+	 * @see plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-product-data.php::save()
+	 */
+	public function parse_date_field_to( $value ) {
+		if ( empty( $value ) ) {
+			return null;
+		}
+
+		if ( preg_match( '/^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])([ 01-9:]*)$/', $value ) ) {
+			// Don't include the time if the field had time in it.
+			$date_field_to_value = current( explode( ' ', $value ) );
+			return date( 'Y-m-d 23:59:59', strtotime( $date_field_to_value ) ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
+		}
+
+		return null;
+	}
+
+	/**
 	 * Parse backorders from a CSV.
 	 *
 	 * @param string $value Field value.
@@ -725,8 +777,8 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 			'type'              => array( $this, 'parse_comma_field' ),
 			'published'         => array( $this, 'parse_published_field' ),
 			'featured'          => array( $this, 'parse_bool_field' ),
-			'date_on_sale_from' => array( $this, 'parse_date_field' ),
-			'date_on_sale_to'   => array( $this, 'parse_date_field' ),
+			'date_on_sale_from' => array( $this, 'parse_date_field_from' ),
+			'date_on_sale_to'   => array( $this, 'parse_date_field_to' ),
 			'name'              => array( $this, 'parse_skip_field' ),
 			'short_description' => array( $this, 'parse_description_field' ),
 			'description'       => array( $this, 'parse_description_field' ),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #38757.

- Makes product CSV importer's treatment of date_on_sale_from and date_on_sale_to mirror meta box field behavior.
- In WordPress admin, when saving date_on_sale_from and date_on_sale_to meta boxes, date_on_sale_from is always forced to midnight of date (Y-m-d 00:00:00) and date_on_sale_to is always forced to end of day (Y-m-d 23:59:59).
- Prior to this patch, the CSV importer had a different behavior for handling date_on_sale_to - it always forced both date_on_sale_from and date_on_sale_to midnight (Y-m-d 00:00:00).
- For example:
    -  If you used the meta boxes to set both date_on_sale_from and date_on_sale_to to today's date, the product would be on sale until end of day.
    - However, if you used the CSV importer to set both date_on_sale_from and date_on_sale_to to today's date, the product would never be on sale because the sales start and end date times would both be forced to midnight today.
- After this patch,  date_on_sale_to will be forced to the end of day to mirror the meta box behavior.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Download and edit attached CSV file
2. Update the "Date sale price starts" and "Date sale price ends" cells for the single product row to use today's date as value. Use this format: YYYY-MM-DD. For example, if today is July 8, 2023, the value for both columns should be 2023-07-08. [Screenshot example](https://prnt.sc/dArg0kFz6kDg)
3. Save your edited CSV file so it is ready to be used for testing.
4. Log in to WordPress
5. Navigate to /wp-admin/edit.php?post_type=product
6. Click the ["Import" button](https://prnt.sc/0_plOXsOP7Lt)
7. Click ["Choose file"](https://prnt.sc/q1I25BtaWKzZ) and upload the CSV file.
8. Click [Continue](https://prnt.sc/q1I25BtaWKzZ)
9. Click ["Run the importer"](https://prnt.sc/DLGRSL1WmUrg)
10. When the importer is finished running, click ["View Products"](https://prnt.sc/OIVujZi-RUxA)
11. Confirm your product is [currently on sale](https://prnt.sc/fV6fdkpxlxTA), with an original price of $45.00 and a sale price of $40.00
12. 
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [X] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [X] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [X] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message Fix product CSV importer start and end times for sale dates

#### Comment Fix product CSV importer start and end times for sale dates

</details>
