### PR TITLE
Add customer address change action to user profile

### DIFF
--- a/plugins/woocommerce/changelog/39252-address_hook
+++ b/plugins/woocommerce/changelog/39252-address_hook
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Makes it possible to use existing action hook `woocommerce_customer_save_address` to detect customer address changes made via the admin environment.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-profile.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-profile.php
@@ -236,7 +236,7 @@ if ( ! class_exists( 'WC_Admin_Profile', false ) ) :
 				 *
 				 * Fires after a customer address has been saved on the user profile admin screen.
 				 *
-				 * @since 8.4.1
+				 * @since 8.5.0
 				 * @param int    $user_id User ID being saved.
 				 * @param string $address_type Type of address; 'billing' or 'shipping'.
 				 */

--- a/plugins/woocommerce/includes/admin/class-wc-admin-profile.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-profile.php
@@ -212,7 +212,7 @@ if ( ! class_exists( 'WC_Admin_Profile', false ) ) :
 
 			$save_fields = $this->get_customer_meta_fields();
 
-			foreach ( $save_fields as $fieldset ) {
+			foreach ( $save_fields as $fieldset_type => $fieldset ) {
 
 				foreach ( $fieldset['fields'] as $key => $field ) {
 
@@ -222,6 +222,25 @@ if ( ! class_exists( 'WC_Admin_Profile', false ) ) :
 						update_user_meta( $user_id, $key, wc_clean( $_POST[ $key ] ) );
 					}
 				}
+
+				// Skip firing the action for any non-internal fieldset types.
+				if ( ! in_array( $fieldset_type, array( 'billing', 'shipping' ) ) ) {
+					continue;
+				}
+
+				// Fieldset type is an internal address type.
+				$address_type = $fieldset_type;
+
+				/**
+				 * Hook: woocommerce_customer_save_address.
+				 *
+				 * Fires after a customer address has been saved on the user profile admin screen.
+				 *
+				 * @since 8.4.1
+				 * @param int    $user_id User ID being saved.
+				 * @param string $address_type Type of address; 'billing' or 'shipping'.
+				 */
+				do_action( 'woocommerce_customer_save_address', $user_id, $address_type );
 			}
 		}
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-profile.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-profile.php
@@ -224,7 +224,7 @@ if ( ! class_exists( 'WC_Admin_Profile', false ) ) :
 				}
 
 				// Skip firing the action for any non-internal fieldset types.
-				if ( ! in_array( $fieldset_type, array( 'billing', 'shipping' ) ) ) {
+				if ( ! in_array( $fieldset_type, array( 'billing', 'shipping' ), true ) ) {
 					continue;
 				}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Describe the bug

When a Customer makes changes to their Billing Address and/or their Shipping Address via their "My account" screen, the [`woocommerce_customer_save_address`](https://github.com/woocommerce/woocommerce/blob/bc942a02157b5ea6ab6672e14994c1d365e1219e/plugins/woocommerce/includes/class-wc-form-handler.php#L209) action fires. When a site admin makes the same changes via the fields on the Customer's User Profile admin screen, no hook is fired. As a result, other plugins cannot be fully informed about Customer Address changes.

### Expected behavior

The `woocommerce_customer_save_address` action should fire in both cases.

### Actual behavior

The `woocommerce_customer_save_address` action only fires when changes are made on the Customer's "My account" screen.

### Steps to reproduce

1. Create a callback for the `woocommerce_customer_save_address` action. For example, you might place the following code in `wp-content/mu-plugins/test-39254.php`:

```php
<?php

add_action( 'woocommerce_customer_save_address', function ( $user_id, $address_type ) {
	$context = $_SERVER['REQUEST_URI'] ?? 'unknown';
	wc_get_logger()->debug( "'Address update ({$address_type}) detected for user {$user_id}. Context: $context." );
}, 10, 2 );
```

2. As a site admin, edit a customer's user profile and change their billing and shipping addresses.
3. Logged in as the customer, make some further updates to the billing and shipping addresses via the **My Account ▸ Addresses** page.
4. All of the changes should be successful.
5. With this branch checked out, you should also find that the snippet has detected and logged information about the address changes (navigate to **WooCommerce ▸ Status ▸ Logs** to see this (note that your logs make look different, depending on how they are configured—the key thing is that the relevant log entries are present):

<div align="center"><img width="750" alt="WooCommerce log screen" src="https://github.com/woocommerce/woocommerce/assets/3594411/b264e8ba-4ddc-4fbf-9930-959efecf80cd" /></div>

In the above screenshot, there are four relevant log entries:

- One for the frontend billing address change.
- Another for the frontend shipping address change.
- One for the backend billing address change.
- Another for the backend shipping address change.

### Changes proposed in this Pull Request:

Completes hook coverage of changes to Customer Addresses.

Closes #39252

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement
