### PR TITLE
Prevent possible fatal error when user holds edit lock for a deleted order

### DIFF
--- a/plugins/woocommerce/changelog/fix-39354
+++ b/plugins/woocommerce/changelog/fix-39354
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent possible fatal error when edit lock is held on deleted order.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/EditLock.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/EditLock.php
@@ -100,7 +100,7 @@ class EditLock {
 		}
 
 		$order = wc_get_order( $order_id );
-		if ( ! current_user_can( get_post_type_object( $order->get_type() )->cap->edit_post, $order->get_id() ) && ! current_user_can( 'manage_woocommerce' ) ) {
+		if ( ! $order || ( ! current_user_can( get_post_type_object( $order->get_type() )->cap->edit_post, $order->get_id() ) && ! current_user_can( 'manage_woocommerce' ) ) ) {
 			return $response;
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
With HPOS enabled, if an order gets deleted while being edited in a different browser window/session, a fatal error is logged when the AJAX heartbeat attempts to refresh the edit lock. This doesn't have any serious implication, other than an error being logged, but better to not produce it at all ("silence is golden").

Closes #39354.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. On the admin, create an order and open it for editing. Do not close this browser tab.
2. Open a new browser tab and go to WC > Orders.
3. Check off the checkbox next to the order from step 1.
4. Choose "Move to trash" in the bulk actions dropdown and click "Apply".
5. Go to the Trash and empty it (or permanently delete the order).
6. Go back to the browser tab from step 1.
7. Wait a few minutes (with the tab open) for a "heartbeat" request to come through.
   You can use the dev tools to monitor for such XHR request.
8. Confirm that:
   - On `trunk`, a PHP critical error is logged:
      ```
      CRITICAL Uncaught Error: Call to a member function get_type() on bool in /.../woocommerce/src/Internal/Admin/Orders/EditLock.php:103
      ```
   - On this branch, no error is triggered.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
