### PR TITLE
Introduce grace period before asking guests to verify their email address

### DIFF
--- a/plugins/woocommerce/.wp-env.json
+++ b/plugins/woocommerce/.wp-env.json
@@ -10,7 +10,8 @@
         "ALTERNATE_WP_CRON": true
     },
     "mappings": {
-        "wp-cli.yml": "./tests/wp-cli.yml"
+        "wp-cli.yml": "./tests/wp-cli.yml",
+        "wp-content/mu-plugins/filter-setter.php": "./tests/e2e-pw/bin/filter-setter.php"
     },
     "lifecycleScripts": {
         "afterStart": "./tests/e2e-pw/bin/test-env-setup.sh",

--- a/plugins/woocommerce/.wp-env.json
+++ b/plugins/woocommerce/.wp-env.json
@@ -11,7 +11,7 @@
     },
     "mappings": {
         "wp-cli.yml": "./tests/wp-cli.yml",
-        "wp-content/mu-plugins/filter-setter.php": "./tests/e2e-pw/bin/filter-setter.php"
+        "wp-content/plugins/filter-setter.php": "./tests/e2e-pw/bin/filter-setter.php"
     },
     "lifecycleScripts": {
         "afterStart": "./tests/e2e-pw/bin/test-env-setup.sh",

--- a/plugins/woocommerce/changelog/fix-order-confirmation-access
+++ b/plugins/woocommerce/changelog/fix-order-confirmation-access
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Adds a grace period during which email verification will not be needed before the order confirmation (or payment) page is rendered.

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -394,10 +394,9 @@ class WC_Shortcode_Checkout {
 		 * Controls the grace period within which we do not require any sort of email verification step before rendering
 		 * the 'order received' or 'order pay' pages.
 		 *
-		 * To eliminate the grace period, set to zero (or to a negative value). However, note that by itself this will
-		 * not cause email verification to be required in all cases, but only those where verification is potentially
-		 * useful. In other words, if the current user is logged in and the order is associated with them, this filter
-		 * will not be invoked.
+		 * To eliminate the grace period, set to zero (or to a negative value). Note that this filter is not invoked
+		 * at all if email verification is deemed to be unnecessary (in other words, it cannot be used to force
+		 * verification in *all* cases).
 		 *
 		 * @since 8.0.0
 		 *

--- a/plugins/woocommerce/tests/e2e-pw/bin/filter-setter.php
+++ b/plugins/woocommerce/tests/e2e-pw/bin/filter-setter.php
@@ -1,6 +1,7 @@
 <?php
 /**
- * Makes it possible to set filters from within E2E tests.
+ * Plugin name: Filter Setter
+ * Description: Utility intended to be used during E2E testing, to make it easy to setup WordPress filters.
  *
  * Intended to function as a (mu-)plugin while tests are running, this code works by inspecting the current cookie
  * for an entry called 'e2e-filters', which is expected to be a JSON description of filter hooks and the values we want
@@ -36,6 +37,8 @@
  *             "priority": 20
  *         }
  *     }
+ *
+ * It hopefully goes without saying, this should not be used in a production environment.
  */
 
 

--- a/plugins/woocommerce/tests/e2e-pw/bin/filter-setter.php
+++ b/plugins/woocommerce/tests/e2e-pw/bin/filter-setter.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Makes it possible to set filters from within E2E tests.
+ *
+ * Intended to function as a (mu-)plugin while tests are running, this code works by inspecting the current cookie
+ * for an entry called 'e2e-filters', which is expected to be a JSON description of filter hooks and the values we want
+ * to set via those filters. For example, given the JSON (pretty printed here for clarity):
+ *
+ *     {
+ *         "wooocommerce_system_timeout": 10
+ *     }
+ *
+ * Then a filter will be added that returns 10 when 'woocommerce_system_timeout' is invoked. Or, given:
+ *
+ *     {
+ *         "woocommerce_enable_deathray": {
+ *             "callback": "__return_false"
+ *         }
+ *     }
+ *
+ * Then the `__return_false()` convenience function will be set up in relation to filter hook
+ * 'woocommerce_enable_deathray'. Additionally, priorities can be specified. Example:
+ *
+ *     {
+ *         "woocommerce_enable_deathray": {
+ *             "callback": "__return_false",
+ *              "priority": 20
+ *         }
+ *     }
+ *
+ * Priorities can also be used in combination with literal values. For example:
+ *
+ *     {
+ *         "woocommerce_default_username": {
+ *             "value": "Geoffrey",
+ *             "priority": 20
+ *         }
+ *     }
+ */
+
+
+if ( ! isset( $_COOKIE ) || ! isset( $_COOKIE['e2e-filters'] ) ) {
+	return;
+}
+
+$filters = json_decode( $_COOKIE['e2e-filters' ], true );
+
+if ( ! is_array( $filters ) ) {
+	return;
+}
+
+foreach ($filters as $hook => $spec ) {
+	// A priority may be specified as part of the spec, else use the default priority (10).
+	$priority = isset( $spec['priority'] ) && is_int( $spec['priority'] )
+		? $spec['priority']
+		: 10;
+
+	// If the spec is not an array, then it is probably intended as the literal value.
+	if ( ! is_array( $spec ) ) {
+		$value = $spec;
+	} elseif ( isset( $spec['value'] ) ) {
+		$value = $spec['value'];
+	}
+
+	// If we know the value, we can establish our filter callback.
+	if ( isset( $value ) ) {
+		$callback = function () use ( $value ) {
+			return $value;
+		};
+	}
+
+	// We also support specifying a callback function.
+	if ( is_array( $spec ) && isset( $spec['callback'] ) && is_string( $spec['callback'] ) ) {
+		$callback = $spec['callback'];
+	}
+
+	// Ensure we have a callback, then setup the filter.
+	if ( isset( $callback ) ) {
+		add_filter( $hook, $callback, $priority );
+	}
+}
+

--- a/plugins/woocommerce/tests/e2e-pw/bin/filter-setter.php
+++ b/plugins/woocommerce/tests/e2e-pw/bin/filter-setter.php
@@ -39,20 +39,22 @@
  *     }
  *
  * It hopefully goes without saying, this should not be used in a production environment.
+ *
+ * @package Automattic\WooCommerce\E2EPlaywright
  */
-
 
 if ( ! isset( $_COOKIE ) || ! isset( $_COOKIE['e2e-filters'] ) ) {
 	return;
 }
 
-$filters = json_decode( $_COOKIE['e2e-filters' ], true );
+// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+$filters = json_decode( $_COOKIE['e2e-filters'], true );
 
 if ( ! is_array( $filters ) ) {
 	return;
 }
 
-foreach ($filters as $hook => $spec ) {
+foreach ( $filters as $hook => $spec ) {
 	// A priority may be specified as part of the spec, else use the default priority (10).
 	$priority = isset( $spec['priority'] ) && is_int( $spec['priority'] )
 		? $spec['priority']

--- a/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
+++ b/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
@@ -10,6 +10,9 @@ wp-env run tests-cli wp theme activate twentynineteen
 echo -e 'Update URL structure \n'
 wp-env run tests-cli wp rewrite structure '/%postname%/' --hard
 
+echo -e 'Activate Filter Setter utility plugin \n'
+wp-env run tests-cli wp plugin activate filter-setter
+
 echo -e 'Add Customer user \n'
 wp-env run tests-cli wp user create customer customer@woocommercecoree2etestsuite.com \
 	--user_pass=password \

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout.spec.js
@@ -236,9 +236,9 @@ test.describe( 'Checkout page', () => {
 
 		await page.locator( 'text=Place order' ).click();
 
-		await expect( page.locator( 'h1.entry-title' ) ).toContainText(
-			'Order received'
-		);
+		await expect(
+			page.getByRole( 'heading', { name: 'Order received' } )
+		).toBeVisible();
 
 		// get order ID from the page
 		const orderReceivedText = await page
@@ -252,9 +252,9 @@ test.describe( 'Checkout page', () => {
 		// grace period following initial order placement, the 'order received' page should still be rendered.
 		await page.context().clearCookies();
 		await page.reload();
-		await expect( page.locator( 'h1.entry-title' ) ).toContainText(
-			'Order received'
-		);
+		await expect(
+			page.getByRole( 'heading', { name: 'Order received' } )
+		).toBeVisible();
 
 		// Let's simulate a scenario where the 10 minute grace period has expired. This time, we expect the shopper to
 		// be presented with a request to verify their email address.
@@ -278,9 +278,9 @@ test.describe( 'Checkout page', () => {
 		// However if they supply the *correct* billing email address, they should see the order received page again.
 		await page.fill( '#email', guestEmail );
 		await page.locator( 'form.woocommerce-verify-email button' ).click();
-		await expect( page.locator( 'h1.entry-title' ) ).toContainText(
-			'Order received'
-		);
+		await expect(
+			page.getByRole( 'heading', { name: 'Order received' } )
+		).toBeVisible();
 
 		await page.goto( 'wp-login.php' );
 		await page.locator( 'input[name="log"]' ).fill( admin.username );
@@ -293,8 +293,8 @@ test.describe( 'Checkout page', () => {
 		);
 
 		await expect(
-			page.locator( 'h2.woocommerce-order-data__heading' )
-		).toContainText( `Order #${ guestOrderId } details` );
+			page.getByRole( 'heading', { name: `Order #${ guestOrderId } details` } )
+		).toBeVisible();
 		await expect( page.locator( '.wc-order-item-name' ) ).toContainText(
 			simpleProductName
 		);
@@ -307,7 +307,7 @@ test.describe( 'Checkout page', () => {
 		await expect( page.locator( 'td.line_cost >> nth=0' ) ).toContainText(
 			twoProductPrice
 		);
-		clearFilters( page );
+		await clearFilters( page );
 	} );
 
 	test( 'allows existing customer to place order', async ( { page } ) => {

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout.spec.js
@@ -247,7 +247,7 @@ test.describe( 'Checkout page', () => {
 		guestOrderId = await orderReceivedText.split( /(\s+)/ )[ 6 ].toString();
 
 
-		// Let's simular a new browser context (by dropping all cookies), and reload the page. This approximates a
+		// Let's simulate a new browser context (by dropping all cookies), and reload the page. This approximates a
 		// scenario where the server can no longer identify the shopper. However, so long as we are within the 10 minute
 		// grace period following initial order placement, the 'order received' page should still be rendered.
 		await page.context().clearCookies();

--- a/plugins/woocommerce/tests/e2e-pw/utils/filters.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/filters.js
@@ -1,0 +1,54 @@
+
+/**
+ * Request that a WordPress filter be established for the specified hook and returning the specified value.
+ *
+ * 'Under the hood', this is done by communicating to a server-side plugin via cookies. Therefore, for the server-side
+ * code to observe the requested filter, you may need to `page.reload()` prior to writing assertions that rely on your
+ * filter.
+ *
+ * @param page
+ * @param hook
+ * @param value
+ * @param priority
+ */
+export async function setFilterValue( page, hook, value, priority = 10 ) {
+	const context         = page.context();
+	const existingCookies = await context.cookies();
+	let   filterSpecs     = {};
+
+	for ( const cookie of existingCookies ) {
+		if ( cookie.name === 'e2e-filters' ) {
+			filterSpecs = JSON.parse( cookie.value );
+			break;
+		}
+	}
+
+	filterSpecs[hook] = {
+		value:    value,
+		priority: priority
+	};
+
+	await context.addCookies( [ {
+		name:  'e2e-filters',
+		value:  JSON.stringify( filterSpecs ),
+		path:   '/',
+		domain: 'localhost'
+	} ] );
+}
+
+/**
+ * Clears any server-side filters setup via setFilterValue().
+ *
+ * As with its sister function, this mechanism relies on cookies and therefore a call to `page.reload()` may be required
+ * before performing further assertions.
+ *
+ * @param page
+ */
+export async function clearFilters( page ) {
+	await page.context().addCookies( [ {
+		name:  'e2e-filters',
+		value:  '',
+		path:   '/',
+		domain: 'localhost'
+	} ] );
+}

--- a/plugins/woocommerce/tests/e2e-pw/utils/filters.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/filters.js
@@ -1,3 +1,5 @@
+const defaultConfig = require( '../playwright.config' );
+const testURL    = new URL( defaultConfig.use.baseURL );
 
 /**
  * Request that a WordPress filter be established for the specified hook and returning the specified value.
@@ -32,7 +34,7 @@ export async function setFilterValue( page, hook, value, priority = 10 ) {
 		name:  'e2e-filters',
 		value:  JSON.stringify( filterSpecs ),
 		path:   '/',
-		domain: 'localhost'
+		domain: testURL.hostname
 	} ] );
 }
 
@@ -49,6 +51,6 @@ export async function clearFilters( page ) {
 		name:  'e2e-filters',
 		value:  '',
 		path:   '/',
-		domain: 'localhost'
+		domain: testURL.hostname
 	} ] );
 }

--- a/plugins/woocommerce/tests/e2e/docker/initialize.sh
+++ b/plugins/woocommerce/tests/e2e/docker/initialize.sh
@@ -24,5 +24,8 @@ wp plugin install https://github.com/woocommerce/woocommerce-reset/zipball/trunk
 # install the WP Mail Logging plugin to test emails
 wp plugin install wp-mail-logging --activate
 
+# Activate our Filter Setter utility.
+wp plugin activate filter-setter
+
 # initialize pretty permalinks
 wp rewrite structure /%postname%/


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In our latest release, we introduced a change that requires shoppers to verify their email address before seeing the order confirmation page, or order payment page, but only if WooCommerce is unable to recognize them.

Naturally, the desire was to make this as friction-free as possible and, for example, shoppers should not have to verify their email address immediately after checking out ... unfortunately, depending on the payment gateway in use, that became possible.

Therefore, this change introduces a grace period during which email verification will not be required. Further, the grace period is filterable so can be removed (or extended) as desired.

> :bulb: To clarify, this softens the requirement for email verification *for guest shoppers.* By itself, it does **not** touch the requirement for authenticated shoppers to be logged in before they can see their order confirmation.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. As a guest shopper, make a purchase.
2. After checking out, you should see the Order Received page.
3. Copy the URL and open this page in a new browser context (ie, an incognito mode tab or else a container tab, if you are using Firefox):
    - If we are within 10 minutes of the order being placed, then the Order Received page should be visible in both tabs (ie, the original tab where the shopper is 'known' and the separate tab where the shopper is unknown).
    - After 10 minutes, refreshing the second tab should result in you being asked to verify your email address (but in the original tab, the Order Received page should still be accessible).
4. There is no change for authenticated shoppers. In this case, if you repeat the above exercise, there is no grace period and if we cannot identify the shopper (as in the second browser context) they will be required to login.

### Notes

1. You don't have to wait 10 minutes when testing, as you can temporarily modify [this line of code](https://github.com/woocommerce/woocommerce/blob/35b85181e251a180486b5d884d5a80624bc13790/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php#L407) and replace `10 * MINUTE_IN_SECONDS` with `0` to simulate having waited 10 minutes. Or, if you don't like to touch core code, you could setup the following snippet in a suitable place (such as `wp-content/mu-plugins/test-39191.php`) then remove after testing:

```php
<?php
add_filter( 'woocommerce_order_email_verification_grace_period', '__return_zero' );
```

2. I am aware of this [related discussion](https://github.com/woocommerce/woocommerce/pull/38983). We still need to decide on the best course of action there (possibly following up with a second PR).

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message <!-- Add a changelog message here -->

Adds a grace period during which email verification will not be needed before the order confirmation (or payment) page is rendered.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
