### PR TITLE
Bump WC Blocks to 10.6.2

### DIFF
--- a/plugins/woocommerce/changelog/2023-07-31-15-12-17-220379
+++ b/plugins/woocommerce/changelog/2023-07-31-15-12-17-220379
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update WooCommerce Blocks to 10.6.2

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -23,7 +23,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.6.1",
-		"woocommerce/woocommerce-blocks": "10.6.1" 
+		"woocommerce/woocommerce-blocks": "10.6.2"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.3.0",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4d0fb9896d4d2729480577c8dad0786a",
+    "content-hash": "dd77d3ba610ad8a4fd6eb33a822b8833",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1004,16 +1004,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "10.6.1",
+            "version": "10.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "5065ccdf0c40bbbfd2efdc30badc99898ef8f10e"
+                "reference": "91343922dfa02154b5a16d5d39478835b023d6af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/5065ccdf0c40bbbfd2efdc30badc99898ef8f10e",
-                "reference": "5065ccdf0c40bbbfd2efdc30badc99898ef8f10e",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/91343922dfa02154b5a16d5d39478835b023d6af",
+                "reference": "91343922dfa02154b5a16d5d39478835b023d6af",
                 "shasum": ""
             },
             "require": {
@@ -1059,9 +1059,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v10.6.1"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v10.6.2"
             },
-            "time": "2023-07-18T08:53:05+00:00"
+            "time": "2023-07-31T15:09:29+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 10.6.2. This is intended to be merged into WooCommerce 8.0.

## Blocks 10.6.2

* [Release PR](https://github.com/woocommerce/woocommerce-blocks/pull/10413)
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/1062.md)

### Changelog entry

#### Enhancements

- Updated Product Hero pattern to have no opinionated styles. ([10255](https://github.com/woocommerce/woocommerce-blocks/pull/10255))
- Only load styles required by the blocks rendered on the page. ([9831](https://github.com/woocommerce/woocommerce-blocks/pull/9831))

#### Bug Fixes

- Fix: Resolve the conflict preventing the navigation block from being correctly previewed in the editor while having WooCommerce enabled. ([10388](https://github.com/woocommerce/woocommerce-blocks/pull/10388))
- Products: Fix the incorrect layout with WordPress 6.3+ without Gutenberg. ([10360](https://github.com/woocommerce/woocommerce-blocks/pull/10360))
- Fixed a rendering bug on content containing Cart and Checkout blocks/shortcode. ([10359](https://github.com/woocommerce/woocommerce-blocks/pull/10359))
- Fix an error occurring due to missing parameters in the `woocommerce_add_to_cart_redirect` filter. ([10316](https://github.com/woocommerce/woocommerce-blocks/pull/10316))
- Single Product Template > Ensure extensions can't trigger fatal errors on customized single product templates without any post content blocks. ([10128](https://github.com/woocommerce/woocommerce-blocks/pull/10128))
- Cart and Checkout Page Migration: Inherit Page template and fix rendering. ([10375](https://github.com/woocommerce/woocommerce-blocks/pull/10375))



****