### PR TITLE
Support inserting NULL values for strict DB mode

### DIFF
--- a/plugins/woocommerce/changelog/fix-35612
+++ b/plugins/woocommerce/changelog/fix-35612
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Support inserting NULL values for strict DB mode for DataBase Util's insert_on_duplicate_key_update method.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1656,9 +1656,10 @@ FROM $order_meta_table
 		if ( 'create' === $context ) {
 			$post_id = wp_insert_post(
 				array(
-					'post_type'   => $data_sync->data_sync_is_enabled() ? $order->get_type() : $data_sync::PLACEHOLDER_ORDER_POST_TYPE,
-					'post_status' => 'draft',
-					'post_parent' => $order->get_changes()['parent_id'] ?? $order->get_data()['parent_id'] ?? 0,
+					'post_type'     => $data_sync->data_sync_is_enabled() ? $order->get_type() : $data_sync::PLACEHOLDER_ORDER_POST_TYPE,
+					'post_status'   => 'draft',
+					'post_parent'   => $order->get_changes()['parent_id'] ?? $order->get_data()['parent_id'] ?? 0,
+					'post_date_gmt' => current_time( 'mysql', 1 ), // We set the date to prevent invalid date errors when using MySQL strict mode.
 				)
 			);
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2288,6 +2288,10 @@ FROM $order_meta_table
 			$order->set_date_created( time() );
 		}
 
+		if ( ! $order->get_date_modified( 'edit' ) ) {
+			$order->set_date_modified( current_time( 'mysql' ) );
+		}
+
 		$this->update_order_meta( $order );
 
 		$this->persist_order_to_db( $order, $force_all_fields );
@@ -2371,7 +2375,7 @@ FROM $order_meta_table
 		$changes = $order->get_changes();
 
 		if ( ! isset( $changes['date_modified'] ) ) {
-			$order->set_date_modified( time() );
+			$order->set_date_modified( current_time( 'mysql' ) );
 		}
 
 		$this->persist_order_to_db( $order );

--- a/plugins/woocommerce/src/Internal/Utilities/DatabaseUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/DatabaseUtil.php
@@ -233,19 +233,35 @@ class DatabaseUtil {
 	 */
 	public function insert_on_duplicate_key_update( $table_name, $data, $format ) : int {
 		global $wpdb;
+		if ( empty( $data ) ) {
+			return 0;
+		}
 
-		$columns             = array_keys( $data );
+		$columns      = array_keys( $data );
+		$value_format = array();
+		$values       = array();
+		$index        = 0;
+		// Directly use NULL for placeholder if the value is NULL, since otherwise $wpdb->prepare will convert it to empty string.
+		foreach ( $data as $key => $value ) {
+			if ( is_null( $value ) ) {
+				$value_format[] = 'NULL';
+			} else {
+				$values[]       = $value;
+				$value_format[] = $format[ $index ];
+			}
+			$index++;
+		}
 		$column_clause       = '`' . implode( '`, `', $columns ) . '`';
-		$value_placeholders  = implode( ', ', array_values( $format ) );
+		$value_format_clause = implode( ', ', $value_format );
 		$on_duplicate_clause = $this->generate_on_duplicate_statement_clause( $columns );
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Values are escaped in $wpdb->prepare.
 		$sql = $wpdb->prepare(
 			"
 INSERT INTO $table_name ( $column_clause )
-VALUES ( $value_placeholders )
+VALUES ( $value_format_clause )
 $on_duplicate_clause
 ",
-			array_values( $data )
+			$values
 		);
 		// phpcs:enable
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql is prepared.

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -1997,6 +1997,25 @@ class OrdersTableDataStoreTests extends HposTestCase {
 	}
 
 	/**
+	 * @testDox Test that inserting with strict SQL mode is also supported.
+	 */
+	public function test_order_create_with_strict_mode_and_null_values() {
+		global $wpdb;
+		$sql_mode = $wpdb->get_var( 'SELECT @@sql_mode' );
+		// Set SQL mode to strict to disallow 0 dates.
+		$wpdb->query( "SET sql_mode = 'TRADITIONAL'" );
+
+		$order = new WC_Order();
+		$this->switch_data_store( $order, $this->sut );
+		$order->save();
+
+		$this->assertTrue( $order->get_id() > 0 );
+
+		// phpcs:ignore -- Hardcoded value.
+		$wpdb->query( "SET sql_mode = '$sql_mode' " );
+	}
+
+	/**
 	 * @testDox Test that multiple calls to read don't try to sync again.
 	 */
 	public function test_read_multiple_dont_sync_again_for_same_order() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This can be considered a follow-up to #38332, as we are making similar changes to support strict SQL mode which disallows zero dates in the insertion/updation of HPOS rows.

This PR has the following changes:

1. Directly add `NULL` in placeholder when we see that the value is NULL, similar to how we did this in #38332.
2. When inserting the placeholder post, we also provide a date argument for post_date_gmt since that can be passed as a zero date otherwise.
3. We also do not leave modified date as empty similar to how [WP_Post set the modified date to created date when it's null](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/post.php#L4264-L4270).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

It needs specific DB settings to reproduce, so we are going to do it in a wp shell:

1. Set HPOS as authoritative and sync to off.
2.  Open a wp shell by running `wp shell` and run the following commands:
```php
// First lets force the MySQL config to what we want.
global $wpdb;

$wpdb->query( "SET sql_mode = 'TRADITIONAL'" );

// Let's test that our config was set as expected, and 0 dates are not allowed.

use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;

$orders_table = Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore::get_orders_table_name();

// this should return an error.
$result = $wpdb->query( "INSERT INTO $orders_table (date_created_gmt) VALUES ('0000-00-00 00:00:00')" ); 

assert( ! $result ); 

// Now we will try to create an order
$order = new WC_Order();

// Let's saving this order, as it has null values for updated dates. There shouldn't be any error in saving
$order->save();

// should be a positive integer.
echo $order->get_id();

```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
