### PR TITLE
[HPOS] Add action for order_edit_form_top as a replacement to edit_form_top

### DIFF
--- a/plugins/woocommerce/changelog/add-order_edit_form_action
+++ b/plugins/woocommerce/changelog/add-order_edit_form_action
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add action for 'order_edit_form_top' as a replacement to edit_form_top for HPOS.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
@@ -324,6 +324,16 @@ class Edit {
 		?>
 		>
 		<?php wp_nonce_field( $this->get_order_edit_nonce_action() ); ?>
+		<?php
+		/**
+		 * Fires at the top of the order edit form. Can be used as a replacement for edit_form_top hook for HPOS.
+		 *
+		 * @param \WC_Order $order Order object.
+		 *
+		 * @since 8.0.0
+		 */
+		do_action( 'order_edit_form_top', $this->order );
+		?>
 		<input type="hidden" id="hiddenaction" name="action" value="<?php echo esc_attr( $form_action ); ?>"/>
 		<input type="hidden" id="original_order_status" name="original_order_status" value="<?php echo esc_attr( $this->order->get_status() ); ?>"/>
 		<input type="hidden" id="referredby" name="referredby" value="<?php echo $referer ? esc_url( $referer ) : ''; ?>"/>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Adds a new action called `order_edit_form_top` as a replacement for `edit_form_top` for HPOS.

Closes #37715

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add the following code snippet that will trigger this action:
```php
add_action( 'order_edit_form_top', function ($order) {
if ( $order instanceof WC_Order) {
    echo "<h1>Action order_edit_form_top triggered.</h1>";
}
}, 10, 1);
```
2. Switch to use HPOS and open any order for edit (or add new order from admin view)
4. You will see this heading `Action order_edit_form_top triggered.` just before the order basic details meta box.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
