### PR TITLE
Ensure FeaturesController is aware of correct HPOS option keys

### DIFF
--- a/plugins/woocommerce/changelog/fix-hpos-feature-options
+++ b/plugins/woocommerce/changelog/fix-hpos-feature-options
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Backports a needed change from trunk/8.1 to the 8.0 branch.
+
+

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -424,7 +424,10 @@ class FeaturesController {
 			case 'new_navigation':
 				return Init::TOGGLE_OPTION_NAME;
 			case 'custom_order_tables':
+			case CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION:
 				return CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION;
+			case DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION:
+				return DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION;
 			default:
 				return "woocommerce_feature_{$feature_id}_enabled";
 		}


### PR DESCRIPTION
⚠️ Note that this PR is merging into the `release/8.0` branch instead of trunk, since the change already exists in trunk.

This is a piece of a change that is already in trunk, but it needs to be backported to 8.0 (see #39250). This ensures that the feature ID and the option key match for each of the two HPOS-related features that were introduced in #38993.

### How to test the changes in this Pull Request:

1. Add the following code snippet somewhere in your test site, like in a file in mu-plugins:
    ```php
	use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
	use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer;
	use Automattic\WooCommerce\Utilities\FeaturesUtil;
	
	add_action(
		'admin_notices',
		function() {
			echo '<div class="notice notice-info"><pre>';
			printf(
				"HPOS tables feature enabled: %s\n",
				FeaturesUtil::feature_is_enabled( CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION ) ? 'true' : 'false'
			);
			printf(
				"Data sync feature enabled: %s\n",
				FeaturesUtil::feature_is_enabled( DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION ) ? 'true' : 'false'
			);
			echo '</pre></div>';
		}
	);
    ```
2. Check out the `release/8.0` branch.
3. Visit the Features settings page, WP Admin > WooCommerce > Settings > Advanced > Features.
4. You should see an admin notice showing the detected status of the HPOS tables feature and the Data Sync feature.
5. Try toggling the radio buttons/checkboxes for these features and saving the changes. Note that the detected status in the notice does not change.
6. Now check out this branch and try toggling again. The detected status for each of these features in the notice should now be correct.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment

Backports a needed change from trunk/8.1 to the 8.0 branch.

</details>
