### PR TITLE
[HPOS] Backfill to post table only after order has persisted in orders table.

### DIFF
--- a/plugins/woocommerce/changelog/fix-37935
+++ b/plugins/woocommerce/changelog/fix-37935
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+[HPOS] Backfill to post table only after order has persisted in orders table.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2373,12 +2373,12 @@ FROM $order_meta_table
 			$order->set_date_modified( time() );
 		}
 
+		$this->persist_order_to_db( $order );
+		$order->save_meta_data();
+
 		if ( $backfill ) {
 			$this->maybe_backfill_post_record( $order );
 		}
-
-		$this->persist_order_to_db( $order );
-		$order->save_meta_data();
 
 		return $changes;
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -2468,4 +2468,32 @@ class OrdersTableDataStoreTests extends HposTestCase {
 			$this->assertSame( $order, $order_from_before_delete );
 		}
 	}
+
+	/**
+	 * @testDox Bacfilling posts doesn't read stale data.
+	 */
+	public function test_backfill_posts_dont_read_stale_data() {
+		$this->toggle_cot_feature_and_usage( true );
+		$this->enable_cot_sync();
+
+		$product = new WC_Product();
+		$product->set_price( 10 );
+		$product->save();
+
+		$order = wc_create_order();
+		$order->add_product( $product );
+		$order->save();
+
+		$this->assertEquals( 0, $product->get_total_sales() );
+
+		$order->set_status('processing');
+		$order->save();
+		$product = wc_get_product( $product->get_id() );
+		$this->assertEquals( 1, $product->get_total_sales() ); // Sale is increased when status is changed to processing.
+
+		$order->set_status('completed');
+		$order->save();
+		$product = wc_get_product( $product->get_id() );
+		$this->assertEquals( 1, $product->get_total_sales() ); // Sale is not increased when status is changed to completed (from processing).
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -2486,12 +2486,12 @@ class OrdersTableDataStoreTests extends HposTestCase {
 
 		$this->assertEquals( 0, $product->get_total_sales() );
 
-		$order->set_status('processing');
+		$order->set_status( 'processing' );
 		$order->save();
 		$product = wc_get_product( $product->get_id() );
 		$this->assertEquals( 1, $product->get_total_sales() ); // Sale is increased when status is changed to processing.
 
-		$order->set_status('completed');
+		$order->set_status( 'completed' );
 		$order->save();
 		$product = wc_get_product( $product->get_id() );
 		$this->assertEquals( 1, $product->get_total_sales() ); // Sale is not increased when status is changed to completed (from processing).


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Earlier, we were backfilling data to the posts table first, and then saving to order tables when sync was enabled. Unfortunately, this caused an issue where if we read from DB before doing the backfill, it would read stale value since orders table is not updated yet.

For example, [we were reading the order props in OrderTableDataStore](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php#L566-L582) and setting to CPT data store, but since data is not yet saved to order table, it was reading stale props. This issue was limited to [the five properties identified as internal data store keys](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php#L85-L91) only.

This PR fixes the issue by saving the data to DB first and then backfilling it to posts. Note that any order saved related action and hooks are still fired after the backfill, so extensions reading from the posts table will still read refreshed data.

Closes #37935 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Release testing is probably not required, however, if desired, @barryhughes 's [original script to reproduce](https://gist.github.com/barryhughes/ec5f09dc0191f6f089ef7ca3cf5fd4ff) can be used verify that the issue is fixed.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
