### PR TITLE
Update WooCommerce blocks to 10.4.6

### DIFF
--- a/plugins/woocommerce/bin/composer/phpcs/composer.lock
+++ b/plugins/woocommerce/bin/composer/phpcs/composer.lock
@@ -258,16 +258,16 @@
         },
         {
             "name": "sirbrillig/phpcs-changed",
-            "version": "v2.10.2",
+            "version": "v2.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sirbrillig/phpcs-changed.git",
-                "reference": "ba0432bc86ffdc31a6946117be6c2419b7e3e16d"
+                "reference": "ebff6bebc105b674f671bb79e3a50c6a24bc0bb7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sirbrillig/phpcs-changed/zipball/ba0432bc86ffdc31a6946117be6c2419b7e3e16d",
-                "reference": "ba0432bc86ffdc31a6946117be6c2419b7e3e16d",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-changed/zipball/ebff6bebc105b674f671bb79e3a50c6a24bc0bb7",
+                "reference": "ebff6bebc105b674f671bb79e3a50c6a24bc0bb7",
                 "shasum": ""
             },
             "require": {
@@ -275,10 +275,10 @@
             },
             "require-dev": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
-                "phpstan/phpstan": "1.4.10 || ^1.7",
                 "phpunit/phpunit": "^6.4 || ^9.5",
                 "sirbrillig/phpcs-variable-analysis": "^2.1.3",
-                "squizlabs/php_codesniffer": "^3.2.1"
+                "squizlabs/php_codesniffer": "^3.2.1",
+                "vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || ^5.0@beta"
             },
             "bin": [
                 "bin/phpcs-changed"
@@ -287,8 +287,6 @@
             "autoload": {
                 "files": [
                     "PhpcsChanged/Cli.php",
-                    "PhpcsChanged/SvnWorkflow.php",
-                    "PhpcsChanged/GitWorkflow.php",
                     "PhpcsChanged/functions.php"
                 ],
                 "psr-4": {
@@ -308,9 +306,9 @@
             "description": "Run phpcs on files, but only report warnings/errors from lines which were changed.",
             "support": {
                 "issues": "https://github.com/sirbrillig/phpcs-changed/issues",
-                "source": "https://github.com/sirbrillig/phpcs-changed/tree/v2.10.2"
+                "source": "https://github.com/sirbrillig/phpcs-changed/tree/v2.11.1"
             },
-            "time": "2023-03-25T15:10:31+00:00"
+            "time": "2023-06-16T02:31:57+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",

--- a/plugins/woocommerce/bin/composer/wp/composer.lock
+++ b/plugins/woocommerce/bin/composer/wp/composer.lock
@@ -222,16 +222,16 @@
         },
         {
             "name": "mck89/peast",
-            "version": "v1.15.1",
+            "version": "v1.15.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mck89/peast.git",
-                "reference": "cf06286910b7efc9dce7503553ebee314df3d3d3"
+                "reference": "07d82a271d372c6f37897a70b0381ca2ec2e364a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mck89/peast/zipball/cf06286910b7efc9dce7503553ebee314df3d3d3",
-                "reference": "cf06286910b7efc9dce7503553ebee314df3d3d3",
+                "url": "https://api.github.com/repos/mck89/peast/zipball/07d82a271d372c6f37897a70b0381ca2ec2e364a",
+                "reference": "07d82a271d372c6f37897a70b0381ca2ec2e364a",
                 "shasum": ""
             },
             "require": {
@@ -244,7 +244,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.15.1-dev"
+                    "dev-master": "1.15.2-dev"
                 }
             },
             "autoload": {
@@ -266,9 +266,9 @@
             "description": "Peast is PHP library that generates AST for JavaScript code",
             "support": {
                 "issues": "https://github.com/mck89/peast/issues",
-                "source": "https://github.com/mck89/peast/tree/v1.15.1"
+                "source": "https://github.com/mck89/peast/tree/v1.15.2"
             },
-            "time": "2023-01-21T13:18:17+00:00"
+            "time": "2023-07-15T12:25:27+00:00"
         },
         {
             "name": "mustache/mustache",

--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-10.4.6
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-10.4.6
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update WooCommerce Blocks to 10.4.6

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -23,7 +23,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.6.1",
-		"woocommerce/woocommerce-blocks": "10.4.5"
+		"woocommerce/woocommerce-blocks": "10.4.6"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.3.0",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "829a099057c5702e82827c5a9598f5c4",
+    "content-hash": "54c85dff61f6ad74f7e6526f1215d150",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1004,16 +1004,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "10.4.5",
+            "version": "10.4.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "b0a691b4270d1dae849d869317aaa536c220f8eb"
+                "reference": "3528a138f412b592a7947658e51cc6de958f321c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/b0a691b4270d1dae849d869317aaa536c220f8eb",
-                "reference": "b0a691b4270d1dae849d869317aaa536c220f8eb",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/3528a138f412b592a7947658e51cc6de958f321c",
+                "reference": "3528a138f412b592a7947658e51cc6de958f321c",
                 "shasum": ""
             },
             "require": {
@@ -1059,9 +1059,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v10.4.5"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v10.4.6"
             },
-            "time": "2023-06-30T12:46:55+00:00"
+            "time": "2023-07-17T18:23:13+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 10.4.6. It includes changes from WooCommerce Blocks 10.4.6 and is intended to target WooCommerce 7.9 for release.
Details from all the different releases included in this pull:

## Blocks 10.4.6

* [Release PR](https://github.com/woocommerce/woocommerce-blocks/pull/10243)
* [Testing instructions](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/internal-developers/testing/releases/1046.md)
* [Release post](#) WIP - coming soon

### Changelog entry

### The following changelog entries are only those that impact existing blocks and functionality surfaced to users:

#### Bug Fixes

- Improve performance and fix memory exhaustion errors that could be triggered for stores with a high volume of products using the Products (Beta) or Products Collection blocks. ([#10198](https://github.com/woocommerce/woocommerce-blocks/pull/10198))
- Fixed formatting for addresses sent to the Store API. ([#10242](https://github.com/woocommerce/woocommerce-blocks/pull/10242))

#### Security
- Update CORS handling in Store API

### Changelog entry

> Dev - Update WooCommerce Blocks version to 10.4.6