### PR TITLE
E2E: Fix and simplify user id retrieval in `a user should see 3 sections by default`

### DIFF
--- a/plugins/woocommerce/changelog/e2e-analytics-overview-simplify-userid-retrieval
+++ b/plugins/woocommerce/changelog/e2e-analytics-overview-simplify-userid-retrieval
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Simplify user id retrieval in analytics-overview.spec.js.

--- a/plugins/woocommerce/tests/e2e-pw/tests/admin-analytics/analytics-overview.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/admin-analytics/analytics-overview.spec.js
@@ -30,12 +30,13 @@ let /**
 	 */
 	page;
 
-const basicAuth = () => {
-	const base64String = Buffer.from(
-		`${ admin.username }:${ admin.password }`
-	).toString( 'base64' );
+const base64String = Buffer.from(
+	`${ admin.username }:${ admin.password }`
+).toString( 'base64' );
 
-	return `Basic ${ base64String }`;
+const headers = {
+	Authorization: `Basic ${ base64String }`,
+	cookie: '',
 };
 
 const hidePerformanceSection = async () => {
@@ -47,10 +48,6 @@ const hidePerformanceSection = async () => {
 			const dashboard_sections = JSON.stringify( [
 				{ key: 'store-performance', isVisible: false },
 			] );
-			const headers = {
-				Authorization: basicAuth(),
-				cookie: '',
-			};
 			const data = {
 				id: userId,
 				woocommerce_meta: {
@@ -88,11 +85,6 @@ const resetSections = async () => {
 			const request = page.request;
 			const url = `/wp-json/wp/v2/users/${ userId }`;
 			const params = { _locale: 'user' };
-			const headers = {
-				Authorization: basicAuth(),
-				cookie: '',
-			};
-
 			const data = {
 				id: userId,
 				woocommerce_meta: {
@@ -129,11 +121,14 @@ test.describe( 'Analytics pages', () => {
 
 		await test.step( `Send GET request to get the current user id`, async () => {
 			const request = page.request;
-			const response = await request.get( '/wp-json/wp/v2/users' );
-			const responseJson = await response.json();
-			const { id } = responseJson.find(
-				( { slug } ) => slug === admin.username
-			);
+			const data = {
+				_fields: 'id',
+			};
+			const response = await request.get( '/wp-json/wp/v2/users/me', {
+				data,
+				headers,
+			} );
+			const { id } = await response.json();
 
 			userId = id;
 		} );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This pull request fixes the failing `a user should see 3 sections by default` E2E test on the daily critical flows tests. An example of a failing run can be seen [here](https://github.com/woocommerce/woocommerce/actions/runs/5664321984/job/15347482965#step:5:826).

**Cause of failure:** The `beforeAll` hook of this test gets the admin user id by using its username to search through the list of users (obtained via the "List Users" (`/wp-json/wp/v2/users`) endpoint earlier in the test). If the username matches the `slug` property of any of the items in the list, then the test would get the `id` of that user and use it as the user id in the test. This approach is wrong. The admin username and its slugified form could end up being different, as in the case of the admin username in the nightly test site. This is why this test passes on localhost, but not on the nightly test site.

<img width="215" alt="xhFGDDnFZ9" src="https://github.com/woocommerce/woocommerce/assets/4509348/c534c924-b7f5-4399-af43-0a1fc392ecdd">


**Solution:** Use the `/wp-json/wp/v2/users/me` endpoint to obtain the user id. This is approach is simpler and more accurate.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Obtain the following values of the nightly test site from the secret store:
    ```bash
    export BASE_URL=""
    export ADMIN_USER=""
    export ADMIN_USER_EMAIL=''
    export ADMIN_PASSWORD=''
    export CUSTOMER_USER=''
    export CUSTOMER_PASSWORD=''
    export CUSTOMER_USER_EMAIL=''
    ```
2. Checkout this branch.
    ```bash
    git checkout e2e/analytics-overview-simplify-userid-retrieval
    ```
3. Install dependencies:
    ```bash
    # cd into the monorepo root
    nmv use
    pnpm install
    # no need to run the build and env:test commands
    ```
1. Using the variables from step 1, run the `a user should see 3 sections by default` test against the nightly test site, and verify that it passes without needing a retry:
    ```bash
    pnpm test:e2e-pw -g "a user should see 3 sections by default" --retries=0
    ```
1. Run the `analytics-overview.spec.js` spec against the nightly test site, and verify that it passes without needing a retry:
    ```bash
    pnpm test:e2e-pw analytics-overview.spec.js --retries=0
    ```
1. Repeat the tests above using the release test site.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
