### PR TITLE
fix: core-profiler intro opt in page tracks ordering

### DIFF
--- a/plugins/woocommerce-admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/index.tsx
@@ -341,22 +341,27 @@ const redirectToJetpackAuthPage = (
 	window.location.href = event.data.url + '&installed_ext_success=1';
 };
 
-const updateTrackingOption = (
-	_context: CoreProfilerStateMachineContext,
-	event: IntroOptInEvent
+const updateTrackingOption = async (
+	context: CoreProfilerStateMachineContext
 ) => {
-	if (
-		event.payload.optInDataSharing &&
-		typeof window.wcTracks.enable === 'function'
-	) {
-		window.wcTracks.enable( () => {
-			initializeExPlat();
-		} );
-	} else if ( ! event.payload.optInDataSharing ) {
-		window.wcTracks.isEnabled = false;
-	}
+	await new Promise< void >( ( resolve ) => {
+		if (
+			context.optInDataSharing &&
+			typeof window.wcTracks.enable === 'function'
+		) {
+			window.wcTracks.enable( () => {
+				initializeExPlat();
+				resolve(); // resolve the promise only after explat is enabled by the callback
+			} );
+		} else {
+			if ( ! context.optInDataSharing ) {
+				window.wcTracks.isEnabled = false;
+			}
+			resolve();
+		}
+	} );
 
-	const trackingValue = event.payload.optInDataSharing ? 'yes' : 'no';
+	const trackingValue = context.optInDataSharing ? 'yes' : 'no';
 	dispatch( OPTIONS_STORE_NAME ).updateOptions( {
 		woocommerce_allow_tracking: trackingValue,
 	} );
@@ -560,7 +565,6 @@ const coreProfilerMachineActions = {
 	...recordTracksActions,
 	handlePlugins,
 	updateQueryStep,
-	updateTrackingOption,
 	handleTrackingOption,
 	handleGeolocation,
 	handleStoreNameOption,
@@ -588,6 +592,7 @@ const coreProfilerMachineServices = {
 	getPlugins,
 	browserPopstateHandler,
 	updateBusinessInfo,
+	updateTrackingOption,
 };
 export const coreProfilerStateMachineDefinition = createMachine( {
 	id: 'coreProfiler',
@@ -722,11 +727,8 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 				introOptIn: {
 					on: {
 						INTRO_COMPLETED: {
-							target: '#userProfile',
-							actions: [
-								'assignOptInDataSharing',
-								'updateTrackingOption',
-							],
+							target: 'postIntroOptIn',
+							actions: [ 'assignOptInDataSharing' ],
 						},
 						INTRO_SKIPPED: {
 							// if the user skips the intro, we set the optInDataSharing to false and go to the Business Location page
@@ -737,33 +739,18 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 							],
 						},
 					},
-					entry: [
-						{
-							type: 'recordTracksStepViewed',
-							step: 'intro_opt_in',
-						},
-						{ type: 'updateQueryStep', step: 'intro-opt-in' },
-					],
-					exit: actions.choose( [
-						{
-							cond: ( _context, event ) =>
-								event.type === 'INTRO_COMPLETED',
-							actions: 'recordTracksIntroCompleted',
-						},
-						{
-							cond: ( _context, event ) =>
-								event.type === 'INTRO_SKIPPED',
-							actions: [
-								{
-									type: 'recordTracksStepSkipped',
-									step: 'intro_opt_in',
-								},
-							],
-						},
-					] ),
 					meta: {
 						progress: 20,
 						component: IntroOptIn,
+					},
+				},
+				postIntroOptIn: {
+					invoke: {
+						src: 'updateTrackingOption',
+						onDone: {
+							actions: [ 'recordTracksIntroCompleted' ],
+							target: '#userProfile',
+						},
 					},
 				},
 			},

--- a/plugins/woocommerce/changelog/fix-core-profiler-intro-opt-in-tracks-ordering
+++ b/plugins/woocommerce/changelog/fix-core-profiler-intro-opt-in-tracks-ordering
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed a race condition that was causing page views on intro-opt-in page to be sent before tracks was enabled.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

- Added a postIntroOptIn state in the introOptIn page so that we can invoke an async service to enable tracking before proceeding with following actions and states
- Removed step view event for intro opt in as it's not meaningful to track this metric since almost all incoming users will not have tracking enabled at this stage.
- Removed the url update for introOptIn as it was causing users to be unable to use the browser button to back out of the core profiler

Closes #39485

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

It's not really possible to observe the ordering without modifying the code, as there are no debug logs for enabling explat.
Thus, please modify the plugin by adding a console log on this line: https://github.com/woocommerce/woocommerce/blob/cdf82902c5215bbca4be96d0227add2778c6f10c/plugins/woocommerce-admin/client/core-profiler/index.tsx#L353

1. Run woocommerce with the above mentioned modification
2. Enable logs by entering `localStorage.debug="*"` 
3. On the core profiler ensure that tracking is opted into before proceeding to the next step
5. Observe that tracking is enabled before the tracks events, as shown in the screenshot below.
6. Also observe that it's now possible to use the browser's back button to back out of the core profiler

![image](https://github.com/woocommerce/woocommerce/assets/27843274/298a04dc-700f-43a3-abd9-e05768596a34)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
