### PR TITLE
Fixes for the WCPay welcome page incentives

### DIFF
--- a/plugins/woocommerce/changelog/fix-wcpay-welcome-page-incentives
+++ b/plugins/woocommerce/changelog/fix-wcpay-welcome-page-incentives
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Address edge-cases around Incentives eligibility and display.

--- a/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
+++ b/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
@@ -189,14 +189,10 @@ class WcPayWelcomePage {
 	 * @return boolean
 	 */
 	private function has_wcpay(): bool {
-		$has_wcpay_setup = false;
-
-		// We consider the store to have WooPayments if:
-		// - the WooPayments plugin is active
-		// - and the WooPayments payment gateway is connected
-		// - and there is meaningful account data in the WooPayments account cache.
-		if ( $this->is_wcpay_active() && $this->is_wcpay_connected() && $this->has_wcpay_account_data() ) {
-			$has_wcpay_setup = true;
+		// We consider the store to have WooPayments if there is meaningful account data in the WooPayments account cache.
+		// This implies that WooPayments is or was active at some point and that it was connected.
+		if ( $this->has_wcpay_account_data() ) {
+			return true;
 		}
 
 		// If there is at least one order processed with WooPayments, we consider the store to have WooPayments.
@@ -209,10 +205,10 @@ class WcPayWelcomePage {
 				]
 			)
 		) ) {
-			$has_wcpay_setup = true;
+			return true;
 		}
 
