### PR TITLE
Adding theme docs

### DIFF
--- a/docs/themes/README.md
+++ b/docs/themes/README.md
@@ -4,7 +4,4 @@
 
 ## Block Themes
 
-## Marketplace Guidelines
-
-* [Theme Development](./marketplace-guidelines/theme-development.md)
-* [Theme Design](./marketplace-guidelines/theme-design.md)
+* [Marketplace Guidelines](marketplace-guidelines.md)

--- a/docs/themes/README.md
+++ b/docs/themes/README.md
@@ -1,0 +1,10 @@
+# Theme Design and Development at Woo
+
+## Classic Themes
+
+## Block Themes
+
+## Marketplace Guidelines
+
+* [Theme Development](./marketplace-guidelines/theme-development.md)
+* [Theme Design](./marketplace-guidelines/theme-design.md)

--- a/docs/themes/marketplace-guidelines.md
+++ b/docs/themes/marketplace-guidelines.md
@@ -1,0 +1,1 @@
+[placeholder]


### PR DESCRIPTION
This PR is for adding theme development/design documentation to the repository.

Addresses: https://github.com/woocommerce/woodocs/issues/50

(Note: once this is merged the structure can be used for any migrated docs as a part of https://github.com/woocommerce/woodocs/issues/29).
