### PR TITLE
HPOS: Ensure refund meta data is saved correctly

### DIFF
--- a/plugins/woocommerce/changelog/fix-39215-refund-meta-keys
+++ b/plugins/woocommerce/changelog/fix-39215-refund-meta-keys
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Ensure refund meta data is saved correctly when HPOS is enabled.

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableRefundDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableRefundDataStoreTests.php
@@ -102,10 +102,15 @@ class OrdersTableRefundDataStoreTests extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testDox Test that refund props are set as expected.
+	 * @testDox Test that refund props are set as expected with HPOS enabled.
 	 */
 	public function test_refund_data_is_set() {
-		$order  = OrderHelper::create_order();
+		$this->toggle_cot_feature_and_usage( true );
+
+		$order = OrderHelper::create_order();
+		$user  = $this->factory()->user->create_and_get( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user->ID );
+
 		$refund = wc_create_refund(
 			array(
 				'order_id' => $order->get_id(),
@@ -119,6 +124,7 @@ class OrdersTableRefundDataStoreTests extends WC_Unit_Test_Case {
 		$this->assertEquals( $refund->get_id(), $refreshed_refund->get_id() );
 		$this->assertEquals( 10, $refreshed_refund->get_data()['amount'] );
 		$this->assertEquals( 'Test', $refreshed_refund->get_data()['reason'] );
+		$this->assertEquals( $user->ID, $refreshed_refund->get_data()['refunded_by'] );
 	}
 
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Implements method overrides in the Refund CRUD object to ensure that unrelated prop setter methods are not used in lieu of generating proper WC_Meta_Data objects. See #39444 for details about the problem.

Fixes #39215 
Fixes #39444

### How to test the changes in this Pull Request:

1. Setup:
    * Make sure you are logged into your test site with an admin user whose user ID is **not** 1, creating a new user if necessary. (This is because the "refunded by" field for refunds defaults to 1 in some places in the code.)
    * Configure HPOS settings so that "Data storage for orders" is set to "High performance order storage" and the "compatibility mode" box is unticked.
    * Create an order with one or more products that can be refunded. Set the order to Completed status. Note the ID of the order.
    * Refund one of the items in the order.
1. On the Edit Order screen, check the list of refunds beneath the list of order items. The refund you just created should be there, and it should say something like `Refund #98 - July 27, 2023, 8:52 pm by yourusername`. The "by yourusername" is the key part here, because it would be missing without the changes in this PR.
2. Use a Rest API client of your choice to make a request to `wc/v3/orders/{order ID}/refunds`. The refund you just created should be listed, and have a `refunded_by` property containing the ID of the admin user you set up.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Ensure refund meta data is saved correctly when HPOS is enabled.

#### Comment

</details>
