### PR TITLE
HPOS Features: Revert to one feature

### DIFF
--- a/plugins/woocommerce/changelog/try-feature-sub-settings
+++ b/plugins/woocommerce/changelog/try-feature-sub-settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Ensure that declaring compatibility with HPOS works.

--- a/plugins/woocommerce/changelog/try-feature-sub-settings
+++ b/plugins/woocommerce/changelog/try-feature-sub-settings
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Ensure that declaring compatibility with HPOS works.
+Consolidate HPOS back into a single feature for the purposes of showing it on the Features settings screen.

--- a/plugins/woocommerce/changelog/try-feature-sub-settings
+++ b/plugins/woocommerce/changelog/try-feature-sub-settings
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Consolidate HPOS back into a single feature for the purposes of showing it on the Features settings screen.
+Consolidate HPOS back into a single "feature" for the purposes of showing it on the Features settings screen.

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -489,10 +489,17 @@ class WC_Install {
 
 		$schema = self::get_schema();
 
-		if (
-			get_option( DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION )
-			|| get_option( CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION )
-		) {
+		$hpos_settings = filter_var_array(
+			array(
+				'cot'       => get_option( CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION ),
+				'data_sync' => get_option( DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION ),
+			),
+			array(
+				'cot'       => FILTER_VALIDATE_BOOL,
+				'data_sync' => FILTER_VALIDATE_BOOL,
+			)
+		);
+		if ( in_array( true, $hpos_settings, true ) ) {
 			$schema .= wc_get_container()
 				->get( OrdersTableDataStore::class )
 				->get_database_schema();

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -8,9 +8,7 @@
 
 use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Admin\Notes\Notes;
-use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
-use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer;
-use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
+use Automattic\WooCommerce\Internal\DataStores\Orders\{ CustomOrdersTableController, DataSynchronizer, OrdersTableDataStore };
 use Automattic\WooCommerce\Internal\Features\FeaturesController;
 use Automattic\WooCommerce\Internal\ProductAttributesLookup\DataRegenerator;
 use Automattic\WooCommerce\Internal\ProductDownloads\ApprovedDirectories\Register as Download_Directories;
@@ -491,10 +489,9 @@ class WC_Install {
 
 		$schema = self::get_schema();
 
-		$feature_controller = wc_get_container()->get( FeaturesController::class );
 		if (
-			$feature_controller->feature_is_enabled( DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION )
-			|| $feature_controller->feature_is_enabled( CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION )
+			get_option( DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION )
+			|| get_option( CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION )
 		) {
 			$schema .= wc_get_container()
 				->get( OrdersTableDataStore::class )

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -495,8 +495,8 @@ class WC_Install {
 				'data_sync' => get_option( DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION ),
 			),
 			array(
-				'cot'       => FILTER_VALIDATE_BOOL,
-				'data_sync' => FILTER_VALIDATE_BOOL,
+				'cot'       => FILTER_VALIDATE_BOOLEAN,
+				'data_sync' => FILTER_VALIDATE_BOOLEAN,
 			)
 		);
 		if ( in_array( true, $hpos_settings, true ) ) {

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -121,7 +121,7 @@ class CustomOrdersTableController {
 		self::add_action( 'woocommerce_after_register_post_type', array( $this, 'register_post_type_for_order_placeholders' ), 10, 0 );
 		self::add_action( 'woocommerce_sections_advanced', array( $this, 'sync_now' ) );
 		self::add_filter( 'removable_query_args', array( $this, 'register_removable_query_arg' ) );
-		self::add_filter( 'woocommerce_feature_definitions', array( $this, 'add_feature_definition' ) );
+		self::add_action( 'woocommerce_register_feature_definitions', array( $this, 'add_feature_definition' ) );
 	}
 
 	/**
@@ -383,22 +383,27 @@ class CustomOrdersTableController {
 	/**
 	 * Add the definition for the HPOS feature.
 	 *
-	 * @param array $feature_definitions The array of feature definitions to add to.
+	 * @param FeaturesController $features_controller The instance of FeaturesController.
 	 *
 	 * @return array
 	 */
-	private function add_feature_definition( $feature_definitions ) {
-		$feature_definitions['custom_order_tables'] = array(
-			'name'                => __( 'High-Performance order storage', 'woocommerce' ),
+	private function add_feature_definition( $features_controller ) {
+		$definition = array(
 			'option_key'          => self::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION,
+			'is_experimental'     => false,
 			'enabled_by_default'  => false,
+			'order'               => 50,
 			'setting'             => $this->get_hpos_setting_for_feature(),
 			'additional_settings' => array(
 				$this->get_hpos_setting_for_sync(),
 			),
 		);
 
-		return $feature_definitions;
+		$features_controller->add_feature_definition(
+			'custom_order_tables',
+			__( 'High-Performance order storage', 'woocommerce' ),
+			$definition
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -391,7 +391,6 @@ class CustomOrdersTableController {
 		$feature_definitions['custom_order_tables'] = array(
 			'name'                => __( 'High-Performance order storage', 'woocommerce' ),
 			'option_key'          => self::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION,
-			'is_experimental'     => true,
 			'enabled_by_default'  => false,
 			'setting'             => $this->get_hpos_setting_for_feature(),
 			'additional_settings' => array(

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -273,8 +273,11 @@ class CustomOrdersTableController {
 	 * @param mixed  $value New value of the setting.
 	 */
 	private function process_updated_option( $option, $old_value, $value ) {
-		if ( DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION === $option && 'no' === $value ) {
-			$this->data_synchronizer->cleanup_synchronization_state();
+		if ( DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION === $option ) {
+			$this->handle_data_sync_option_changed();
+			if ( 'no' === $value ) {
+				$this->data_synchronizer->cleanup_synchronization_state();
+			}
 		}
 	}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -272,11 +272,8 @@ class CustomOrdersTableController {
 	 * @param mixed  $value New value of the setting.
 	 */
 	private function process_updated_option( $option, $old_value, $value ) {
-		if ( DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION === $option && $value !== $old_value ) {
-			$this->handle_data_sync_option_changed();
-			if ( 'no' === $value ) {
-				$this->data_synchronizer->cleanup_synchronization_state();
-			}
+		if ( DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION === $option && 'no' === $value ) {
+			$this->data_synchronizer->cleanup_synchronization_state();
 		}
 	}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -386,7 +386,7 @@ class CustomOrdersTableController {
 	 * @return array Feature setting object.
 	 */
 	public function get_hpos_setting_for_feature() {
-		if ( ! did_action( 'woocommerce_init' ) ) {
+		if ( 'yes' === get_transient( 'wc_installing' ) ) {
 			return array();
 		}
 		$sync_status             = $this->data_synchronizer->get_sync_status();
@@ -425,7 +425,7 @@ class CustomOrdersTableController {
 	 * @return array Feature setting object.
 	 */
 	public function get_hpos_setting_for_sync() {
-		if ( ! did_action( 'woocommerce_init' ) ) {
+		if ( 'yes' === get_transient( 'wc_installing' ) ) {
 			return array();
 		}
 		$sync_status      = $this->data_synchronizer->get_sync_status();

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -120,7 +120,6 @@ class CustomOrdersTableController {
 		self::add_filter( 'updated_option', array( $this, 'process_updated_option' ), 999, 3 );
 		self::add_filter( 'pre_update_option', array( $this, 'process_pre_update_option' ), 999, 3 );
 		self::add_action( 'woocommerce_after_register_post_type', array( $this, 'register_post_type_for_order_placeholders' ), 10, 0 );
-		self::add_action( FeaturesController::FEATURE_ENABLED_CHANGED_ACTION, array( $this, 'handle_feature_enabled_changed' ), 10, 2 );
 		self::add_action( 'woocommerce_sections_advanced', array( $this, 'sync_now' ) );
 		self::add_filter( 'removable_query_args', array( $this, 'register_removable_query_arg' ) );
 	}
@@ -297,12 +296,19 @@ class CustomOrdersTableController {
 			return $value;
 		}
 
-		if ( self::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION !== $option || $value === $old_value || false === $old_value ) {
+		if ( self::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION !== $option || 'no' === $value ) {
 			return $value;
 		}
 
 		$this->order_cache->flush();
+		if ( ! $this->data_synchronizer->check_orders_table_exists() ) {
+			$this->data_synchronizer->create_database_tables();
+		}
 
+		$tables_created = get_option( DataSynchronizer::ORDERS_TABLE_CREATED ) === 'yes';
+		if ( ! $tables_created ) {
+			return 'no';
+		}
 		/**
 		 * Re-enable the following code once the COT to posts table sync is implemented (it's currently commented out to ease testing).
 		$sync_is_pending = 0 !== $this->data_synchronizer->get_current_orders_pending_sync_count();
@@ -344,26 +350,6 @@ class CustomOrdersTableController {
 	}
 
 	/**
-	 * Handle the 'woocommerce_feature_enabled_changed' action,
-	 * if the custom orders table feature is enabled create the database tables if they don't exist.
-	 *
-	 * @param string $feature_id The id of the feature that is being enabled or disabled.
-	 * @param bool   $is_enabled True if the feature is being enabled, false if it's being disabled.
-	 */
-	private function handle_feature_enabled_changed( $feature_id, $is_enabled ): void {
-		if ( self::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION !== $feature_id || ! $is_enabled ) {
-			return;
-		}
-
-		if ( ! $this->data_synchronizer->check_orders_table_exists() ) {
-			$success = $this->data_synchronizer->create_database_tables();
-			if ( ! $success ) {
-				update_option( self::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, 'no' );
-			}
-		}
-	}
-
-	/**
 	 * Handler for the woocommerce_after_register_post_type post,
 	 * registers the post type for placeholder orders.
 	 *
@@ -400,10 +386,9 @@ class CustomOrdersTableController {
 	 * @return array Feature setting object.
 	 */
 	public function get_hpos_setting_for_feature() {
-		if ( Constants::get_constant( 'WC_INSTALLING' ) ) {
+		if ( ! did_action( 'woocommerce_init' ) ) {
 			return array();
 		}
-
 		$sync_status             = $this->data_synchronizer->get_sync_status();
 		$hpos_enabled            = $this->custom_orders_table_usage_is_enabled();
 		$plugin_info             = $this->features_controller->get_compatible_plugins_for_feature( 'custom_order_tables', true );
@@ -440,10 +425,9 @@ class CustomOrdersTableController {
 	 * @return array Feature setting object.
 	 */
 	public function get_hpos_setting_for_sync() {
-		if ( Constants::get_constant( 'WC_INSTALLING' ) ) {
+		if ( ! did_action( 'woocommerce_init' ) ) {
 			return array();
 		}
-
 		$sync_status      = $this->data_synchronizer->get_sync_status();
 		$sync_in_progress = $this->batch_processing_controller->is_enqueued( get_class( $this->data_synchronizer ) );
 		$sync_enabled     = $this->data_synchronizer->data_sync_is_enabled();

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -272,7 +272,7 @@ class CustomOrdersTableController {
 	 * @param mixed  $value New value of the setting.
 	 */
 	private function process_updated_option( $option, $old_value, $value ) {
-		if ( DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION === $option ) {
+		if ( DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION === $option && $value !== $old_value ) {
 			$this->handle_data_sync_option_changed();
 			if ( 'no' === $value ) {
 				$this->data_synchronizer->cleanup_synchronization_state();

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -390,6 +390,7 @@ class CustomOrdersTableController {
 	private function add_feature_definition( $feature_definitions ) {
 		$feature_definitions['custom_order_tables'] = array(
 			'name'                => __( 'High-Performance order storage', 'woocommerce' ),
+			'option_key'          => self::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION,
 			'is_experimental'     => true,
 			'enabled_by_default'  => false,
 			'setting'             => $this->get_hpos_setting_for_feature(),

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -382,7 +382,7 @@ class CustomOrdersTableController {
 	 *
 	 * @param FeaturesController $features_controller The instance of FeaturesController.
 	 *
-	 * @return array
+	 * @return void
 	 */
 	private function add_feature_definition( $features_controller ) {
 		$definition = array(
@@ -498,10 +498,12 @@ class CustomOrdersTableController {
 					wc_get_container()->get( FeaturesController::class )->get_features_page_url()
 				);
 
-				$sync_message[] = wp_kses_data( __(
-					'You can switch order data storage <strong>only when the posts and orders tables are in sync</strong>.',
-					'woocommerce'
-				) );
+				$sync_message[] = wp_kses_data(
+					__(
+						'You can switch order data storage <strong>only when the posts and orders tables are in sync</strong>.',
+						'woocommerce'
+					)
+				);
 
 				$sync_message[] = sprintf(
 					'<a href="%1$s" class="button button-link">%2$s</a>',
@@ -523,12 +525,12 @@ class CustomOrdersTableController {
 		};
 
 		return array(
-			'id'       => DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION,
-			'title'    => '',
-			'type'     => 'checkbox',
-			'desc'     => __( 'Enable compatibility mode (synchronizes orders to the posts table).', 'woocommerce' ),
-			'value'    => $get_value,
-			'desc_tip' => $get_sync_message,
+			'id'        => DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION,
+			'title'     => '',
+			'type'      => 'checkbox',
+			'desc'      => __( 'Enable compatibility mode (synchronizes orders to the posts table).', 'woocommerce' ),
+			'value'     => $get_value,
+			'desc_tip'  => $get_sync_message,
 			'row_class' => DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION,
 		);
 	}

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -89,7 +89,7 @@ class FeaturesController {
 	 * Creates a new instance of the class.
 	 */
 	public function __construct() {
-		$features           = array(
+		$features = array(
 			'analytics'            => array(
 				'name'               => __( 'Analytics', 'woocommerce' ),
 				'description'        => __( 'Enable WooCommerce Analytics', 'woocommerce' ),
@@ -745,6 +745,7 @@ class FeaturesController {
 			'tooltip'  => $tooltip,
 			'default'  => $this->feature_is_enabled_by_default( $feature_id ) ? 'yes' : 'no',
 		);
+
 		$feature_setting = wp_parse_args( $setting_definition, $feature_setting_defaults );
 
 		/**

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -8,7 +8,7 @@ namespace Automattic\WooCommerce\Internal\Features;
 use Automattic\WooCommerce\Internal\Admin\Analytics;
 use Automattic\WooCommerce\Admin\Features\Navigation\Init;
 use Automattic\WooCommerce\Admin\Features\NewProductManagementExperience;
-use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
+use Automattic\WooCommerce\Internal\DataStores\Orders\{ CustomOrdersTableController, DataSynchronizer };
 use Automattic\WooCommerce\Internal\Traits\AccessiblePrivateMethods;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
 use Automattic\WooCommerce\Utilities\ArrayUtil;
@@ -136,9 +136,6 @@ class FeaturesController {
 			'new_navigation',
 			'product_block_editor',
 			'marketplace',
-			// Compatibility for COT is determined by `custom_order_tables'.
-			CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION,
-			DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION,
 		);
 
 		$this->init_features( $features );
@@ -780,7 +777,6 @@ class FeaturesController {
 
 			$incompatibles = $this->compatibility_info_by_feature[ $feature ]['incompatible'];
 			$this->compatibility_info_by_feature[ $feature ]['incompatible'] = array_diff( $incompatibles, array( $plugin_name ) );
-
 		}
 	}
 

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -162,6 +162,8 @@ class FeaturesController {
 			/**
 			 * Filter the definitions of the features listed on the Features Settings screen.
 			 *
+			 * @since 8.1.0
+			 *
 			 * @param array $features The feature definitions.
 			 */
 			$this->features = apply_filters( 'woocommerce_feature_definitions', $features );

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -143,7 +143,7 @@ class FeaturesController {
 			'name'               => $name,
 			'order'              => 10,
 		);
-		$args = wp_parse_args( $args, $defaults );
+		$args     = wp_parse_args( $args, $defaults );
 
 		$this->features[ $slug ] = $args;
 	}

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -176,7 +176,6 @@ class FeaturesController {
 				'product_block_editor' => array(
 					'name'            => __( 'New product editor', 'woocommerce' ),
 					'description'     => __( 'Try the new product editor (Beta)', 'woocommerce' ),
-					'option_key'      => NewProductManagementExperience::TOGGLE_OPTION_NAME,
 					'is_experimental' => true,
 					'disable_ui'      => false,
 					'is_legacy'       => true,

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
@@ -572,13 +572,26 @@ class DataSynchronizerTests extends HposTestCase {
 		$this->disable_cot_sync();
 		OrderHelper::create_order();
 
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- This is a test.
-		$cot_setting = apply_filters( 'woocommerce_feature_setting', array(), CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION );
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- test code.
+		$features = apply_filters( 'woocommerce_get_settings_advanced', array(), 'features' );
+
+		$cot_setting = array_filter(
+			$features,
+			function( $feature ) {
+				return CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION === $feature['id'];
+			}
+		);
+		$cot_setting = array_values( $cot_setting )[0];
 		$this->assertEquals( $cot_setting['value'], 'no' );
 		$this->assertEquals( $cot_setting['disabled'], array( 'yes', 'no' ) );
 
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- This is a test.
-		$sync_setting = apply_filters( 'woocommerce_feature_setting', array(), $this->sut::ORDERS_DATA_SYNC_ENABLED_OPTION );
+		$sync_setting = array_filter(
+			$features,
+			function( $feature ) {
+				return DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION === $feature['id'];
+			}
+		);
+		$sync_setting = array_values( $sync_setting )[0];
 		$this->assertEquals( $sync_setting['value'], 'no' );
 		$this->assertTrue( str_contains( $sync_setting['desc_tip'], 'Sync 1 pending order' ) );
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/Features/FeaturesControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Features/FeaturesControllerTest.php
@@ -60,9 +60,12 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 
 		$this->set_up_plugins();
 
-		add_filter( 'woocommerce_feature_definitions', function() use ( $features ) {
-			return $features;
-		} );
+		add_filter(
+			'woocommerce_feature_definitions',
+			function() use ( $features ) {
+				return $features;
+			}
+		);
 
 		$this->sut = new FeaturesController();
 		$this->sut->init( wc_get_container()->get( LegacyProxy::class ), $this->fake_plugin_util );
@@ -826,7 +829,7 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 			'woocommerce_feature_definitions',
 			function() {
 				return array(
-					'custom_order_tables' => array(
+					'custom_order_tables'  => array(
 						'name'               => __( 'High-Performance order storage', 'woocommerce' ),
 						'is_experimental'    => true,
 						'enabled_by_default' => false,
@@ -903,7 +906,7 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 			'woocommerce_feature_definitions',
 			function() {
 				return array(
-					'custom_order_tables' => array(
+					'custom_order_tables'  => array(
 						'name'               => __( 'High-Performance order storage', 'woocommerce' ),
 						'is_experimental'    => true,
 						'enabled_by_default' => false,

--- a/plugins/woocommerce/tests/php/src/Internal/Features/FeaturesControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Features/FeaturesControllerTest.php
@@ -816,16 +816,17 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 			$local_sut->declare_compatibility( 'custom_order_tables', $plugin );
 			$local_sut->declare_compatibility( 'cart_checkout_blocks', $plugin );
 		}
+
 		$cot_controller   = new CustomOrdersTableController();
 		$cot_setting_call = function () use ( $fake_plugin_util, $local_sut ) {
 			$this->plugin_util         = $fake_plugin_util;
 			$this->features_controller = $local_sut;
 			$this->data_synchronizer   = wc_get_container()->get( DataSynchronizer::class );
-			return $this->get_hpos_feature_setting( array(), CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION );
+			return $this->get_hpos_setting_for_feature();
 		};
 		$cot_setting      = $cot_setting_call->call( $cot_controller );
-
 		$this->assertEquals( $cot_setting['disabled'], array() );
+
 		$incompatible_plugins = function () use ( $plugins ) {
 			return $this->get_incompatible_plugins( 'all', array_flip( $plugins ) );
 		};
@@ -875,11 +876,11 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 			$this->plugin_util         = $fake_plugin_util;
 			$this->features_controller = $local_sut;
 			$this->data_synchronizer   = wc_get_container()->get( DataSynchronizer::class );
-			return $this->get_hpos_feature_setting( array(), CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION );
+			return $this->get_hpos_setting_for_feature();
 		};
 		$cot_setting      = $cot_setting_call->call( $cot_controller );
-
 		$this->assertEquals( $cot_setting['disabled'], array( 'yes' ) );
+
 		$incompatible_plugins = function () use ( $plugins ) {
 			return $this->get_incompatible_plugins( 'all', array_flip( $plugins ) );
 		};

--- a/plugins/woocommerce/tests/php/src/Internal/Features/FeaturesControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Features/FeaturesControllerTest.php
@@ -856,10 +856,12 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 			$this->plugin_util         = $fake_plugin_util;
 			$this->features_controller = $local_sut;
 			$this->data_synchronizer   = wc_get_container()->get( DataSynchronizer::class );
+
 			return $this->get_hpos_setting_for_feature();
 		};
 		$cot_setting      = $cot_setting_call->call( $cot_controller );
-		$this->assertEquals( $cot_setting['disabled'], array() );
+		$actual           = call_user_func( $cot_setting['disabled'] );
+		$this->assertEquals( array(), $actual );
 
 		$incompatible_plugins = function () use ( $plugins ) {
 			return $this->get_incompatible_plugins( 'all', array_flip( $plugins ) );
@@ -930,10 +932,12 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 			$this->plugin_util         = $fake_plugin_util;
 			$this->features_controller = $local_sut;
 			$this->data_synchronizer   = wc_get_container()->get( DataSynchronizer::class );
+
 			return $this->get_hpos_setting_for_feature();
 		};
 		$cot_setting      = $cot_setting_call->call( $cot_controller );
-		$this->assertEquals( $cot_setting['disabled'], array( 'yes' ) );
+		$actual           = call_user_func( $cot_setting['disabled'] );
+		$this->assertEquals( array( 'yes' ), $actual );
 
 		$incompatible_plugins = function () use ( $plugins ) {
 			return $this->get_incompatible_plugins( 'all', array_flip( $plugins ) );

--- a/plugins/woocommerce/tests/php/src/Internal/Features/FeaturesControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Features/FeaturesControllerTest.php
@@ -125,6 +125,8 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 	/**
 	 * Resets the array of registered features so we can populate it with test features.
 	 *
+	 * @param FeaturesController $sut The instance of the FeaturesController class.
+	 *
 	 * @return void
 	 */
 	private function reset_features_list( $sut ) {


### PR DESCRIPTION
In #38993, the `custom_order_tables` feature was split into two separate features, one for choosing which tables to use, and one for toggling data synchronization. My understanding is that this was done in order to have both of those settings appear on the Features settings page, instead of having to create a separate page for other HPOS-specific settings. However, this added some extra complexity, which then led to #39250 causing a regression where extensions that declared compatibility with HPOS were no longer recognized as compatible.

### Changes proposed in this Pull Request:

With this PR, we're reverting back to only having one "feature" for HPOS, but introducing a way to add additional setting controls to the Features settings page. This also does some refactoring of the FeaturesController class to make it more "functional", so that logic for specific features can live closer to those features in the codebase, without having to add a bunch of feature-specific code to the class.

### How to test the changes in this Pull Request:

**Test the feature management for HPOS:**

1. In WP Admin on your test site, go to WooCommerce > Settings > Advanced > Features.
2. "Data storage for orders" should appear under "Experimental features".
3. Try switching between "WordPress post tables" and "High performance order storage" for the setting, and saving. After refreshing the screen, the value of the setting should be retained.
4. The same applies to checking/unchecking the box for "Keep the posts and orders tables in sync".
5. With HPOS activated and syncing turned **off**, create an order. Back on the Features screen the "Data storage" radio buttons should be disabled and there should be a message beneath the data syncing checkbox saying the orders must be synced before the tables can be switched.
6. Sync the orders. Back on the Features screen the settings should be changeable again.

**Test the general functionality of the Features controller:**

1. Try enabling and disabling other features on the Features screen.
2. Add this snippet to your site:
    ```php
	add_action(
		'woocommerce_feature_enabled_changed',
		function() {
			wp_die( 'Hook reached!' );
		}
	);
    ```
3. Now try enabling or disabling a feature. You should see a "Hook reached!" message, indicating that the `woocommerce_feature_enabled_changed` action is successfully firing after a feature status is changed.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Consolidate HPOS back into a single "feature" for the purposes of showing it on the Features settings screen.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
