### PR TITLE
Set the HPOS-related features back to "experimental"

### DIFF
--- a/plugins/woocommerce/changelog/update-hpos-feature-experimental
+++ b/plugins/woocommerce/changelog/update-hpos-feature-experimental
@@ -1,0 +1,5 @@
+Significance: patch
+Type: update
+Comment: Reverting HPOS to an experimental feature for now.
+
+

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -116,13 +116,16 @@ class FeaturesController {
 			// Options for HPOS features are added in CustomOrdersTableController to keep the logic in same place.
 			'custom_order_tables'  => array( // This exists for back-compat only, otherwise it's value is superseded by $hpos_authoritative option.
 				'name'               => __( 'High-Performance order storage (COT)', 'woocommerce' ),
+				'is_experimental'    => true,
 				'enabled_by_default' => false,
 			),
 			$hpos_authoritative    => array(
-				'name' => __( 'High performance order storage', 'woocommerce' ),
+				'name'            => __( 'High performance order storage', 'woocommerce' ),
+				'is_experimental' => true,
 			),
 			$hpos_enable_sync      => array(
-				'name' => '',
+				'name'            => '',
+				'is_experimental' => true,
 			),
 			'cart_checkout_blocks' => array(
 				'name'            => __( 'Cart & Checkout Blocks', 'woocommerce' ),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

We determined that there are a few more issues that need to be resolved before HPOS can be classified as a "mature" feature.

More context: p1690907386499049-slack-C0E1AV8T0

### How to test the changes in this Pull Request:

1. On trunk, go to the WP Admin and navigate to WooCommerce > Settings > Advanced > Features.
2. "Data storage for orders" will be listed under "Features" instead of "Experimental Features".
3. Check out this branch, and refresh the tab.
4. Now "Data storage for orders should be listed under "Experimental Features".

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment

Reverting HPOS to an "experimental" feature for now.

</details>