### PR TITLE
Shard unit test runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,20 @@ jobs:
             matrix:
                 php: ['7.4', '8.0']
                 wp: ['latest']
+                unittests: ['shard1', 'shard2']
                 include:
                     - wp: nightly
                       php: '7.4'
+                      unittests: 'shard1'
+                    - wp: nightly
+                      php: '7.4'
+                      unittests: 'shard2'
                     - wp: '6.1'
                       php: 7.4
+                      unittests: 'shard1'
+                    - wp: '6.1'
+                      php: 7.4
+                      unittests: 'shard2'
         services:
             database:
                 image: mysql:5.6
@@ -62,20 +71,20 @@ jobs:
               name: Parse Matrix Variables
               uses: actions/github-script@v6
               with:
-                script: |
-                    const parseWPVersion = require( './.github/workflows/scripts/parse-wp-version' );
-                    parseWPVersion( '${{ matrix.wp }}' ).then( ( version ) => {
-                      core.setOutput( 'wpVersion', version );
-                    } );
+                  script: |
+                      const parseWPVersion = require( './.github/workflows/scripts/parse-wp-version' );
+                      parseWPVersion( '${{ matrix.wp }}' ).then( ( version ) => {
+                        core.setOutput( 'wpVersion', version );
+                      } );
 
             - name: Prepare Testing Environment
               env:
-                WP_ENV_CORE: ${{ steps.parseMatrix.outputs.wpVersion }}
-                WP_ENV_PHP_VERSION: ${{ matrix.php }}
+                  WP_ENV_CORE: ${{ steps.parseMatrix.outputs.wpVersion }}
+                  WP_ENV_PHP_VERSION: ${{ matrix.php }}
               run: pnpm --filter=woocommerce env:test
 
             - name: Run Tests
               env:
-                WP_ENV_CORE: ${{ steps.parseMatrix.outputs.wpVersion }}
-                WP_ENV_PHP_VERSION: ${{ matrix.php }}
-              run: pnpm --filter=woocommerce test:unit:env
+                  WP_ENV_CORE: ${{ steps.parseMatrix.outputs.wpVersion }}
+                  WP_ENV_PHP_VERSION: ${{ matrix.php }}
+              run: pnpm --filter=woocommerce test:unit:env --testsuite ${{ matrix.unittests }}

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -28,14 +28,28 @@ jobs:
             matrix:
                 php: ['7.4', '8.0']
                 wp: ['latest']
+                unittests: ['shard1', 'shard2']
                 include:
                     - wp: nightly
                       php: '7.4'
+                      unittests: 'shard1'
+                    - wp: nightly
+                      php: '7.4'
+                      unittests: 'shard2'
                     - wp: '6.1'
                       php: 7.4
+                      unittests: 'shard1'
+                    - wp: '6.1'
+                      php: 7.4
+                      unittests: 'shard2'
                     - wp: 'latest'
                       php: '7.4'
                       hpos: true
+                      unittests: 'shard1'
+                    - wp: 'latest'
+                      php: '7.4'
+                      hpos: true
+                      unittests: 'shard2'
         services:
             database:
                 image: mysql:5.6
@@ -56,20 +70,20 @@ jobs:
               name: Parse Matrix Variables
               uses: actions/github-script@v6
               with:
-                script: |
-                    const parseWPVersion = require( './.github/workflows/scripts/parse-wp-version' );
-                    parseWPVersion( '${{ matrix.wp }}' ).then( ( version ) => {
-                      core.setOutput( 'wpVersion', version );
-                    } );
+                  script: |
+                      const parseWPVersion = require( './.github/workflows/scripts/parse-wp-version' );
+                      parseWPVersion( '${{ matrix.wp }}' ).then( ( version ) => {
+                        core.setOutput( 'wpVersion', version );
+                      } );
 
             - name: Prepare Testing Environment
               env:
-                WP_ENV_CORE: ${{ steps.parseMatrix.outputs.wpVersion }}
-                WP_ENV_PHP_VERSION: ${{ matrix.php }}
+                  WP_ENV_CORE: ${{ steps.parseMatrix.outputs.wpVersion }}
+                  WP_ENV_PHP_VERSION: ${{ matrix.php }}
               run: pnpm --filter=woocommerce env:test
 
             - name: Run Tests
               env:
