### PR TITLE
Revert "Shard unit test runs"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,20 +28,11 @@ jobs:
             matrix:
                 php: ['7.4', '8.0']
                 wp: ['latest']
-                unittests: ['shard1', 'shard2']
                 include:
                     - wp: nightly
                       php: '7.4'
-                      unittests: 'shard1'
-                    - wp: nightly
-                      php: '7.4'
-                      unittests: 'shard2'
                     - wp: '6.1'
                       php: 7.4
-                      unittests: 'shard1'
-                    - wp: '6.1'
-                      php: 7.4
-                      unittests: 'shard2'
         services:
             database:
                 image: mysql:5.6
@@ -87,4 +78,4 @@ jobs:
               env:
                 WP_ENV_CORE: ${{ steps.parseMatrix.outputs.wpVersion }}
                 WP_ENV_PHP_VERSION: ${{ matrix.php }}
-              run: pnpm --filter=woocommerce test:unit:env --testsuite ${{ matrix.unittests }}
+              run: pnpm --filter=woocommerce test:unit:env

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -28,28 +28,14 @@ jobs:
             matrix:
                 php: ['7.4', '8.0']
                 wp: ['latest']
-                unittests: ['shard1', 'shard2']
                 include:
                     - wp: nightly
                       php: '7.4'
-                      unittests: 'shard1'
-                    - wp: nightly
-                      php: '7.4'
-                      unittests: 'shard2'
                     - wp: '6.1'
                       php: 7.4
-                      unittests: 'shard1'
-                    - wp: '6.1'
-                      php: 7.4
-                      unittests: 'shard2'
                     - wp: 'latest'
                       php: '7.4'
                       hpos: true
-                      unittests: 'shard1'
-                    - wp: 'latest'
-                      php: '7.4'
-                      hpos: true
-                      unittests: 'shard2'
         services:
             database:
                 image: mysql:5.6
@@ -86,4 +72,4 @@ jobs:
               env:
                 WP_ENV_CORE: ${{ steps.parseMatrix.outputs.wpVersion }}
                 WP_ENV_PHP_VERSION: ${{ matrix.php }}
-              run: pnpm --filter=woocommerce test:unit:env --testsuite ${{ matrix.unittests }}
+              run: pnpm --filter=woocommerce test:unit:env

--- a/plugins/woocommerce/changelog/dev-shard-unit-tests
+++ b/plugins/woocommerce/changelog/dev-shard-unit-tests
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Shard the unit tests running on GitHub Actions.

--- a/plugins/woocommerce/phpunit.xml
+++ b/plugins/woocommerce/phpunit.xml
@@ -9,17 +9,9 @@
 	verbose="true"
 	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
 	<testsuites>
-		<testsuite name="wc-unittests-all">
+		<testsuite name="WooCommerce Test Suite">
 			<directory suffix=".php">./tests/legacy/unit-tests</directory>
 			<directory suffix=".php">./tests/php</directory>
-		</testsuite>
-		<testsuite name="shard1">
-			<directory suffix=".php">./tests/legacy/unit-tests</directory>
-			<directory suffix=".php">./tests/php</directory>
-			<exclude>./tests/legacy/unit-tests/woocommerce-admin</exclude>
-		</testsuite>
-		<testsuite name="shard2">
-			<directory suffix=".php">./tests/legacy/unit-tests/woocommerce-admin</directory>
 		</testsuite>
 	</testsuites>
 	<coverage includeUncoveredFiles="true">

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/class-wc-tests-ces-tracks.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/class-wc-tests-ces-tracks.php
@@ -7,19 +7,10 @@
 
 use Automattic\WooCommerce\Internal\Admin\CustomerEffortScoreTracks;
 
-// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
-
-if ( ! class_exists( 'CurrentScreenMock' ) ) {
-	/**
-	 * Class CurrentScreenMock
-	 */
-	class CurrentScreenMock {
-		/**
-		 * CustomerEffortScoreTracks only works in wp-admin, so let's fake it.
-		 */
-		public function in_admin() {
-			return true;
-		}
+// CustomerEffortScoreTracks only works in wp-admin, so let's fake it.
+class CurrentScreenMock {
+	public function in_admin() {
+	    return true;
 	}
 }
 
@@ -51,7 +42,7 @@ class WC_Admin_Tests_CES_Tracks extends WC_Unit_Test_Case {
 	}
 
 	public function tearDown(): void {
-		parent::tearDown();
+	    parent::tearDown();
 		if ( $this->current_screen_backup ) {
 			$GLOBALS['current_screen'] = $this->current_screen_backup;
 		}

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders-stats.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/reports/class-wc-tests-reports-orders-stats.php
@@ -666,11 +666,7 @@ class WC_Admin_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
 			$orders[] = $order;
 		}
 
-		$this->assertEquals( 15, count( WC_Helper_Queue::get_all_pending() ) );
-
 		WC_Helper_Queue::run_all_pending();
-
-		$this->assertEquals( 0, count( WC_Helper_Queue::get_all_pending() ) );
 
 		$data_store = new OrdersStatsDataStore();
 

--- a/plugins/woocommerce/tests/php/includes/class-wc-orders-tracking-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-orders-tracking-test.php
@@ -1,21 +1,5 @@
 <?php
 
-// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
-
-if ( ! class_exists( 'CurrentScreenMock' ) ) {
-	/**
-	 * Class CurrentScreenMock
-	 */
-	class CurrentScreenMock {
-		/**
-		 * CustomerEffortScoreTracks only works in wp-admin, so let's fake it.
-		 */
-		public function in_admin() {
-			return true;
-		}
-	}
-}
-
 /**
  * Class WC_Orders_Tracking_Test.
  */


### PR DESCRIPTION
Reverts woocommerce/woocommerce#39302

This has introduced a failing test, which can not be reproduced locally. Let's revert this for now until we understand better what's going on there. 

To review: 

- Ensure CI passes
- also create a manual run of CI.yml and ensure that passes. 