### PR TITLE
Include postcode in Vietnam address format

### DIFF
--- a/plugins/woocommerce/changelog/fix-39164
+++ b/plugins/woocommerce/changelog/fix-39164
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Adds display of postcodes to Vietnam addresses.

--- a/plugins/woocommerce/includes/class-wc-countries.php
+++ b/plugins/woocommerce/includes/class-wc-countries.php
@@ -592,7 +592,7 @@ class WC_Countries {
 					'TW'      => "{company}\n{last_name} {first_name}\n{address_1}\n{address_2}\n{state}, {city} {postcode}\n{country}",
 					'UG'      => "{name}\n{company}\n{address_1}\n{address_2}\n{city}\n{state}, {country}",
 					'US'      => "{name}\n{company}\n{address_1}\n{address_2}\n{city}, {state_code} {postcode}\n{country}",
-					'VN'      => "{name}\n{company}\n{address_1}\n{city}\n{country}",
+					'VN'      => "{name}\n{company}\n{address_1}\n{address_2}\n{city} {postcode}\n{country}",
 				)
 			);
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
It's been reported that postcodes are, in fact, used in Vietnam.
When we originally introduced the Vietnam address format, we omitted both state and postcodes ([link](https://github.com/woocommerce/woocommerce/commit/81de864a13ce7177346b40d19d40cc5e4028443e#diff-a987b6f91075b2ddaca33bb942e1b66cd58eba5a4359c958dfb2099da49bfaf1R579)).

This PR adds the postcode to the address format, following the [UPU's address format for Vietnam](https://www.upu.int/UPU/media/upu/PostalEntitiesFiles/addressingUnit/vnmEn.pdf), which indicates that the postcode should go next to the province/city.

Closes #39164.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add a product to the cart.
2. Complete checkout for said product using Vietnam as country and any details you want. Make sure to include a postcode and address line 2.
3. Go to the admin and to the specific order created in the previous step.
4. Confirm that:
   - On `trunk`, neither "Billing Address" nor "Shipping Address" (if the product was shippable) include postcode or address line 2 information.
     Trying to edit the address does show that the postcode and address line 2 was in fact stored.
   - On this branch, both "Billing Address" and "Shipping Address" should include the postcode and address line 2 in the details.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
