### PR TITLE
Create global attributes by default

### DIFF
--- a/packages/js/product-editor/changelog/add-38884_create_global_attributes_by_default
+++ b/packages/js/product-editor/changelog/add-38884_create_global_attributes_by_default
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add support to attribute input field for creating global attributes by default and enable this for variation blocks.

--- a/packages/js/product-editor/src/blocks/variation-options/edit.tsx
+++ b/packages/js/product-editor/src/blocks/variation-options/edit.tsx
@@ -36,6 +36,7 @@ export function Edit() {
 			<AttributeControl
 				value={ attributes }
 				onChange={ handleChange }
+				createNewAttributesAsGlobal={ true }
 				uiStrings={ {
 					globalAttributeHelperMessage: '',
 					customAttributeHelperMessage: '',

--- a/packages/js/product-editor/src/blocks/variations/edit.tsx
+++ b/packages/js/product-editor/src/blocks/variations/edit.tsx
@@ -133,6 +133,7 @@ export function Edit( {
 							),
 						}
 					) }
+					createNewAttributesAsGlobal={ true }
 					notice={ '' }
 					onCancel={ () => {
 						closeNewModal();

--- a/packages/js/product-editor/src/components/attribute-control/attribute-control.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/attribute-control.tsx
@@ -44,6 +44,7 @@ type AttributeControlProps = {
 	onEditModalCancel?: ( attribute?: ProductAttribute ) => void;
 	onEditModalClose?: ( attribute?: ProductAttribute ) => void;
 	onEditModalOpen?: ( attribute?: ProductAttribute ) => void;
+	createNewAttributesAsGlobal?: boolean;
 	uiStrings?: {
 		emptyStateSubtitle?: string;
 		newAttributeListItemLabel?: string;
@@ -71,6 +72,7 @@ export const AttributeControl: React.FC< AttributeControlProps > = ( {
 	onRemove = () => {},
 	onRemoveCancel = () => {},
 	uiStrings,
+	createNewAttributesAsGlobal = false,
 } ) => {
 	uiStrings = {
 		newAttributeListItemLabel: __( 'Add new', 'woocommerce' ),
@@ -246,6 +248,7 @@ export const AttributeControl: React.FC< AttributeControlProps > = ( {
 					} }
 					onAdd={ handleAdd }
 					selectedAttributeIds={ value.map( ( attr ) => attr.id ) }
+					createNewAttributesAsGlobal={ createNewAttributesAsGlobal }
 				/>
 			) }
 			<SelectControlMenuSlot />

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
@@ -49,6 +49,7 @@ type NewAttributeModalProps = {
 	onCancel: () => void;
 	onAdd: ( newCategories: EnhancedProductAttribute[] ) => void;
 	selectedAttributeIds?: number[];
+	createNewAttributesAsGlobal?: boolean;
 };
 
 type AttributeForm = {
@@ -81,6 +82,7 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 	onCancel,
 	onAdd,
 	selectedAttributeIds = [],
+	createNewAttributesAsGlobal = false,
 } ) => {
 	const scrollAttributeIntoView = ( index: number ) => {
 		setTimeout( () => {
@@ -298,6 +300,9 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 																			undefined
 																	),
 															] }
+															createNewAttributesAsGlobal={
+																createNewAttributesAsGlobal
+															}
 														/>
 													</td>
 													<td className="woocommerce-new-attribute-modal__table-attribute-value-column">

--- a/packages/js/product-editor/src/components/attribute-input-field/test/attribute-input-field.spec.tsx
+++ b/packages/js/product-editor/src/components/attribute-input-field/test/attribute-input-field.spec.tsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import { render } from '@testing-library/react';
-import { useSelect } from '@wordpress/data';
+import { render, waitFor } from '@testing-library/react';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useState, createElement } from '@wordpress/element';
 import { ProductAttribute, QueryProductAttribute } from '@woocommerce/data';
 
@@ -14,6 +14,11 @@ import { AttributeInputField } from '../attribute-input-field';
 jest.mock( '@wordpress/data', () => ( {
 	...jest.requireActual( '@wordpress/data' ),
 	useSelect: jest.fn(),
+	useDispatch: jest.fn().mockReturnValue( {
+		createErrorNotice: jest.fn(),
+		createProductAttribute: jest.fn(),
+		invalidateResolution: jest.fn(),
+	} ),
 } ) );
 
 jest.mock( '@wordpress/components', () => ( {
@@ -264,5 +269,98 @@ describe( 'AttributeInputField', () => {
 		queryByText( 'Update Input' )?.click();
 		queryByText( 'Create "Co"' )?.click();
 		expect( onChangeMock ).toHaveBeenCalledWith( 'Co' );
+	} );
+
+	describe( 'createNewAttributesAsGlobal is true', () => {
+		it( 'should create a new global attribute and invalidate product attributes', async () => {
+			const onChangeMock = jest.fn();
+			( useSelect as jest.Mock ).mockReturnValue( {
+				isLoading: false,
+				attributes: [ attributeList[ 0 ] ],
+			} );
+			const createProductAttributeMock = jest
+				.fn()
+				.mockImplementation(
+					(
+						newAttribute: Partial< Omit< ProductAttribute, 'id' > >
+					) => {
+						return Promise.resolve( {
+							name: newAttribute.name,
+							id: 123,
+							slug: newAttribute.name?.toLowerCase(),
+						} );
+					}
+				);
+			const invalidateResolutionMock = jest.fn();
+			( useDispatch as jest.Mock ).mockReturnValue( {
+				createErrorNotice: jest.fn(),
+				createProductAttribute: createProductAttributeMock,
+				invalidateResolution: invalidateResolutionMock,
+			} );
+			const { queryByText } = render(
+				<AttributeInputField
+					onChange={ onChangeMock }
+					createNewAttributesAsGlobal={ true }
+				/>
+			);
+			queryByText( 'Update Input' )?.click();
+			queryByText( 'Create "Co"' )?.click();
+			expect( createProductAttributeMock ).toHaveBeenCalledWith( {
+				name: 'Co',
+			} );
+			await waitFor( () => {
+				expect( invalidateResolutionMock ).toHaveBeenCalledWith(
+					'getProductAttributes'
+				);
+			} );
+			expect( onChangeMock ).toHaveBeenCalledWith( {
+				name: 'Co',
+				slug: 'co',
+				id: 123,
+				options: [],
+			} );
+		} );
+
+		it( 'should show an error notice and not call onChange when creation failed', async () => {
+			const onChangeMock = jest.fn();
+			( useSelect as jest.Mock ).mockReturnValue( {
+				isLoading: false,
+				attributes: [ attributeList[ 0 ] ],
+			} );
+			const createProductAttributeMock = jest
+				.fn()
+				.mockImplementation( () => {
+					return Promise.reject( {
+						code: 'woocommerce_rest_cannot_create',
+						message: 'Duplicate slug',
+					} );
+				} );
+			const invalidateResolutionMock = jest.fn();
+			const createErrorNoticeMock = jest.fn();
+			( useDispatch as jest.Mock ).mockReturnValue( {
+				createErrorNotice: createErrorNoticeMock,
+				createProductAttribute: createProductAttributeMock,
+				invalidateResolution: invalidateResolutionMock,
+			} );
+			const { queryByText } = render(
+				<AttributeInputField
+					onChange={ onChangeMock }
+					createNewAttributesAsGlobal={ true }
+				/>
+			);
+			queryByText( 'Update Input' )?.click();
+			queryByText( 'Create "Co"' )?.click();
+			expect( createProductAttributeMock ).toHaveBeenCalledWith( {
+				name: 'Co',
+			} );
+			await waitFor( () => {
+				expect( createErrorNoticeMock ).toHaveBeenCalledWith(
+					'Duplicate slug',
+					{ explicitDismiss: true }
+				);
+			} );
+			expect( invalidateResolutionMock ).not.toHaveBeenCalled();
+			expect( onChangeMock ).not.toHaveBeenCalled();
+		} );
 	} );
 } );

--- a/packages/js/product-editor/src/components/attribute-term-input-field/attribute-term-input-field.tsx
+++ b/packages/js/product-editor/src/components/attribute-term-input-field/attribute-term-input-field.tsx
@@ -3,7 +3,7 @@
  */
 import { sprintf, __ } from '@wordpress/i18n';
 import { CheckboxControl, Icon, Spinner } from '@wordpress/components';
-import { resolveSelect } from '@wordpress/data';
+import { resolveSelect, useDispatch } from '@wordpress/data';
 import {
 	useCallback,
 	useEffect,
@@ -51,6 +51,9 @@ export const AttributeTermInputField: React.FC<
 	attributeId,
 	label = '',
 } ) => {
+	const { invalidateResolutionForStoreSelector } = useDispatch(
+		EXPERIMENTAL_PRODUCT_ATTRIBUTE_TERMS_STORE_NAME
+	);
 	const attributeTermInputId = useRef(
 		`woocommerce-attribute-term-field-${ ++uniqueId }`
 	);
@@ -286,6 +289,9 @@ export const AttributeTermInputField: React.FC<
 					onCreated={ ( newAttribute ) => {
 						onSelect( newAttribute );
 						setAddNewAttributeTermName( undefined );
+						invalidateResolutionForStoreSelector(
+							'getProductAttributeTerms'
+						);
 						focusSelectControl();
 					} }
 				/>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #38884  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Load this branch and enable the new product editor under **WooCommerce > Settings > Advanced > Features**
2. Install the WooCommerce Beta tester plugin and enable the `product-variation-management` feature under **Tools > WCA Test Helper > Features**
3. Go to **Products > Add New**
4. It should load the new product editor and a **Variations** tab should be present.
5. Go to **Variations** tab and click **Add variation options**
6. A modal should show to add new variation options ( attributes )
7. Start typing an attribute that doesn't exist yet and click **Create 'new attribute'**
8. This should create a new global attribute, you can check the **Products > Attributes** page in a new tab
9. Now add some new terms, this will show the additional modal (which will be removed in another PR)
10. Click **Add**
11. Now click the **Add new** button on top of the list (slightly different) and follow the same steps from step 7-10
12. Go to the Organization tab and go to the Attributes field and add some attributes ( creating some new one's )
13. Notice how the new attributes are still local (not created as global attributes)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
