### PR TITLE
Update the admin's menu remaining tasks bubble CSS class and loosen the query selector for handling the runtime update

### DIFF
--- a/plugins/woocommerce-admin/client/task-lists/components/task.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/components/task.tsx
@@ -33,7 +33,7 @@ export const Task: React.FC< TaskProps > = ( { query, task } ) => {
 
 	const updateBadge = useCallback( () => {
 		const badgeElement: HTMLElement | null = document.querySelector(
-			'.toplevel_page_woocommerce .remaining-tasks-badge'
+			'#adminmenu .woocommerce-task-list-remaining-tasks-badge'
 		);
 
 		if ( ! badgeElement ) {

--- a/plugins/woocommerce-admin/client/task-lists/components/task.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/components/task.tsx
@@ -38,7 +38,6 @@ export const Task: React.FC< TaskProps > = ( { query, task } ) => {
 				'#adminmenu .woocommerce-task-list-remaining-tasks-badge'
 			)
 		);
-		window.console.log("badgeElements", badgeElements);
 
 		if ( ! badgeElements?.length ) {
 			return;

--- a/plugins/woocommerce-admin/client/task-lists/components/task.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/components/task.tsx
@@ -32,21 +32,27 @@ export const Task: React.FC< TaskProps > = ( { query, task } ) => {
 		useDispatch( ONBOARDING_STORE_NAME );
 
 	const updateBadge = useCallback( () => {
-		const badgeElement: HTMLElement | null = document.querySelector(
-			'#adminmenu .woocommerce-task-list-remaining-tasks-badge'
+		window.console.log("RUNNING");
+		const badgeElements: Array< HTMLElement > | null = Array.from(
+			document.querySelectorAll(
+				'#adminmenu .woocommerce-task-list-remaining-tasks-badge'
+			)
 		);
+		window.console.log("badgeElements", badgeElements);
 
-		if ( ! badgeElement ) {
+		if ( ! badgeElements?.length ) {
 			return;
 		}
 
-		const currentBadgeCount = Number( badgeElement.innerText );
+		badgeElements.forEach( ( badgeElement ) => {
+			const currentBadgeCount = Number( badgeElement.innerText );
 
-		if ( currentBadgeCount === 1 ) {
-			badgeElement.remove();
-		}
-
-		badgeElement.innerHTML = String( currentBadgeCount - 1 );
+			if ( currentBadgeCount === 1 ) {
+				badgeElement.remove();
+			} else {
+				badgeElement.innerHTML = String( currentBadgeCount - 1 );
+			}
+		} );
 	}, [] );
 
 	const onComplete = useCallback(

--- a/plugins/woocommerce-admin/client/task-lists/components/task.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/components/task.tsx
@@ -32,7 +32,6 @@ export const Task: React.FC< TaskProps > = ( { query, task } ) => {
 		useDispatch( ONBOARDING_STORE_NAME );
 
 	const updateBadge = useCallback( () => {
-		window.console.log("RUNNING");
 		const badgeElements: Array< HTMLElement > | null = Array.from(
 			document.querySelectorAll(
 				'#adminmenu .woocommerce-task-list-remaining-tasks-badge'

--- a/plugins/woocommerce/changelog/fix-39045-remaining-tasks-bubble
+++ b/plugins/woocommerce/changelog/fix-39045-remaining-tasks-bubble
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Update the admin's menu remaining tasks bubble CSS class and handling

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
@@ -431,7 +431,7 @@ class TaskLists {
 
 		foreach ( $submenu['woocommerce'] as $key => $menu_item ) {
 			if ( 0 === strpos( $menu_item[0], _x( 'Home', 'Admin menu name', 'woocommerce' ) ) ) {
-				$submenu['woocommerce'][ $key ][0] .= ' <span class="awaiting-mod update-plugins remaining-tasks-badge count-' . esc_attr( $tasks_count ) . '">' . number_format_i18n( $tasks_count ) . '</span>'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+				$submenu['woocommerce'][ $key ][0] .= ' <span class="awaiting-mod update-plugins remaining-tasks-badge woocommerce-task-list-remaining-tasks-badge"><span class="count-' . esc_attr( $tasks_count ) . '">' . absint( $tasks_count ) . '</span></span>'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 				break;
 			}
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The tasks bubble/nudge in the **WooCommerce > Home** admin menu is limited to the current structure, which poses a challenge for third-party developers (3PDs) to rearrange the menu and still keep the badge updated automatically.

This PR aims to:
- Add a more specific class name to the bubble element, and;
- Update the `updateBadge()` function to accommodate different menu structures by loosening the query selector and ensuring that multiple elements can be handled.

Closes #39045 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Pick a task to handle the completion status with ease; for example, we'll use the "Personalize your store" task.
2. Create a new shop or use an existing one and if the task is completed, update the `woocommerce_task_list_tracked_completed_actions` option and remove the `appearance` id from the serialized array.
3. Apply this patch and build `woocommerce/admin/client`.
4. Click on the task, and then continue by clicking "Skip" on the homepage prompt and then the "Complete task" button.
5. Ensure that the bubble next to **WooCommerce > Home** menu item updates automatically. 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
