### PR TITLE
Change the logic flow for the order confirmation thankyou screen

### DIFF
--- a/plugins/woocommerce/changelog/try-order-thankyou-reorg
+++ b/plugins/woocommerce/changelog/try-order-thankyou-reorg
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Change the order confirmation screen to always show the 'Thank you for your order' message, even if the viewer must log in or confirm the order email to see the details of the order.

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -297,7 +297,7 @@ class WC_Shortcode_Checkout {
 			return;
 		}
 
-		$template_args     = array( 
+		$template_args     = array(
 			'needs_verification' => false,
 			'order'              => $order,
 		);

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -297,7 +297,10 @@ class WC_Shortcode_Checkout {
 			return;
 		}
 
-		$template_args     = array( 'order' => $order );
+		$template_args     = array( 
+			'needs_verification' => false,
+			'order'              => $order,
+		);
 		$order_customer_id = $order->get_customer_id();
 
 		if ( ! $order_customer_id && self::guest_should_verify_email( $order, 'order-received' ) ) {

--- a/plugins/woocommerce/templates/checkout/thankyou.php
+++ b/plugins/woocommerce/templates/checkout/thankyou.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 8.0.0
+ * @version 8.1.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/plugins/woocommerce/templates/checkout/thankyou.php
+++ b/plugins/woocommerce/templates/checkout/thankyou.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 3.7.0
+ * @version 8.0.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -41,43 +41,70 @@ defined( 'ABSPATH' ) || exit;
 
 			<p class="woocommerce-notice woocommerce-notice--success woocommerce-thankyou-order-received"><?php echo apply_filters( 'woocommerce_thankyou_order_received_text', esc_html__( 'Thank you. Your order has been received.', 'woocommerce' ), $order ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></p>
 
-			<ul class="woocommerce-order-overview woocommerce-thankyou-order-details order_details">
+			<?php if ( $needs_verification ) : ?>
 
-				<li class="woocommerce-order-overview__order order">
-					<?php esc_html_e( 'Order number:', 'woocommerce' ); ?>
-					<strong><?php echo $order->get_order_number(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></strong>
-				</li>
+				<?php if ( 'login' === $needs_verification ) : ?>
 
-				<li class="woocommerce-order-overview__date date">
-					<?php esc_html_e( 'Date:', 'woocommerce' ); ?>
-					<strong><?php echo wc_format_datetime( $order->get_date_created() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></strong>
-				</li>
+					<?php
+					wc_print_notice( esc_html__( 'Please log in to your account to view this order.', 'woocommerce' ), 'notice' );
+					woocommerce_login_form( array( 'redirect' => $order->get_checkout_order_received_url() ) );
+					?>
 
-				<?php if ( is_user_logged_in() && $order->get_user_id() === get_current_user_id() && $order->get_billing_email() ) : ?>
-					<li class="woocommerce-order-overview__email email">
-						<?php esc_html_e( 'Email:', 'woocommerce' ); ?>
-						<strong><?php echo $order->get_billing_email(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></strong>
-					</li>
+				<?php elseif ( 'email' === $needs_verification ) : ?>
+
+					<?php
+					wc_get_template(
+						'checkout/form-verify-email.php',
+						array(
+							'failed_submission' => ! empty( $_POST['email'] ), // phpcs:ignore WordPress.Security.NonceVerification.Missing
+							'verify_url'        => $order->get_checkout_order_received_url(),
+						)
+					);
+					?>
+
 				<?php endif; ?>
 
-				<li class="woocommerce-order-overview__total total">
-					<?php esc_html_e( 'Total:', 'woocommerce' ); ?>
-					<strong><?php echo $order->get_formatted_order_total(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></strong>
-				</li>
+			<?php else : ?>
 
-				<?php if ( $order->get_payment_method_title() ) : ?>
-					<li class="woocommerce-order-overview__payment-method method">
-						<?php esc_html_e( 'Payment method:', 'woocommerce' ); ?>
-						<strong><?php echo wp_kses_post( $order->get_payment_method_title() ); ?></strong>
+				<ul class="woocommerce-order-overview woocommerce-thankyou-order-details order_details">
+
+					<li class="woocommerce-order-overview__order order">
+						<?php esc_html_e( 'Order number:', 'woocommerce' ); ?>
+						<strong><?php echo $order->get_order_number(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></strong>
 					</li>
-				<?php endif; ?>
 
-			</ul>
+					<li class="woocommerce-order-overview__date date">
+						<?php esc_html_e( 'Date:', 'woocommerce' ); ?>
+						<strong><?php echo wc_format_datetime( $order->get_date_created() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></strong>
+					</li>
+
+					<?php if ( is_user_logged_in() && $order->get_user_id() === get_current_user_id() && $order->get_billing_email() ) : ?>
+						<li class="woocommerce-order-overview__email email">
+							<?php esc_html_e( 'Email:', 'woocommerce' ); ?>
+							<strong><?php echo $order->get_billing_email(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></strong>
+						</li>
+					<?php endif; ?>
+
+					<li class="woocommerce-order-overview__total total">
+						<?php esc_html_e( 'Total:', 'woocommerce' ); ?>
+						<strong><?php echo $order->get_formatted_order_total(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></strong>
+					</li>
+
+					<?php if ( $order->get_payment_method_title() ) : ?>
+						<li class="woocommerce-order-overview__payment-method method">
+							<?php esc_html_e( 'Payment method:', 'woocommerce' ); ?>
+							<strong><?php echo wp_kses_post( $order->get_payment_method_title() ); ?></strong>
+						</li>
+					<?php endif; ?>
+
+				</ul>
+
+				<?php do_action( 'woocommerce_thankyou_' . $order->get_payment_method(), $order->get_id() ); ?>
+				<?php do_action( 'woocommerce_thankyou', $order->get_id() ); ?>
+
+			<?php endif; ?>
 
 		<?php endif; ?>
-
-		<?php do_action( 'woocommerce_thankyou_' . $order->get_payment_method(), $order->get_id() ); ?>
-		<?php do_action( 'woocommerce_thankyou', $order->get_id() ); ?>
 
 	<?php else : ?>
 

--- a/plugins/woocommerce/templates/checkout/thankyou.php
+++ b/plugins/woocommerce/templates/checkout/thankyou.php
@@ -99,8 +99,26 @@ defined( 'ABSPATH' ) || exit;
 
 				</ul>
 
-				<?php do_action( 'woocommerce_thankyou_' . $order->get_payment_method(), $order->get_id() ); ?>
-				<?php do_action( 'woocommerce_thankyou', $order->get_id() ); ?>
+				<?php
+				/**
+				 * Action fires at the bottom of the Order Confirmation screen for a specific payment method.
+				 *
+				 * @since 8.1.0
+				 *
+				 * @param int The ID of the order.
+				 */
+				do_action( 'woocommerce_thankyou_' . $order->get_payment_method(), $order->get_id() );
+				?>
+				<?php
+				/**
+				 * Action fires at the bottom of the Order Confirmation screen.
+				 *
+				 * @since 8.1.0
+				 *
+				 * @param int The ID of the order.
+				 */
+				do_action( 'woocommerce_thankyou', $order->get_id() );
+				?>
 
 			<?php endif; ?>
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

On the heels of #38983 and #39191, this changes the flow a bit so that the "thank you" message will always be shown when loading the "order received" URL. However, the verification requirement still prevents the details of the order being shown unless the customer is verified, either by confirming the email or by logging in. If unverified, the login/email form is shown on the thank you screen instead of the details of the order.

This attempts to solve cases where a newly created order has a customer record attached to it (i.e. is not a guest checkout) but the customer is not actually logged in. Currently this can cause the customer to see a login screen right after completing checkout, rather than an acknowledgment that the order has been received. This ensures that the customer gets that acknowledgment. Further, it allows developers to modify this part of their custom checkout flows, if necessary, by customizing the thankyou template file.

See [this conversation](https://github.com/woocommerce/woocommerce/pull/38983#issuecomment-1633890821) for more details on the issues this is attempting to resolve.

### To do

- [ ] If this seems like a worthwhile change to pursue, the e2e tests will probably need to be updated.

### How to test the changes in this Pull Request:

The instructions in #39191 apply to this PR as well. The only change should be that the "Thank you. Your order has been received." message should be shown even when viewed as an unverified customer.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Change the order confirmation screen to always show the 'Thank you for your order' message, even if the viewer must log in or confirm the order email to see the details of the order.

#### Comment

</details>
