### PR TITLE
Add sync and usage flags to legacy features.

### DIFF
--- a/plugins/woocommerce/changelog/fix-incompat-warning
+++ b/plugins/woocommerce/changelog/fix-incompat-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add derivative features to legacy list so that warning is not generated for them.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -441,7 +441,7 @@ class CustomOrdersTableController {
 			return $feature_setting;
 		}
 
-		if ( Constants::get_constant( 'WC_INSTALLING', false ) ) {
+		if ( 'yes' === get_transient( 'wc_installing' ) ) {
 			return $feature_setting;
 		}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -125,7 +125,11 @@ class DataSynchronizer implements BatchProcessorInterface {
 	public function check_orders_table_exists(): bool {
 		$missing_tables = $this->database_util->get_missing_tables( $this->data_store->get_database_schema() );
 
-		return count( $missing_tables ) === 0;
+		if ( count( $missing_tables ) === 0 ) {
+			update_option( self::ORDERS_TABLE_CREATED, 'yes') ;
+			return true;
+		}
+		return false;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -126,7 +126,7 @@ class DataSynchronizer implements BatchProcessorInterface {
 		$missing_tables = $this->database_util->get_missing_tables( $this->data_store->get_database_schema() );
 
 		if ( count( $missing_tables ) === 0 ) {
-			update_option( self::ORDERS_TABLE_CREATED, 'yes') ;
+			update_option( self::ORDERS_TABLE_CREATED, 'yes' );
 			return true;
 		}
 		return false;

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -132,7 +132,14 @@ class FeaturesController {
 			),
 		);
 
-		$this->legacy_feature_ids = array( 'analytics', 'new_navigation', 'product_block_editor' );
+		$this->legacy_feature_ids = array(
+			'analytics',
+			'new_navigation',
+			'product_block_editor',
+			// Compatibility for COT is determined by `custom_order_tables'.
+			CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION,
+			DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION,
+		);
 
 		$this->init_features( $features );
 

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -784,6 +784,18 @@ class FeaturesController {
 			return $list;
 		}
 
+		return $this->get_incompatible_plugins( $feature_id, $list );
+	}
+
+	/**
+	 * Returns the list of plugins incompatible with a given feature.
+	 *
+	 * @param string $feature_id ID of the feature. Can also be `all` to denote all features.
+	 * @param array  $list       List of plugins to filter.
+	 *
+	 * @return array List of plugins incompatible with the given feature.
+	 */
+	private function get_incompatible_plugins( $feature_id, $list ) {
 		$incompatibles = array();
 
 		// phpcs:enable WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Helpers/OrderHelper.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Helpers/OrderHelper.php
@@ -157,7 +157,6 @@ class OrderHelper {
 	 * @return void
 	 */
 	public static function toggle_cot_feature_and_usage( bool $enabled ) {
-		global $wpdb;
 		$features_controller = wc_get_container()->get( Featurescontroller::class );
 		$features_controller->change_feature_enable( 'custom_order_tables', $enabled );
 

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
@@ -1,9 +1,9 @@
 <?php
 
+use Automattic\WooCommerce\Internal\BatchProcessing\BatchProcessingController;
 use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
 use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer;
 use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
-use Automattic\WooCommerce\Internal\Features\FeaturesController;
 use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
 use Automattic\WooCommerce\RestApi\UnitTests\HPOSToggleTrait;
 use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
@@ -532,4 +532,52 @@ class DataSynchronizerTests extends HposTestCase {
 		$this->assertNotContains( $order1->get_id(), $orders );
 	}
 
+	/**
+	 * @testDox When HPOS is enabled, the custom orders table is created.
+	 */
+	public function test_tables_are_created_when_hpos_enabled() {
+		update_option( $this->sut::ORDERS_DATA_SYNC_ENABLED_OPTION, 'no' );
+		update_option( CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, 'no' );
+		$this->sut->delete_database_tables();
+		$this->assertFalse( $this->sut->check_orders_table_exists() );
+
+		update_option( CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, 'yes' );
+		$this->assertTrue( $this->sut->check_orders_table_exists() );
+		$this->assertEquals( get_option( DataSynchronizer::ORDERS_TABLE_CREATED ), 'yes' );
+	}
+
+	/**
+	 * @testDox When sync is enabled, the custom orders table is created.
+	 */
+	public function test_tables_are_created_when_sync_is_enabled() {
+		update_option( $this->sut::ORDERS_DATA_SYNC_ENABLED_OPTION, 'no' );
+		update_option( CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, 'no' );
+		$this->sut->delete_database_tables();
+		$this->assertFalse( $this->sut->check_orders_table_exists() );
+
+		update_option( $this->sut::ORDERS_DATA_SYNC_ENABLED_OPTION, 'yes' );
+		$this->assertTrue( $this->sut->check_orders_table_exists() );
+		$this->assertEquals( get_option( DataSynchronizer::ORDERS_TABLE_CREATED ), 'yes' );
+		$this->assertTrue( wc_get_container()->get( BatchProcessingController::class )->is_enqueued( DataSynchronizer::class ) );
+	}
+
+	/**
+	 * @testDox HPOS cannot be turned on when there are pending orders.
+	 */
+	public function test_hpos_option_is_disabled_but_sync_enabled_with_pending_orders() {
+		$this->sut->delete_database_tables();
+		$this->toggle_cot_authoritative( false );
+		$this->disable_cot_sync();
+		OrderHelper::create_order();
+
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- This is a test.
+		$cot_setting = apply_filters( 'woocommerce_feature_setting', array(), CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION );
+		$this->assertEquals( $cot_setting['value'], 'no' );
+		$this->assertEquals( $cot_setting['disabled'], array( 'yes', 'no' ) );
+
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- This is a test.
+		$sync_setting = apply_filters( 'woocommerce_feature_setting', array(), $this->sut::ORDERS_DATA_SYNC_ENABLED_OPTION );
+		$this->assertEquals( $sync_setting['value'], 'no' );
+		$this->assertTrue( str_contains( $sync_setting['desc_tip'], 'Sync 1 pending order' ) );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
@@ -555,10 +555,12 @@ class DataSynchronizerTests extends HposTestCase {
 		$this->sut->delete_database_tables();
 		$this->assertFalse( $this->sut->check_orders_table_exists() );
 
+		$cot_sync_value = get_option( $this->sut::ORDERS_DATA_SYNC_ENABLED_OPTION );
 		update_option( $this->sut::ORDERS_DATA_SYNC_ENABLED_OPTION, 'yes' );
 		$this->assertTrue( $this->sut->check_orders_table_exists() );
 		$this->assertEquals( get_option( DataSynchronizer::ORDERS_TABLE_CREATED ), 'yes' );
 		$this->assertTrue( wc_get_container()->get( BatchProcessingController::class )->is_enqueued( DataSynchronizer::class ) );
+		update_option( $this->sut::ORDERS_DATA_SYNC_ENABLED_OPTION, $cot_sync_value );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -107,6 +107,7 @@ class OrdersTableDataStoreTests extends HposTestCase {
 	 */
 	public function test_backfill_post_record() {
 		$post_order_id = OrderHelper::create_complex_wp_post_order();
+		$this->disable_cot_sync();
 		$this->migrator->migrate_orders( array( $post_order_id ) );
 
 		$post_data             = get_post( $post_order_id, ARRAY_A );
@@ -1873,6 +1874,7 @@ class OrdersTableDataStoreTests extends HposTestCase {
 	 */
 	public function test_legacy_getters_setters() {
 		$this->toggle_cot_feature_and_usage( true );
+		$this->disable_cot_sync();
 		$order_id = OrderHelper::create_complex_data_store_order( $this->sut );
 		$order    = wc_get_order( $order_id );
 		$this->switch_data_store( $order, $this->sut );
@@ -2033,6 +2035,7 @@ class OrdersTableDataStoreTests extends HposTestCase {
 	 */
 	public function test_read_multiple_dont_sync_again_for_same_order() {
 		$this->toggle_cot_feature_and_usage( true );
+		$this->disable_cot_sync();
 		$order = $this->create_complex_cot_order();
 		$this->sut->backfill_post_record( $order );
 		$this->enable_cot_sync();

--- a/plugins/woocommerce/tests/php/src/Internal/Features/FeaturesControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Features/FeaturesControllerTest.php
@@ -5,8 +5,9 @@
 
 namespace Automattic\WooCommerce\Tests\Internal\Features;
 
+use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
+use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer;
 use Automattic\WooCommerce\Internal\Features\FeaturesController;
-use Automattic\WooCommerce\Internal\Traits\AccessiblePrivateMethods;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
 use Automattic\WooCommerce\Utilities\PluginUtil;
 
@@ -83,12 +84,20 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 				if ( ! $active_only ) {
 					$plugins[] = 'the_plugin_inactive';
 				}
+
 				return $plugins;
 			}
 		};
 		// phpcs:enable Squiz.Commenting
 
-		$this->fake_plugin_util->set_active_plugins( array( 'the_plugin', 'the_plugin_2', 'the_plugin_3', 'the_plugin_4' ) );
+		$this->fake_plugin_util->set_active_plugins(
+			array(
+				'the_plugin',
+				'the_plugin_2',
+				'the_plugin_3',
+				'the_plugin_4',
+			)
+		);
 
 		$this->sut = new FeaturesController();
 		$this->sut->init( wc_get_container()->get( LegacyProxy::class ), $this->fake_plugin_util );
@@ -267,7 +276,7 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'wc_doing_it_wrong' => function( $f, $m, $v ) use ( &$function, &$message, &$version ) {
+				'wc_doing_it_wrong' => function ( $f, $m, $v ) use ( &$function, &$message, &$version ) {
 					$function = $f;
 					$message  = $m;
 					$version  = $v;
@@ -403,10 +412,10 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'did_action'        => function( $action_name ) {
+				'did_action'        => function ( $action_name ) {
 					return 'woocommerce_init' === $action_name ? false : did_action( $action_name );
 				},
-				'wc_doing_it_wrong' => function( $f, $m, $v ) use ( &$function, &$message, &$version ) {
+				'wc_doing_it_wrong' => function ( $f, $m, $v ) use ( &$function, &$message, &$version ) {
 					$function = $f;
 					$message  = $m;
 					$version  = $v;
@@ -544,10 +553,10 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'did_action'        => function( $action_name ) {
+				'did_action'        => function ( $action_name ) {
 					return 'woocommerce_init' === $action_name ? false : did_action( $action_name );
 				},
-				'wc_doing_it_wrong' => function( $f, $m, $v ) use ( &$function, &$message, &$version ) {
+				'wc_doing_it_wrong' => function ( $f, $m, $v ) use ( &$function, &$message, &$version ) {
 					$function = $f;
 					$message  = $m;
 					$version  = $v;
@@ -589,7 +598,13 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 		$expected = array(
 			'compatible'   => array(),
 			'incompatible' => array(),
-			'uncertain'    => array( 'the_plugin', 'the_plugin_2', 'the_plugin_3', 'the_plugin_4', 'the_plugin_inactive' ),
+			'uncertain'    => array(
+				'the_plugin',
+				'the_plugin_2',
+				'the_plugin_3',
+				'the_plugin_4',
+				'the_plugin_inactive',
+			),
 		);
 		$this->assertEquals( $expected, $result );
 	}
@@ -621,7 +636,13 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 		$expected = array(
 			'compatible'   => array(),
 			'incompatible' => array(),
-			'uncertain'    => array( 'the_plugin', 'the_plugin_2', 'the_plugin_3', 'the_plugin_4', 'the_plugin_inactive' ),
+			'uncertain'    => array(
+				'the_plugin',
+				'the_plugin_2',
+				'the_plugin_3',
+				'the_plugin_4',
+				'the_plugin_inactive',
+			),
 		);
 		$this->assertEquals( $expected, $result );
 	}
@@ -637,7 +658,16 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 	public function test_get_compatible_plugins_for_feature( bool $active_only ) {
 		$this->simulate_inside_before_woocommerce_init_hook();
 
-		$this->fake_plugin_util->set_active_plugins( array( 'the_plugin', 'the_plugin_2', 'the_plugin_3', 'the_plugin_4', 'the_plugin_5', 'the_plugin_6' ) );
+		$this->fake_plugin_util->set_active_plugins(
+			array(
+				'the_plugin',
+				'the_plugin_2',
+				'the_plugin_3',
+				'the_plugin_4',
+				'the_plugin_5',
+				'the_plugin_6',
+			)
+		);
 
 		$this->sut->declare_compatibility( 'mature1', 'the_plugin', true );
 		$this->sut->declare_compatibility( 'mature1', 'the_plugin_2', true );
@@ -646,7 +676,11 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 
 		$this->simulate_after_woocommerce_init_hook();
 		$result             = $this->sut->get_compatible_plugins_for_feature( 'mature1', $active_only );
-		$expected_uncertain = $active_only ? array( 'the_plugin_5', 'the_plugin_6' ) : array( 'the_plugin_5', 'the_plugin_6', 'the_plugin_inactive' );
+		$expected_uncertain = $active_only ? array( 'the_plugin_5', 'the_plugin_6' ) : array(
+			'the_plugin_5',
+			'the_plugin_6',
+			'the_plugin_inactive',
+		);
 		$expected           = array(
 			'compatible'   => array( 'the_plugin', 'the_plugin_2' ),
 			'incompatible' => array( 'the_plugin_3', 'the_plugin_4' ),
@@ -685,7 +719,7 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 
 		add_action(
 			FeaturesController::FEATURE_ENABLED_CHANGED_ACTION,
-			function( $f, $e ) use ( &$feature_id, &$enabled ) {
+			function ( $f, $e ) use ( &$feature_id, &$enabled ) {
 				$feature_id = $f;
 				$enabled    = $e;
 			},
@@ -705,7 +739,7 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 	private function simulate_inside_before_woocommerce_init_hook() {
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'doing_action' => function( $action_name ) {
+				'doing_action' => function ( $action_name ) {
 					return 'before_woocommerce_init' === $action_name || doing_action( $action_name );
 				},
 			)
@@ -718,10 +752,137 @@ class FeaturesControllerTest extends \WC_Unit_Test_Case {
 	private function simulate_after_woocommerce_init_hook() {
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'did_action' => function( $action_name ) {
+				'did_action' => function ( $action_name ) {
 					return 'woocommerce_init' === $action_name || did_action( $action_name );
 				},
 			)
 		);
+	}
+
+	/**
+	 * Helper method to disable warning when calling declare_compatibility outside of before_init hook.
+	 */
+	private function disable_verify_init_warning() {
+		$function = null;
+		$message  = null;
+		$version  = null;
+
+		$this->register_legacy_proxy_function_mocks(
+			array(
+				'wc_doing_it_wrong' => function ( $f, $m, $v ) use ( &$function, &$message, &$version ) {
+					$function = $f;
+					$message  = $m;
+					$version  = $v;
+				},
+			)
+		);
+	}
+
+	/**
+	 * @testDox No warning is generated when all plugins have declared compatibility.
+	 */
+	public function test_no_warning_when_all_plugin_are_hpos_compatible() {
+		$this->simulate_inside_before_woocommerce_init_hook();
+		// phpcs:disable Squiz.Commenting
+		$fake_plugin_util = new class() extends PluginUtil {
+			private $active_plugins;
+
+			public function __construct() {
+			}
+
+			public function set_active_plugins( $plugins ) {
+				$this->active_plugins = $plugins;
+			}
+
+			public function get_woocommerce_aware_plugins( bool $active_only = false ): array {
+				return $this->active_plugins;
+			}
+		};
+
+		$this->register_legacy_proxy_function_mocks(
+			array(
+				'is_plugin_active' => function ( $plugin ) {
+					return true;
+				},
+			)
+		);
+		// phpcs:enable
+
+		$local_sut = new FeaturesController();
+		$local_sut->init( wc_get_container()->get( LegacyProxy::class ), $fake_plugin_util );
+		$plugins = array( 'compatible_plugin1', 'compatible_plugin2' );
+		$fake_plugin_util->set_active_plugins( $plugins );
+		foreach ( $plugins as $plugin ) {
+			$local_sut->declare_compatibility( 'custom_order_tables', $plugin );
+			$local_sut->declare_compatibility( 'cart_checkout_blocks', $plugin );
+		}
+		$cot_controller   = new CustomOrdersTableController();
+		$cot_setting_call = function () use ( $fake_plugin_util, $local_sut ) {
+			$this->plugin_util         = $fake_plugin_util;
+			$this->features_controller = $local_sut;
+			$this->data_synchronizer   = wc_get_container()->get( DataSynchronizer::class );
+			return $this->get_hpos_feature_setting( array(), CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION );
+		};
+		$cot_setting      = $cot_setting_call->call( $cot_controller );
+
+		$this->assertEquals( $cot_setting['disabled'], array() );
+		$incompatible_plugins = function () use ( $plugins ) {
+			return $this->get_incompatible_plugins( 'all', array_flip( $plugins ) );
+		};
+		$this->assertEmpty( $incompatible_plugins->call( $local_sut ) );
+	}
+
+	/**
+	 * @testDox If there is an incompatible plugin, it is returned by get_incompatible_plugins.
+	 */
+	public function test_show_warning_when_a_plugin_is_not_hpos_compatible() {
+		$this->simulate_inside_before_woocommerce_init_hook();
+		// phpcs:disable Squiz.Commenting
+		$fake_plugin_util = new class() extends PluginUtil {
+			private $active_plugins;
+
+			public function __construct() {
+			}
+
+			public function set_active_plugins( $plugins ) {
+				$this->active_plugins = $plugins;
+			}
+
+			public function get_woocommerce_aware_plugins( bool $active_only = false ): array {
+				return $this->active_plugins;
+			}
+		};
+		// phpcs:enable
+
+		$this->register_legacy_proxy_function_mocks(
+			array(
+				'is_plugin_active' => function ( $plugin ) {
+					return true;
+				},
+			)
+		);
+
+		$local_sut = new FeaturesController();
+		$local_sut->init( wc_get_container()->get( LegacyProxy::class ), $fake_plugin_util );
+		$plugins = array( 'compatible_plugin', 'incompatible_plugin' );
+		$fake_plugin_util->set_active_plugins( $plugins );
+		$local_sut->declare_compatibility( 'custom_order_tables', 'compatible_plugin' );
+		$local_sut->declare_compatibility( 'cart_checkout_blocks', 'compatible_plugin' );
+		$local_sut->declare_compatibility( 'custom_order_tables', 'incompatible_plugin', false );
+
+		$cot_controller   = new CustomOrdersTableController();
+		$cot_setting_call = function () use ( $fake_plugin_util, $local_sut ) {
+			$this->plugin_util         = $fake_plugin_util;
+			$this->features_controller = $local_sut;
+			$this->data_synchronizer   = wc_get_container()->get( DataSynchronizer::class );
+			return $this->get_hpos_feature_setting( array(), CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION );
+		};
+		$cot_setting      = $cot_setting_call->call( $cot_controller );
+
+		$this->assertEquals( $cot_setting['disabled'], array( 'yes' ) );
+		$incompatible_plugins = function () use ( $plugins ) {
+			return $this->get_incompatible_plugins( 'all', array_flip( $plugins ) );
+		};
+		$this->assertEquals( array( 'incompatible_plugin' ), array_keys( $incompatible_plugins->call( $local_sut ) ) );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Add the sync and custom table usage enabled flag to legacy so that it does not generate warnings when no compatibility is declared explicitly. The compatibility is taken cared by the `custom_order_tables` flag and so checking for these new feature flags is not required.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check out `trunk`.
1. Enable a plugin that has declared compatibility with HPOS. For example, the WooCommerce Stripe gateway.
1. You should be seeing the incompatibility warning on all admin screens:
   <img width="983" alt="Screenshot 2023-08-02 at 14 10 52" src="https://github.com/woocommerce/woocommerce/assets/184724/cf5d8b5b-fc15-4d4b-b001-9ef3f9dabe60">
1. Go to `wp-admin/plugins.php?plugin_status=incompatible_with_feature` and confirm that the Stripe gateway is listed as incompatible (despite it being compatible). In particular, you'll see that it is listed as incompatible with COT but also a `''` feature:
   <img width="1558" alt="Screenshot 2023-08-02 at 14 08 01" src="https://github.com/woocommerce/woocommerce/assets/184724/2bec81fe-fc60-4fb9-99ec-5fb528781252">
1. Check out this branch and refresh the page.
1. The warning should now be gone.
1. The list of plugins on `wp-admin/plugins.php?plugin_status=incompatible_with_feature` should no longer indicate that Stripe is incompatible with COT.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