-                WP_ENV_CORE: ${{ steps.parseMatrix.outputs.wpVersion }}
-                WP_ENV_PHP_VERSION: ${{ matrix.php }}
-              run: pnpm --filter=woocommerce test:unit:env
+                  WP_ENV_CORE: ${{ steps.parseMatrix.outputs.wpVersion }}
+                  WP_ENV_PHP_VERSION: ${{ matrix.php }}
+              run: pnpm --filter=woocommerce test:unit:env --testsuite ${{ matrix.unittests }}

--- a/plugins/woocommerce/changelog/dev-shard-unit-tests-take-two
+++ b/plugins/woocommerce/changelog/dev-shard-unit-tests-take-two
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Shard the unit tests into two test suites.

--- a/plugins/woocommerce/phpunit.xml
+++ b/plugins/woocommerce/phpunit.xml
@@ -9,9 +9,17 @@
 	verbose="true"
 	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
 	<testsuites>
-		<testsuite name="WooCommerce Test Suite">
+		<testsuite name="wc-unittests-all">
 			<directory suffix=".php">./tests/legacy/unit-tests</directory>
 			<directory suffix=".php">./tests/php</directory>
+		</testsuite>
+		<testsuite name="shard1">
+			<directory suffix=".php">./tests/legacy/unit-tests</directory>
+			<directory suffix=".php">./tests/php</directory>
+			<exclude>./tests/legacy/unit-tests/woocommerce-admin</exclude>
+		</testsuite>
+		<testsuite name="shard2">
+			<directory suffix=".php">./tests/legacy/unit-tests/woocommerce-admin</directory>
 		</testsuite>
 	</testsuites>
 	<coverage includeUncoveredFiles="true">

--- a/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/class-wc-tests-ces-tracks.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/woocommerce-admin/features/class-wc-tests-ces-tracks.php
@@ -7,10 +7,18 @@
 
 use Automattic\WooCommerce\Internal\Admin\CustomerEffortScoreTracks;
 
-// CustomerEffortScoreTracks only works in wp-admin, so let's fake it.
-class CurrentScreenMock {
-	public function in_admin() {
-	    return true;
+// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
+if ( ! class_exists( 'CurrentScreenMock' ) ) {
+	/**
+	 * Class CurrentScreenMock
+	 */
+	class CurrentScreenMock {
+		/**
+		 * CustomerEffortScoreTracks only works in wp-admin, so let's fake it.
+		 */
+		public function in_admin() {
+			return true;
+		}
 	}
 }
 
@@ -42,7 +50,7 @@ class WC_Admin_Tests_CES_Tracks extends WC_Unit_Test_Case {
 	}
 
 	public function tearDown(): void {
-	    parent::tearDown();
+		parent::tearDown();
 		if ( $this->current_screen_backup ) {
 			$GLOBALS['current_screen'] = $this->current_screen_backup;
 		}

--- a/plugins/woocommerce/tests/php/includes/class-wc-orders-tracking-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-orders-tracking-test.php
@@ -1,5 +1,20 @@
 <?php
 
+// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
+if ( ! class_exists( 'CurrentScreenMock' ) ) {
+	/**
+	 * Class CurrentScreenMock
+	 */
+	class CurrentScreenMock {
+		/**
+		 * CustomerEffortScoreTracks only works in wp-admin, so let's fake it.
+		 */
+		public function in_admin() {
+			return true;
+		}
+	}
+}
+
 /**
  * Class WC_Orders_Tracking_Test.
  */


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Divides our unit tests into two test suites that, after experimenting with different combinations, I've found to have similar runtimes that are also possible to define in a light-weight and relatively future-proof manner. Adds those two shards to the matrix of the CI and PR unit test workflows. 

Another attempt at the reverted #39302. 

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. ensure checks pass
2. ensure the unit test shards were executed as intended
3. ensure that [the manual CI run here](https://github.com/woocommerce/woocommerce/actions/runs/5623141637) passes
4. I'd especially be interested in whether there's a better way to handle the `include` parts of the matrix -- when not adding a shard explicitly, the `unittests` option is left empty, but copying as in [07db3db](https://github.com/woocommerce/woocommerce/pull/39302/commits/07db3db977512c7e9f2287dc44a8f5148328be49) feels sub-optimal. I found [this issue](https://github.com/orgs/community/discussions/7835) that seems to imply that that's probably the only option. 
