### PR TITLE
WooCommerce Docs: Update manifest hash on content update

### DIFF
--- a/plugins/woocommerce-docs/scripts/manifest.json
+++ b/plugins/woocommerce-docs/scripts/manifest.json
@@ -6,8 +6,9 @@
         {
           "post_title": "Local Development",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/plugins/woocommerce-docs/example-docs/get-started/local-development.md",
+          "hash": "7fa2ec20fa654573e07b0d6237a0618ab19999467472a2362fa4ec1955b229f7",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/plugins/woocommerce-docs/example-docs/get-started/local-development.md",
-          "id": "c387a046f8307a4f459091a2c45e82263b45e777"
+          "id": "1a3672ea88756c6d00a3b3baa3f7481b361c8a1e"
         }
       ],
       "categories": [
@@ -17,8 +18,9 @@
             {
               "post_title": "Install the Plugin",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/plugins/woocommerce-docs/example-docs/get-started/installation/install-plugin.md",
+              "hash": "89be25e4e91f5c807c7dc9ff778b2b76c6f7061cb9aca6e0cfc7fddb0cc28b6b",
               "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/plugins/woocommerce-docs/example-docs/get-started/installation/install-plugin.md",
-              "id": "c4ac8c48c3445186189d15f01028eacd517b9707"
+              "id": "6c7bb21cb195798a444844fef0ff79aacff86de1"
             }
           ],
           "categories": []
@@ -29,8 +31,9 @@
             {
               "post_title": "What Went Wrong?",
               "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/plugins/woocommerce-docs/example-docs/get-started/troubleshooting/what-went-wrong.md",
+              "hash": "9868a39ccc26aa79f06caed1dc3576878953e6279facf7a66ad6f45fd2cd7d0a",
               "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/plugins/woocommerce-docs/example-docs/get-started/troubleshooting/what-went-wrong.md",
-              "id": "f87dcc9b8177ad2d8549ef7298d66fb7c8616d71"
+              "id": "e2f590a5994fada97bdbdcac751e8bc441530868"
             }
           ],
           "categories": []
@@ -43,18 +46,20 @@
         {
           "post_title": "Unit Testing",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/plugins/woocommerce-docs/example-docs/testing/unit-tests.md",
+          "hash": "f4950c5597f1ef70f546fd3c4b92fd3c23518317aca2d72edb5a7da519c9946f",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/plugins/woocommerce-docs/example-docs/testing/unit-tests.md",
-          "id": "1b9de005cc5da3b49d12c24837a5a574aa58ad96"
+          "id": "6f1b9c74de42a10cf4c77c2843e0fbdf1ff46316"
         },
         {
           "post_title": "Integration Testing",
           "edit_url": "https://github.com/woocommerce/woocommerce/edit/trunk/plugins/woocommerce-docs/example-docs/testing/integration-tests.md",
+          "hash": "6929e58b2a32d027f1049eea2ff6136f47b8fb52d4d1781f257de59b999155b0",
           "url": "https://raw.githubusercontent.com/woocommerce/woocommerce/trunk/plugins/woocommerce-docs/example-docs/testing/integration-tests.md",
-          "id": "ee3fd61c9d7b13614e4431708c336f20c9779e1f"
+          "id": "09c092c2b450edc45b9c247e0a983b7d176984a1"
         }
       ],
       "categories": []
     }
   ],
-  "hash": "84a06ceffaced22a955a131c1272ec9a1d14ae0a7cf9bac4ed21874384f86e9a"
+  "hash": "80feb7e964daa576ce2c4265dc0e0e5d05a0df4fce356cdf63e245e22435e9ba"
 }

--- a/tools/monorepo-utils/src/md-docs/lib/__tests__/generate-manifest.ts
+++ b/tools/monorepo-utils/src/md-docs/lib/__tests__/generate-manifest.ts
@@ -11,7 +11,6 @@ import {
 	generateManifestFromDirectory,
 	generatePostId,
 } from '../generate-manifest';
