### PR TITLE
Guest verification: Be more precise when checking form submission data

### DIFF
--- a/plugins/woocommerce/changelog/fix-39399-guest-verify-email-hook
+++ b/plugins/woocommerce/changelog/fix-39399-guest-verify-email-hook
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Be more precise when checking submission data from the email verification form on the order confirmation screen.

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -385,8 +385,9 @@ class WC_Shortcode_Checkout {
 			return false;
 		}
 
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		if ( ! empty( $_POST ) && ! wp_verify_nonce( $_POST['check_submission'] ?? '', 'wc_verify_email' ) ) {
+		$email = filter_input( INPUT_POST, 'email' );
+		$nonce = filter_input( INPUT_POST, 'check_submission' );
+		if ( $email && ! wp_verify_nonce( $nonce, 'wc_verify_email' ) ) {
 			return true;
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In `WC_Shortcode_Checkout::guest_should_verify_email()` we do double duty in that we check the conditions to see if a non-logged in user should verify their email to see order details, but then we're also sort of validating submissions from the email verification form by checking the nonce associated with the form. The problem is that the code assumes that if there is any data at all in `$_POST`, the nonce should be checked. As discussed in #39399, this may not always be the case, and a failed nonce check exits the function before getting to the `woocommerce_order_email_verification_required` filter hook. With this change, we look for specific keys in $_POST to determine whether or not the nonce should actually be checked.

Fixes #39399

### How to test the changes in this Pull Request:

Testing this should ensure that the nonce check still works and that the `woocommerce_order_email_verification_required` hook can still be reached if unrelated POST data is included in the request.

1. Setup
    * Set the email verification grace period to 0 so you don't have to wait 10 minutes while testing: `add_filter( 'woocommerce_order_email_verification_grace_period', '__return_zero' );`
    * Do a purchase checkout from your test store as a guest (not logged in).
    * On the subsequent Order Confirmation screen, copy the URL and paste it into a private or incognito window.
    * Instead of showing the confirmation screen with the order details, this should show an email verification form (since the grace period is disabled).
2. Submitting the form with an incorrect email address but the correct nonce should not work (returns to the form again with an error message).
3. Submitting the form with the correct email address but an incorrect nonce should not work. Use the browser inspector tool to modify the value of the hidden `check_submission` field to send an incorrect nonce.

Testing whether the `woocommerce_order_email_verification_required` hook can still be reached is a bit trickier. For this, you can add this snippet somewhere on your test site, like in an mu-plugins file:

```php
add_filter(
	'woocommerce_order_email_verification_required',
	function( $email_verification_required ) {
		if ( ! empty( $_POST ) ) {
			wp_die( 'Hook reached!' );
		}

		return $email_verification_required;
	}
);
```

5. Use the browser inspector tool to make two changes to the email form:
    * Change the `name` attribute of the email field, e.g. "email2"
    * Remove the hidden `check_submission` field altogether
6. Type something into the modified email field and then submit the form. This simulates a request that has post data but is not actually submitting the email verification form.
7. You should see the "Hook reached!" message. If you try this again on trunk, you should instead just see the email verification form again.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Be more precise when checking submission data from the email verification form on the order confirmation screen.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
