### PR TITLE
Monorepo Utils: Fix no merge base in changefile script

### DIFF
--- a/tools/monorepo-utils/src/changefile/index.ts
+++ b/tools/monorepo-utils/src/changefile/index.ts
@@ -94,7 +94,7 @@ const program = new Command( 'changefile' )
 			// If a pull request is coming from a contributor's fork's trunk branch, we don't nee to checkout the remote branch because its already available as part of the clone.
 			if ( branch !== 'trunk' ) {
 				Logger.notice( `Checking out remote branch ${ branch }` );
-				await checkoutRemoteBranch( tmpRepoPath, branch );
+				await checkoutRemoteBranch( tmpRepoPath, branch, false );
 			}
 
 			Logger.notice(

--- a/tools/monorepo-utils/src/core/git.ts
+++ b/tools/monorepo-utils/src/core/git.ts
@@ -456,8 +456,6 @@ export const checkoutRemoteBranch = async (
 	const fetchArgs = [ 'fetch', 'origin', branch ];
 	if ( isShallow ) {
 		fetchArgs.push( '--depth=1' );
-	} else {
-		fetchArgs.push( '--unshallow' );
 	}
 	await git.raw( fetchArgs );
 	await git.raw( [ 'checkout', '-b', branch, `origin/${ branch }` ] );

--- a/tools/monorepo-utils/src/core/git.ts
+++ b/tools/monorepo-utils/src/core/git.ts
@@ -456,6 +456,8 @@ export const checkoutRemoteBranch = async (
 	const fetchArgs = [ 'fetch', 'origin', branch ];
 	if ( isShallow ) {
 		fetchArgs.push( '--depth=1' );
+	} else {
+		fetchArgs.push( '--unshallow' );
 	}
 	await git.raw( fetchArgs );
 	await git.raw( [ 'checkout', '-b', branch, `origin/${ branch }` ] );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

When checking out a PR's remote branch in order to perform `git diff`, the changefile script was using a shallow clone. This resulted in no common ancestor when comparing branches in `git diff` and a fatal error.

This PR passes a `false` flag to `checkoutRemoteBranch` to make sure the history is also gathered.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Lets use https://github.com/woocommerce/woocommerce/pull/39348 as an example because the changefile script fails.
2. See there error because there is no merge base https://github.com/woocommerce/woocommerce/actions/runs/5685982910/job/15411962568?pr=39348
3. Next pull this branch down and `pnpm install` 
4. Run the script locally to ensure it passes. Note no commit will be generated because there is no change in the changefile, but a diff will have been successfully created.
```
pnpm utils changefile 39348
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
