### PR TITLE
Update task list progress bar default setting

### DIFF
--- a/plugins/woocommerce-admin/client/task-lists/components/progress-header/default-progress-header.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/components/progress-header/default-progress-header.tsx
@@ -62,7 +62,7 @@ export const DefaultProgressHeader: React.FC< DefaultProgressHeaderProps > = ( {
 						<progress
 							className="woocommerce-task-progress-header__progress-bar"
 							max={ tasksCount }
-							value={ completedCount || 0.1 }
+							value={ completedCount || 0.25 }
 						/>
 					</>
 				) : null }

--- a/plugins/woocommerce-admin/client/task-lists/components/progress-header/default-progress-header.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/components/progress-header/default-progress-header.tsx
@@ -62,7 +62,7 @@ export const DefaultProgressHeader: React.FC< DefaultProgressHeaderProps > = ( {
 						<progress
 							className="woocommerce-task-progress-header__progress-bar"
 							max={ tasksCount }
-							value={ completedCount || 0 }
+							value={ completedCount || 0.1 }
 						/>
 					</>
 				) : null }

--- a/plugins/woocommerce/changelog/update-38752-task-list-progress-bar
+++ b/plugins/woocommerce/changelog/update-38752-task-list-progress-bar
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Update the default setting for the task list progress bar from 0 to 0.1, which gives the progress better visual context when no tasks have been completed.
+Update the default setting for the task list progress bar from 0 to 0.25, which gives the progress better visual context when no tasks have been completed.

--- a/plugins/woocommerce/changelog/update-38752-task-list-progress-bar
+++ b/plugins/woocommerce/changelog/update-38752-task-list-progress-bar
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Update the default setting for the task list progress bar from 0 to 0.1, which gives the progress better visual context when no tasks have been completed.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Update the default setting for the task list progress bar from 0 to 0.25, which gives the progress better visual context when no tasks have been completed.

Closes #38752.

**Before:**
<img width="718" alt="Screen Shot 2023-07-21 at 1 03 17 PM" src="https://github.com/woocommerce/woocommerce/assets/4297811/54776bf6-639e-4736-9e87-7afa9d438495">

**After:**
<img width="742" alt="Screen Shot 2023-08-29 at 2 58 32 PM" src="https://github.com/woocommerce/woocommerce/assets/4297811/d513cfdd-8710-47a1-a401-be880a6837ee">

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Testing Instructions**

1. Build this branch
2. On a fresh WooCommerce install, skip the onboarding wizard to land at the home screen.
3. The task list should have no tasks complete, and the progress bar should have a small amount filled (see "After" screenshot above)
4. Complete the first task ("Add products").
5. Verify that the filled amount increased after completing the first task, i.e., there was indeed progress in the progress bar.


<!-- End testing instructions -->

### Changelog entry

-   [ ] Update the default setting for the task list progress bar from 0 to 0.1, which gives the progress better visual context when no tasks have been completed.