-		return $has_wcpay_setup;
+		return false;
 	}
 
 	/**
@@ -222,24 +218,6 @@ class WcPayWelcomePage {
 	 */
 	private function is_wcpay_active(): bool {
 		return class_exists( '\WC_Payments' );
-	}
-
-	/**
-	 * Check if the WooPayments payment gateway has a connected account.
-	 *
-	 * @see WC_Payment_Gateway_WCPay::is_connected()
-	 *
-	 * @return boolean
-	 */
-	private function is_wcpay_connected(): bool {
-		if ( class_exists( '\WC_Payments' ) ) {
-			$wc_payments_gateway = \WC_Payments::get_gateway();
-			return method_exists( $wc_payments_gateway, 'is_connected' )
-				? $wc_payments_gateway->is_connected()
-				: false;
-		}
-
-		return false;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
+++ b/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
@@ -170,10 +170,14 @@ class WcPayWelcomePage {
 	 * @param array $promo_notes Allowed promo notes.
 	 * @return array
 	 */
-	public function allowed_promo_notes( $promo_notes = [] ) {
-		if ( $this->get_incentive() ) {
-			$promo_notes[] = $this->get_incentive()['id'];
+	public function allowed_promo_notes( $promo_notes = [] ): array {
+		// Return early if there is no eligible incentive.
+		if ( empty( $this->get_incentive() ) ) {
+			return $promo_notes;
 		}
+
+		// Add our incentive ID to the promo notes.
+		$promo_notes[] = $this->get_incentive()['id'];
 
 		return $promo_notes;
 	}

--- a/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
+++ b/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
@@ -68,8 +68,8 @@ class WcPayWelcomePage {
 			return false;
 		}
 
-		// WCPay must not be in use or previously used.
-		if ( $this->has_wcpay() ) {
+		// The WooPayments plugin must not be active.
+		if ( $this->is_wcpay_active() ) {
 			return false;
 		}
 
@@ -212,6 +212,14 @@ class WcPayWelcomePage {
 			)
 		) ) {
 			return true;
+	/**
+	 * Check if the WooPayments plugin is active.
+	 *
+	 * @return boolean
+	 */
+	private function is_wcpay_active(): bool {
+		return class_exists( '\WC_Payments' );
+	}
 		}
 
 		return false;

--- a/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
+++ b/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
@@ -42,7 +42,7 @@ class WcPayWelcomePage {
 	 */
 	public function __construct() {
 		add_action( 'admin_menu', [ $this, 'register_payments_welcome_page' ] );
-		add_filter( 'woocommerce_admin_shared_settings', array( $this, 'shared_settings' ) );
+		add_filter( 'woocommerce_admin_shared_settings', [ $this, 'shared_settings' ] );
 		add_filter( 'woocommerce_admin_allowed_promo_notes', [ $this, 'allowed_promo_notes' ] );
 	}
 
@@ -98,7 +98,7 @@ class WcPayWelcomePage {
 
 		$menu_icon = 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI4NTIiIGhlaWdodD0iNjg0Ij48cGF0aCBmaWxsPSIjYTJhYWIyIiBkPSJNODIgODZ2NTEyaDY4NFY4NlptMCA1OThjLTQ4IDAtODQtMzgtODQtODZWODZDLTIgMzggMzQgMCA4MiAwaDY4NGM0OCAwIDg0IDM4IDg0IDg2djUxMmMwIDQ4LTM2IDg2LTg0IDg2em0zODQtNTU2djQ0aDg2djg0SDM4MnY0NGgxMjhjMjQgMCA0MiAxOCA0MiA0MnYxMjhjMCAyNC0xOCA0Mi00MiA0MmgtNDR2NDRoLTg0di00NGgtODZ2LTg0aDE3MHYtNDRIMzM4Yy0yNCAwLTQyLTE4LTQyLTQyVjIxNGMwLTI0IDE4LTQyIDQyLTQyaDQ0di00NHoiLz48L3N2Zz4=';
 
-		$menu_data = array(
+		$menu_data = [
 			'id'       => 'wc-calypso-bridge-payments-welcome-page',
 			'title'    => esc_html__( 'Payments', 'woocommerce' ),
 			'path'     => '/wc-pay-welcome-page',
@@ -110,7 +110,7 @@ class WcPayWelcomePage {
 				'is_top_level' => true,
 			],
 			'icon'     => $menu_icon,
-		);
+		];
 
 		wc_admin_register_page( $menu_data );
 
@@ -119,7 +119,7 @@ class WcPayWelcomePage {
 		// We need to register this menu via add_menu_page so that it doesn't become a child of
 		// WooCommerce menu.
 		if ( get_option( 'woocommerce_navigation_enabled', 'no' ) === 'yes' ) {
-			$menu_with_nav_data = array(
+			$menu_with_nav_data = [
 				esc_html__( 'Payments', 'woocommerce' ),
 				esc_html__( 'Payments', 'woocommerce' ),
 				'view_woocommerce_reports',
@@ -127,7 +127,7 @@ class WcPayWelcomePage {
 				null,
 				$menu_icon,
 				56,
-			);
+			];
 
 			call_user_func_array( 'add_menu_page', $menu_with_nav_data );
 		}

--- a/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
+++ b/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
@@ -51,7 +51,7 @@ class WcPayWelcomePage {
 	 *
 	 * @return boolean
 	 */
-	public function must_be_visible() {
+	public function must_be_visible(): bool {
 		// Suggestions not disabled via a setting.
 		if ( get_option( 'woocommerce_show_marketplace_suggestions', 'yes' ) === 'no' ) {
 			return false;
@@ -148,7 +148,7 @@ class WcPayWelcomePage {
 	 * @param array $settings Shared settings.
 	 * @return array
 	 */
-	public function shared_settings( $settings ) {
+	public function shared_settings( $settings ): array {
 		// Return early if not on a wc-admin powered page.
 		if ( ! PageController::is_admin_page() ) {
 			return $settings;
@@ -242,8 +242,8 @@ class WcPayWelcomePage {
 	 *
 	 * @return array|null Array of eligible incentive or null.
 	 */
-	private function get_incentive() {
-		// Return local cached incentive if it exists.
+	private function get_incentive(): ?array {
+		// Return in-memory cached incentive if it is set.
 		if ( isset( $this->incentive ) ) {
 			return $this->incentive;
 		}

--- a/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
+++ b/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
@@ -47,7 +47,7 @@ class WcPayWelcomePage {
 	}
 
 	/**
-	 * Whether the WooPayments welcome page is visible.
+	 * Whether the WooPayments welcome page should be visible.
 	 *
 	 * @return boolean
 	 */
@@ -60,7 +60,7 @@ class WcPayWelcomePage {
 		/**
 		 * Filter allow marketplace suggestions.
 		 *
-		 * User can disabled all suggestions via filter.
+		 * User can disable all suggestions via filter.
 		 *
 		 * @since 3.6.0
 		 */
@@ -143,7 +143,7 @@ class WcPayWelcomePage {
 	}
 
 	/**
-	 * Adds shared settings for WCPay incentive.
+	 * Adds shared settings for the WooPayments incentive.
 	 *
 	 * @param array $settings Shared settings.
 	 * @return array
@@ -165,7 +165,7 @@ class WcPayWelcomePage {
 	}
 
 	/**
-	 * Adds allowed promo notes from WCPay incentive.
+	 * Adds allowed promo notes from the WooPayments incentive.
 	 *
 	 * @param array $promo_notes Allowed promo notes.
 	 * @return array
@@ -179,7 +179,8 @@ class WcPayWelcomePage {
 	}
 
 	/**
-	 * Whether WCPay is installed, connected, an account exists, or there are orders processed with it.
+	 * Check if the WooPayments payment gateway is active and set up,
+	 * or there are orders processed with it, at some moment.
 	 *
 	 * @return boolean
 	 */
@@ -217,7 +218,7 @@ class WcPayWelcomePage {
 	}
 
 	/**
-	 * Whether the current incentive has been manually dismissed.
+	 * Check if there is meaningful data in the WooPayments account cache.
 	 *
 	 * @return boolean
 	 */
@@ -238,7 +239,7 @@ class WcPayWelcomePage {
 	}
 
 	/**
-	 * Fetches and cache eligible incentive from WCPay API.
+	 * Fetches and caches eligible incentive from the WooPayments API.
 	 *
 	 * @return array|null Array of eligible incentive or null.
 	 */


### PR DESCRIPTION
Closes https://github.com/Automattic/woocommerce-payments-server/issues/3637

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

- To avoid edge cases where merchants are shown incentives that shouldn't be shown anymore, we implement cache invalidation based on a store content hash that is saved together with the cached incentives data.
- We have clarified and streamlined the logic for determining the value of `has_wcpay` to be aligned with the original intent (and the server's interpretation of it).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

#### Setup

To see the incentive welcome page, you need to meet the following requirements:
  - Have **WooCommerce → Settings → Advanced → WooCommerce.com → Display suggestions withing WooCommerced** enabled.
  - Do not have WCPay installed or an existing account cached.
  - Do not have it dismissed by `wcpay_welcome_page_incentives_dismissed` option.
  - Trash all existing orders, or at least those processed with WooPayments (if any)

#### Switch incentive
- Make your store eligible for it:
  * Set your store base country to `ES` from the WooCommerce > Settings > General tab
  * Set the store installation timestamp to a date older than 90 days (use Tools > WCA Test Helper > Tools tab)
  * Make sure you have an active payment gateway (not WooPayments which should not be active)
  * Have at least one order processed with this payment gateway
-  **Payments (1)** should be visible on the admin sidebar.
- Clicking on it should display the switch incentive offer (20% off for 6 months)
- Choosing `Install WooPayments for free` should successfully create the promo note. Look for the incentive ID on `wc_admin_notes` table.
- Trash the order(s)
- The incentive should be gone
- Restore the order(s)
- The incentive should be shown again
- Change your store base country to `RO`
- The incentive should be gone
- Change your store base country to `US`
- The incentive should be back
- Change your store base country to `UK`
- The incentive should be updated with the 15% discount
- Disable your payment gateway (so there are none active) from WooCommerce > Settings > Payments
- The incentive should be gone
- Enable the payment gateway
- The incentive should be back

#### Action incentive
- Make your store eligible for it:
  * Set your store base country to `RO` from the WooCommerce > Settings > General tab
  * Set the store installation timestamp to a date NOT older than 90 days (use Tools > WCA Test Helper > Tools tab)
  * Make sure you have NO active payment gateway in WooCommerce > Settings > Payments
  * Have no processed orders
-  **Payments (1)** should be visible on the admin sidebar.
- Clicking on it should display the action incentive offer (10% for 3 months)
- Choosing `Install WooPayments for free` should successfully create the promo note. Look for incentive ID on `wc_admin_notes` table.
- Create or restore the order(s)
- The incentive should be gone
- Trash the order(s)
- The incentive should be shown again
- Change your store base country to `BR`
- The incentive should be gone
- Change your store base country to `US`
- The incentive should be back
- Enable a payment gateway from WooCommerce > Settings > Payments
- The incentive should be gone
- Disable the payment gateway
- The incentive should be back

<!-- End testing instructions -->
