### PR TITLE
Dequeue conflicting styles within product editor

### DIFF
--- a/plugins/woocommerce/changelog/fix-styling_conflict
+++ b/plugins/woocommerce/changelog/fix-styling_conflict
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Dequeue blocktheme styles on WooCommerce Admin pages when product block editor is enabled.

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -112,7 +112,7 @@ class Init {
 		do_action( 'enqueue_block_editor_assets' );
 	}
 
-	/** 
+	/**
 	 * Dequeue conflicting styles.
 	 */
 	public function dequeue_conflicting_styles() {
@@ -122,7 +122,8 @@ class Init {
 
 	/**
 	 * Update the edit product links when the new experience is enabled.
-	 *	 * @param string $link    The edit link.
+	 *
+	 * @param string $link    The edit link.
 	 * @param int    $post_id Post ID.
 	 * @return string
 	 */

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -43,6 +43,7 @@ class Init {
 		if ( \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_block_editor' ) ) {
 			if ( ! Features::is_enabled( 'new-product-management-experience' ) ) {
 				add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_styles' ) );
+				add_action( 'admin_enqueue_scripts', array( $this, 'dequeue_conflicting_styles' ), 100 );
 				add_action( 'get_edit_post_link', array( $this, 'update_edit_product_link' ), 10, 2 );
 			}
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
@@ -111,10 +112,17 @@ class Init {
 		do_action( 'enqueue_block_editor_assets' );
 	}
 
+	/** 
+	 * Dequeue conflicting styles.
+	 */
+	public function dequeue_conflicting_styles() {
+		// Dequeing this to avoid conflicts, until we remove the 'woocommerce-page' class.
+		wp_dequeue_style( 'woocommerce-blocktheme' );
+	}
+
 	/**
 	 * Update the edit product links when the new experience is enabled.
-	 *
-	 * @param string $link    The edit link.
+	 *	 * @param string $link    The edit link.
 	 * @param int    $post_id Post ID.
 	 * @return string
 	 */

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -116,6 +116,9 @@ class Init {
 	 * Dequeue conflicting styles.
 	 */
 	public function dequeue_conflicting_styles() {
+		if ( ! PageController::is_admin_or_embed_page() ) {
+			return;
+		}
 		// Dequeing this to avoid conflicts, until we remove the 'woocommerce-page' class.
 		wp_dequeue_style( 'woocommerce-blocktheme' );
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR dequeue's the `blocktheme` styling that has been enqueued in some recent WooCommerce/WooCommerce Block changes. This caused a conflict with our label styling, and this fixes that.
We don't need the `blocktheme` style within our product editor anyhow.

See this Slack thread for more context: p1690533982097649-slack-C01CMSA1VHS

Before:
<img width="724" alt="Screenshot 2023-07-28 at 4 56 52 PM" src="https://github.com/woocommerce/woocommerce/assets/2240960/3b7ed165-c8af-41e1-a44e-56a4382bcddc">

After:
<img width="712" alt="Screenshot 2023-07-28 at 4 58 24 PM" src="https://github.com/woocommerce/woocommerce/assets/2240960/4a387dec-5f75-47dd-a400-059e28e690a2">

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Load `trunk` and enable the product editor and go to **Products > Add New**
2. Notice the extra spacing underneath the labels ( really noticeable within list and sale price )
3. Open your console and load the `sources` panel, and search for `blocktheme`. Notice how there is a `woocommerce-blocktheme.css` being imported.
4. Load this branch and refresh the **Products > Add New** page
5. Notice how the labels look correct again
6. Try searching for `woocommerce-blocktheme.css` in your `sources` panel again, it shouldn't be present now.
7.  Check if you have a block theme enabled like Twenty Twenty Three (or Two) and go to **Appearance > Editor**
8. Click on the **Simple product** template
9. Now open your console and search the `sources` tab for the `woocommerce-blocktheme.css` file, it should be present.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>