### PR TITLE
[Block Product Editor]: Only run name validation if the field has been edited

### DIFF
--- a/packages/js/product-editor/changelog/update-name-validation
+++ b/packages/js/product-editor/changelog/update-name-validation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Run field validation and set SKU only if field was filled
+
+

--- a/packages/js/product-editor/src/blocks/name/edit.tsx
+++ b/packages/js/product-editor/src/blocks/name/edit.tsx
@@ -38,11 +38,14 @@ import { AUTO_DRAFT_NAME } from '../../utils';
 import { EditProductLinkModal } from '../../components/edit-product-link-modal';
 import { useValidation } from '../../contexts/validation-context';
 import { NameBlockAttributes } from './types';
+import { useProductEdits } from '../../hooks/use-product-edits';
 
 export function Edit( { attributes }: BlockEditProps< NameBlockAttributes > ) {
 	const blockProps = useBlockProps();
 
 	const { editEntityRecord, saveEntityRecord } = useDispatch( 'core' );
+
+	const { hasEdit } = useProductEdits();
 
 	const [ showProductLinkEditModal, setShowProductLinkEditModal ] =
 		useState( false );
@@ -173,8 +176,10 @@ export function Edit( { attributes }: BlockEditProps< NameBlockAttributes > ) {
 						autoComplete="off"
 						data-1p-ignore
 						onBlur={ () => {
-							setSkuIfEmpty();
-							validateName();
+							if ( hasEdit( 'name' ) ) {
+								setSkuIfEmpty();
+								validateName();
+							}
 						} }
 					/>
 				</BaseControl>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

We were getting a confirmation pop up when trying to navigate away from the product editor without touching any of the fields after focusing automatically on the name field. 

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the block product editor
2. Go to Product > Add New.
3. Without touching any of the fields, navigate to another page (e.g. Products > All Products).
4. Verify that the confirmation dialog is NOT shown.

Here's how the confirmation dialog looked like before this fix:

<img width="942" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13437655/79c593e6-4be6-4813-9900-9d7e14c8c5fb">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
