### PR TITLE
WooCommerce Docs: Fix a bug where passing full file urls made ids unstable.

### DIFF
--- a/tools/monorepo-utils/src/md-docs/lib/__tests__/generate-manifest.ts
+++ b/tools/monorepo-utils/src/md-docs/lib/__tests__/generate-manifest.ts
@@ -6,7 +6,10 @@ import path from 'path';
 /**
  * Internal dependencies
  */
-import { generateManifestFromDirectory } from '../generate-manifest';
+import {
+	generateManifestFromDirectory,
+	generatePostId,
+} from '../generate-manifest';
 
 describe( 'generateManifest', () => {
 	const dir = path.join( __dirname, './fixtures/example-docs' );
@@ -72,6 +75,20 @@ describe( 'generateManifest', () => {
 		);
 	} );
 
+	it( 'should generate posts with stable IDs', async () => {
+		const manifest = await generateManifestFromDirectory(
+			rootDir,
+			dir,
+			'example-docs',
+			'https://example.com',
+			'https://example.com/edit'
+		);
+
+		expect( manifest.categories[ 0 ].posts[ 0 ].id ).toEqual(
+			'29bce0a522cef4cd72aad4dd1c9ad5d0b6780704'
+		);
+	} );
+
 	it( 'should create a hash for each manifest', async () => {
 		const manifest = await generateManifestFromDirectory(
 			rootDir,
@@ -96,5 +113,35 @@ describe( 'generateManifest', () => {
 		expect( manifest.categories[ 0 ].posts[ 0 ].edit_url ).toEqual(
 			'https://github.com/edit/example-docs/get-started/local-development.md'
 		);
+	} );
+} );
+
+describe( 'generatePostId', () => {
+	it( 'should generate a stable ID for the same file', () => {
+		const id1 = generatePostId(
+			'get-started/local-development.md',
+			'woodocs'
+		);
+
+		const id2 = generatePostId(
+			'get-started/local-development.md',
+			'woodocs'
+		);
+
+		expect( id1 ).toEqual( id2 );
+	} );
+
+	it( 'should generate a different ID for different prefixes', () => {
+		const id1 = generatePostId(
+			'get-started/local-development.md',
+			'foodocs'
+		);
+
+		const id2 = generatePostId(
+			'get-started/local-development.md',
+			'woodocs'
+		);
+
+		expect( id1 ).not.toEqual( id2 );
 	} );
 } );

--- a/tools/monorepo-utils/src/md-docs/lib/generate-manifest.ts
+++ b/tools/monorepo-utils/src/md-docs/lib/generate-manifest.ts
@@ -22,9 +22,9 @@ interface Post {
 	[ key: string ]: unknown;
 }
 
-function generatePageId( filePath: string, prefix = '' ) {
+export function generatePostId( filePath: string, prefix = '' ) {
 	const hash = crypto.createHash( 'sha1' );
-	hash.update( prefix + filePath );
+	hash.update( `${ prefix }/${ filePath }` );
 	return hash.digest( 'hex' );
 }
 
@@ -34,6 +34,7 @@ async function processDirectory(
 	projectName: string,
 	baseUrl: string,
 	baseEditUrl: string,
+	fullPathToDocs: string,
 	checkReadme = true
 ): Promise< Category > {
 	const category: Category = {};
@@ -72,6 +73,9 @@ async function processDirectory(
 
 			const post: Post = { ...fileFrontmatter };
 
+			// get the folder name of rootDirectory.
+			const relativePath = path.relative( fullPathToDocs, filePath );
+
 			category.posts.push( {
 				...post,
 				url: generateFileUrl(
@@ -80,7 +84,7 @@ async function processDirectory(
 					subDirectory,
 					filePath
 				),
-				id: generatePageId( filePath, projectName ),
+				id: generatePostId( relativePath, projectName ),
 			} );
 		}
 	} );
@@ -97,7 +101,8 @@ async function processDirectory(
 			subdirectory,
 			projectName,
 			baseUrl,
-			baseEditUrl
+			baseEditUrl,
+			fullPathToDocs
 		);
 
 		category.categories.push( subcategory );
@@ -113,12 +118,15 @@ export async function generateManifestFromDirectory(
 	baseUrl: string,
 	baseEditUrl: string
 ) {
+	const fullPathToDocs = subDirectory;
+
 	const manifest = await processDirectory(
 		rootDirectory,
 		subDirectory,
 		projectName,
 		baseUrl,
 		baseEditUrl,
+		fullPathToDocs,
 		false
 	);
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This fixes a bug noticed by @psealock where stable IDs would not be stable if the manifest was generated on 2 different systems because we passed the full absolute file path to the ID generator.

Now this passes a path relative to the top of the directory being processed to the id generator and includes covering tests.
<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

I think the tests passing in CI should be enough because CI will run the tests in its own environment and ensures that IDs are stable even if the paths are different to my local environment.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
