### PR TITLE
Restore the woocommerce_variations_added jQuery trigger

### DIFF
--- a/plugins/woocommerce/changelog/fix-variations_added_trigger
+++ b/plugins/woocommerce/changelog/fix-variations_added_trigger
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Restore woocommerce_variations_added jQuery trigger.

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product-variation.js
@@ -988,6 +988,9 @@ jQuery( function ( $ ) {
 					);
 
 					wc_meta_boxes_product_variations_ajax.show_hide_variation_empty_state();
+
+					$( '#variable_product_options' ).trigger( 'woocommerce_variations_added', 1 );
+
 					wc_meta_boxes_product_variations_ajax.unblock();
 				}
 			);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR restores the `woocommerce_variations_added` jQuery trigger that third-party extensions may depend on.

The e2e tests have also been updated to verify that this trigger is fired when a variation is manually added.

Closes #39291.

#### WooCommerce 7.8/7.9 (incorrect)

<img width="700" alt="Screenshot 2023-07-18 at 3 59 34 pm" src="https://github.com/woocommerce/woocommerce/assets/8490476/301b7b63-8edb-463f-a1ac-62d59f6b8203">

#### WooCommerce 7.7 (correct)

<img width="1268" alt="Variable subscription - 7 7" src="https://github.com/woocommerce/woocommerce/assets/2098816/86866c1c-4fd7-4cf7-b8f6-e62b3c53f6b4">

#### This PR (correct)

<img width="1268" alt="Variable subscription - fix" src="https://github.com/woocommerce/woocommerce/assets/2098816/cbc800c8-a71b-47d9-bb32-6f8719a1e91d">


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install WooCommerce Subscriptions plugin
2. Create a new variable subscription product
    - Product > Add New
    - Product type: "Variable subscription"
4. Add an attribute "used for variations" to the product
    - Attributes tab
6. Create a variation manually
    - Variations tab
8. Verify that the correct fields are shown for the variation
9. Also use "Generate variations" and ensure the correct fields are shown 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
