### PR TITLE
Use direct post calls for meta CRUD for performance.

### DIFF
--- a/plugins/woocommerce/changelog/enhance-faster_backfill
+++ b/plugins/woocommerce/changelog/enhance-faster_backfill
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Use direct meta calls for backfilling instead of expensive object update.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Instead of making expensive backfill calls, we now use direct post-meta updates when we only need to update metadata. Previously, we would do a backfill of the entire object, which could become costly when there is a large amount of metadata to store.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

This flow is well covered by unit tests, so unit tests passing is enough. However to test (note that this is not fixing a bug, so testing against previous version of WooCommerce will not show any difference):

1.  With HPOS authoritative and sync enabled, open a `wp shell` and run the following commands:
```php
// Create a new order where we will add new meta.
$order = wc_create_order();

// Add a test meta to order.
$order->add_meta( 'test_key', 'test_value');
$order->save();

// Let's check that order meta is backfilled.
get_post_meta( $order->get_id(), 'test_key', true ); // should be 'test_value'
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
