### PR TITLE
Bulk actions: within URL, specify orders using `id[]` rather than `order[]`

### DIFF
--- a/plugins/woocommerce/changelog/fix-35130-bulk-action-order-id-keys
+++ b/plugins/woocommerce/changelog/fix-35130-bulk-action-order-id-keys
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Safety measures to prevent future breakages when executing bulk actions in the order list table (HPOS).

--- a/plugins/woocommerce/src/Internal/Admin/Orders/COTRedirectionController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/COTRedirectionController.php
@@ -58,10 +58,10 @@ class COTRedirectionController {
 				$params['_wpnonce']         = wp_create_nonce( 'bulk-posts' );
 			}
 
-			// If an `order` array parameter is present, rename as `post`.
-			if ( isset( $params['order'] ) && is_array( $params['order'] ) ) {
-				$params['post'] = $params['order'];
-				unset( $params['order'] );
+			// If an `id` array parameter is present, rename as `post`
+			if ( isset( $params['id'] ) && is_array( $params['id'] ) ) {
+				$params['post'] = $params['id'];
+				unset( $params['id'] );
 			}
 
 			$params['post_type'] = 'shop_order';

--- a/plugins/woocommerce/src/Internal/Admin/Orders/COTRedirectionController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/COTRedirectionController.php
@@ -58,7 +58,7 @@ class COTRedirectionController {
 				$params['_wpnonce']         = wp_create_nonce( 'bulk-posts' );
 			}
 
-			// If an `id` array parameter is present, rename as `post`
+			// If an `id` array parameter is present, rename as `post`.
 			if ( isset( $params['id'] ) && is_array( $params['id'] ) ) {
 				$params['post'] = $params['id'];
 				unset( $params['id'] );

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -867,7 +867,7 @@ class ListTable extends WP_List_Table {
 	public function column_cb( $item ) {
 		ob_start();
 		?>
-		<input id="cb-select-<?php echo esc_attr( $item->get_id() ); ?>" type="checkbox" name="<?php echo esc_attr( $this->_args['singular'] ); ?>[]" value="<?php echo esc_attr( $item->get_id() ); ?>" />
+		<input id="cb-select-<?php echo esc_attr( $item->get_id() ); ?>" type="checkbox" name="id[]" value="<?php echo esc_attr( $item->get_id() ); ?>" />
 
 		<div class="locked-indicator">
 			<span class="locked-indicator-icon" aria-hidden="true"></span>
@@ -1197,7 +1197,7 @@ class ListTable extends WP_List_Table {
 
 			$action = 'delete';
 		} else {
-			$ids = isset( $_REQUEST['order'] ) ? array_reverse( array_map( 'absint', (array) $_REQUEST['order'] ) ) : array();
+			$ids = isset( $_REQUEST['id'] ) ? array_reverse( array_map( 'absint', (array) $_REQUEST['id'] ) ) : array();
 		}
 
 		/**

--- a/plugins/woocommerce/src/Internal/Admin/Orders/PostsRedirectionController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/PostsRedirectionController.php
@@ -84,7 +84,7 @@ class PostsRedirectionController {
 			$new_url = add_query_arg(
 				array(
 					'action'           => $action,
-					'order'            => $posts,
+					'id'               => $posts,
 					'_wp_http_referer' => $this->page_controller->get_orders_url(),
 					'_wpnonce'         => wp_create_nonce( 'bulk-orders' ),
 				),

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/COTRedirectionControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Orders/COTRedirectionControllerTest.php
@@ -139,7 +139,7 @@ class COTRedirectionControllerTest extends WC_Unit_Test_Case {
 		$this->sut->handle_hpos_admin_requests(
 			array(
 				'arbitrary' => '3pd-integration',
-				'order'     => array(
+				'id'        => array(
 					123,
 					456,
 				),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In the admin list table for orders (when HPOS is enabled), selecting one or more orders and applying a bulk action results in a URL looking something like:

```
local.wp/wp-admin/admin.php?page=wc-orders&action=mark_completed&order[]=100&order[]=101
```

To be clear, the above is temporary (it is immediately followed by a redirect, so to observe it you would need to use your browser's dev tools or similar).

The issue we are addressing here is that the use of `order[]` (to list order IDs) *potentially* conflicts with `order` (used to specify the sort direction). This does not result in a live problem at present, so this PR is really just an attempt to head off potential trouble in the future—and works by switching from `order[]` to `id[]`:

```
local.wp/wp-admin/admin.php?page=wc-orders&action=mark_completed&id[]=100&id[]=101
```

Closes #35130.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Follow the usual steps to enable HPOS via **WooCommerce ▸ Settings ▸ Advanced ▸ Features**.
2. Navigate to **WooCommerce ▸ Orders**.
3. Test that you can successfully select multiple orders and apply a bulk action (such as 'mark completed').
4. This should essentially work just as it did before this change.

Second set of steps, confirming CPT <-> HPOS admin redirects work as before:

1. Set the post table store to be authoritative (also done via the **WooCommerce ▸ Settings ▸ Advanced ▸ Features** screen). Please also enable sync (compatibility mode).
2. Visit the list of orders (ensure the URL contains `post_type=shop_order`) and select multiple orders, and a bulk action ... but **do not click on Apply just yet!**
3. In a new tab, return to the same admin screen as in step 1, and set HPOS as the authoritative store. Save.
4. In the previous tab (the list of orders) click on **Apply**.
5. The bulk action should be successfully applied, and when the screen reloads you should find you are in the HPOS version of the admin list table (to verify this, look for `page=wc-orders` in the URL).

Third set of steps, basically the reverse of the above:

1. Set the HPOS table store to be authoritative (also done via the **WooCommerce ▸ Settings ▸ Advanced ▸ Features** screen). Again, ensure sync (compatibility mode) is enabled.
2. Visit the list of orders (ensure the URL contains `page=wc-orders`) and select multiple orders, and a bulk action ... but **do not click on Apply just yet!**
3. In a new tab, return to the same admin screen as in step 1, and set posts as the authoritative store. Save.
4. In the previous tab (the list of orders) click on **Apply**.
5. The bulk action should be successfully applied, and when the screen reloads you should find you are in the HPOS version of the admin list table (to verify this, look for `post_type=shop_order` in the URL).

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Safety measures to prevent future breakages when executing bulk actions in the order list table (HPOS).

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
