### PR TITLE
Fix cloning cart keeps wrong reference in session and fee

### DIFF
--- a/plugins/woocommerce/changelog/trunk
+++ b/plugins/woocommerce/changelog/trunk
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fixes PHP error when WooCommerce menus are created without a position and when users view the WordPress admin dashboard without having WooCommerce admin permissions.
+Use correct object reference when cloning a cart

--- a/plugins/woocommerce/includes/class-wc-cart-fees.php
+++ b/plugins/woocommerce/includes/class-wc-cart-fees.php
@@ -43,7 +43,7 @@ final class WC_Cart_Fees {
 	/**
 	 * Constructor. Reference to the cart.
 	 *
-	 * @param null $deprecated Deprecated since WooCommerce 7.9.1.
+	 * @param null $deprecated Deprecated since WooCommerce 8.0.4.
 	 *
 	 * @since 3.2.0
 	 */
@@ -52,7 +52,7 @@ final class WC_Cart_Fees {
 			wc_doing_it_wrong(
 				'new WC_Cart_Fees',
 				'You don\'t need to pass a cart parameter to the WC_Cart_Fees constructor anymore',
-				'7.9.1'
+				'8.0.4'
 			);
 		}
 	}

--- a/plugins/woocommerce/includes/class-wc-cart-fees.php
+++ b/plugins/woocommerce/includes/class-wc-cart-fees.php
@@ -27,14 +27,6 @@ final class WC_Cart_Fees {
 	private $fees = array();
 
 	/**
-	 * Reference to cart object.
-	 *
-	 * @since 3.2.0
-	 * @var WC_Cart
-	 */
-	private $cart;
-
-	/**
 	 * New fees are made out of these props.
 	 *
 	 * @var array
@@ -51,16 +43,18 @@ final class WC_Cart_Fees {
 	/**
 	 * Constructor. Reference to the cart.
 	 *
+	 * @param null $deprecated Deprecated since WooCommerce 7.9.1.
+	 *
 	 * @since 3.2.0
-	 * @throws Exception If missing WC_Cart object.
-	 * @param WC_Cart $cart Cart object.
 	 */
-	public function __construct( &$cart ) {
-		if ( ! is_a( $cart, 'WC_Cart' ) ) {
-			throw new Exception( 'A valid WC_Cart object is required' );
+	public function __construct( $deprecated = null ) {
+		if ( isset( $deprecated ) ) {
+			wc_doing_it_wrong(
+				'new WC_Cart_Fees',
+				'You don\'t need to pass a cart parameter to the WC_Cart_Fees constructor anymore',
+				'7.9.1'
+			);
 		}
-
-		$this->cart = $cart;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-cart-fees.php
+++ b/plugins/woocommerce/includes/class-wc-cart-fees.php
@@ -43,7 +43,7 @@ final class WC_Cart_Fees {
 	/**
 	 * Constructor. Reference to the cart.
 	 *
-	 * @param null $deprecated Deprecated since WooCommerce 8.0.4.
+	 * @param null $deprecated Deprecated since WooCommerce 8.2.0.
 	 *
 	 * @since 3.2.0
 	 */
@@ -52,7 +52,7 @@ final class WC_Cart_Fees {
 			wc_doing_it_wrong(
 				'new WC_Cart_Fees',
 				'You don\'t need to pass a cart parameter to the WC_Cart_Fees constructor anymore',
-				'8.0.4'
+				'8.2.0'
 			);
 		}
 	}

--- a/plugins/woocommerce/includes/class-wc-cart-session.php
+++ b/plugins/woocommerce/includes/class-wc-cart-session.php
@@ -33,13 +33,23 @@ final class WC_Cart_Session {
 	 *
 	 * @param WC_Cart $cart Cart object to calculate totals for.
 	 */
-	public function __construct( &$cart ) {
+	public function __construct( $cart ) {
 		if ( ! is_a( $cart, 'WC_Cart' ) ) {
 			throw new Exception( 'A valid WC_Cart object is required' );
 		}
 
+		$this->set_cart( $cart );
+	}
+
+	/**
+	 * Sets the cart instance.
+	 *
+	 * @param WC_Cart $cart Cart object.
+	 */
+	public function set_cart( WC_Cart $cart ) {
 		$this->cart = $cart;
 	}
+
 
 	/**
 	 * Register methods for this object on the appropriate WordPress hooks.

--- a/plugins/woocommerce/includes/class-wc-cart.php
+++ b/plugins/woocommerce/includes/class-wc-cart.php
@@ -98,7 +98,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 */
 	public function __construct() {
 		$this->session  = new WC_Cart_Session( $this );
-		$this->fees_api = new WC_Cart_Fees( $this );
+		$this->fees_api = new WC_Cart_Fees();
 
 		// Register hooks for the objects.
 		$this->session->init();
@@ -120,6 +120,8 @@ class WC_Cart extends WC_Legacy_Cart {
 	public function __clone() {
 		$this->session  = clone $this->session;
 		$this->fees_api = clone $this->fees_api;
+
+		$this->session->set_cart( $this );
 	}
 
 	/*
@@ -667,7 +669,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	public function get_cart_contents_weight() {
 		$weight = 0.0;
 
-		foreach ( $this->get_cart() as $cart_item_key => $values ) {
+		foreach ( $this->get_cart() as $values ) {
 			if ( $values['data']->has_weight() ) {
 				$weight += (float) $values['data']->get_weight() * $values['quantity'];
 			}
@@ -684,7 +686,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	public function get_cart_item_quantities() {
 		$quantities = array();
 
-		foreach ( $this->get_cart() as $cart_item_key => $values ) {
+		foreach ( $this->get_cart() as $values ) {
 			$product = $values['data'];
 			$quantities[ $product->get_stock_managed_by_id() ] = isset( $quantities[ $product->get_stock_managed_by_id() ] ) ? $quantities[ $product->get_stock_managed_by_id() ] + $values['quantity'] : $values['quantity'];
 		}
@@ -759,7 +761,7 @@ class WC_Cart extends WC_Legacy_Cart {
 		$product_qty_in_cart      = $this->get_cart_item_quantities();
 		$current_session_order_id = isset( WC()->session->order_awaiting_payment ) ? absint( WC()->session->order_awaiting_payment ) : 0;
 
-		foreach ( $this->get_cart() as $cart_item_key => $values ) {
+		foreach ( $this->get_cart() as $values ) {
 			$product = $values['data'];
 
 			// Check stock based on stock-status.
@@ -818,7 +820,7 @@ class WC_Cart extends WC_Legacy_Cart {
 		$cross_sells = array();
 		$in_cart     = array();
 		if ( ! $this->is_empty() ) {
-			foreach ( $this->get_cart() as $cart_item_key => $values ) {
+			foreach ( $this->get_cart() as $values ) {
 				if ( $values['quantity'] > 0 ) {
 					$cross_sells = array_merge( $values['data']->get_cross_sell_ids(), $cross_sells );
 					$in_cart[]   = $values['product_id'];
@@ -908,7 +910,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	public function get_cart_item_tax_classes() {
 		$found_tax_classes = array();
 
-		foreach ( WC()->cart->get_cart() as $item ) {
+		foreach ( $this->get_cart() as $item ) {
 			if ( $item['data'] && ( $item['data']->is_taxable() || $item['data']->is_shipping_taxable() ) ) {
 				$found_tax_classes[] = $item['data']->get_tax_class();
 			}
@@ -925,7 +927,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	public function get_cart_item_tax_classes_for_shipping() {
 		$found_tax_classes = array();
 
-		foreach ( WC()->cart->get_cart() as $item ) {
+		foreach ( $this->get_cart() as $item ) {
 			if ( $item['data'] && ( $item['data']->is_shipping_taxable() ) ) {
 				$found_tax_classes[] = $item['data']->get_tax_class();
 			}
@@ -1536,7 +1538,7 @@ class WC_Cart extends WC_Legacy_Cart {
 		}
 		$needs_shipping = false;
 
-		foreach ( $this->get_cart_contents() as $cart_item_key => $values ) {
+		foreach ( $this->get_cart_contents() as $values ) {
 			if ( $values['data']->needs_shipping() ) {
 				$needs_shipping = true;
 				break;

--- a/plugins/woocommerce/tests/legacy/unit-tests/cart/cart-fees.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/cart/cart-fees.php
@@ -14,7 +14,7 @@ class WC_Tests_WC_Cart_Fees extends WC_Unit_Test_Case {
 	 */
 	public function test_set_get_remove_fees() {
 
-		$cart_fees = new WC_Cart_Fees( wc()->cart );
+		$cart_fees = new WC_Cart_Fees();
 
 		// Test add_fee.
 		$args = array(

--- a/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-cart-test.php
@@ -97,6 +97,37 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test cloning cart holds no references in session
+	 */
+	public function test_cloning_cart_session() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		// Initialize $cart1 and $cart2 as empty carts.
+		$cart1 = WC()->cart;
+		$cart1->empty_cart();
+		$cart2 = clone $cart1;
+
+		// Create a cart in session.
+		$cart1->add_to_cart( $product->get_id(), 1 );
+		$cart1->set_session();
+
+		// Empty the cart without clearing the session.
+		$cart1->set_cart_contents( array() );
+
+		// Both carts are empty at that point.
+		$this->assertTrue( $cart2->is_empty() );
+		$this->assertTrue( $cart1->is_empty() );
+
+		$cart2->get_cart_from_session();
+
+		// We retrieved $cart2 from the previously set session so it should not be empty.
+		$this->assertFalse( $cart2->is_empty() );
+
+		// We didn't touch $cart1 so it should still be empty.
+		$this->assertTrue( $cart1->is_empty() );
+	}
+
+	/**
 	 * Test show shipping.
 	 */
 	public function test_show_shipping() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Since the change in https://github.com/woocommerce/woocommerce/pull/18072, which doesn't seem to have taken into account the comment on top of the `__clone` method, the reference in the `session` and `fee_api` objects still point to the old cart, making calculations or restorations apply to the original cart instead of the cloned cart, this fixes this by updating the reference to the clone. This allows multiple carts to be stored in session.

Since the `WC_Cart_Fees` class is final and it's cart property is private and never used I want ahead and deleted it

I also see a lot of objects passed by reference in the core as well (`&$cart`, `&$order`), but they are never updated and I think there was a misconstructing how references work in php, in php there is no benefit in passing object by reference as they are already passed by reference and the only use case would be to update the reference of the variable in the calling scope of the function, but since the variables are never updated anywhere, this is not useful and just lowers readability of the code, I removed one here, but there is more and I might make a follow up PR to remove them were possible without creating breaking changes
<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->
If you clone a cart and try to get the cloned cart from the session, the original cart should not be updated with this PR

1- Add this code snippet
```
add_action( 'wp_footer', function() {
	$cart1 = WC()->cart;
	echo wp_json_encode( [ 'cart1 is empty at start', $cart1->is_empty() ] ) . '<br/>';
	$cart2 = clone $cart1;
	echo wp_json_encode( [ 'cart2 is empty at start', $cart2->is_empty() ] ) . '<br/>';
	$cart2->empty_cart();
	echo wp_json_encode( [ 'cart2 is empty after empty', $cart2->is_empty() ] ) . '<br/>';
	echo wp_json_encode( [ 'cart1 is empty after empty', $cart1->is_empty() ] ) . '<br/>';
	$cart2->get_cart_from_session();
	echo wp_json_encode( [ 'cart2 is empty after session' 2, $cart2->is_empty() ] ) . '<br/>';
	echo wp_json_encode( [ 'cart1 is empty after session 2', $cart1->is_empty() ] ) . '<br/>';
	$cart1->get_cart_from_session();
	echo wp_json_encode( [ 'cart2 is empty after session 1', $cart2->is_empty() ] ) . '<br/>';
	echo wp_json_encode( [ 'cart1 is empty after session 1', $cart1->is_empty() ] ) . '<br/>';
} );
```
2- Add an item to the cart
3- Go to the cart page
4- You should see the following in the site footer
```
["cart1 is empty at start",false]
["cart2 is empty at start",false]
["cart2 is empty after empty",true]
["cart1 is empty after empty",false]
["cart2 is empty after session 2",true]
["cart1 is empty after session 2",false]
["cart2 is empty after session 1",true]
["cart1 is empty after session 1",false]
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message <!-- Add a changelog message here -->
Use correct object reference when cloning a cart

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
