### PR TITLE
Do not disable "Used for variations" checkbox

### DIFF
--- a/plugins/woocommerce/changelog/fix-used-for-variations-checkbox-disabled
+++ b/plugins/woocommerce/changelog/fix-used-for-variations-checkbox-disabled
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Do not disable "Used for variations" checkbox on attribute.

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -411,13 +411,15 @@ jQuery( function ( $ ) {
 		$( '#product_attributes' ).on( 'woocommerce_tab_shown', function() {
 			remove_blank_custom_attribute_if_no_other_attributes();
 
-			var woocommerce_attribute_items = $product_attributes.find( '.woocommerce_attribute' ).get();
+			const woocommerce_attribute_items = $product_attributes.find( '.woocommerce_attribute' ).get();
 
 			// If the product has no attributes, add an empty attribute to be filled out by the user.
 			if ( woocommerce_attribute_items.length === 0  ) {
 				add_custom_attribute_to_list();
 			}
 		} );
+
+		const woocommerce_attribute_items = $product_attributes.find( '.woocommerce_attribute' ).get();
 
 		// Sort the attributes by their position.
 		woocommerce_attribute_items.sort( function ( a, b ) {
@@ -544,6 +546,8 @@ jQuery( function ( $ ) {
 			update_attribute_row_indexes();
 
 			toggle_expansion_of_attribute_list_item( $attributeListItem );
+
+			$( document.body ).trigger( 'woocommerce_added_attribute' );
 
 			jQuery.maybe_disable_save_button();
 		} catch ( error ) {

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -436,12 +436,17 @@ jQuery( function ( $ ) {
 	// Set up attributes, if current page has the attributes list.
 	const $product_attributes = $( '.product_attributes' );
 	if ( $product_attributes.length === 1 ) {
-		var woocommerce_attribute_items = $product_attributes.find( '.woocommerce_attribute' ).get();
+		// When the attributes tab is shown, add an empty attribute to be filled out by the user.
+		$( '#product_attributes' ).on( 'woocommerce_tab_shown', function() {
+			remove_blank_custom_attribute_if_no_other_attributes();
 
-		// If the product has no attributes, add an empty attribute to be filled out by the user.
-		if ( woocommerce_attribute_items.length === 0  ) {
-			add_custom_attribute_to_list();
-		}
+			var woocommerce_attribute_items = $product_attributes.find( '.woocommerce_attribute' ).get();
+
+			// If the product has no attributes, add an empty attribute to be filled out by the user.
+			if ( woocommerce_attribute_items.length === 0  ) {
+				add_custom_attribute_to_list();
+			}
+		} );
 
 		// Sort the attributes by their position.
 		woocommerce_attribute_items.sort( function ( a, b ) {
@@ -500,6 +505,7 @@ jQuery( function ( $ ) {
 				url: woocommerce_admin_meta_boxes.ajax_url,
 				data: {
 					action: 'woocommerce_add_attribute',
+					product_type: $( '#product-type' ).val(),
 					taxonomy: globalAttributeId ? globalAttributeId : '',
 					i: indexInList,
 					security: woocommerce_admin_meta_boxes.add_attribute_nonce,

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -126,34 +126,6 @@ jQuery( function ( $ ) {
 			return false;
 		} );
 
-	function disable_or_enable_fields() {
-		var product_type = $( 'select#product-type' ).val();
-		$( `.enable_if_simple` ).each( function () {
-			$( this ).addClass( 'disabled' );
-			if ( $( this ).is( 'input' ) ) {
-				$( this ).prop( 'disabled', true );
-			}
-		} );
-		$( `.enable_if_external` ).each( function () {
-			$( this ).addClass( 'disabled' );
-			if ( $( this ).is( 'input' ) ) {
-				$( this ).prop( 'disabled', true );
-			}
-		} );
-		$( `.enable_if_variable` ).each( function () {
-			$( this ).addClass( 'disabled' );
-			if ( $( this ).is( 'input' ) ) {
-				$( this ).prop( 'disabled', true );
-			}
-		} );
-		$( `.enable_if_${ product_type }` ).each( function () {
-			$( this ).removeClass( 'disabled' );
-			if ( $( this ).is( 'input' ) ) {
-				$( this ).prop( 'disabled', false );
-			}
-		} );
-	}
-
 	// Product type specific options.
 	$( 'select#product-type' )
 		.on( 'change', function () {
@@ -173,7 +145,6 @@ jQuery( function ( $ ) {
 			}
 
 			show_and_hide_panels();
-			disable_or_enable_fields();
 			change_product_type_tip( get_product_tip_content( select_val ) );
 
 			$( 'ul.wc-tabs li:visible' ).eq( 0 ).find( 'a' ).trigger( 'click' );
@@ -574,8 +545,6 @@ jQuery( function ( $ ) {
 
 			toggle_expansion_of_attribute_list_item( $attributeListItem );
 
-			disable_or_enable_fields();
-
 			jQuery.maybe_disable_save_button();
 		} catch ( error ) {
 			if ( isPageUnloading ) {
@@ -919,8 +888,6 @@ jQuery( function ( $ ) {
 
 					// Hide the 'Used for variations' checkbox if not viewing a variable product
 					show_and_hide_panels();
-
-					disable_or_enable_fields();
 
 					// Make sure the dropdown is not disabled for empty value attributes.
 					$( 'select.attribute_taxonomy' )

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes.js
@@ -126,7 +126,9 @@ jQuery( function ( $ ) {
 				$( 'ul.wc-tabs li', panel_wrap ).removeClass( 'active' );
 				$( this ).parent().addClass( 'active' );
 				$( 'div.panel', panel_wrap ).hide();
-				$( $( this ).attr( 'href' ) ).show();
+				$( $( this ).attr( 'href' ) ).show( 0, function () {
+					$( this ).trigger( 'woocommerce_tab_shown' );
+				} );
 			} );
 			$( 'div.panel-wrap' ).each( function () {
 				$( this )

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute-inner.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute-inner.php
@@ -93,7 +93,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<tr>
 		<td>
 			<div class="enable_variation show_if_variable">
-				<label><input type="checkbox" disabled class="woocommerce_attribute_used_for_variations checkbox enable_if_variable" <?php checked( $attribute->get_variation(), true ); ?> name="attribute_variation[<?php echo esc_attr( $i ); ?>]" value="1" /> <?php esc_html_e( 'Used for variations', 'woocommerce' ); ?></label>
+				<label><input type="checkbox" class="woocommerce_attribute_used_for_variations checkbox" <?php checked( $attribute->get_variation(), true ); ?> name="attribute_variation[<?php echo esc_attr( $i ); ?>]" value="1" /> <?php esc_html_e( 'Used for variations', 'woocommerce' ); ?></label>
 			</div>
 		</td>
 	</tr>

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -611,7 +611,7 @@ class WC_AJAX {
 			wp_die( -1 );
 		}
 
-		$product_type = sanitize_text_field( wp_unslash( $_POST['product_type'] ) );
+		$product_type = isset( $_POST['product_type'] ) ? sanitize_text_field( wp_unslash( $_POST['product_type'] ) ) : 'simple';
 
 		$i             = absint( $_POST['i'] );
 		$metabox_class = array();

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -611,6 +611,8 @@ class WC_AJAX {
 			wp_die( -1 );
 		}
 
+		$product_type = sanitize_text_field( wp_unslash( $_POST['product_type'] ) );
+
 		$i             = absint( $_POST['i'] );
 		$metabox_class = array();
 		$attribute     = new WC_Product_Attribute();
@@ -619,7 +621,13 @@ class WC_AJAX {
 		$attribute->set_name( sanitize_text_field( wp_unslash( $_POST['taxonomy'] ) ) );
 		/* phpcs:disable WooCommerce.Commenting.CommentHooks.MissingHookComment */
 		$attribute->set_visible( apply_filters( 'woocommerce_attribute_default_visibility', 1 ) );
-		$attribute->set_variation( apply_filters( 'woocommerce_attribute_default_is_variation', 1 ) );
+		$attribute->set_variation(
+			apply_filters(
+				'woocommerce_attribute_default_is_variation',
+				'variable' === $product_type ? 1 : 0,
+				$product_type
+			)
+		);
 		/* phpcs: enable */
 
 		if ( $attribute->is_taxonomy() ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR makes a few changes related to the "Used for variations" checkbox:

* The "Used for variations" checkbox is never disabled. I've reverted the behavior that disabled the checkbox when the product type was not `variable`.
    * This returns the behavior of the checkbox to what it was in WooCommerce 7.8.
    * I have determined that there would not be a way to implement disabling the checkbox without potentially breaking extensions, such as WooCommerce Subscriptions. If we were to add such a feature in the future we would need to be careful to proactively let extensions know that this change would be coming and provide them with a clear way to modify the behavior.
* The `woocommerce_added_attribute` trigger has been restored. This is needed by extensions such as WooCommerce Subscriptions in order to re-show the "Used for variations" checkbox when it is hidden.
* The requesting and generation of the empty attribute form has been moved from when the product edit screen loads to when the "Attributes" tab is shown. This allows for the scenario where the product type is changed from "simple" to something else before clicking the "Attributes" tab. The "Used for variations" checkbox will now be correctly defaulted to checked when on a variable product and unchecked for all other product types. This change will also partially address the lingering issue #39377.

Fixes #39490.
Fixes #39338 (this was closed previously even though it was not fixed)
Fixes #39502 (this was closed previously even though it was not fixed)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Perform general regression testing by creating and editing Simple products, Variable products, etc.
    - The "Used for variations" checkbox should be checked by default for Variable products.
    - The "Used for variations" checkbox should be hidden for all other product types (unless an extension has re-shown it, which is actually what WooCommerce Subscriptions is doing to get it to appear).
3. Install WooCommerce Subscriptions 5.2.0 and create and edit Subscriptions and Variable Subscriptions.
    - WooCommerce Subscriptions 5.2.0 does *not* contain any fixes to handle the issues fixed by this PR, so it is a good test of an extension that was experiencing problems.
    - The "Used for variations" checkbox should be unchecked by default for Variable Subscription products.
    - The "Used for variations" checkbox should be hidden for Subscription products.
    - (In other words, WooCommerce Subscriptions 5.2.0 should work with this fix)
4. Install WooCommerce Subscriptions 5.3.1 and verify that the fixes in that version still work with the fixes in this PR.
    - The "Used for variations" checkbox should be unchecked by default for Variable Subscription products.
    - The "Used for variations" checkbox should be hidden for Subscription products.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
