### PR TITLE
Introduce the add and edit view Tracks events in the new form

### DIFF
--- a/plugins/woocommerce-admin/client/products/product-page.tsx
+++ b/plugins/woocommerce-admin/client/products/product-page.tsx
@@ -6,7 +6,9 @@ import {
 	__experimentalInitBlocks as initBlocks,
 	ProductEditorSettings,
 	productApiFetchMiddleware,
+	TRACKS_SOURCE,
 } from '@woocommerce/product-editor';
+import { recordEvent } from '@woocommerce/tracks';
 import { Spinner } from '@wordpress/components';
 import { useEffect } from '@wordpress/element';
 import { useParams } from 'react-router-dom';
@@ -31,6 +33,22 @@ export default function ProductPage() {
 	useEffect( () => {
 		return initBlocks();
 	}, [] );
+
+	useEffect(
+		function trackViewEvents() {
+			if ( productId ) {
+				recordEvent( 'product_edit_view', {
+					source: TRACKS_SOURCE,
+					product_id: productId,
+				} );
+			} else {
+				recordEvent( 'product_add_view', {
+					source: TRACKS_SOURCE,
+				} );
+			}
+		},
+		[ productId ]
+	);
 
 	if ( ! product?.id ) {
 		return <Spinner />;

--- a/plugins/woocommerce/changelog/add-39089
+++ b/plugins/woocommerce/changelog/add-39089
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Introduce the add and edit view Tracks events in the new form


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #39089

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure `New product editor` feature is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Go to `/wp-admin/tools.php?page=woocommerce-admin-test-helper` and under the `Tools` tab run the `Enable wc-admin Tracking` option
3. Open the browser DevTools Console and select the verbose log level
4. When visiting `/wp-admin/admin.php?page=wc-admin&path=/add-product` the console should show 
<img width="677" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/0c105af8-1a95-435b-8ced-97a0b0828a68">

5. When visiting `http://woodev.local/wp-admin/admin.php?page=wc-admin&path=/product/{productId}` (replace `{productId}` by a valid physical product id) the console should show 
<img width="666" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/d9273846-41c8-4a4c-8252-a68f544817ff">

6. Verify that the ACs described in  #39089 are all met

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
