### PR TITLE
Support dynamic prop setting for order subclasses.

### DIFF
--- a/plugins/woocommerce/changelog/fix-37697
+++ b/plugins/woocommerce/changelog/fix-37697
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Support dynamic prop setting to use in refunds for setting correct props.

--- a/plugins/woocommerce/includes/class-wc-order-refund.php
+++ b/plugins/woocommerce/includes/class-wc-order-refund.php
@@ -49,6 +49,8 @@ class WC_Order_Refund extends WC_Abstract_Order {
 	 * @var array
 	 */
 	protected $legacy_datastore_props = array(
+		'_refund_amount',
+		'_refund_reason',
 		'_refunded_by',
 		'_refunded_payment',
 	);

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1366,7 +1366,7 @@ WHERE
 	 * @param \WC_Abstract_Order $order      The order object.
 	 * @param object             $order_data A row of order data from the database.
 	 */
-	private function set_order_props_from_data( &$order, $order_data ) {
+	protected function set_order_props_from_data( &$order, $order_data ) {
 		foreach ( $this->get_all_order_column_mappings() as $table_name => $column_mapping ) {
 			foreach ( $column_mapping as $column_name => $prop_details ) {
 				if ( ! isset( $prop_details['name'] ) ) {

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableRefundDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableRefundDataStore.php
@@ -97,6 +97,8 @@ class OrdersTableRefundDataStore extends OrdersTableDataStore {
 	 *
 	 * @param \WC_Order_Refund $refund Refund object.
 	 * @param object           $data   DB data object.
+	 *
+	 * @since 8.0.0
 	 */
 	protected function set_order_props_from_data( &$refund, $data ) {
 		parent::set_order_props_from_data( $refund, $data );

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableRefundDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableRefundDataStore.php
@@ -50,6 +50,16 @@ class OrdersTableRefundDataStore extends OrdersTableDataStore {
 	);
 
 	/**
+	 * We do not have and use all the getters and setters from OrderTableDataStore, so we only select the props we actually need.
+	 */
+	protected $internal_meta_keys = array(
+		'_refund_amount',
+		'_refund_reason',
+		'_refunded_payment',
+		'_refunded_by',
+	);
+
+	/**
 	 * Delete a refund order from database.
 	 *
 	 * @param \WC_Order $refund Refund object to delete.
@@ -93,31 +103,28 @@ class OrdersTableRefundDataStore extends OrdersTableDataStore {
 	}
 
 	/**
-	 * Read multiple refund objects from custom tables.
-	 *
-	 * @param \WC_Order $refunds Refund objects.
-	 */
-	public function read_multiple( &$refunds ) {
-		parent::read_multiple( $refunds );
-		foreach ( $refunds as $refund ) {
-			$this->set_refund_props( $refund );
-		}
-	}
-
-	/**
 	 * Helper method to set refund props.
 	 *
-	 * @param \WC_Order $refund Refund object.
+	 * @param \WC_Order_Refund $refund Refund object.
 	 */
-	private function set_refund_props( $refund ) {
-		$refund->set_props(
-			array(
-				'amount'           => $refund->get_meta( '_refund_amount', true ),
-				'refunded_by'      => $refund->get_meta( '_refunded_by', true ),
-				'refunded_payment' => wc_string_to_bool( $refund->get_meta( '_refunded_payment', true ) ),
-				'reason'           => $refund->get_meta( '_refund_reason', true ),
-			)
-		);
+	protected function set_order_props_from_data( &$refund, $data ) {
+		parent::set_order_props_from_data( $refund, $data );
+		foreach ( $data->meta_data as $meta ) {
+			switch ( $meta->meta_key ) {
+				case '_refund_amount':
+					$refund->set_amount( $meta->meta_value );
+					break;
+				case '_refunded_by':
+					$refund->set_refunded_by( $meta->meta_value );
+					break;
+				case '_refunded_payment':
+					$refund->set_refunded_payment( wc_string_to_bool( $meta->meta_value ) );
+					break;
+				case '_refund_reason':
+					$refund->set_reason( $meta->meta_value );
+					break;
+			}
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableRefundDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableRefundDataStore.php
@@ -50,16 +50,6 @@ class OrdersTableRefundDataStore extends OrdersTableDataStore {
 	);
 
 	/**
-	 * We do not have and use all the getters and setters from OrderTableDataStore, so we only select the props we actually need.
-	 */
-	protected $internal_meta_keys = array(
-		'_refund_amount',
-		'_refund_reason',
-		'_refunded_payment',
-		'_refunded_by',
-	);
-
-	/**
 	 * Delete a refund order from database.
 	 *
 	 * @param \WC_Order $refund Refund object to delete.
@@ -91,21 +81,10 @@ class OrdersTableRefundDataStore extends OrdersTableDataStore {
 	}
 
 	/**
-	 * Read a refund object from custom tables.
-	 *
-	 * @param \WC_Abstract_Order $refund Refund object.
-	 *
-	 * @return void
-	 */
-	public function read( &$refund ) {
-		parent::read( $refund );
-		$this->set_refund_props( $refund );
-	}
-
-	/**
 	 * Helper method to set refund props.
 	 *
 	 * @param \WC_Order_Refund $refund Refund object.
+	 * @param object           $data   DB data object.
 	 */
 	protected function set_order_props_from_data( &$refund, $data ) {
 		parent::set_order_props_from_data( $refund, $data );

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableRefundDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableRefundDataStore.php
@@ -12,6 +12,18 @@ namespace Automattic\WooCommerce\Internal\DataStores\Orders;
 class OrdersTableRefundDataStore extends OrdersTableDataStore {
 
 	/**
+	 * Data stored in meta keys, but not considered "meta" for refund.
+	 *
+	 * @var string[]
+	 */
+	protected $internal_meta_keys = array(
+		'_refund_amount',
+		'_refund_reason',
+		'_refunded_by',
+		'_refunded_payment',
+	);
+
+	/**
 	 * We do not have and use all the getters and setters from OrderTableDataStore, so we only select the props we actually need.
 	 *
 	 * @var \string[][]

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableRefundDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableRefundDataStoreTests.php
@@ -101,4 +101,24 @@ class OrdersTableRefundDataStoreTests extends WC_Unit_Test_Case {
 		$this->assertEquals( 'Test', $refreshed_refund->get_reason() );
 	}
 
+	/**
+	 * @testDox Test that refund props are set as expected.
+	 */
+	public function test_refund_data_is_set() {
+		$order  = OrderHelper::create_order();
+		$refund = wc_create_refund(
+			array(
+				'order_id' => $order->get_id(),
+				'amount'   => 10,
+				'reason'   => 'Test',
+			)
+		);
+		$refund->save();
+
+		$refreshed_refund = wc_get_order( $order->get_id() )->get_refunds()[0];
+		$this->assertEquals( $refund->get_id(), $refreshed_refund->get_id() );
+		$this->assertEquals( 10, $refreshed_refund->get_data()['amount'] );
+		$this->assertEquals( 'Test', $refreshed_refund->get_data()['reason'] );
+	}
+
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Internal props that are still being stored in the metadata, such as `_refund_amount` and `_refund_reason` for refunds was not being initialized properly since it was set after `$object->read` property was set to true. A consequence of this would be that `$refund->get_data()` will not return the value of these props correctly since they will be stored in the changed array instead of the data array.

This PR fixes the behavior by exposing setting the prop dynamically and registering above keys as internal metadata.

Closes #37697 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

With HPOS set as authoritative:
1. Create an order with at least one product. Set the status to completed. Let's say the ID of the order is XX.
2. From the admin, add a refund to the order. Save the order.
3. Fetch the order via rest API like so: `wp-json/wc/v3/orders/XX/refunds`. In the returned refunds list, check the amount and refund reason is set properly, and is not included as the meta key.

```json
[
  {
    "id": 1792,
    "date_created": "2023-07-10T12:21:21",
    "date_created_gmt": "2023-07-10T12:21:21",
    "amount": "2116.36",
    "reason": "did not liked products",
    "refunded_by": 0,
    "refunded_payment": false,
    "meta_data": [
      {
        "id": 4526,
        "key": "test",
        "value": "test_value"
      }
    ],
...
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
