### PR TITLE
Changefile from PR description: Fix community PR permissions issue

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -55,7 +55,7 @@ Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerc
 -   [ ] Dev - Development related task
 -   [ ] Tweak - A minor adjustment to the codebase
 -   [ ] Performance - Address performance issues
--   [ ] Enhancement
+-   [ ] Enhancement - Improvement to existing functionality
 
 #### Message <!-- Add a changelog message here -->
 

--- a/.github/workflows/changelog-auto-add.yml
+++ b/.github/workflows/changelog-auto-add.yml
@@ -1,6 +1,6 @@
 name: 'Changelog Auto Add'
 on:
-    pull_request:
+    pull_request_target:
         types: [opened, synchronize, reopened, edited]
     workflow_dispatch:
         inputs:


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # https://github.com/woocommerce/woocommerce/issues/39285

This PR changes the event to add changefiles to [pull_request_target](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) in order to expand permissions. This works by running the action from the target's branch instead of the head branch. Previously, the Github Actions Bot would not have permissions to push commit's to a fork's pull request. 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. See https://github.com/woocommerce/woocommerce/pull/39074, which is a pull request from my fork with this PR's branch as a base. This means the Changelog Auto Add action will run using this branch's code. It should show passing status.
2. Edit the description's Changelog entry's details. Any part like the message or significance.
3. Once you save, see the Changelog Auto Add action kick off again. Once it succeeds, you will see the changefile updated with your edits.

We can see the Changelog Auto Add actions with without problems

https://github.com/woocommerce/woocommerce/pull/39074


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
