### PR TITLE
E2E: Update locators and force-check in `order-email-receiving` and `order-emails` specs

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-order-emails-wp-6.3
+++ b/plugins/woocommerce/changelog/e2e-fix-order-emails-wp-6.3
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update locators in `order-emails` and `order-email-receiving` specs so that they pass on WP 6.3.

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-emails.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-emails.spec.js
@@ -39,7 +39,12 @@ test.describe( 'Merchant > Order Action emails received', () => {
 		while (
 			await page.locator( '#bulk-action-selector-top' ).isVisible()
 		) {
-			await page.locator( '#cb-select-all-1' ).check();
+			// In WP 6.3, label intercepts check action. Need to force.
+			await page
+				.getByLabel( 'Select All' )
+				.first()
+				.check( { force: true } );
+
 			await page
 				.locator( '#bulk-action-selector-top' )
 				.selectOption( 'delete' );

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/order-email-receiving.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/order-email-receiving.spec.js
@@ -30,7 +30,11 @@ test.describe( 'Shopper Order Email Receiving', () => {
 		while (
 			await page.locator( '#bulk-action-selector-top' ).isVisible()
 		) {
-			await page.locator( '#cb-select-all-1' ).click();
+			// In WP 6.3, label intercepts check action. Need to force.
+			await page
+				.getByLabel( 'Select All' )
+				.first()
+				.check( { force: true } );
 			await page
 				.locator( '#bulk-action-selector-top' )
 				.selectOption( 'delete' );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #39148.

We discovered that these 2 E2E specs were failing when run against WP 6.3 Beta 3:
- `order-email-receiving.spec.js`
- `order-emails.spec.js`

> <img width="414" alt="zEjE9ZkXgB" src="https://github.com/woocommerce/woocommerce/assets/4509348/bb890d1c-a861-4baa-bbab-ba05c7e7b626">

This is because the "Select all" checkbox in _WP Mail Logging > Email Log_ has an invisible label, and that label intercepts the mouse click intended for the checkbox itself, resulting to the error shown below. This doesn't happen in WP 6.2.2.

> <img width="576" alt="K90Yj2YMXA" src="https://github.com/woocommerce/woocommerce/assets/4509348/655dd645-4848-4b88-962b-677d1b732489">

If you inspect the `<label>` tag in WP 6.3 beta 3, you'd see that the label is wrapped around a `<span>` like so:

> <img width="435" alt="3SLambs0hv" src="https://github.com/woocommerce/woocommerce/assets/4509348/497e5000-1042-4c77-aabb-b63e4830426f">


Compare it with WP 6.2.2, where there's no `<span>` wrapped around the label text.

> <img width="441" alt="GNN28zsprV" src="https://github.com/woocommerce/woocommerce/assets/4509348/40fb3255-22fc-4784-88e8-fb1439f57eda">


I think the extra `span`, for some reason, blocks Playwright from interacting directly with the checkbox. We therefore need to force check that checkbox in preparation for WP 6.3. 

> <img width="430" alt="4Yc1C5xRMu" src="https://github.com/woocommerce/woocommerce/assets/4509348/4ed23b23-bf89-428c-a3d7-569bac405749">



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout this branch.
    ```bash
    git checkout e2e/fix-order-emails-wp-6.3
    ```
1. Launch the local e2e environment.
1. Install the WordPress Beta Tester plugin, and update the WordPress version to 6.3 Beta 3. Also update the database when asked.
2. From the `plugins/woocommerce` folder, run the 2 test files mentioned above with repeat-each set to 1 to make sure they're repeatable:
    ```bash
    pnpm test:e2e-pw "order-email-receiving.spec order-emails.spec" --workers=1 --repeat-each=2 --retries=0
    ```
3. Verify that they pass.
1. Downgrade WordPress to 6.2.2 and rerun the 2 test files above. Verify that they still pass.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
