### PR TITLE
Fix/38932 slow low in stock query

### DIFF
--- a/plugins/woocommerce/changelog/fix-38932-slow-low-in-stock-query
+++ b/plugins/woocommerce/changelog/fix-38932-slow-low-in-stock-query
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Low in stock query - Avoid ordering the results. Order by can cause slow query for certain versions of mysql/mariahdb.

--- a/plugins/woocommerce/changelog/fix-38932-slow-low-in-stock-query
+++ b/plugins/woocommerce/changelog/fix-38932-slow-low-in-stock-query
@@ -1,4 +1,4 @@
 Significance: minor
 Type: performance
 
-Low in stock query - Avoid ordering the results. Order by can cause slow query for certain versions of mysql/mariahdb.
+Low in stock query - Avoid ordering the results. Order by can cause slow query for certain versions of mysql/mariadb.

--- a/plugins/woocommerce/src/Admin/API/ProductsLowInStock.php
+++ b/plugins/woocommerce/src/Admin/API/ProductsLowInStock.php
@@ -71,6 +71,7 @@ final class ProductsLowInStock extends \WC_REST_Products_Controller {
 
 		// set last_order_date.
 		$query_results['results'] = $this->set_last_order_date( $query_results['results'] );
+		krsort( $query_results['results'] );
 
 		// convert the post data to the expected API response for the backward compatibility.
 		$query_results['results'] = array_map( array( $this, 'transform_post_to_api_response' ), $query_results['results'] );
@@ -236,7 +237,6 @@ final class ProductsLowInStock extends \WC_REST_Products_Controller {
 			  AND wc_product_meta_lookup.stock_quantity IS NOT NULL
 			  AND wc_product_meta_lookup.stock_status IN('instock', 'outofstock')
 			  :postmeta_wheres
-			order by wc_product_meta_lookup.product_id DESC
 			limit %d, %d
 		";
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #38932

This PR fixes potential slow queries from the low-in-stock endpoint for some mysql/mariahdb versions.

The problem described in the issue was very hard to reproduce. The query worked just fine on my local and JN sites. There have not been any other reports either. However, I could reproduce it on a MariahDB instance with the 10.4.20 version (10.4.20-MariaDB-1:10.4.20+maria~buster-log - mariadb.org binary distribution)

`order by` was not using the expected index (or the optimizer behaved differently than other MySQL versions), causing a large # of row scans.

Since we can order the results in PHP and the size of the result isn't big, I removed it and used `krsort` instead. 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

It would be best if you could test the changes with MariahDB 10.4.20 (10.4.20-MariaDB-1:10.4.20+maria~buster-log - mariadb.org binary distribution) to reproduce the issue first, but testing the endpoint returns the same data should be good enough. 

Follow the same test instructions from the first PR https://github.com/woocommerce/woocommerce-admin/pull/7377

1. Test without this branch.
2. Checkout this branch and confirm the API returns the same data.

Explain with `order by`:
![Screen Shot 2023-07-31 at 2 38 14 PM](https://github.com/woocommerce/woocommerce/assets/4723145/7ba012b1-211e-4194-92fc-d62e20820736)

Explain without `order by`:
![Screen Shot 2023-07-31 at 2 38 26 PM](https://github.com/woocommerce/woocommerce/assets/4723145/5a7ed160-a424-44d7-b41c-87bbc8093802)

Notice the # of rows. 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
