### PR TITLE
Enhancement class-wc-admin-api-keys-table-list.php

### DIFF
--- a/plugins/woocommerce/changelog/fix-39194
+++ b/plugins/woocommerce/changelog/fix-39194
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+When displaying partial consumer keys in the REST API settings, replace ellipses with asterisks.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-api-keys-table-list.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-api-keys-table-list.php
@@ -129,7 +129,7 @@ class WC_Admin_API_Keys_Table_List extends WP_List_Table {
 	 * @return string
 	 */
 	public function column_truncated_key( $key ) {
-		return '<code>&hellip;' . esc_html( $key['truncated_key'] ) . '</code>';
+		return '<code>***' . esc_html( $key['truncated_key'] ) . '</code>';
 	}
 
 	/**


### PR DESCRIPTION
When generating REST API Keys, they are hidden using an ellipsis generated by `&hellip;`

This is unorthadox, and usually most API Keys are hidden or partially hidden using Asterisks.

My PR addresses this small enhancement.

Fixes #39194 
<img width="1440" alt="asterisk" src="https://github.com/woocommerce/woocommerce/assets/38789408/9abb6f3b-33ef-450a-a0c0-e46494febbfe">
<img width="1440" alt="ellipses" src="https://github.com/woocommerce/woocommerce/assets/38789408/5ac94a94-69b7-4db0-aa73-166eebea1712">


### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Replace ellipses with asterisk in the REST API tab in Settings to enhance the look of this page.

Closes #39194 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Visit /wp-admin/admin.php?page=wc-settings&tab=advanced&section=keys
2. View created keys (or add a new one for testing purposes if currently there are none)
3. Look at the format of the partially hidden Consumer Key in the second column.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

Replace the ellipses with asterisks which partially display the active Consumer Keys in the REST API tab.

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message <!-- Add a changelog message here -->
Replace the ellipses with asterisks which partially display the active Consumer Keys in the REST API tab.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
