### PR TITLE
Experiment: add simple integration of command palette

### DIFF
--- a/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette/index.js
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import { useCommand } from '@wordpress/commands';
+import { registerPlugin } from '@wordpress/plugins';
+import { __ } from '@wordpress/i18n';
+import { box } from '@wordpress/icons';
+
+const WooCommerceCommands = () => {
+	useCommand( {
+		name: 'woocommere-commands-view-products',
+		label: __( 'View Products', 'woocommerce' ),
+		searchLabel: __( 'View Products', 'woocommerce' ),
+		icon: box,
+		callback: () => {
+			window.location.href = '/wp-admin/edit.php?post_type=product';
+		},
+	} );
+	return null;
+};
+
+registerPlugin( 'woocommerce-commands-registration', {
+	render: WooCommerceCommands,
+} );

--- a/plugins/woocommerce-admin/webpack.config.js
+++ b/plugins/woocommerce-admin/webpack.config.js
@@ -67,6 +67,7 @@ const wpAdminScripts = [
 	'product-import-tracking',
 	'variable-product-tour',
 	'product-category-metabox',
+	'command-palette',
 ];
 const getEntryPoints = () => {
 	const entryPoints = {

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -27,6 +27,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 		public function __construct() {
 			add_action( 'admin_enqueue_scripts', array( $this, 'admin_styles' ) );
 			add_action( 'admin_enqueue_scripts', array( $this, 'admin_scripts' ) );
+			add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ) );
 		}
 
 		/**
@@ -550,6 +551,15 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 				wp_enqueue_script( 'marketplace-suggestions' );
 			}
 
+		}
+
+		/**
+		 * Enqueue block editor assets.
+		 *
+		 * @return void
+		 */
+		public function enqueue_block_editor_assets() {
+			WCAdminAssets::register_script( 'wp-admin-scripts', 'command-palette' );
 		}
 
 		/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

WordPress 6.3 will release with the new [Command Palette](https://make.wordpress.org/core/2023/07/17/introducing-the-wordpress-command-palette-api/) which includes a public API for registering public commands.

Via this PR, we can experiment with registering custom commands for WooCommerce. 

**Some caveats:**

- Currently the Command Palette is only supported in two contexts: site editor, block editor. [Custom contexts are not yet supported](https://github.com/WordPress/gutenberg/pull/51169).
- I think it's okay for initial Woo integration to be relegated to the above contexts. We _can_ likely trigger the palette in other contexts (product-editor for example) but it won't provide contextual awareness out of the box (we should definitely explore this though).

Some ideas for further exploration (that can be done in parallel):

* [ ] Implement a bunch of various locator commands ("View Orders" etc).
* [ ] Implement a command loader for _specific_ routes (i.e. a specific order) - I think `useCommandLoader` would be the API for this.
* [ ] Look into implementing `CommandComponent` in the Product editor?

Here's an example of the initial command added, "View Products" which redirects to the product list table.

https://github.com/woocommerce/woocommerce/assets/1429108/366d52d9-ad41-4144-a725-0802689b98e1

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1.
2.
3.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
