### PR TITLE
POC: Add client-side template utils to allow runtime changes to block templates

### DIFF
--- a/packages/js/product-editor/src/blocks/attributes/index.ts
+++ b/packages/js/product-editor/src/blocks/attributes/index.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils';
+import { registerWooBlockType } from '../../utils';
 import metadata from './block.json';
 import { Edit } from './edit';
 
@@ -15,7 +15,7 @@ export const settings = {
 };
 
 export const init = () =>
-	initBlock( {
+	registerWooBlockType( {
 		name,
 		metadata: metadata as never,
 		settings,

--- a/packages/js/product-editor/src/blocks/category/index.ts
+++ b/packages/js/product-editor/src/blocks/category/index.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils';
+import { registerWooBlockType } from '../../utils';
 import metadata from './block.json';
 import { Edit } from './edit';
 
@@ -15,4 +15,4 @@ export const settings = {
 };
 
 export const init = () =>
-	initBlock( { name, metadata: metadata as never, settings } );
+	registerWooBlockType( { name, metadata: metadata as never, settings } );

--- a/packages/js/product-editor/src/blocks/checkbox/index.ts
+++ b/packages/js/product-editor/src/blocks/checkbox/index.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import initBlock from '../../utils/init-block';
+import { registerWooBlockType } from '../../utils';
 import metadata from './block.json';
 import { Edit } from './edit';
 
@@ -14,4 +14,5 @@ export const settings = {
 	edit: Edit,
 };
 
-export const init = () => initBlock( { name, metadata, settings } );
+export const init = () =>
+	registerWooBlockType( { name, metadata: metadata as never, settings } );

--- a/packages/js/product-editor/src/blocks/collapsible/index.ts
+++ b/packages/js/product-editor/src/blocks/collapsible/index.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils';
+import { registerWooBlockType } from '../../utils';
 import metadata from './block.json';
 import { Edit } from './edit';
 
@@ -15,4 +15,4 @@ export const settings = {
 };
 
 export const init = () =>
-	initBlock( { name, metadata: metadata as never, settings } );
+	registerWooBlockType( { name, metadata: metadata as never, settings } );

--- a/packages/js/product-editor/src/blocks/conditional/index.ts
+++ b/packages/js/product-editor/src/blocks/conditional/index.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils';
+import { registerWooBlockType } from '../../utils';
 import metadata from './block.json';
 import { Edit } from './edit';
 
@@ -15,4 +15,4 @@ export const settings = {
 };
 
 export const init = () =>
-	initBlock( { name, metadata: metadata as never, settings } );
+	registerWooBlockType( { name, metadata: metadata as never, settings } );

--- a/packages/js/product-editor/src/blocks/description/index.ts
+++ b/packages/js/product-editor/src/blocks/description/index.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import initBlock from '../../utils/init-block';
+import { registerWooBlockType } from '../../utils';
 import metadata from './block.json';
 import { Edit } from './edit';
 
@@ -14,4 +14,5 @@ export const settings = {
 	edit: Edit,
 };
 
-export const init = () => initBlock( { name, metadata, settings } );
+export const init = () =>
+	registerWooBlockType( { name, metadata: metadata as never, settings } );

--- a/packages/js/product-editor/src/blocks/images/index.ts
+++ b/packages/js/product-editor/src/blocks/images/index.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils';
+import { registerWooBlockType } from '../../utils';
 import metadata from './block.json';
 import { Edit } from './edit';
 
@@ -15,7 +15,7 @@ export const settings = {
 };
 
 export const init = () =>
-	initBlock( {
+	registerWooBlockType( {
 		name,
 		metadata: metadata as never,
 		settings,

--- a/packages/js/product-editor/src/blocks/inventory-email/index.ts
+++ b/packages/js/product-editor/src/blocks/inventory-email/index.ts
@@ -7,7 +7,7 @@ import { BlockConfiguration } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils/init-blocks';
+import { registerWooBlockType } from '../../utils';
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
 import { InventoryEmailBlockAttributes } from './types';
@@ -25,5 +25,5 @@ export const settings: Partial<
 };
 
 export function init() {
-	return initBlock( { name, metadata, settings } );
+	return registerWooBlockType( { name, metadata, settings } );
 }

--- a/packages/js/product-editor/src/blocks/inventory-quantity/index.ts
+++ b/packages/js/product-editor/src/blocks/inventory-quantity/index.ts
@@ -7,7 +7,7 @@ import { BlockConfiguration } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils/init-blocks';
+import { registerWooBlockType } from '../../utils';
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
 import { TrackInventoryBlockAttributes } from './types';
@@ -25,5 +25,5 @@ export const settings: Partial<
 };
 
 export function init() {
-	return initBlock( { name, metadata, settings } );
+	return registerWooBlockType( { name, metadata, settings } );
 }

--- a/packages/js/product-editor/src/blocks/inventory-sku/index.ts
+++ b/packages/js/product-editor/src/blocks/inventory-sku/index.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import initBlock from '../../utils/init-block';
+import { registerWooBlockType } from '../../utils';
 import metadata from './block.json';
 import { Edit } from './edit';
 
@@ -14,4 +14,5 @@ export const settings = {
 	edit: Edit,
 };
 
-export const init = () => initBlock( { name, metadata, settings } );
+export const init = () =>
+	registerWooBlockType( { name, metadata: metadata as never, settings } );

--- a/packages/js/product-editor/src/blocks/name/index.ts
+++ b/packages/js/product-editor/src/blocks/name/index.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils';
+import { registerWooBlockType } from '../../utils';
 import metadata from './block.json';
 import { Edit } from './edit';
 
@@ -15,7 +15,7 @@ export const settings = {
 };
 
 export const init = () =>
-	initBlock( {
+	registerWooBlockType( {
 		name,
 		metadata: metadata as never,
 		settings,

--- a/packages/js/product-editor/src/blocks/pricing/index.ts
+++ b/packages/js/product-editor/src/blocks/pricing/index.ts
@@ -6,7 +6,7 @@ import { BlockConfiguration } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils/init-blocks';
+import { registerWooBlockType } from '../../utils';
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
 import { PricingBlockAttributes } from './types';
@@ -23,5 +23,5 @@ export const settings: Partial< BlockConfiguration< PricingBlockAttributes > > =
 	};
 
 export function init() {
-	return initBlock( { name, metadata, settings } );
+	return registerWooBlockType( { name, metadata, settings } );
 }

--- a/packages/js/product-editor/src/blocks/radio/index.ts
+++ b/packages/js/product-editor/src/blocks/radio/index.ts
@@ -6,7 +6,7 @@ import { BlockConfiguration } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils/init-blocks';
+import { registerWooBlockType } from '../../utils';
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
 import { RadioBlockAttributes } from './types';
@@ -22,5 +22,5 @@ export const settings: Partial< BlockConfiguration< RadioBlockAttributes > > = {
 };
 
 export function init() {
-	return initBlock( { name, metadata, settings } );
+	return registerWooBlockType( { name, metadata, settings } );
 }

--- a/packages/js/product-editor/src/blocks/regular-price/index.ts
+++ b/packages/js/product-editor/src/blocks/regular-price/index.ts
@@ -6,7 +6,7 @@ import { BlockConfiguration } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils/init-blocks';
+import { registerWooBlockType } from '../../utils';
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
 import { SalePriceBlockAttributes } from './types';
@@ -24,5 +24,5 @@ export const settings: Partial<
 };
 
 export function init() {
-	return initBlock( { name, metadata, settings } );
+	return registerWooBlockType( { name, metadata, settings } );
 }

--- a/packages/js/product-editor/src/blocks/sale-price/index.ts
+++ b/packages/js/product-editor/src/blocks/sale-price/index.ts
@@ -6,7 +6,7 @@ import { BlockConfiguration } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils/init-blocks';
+import { registerWooBlockType } from '../../utils';
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
 import { SalePriceBlockAttributes } from './types';
@@ -24,5 +24,5 @@ export const settings: Partial<
 };
 
 export function init() {
-	return initBlock( { name, metadata, settings } );
+	return registerWooBlockType( { name, metadata, settings } );
 }

--- a/packages/js/product-editor/src/blocks/schedule-sale/index.ts
+++ b/packages/js/product-editor/src/blocks/schedule-sale/index.ts
@@ -7,7 +7,7 @@ import { BlockConfiguration } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils/init-blocks';
+import { registerWooBlockType } from '../../utils';
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
 import { ScheduleSalePricingBlockAttributes } from './types';
@@ -25,5 +25,5 @@ export const settings: Partial<
 };
 
 export function init() {
-	return initBlock( { name, metadata, settings } );
+	return registerWooBlockType( { name, metadata, settings } );
 }

--- a/packages/js/product-editor/src/blocks/section/index.ts
+++ b/packages/js/product-editor/src/blocks/section/index.ts
@@ -7,7 +7,7 @@ import { BlockConfiguration } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils/init-blocks';
+import { registerWooBlockType } from '../../utils';
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
 import { SectionBlockAttributes } from './types';
@@ -24,5 +24,5 @@ export const settings: Partial< BlockConfiguration< SectionBlockAttributes > > =
 	};
 
 export function init() {
-	return initBlock( { name, metadata, settings } );
+	return registerWooBlockType( { name, metadata, settings } );
 }

--- a/packages/js/product-editor/src/blocks/shipping-class/index.ts
+++ b/packages/js/product-editor/src/blocks/shipping-class/index.ts
@@ -7,7 +7,7 @@ import { BlockConfiguration } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils/init-blocks';
+import { registerWooBlockType } from '../../utils';
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
 import { ShippingClassBlockAttributes } from './types';
@@ -25,5 +25,5 @@ export const settings: Partial<
 };
 
 export function init() {
-	return initBlock( { name, metadata, settings } );
+	return registerWooBlockType( { name, metadata, settings } );
 }

--- a/packages/js/product-editor/src/blocks/shipping-dimensions/index.ts
+++ b/packages/js/product-editor/src/blocks/shipping-dimensions/index.ts
@@ -7,7 +7,7 @@ import { BlockConfiguration } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils/init-blocks';
+import { registerWooBlockType } from '../../utils';
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
 import { ShippingDimensionsBlockAttributes } from './types';
@@ -25,5 +25,5 @@ export const settings: Partial<
 };
 
 export function init() {
-	return initBlock( { name, metadata, settings } );
+	return registerWooBlockType( { name, metadata, settings } );
 }

--- a/packages/js/product-editor/src/blocks/summary/index.ts
+++ b/packages/js/product-editor/src/blocks/summary/index.ts
@@ -6,7 +6,7 @@ import { BlockConfiguration } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils';
+import { registerWooBlockType } from '../../utils';
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
 import { SummaryAttributes } from './types';
@@ -22,7 +22,7 @@ export const settings = {
 };
 
 export function init() {
-	return initBlock< SummaryAttributes >( {
+	return registerWooBlockType< SummaryAttributes >( {
 		name,
 		metadata,
 		settings,

--- a/packages/js/product-editor/src/blocks/tab/index.ts
+++ b/packages/js/product-editor/src/blocks/tab/index.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import initBlock from '../../utils/init-block';
+import { registerWooBlockType } from '../../utils';
 import metadata from './block.json';
 import { Edit } from './edit';
 
@@ -14,4 +14,5 @@ export const settings = {
 	edit: Edit,
 };
 
-export const init = () => initBlock( { name, metadata, settings } );
+export const init = () =>
+	registerWooBlockType( { name, metadata: metadata as never, settings } );

--- a/packages/js/product-editor/src/blocks/toggle/index.ts
+++ b/packages/js/product-editor/src/blocks/toggle/index.ts
@@ -6,7 +6,7 @@ import { BlockConfiguration } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils/init-blocks';
+import { registerWooBlockType } from '../../utils';
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
 import { ToggleBlockAttributes } from './types';
@@ -23,5 +23,5 @@ export const settings: Partial< BlockConfiguration< ToggleBlockAttributes > > =
 	};
 
 export function init() {
-	return initBlock( { name, metadata, settings } );
+	return registerWooBlockType( { name, metadata, settings } );
 }

--- a/packages/js/product-editor/src/components/block-editor/block-editor.tsx
+++ b/packages/js/product-editor/src/components/block-editor/block-editor.tsx
@@ -31,7 +31,7 @@ import {
 /**
  * Internal dependencies
  */
-import { BlocksTemplate } from '../blocks-template';
+import { BlockTemplateProvider } from '../block-template-provider';
 
 type BlockEditorProps = {
 	context: {
@@ -92,22 +92,23 @@ export function BlockEditor( {
 	return (
 		<div className="woocommerce-product-block-editor">
 			<BlockContextProvider value={ context }>
-				<BlocksTemplate />
-				<BlockEditorProvider
-					value={ blocks }
-					onInput={ onInput }
-					onChange={ onChange }
-					settings={ settings }
-				>
-					{ /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */ }
-					{ /* @ts-ignore No types for this exist yet. */ }
-					<BlockEditorKeyboardShortcuts.Register />
-					<BlockTools>
-						<ObserveTyping>
-							<BlockList className="woocommerce-product-block-editor__block-list" />
-						</ObserveTyping>
-					</BlockTools>
-				</BlockEditorProvider>
+				<BlockTemplateProvider>
+					<BlockEditorProvider
+						value={ blocks }
+						onInput={ onInput }
+						onChange={ onChange }
+						settings={ settings }
+					>
+						{ /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */ }
+						{ /* @ts-ignore No types for this exist yet. */ }
+						<BlockEditorKeyboardShortcuts.Register />
+						<BlockTools>
+							<ObserveTyping>
+								<BlockList className="woocommerce-product-block-editor__block-list" />
+							</ObserveTyping>
+						</BlockTools>
+					</BlockEditorProvider>
+				</BlockTemplateProvider>
 			</BlockContextProvider>
 		</div>
 	);

--- a/packages/js/product-editor/src/components/block-editor/block-editor.tsx
+++ b/packages/js/product-editor/src/components/block-editor/block-editor.tsx
@@ -106,7 +106,7 @@ export function BlockEditor( {
 			<BlockContextProvider value={ context }>
 				<BlockTemplateProvider
 					onChange={ onChange }
-					initialTemplateId={
+					initialTemplate={
 						'woocommerce/woocommerce//product-editor_simple'
 					}
 					templates={ templates }

--- a/packages/js/product-editor/src/components/block-editor/block-editor.tsx
+++ b/packages/js/product-editor/src/components/block-editor/block-editor.tsx
@@ -26,6 +26,9 @@ import {
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore store should be included.
 	useEntityBlockEditor,
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore store should be included.
+	useEntityRecords,
 } from '@wordpress/core-data';
 
 /**
@@ -85,14 +88,29 @@ export function BlockEditor( {
 		{ id: product.id }
 	);
 
-	if ( ! blocks ) {
+	const { records: templates } = useEntityRecords(
+		'postType',
+		'wp_template',
+		{
+			post_type: 'woocommerce_product_editor_template',
+			per_page: -1,
+		}
+	);
+
+	if ( ! blocks || ! templates ) {
 		return null;
 	}
 
 	return (
 		<div className="woocommerce-product-block-editor">
 			<BlockContextProvider value={ context }>
-				<BlockTemplateProvider>
+				<BlockTemplateProvider
+					onChange={ onChange }
+					initialTemplateId={
+						'woocommerce/woocommerce//product-editor_simple'
+					}
+					templates={ templates }
+				>
 					<BlockEditorProvider
 						value={ blocks }
 						onInput={ onInput }

--- a/packages/js/product-editor/src/components/block-template-provider/block-template-provider.tsx
+++ b/packages/js/product-editor/src/components/block-template-provider/block-template-provider.tsx
@@ -1,12 +1,14 @@
 /**
  * External dependencies
  */
-import { createElement, useLayoutEffect, useState } from '@wordpress/element';
-import { SelectControl } from '@wordpress/components';
 import {
-	BlockInstance,
-	synchronizeBlocksWithTemplate,
-} from '@wordpress/blocks';
+	createElement,
+	Fragment,
+	useLayoutEffect,
+	useState,
+} from '@wordpress/element';
+import { SelectControl } from '@wordpress/components';
+import { synchronizeBlocksWithTemplate } from '@wordpress/blocks';
 import {
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore
@@ -19,6 +21,11 @@ import {
 	useEntityRecords,
 } from '@wordpress/core-data';
 
+/**
+ * Internal dependencies
+ */
+import { getVisibleBlocks } from './get-visible-blocks';
+
 type Template = {
 	id: string;
 	title: {
@@ -27,28 +34,13 @@ type Template = {
 	};
 };
 
-export function getVisibleBlocks(
-	blocks: BlockInstance[],
-	hiddenBlockIds: string[]
-) {
-	const visibleBlocks: BlockInstance[] = [];
+type BlockTemplateProviderProps = {
+	children: JSX.Element;
+};
 
-	blocks.forEach( ( block ) => {
-		if ( hiddenBlockIds.includes( block.attributes._templateId ) ) {
-			return;
-		}
-		const visibleInnerBlocks = getVisibleBlocks(
-			block.innerBlocks,
-			hiddenBlockIds
-		);
-		const visibleBlock = { ...block, innerBlocks: visibleInnerBlocks };
-		visibleBlocks.push( visibleBlock );
-	} );
-
-	return visibleBlocks;
-}
-
-export function BlocksTemplate() {
+export function BlockTemplateProvider( {
+	children,
+}: BlockTemplateProviderProps ) {
 	const [ selectedTemplateId, setSelectedTemplateId ] = useState(
 		'woocommerce/woocommerce//product-editor_simple'
 	);
@@ -91,15 +83,18 @@ export function BlocksTemplate() {
 	}
 
 	return (
-		<SelectControl
-			className="woocommerce-template-switcher"
-			options={ templates.map( ( template: Template ) => ( {
-				label: template.title.rendered,
-				value: template.id,
-			} ) ) }
-			onChange={ ( templateId ) =>
-				setSelectedTemplateId( templateId as string )
-			}
-		/>
+		<>
+			<SelectControl
+				className="woocommerce-template-switcher"
+				options={ templates.map( ( template: Template ) => ( {
+					label: template.title.rendered,
+					value: template.id,
+				} ) ) }
+				onChange={ ( templateId ) =>
+					setSelectedTemplateId( templateId as string )
+				}
+			/>
+			{ children }
+		</>
 	);
 }

--- a/packages/js/product-editor/src/components/block-template-provider/context.ts
+++ b/packages/js/product-editor/src/components/block-template-provider/context.ts
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { createContext, useContext } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { Template } from './types';
+
+const DEFAULT_BLOCK_TEMPLATE_CONTEXT = {
+	hideBlock: () => null,
+	hiddenBlocks: [],
+	templates: [],
+	selectedTemplate: null,
+	selectTemplate: () => null,
+	unhideBlock: () => null,
+};
+
+type ContextType = {
+	hideBlock: ( blockId: string ) => void;
+	hiddenBlocks: string[];
+	templates: Template[];
+	selectedTemplate: string | null;
+	selectTemplate: ( templateId: string ) => void;
+	unhideBlock: ( blockId: string ) => void;
+};
+
+const Context = createContext< ContextType >( DEFAULT_BLOCK_TEMPLATE_CONTEXT );
+export const { Provider } = Context;
+
+/**
+ * A hook that returns the block edit context.
+ *
+ * @return {Object} Block edit context
+ */
+export function useBlockTemplate() {
+	return useContext( Context );
+}

--- a/packages/js/product-editor/src/components/block-template-provider/get-visible-blocks.ts
+++ b/packages/js/product-editor/src/components/block-template-provider/get-visible-blocks.ts
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import { BlockInstance } from '@wordpress/blocks';
+
+export function getVisibleBlocks(
+	blocks: BlockInstance[],
+	hiddenBlockIds: string[]
+) {
+	const visibleBlocks: BlockInstance[] = [];
+
+	blocks.forEach( ( block ) => {
+		if ( hiddenBlockIds.includes( block.attributes._templateId ) ) {
+			return;
+		}
+		const visibleInnerBlocks = getVisibleBlocks(
+			block.innerBlocks,
+			hiddenBlockIds
+		);
+		const visibleBlock = { ...block, innerBlocks: visibleInnerBlocks };
+		visibleBlocks.push( visibleBlock );
+	} );
+
+	return visibleBlocks;
+}

--- a/packages/js/product-editor/src/components/block-template-provider/index.ts
+++ b/packages/js/product-editor/src/components/block-template-provider/index.ts
@@ -1,0 +1,1 @@
+export * from './block-template-provider';

--- a/packages/js/product-editor/src/components/block-template-provider/index.ts
+++ b/packages/js/product-editor/src/components/block-template-provider/index.ts
@@ -1,1 +1,2 @@
 export * from './block-template-provider';
+export * from './context';

--- a/packages/js/product-editor/src/components/block-template-provider/test-template-component.tsx
+++ b/packages/js/product-editor/src/components/block-template-provider/test-template-component.tsx
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import { createElement, Fragment } from '@wordpress/element';
+import { Button, SelectControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { Template } from './types';
+import { useBlockTemplate } from './';
+
+export function TestTemplateComponent() {
+	const { hiddenBlocks, hideBlock, templates, selectTemplate, unhideBlock } =
+		useBlockTemplate();
+
+	function toggleBasicDetails() {
+		if ( hiddenBlocks.includes( 'section/basic-details' ) ) {
+			unhideBlock( 'section/basic-details' );
+			return;
+		}
+		hideBlock( 'section/basic-details' );
+	}
+
+	return (
+		<>
+			<SelectControl
+				className="woocommerce-template-switcher"
+				options={ templates.map( ( template: Template ) => ( {
+					label: template.title.rendered,
+					value: template.id,
+				} ) ) }
+				onChange={ ( templateId ) =>
+					selectTemplate( templateId as string )
+				}
+			/>
+			<Button onClick={ toggleBasicDetails }>
+				Toggle basic details section
+			</Button>
+		</>
+	);
+}

--- a/packages/js/product-editor/src/components/block-template-provider/types.ts
+++ b/packages/js/product-editor/src/components/block-template-provider/types.ts
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+import { TemplateArray } from '@wordpress/blocks';
+
+export type Template = {
+	id: string;
+	title: {
+		raw: string;
+		rendered: string;
+	};
+	content: {
+		raw: TemplateArray;
+	};
+};

--- a/packages/js/product-editor/src/components/blocks-template/index.ts
+++ b/packages/js/product-editor/src/components/blocks-template/index.ts
@@ -1,1 +1,0 @@
-export * from './blocks-template';

--- a/packages/js/product-editor/src/utils/index.ts
+++ b/packages/js/product-editor/src/utils/index.ts
@@ -21,7 +21,7 @@ import { preventLeavingProductForm } from './prevent-leaving-product-form';
 
 export * from './create-ordered-children';
 export * from './sort-fills-by-order';
-export * from './init-blocks';
+export * from './register-woo-block-type';
 export * from './product-apifetch-middleware';
 export * from './sift';
 

--- a/packages/js/product-editor/src/utils/register-woo-block-type.ts
+++ b/packages/js/product-editor/src/utils/register-woo-block-type.ts
@@ -19,7 +19,7 @@ interface BlockRepresentation< T extends Record< string, object > > {
  * @param  block The block to be registered.
  * @return The block, if it has been successfully registered; otherwise `undefined`.
  */
-export function initBlock<
+export function registerWooBlockType<
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	T extends Record< string, any > = Record< string, any >
 >( block: BlockRepresentation< T > ): Block< T > | undefined {
@@ -27,5 +27,14 @@ export function initBlock<
 		return;
 	}
 	const { metadata, settings, name } = block;
-	return registerBlockType< T >( { name, ...metadata }, settings );
+	const attributes = {
+		...metadata.attributes,
+		_templateId: {
+			type: 'string',
+		},
+	};
+	return registerBlockType< T >(
+		{ name, ...metadata, attributes },
+		settings
+	);
 }

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/WooCommerceBlockTemplate.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/WooCommerceBlockTemplate.php
@@ -171,7 +171,7 @@ class WooCommerceBlockTemplate {
             array_merge(
                 $block[ self::BLOCK_ATTRS_KEY ],
                 array(
-                    'parsed' => true,
+                    '_templateId' => $block[ self::ID_KEY ],
                 )
             ),
             isset( $block[ self::INNER_BLOCKS_KEY ] ) ? $this->parse_blocks( $block[ self::INNER_BLOCKS_KEY ] ) : array()


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

This concept introduces a few key utils/components to allow changing templates and hiding blocks by ID in the client.

* Creates a `registerWooBlockType` function that handles block registration in addition to appending relevant Woo-specific block attributes and information.
* Adds a `<BlockTemplateProvider>` HOC to handle templating and providing template context.
* Adds a `useBlockTemplate` hook to allow checking the templates, switching templates, and hiding blocks.  This can be used by all nested components/blocks, including 3PD blocks.

<img width="886" alt="Screen Shot 2023-08-01 at 8 37 58 AM" src="https://github.com/woocommerce/woocommerce/assets/10561050/55452651-ef12-4181-876c-eb0724b3d590">


Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the blocks product editor under WooCommerce -> Settings -> Advanced -> Features
2. Navigate to the add product page
3. Install this plugin - https://github.com/joshuatf/template-extensibility-example
4. Check the test component which includes a dropdown to change the template and button to toggle the basic details section on/off

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
