### PR TITLE
Ensure My Subscriptions page is still accessible when new marketplace is enabled

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx
@@ -22,6 +22,7 @@ export interface TabsProps {
 interface Tab {
 	name: string;
 	title: string;
+	href?: string;
 }
 
 interface Tabs {
@@ -36,6 +37,17 @@ const tabs: Tabs = {
 	extensions: {
 		name: 'extensions',
 		title: __( 'Browse', 'woocommerce' ),
+	},
+	'my-subscriptions': {
+		name: 'my-subscriptions',
+		title: __( 'My Subscriptions', 'woocommerce' ),
+		href: getNewPath(
+			{
+				page: 'wc-addons',
+				section: 'helper',
+			},
+			''
+		),
 	},
 };
 
@@ -56,18 +68,33 @@ const renderTabs = ( props: TabsProps ) => {
 	const tabContent = [];
 	for ( const tabKey in tabs ) {
 		tabContent.push(
-			<Button
-				className={ classNames( 'woocommerce-marketplace__tab-button', {
-					'is-active': tabKey === selectedTab,
-				} ) }
-				onClick={ () => {
-					setSelectedTab( tabKey );
-					setUrlTabParam( tabKey );
-				} }
-				key={ tabKey }
-			>
-				{ tabs[ tabKey ]?.title }
-			</Button>
+			<>
+				{ tabs[ tabKey ]?.href ? (
+					<a
+						className="woocommerce-marketplace__tab-button components-button"
+						href={ tabs[ tabKey ]?.href }
+						key={ tabKey }
+					>
+						{ tabs[ tabKey ]?.title }
+					</a>
+				) : (
+					<Button
+						className={ classNames(
+							'woocommerce-marketplace__tab-button',
+							{
+								'is-active': tabKey === selectedTab,
+							}
+						) }
+						onClick={ () => {
+							setSelectedTab( tabKey );
+							setUrlTabParam( tabKey );
+						} }
+						key={ tabKey }
+					>
+						{ tabs[ tabKey ]?.title }
+					</Button>
+				) }
+			</>
 		);
 	}
 	return tabContent;

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -6,12 +6,14 @@
  * @version 2.5.0
  */
 
+use Automattic\WooCommerce\Admin\Features\Features;
+use Automattic\WooCommerce\Admin\PageController;
+use Automattic\WooCommerce\Internal\Admin\Marketplace;
 use Automattic\WooCommerce\Internal\Admin\Orders\COTRedirectionController;
 use Automattic\WooCommerce\Internal\Admin\Orders\PageController as Custom_Orders_PageController;
+use Automattic\WooCommerce\Internal\Admin\WCAdminAssets;
 use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
-use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
-use Automattic\WooCommerce\Internal\Admin\Marketplace;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -41,6 +43,8 @@ class WC_Admin_Menus {
 		if ( FeaturesUtil::feature_is_enabled( 'marketplace' ) ) {
 			$container = wc_get_container();
 			$container->get( Marketplace::class );
+
+			add_action( 'admin_menu', array( $this, 'addons_my_subscriptions' ), 70 );
 		} else {
 			add_action( 'admin_menu', array( $this, 'addons_menu' ), 70 );
 		}
@@ -174,6 +178,16 @@ class WC_Admin_Menus {
 		/* translators: %s: extensions count */
 		$menu_title = sprintf( __( 'Extensions %s', 'woocommerce' ), $count_html );
 		add_submenu_page( 'woocommerce', __( 'WooCommerce extensions', 'woocommerce' ), $menu_title, 'manage_woocommerce', 'wc-addons', array( $this, 'addons_page' ) );
+	}
+
+	/**
+	 * Registers the wc-addons page within the WooCommerce menu.
+	 * Temporary measure till we convert the whole page to React.
+	 *
+	 * @return void
+	 */
+	public function addons_my_subscriptions() {
+		add_submenu_page( 'woocommerce', __( 'WooCommerce extensions', 'woocommerce' ), null, 'manage_woocommerce', 'wc-addons', array( $this, 'addons_page' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-admin.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-admin.php
@@ -67,8 +67,6 @@ class WC_Helper_Admin {
 				admin_url( 'admin.php' )
 			);
 
-			// TODO: this may be needed to make the URL work.
-			// include WC_Helper::get_view_filename( 'html-oauth-start.php' );
 			return $connect_url;
 		}
 

--- a/plugins/woocommerce/includes/admin/helper/views/html-section-nav.php
+++ b/plugins/woocommerce/includes/admin/helper/views/html-section-nav.php
@@ -7,10 +7,17 @@
  * @deprecated 5.7.0
  */
 
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+
+$addons_url = admin_url( 'admin.php?page=wc-addons' );
+if ( FeaturesUtil::feature_is_enabled( 'marketplace' ) ) {
+	$addons_url = admin_url( 'admin.php?page=wc-admin&path=/extensions&tab=extensions' );
+}
+
 defined( 'ABSPATH' ) || exit(); ?>
 
 <nav class="nav-tab-wrapper woo-nav-tab-wrapper">
-	<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-addons' ) ); ?>" class="nav-tab"><?php esc_html_e( 'Browse Extensions', 'woocommerce' ); ?></a>
+	<a href="<?php echo esc_url( $addons_url ); ?>" class="nav-tab"><?php esc_html_e( 'Browse Extensions', 'woocommerce' ); ?></a>
 
 	<?php
 		$count_html = WC_Helper_Updater::get_updates_count_html();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes 17518-gh-Automattic/woocommerce.com. Keeps My Subscriptions page accessible at its current address when the new marketplace is enabled.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check out the branch.
2. From the `plugins/woocommerce` folder, run `pnpm build --filter=woocommerce`.
3. If you get a fatal error, run `composer dump-autoload` to refresh the composer autoload file.
4. Visit the Extensions page. ((WP Env URL is http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fextensions).)
5. You should see tabs for `Discover`, `Browse` and `My Subscriptions`. 
6. Click on `My Subscriptions`. You should see the My Subscriptions page. This page should continue to function as normal. (While the WooCommerce menu remains open, the `Extensions` menu item is not highlighted when you are on this page. This isn't ideal, but will only be a problem till we can convert this page to WC Admin.) 
a. You should see your connection status, and be able to disconnect and reconnect.
b. You should see your subscriptions, and download the extensions for them.
c. You should be able to refresh the list by clicking the `Update` button.
7. Click the `Browse Extensions` tab. You should go to the Extensions tab of the new marketplace UI.
8. Click the user menu in the new marketplace UI. Make sure the `Connect account` and `Disconnect account` links work. (If they do, please close 17764-gh-Automattic/woocommerce.com with a comment.)

### Screenshots

<img width="500" src="https://github.com/woocommerce/woocommerce/assets/1647564/9b697f9c-0d8e-4cd5-ab62-4701f755a7f7">

<img width="500" src="https://github.com/woocommerce/woocommerce/assets/1647564/9b2d2bc6-f696-4f47-a592-5c6e0b6775a1">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>