### PR TITLE
Add new variation modal

### DIFF
--- a/packages/js/product-editor/changelog/add-38884_add_variation_modal
+++ b/packages/js/product-editor/changelog/add-38884_add_variation_modal
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add new attribute modal to variations field and include tests for useProductAttributes hook.

--- a/packages/js/product-editor/src/blocks/variation-options/edit.tsx
+++ b/packages/js/product-editor/src/blocks/variation-options/edit.tsx
@@ -3,8 +3,9 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useBlockProps } from '@wordpress/block-editor';
-import { createElement } from '@wordpress/element';
+import { createElement, createInterpolateElement } from '@wordpress/element';
 import { ProductAttribute } from '@woocommerce/data';
+import { Link } from '@woocommerce/components';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore No types for this exist yet.
 // eslint-disable-next-line @woocommerce/dependency-group
@@ -42,6 +43,21 @@ export function Edit() {
 					newAttributeModalTitle: __(
 						'Add variation options',
 						'woocommerce'
+					),
+					newAttributeModalDescription: createInterpolateElement(
+						__(
+							'Select from existing <globalAttributeLink>global attributes</globalAttributeLink> or create options for buyers to choose on the product page. You can change the order later.',
+							'woocommerce'
+						),
+						{
+							globalAttributeLink: (
+								<Link
+									href="https://woocommerce.com/document/variable-product/#add-attributes-to-use-for-variations"
+									type="external"
+									target="_blank"
+								/>
+							),
+						}
 					),
 					attributeRemoveLabel: __(
 						'Remove variation option',

--- a/packages/js/product-editor/src/blocks/variations/edit.tsx
+++ b/packages/js/product-editor/src/blocks/variations/edit.tsx
@@ -4,15 +4,23 @@
 import classNames from 'classnames';
 import type { BlockEditProps } from '@wordpress/blocks';
 import { Button } from '@wordpress/components';
-import { useEntityProp } from '@wordpress/core-data';
-import { Product } from '@woocommerce/data';
-import { createElement } from '@wordpress/element';
+import { Link } from '@woocommerce/components';
+import { Product, ProductAttribute } from '@woocommerce/data';
+import {
+	createElement,
+	useState,
+	createInterpolateElement,
+} from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import {
 	useBlockProps,
 	// @ts-expect-error no exported member.
 	useInnerBlocksProps,
 } from '@wordpress/block-editor';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore No types for this exist yet.
+// eslint-disable-next-line @woocommerce/dependency-group
+import { useEntityProp, useEntityId } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -20,6 +28,12 @@ import {
 import { sanitizeHTML } from '../../utils/sanitize-html';
 import { VariationsBlockAttributes } from './types';
 import { EmptyVariationsImage } from './empty-variations-image';
+import { NewAttributeModal } from '../../components/attribute-control/new-attribute-modal';
+import {
+	EnhancedProductAttribute,
+	useProductAttributes,
+} from '../../hooks/use-product-attributes';
+import { getAttributeId } from '../../components/attribute-control/utils';
 
 function hasAttributesUsedForVariations(
 	productAttributes: Product[ 'attributes' ]
@@ -32,10 +46,18 @@ export function Edit( {
 }: BlockEditProps< VariationsBlockAttributes > ) {
 	const { description } = attributes;
 
-	const [ productAttributes ] = useEntityProp< Product[ 'attributes' ] >(
-		'postType',
-		'product',
-		'attributes'
+	const [ isNewModalVisible, setIsNewModalVisible ] = useState( false );
+	const [ productAttributes, setProductAttributes ] = useEntityProp<
+		Product[ 'attributes' ]
+	>( 'postType', 'product', 'attributes' );
+
+	const { attributes: variationOptions, handleChange } = useProductAttributes(
+		{
+			allAttributes: productAttributes,
+			onChange: setProductAttributes,
+			isVariationAttributes: true,
+			productId: useEntityId( 'postType', 'product' ),
+		}
 	);
 
 	const hasAttributes = hasAttributesUsedForVariations( productAttributes );
@@ -54,6 +76,27 @@ export function Edit( {
 		{ templateLock: 'all' }
 	);
 
+	const openNewModal = () => {
+		setIsNewModalVisible( true );
+	};
+
+	const closeNewModal = () => {
+		setIsNewModalVisible( false );
+	};
+
+	const handleAdd = ( newOptions: EnhancedProductAttribute[] ) => {
+		handleChange( [
+			...newOptions.filter(
+				( newAttr ) =>
+					! variationOptions.find(
+						( attr: ProductAttribute ) =>
+							getAttributeId( newAttr ) === getAttributeId( attr )
+					)
+			),
+		] );
+		closeNewModal();
+	};
+
 	return (
 		<div { ...blockProps }>
 			<div className="wp-block-woocommerce-product-variations-fields__heading">
@@ -65,13 +108,41 @@ export function Edit( {
 					dangerouslySetInnerHTML={ sanitizeHTML( description ) }
 				/>
 				<div className="wp-block-woocommerce-product-variations-fields__heading-actions">
-					<Button variant="primary" aria-disabled="true">
+					<Button variant="primary" onClick={ openNewModal }>
 						{ __( 'Add variation options', 'woocommerce' ) }
 					</Button>
 				</div>
 			</div>
 
 			<div { ...innerBlockProps } />
+			{ isNewModalVisible && (
+				<NewAttributeModal
+					title={ __( 'Add variation options', 'woocommerce' ) }
+					description={ createInterpolateElement(
+						__(
+							'Select from existing <globalAttributeLink>global attributes</globalAttributeLink> or create options for buyers to choose on the product page. You can change the order later.',
+							'woocommerce'
+						),
+						{
+							globalAttributeLink: (
+								<Link
+									href="https://woocommerce.com/document/variable-product/#add-attributes-to-use-for-variations"
+									type="external"
+									target="_blank"
+								/>
+							),
+						}
+					) }
+					notice={ '' }
+					onCancel={ () => {
+						closeNewModal();
+					} }
+					onAdd={ handleAdd }
+					selectedAttributeIds={ variationOptions.map(
+						( attr ) => attr.id
+					) }
+				/>
+			) }
 		</div>
 	);
 }

--- a/packages/js/product-editor/src/components/attribute-control/attribute-control.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/attribute-control.tsx
@@ -48,6 +48,7 @@ type AttributeControlProps = {
 		emptyStateSubtitle?: string;
 		newAttributeListItemLabel?: string;
 		newAttributeModalTitle?: string;
+		newAttributeModalDescription?: string | React.ReactElement;
 		newAttributeModalNotice?: string;
 		customAttributeHelperMessage?: string;
 		attributeRemoveLabel?: string;
@@ -237,6 +238,7 @@ export const AttributeControl: React.FC< AttributeControlProps > = ( {
 			{ isNewModalVisible && (
 				<NewAttributeModal
 					title={ uiStrings.newAttributeModalTitle }
+					description={ uiStrings.newAttributeModalDescription }
 					notice={ uiStrings.newAttributeModalNotice }
 					onCancel={ () => {
 						closeNewModal();

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
@@ -31,6 +31,7 @@ import { getProductAttributeObject } from './utils';
 
 type NewAttributeModalProps = {
 	title?: string;
+	description?: string | React.ReactElement;
 	notice?: string;
 	attributeLabel?: string;
 	valueLabel?: string;
@@ -56,6 +57,7 @@ type AttributeForm = {
 
 export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 	title = __( 'Add attributes', 'woocommerce' ),
+	description = '',
 	notice = __(
 		'By default, attributes are filterable and visible on the product page. You can change these settings for each attribute separately later.',
 		'woocommerce'
@@ -234,6 +236,8 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 									<p>{ notice }</p>
 								</Notice>
 							) }
+
+							{ description && <p>{ description }</p> }
 
 							<div className="woocommerce-new-attribute-modal__body">
 								<table className="woocommerce-new-attribute-modal__table">

--- a/packages/js/product-editor/src/hooks/test/use-product-attributes.test.ts
+++ b/packages/js/product-editor/src/hooks/test/use-product-attributes.test.ts
@@ -254,6 +254,32 @@ describe( 'useProductAttributes', () => {
 				{ ...allAttributes[ 0 ], position: 1, variation: true },
 			] );
 		} );
+
+		it( 'should remove duplicate locals by name', async () => {
+			const allAttributes = [
+				{ ...testAttributes[ 0 ] },
+				{ ...testAttributes[ 1 ] },
+			];
+			const onChange = jest.fn();
+			const { result, waitForNextUpdate } = renderHook(
+				useProductAttributes,
+				{
+					initialProps: {
+						allAttributes,
+						onChange,
+						isVariationAttributes: true,
+						productId: 123,
+					},
+				}
+			);
+			jest.runOnlyPendingTimers();
+			await waitForNextUpdate();
+			result.current.handleChange( [ { ...testAttributes[ 0 ] } ] );
+			expect( onChange ).toHaveBeenCalledWith( [
+				{ ...allAttributes[ 1 ], position: 0 },
+				{ ...allAttributes[ 0 ], position: 1, variation: true },
+			] );
+		} );
 	} );
 
 	describe( 'is not variation', () => {

--- a/packages/js/product-editor/src/hooks/test/use-product-attributes.test.ts
+++ b/packages/js/product-editor/src/hooks/test/use-product-attributes.test.ts
@@ -1,0 +1,361 @@
+/**
+ * External dependencies
+ */
+import { renderHook, cleanup } from '@testing-library/react-hooks';
+import { ProductAttribute, ProductAttributeTerm } from '@woocommerce/data';
+import { resolveSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { useProductAttributes } from '../use-product-attributes';
+
+const attributeTerms: Record< number, ProductAttributeTerm[] > = {
+	2: [
+		{
+			id: 64,
+			name: 'Blue',
+			slug: 'blue',
+			description: '',
+			menu_order: 0,
+			count: 2,
+		},
+		{
+			id: 76,
+			name: 'Green',
+			slug: 'green',
+			description: '',
+			menu_order: 0,
+			count: 1,
+		},
+		{
+			id: 63,
+			name: 'Red',
+			slug: 'red',
+			description: '',
+			menu_order: 0,
+			count: 2,
+		},
+		{
+			id: 65,
+			name: 'Velvet',
+			slug: 'velvet',
+			description: '',
+			menu_order: 0,
+			count: 2,
+		},
+	],
+	3: [
+		{
+			id: 64,
+			name: 'Small',
+			slug: 'small',
+			description: '',
+			menu_order: 0,
+			count: 2,
+		},
+		{
+			id: 76,
+			name: 'Medium',
+			slug: 'medium',
+			description: '',
+			menu_order: 0,
+			count: 1,
+		},
+		{
+			id: 63,
+			name: 'Large',
+			slug: 'large',
+			description: '',
+			menu_order: 0,
+			count: 2,
+		},
+	],
+};
+
+jest.useFakeTimers();
+jest.mock( '@wordpress/data', () => ( {
+	...jest.requireActual( '@wordpress/data' ),
+	resolveSelect: jest.fn().mockReturnValue( {
+		getProductAttributeTerms: jest
+			.fn()
+			.mockImplementation( ( { attribute_id } ) => {
+				return new Promise( ( resolve ) => {
+					setTimeout( () => {
+						if ( attributeTerms[ attribute_id ] ) {
+							return resolve( attributeTerms[ attribute_id ] );
+						}
+						return resolve( [] );
+					}, 100 );
+				} );
+			} ),
+	} ),
+} ) );
+
+const testAttributes: ProductAttribute[] = [
+	{
+		id: 0,
+		name: 'Local',
+		options: [ 'option 1', 'option 2' ],
+		position: 0,
+		variation: false,
+		visible: false,
+	},
+	{
+		id: 2,
+		name: 'Global: Color',
+		options: [ 'Red', 'Yellow' ],
+		position: 1,
+		variation: false,
+		visible: true,
+	},
+	{
+		id: 3,
+		name: 'Global: Size',
+		options: [ 'Small', 'Medium', 'Large' ],
+		position: 2,
+		variation: false,
+		visible: true,
+	},
+];
+
+describe( 'useProductAttributes', () => {
+	afterEach( () => {
+		cleanup();
+		( resolveSelect as jest.Mock ).mockClear();
+		jest.runOnlyPendingTimers();
+	} );
+
+	it( 'should return empty array when no attributes', async () => {
+		const { result, waitForNextUpdate } = renderHook(
+			useProductAttributes,
+			{
+				initialProps: {
+					allAttributes: [],
+					onChange: jest.fn(),
+					isVariationAttributes: false,
+					productId: 123,
+				},
+			}
+		);
+		await waitForNextUpdate();
+		expect( resolveSelect ).not.toHaveBeenCalled();
+		expect( result.current.attributes ).toEqual( [] );
+	} );
+
+	describe( 'handleChange', () => {
+		it( 'should call onChange when handleChange is called with updated attributes', async () => {
+			const allAttributes = [
+				{ ...testAttributes[ 1 ] },
+				{ ...testAttributes[ 2 ] },
+			];
+			const onChange = jest.fn();
+			const { result, waitForNextUpdate } = renderHook(
+				useProductAttributes,
+				{
+					initialProps: {
+						allAttributes,
+						onChange,
+						isVariationAttributes: false,
+						productId: 123,
+					},
+				}
+			);
+			jest.runOnlyPendingTimers();
+			await waitForNextUpdate();
+			result.current.handleChange( [
+				allAttributes[ 0 ],
+				allAttributes[ 1 ],
+				{ ...testAttributes[ 0 ] },
+			] );
+			expect( onChange ).toHaveBeenCalledWith( [
+				{ ...allAttributes[ 0 ], position: 0 },
+				{ ...allAttributes[ 1 ], position: 1 },
+				{ ...testAttributes[ 0 ], variation: false, position: 2 },
+			] );
+		} );
+
+		it( 'should keep both variable and non variable as part of the onChange list, when isVariation is false', async () => {
+			const allAttributes = [
+				{ ...testAttributes[ 1 ], variation: true },
+				{ ...testAttributes[ 2 ], variation: true },
+			];
+			const onChange = jest.fn();
+			const { result, waitForNextUpdate } = renderHook(
+				useProductAttributes,
+				{
+					initialProps: {
+						allAttributes,
+						onChange,
+						isVariationAttributes: false,
+						productId: 123,
+					},
+				}
+			);
+			jest.runOnlyPendingTimers();
+			await waitForNextUpdate();
+			result.current.handleChange( [ { ...testAttributes[ 0 ] } ] );
+			expect( onChange ).toHaveBeenCalledWith( [
+				{ ...testAttributes[ 0 ], variation: false, position: 0 },
+				{ ...allAttributes[ 0 ], position: 1 },
+				{ ...allAttributes[ 1 ], position: 2 },
+			] );
+		} );
+
+		it( 'should keep both variable and non variable as part of the onChange list, when isVariation is true', async () => {
+			const allAttributes = [
+				{ ...testAttributes[ 1 ] },
+				{ ...testAttributes[ 2 ] },
+			];
+			const onChange = jest.fn();
+			const { result, waitForNextUpdate } = renderHook(
+				useProductAttributes,
+				{
+					initialProps: {
+						allAttributes,
+						onChange,
+						isVariationAttributes: true,
+						productId: 123,
+					},
+				}
+			);
+			jest.runOnlyPendingTimers();
+			await waitForNextUpdate();
+			result.current.handleChange( [ { ...testAttributes[ 0 ] } ] );
+			expect( onChange ).toHaveBeenCalledWith( [
+				{ ...allAttributes[ 0 ], position: 0 },
+				{ ...allAttributes[ 1 ], position: 1 },
+				{ ...testAttributes[ 0 ], variation: true, position: 2 },
+			] );
+		} );
+
+		it( 'should remove duplicate globals', async () => {
+			const allAttributes = [
+				{ ...testAttributes[ 1 ] },
+				{ ...testAttributes[ 2 ] },
+			];
+			const onChange = jest.fn();
+			const { result, waitForNextUpdate } = renderHook(
+				useProductAttributes,
+				{
+					initialProps: {
+						allAttributes,
+						onChange,
+						isVariationAttributes: true,
+						productId: 123,
+					},
+				}
+			);
+			jest.runOnlyPendingTimers();
+			await waitForNextUpdate();
+			result.current.handleChange( [ { ...testAttributes[ 1 ] } ] );
+			expect( onChange ).toHaveBeenCalledWith( [
+				{ ...allAttributes[ 0 ], position: 0 },
+				{ ...allAttributes[ 1 ], position: 1, variation: true },
+			] );
+		} );
+	} );
+
+	describe( 'is not variation', () => {
+		it( 'should filter out variation attributes', async () => {
+			const allAttributes = [
+				{ ...testAttributes[ 0 ] },
+				{ ...testAttributes[ 1 ], variation: true },
+				{ ...testAttributes[ 2 ] },
+			];
+			const { result, waitForNextUpdate } = renderHook(
+				useProductAttributes,
+				{
+					initialProps: {
+						allAttributes,
+						onChange: jest.fn(),
+						isVariationAttributes: false,
+						productId: 123,
+					},
+				}
+			);
+			jest.runOnlyPendingTimers();
+			await waitForNextUpdate();
+			expect( result.current.attributes.length ).toBe( 2 );
+			// Sets global attributes first.
+			expect( result.current.attributes[ 0 ].name ).toEqual(
+				allAttributes[ 2 ].name
+			);
+			expect( result.current.attributes[ 1 ].name ).toEqual(
+				allAttributes[ 0 ].name
+			);
+		} );
+
+		it( 'should update array if allAttributes update', async () => {
+			const allAttributes = [
+				{ ...testAttributes[ 0 ] },
+				{ ...testAttributes[ 1 ], variation: true },
+				{ ...testAttributes[ 2 ] },
+			];
+			const onChange = jest.fn();
+			const { result, rerender, waitForNextUpdate } = renderHook(
+				useProductAttributes,
+				{
+					initialProps: {
+						allAttributes,
+						onChange,
+						isVariationAttributes: false,
+						productId: 123,
+					},
+				}
+			);
+			jest.runOnlyPendingTimers();
+			await waitForNextUpdate();
+			expect( result.current.attributes.length ).toBe( 2 );
+
+			const filteredAttributes = [
+				allAttributes[ 0 ],
+				allAttributes[ 1 ],
+			];
+
+			rerender( {
+				allAttributes: filteredAttributes,
+				onChange,
+				isVariationAttributes: false,
+				productId: 123,
+			} );
+			jest.runOnlyPendingTimers();
+			await waitForNextUpdate();
+			expect( result.current.attributes.length ).toBe( 1 );
+			expect( result.current.attributes[ 0 ].name ).toEqual(
+				allAttributes[ 0 ].name
+			);
+		} );
+
+		it( 'sets terms for any global attributes and options to empty array', async () => {
+			const allAttributes = [
+				{ ...testAttributes[ 0 ] },
+				{ ...testAttributes[ 1 ] },
+				{ ...testAttributes[ 2 ] },
+			];
+			const onChange = jest.fn();
+			const { result, waitForNextUpdate } = renderHook(
+				useProductAttributes,
+				{
+					initialProps: {
+						allAttributes,
+						onChange,
+						isVariationAttributes: false,
+						productId: 123,
+					},
+				}
+			);
+			jest.runOnlyPendingTimers();
+			await waitForNextUpdate();
+			expect( result.current.attributes.length ).toBe( 3 );
+			expect( result.current.attributes[ 0 ].terms ).toEqual(
+				attributeTerms[ result.current.attributes[ 0 ].id ]
+			);
+			expect( result.current.attributes[ 0 ].options ).toEqual( [] );
+			expect( result.current.attributes[ 1 ].terms ).toEqual(
+				attributeTerms[ result.current.attributes[ 1 ].id ]
+			);
+			expect( result.current.attributes[ 1 ].options ).toEqual( [] );
+		} );
+	} );
+} );

--- a/packages/js/product-editor/src/hooks/test/use-product-attributes.test.ts
+++ b/packages/js/product-editor/src/hooks/test/use-product-attributes.test.ts
@@ -250,8 +250,8 @@ describe( 'useProductAttributes', () => {
 			await waitForNextUpdate();
 			result.current.handleChange( [ { ...testAttributes[ 1 ] } ] );
 			expect( onChange ).toHaveBeenCalledWith( [
-				{ ...allAttributes[ 0 ], position: 0 },
-				{ ...allAttributes[ 1 ], position: 1, variation: true },
+				{ ...allAttributes[ 1 ], position: 0 },
+				{ ...allAttributes[ 0 ], position: 1, variation: true },
 			] );
 		} );
 	} );

--- a/packages/js/product-editor/src/hooks/use-product-attributes.ts
+++ b/packages/js/product-editor/src/hooks/use-product-attributes.ts
@@ -102,6 +102,15 @@ export function useProductAttributes( {
 			) {
 				return false;
 			}
+			// Local attributes we check by name.
+			if (
+				attr.id === 0 &&
+				newAttributes.findIndex(
+					( a ) => a.name.toLowerCase() === attr.name.toLowerCase()
+				) !== -1
+			) {
+				return false;
+			}
 			return true;
 		} );
 		const newAugmentedAttributes = getAugmentedAttributes(

--- a/packages/js/product-editor/src/hooks/use-product-attributes.ts
+++ b/packages/js/product-editor/src/hooks/use-product-attributes.ts
@@ -138,7 +138,6 @@ export function useProductAttributes( {
 	};
 
 	useEffect( () => {
-		console.log( 'useEffect' );
 		const [ localAttributes, globalAttributes ]: ProductAttribute[][] =
 			sift(
 				getFilteredAttributes( allAttributes, isVariationAttributes ),

--- a/packages/js/product-editor/src/hooks/use-product-attributes.ts
+++ b/packages/js/product-editor/src/hooks/use-product-attributes.ts
@@ -90,9 +90,20 @@ export function useProductAttributes( {
 	};
 
 	const handleChange = ( newAttributes: ProductAttribute[] ) => {
-		const otherAttributes = isVariationAttributes
+		let otherAttributes = isVariationAttributes
 			? allAttributes.filter( ( attribute ) => ! attribute.variation )
 			: allAttributes.filter( ( attribute ) => !! attribute.variation );
+
+		// Remove duplicate global attributes.
+		otherAttributes = otherAttributes.filter( ( attr ) => {
+			if (
+				attr.id > 0 &&
+				newAttributes.findIndex( ( a ) => a.id === attr.id ) !== -1
+			) {
+				return false;
+			}
+			return true;
+		} );
 		const newAugmentedAttributes = getAugmentedAttributes(
 			newAttributes,
 			isVariationAttributes,
@@ -102,18 +113,7 @@ export function useProductAttributes( {
 			otherAttributes,
 			! isVariationAttributes,
 			isVariationAttributes ? 0 : newAttributes.length
-		).filter( ( attr ) => {
-			// Remove duplicate global attributes.
-			if (
-				attr.id > 0 &&
-				newAugmentedAttributes.findIndex(
-					( a ) => a.id === attr.id
-				) !== -1
-			) {
-				return false;
-			}
-			return true;
-		} );
+		);
 
 		if ( isVariationAttributes ) {
 			onChange( [

--- a/packages/js/product-editor/src/hooks/use-product-attributes.ts
+++ b/packages/js/product-editor/src/hooks/use-product-attributes.ts
@@ -98,16 +98,16 @@ export function useProductAttributes( {
 		otherAttributes = otherAttributes.filter( ( attr ) => {
 			if (
 				attr.id > 0 &&
-				newAttributes.findIndex( ( a ) => a.id === attr.id ) !== -1
+				newAttributes.some( ( a ) => a.id === attr.id )
 			) {
 				return false;
 			}
 			// Local attributes we check by name.
 			if (
 				attr.id === 0 &&
-				newAttributes.findIndex(
+				newAttributes.some(
 					( a ) => a.name.toLowerCase() === attr.name.toLowerCase()
-				) !== -1
+				)
 			) {
 				return false;
 			}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This adds the new attributes modal to the variations blocks empty state, to allow attributes to be added.

Closes #38884  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Load this branch and enable the new product editor under **WooCommerce > Settings > Advanced > Features**
2. Install the WooCommerce Beta tester plugin and enable the `product-variation-management` feature under **Tools > WCA Test Helper > Features**
3. Go to **Products > Add New**
4. It should load the new product editor and a **Variations** tab should be present.
5. Go to **Variations** tab and click **Add variation options**
6. A modal should show to add new variation options ( attributes )
7. Add a couple attributes and save the product
8. Refresh the page, the variation options should still be shown on the Variations tab
9. Go to the Organization tab and notice the variations options aren't showing up there.
10. Now make sure you have some global attributes and add the same global attribute to the attributes within the Organization tab.
11. Go back to the Variations tab, the global option should not be present anymore that was selected in Attributes (note: I only did this for global attributes, as local attributes don't have id's, and comparing by name seemed weird )

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