-import exp from 'constants';
 
 describe( 'generateManifest', () => {
 	const dir = path.join( __dirname, './fixtures/example-docs' );

--- a/tools/monorepo-utils/src/md-docs/lib/__tests__/generate-manifest.ts
+++ b/tools/monorepo-utils/src/md-docs/lib/__tests__/generate-manifest.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import path from 'path';
+import fs from 'fs';
 
 /**
  * Internal dependencies
@@ -10,6 +11,7 @@ import {
 	generateManifestFromDirectory,
 	generatePostId,
 } from '../generate-manifest';
+import exp from 'constants';
 
 describe( 'generateManifest', () => {
 	const dir = path.join( __dirname, './fixtures/example-docs' );
@@ -136,6 +138,104 @@ describe( 'generateManifest', () => {
 		expect( manifest.categories[ 0 ].posts[ 0 ].edit_url ).toEqual(
 			'https://github.com/edit/example-docs/get-started/local-development.md'
 		);
+	} );
+
+	it( 'should create a hash for each post in a manifest', async () => {
+		const manifest = await generateManifestFromDirectory(
+			rootDir,
+			dir,
+			'example-docs',
+			'https://example.com',
+			'https://example.com/edit'
+		);
+
+		const topLevelCategories = manifest.categories;
+
+		const posts = [
+			...topLevelCategories[ 0 ].posts,
+			...topLevelCategories[ 0 ].categories[ 0 ].posts,
+			...topLevelCategories[ 0 ].categories[ 1 ].posts,
+			...topLevelCategories[ 1 ].posts,
+		];
+
+		posts.forEach( ( post ) => {
+			expect( post.hash ).not.toBeUndefined();
+		} );
+	} );
+
+	it( 'should update a post hash and manifest hash when content is updated', async () => {
+		const manifest = await generateManifestFromDirectory(
+			rootDir,
+			dir,
+			'example-docs',
+			'https://example.com',
+			'https://example.com/edit'
+		);
+		const post = manifest.categories[ 0 ].posts[ 0 ];
+		const originalPostHash = post.hash;
+		const originalManifestHash = manifest.hash;
+
+		// Confirm hashes are not undefined
+		expect( originalPostHash ).not.toBeUndefined();
+		expect( originalManifestHash ).not.toBeUndefined();
+
+		// Update the file content of the corresponding post
+		const filePath = path.join( dir, 'get-started/local-development.md' );
+		const fileContent = fs.readFileSync( filePath, 'utf-8' );
+		const updatedFileContent = fileContent + '\n\n<!-- updated -->';
+		fs.writeFileSync( filePath, updatedFileContent );
+
+		// Generate a new manifest
+		const nextManifest = await generateManifestFromDirectory(
+			rootDir,
+			dir,
+			'example-docs',
+			'https://example.com',
+			'https://example.com/edit'
+		);
+		const nextPost = nextManifest.categories[ 0 ].posts[ 0 ];
+		const NextPostHash = nextPost.hash;
+		const NextManifestHash = nextManifest.hash;
+
+		// Confirm hashes are newly created.
+		expect( NextPostHash ).not.toEqual( originalPostHash );
+		expect( NextManifestHash ).not.toEqual( originalManifestHash );
+
+		// Reset the file content
+		fs.writeFileSync( filePath, fileContent );
+	} );
+
+	it( 'should not update a post hash and manifest hash when content is unchanged', async () => {
+		const manifest = await generateManifestFromDirectory(
+			rootDir,
+			dir,
+			'example-docs',
+			'https://example.com',
+			'https://example.com/edit'
+		);
+		const post = manifest.categories[ 0 ].posts[ 0 ];
+		const originalPostHash = post.hash;
+		const originalManifestHash = manifest.hash;
+
+		// Confirm hashes are not undefined
+		expect( originalPostHash ).not.toBeUndefined();
+		expect( originalManifestHash ).not.toBeUndefined();
+
+		// Generate a new manifest
+		const nextManifest = await generateManifestFromDirectory(
+			rootDir,
+			dir,
+			'example-docs',
+			'https://example.com',
+			'https://example.com/edit'
+		);
+		const nextPost = nextManifest.categories[ 0 ].posts[ 0 ];
+		const NextPostHash = nextPost.hash;
+		const NextManifestHash = nextManifest.hash;
+
+		// Confirm hashes are newly created.
+		expect( NextPostHash ).toEqual( originalPostHash );
+		expect( NextManifestHash ).toEqual( originalManifestHash );
 	} );
 } );
 

--- a/tools/monorepo-utils/src/md-docs/lib/__tests__/generate-manifest.ts
+++ b/tools/monorepo-utils/src/md-docs/lib/__tests__/generate-manifest.ts
@@ -194,12 +194,12 @@ describe( 'generateManifest', () => {
 			'https://example.com/edit'
 		);
 		const nextPost = nextManifest.categories[ 0 ].posts[ 0 ];
-		const NextPostHash = nextPost.hash;
-		const NextManifestHash = nextManifest.hash;
+		const nextPostHash = nextPost.hash;
+		const nextManifestHash = nextManifest.hash;
 
 		// Confirm hashes are newly created.
-		expect( NextPostHash ).not.toEqual( originalPostHash );
-		expect( NextManifestHash ).not.toEqual( originalManifestHash );
+		expect( nextPostHash ).not.toEqual( originalPostHash );
+		expect( nextManifestHash ).not.toEqual( originalManifestHash );
 
 		// Reset the file content
 		fs.writeFileSync( filePath, fileContent );
@@ -230,12 +230,12 @@ describe( 'generateManifest', () => {
 			'https://example.com/edit'
 		);
 		const nextPost = nextManifest.categories[ 0 ].posts[ 0 ];
-		const NextPostHash = nextPost.hash;
-		const NextManifestHash = nextManifest.hash;
+		const nextPostHash = nextPost.hash;
+		const nextManifestHash = nextManifest.hash;
 
 		// Confirm hashes are newly created.
-		expect( NextPostHash ).toEqual( originalPostHash );
-		expect( NextManifestHash ).toEqual( originalManifestHash );
+		expect( nextPostHash ).toEqual( originalPostHash );
+		expect( nextManifestHash ).toEqual( originalManifestHash );
 	} );
 } );
 

--- a/tools/monorepo-utils/src/md-docs/lib/generate-manifest.ts
+++ b/tools/monorepo-utils/src/md-docs/lib/generate-manifest.ts
@@ -77,6 +77,12 @@ async function processDirectory(
 
 			const post: Post = { ...fileFrontmatter };
 
+			// Generate hash of the post contents.
+			post.hash = crypto
+				.createHash( 'sha256' )
+				.update( JSON.stringify( fileContent ) )
+				.digest( 'hex' );
+
 			// get the folder name of rootDirectory.
 			const relativePath = path.relative( fullPathToDocs, filePath );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

A new manifest hash needs to be created when content changes. A new hash tells the ingestion portion of WooCommerce Docs to update or create posts. This PR adds a new has for posts based on content. When the content changes, a new hash is created, which causes the manifest hash to update as well.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Pull down this branch locally.
2. Create a new manifest.
```
pnpm utils md-docs create ./plugins/woocommerce-docs/example-docs woodocs --outputFilePath ./plugins/woocommerce-docs/scripts/manifest.json
```
3. See that no changes have been made to the manifest.
4. Edit any of the markdown files in `/plugins/woocommerce-docs/example-docs`.
5. Recreate the manifest
```
pnpm utils md-docs create ./plugins/woocommerce-docs/example-docs woodocs --outputFilePath ./plugins/woocommerce-docs/scripts/manifest.json
```
6. Confirm the hash from the corresponding post you've edited is different and the root hash of the manifest is also different.
7. Run JS unit tests.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
