### PR TITLE
Beta Tester: Do not run code in tracks debug unless WC_ABSPATH is defined.

### DIFF
--- a/plugins/woocommerce-beta-tester/api/tracks/class-tracks-debug-log.php
+++ b/plugins/woocommerce-beta-tester/api/tracks/class-tracks-debug-log.php
@@ -42,7 +42,7 @@ class Tracks_Debug_Log {
 	 */
 	public function __construct() {
 		// WooCommerce might not be installed/activated between installs of WC versions.
-		if ( class_exists( 'WooCommerce' ) ) {
+		if ( defined( 'WC_ABSPATH' ) ) {
 			include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-client.php';
 			include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-footer-pixel.php';
 

--- a/plugins/woocommerce-beta-tester/changelog/dev-fix-beta-tester-error
+++ b/plugins/woocommerce-beta-tester/changelog/dev-fix-beta-tester-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix a bug where WC_ABSPATH is used when the WooCommerce instance might not have defined it yet.

--- a/plugins/woocommerce-beta-tester/includes/class-wc-beta-tester-live-branches.php
+++ b/plugins/woocommerce-beta-tester/includes/class-wc-beta-tester-live-branches.php
@@ -15,8 +15,21 @@ class WC_Beta_Tester_Live_Branches {
 	 * Constructor.
 	 */
 	public function __construct() {
+		if ( ! $this->woocommerce_is_installed() ) {
+			return;
+		}
+
 		add_action( 'admin_menu', array( $this, 'register_page' ) );
 		add_action( 'admin_init', array( $this, 'register_scripts' ) );
+	}
+
+	/**
+	 * Check if WooCommerce is installed.
+	 *
+	 * @return bool - True if WooCommerce is installed, false otherwise.
+	 */
+	private function woocommerce_is_installed() {
+		return class_exists( 'WooCommerce' );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fix 2 bugs that cause beta tester to crash:

1. Fix an edge case in running code of the beta tester that depends on WC_ABSPATH being defined.

Between activations of versions of WC that beta tester installs, the PHP code of the beta tester can run and in most cases I removed dependencies on WC itself to avoid that happening or made sure the code does not run if WC is not installed. But in this case I checked for WooCommerce class existing, but technically that's not robust enough.

If the class exists but hasn't been instantiated (which is when it creates WC_ABSPATH) and this code runs first then it will error as it seems to have in https://github.com/woocommerce/woocommerce/issues/39441

2. Fix a bug where if beta tester is installed without WooCommerce it crashes. This was due to loading a class that is not loaded when WooCommerce is not present. We now when registering scripts for live branches avoid doing that work altogether if Woo is not installed and we rely on the error message to inform users to install WooCommerce. In future we can remove all dependence on WooCommerce from beta tester but for now this doesn't crash the plugin. This solves https://github.com/woocommerce/woocommerce/issues/38804



### How to test the changes in this Pull Request:

1. For the first bug you can create an AT site to ensure it doesn't crash. Build a zip of the beta tester plugin from this branch (from the project subdir run `pnpm build:zip`

2. Install the plugin zip on your AT site alongside WooCommerce. Activate it. It should not crash.

3. For the second bug, remove beta tester, then remove WooCommerce just to ensure your AT site is in clean state.

4. Now just install and activate beta tester without WooCommerce.

5. It should not crash and you should see a error message stating you need WooCommerce installed to use beta tester.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message 
Fix a bug where WC_ABSPATH is used when the WooCommerce instance might not have defined it yet.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
