### PR TITLE
Add filter `woocommerce_redirect_order_location` for consistency with posts and HPOS.

### DIFF
--- a/plugins/woocommerce/changelog/fix-36537
+++ b/plugins/woocommerce/changelog/fix-36537
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add filter `woocommerce_redirect_order_location` for consistency with posts and HPOS.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
@@ -114,6 +114,8 @@ class Edit {
 	/**
 	 * Returns the PageController for this edit form. This method is protected to allow child classes to overwrite the PageController object and return custom links.
 	 *
+	 * @since 8.0.0
+	 *
 	 * @return PageController PageController object.
 	 */
 	protected function get_page_controller() {
@@ -239,6 +241,8 @@ class Edit {
 
 	/**
 	 * Helper method to redirect to order edit page.
+	 *
+	 * @since 8.0.0
 	 *
 	 * @param \WC_Order $order Order object.
 	 */

--- a/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
@@ -56,6 +56,13 @@ class Edit {
 	private $message;
 
 	/**
+	 * Controller for orders page. Used to determine redirection URLs.
+	 *
+	 * @var PageController
+	 */
+	private $orders_page_controller;
+
+	/**
 	 * Hooks all meta-boxes for order edit page. This is static since this may be called by post edit form rendering.
 	 *
 	 * @param string $screen_id Screen ID.
@@ -102,6 +109,18 @@ class Edit {
 			wp_enqueue_script( 'jquery-touch-punch' );
 		}
 		wp_enqueue_script( 'post' ); // Ensure existing JS libraries are still available for backward compat.
+	}
+
+	/**
+	 * Returns the PageController for this edit form. This method is protected to allow child classes to overwrite the PageController object and return custom links.
+	 *
+	 * @return PageController PageController object.
+	 */
+	protected function get_page_controller() {
+		if ( ! isset( $this->orders_page_controller ) ) {
+			$this->orders_page_controller = wc_get_container()->get( PageController::class );
+		}
+		return $this->orders_page_controller;
 	}
 
 	/**
@@ -215,9 +234,37 @@ class Edit {
 		// Order updated message.
 		$this->message = 1;
 
-		// Refresh the order from DB.
-		$this->order = wc_get_order( $this->order->get_id() );
-		$theorder    = $this->order;
+		$this->redirect_order( $this->order );
+	}
+
+	/**
+	 * Helper method to redirect to order edit page.
+	 *
+	 * @param \WC_Order $order Order object.
+	 */
+	private function redirect_order( \WC_Order $order ) {
+		$redirect_to = $this->get_page_controller()->get_edit_url( $order->get_id() );
+		if ( isset( $this->message ) ) {
+			$redirect_to = add_query_arg( 'message', $this->message, $redirect_to );
+		}
+		wp_safe_redirect(
+			/**
+			 * Filter the URL used to redirect after an order is updated. Similar to the WP post's `redirect_post_location` filter.
+			 *
+			 * @param string    $redirect_to The redirect destination URL.
+			 * @param int       $order_id The order ID.
+			 * @param \WC_Order $order The order object.
+			 *
+			 * @since 8.0.0
+			 */
+			apply_filters(
+				'woocommerce_redirect_order_location',
+				$redirect_to,
+				$order->get_id(),
+				$order
+			)
+		);
+		exit;
 	}
 
 	/**
@@ -279,10 +326,10 @@ class Edit {
 	private function render_wrapper_start( $notice = '', $message = '' ) {
 		$post_type = get_post_type_object( $this->order->get_type() );
 
-		$edit_page_url = wc_get_container()->get( PageController::class )->get_edit_url( $this->order->get_id() );
+		$edit_page_url = $this->get_page_controller()->get_edit_url( $this->order->get_id() );
 		$form_action   = 'edit_order';
 		$referer       = wp_get_referer();
-		$new_page_url  = wc_get_container()->get( PageController::class )->get_new_page_url( $this->order->get_type() );
+		$new_page_url  = $this->get_page_controller()->get_new_page_url( $this->order->get_type() );
 
 		?>
 		<div class="wrap">


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds two changes:

1. Add the redirection behavior after an order is updated, similar to how it works for the posts screen where when the post is updated, it redirects to the edit page. This allows plugins to hook in and add custom logic, or redirect to some other page if needed.
2. Add the filter `woocommerce_redirect_order_location` which is similar to the `redirect_post_location` filter and allows extensions to change or add query params to the subsequent GET request.

Closes #36537 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. With HPOS authoritative, test the order edit flow, by editing an order in a few different areas in the admin view and clicking on update. The order should be updated as expected. Also try to trash the order and verify it's trashed as expected.
3. To test the new filter, add the following snippet:
```php
add_filter( 'woocommerce_redirect_order_location', function ($location, $order_id) {
	return add_query_arg( 'test', $order_id, $location );
}, 10, 2);
```
4. Try to edit an order, after clicking on update, check the URL in address bar of browser, it should have a new GET param add the end with value `test={order_id}`

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
