### PR TITLE
Add doc for adjusting quantity input values snippet

### DIFF
--- a/docs/snippets/README.md
+++ b/docs/snippets/README.md
@@ -2,9 +2,11 @@
 
 Various code snippets you can add to your site to enable custom functionality:
 
-- [Add a message above the login / register form](./before-login--register-form.md)
-- [Add a currency and symbol](./add-a-currency-symbol.md)
-- [Change number of related products output](./number-of-products-per-row.md)
-- [Rename a country](./rename-a-country.md)
-- [Change a currency symbol](./change-a-currency-symbol.md)
-- [Unhook and remove WooCommerce emails](./unhook--remove-woocommerce-emails.md)
+-   [Add a message above the login / register form](./before-login--register-form.md)
+-   [Add a currency and symbol](./add-a-currency-symbol.md)
+-   [Change number of related products output](./number-of-products-per-row.md)
+-   [Rename a country](./rename-a-country.md)
+-   [Change a currency symbol](./change-a-currency-symbol.md)
+-   [Unhook and remove WooCommerce emails](./unhook--remove-woocommerce-emails.md)
+-   [Unhook and remove WooCommerce emails](./unhook--remove-woocommerce-emails.md);
+-   [Adjust the quantity input values](./adjust-quantity-input-values.md)

--- a/docs/snippets/adjust-quantity-input-values.md
+++ b/docs/snippets/adjust-quantity-input-values.md
@@ -1,0 +1,47 @@
+# Adjust the quantity input values
+
+> This is a **Developer level** doc. If you are unfamiliar with code and resolving potential conflicts, select a [WooExpert or Developer](https://woocommerce.com/customizations/) for assistance. We are unable to provide support for customizations under our  [Support Policy](http://www.woocommerce.com/support-policy/).
+
+Set the starting value, maximum value, minimum value, and increment amount for quantity input fields on product pages.
+
+Add this code to your child theme’s `functions.php` file or via a plugin that allows custom functions to be added, such as the [Code snippets](https://wordpress.org/plugins/code-snippets/) plugin. Avoid adding custom code directly to your parent theme’s `functions.php` file, as this will be wiped entirely when you update the theme.
+
+```php
+if ( ! function_exists( 'YOUR_PREFIX_woocommerce_quantity_input_args' ) ) {
+	/**
+	 * Adjust the quantity input values for simple products
+	 */
+	function YOUR_PREFIX_woocommerce_quantity_input_args( $args, $product ) {
+		// Only affect the starting value on product pages, not the cart
+		if ( is_singular( 'product' ) ) {
+			$args['input_value'] = 4;
+		}
+
+		$args['max_value'] 	= 10; // Maximum value
+		$args['min_value'] 	= 2;  // Minimum value
+		$args['step'] 		= 2;  // Quantity steps
+
+		return $args;
+	}
+
+	add_filter( 'woocommerce_quantity_input_args', 'YOUR_PREFIX_woocommerce_quantity_input_args', 10, 2 );
+}
+
+if ( ! function_exists( 'YOUR_PREFIX_woocommerce_available_variation' ) ) {
+	/**
+	 * Adjust the quantity input values for variations
+	 */
+	function YOUR_PREFIX_woocommerce_available_variation( $args ) {
+		$args['max_qty'] = 20; // Maximum value (variations)
+		$args['min_qty'] = 2;  // Minimum value (variations)
+		
+		// Note: the starting value and step for variations is controlled
+		// from the 'woocommerce_quantity_input_args' filter shown above for
+    // simple products
+
+		return $args;
+	}
+
+	add_filter( 'woocommerce_available_variation', 'YOUR_PREFIX_woocommerce_available_variation' );
+}
+```

--- a/docs/snippets/adjust-quantity-input-values.md
+++ b/docs/snippets/adjust-quantity-input-values.md
@@ -45,3 +45,5 @@ if ( ! function_exists( 'YOUR_PREFIX_woocommerce_available_variation' ) ) {
 	add_filter( 'woocommerce_available_variation', 'YOUR_PREFIX_woocommerce_available_variation' );
 }
 ```
+
+If you are looking for a little more power, check out our [Min/Max Quantities](http://woocommerce.com/products/minmax-quantities) extension!


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Adds a snippet that shows how to adjust quantity input valuges.

Closes https://github.com/woocommerce/woodocs/issues/104.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Preview document and make sure it appears properly.
2. Try snippet and verify that it works as expected.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
