### PR TITLE
Add linting to CI for monorepo utils, add to CI unit tests for docs.

### DIFF
--- a/.github/workflows/pr-lint-test-js.yml
+++ b/.github/workflows/pr-lint-test-js.yml
@@ -23,7 +23,7 @@ jobs:
               uses: ./.github/actions/setup-woocommerce-monorepo
 
             - name: Lint
-              run: pnpm run -r --filter='release-posts' --filter='@woocommerce/monorepo-utils' --filter='woocommerce/client/admin...' --filter='!@woocommerce/e2e*' --filter='!@woocommerce/api' --color lint
+              run: pnpm run -r --filter='release-posts' --filter='woocommerce/client/admin...' --filter='@woocommerce/monorepo-utils' --filter='!@woocommerce/e2e*' --filter='!@woocommerce/api' --color lint
 
             - name: Test
               run: pnpm run test --filter='woocommerce/client/admin...' --filter='@woocommerce/monorepo-utils' --filter='!@woocommerce/e2e*' --filter='@woocommerce/monorepo-utils' --filter='!@woocommerce/api' --color

--- a/.github/workflows/pr-lint-test-js.yml
+++ b/.github/workflows/pr-lint-test-js.yml
@@ -23,7 +23,7 @@ jobs:
               uses: ./.github/actions/setup-woocommerce-monorepo
 
             - name: Lint
-              run: pnpm run -r --filter='release-posts' --filter='woocommerce/client/admin...' --filter='@woocommerce/monorepo-utils' --filter='!@woocommerce/e2e*' --filter='!@woocommerce/api' --color lint
+              run: pnpm run -r --filter='release-posts' --filter='@woocommerce/monorepo-utils' --filter='woocommerce/client/admin...' --filter='!@woocommerce/e2e*' --filter='!@woocommerce/api' --color lint
 
             - name: Test
-              run: pnpm run test --filter='woocommerce/client/admin...' --filter='!@woocommerce/e2e*' --filter='!@woocommerce/api' --color
+              run: pnpm run test --filter='woocommerce/client/admin...' --filter='@woocommerce/monorepo-utils' --filter='!@woocommerce/e2e*' --filter='@woocommerce/monorepo-utils' --filter='!@woocommerce/api' --color

--- a/.github/workflows/pr-unit-test-other-plugins.yml
+++ b/.github/workflows/pr-unit-test-other-plugins.yml
@@ -1,0 +1,24 @@
+name: Run unit for other PHP plugins
+on:
+    pull_request:
+        paths-ignore:
+            - '**/changelog/**'
+
+permissions: {}
+
+jobs:
+    test:
+        runs-on: ubuntu-20.04
+        permissions:
+            contents: read
+        steps:
+            - uses: actions/checkout@v3
+
+            - name: Setup WooCommerce Monorepo
+              uses: ./.github/actions/setup-woocommerce-monorepo
+              with:
+                  php-version: '8.0'
+
+            - name: Run WooCommerce Docs Tests
+              run: pnpm test:unit
+              working-directory: ./plugins/woocommerce-docs

--- a/plugins/woocommerce-docs/package.json
+++ b/plugins/woocommerce-docs/package.json
@@ -4,7 +4,6 @@
 	"description": "WooCommerce Docs Plugin",
 	"main": "index.js",
 	"scripts": {
-		"test": "echo \"Error: no test specified\" && exit 1",
 		"build": "wp-scripts build",
 		"start": "wp-scripts start",
 		"postinstall": "composer install",

--- a/tools/monorepo-utils/package.json
+++ b/tools/monorepo-utils/package.json
@@ -44,7 +44,8 @@
 		"start": "tsc --watch",
 		"lint": "eslint . --ext .ts",
 		"postinstall": "pnpm run build",
-		"test": "jest"
+		"turbo:test": "jest",
+		"test": "pnpm -w exec turbo run turbo:test --filter=$npm_package_name"
 	},
 	"engines": {
 		"node": "^16.14.1",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Monorepo utils has not been tested in the past and it leads to some friction since this tool has become more important and actively developed. This adds the existing test suite to the CI checks for that package.

Also none of the PHP plugins in the Monorepo apart from core are having unit tests run, so this starts that trend by running the unit tests of WooCommerce docs as a separate workflow (the other plugins don't need the matrix or HPOS stuff thats used in the core unit tests action).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. There should be a new passing CI job in the PR
2. The lint and test JS action should be passing and it should now be running the monorepo utils tests, this should be confirmable from the CI output.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
