### PR TITLE
Prevent read on sync while inside a backfill.

### DIFF
--- a/plugins/woocommerce/changelog/enhance-faster_backfill
+++ b/plugins/woocommerce/changelog/enhance-faster_backfill
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Use direct meta calls for backfilling instead of expensive object update.

--- a/plugins/woocommerce/changelog/fix-reduce_read_on_sync
+++ b/plugins/woocommerce/changelog/fix-reduce_read_on_sync
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Disable read on sync while backfilling.

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -715,6 +715,10 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 
 		foreach ( $order->get_meta_data() as $meta_data ) {
 			if ( isset( $existing_meta_data[ $meta_data->key ] ) ) {
+				// We don't know if the meta is single or array, so we assume it to be array.
+				if ( ! is_array( $meta_data->value ) ) {
+					$meta_data->value = array( $meta_data->value );
+				}
 				if ( $existing_meta_data[ $meta_data->key ] === $meta_data->value ) {
 					unset( $existing_meta_data[ $meta_data->key ] );
 					continue;

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -716,10 +716,8 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 		foreach ( $order->get_meta_data() as $meta_data ) {
 			if ( isset( $existing_meta_data[ $meta_data->key ] ) ) {
 				// We don't know if the meta is single or array, so we assume it to be array.
-				if ( ! is_array( $meta_data->value ) ) {
-					$meta_data->value = array( $meta_data->value );
-				}
-				if ( $existing_meta_data[ $meta_data->key ] === $meta_data->value ) {
+				$meta_value = is_array( $meta_data->value ) ? $meta_data->value : array( $meta_data->value );
+				if ( $existing_meta_data[ $meta_data->key ] === $meta_value ) {
 					unset( $existing_meta_data[ $meta_data->key ] );
 					continue;
 				}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -23,7 +23,7 @@ defined( 'ABSPATH' ) || exit;
 class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements \WC_Object_Data_Store_Interface, \WC_Order_Data_Store_Interface {
 
 	/**
-	 * Order IDs for which we are checking sync on read in the current request. In WooCommerce, using wc_get_order is a very common pattern, to avoid performance issues, we only sync on read once per request per order. This works because we consider out of sync orders to anomaly, so we don't recommend running HPOS with incompatible plugins.
+	 * Order IDs for which we are checking sync on read in the current request. In WooCommerce, using wc_get_order is a very common pattern, to avoid performance issues, we only sync on read once per request per order. This works because we consider out of sync orders to be an anomaly, so we don't recommend running HPOS with incompatible plugins.
 	 *
 	 * @var array.
 	 */

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2399,6 +2399,16 @@ FROM $order_meta_table
 	}
 
 	/**
+	 * Helper method to check whether to backfill post record.
+	 *
+	 * @return bool
+	 */
+	private function should_backfill_post_record() {
+		$data_sync = wc_get_container()->get( DataSynchronizer::class );
+		return $data_sync->data_sync_is_enabled();
+	}
+
+	/**
 	 * Helper function to decide whether to backfill post record.
 	 *
 	 * @param \WC_Abstract_Order $order Order object.
@@ -2406,8 +2416,7 @@ FROM $order_meta_table
 	 * @return void
 	 */
 	private function maybe_backfill_post_record( $order ) {
-		$data_sync = wc_get_container()->get( DataSynchronizer::class );
-		if ( $data_sync->data_sync_is_enabled() ) {
+		if ( $this->should_backfill_post_record() ) {
 			$this->backfill_post_record( $order );
 		}
 	}
@@ -2704,8 +2713,8 @@ CREATE TABLE $meta_table (
 	public function delete_meta( &$object, $meta ) {
 		$delete_meta = $this->data_store_meta->delete_meta( $object, $meta );
 
-		if ( $object instanceof WC_Abstract_Order ) {
-			$this->maybe_backfill_post_record( $object );
+		if ( $object instanceof WC_Abstract_Order && $this->should_backfill_post_record() ) {
+			delete_post_meta( $object->get_id(), $meta->key, $meta->value );
 		}
 
 		return $delete_meta;
@@ -2722,8 +2731,8 @@ CREATE TABLE $meta_table (
 	public function add_meta( &$object, $meta ) {
 		$add_meta = $this->data_store_meta->add_meta( $object, $meta );
 
-		if ( $object instanceof WC_Abstract_Order ) {
-			$this->maybe_backfill_post_record( $object );
+		if ( $object instanceof WC_Abstract_Order && $this->should_backfill_post_record() ) {
+			add_post_meta( $object->get_id(), $meta->key, $meta->value, true );
 		}
 
 		return $add_meta;
@@ -2740,8 +2749,8 @@ CREATE TABLE $meta_table (
 	public function update_meta( &$object, $meta ) {
 		$update_meta = $this->data_store_meta->update_meta( $object, $meta );
 
-		if ( $object instanceof WC_Abstract_Order ) {
-			$this->maybe_backfill_post_record( $object );
+		if ( $object instanceof WC_Abstract_Order && $this->should_backfill_post_record() ) {
+			update_post_meta( $object->get_id(), $meta->key, $meta->value );
 		}
 
 		return $update_meta;

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2396,7 +2396,10 @@ FROM $order_meta_table
 		$order->save_meta_data();
 
 		if ( $backfill ) {
+			self::$backfilling_order_ids[] = $order->get_id();
+			$order = wc_get_order( $order->get_id() ); // Refresh order to account for DB changes from post hooks.
 			$this->maybe_backfill_post_record( $order );
+			self::$backfilling_order_ids = array_diff( self::$backfilling_order_ids, array( $order->get_id() ) );
 		}
 
 		return $changes;

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2309,14 +2309,14 @@ FROM $order_meta_table
 		$order->save_meta_data();
 		$order->apply_changes();
 
+		$this->clear_caches( $order );
+
 		if ( $backfill ) {
 			self::$backfilling_order_ids[] = $order->get_id();
-			$order                         = wc_get_order( $order->get_id() ); // Refresh order to account for DB changes from post hooks.
-			$this->maybe_backfill_post_record( $order );
+			$r_order                       = wc_get_order( $order->get_id() ); // Refresh order to account for DB changes from post hooks.
+			$this->maybe_backfill_post_record( $r_order );
 			self::$backfilling_order_ids = array_diff( self::$backfilling_order_ids, array( $order->get_id() ) );
 		}
-
-		$this->clear_caches( $order );
 	}
 
 	/**
@@ -2397,8 +2397,8 @@ FROM $order_meta_table
 
 		if ( $backfill ) {
 			self::$backfilling_order_ids[] = $order->get_id();
-			$order = wc_get_order( $order->get_id() ); // Refresh order to account for DB changes from post hooks.
-			$this->maybe_backfill_post_record( $order );
+			$r_order                       = wc_get_order( $order->get_id() ); // Refresh order to account for DB changes from post hooks.
+			$this->maybe_backfill_post_record( $r_order );
 			self::$backfilling_order_ids = array_diff( self::$backfilling_order_ids, array( $order->get_id() ) );
 		}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -582,7 +582,7 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 				);
 			}
 		}
-		unset( self::$reading_order_ids[ $order->get_id() ] );
+		self::$reading_order_ids = array_diff( self::$reading_order_ids, array( $order->get_id() ) );
 	}
 
 	/**
@@ -1066,7 +1066,6 @@ WHERE
 			if ( $data_sync_enabled && $this->should_sync_order( $order ) && isset( $post_orders[ $order_id ] ) ) {
 				self::$reading_order_ids[] = $order_id;
 				$this->maybe_sync_order( $order, $post_orders[ $order->get_id() ] );
-				unset( self::$reading_order_ids[ $order_id ] );
 			}
 		}
 	}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2310,8 +2310,10 @@ FROM $order_meta_table
 		$order->apply_changes();
 
 		if ( $backfill ) {
+			self::$reading_order_ids[] = $order->get_id();
 			$this->maybe_backfill_post_record( $order );
 		}
+
 		$this->clear_caches( $order );
 	}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2309,14 +2309,13 @@ FROM $order_meta_table
 		$order->save_meta_data();
 		$order->apply_changes();
 
-		$this->clear_caches( $order );
-
 		if ( $backfill ) {
 			self::$backfilling_order_ids[] = $order->get_id();
 			$r_order                       = wc_get_order( $order->get_id() ); // Refresh order to account for DB changes from post hooks.
 			$this->maybe_backfill_post_record( $r_order );
 			self::$backfilling_order_ids = array_diff( self::$backfilling_order_ids, array( $order->get_id() ) );
 		}
+		$this->clear_caches( $order );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -564,7 +564,7 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 	 * @param \WC_Abstract_Order $order Order object to backfill.
 	 */
 	public function backfill_post_record( $order ) {
-		$cpt_data_store                = $this->get_post_data_store_for_backfill();
+		$cpt_data_store = $this->get_post_data_store_for_backfill();
 		if ( is_null( $cpt_data_store ) || ! method_exists( $cpt_data_store, 'update_order_from_object' ) ) {
 			return;
 		}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -23,11 +23,18 @@ defined( 'ABSPATH' ) || exit;
 class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements \WC_Object_Data_Store_Interface, \WC_Order_Data_Store_Interface {
 
 	/**
-	 * Order IDs for which we are checking read on sync in the current request.
+	 * Order IDs for which we are checking sync on read in the current request. In WooCommerce, using wc_get_order is a very common pattern, to avoid performance issues, we only sync on read once per request per order. This works because we consider out of sync orders to anomaly, so we don't recommend running HPOS with incompatible plugins.
 	 *
 	 * @var array.
 	 */
 	private static $reading_order_ids = array();
+
+	/**
+	 * Keep track of order IDs that are actively being backfilled. We use this to prevent further read on sync from add_|update_|delete_postmeta etc hooks. If we allow this, then we would end up syncing the same order multiple times as it is being backfilled.
+	 *
+	 * @var array
+	 */
+	private static $backfilling_order_ids = array();
 
 	/**
 	 * Data stored in meta keys, but not considered "meta" for an order.
@@ -558,8 +565,8 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 	 */
 	public function backfill_post_record( $order ) {
 		// Prevent read on sync till backfill is complete to avoid read on sync being triggered by add_|update_|delete_postmeta etc hooks.
-		self::$reading_order_ids[] = $order->get_id();
-		$cpt_data_store = $this->get_post_data_store_for_backfill();
+		self::$backfilling_order_ids[] = $order->get_id();
+		$cpt_data_store                = $this->get_post_data_store_for_backfill();
 		if ( is_null( $cpt_data_store ) || ! method_exists( $cpt_data_store, 'update_order_from_object' ) ) {
 			return;
 		}
@@ -582,7 +589,7 @@ class OrdersTableDataStore extends \Abstract_WC_Order_Data_Store_CPT implements 
 				);
 			}
 		}
-		self::$reading_order_ids = array_diff( self::$reading_order_ids, array( $order->get_id() ) );
+		self::$backfilling_order_ids = array_diff( self::$backfilling_order_ids, array( $order->get_id() ) );
 	}
 
 	/**
@@ -1054,7 +1061,7 @@ WHERE
 		}
 
 		$data_sync_enabled = $data_synchronizer->data_sync_is_enabled();
-		$load_posts_for    = array_diff( $order_ids, self::$reading_order_ids );
+		$load_posts_for    = array_diff( $order_ids, array_merge( self::$reading_order_ids, self::$backfilling_order_ids ) );
 		$post_orders       = $data_sync_enabled ? $this->get_post_orders_for_ids( array_intersect_key( $orders, array_flip( $load_posts_for ) ) ) : array();
 
 		foreach ( $data as $order_data ) {

--- a/plugins/woocommerce/src/Utilities/ArrayUtil.php
+++ b/plugins/woocommerce/src/Utilities/ArrayUtil.php
@@ -253,6 +253,7 @@ class ArrayUtil {
 						return true;
 					}
 					$diff[ $key ] = $value;
+					continue;
 				}
 				$new_diff = self::deep_assoc_array_diff( $value, $array2[ $key ], $strict );
 				if ( ! empty( $new_diff ) ) {

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -2547,7 +2547,6 @@ class OrdersTableDataStoreTests extends HposTestCase {
 		$this->assertEquals( 'test_value', $r_order->get_meta( 'test_key', true ) );
 		$this->assertEquals( 'test_value_2', $r_order->get_meta( 'test_key_2', true ) );
 		$this->assertEquals( 'test_value_3', $r_order->get_meta( 'test_key_3', true ) );
-		$this->assertEquals( 2, $order->get_customer_id() );
 		remove_filter( 'added_post_meta', array( $this, 'add_meta_when_meta_added' ) );
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -1276,6 +1276,7 @@ class OrdersTableDataStoreTests extends HposTestCase {
 	 * @testDox Test that we are able to correctly detect when order and post are out of sync.
 	 */
 	public function test_is_post_different_from_order() {
+		$this->toggle_cot_feature_and_usage( true );
 		$this->enable_cot_sync();
 		$order                         = $this->create_complex_cot_order();
 		$post_order_comparison_closure = function ( $order ) {
@@ -2564,6 +2565,28 @@ class OrdersTableDataStoreTests extends HposTestCase {
 			$order->save_meta_data();
 			$order->add_meta_data( 'test_key_3', 'test_value_3' );
 			$order->save();
+			echo 'ehere';
 		}
+	}
+
+	/**
+	 * @testDox When creating a new order, test that we are not backfilling stale data when there is a postmeta hooks that modifies data on the order.
+	 */
+	public function test_backfill_does_not_trigger_when_creating_orders_with_filter() {
+		$this->toggle_cot_feature_and_usage( true );
+		$this->enable_cot_sync();
+
+		add_filter( 'added_post_meta', array( $this, 'add_meta_when_meta_added' ), 10, 4 );
+		$order = new WC_Order();
+		$order->set_customer_id( 1 );
+		$order->add_meta_data( 'test_key', 'test_value' );
+		$order->save();
+
+		$r_order = wc_get_order( $order->get_id() );
+		$this->assertEquals( 'test_value', $r_order->get_meta( 'test_key', true ) );
+		$this->assertEquals( 'test_value_2', $r_order->get_meta( 'test_key_2', true ) );
+		$this->assertEquals( 'test_value_3', $r_order->get_meta( 'test_key_3', true ) );
+		$this->assertEquals( 1, $r_order->get_customer_id() );
+		remove_filter( 'added_post_meta', array( $this, 'add_meta_when_meta_added' ) );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -502,6 +502,7 @@ class OrdersTableDataStoreTests extends HposTestCase {
 		global $wpdb;
 
 		$this->enable_cot_sync();
+		$this->toggle_cot_feature_and_usage( true );
 
 		// Tests trashing of orders.
 		$order = $this->create_complex_cot_order();
@@ -1218,6 +1219,7 @@ class OrdersTableDataStoreTests extends HposTestCase {
 	 * @testDox Direct write to metadata should propagate to the orders table when reading.
 	 */
 	public function test_read_with_direct_meta_write() {
+		$this->toggle_cot_feature_and_usage( true );
 		$this->enable_cot_sync();
 		$order = $this->create_complex_cot_order();
 
@@ -1241,6 +1243,7 @@ class OrdersTableDataStoreTests extends HposTestCase {
 	 */
 	public function test_read_multiple_with_direct_write() {
 		$this->enable_cot_sync();
+		$this->toggle_cot_feature_and_usage( true );
 		$order       = $this->create_complex_cot_order();
 		$order_total = $order->get_total();
 		$order->add_meta_data( 'custom_meta_1', 'custom_value_1' );

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -2528,4 +2528,43 @@ class OrdersTableDataStoreTests extends HposTestCase {
 		$product = wc_get_product( $product->get_id() );
 		$this->assertEquals( 1, $product->get_total_sales() ); // Sale is not increased when status is changed to completed (from processing).
 	}
+
+	/**
+	 * @testDox Test that adding meta, while in callback for adding another meta also works as expected.
+	 */
+	public function test_backfill_does_not_trigger_read_on_sync_with_filters() {
+		$this->toggle_cot_feature_and_usage( true );
+		$this->enable_cot_sync();
+
+		add_filter( 'added_post_meta', array( $this, 'add_meta_when_meta_added' ), 10, 4 );
+
+		$order = OrderHelper::create_order();
+		$order->set_customer_id( 1 );
+		$order->add_meta_data( 'test_key', 'test_value' );
+		$order->save();
+
+		$r_order = wc_get_order( $order->get_id() );
+		$this->assertEquals( 'test_value', $r_order->get_meta( 'test_key', true ) );
+		$this->assertEquals( 'test_value_2', $r_order->get_meta( 'test_key_2', true ) );
+		$this->assertEquals( 'test_value_3', $r_order->get_meta( 'test_key_3', true ) );
+		$this->assertEquals( 2, $order->get_customer_id() );
+		remove_filter( 'added_post_meta', array( $this, 'add_meta_when_meta_added' ) );
+	}
+
+	/**
+	 * Helper function to simulate adding meta withing a adding meta callback.
+	 * @param int    $meta_id Meta ID.
+	 * @param int    $post_id Post ID.
+	 * @param string $meta_key Meta key.
+	 * @param string $meta_value Meta value.
+	 */
+	public function add_meta_when_meta_added( $meta_id, $post_id, $meta_key, $meta_value ) {
+		if ( 'test_key' === $meta_key ) {
+			$order = wc_get_order( $post_id );
+			$order->add_meta_data( 'test_key_2', 'test_value_2' );
+			$order->save_meta_data();
+			$order->add_meta_data( 'test_key_3', 'test_value_3' );
+			$order->save();
+		}
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -2565,7 +2565,6 @@ class OrdersTableDataStoreTests extends HposTestCase {
 			$order->save_meta_data();
 			$order->add_meta_data( 'test_key_3', 'test_value_3' );
 			$order->save();
-			echo 'ehere';
 		}
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Depends on #39446

This addresses a bug we found in the process of upgrading WCCOM to use HPOS. Basically, if we are in the middle of backfilling, and if there is a filter/action hooked into add_|update_|delete_postmeta, which also inserts another postmeta, and calls save, then we will try to read on sync but at that time it's possible that earlier backfill is not complete, so we will replace the order record in HPOS with incomplete post record.

To fix this, we not do not read on sync, till backfill is complete. This PR also has couple of small bug fixes that were discovered as part of fixing the original bug:

1. Property handle array meta data.
2. Add proper comments to flag lifecycle variables.
<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

This is another PR where bug can be seen only with a plugin, and not with core. So to test, we will use a custom snippet:
1. Add this snippet which reads to add_metadata hook and add another metadata when the hook is fired:
```php
function add_meta_when_meta_added( $meta_id, $post_id, $meta_key, $meta_value ) {
		if ( 'test_key' === $meta_key ) {
			$order = wc_get_order( $post_id );
			$order->add_meta_data( 'test_key_2', 'test_value_2' );
			$order->save_meta_data();
			$order->add_meta_data( 'test_key_3', 'test_value_3' );
			$order->save();
		}
	}
add_filter( 'added_post_meta', 'add_meta_when_meta_added', 10, 4 );
```
3.  Set HPOS to authoritative and sync to on.
4. Go to edit order screen for any order, scroll down and enter a new key `test_key` in the custom meta box. Click update, and it should add test_key_2 and test_key_3 as well. On trunk, this will either run into infinite loop, or the meta won't be added, depending upon when #39446 is merged or not.

<img width="1222" alt="Screenshot 2023-07-28 at 6 25 11 PM" src="https://github.com/woocommerce/woocommerce/assets/7571618/7b9bfa55-a95c-4bb4-9261-9e3357ad17c7">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
