### PR TITLE
Removes the "for your state" string from the checkout page if there are no current payment methods available.

### DIFF
--- a/plugins/woocommerce/changelog/payment-methods-for-your-state
+++ b/plugins/woocommerce/changelog/payment-methods-for-your-state
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Modified the error message shown to customers in the event that no payment gateways are available.

--- a/plugins/woocommerce/templates/checkout/payment.php
+++ b/plugins/woocommerce/templates/checkout/payment.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.8.0
+ * @version 8.1.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/checkout/payment.php
+++ b/plugins/woocommerce/templates/checkout/payment.php
@@ -31,7 +31,7 @@ if ( ! wp_doing_ajax() ) {
 				}
 			} else {
 				echo '<li>';
-				wc_print_notice( apply_filters( 'woocommerce_no_available_payment_methods_message', WC()->customer->get_billing_country() ? esc_html__( 'Sorry, it seems that there are no available payment methods for your state. Please contact us if you require assistance or wish to make alternate arrangements.', 'woocommerce' ) : esc_html__( 'Please fill in your details above to see available payment methods.', 'woocommerce' ) ), 'notice' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+				wc_print_notice( apply_filters( 'woocommerce_no_available_payment_methods_message', WC()->customer->get_billing_country() ? esc_html__( 'Sorry, it seems that there are no available payment methods. Please contact us if you require assistance or wish to make alternate arrangements.', 'woocommerce' ) : esc_html__( 'Please fill in your details above to see available payment methods.', 'woocommerce' ) ), 'notice' ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 				echo '</li>';
 			}
 			?>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Note

This is my first PR, so let me know what I may have missed :)

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

When there are no payment methods available for customers, this produces the following notice:

```
Sorry, it seems that there are no available payment methods for your state. Please contact us if you require assistance or wish to make alternate arrangements.
```

The `for your state` element generates confusion for merchants and HEs alike because of the [homonym](https://en.wikipedia.org/wiki/Homonym) `state`. There is regularly an assumption that this is referring to a geographical state (e.g., the state of California) instead of a system state. 

Removing the `for your state` string from this message retains the original message but eliminates confusion that may be brought on by using the word `state`.

Some related discussions in Slack:
- p1689676830073449-slack-C3NCP7ZJ6
- p1649763258135259-slack-C3NCP7ZJ6
- p1589141962469900-slack-C3NCP7ZJ6

Since this is a customer-facing error, it is best to display it in such a fashion that more clearly defines what the issue is. Removing the `for your state` string accomplishes that.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a product.
2. Disable all payment gateways at **WooCommerce > Settings > Payments > All payment methods**
3. Attempt to purchase the product created in step 1.
4. Assess the error produced, as no payment methods are available.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message Modified the error message shown to customers in the event that no payment gateways are available.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>