### PR TITLE
Try: Allow conditional blocks to match context properties

### DIFF
--- a/packages/js/product-editor/src/blocks/conditional/block.json
+++ b/packages/js/product-editor/src/blocks/conditional/block.json
@@ -14,8 +14,17 @@
 				"type": "object"
 			},
 			"default": []
+		},
+		"conditions": {
+			"__experimentalRole": "content",
+			"type": "array",
+			"items": {
+				"type": "object"
+			},
+			"default": []
 		}
 	},
+	"usesContext": [ "editedProduct" ],
 	"supports": {
 		"align": false,
 		"html": false,

--- a/packages/js/product-editor/src/blocks/conditional/edit.tsx
+++ b/packages/js/product-editor/src/blocks/conditional/edit.tsx
@@ -12,44 +12,10 @@ import { Product } from '@woocommerce/data';
 // eslint-disable-next-line @woocommerce/dependency-group
 import { useEntityId } from '@wordpress/core-data';
 
-type Condition = {
-	key: string;
-	operator: string;
-	value: unknown;
-};
-
-type Data = {
-	[ key: string ]: unknown;
-};
-
-function getValueByString( data: Data, key: string ) {
-	const keys = key.split( '.' );
-	let value = { ...data };
-	for ( let i = 0; i < keys.length; i++ ) {
-		if ( ! value.hasOwnProperty( keys[ i ] ) ) {
-			return undefined;
-		}
-		// @ts-ignore
-		value = value[ keys[ i ] ];
-	}
-	return value;
-}
-
-function evaluate( data: Data, condition: Condition ) {
-	const { key, operator, value } = condition;
-	const dataValue = getValueByString( data, key ) as unknown;
-	switch ( operator ) {
-		case '>':
-			return ( value as number ) > ( dataValue as number );
-		case '<':
-			return ( value as number ) < ( dataValue as number );
-		case '!=':
-			return dataValue !== value;
-		case '=':
-		default:
-			return dataValue === value;
-	}
-}
+/**
+ * Internal dependencies
+ */
+import { Condition, evaluateCondition } from '../../utils/evaluate-condition';
 
 export function Edit( {
 	attributes,
@@ -80,7 +46,7 @@ export function Edit( {
 				if ( ! evaluated ) {
 					return false;
 				}
-				return evaluate( context, condition );
+				return evaluateCondition( context, condition );
 			},
 			true
 		);

--- a/packages/js/product-editor/src/components/block-editor/block-editor.tsx
+++ b/packages/js/product-editor/src/components/block-editor/block-editor.tsx
@@ -94,13 +94,21 @@ export function BlockEditor( {
 		);
 	}, [ product.id ] );
 
+	const editedProduct: Product = useSelect( ( select ) =>
+		select( 'core' ).getEditedEntityRecord(
+			'postType',
+			'product',
+			product.id
+		)
+	);
+
 	if ( ! blocks ) {
 		return null;
 	}
 
 	return (
 		<div className="woocommerce-product-block-editor">
-			<BlockContextProvider value={ context }>
+			<BlockContextProvider value={ { ...context, editedProduct } }>
 				<BlockEditorProvider
 					value={ blocks }
 					onInput={ onInput }

--- a/packages/js/product-editor/src/utils/evaluate-condition.ts
+++ b/packages/js/product-editor/src/utils/evaluate-condition.ts
@@ -1,0 +1,38 @@
+export type Condition = {
+	key: string;
+	operator: string;
+	value: unknown;
+};
+
+export type Data = {
+	[ key: string ]: unknown;
+};
+
+function getValueByString( data: Data, key: string ) {
+	const keys = key.split( '.' );
+	let value = { ...data };
+	for ( let i = 0; i < keys.length; i++ ) {
+		if ( ! value.hasOwnProperty( keys[ i ] ) ) {
+			return undefined;
+		}
+		// @ts-ignore
+		value = value[ keys[ i ] ];
+	}
+	return value;
+}
+
+export function evaluateCondition( data: Data, condition: Condition ) {
+	const { key, operator, value } = condition;
+	const dataValue = getValueByString( data, key ) as unknown;
+	switch ( operator ) {
+		case '>':
+			return ( value as number ) > ( dataValue as number );
+		case '<':
+			return ( value as number ) < ( dataValue as number );
+		case '!=':
+			return dataValue !== value;
+		case '=':
+		default:
+			return dataValue === value;
+	}
+}

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -546,8 +546,12 @@ class Init {
 										array(
 											'woocommerce/conditional',
 											array(
-												'mustMatch' => array(
-													'manage_stock' => array( true ),
+												'conditions' => array(
+													array(
+														'key'      => 'editedProduct.manage_stock',
+														'operator' => '=',
+														'value'    => true,
+													),
 												),
 											),
 											array(
@@ -561,8 +565,12 @@ class Init {
 								array(
 									'woocommerce/conditional',
 									array(
-										'mustMatch' => array(
-											'manage_stock' => array( false ),
+										'conditions' => array(
+											array(
+												'key'      => 'editedProduct.manage_stock',
+												'operator' => '=',
+												'value'    => false,
+											),
 										),
 									),
 									array(
@@ -606,8 +614,12 @@ class Init {
 												array(
 													'woocommerce/conditional',
 													array(
-														'mustMatch' => array(
-															'manage_stock' => array( true ),
+														'conditions' => array(
+															array(
+																'key'      => 'editedProduct.manage_stock',
+																'operator' => '=',
+																'value'    => true,
+															),
 														),
 													),
 													array(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR changes how the conditional block works to allow:

* Any context properties to be used in conditions.  This will allow other non-product templates to also use this block or to check other properties within the product editor.
* Evaluate more conditions beyond strict equality.

Usage is pretty similar to the existing, but with a rename of `must_match` to `conditions` and arguments updated to:

* `key` - The context key to check (left side operand).  This can accept dot notation and will check nested properties.
* `operator` - The operator to use for comparison.  This can be `=`, `!=`, `>`, or `<`.
* `value` - The expected value (right side operand) in order for the block to show.

```
array(
	'woocommerce/conditional',
	array(
		'conditions' => array(
			array(
				'key'      => 'editedProduct.manage_stock',
				'operator' => '=',
				'value'    => true,
			),
		),
	),
	array(
		array(
			'woocommerce/product-inventory-quantity-field',
		),
	),
),
```

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the product blocks editor under WooCommerce -> Settings -> Advanced -> Features.
2. Navigate to the add product page
3. Check that conditional blocks work as expected (click `Track stock quantity for this product` and make sure this toggles respective quantity fields when enabled or disabled)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
