### PR TITLE
Replace 'end' CSS props with 'flex-end' when using 'display: flex'

### DIFF
--- a/plugins/woocommerce-admin/client/products/fields/variations/variations.scss
+++ b/plugins/woocommerce-admin/client/products/fields/variations/variations.scss
@@ -47,7 +47,7 @@
 	&__actions {
 		display: flex;
 		align-items: center;
-		justify-content: end;
+		justify-content: flex-end;
 
 		.components-button {
 			position: relative;

--- a/plugins/woocommerce-admin/client/products/product-variation-form.scss
+++ b/plugins/woocommerce-admin/client/products/product-variation-form.scss
@@ -1,6 +1,6 @@
 .product-variation-form__navigation {
 	display: flex;
-	align-items: end;
+	align-items: flex-end;
 	justify-content: center;
 	width: 100%;
 	position: fixed;

--- a/plugins/woocommerce/changelog/update-fix-invalid-css-properties
+++ b/plugins/woocommerce/changelog/update-fix-invalid-css-properties
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Update CSS prop 'end' to 'flex-end' when using flexbox.


### PR DESCRIPTION
This particular issue came to my attention when we noticed an [issue with NUX on an older version of Safari](https://github.com/Automattic/woocommerce.com/issues/16572) where the "Skip" link wasn't aligned to the right as expected. The CSS was valid on newer browsers, but that older version of Safari did not support or 'end' as a property for `justify-content`. Soon after I noticed that there were a bunch of CSS related warnings showing up in the build process:

> autoprefixer: end value has mixed support, consider using flex-end instead

This PR fixes two of these build warnings. This change was actually difficult to test, as the CSS in this PR is present in the new product editor, and I was unable to get the variations functionality to work locally. In my experience, there should be no issues with this change as `end` is an alias for `flex-end` in newer browsers.

tl;dr - It's better to use `flex-end` vs `end` when using flexbox, as it has better browser support.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

- Updates two instances of the CSS prop `end` used in a flexbox context, and updates them to `flex-end` which has wider browser support. 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Navigate to WooCommerce > Settings > Advanced > Features.
2. Check “Try new product editor (Beta)” and save changes.
3. Go to Products > Add new and view the new interface.
4. Add product variations and check that the interface does not have misaligned items.

<!-- End testing instructions -->
