### PR TITLE
Prevent possible fatal error when refreshing edit lock for orders

### DIFF
--- a/plugins/woocommerce/changelog/fix-39353
+++ b/plugins/woocommerce/changelog/fix-39353
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent possible error when refreshing order edit locks.

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -3607,7 +3607,7 @@ class WC_AJAX {
 	 * @param array $data     Data sent through the heartbeat.
 	 * @return array Response to be sent.
 	 */
-	private static function order_refresh_lock( $response, $data ) : array {
+	private static function order_refresh_lock( $response, $data ) {
 		return wc_get_container()->get( Automattic\WooCommerce\Internal\Admin\Orders\EditLock::class )->refresh_lock_ajax( $response, $data );
 	}
 
@@ -3620,7 +3620,7 @@ class WC_AJAX {
 	 * @param array $data     Data sent through the heartbeat.
 	 * @return array Response to be sent.
 	 */
-	private static function check_locked_orders( $response, $data ) : array {
+	private static function check_locked_orders( $response, $data ) {
 		return wc_get_container()->get( Automattic\WooCommerce\Internal\Admin\Orders\EditLock::class )->check_locked_orders_ajax( $response, $data );
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
We make use of the `heartbeat_received` filter to check/refresh edit locks on orders when HPOS is enabled. This filter operates on an array, but apparently some plugins are returning other values (such as NULL) which can produce fatal errors when our code gets called as the signatures on our callbacks explicitly indicate `array` as the return value and there are a few early returns in our function.

This PR removes the return type from the function signatures. Even though we could force the return value to be an array, I chose to not do this because the errors seem to only be triggered when **not** checking/refreshing order edit locks. Otherwise, our code would produce an array anyways.

Closes #39353.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check out `trunk`.
1. Drop the following snippet as `39498.php` inside `wp-content/mu-plugins/` to "simulate" a problematic plugin:
   ```php
   <?php
   add_filter(
	   'heartbeat_received',
	   function( $response, $data ) {
		   return;
	   },
	   0,
	   2
   );
   ```
1. As admin, go to Posts and wait a few seconds.
   This is deliberate (i.e. we're not visiting WC > Orders) as we don't want our callbacks to actually perform their job and return an array.
1. Check your logs and you should have an entry similar to this one:
   ```
   PHP Fatal error: Uncaught TypeError: Return value of WC_AJAX::order_refresh_lock() must be of the type array, null returned in /woocommerce/includes/class-wc-ajax.php:3475
   ```
1. Check out this branch.
1. Repeat step 3.
1. Confirm that no error is logged.
1. ❗️ Make sure to remove the snippet in the `wp-content/mu-plugins/` directory, unless you want to break the WP heartbeat!

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
