### PR TITLE
Product Editor: Disable autocomplete on product name field

### DIFF
--- a/packages/js/product-editor/changelog/fix-disable-autocomplete-product-name
+++ b/packages/js/product-editor/changelog/fix-disable-autocomplete-product-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Disable autocomplete for the product name field.

--- a/packages/js/product-editor/src/blocks/name/edit.tsx
+++ b/packages/js/product-editor/src/blocks/name/edit.tsx
@@ -170,6 +170,8 @@ export function Edit( { attributes }: BlockEditProps< NameBlockAttributes > ) {
 						) }
 						onChange={ setName }
 						value={ name && name !== AUTO_DRAFT_NAME ? name : '' }
+						autoComplete="off"
+						data-1p-ignore
 						onBlur={ () => {
 							setSkuIfEmpty();
 							validateName();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In Chrome (and Chrome-based browsers such as Arc), if you have the 1Password extension enabled, it will suggest "names" for the product name field...

<img width="1259" alt="Screenshot 2023-07-12 at 14 39 02" src="https://github.com/woocommerce/woocommerce/assets/2098816/60076f39-2144-4ce4-82a6-eb1197719149">

This clutters our UI, and is useless and confusing.

This PR disables autocomplete for the name field, which stops 1Password (and other password managers, including built-in ones) from auto-suggesting completions.

It also explicitly set the field to be ignored by 1Password, which stops 1Password from putting its icon in the right of the field (again, it is useless on this field).

<img width="1259" alt="Screenshot 2023-07-12 at 15 36 43" src="https://github.com/woocommerce/woocommerce/assets/2098816/49e6c551-ac4f-42af-a044-5b0188c807a0">

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

With 1Password extension enabled in Chrome (or Arc)...

1. Enable the new product editor.
2. Create a new product.
3. Verify that no values are suggested for autocompletion on the name field.
4. Verify that no 1Password icon is displayed in the name field.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
