### PR TITLE
add `?ts=` query param to `/wp-json/helper/1.0/ssr/` wccom request

### DIFF
--- a/plugins/woocommerce/changelog/update-17568-add-ts-query-string-to-wccom-ssr-endpoint
+++ b/plugins/woocommerce/changelog/update-17568-add-ts-query-string-to-wccom-ssr-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Add query parameter ts in SSR submission request to bypass the cache

--- a/plugins/woocommerce/includes/wccom-site/rest-api/endpoints/class-wc-rest-wccom-site-ssr-controller.php
+++ b/plugins/woocommerce/includes/wccom-site/rest-api/endpoints/class-wc-rest-wccom-site-ssr-controller.php
@@ -112,6 +112,7 @@ class WC_REST_WCCOM_Site_SSR_Controller extends WC_REST_Controller {
 			array(
 				'body'          => wp_json_encode( array( 'data' => $data ) ),
 				'authenticated' => true,
+				'query_string'  => esc_url( '?ts=' . time() ),
 			)
 		);
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
While investigating an issue with SSR not being updated on our side, even when the remote store responds that it was updated, we found that the remote site doesn't request WCCOM; we believe this is due to the remote site server caching a previous request to WCCOM. With this PR we're attempting to invalidate the cache by adding a timestamp to the request.

Related to https://github.com/Automattic/woocommerce.com/issues/17591 .


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. In the test site connected to WCCOM, update `/wp-content/plugins/woocommerce/includes/wccom-site/rest-api/endpoints/class-wc-rest-wccom-site-ssr-controller.php:115` and manually add:
```php
'query_string'  => esc_url( '?ts=' . time() ),
```

3. Follow test instructions from https://github.com/Automattic/woocommerce.com/pull/17269
4. Confirm request contains the `ts` and that the request still works as expected and there are no regressions

<img width="660" alt="Screenshot 2023-08-01 at 20 48 44" src="https://github.com/woocommerce/woocommerce/assets/532402/0f3658b5-1a7b-42a2-ab13-9e7cc81f3d29">
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Add query parameter ts in SSR submission request to bypass the cache

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
