### PR TITLE
Product Editor: Add help menu item to description modal editor

### DIFF
--- a/packages/js/product-editor/changelog/add-product-description-modal-more-menu
+++ b/packages/js/product-editor/changelog/add-product-description-modal-more-menu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add more menu to modal editor.

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
@@ -33,6 +33,7 @@ import EditorHistoryRedo from './editor-history-redo';
 import EditorHistoryUndo from './editor-history-undo';
 import { DocumentOverview } from './document-overview';
 import { ShowBlockInspectorPanel } from './show-block-inspector-panel';
+import { MoreMenu } from './more-menu';
 
 export function HeaderToolbar() {
 	const { isInserterOpened, setIsInserterOpened } =
@@ -122,6 +123,7 @@ export function HeaderToolbar() {
 			</div>
 			<div className="woocommerce-iframe-editor__header-toolbar-right">
 				<ToolbarItem as={ ShowBlockInspectorPanel } />
+				<ToolbarItem as={ MoreMenu } />
 			</div>
 		</NavigableToolbar>
 	);

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/more-menu/help-menu-item.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/more-menu/help-menu-item.tsx
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import { MenuItem, VisuallyHidden } from '@wordpress/components';
+import { createElement } from '@wordpress/element';
+import { external } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+
+export const HelpMenuItem = () => {
+	return (
+		<MenuItem
+			role="menuitem"
+			icon={ external }
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore href is okay here
+			href={ __(
+				'https://wordpress.org/documentation/article/wordpress-block-editor/',
+				'woocommerce'
+			) }
+			target="_blank"
+			rel="noopener noreferrer"
+		>
+			{ __( 'Help', 'woocommerce' ) }
+			<VisuallyHidden as="span">
+				{
+					/* translators: accessibility text */
+					__( '(opens in a new tab)', 'woocommerce' )
+				}
+			</VisuallyHidden>
+		</MenuItem>
+	);
+};

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/more-menu/help-menu-item.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/more-menu/help-menu-item.tsx
@@ -5,8 +5,13 @@ import { MenuItem, VisuallyHidden } from '@wordpress/components';
 import { createElement } from '@wordpress/element';
 import { external } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
+import { recordEvent } from '@woocommerce/tracks';
 
 export const HelpMenuItem = () => {
+	const recordClick = () => {
+		recordEvent( 'product_iframe_editor_help_menu_item_click' );
+	};
+
 	return (
 		<MenuItem
 			role="menuitem"
@@ -17,6 +22,7 @@ export const HelpMenuItem = () => {
 				'https://wordpress.org/documentation/article/wordpress-block-editor/',
 				'woocommerce'
 			) }
+			onClick={ recordClick }
 			target="_blank"
 			rel="noopener noreferrer"
 		>

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/more-menu/index.ts
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/more-menu/index.ts
@@ -1,0 +1,1 @@
+export * from './more-menu';

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/more-menu/more-menu.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/more-menu/more-menu.tsx
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import { Ref } from 'react';
-import { createElement, forwardRef, Fragment } from '@wordpress/element';
+import { createElement, Fragment } from '@wordpress/element';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore No types for this exist yet.
 // eslint-disable-next-line @woocommerce/dependency-group
@@ -13,16 +12,14 @@ import { MoreMenuDropdown } from '@wordpress/interface';
  */
 import { ToolsMenuGroup } from './tools-menu-group';
 
-export const MoreMenu = forwardRef( function ForwardedRefMoreMenu(
-	ref: Ref< HTMLButtonElement >
-) {
+export const MoreMenu = () => {
 	return (
-		<MoreMenuDropdown ref={ ref }>
-			{ ( { onClose }: { onClose: () => void } ) => (
+		<MoreMenuDropdown>
+			{ () => (
 				<>
 					<ToolsMenuGroup />
 				</>
 			) }
 		</MoreMenuDropdown>
 	);
-} );
+};

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/more-menu/more-menu.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/more-menu/more-menu.tsx
@@ -8,6 +8,11 @@ import { createElement, forwardRef, Fragment } from '@wordpress/element';
 // eslint-disable-next-line @woocommerce/dependency-group
 import { MoreMenuDropdown } from '@wordpress/interface';
 
+/**
+ * Internal dependencies
+ */
+import { ToolsMenuGroup } from './tools-menu-group';
+
 export const MoreMenu = forwardRef( function ForwardedRefMoreMenu(
 	ref: Ref< HTMLButtonElement >
 ) {
@@ -15,7 +20,7 @@ export const MoreMenu = forwardRef( function ForwardedRefMoreMenu(
 		<MoreMenuDropdown ref={ ref }>
 			{ ( { onClose }: { onClose: () => void } ) => (
 				<>
-					<div>Hi there</div>
+					<ToolsMenuGroup />
 				</>
 			) }
 		</MoreMenuDropdown>

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/more-menu/more-menu.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/more-menu/more-menu.tsx
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { Ref } from 'react';
+import { createElement, forwardRef, Fragment } from '@wordpress/element';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore No types for this exist yet.
+// eslint-disable-next-line @woocommerce/dependency-group
+import { MoreMenuDropdown } from '@wordpress/interface';
+
+export const MoreMenu = forwardRef( function ForwardedRefMoreMenu(
+	ref: Ref< HTMLButtonElement >
+) {
+	return (
+		<MoreMenuDropdown ref={ ref }>
+			{ ( { onClose }: { onClose: () => void } ) => (
+				<>
+					<div>Hi there</div>
+				</>
+			) }
+		</MoreMenuDropdown>
+	);
+} );

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/more-menu/tools-menu-group.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/more-menu/tools-menu-group.tsx
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import { MenuGroup } from '@wordpress/components';
+import { createElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { HelpMenuItem } from './help-menu-item';
+
+export const ToolsMenuGroup = () => {
+	return (
+		<MenuGroup label={ __( 'Tools', 'woocommerce' ) }>
+			<HelpMenuItem />
+		</MenuGroup>
+	);
+};


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds the help menu item to the more menu in the description editor modal (it also adds the more menu itself, since this is the first PR relating to the more menu).

Fixes #39181

<img width="1252" alt="Screenshot 2023-07-11 at 10 51 42" src="https://github.com/woocommerce/woocommerce/assets/2098816/1614cae6-28cf-4192-b213-f34776124679">

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Enable the new block-based product editor.
2. Create a new simple product.
3. Click on "Edit description" to bring up the description modal editor.
4. Click on the "..." more menu dropdown.
5. Click on the "Help" menu item.
6. Verify that a new browser tab is opened with `https://wordpress.org/documentation/article/wordpress-block-editor/`.
7. Verify that the Tracks event `wcadmin_product_iframe_editor_help_menu_item_click ` is logged.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
