### PR TITLE
Changefile from PR description: Fix community PRs from branch named trunk

### DIFF
--- a/tools/monorepo-utils/src/changefile/index.ts
+++ b/tools/monorepo-utils/src/changefile/index.ts
@@ -91,8 +91,11 @@ const program = new Command( 'changefile' )
 				`Temporary clone of '${ headOwner }/${ name }' created at ${ tmpRepoPath }`
 			);
 
-			Logger.notice( `Checking out remote branch ${ branch }` );
-			await checkoutRemoteBranch( tmpRepoPath, branch );
+			// If a pull request is coming from a contributor's fork's trunk branch, we need to checkout the remote branch.
+			if ( branch !== 'trunk' ) {
+				Logger.notice( `Checking out remote branch ${ branch }` );
+				await checkoutRemoteBranch( tmpRepoPath, branch );
+			}
 
 			Logger.notice(
 				`Getting all touched projects requiring a changelog`

--- a/tools/monorepo-utils/src/changefile/index.ts
+++ b/tools/monorepo-utils/src/changefile/index.ts
@@ -91,7 +91,7 @@ const program = new Command( 'changefile' )
 				`Temporary clone of '${ headOwner }/${ name }' created at ${ tmpRepoPath }`
 			);
 
-			// If a pull request is coming from a contributor's fork's trunk branch, we need to checkout the remote branch.
+			// If a pull request is coming from a contributor's fork's trunk branch, we don't nee to checkout the remote branch because its already available as part of the clone.
 			if ( branch !== 'trunk' ) {
 				Logger.notice( `Checking out remote branch ${ branch }` );
 				await checkoutRemoteBranch( tmpRepoPath, branch );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

PRs from community contributors using the `trunk` branch fails because the changefile script was attempting to fetch and create the main branch, which already exists. If the branch is named `trunk`, there is no need, so this PR skips the remote checkout in this case.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. See https://github.com/woocommerce/woocommerce/pull/39307, which is a PR from my fork's `trunk` branch.
2. See the Changelog Auto Add Action on that PR. Note: it fails
3. See the action from a current open PR from a community contributor's fork with a head branch named `trunk`, https://github.com/woocommerce/woocommerce/actions/runs/5593108788/jobs/10226381499?pr=39155. The action fails with a message `Error: fatal: a branch named 'trunk' already exists`.
4. Now go back to the same action from https://github.com/woocommerce/woocommerce/pull/39307. The reason it fails is permissions issue which are fixed separately in https://github.com/woocommerce/woocommerce/pull/39290. Confirm it manages to get past the checking out remote branch step by seeing a log, `Getting all touched projects requiring a changelog`, which is the next step.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
