### PR TITLE
Manage default variation option

### DIFF
--- a/packages/js/data/changelog/add-39440
+++ b/packages/js/data/changelog/add-39440
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add default attributes property to the Product type

--- a/packages/js/data/src/products/types.ts
+++ b/packages/js/data/src/products/types.ts
@@ -36,6 +36,24 @@ export type ProductAttribute = {
 	options: string[];
 };
 
+/**
+ * Product - Default attributes properties
+ */
+export type ProductDefaultAttribute = {
+	/**
+	 * Attribute ID.
+	 */
+	id: number;
+	/**
+	 * Attribute name.
+	 */
+	name: string;
+	/**
+	 * Selected attribute term name.
+	 */
+	option: string;
+};
+
 export type ProductDimensions = {
 	width: string;
 	height: string;
@@ -59,6 +77,7 @@ export type Product< Status = ProductStatus, Type = ProductType > = Omit<
 	date_modified_gmt: string;
 	date_on_sale_from_gmt: string | null;
 	date_on_sale_to_gmt: string | null;
+	default_attributes: ProductDefaultAttribute[];
 	description: string;
 	dimensions: ProductDimensions;
 	download_expiry: number;

--- a/packages/js/product-editor/changelog/add-39440
+++ b/packages/js/product-editor/changelog/add-39440
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add set default value checkbox to the edit attribute options modal

--- a/packages/js/product-editor/src/blocks/variation-options/edit.tsx
+++ b/packages/js/product-editor/src/blocks/variation-options/edit.tsx
@@ -3,8 +3,12 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useBlockProps } from '@wordpress/block-editor';
-import { createElement, createInterpolateElement } from '@wordpress/element';
-import { ProductAttribute } from '@woocommerce/data';
+import {
+	createElement,
+	createInterpolateElement,
+	useMemo,
+} from '@wordpress/element';
+import { Product, ProductAttribute } from '@woocommerce/data';
 import { Link } from '@woocommerce/components';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore No types for this exist yet.
@@ -14,8 +18,30 @@ import { useEntityProp, useEntityId } from '@wordpress/core-data';
 /**
  * Internal dependencies
  */
-import { useProductAttributes } from '../../hooks/use-product-attributes';
+import {
+	EnhancedProductAttribute,
+	useProductAttributes,
+} from '../../hooks/use-product-attributes';
 import { AttributeControl } from '../../components/attribute-control';
+
+function manageDefaultAttributes( values: EnhancedProductAttribute[] ) {
+	return values.reduce< Product[ 'default_attributes' ] >(
+		( prevDefaultAttributes, currentAttribute ) => {
+			if ( currentAttribute.isDefault ) {
+				return [
+					...prevDefaultAttributes,
+					{
+						id: currentAttribute.id,
+						name: currentAttribute.name,
+						option: currentAttribute.options[ 0 ],
+					},
+				];
+			}
+			return prevDefaultAttributes;
+		},
+		[]
+	);
+}
 
 export function Edit() {
 	const blockProps = useBlockProps();
@@ -24,17 +50,41 @@ export function Edit() {
 		ProductAttribute[]
 	>( 'postType', 'product', 'attributes' );
 
+	const [ entityDefaultAttributes, setEntityDefaultAttributes ] =
+		useEntityProp< Product[ 'default_attributes' ] >(
+			'postType',
+			'product',
+			'default_attributes'
+		);
+
 	const { attributes, handleChange } = useProductAttributes( {
 		allAttributes: entityAttributes,
-		onChange: setEntityAttributes,
 		isVariationAttributes: true,
 		productId: useEntityId( 'postType', 'product' ),
+		onChange( values ) {
+			setEntityAttributes( values );
+			setEntityDefaultAttributes( manageDefaultAttributes( values ) );
+		},
 	} );
+
+	function mapDefaultAttributes() {
+		return attributes.map( ( attribute ) => ( {
+			...attribute,
+			isDefault: entityDefaultAttributes.some(
+				( defaultAttribute ) =>
+					defaultAttribute.id === attribute.id ||
+					defaultAttribute.name === attribute.name
+			),
+		} ) );
+	}
 
 	return (
 		<div { ...blockProps }>
 			<AttributeControl
-				value={ attributes }
+				value={ useMemo( mapDefaultAttributes, [
+					attributes,
+					entityDefaultAttributes,
+				] ) }
 				onChange={ handleChange }
 				uiStrings={ {
 					globalAttributeHelperMessage: '',

--- a/packages/js/product-editor/src/blocks/variations/edit.tsx
+++ b/packages/js/product-editor/src/blocks/variations/edit.tsx
@@ -41,6 +41,16 @@ function hasAttributesUsedForVariations(
 	return productAttributes.some( ( { variation } ) => variation );
 }
 
+function getFirstOptionFromEachAttribute(
+	attributes: Product[ 'attributes' ]
+): Product[ 'default_attributes' ] {
+	return attributes.map( ( attribute ) => ( {
+		id: attribute.id,
+		name: attribute.name,
+		option: attribute.options[ 0 ],
+	} ) );
+}
+
 export function Edit( {
 	attributes,
 }: BlockEditProps< VariationsBlockAttributes > ) {
@@ -50,13 +60,21 @@ export function Edit( {
 	const [ productAttributes, setProductAttributes ] = useEntityProp<
 		Product[ 'attributes' ]
 	>( 'postType', 'product', 'attributes' );
+	const [ , setDefaultProductAttributes ] = useEntityProp<
+		Product[ 'default_attributes' ]
+	>( 'postType', 'product', 'default_attributes' );
 
 	const { attributes: variationOptions, handleChange } = useProductAttributes(
 		{
 			allAttributes: productAttributes,
-			onChange: setProductAttributes,
 			isVariationAttributes: true,
 			productId: useEntityId( 'postType', 'product' ),
+			onChange( values ) {
+				setProductAttributes( values );
+				setDefaultProductAttributes(
+					getFirstOptionFromEachAttribute( values )
+				);
+			},
 		}
 	);
 

--- a/packages/js/product-editor/src/components/attribute-control/attribute-control.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/attribute-control.tsx
@@ -32,7 +32,7 @@ import { AttributeListItem } from '../attribute-list-item';
 import { NewAttributeModal } from './new-attribute-modal';
 
 type AttributeControlProps = {
-	value: ProductAttribute[];
+	value: EnhancedProductAttribute[];
 	onAdd?: ( attribute: EnhancedProductAttribute[] ) => void;
 	onChange: ( value: ProductAttribute[] ) => void;
 	onEdit?: ( attribute: ProductAttribute ) => void;
@@ -189,7 +189,7 @@ export const AttributeControl: React.FC< AttributeControlProps > = ( {
 
 	const currentAttribute = value.find(
 		( attr ) => getAttributeId( attr ) === currentAttributeId
-	) as EnhancedProductAttribute;
+	);
 
 	return (
 		<div className="woocommerce-attribute-field">

--- a/packages/js/product-editor/src/components/attribute-control/edit-attribute-modal.scss
+++ b/packages/js/product-editor/src/components/attribute-control/edit-attribute-modal.scss
@@ -14,7 +14,8 @@
 	width: 500px;
 	max-width: 100%;
 
-	.woocommerce-experimental-select-control + .woocommerce-experimental-select-control {
+	.woocommerce-experimental-select-control
+		+ .woocommerce-experimental-select-control {
 		margin-top: 1.3em;
 	}
 
@@ -30,6 +31,10 @@
 		display: flex;
 		flex-direction: row;
 		align-items: center;
+
+		.components-checkbox-control .components-base-control__field {
+			margin-bottom: 0;
+		}
 	}
 
 	.woocommerce-attribute-term-field {

--- a/packages/js/product-editor/src/components/attribute-control/edit-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/edit-attribute-modal.tsx
@@ -27,6 +27,8 @@ type EditAttributeModalProps = {
 	customAttributeHelperMessage?: string;
 	termsLabel?: string;
 	termsPlaceholder?: string;
+	isDefaultLabel?: string;
+	isDefaultTooltip?: string;
 	visibleLabel?: string;
 	visibleTooltip?: string;
 	cancelAccessibleLabel?: string;
@@ -48,6 +50,11 @@ export const EditAttributeModal: React.FC< EditAttributeModalProps > = ( {
 	),
 	termsLabel = __( 'Values', 'woocommerce' ),
 	termsPlaceholder = __( 'Search or create value', 'woocommerce' ),
+	isDefaultLabel = __( 'Set default value', 'woocommerce' ),
+	isDefaultTooltip = __(
+		'Check to preselect the first choice when customers enter the product page.',
+		'woocommerce'
+	),
 	visibleLabel = __( 'Visible to customers', 'woocommerce' ),
 	visibleTooltip = __(
 		'Show or hide this attribute on the product page',
@@ -120,18 +127,34 @@ export const EditAttributeModal: React.FC< EditAttributeModalProps > = ( {
 					/>
 				) }
 
-				<div className="woocommerce-edit-attribute-modal__option-container">
-					<CheckboxControl
-						onChange={ ( val ) =>
-							setEditableAttribute( {
-								...( editableAttribute as EnhancedProductAttribute ),
-								visible: val,
-							} )
-						}
-						checked={ editableAttribute?.visible }
-						label={ visibleLabel }
-					/>
-					<Tooltip text={ visibleTooltip } />
+				<div className="woocommerce-edit-attribute-modal__options">
+					<div className="woocommerce-edit-attribute-modal__option-container">
+						<CheckboxControl
+							onChange={ ( checked ) =>
+								setEditableAttribute( {
+									...( editableAttribute as EnhancedProductAttribute ),
+									isDefault: checked,
+								} )
+							}
+							checked={ editableAttribute?.isDefault }
+							label={ isDefaultLabel }
+						/>
+						<Tooltip text={ isDefaultTooltip } />
+					</div>
+
+					<div className="woocommerce-edit-attribute-modal__option-container">
+						<CheckboxControl
+							onChange={ ( val ) =>
+								setEditableAttribute( {
+									...( editableAttribute as EnhancedProductAttribute ),
+									visible: val,
+								} )
+							}
+							checked={ editableAttribute?.visible }
+							label={ visibleLabel }
+						/>
+						<Tooltip text={ visibleTooltip } />
+					</div>
 				</div>
 			</div>
 			<div className="woocommerce-edit-attribute-modal__buttons">

--- a/packages/js/product-editor/src/components/attribute-control/edit-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/edit-attribute-modal.tsx
@@ -128,19 +128,21 @@ export const EditAttributeModal: React.FC< EditAttributeModalProps > = ( {
 				) }
 
 				<div className="woocommerce-edit-attribute-modal__options">
-					<div className="woocommerce-edit-attribute-modal__option-container">
-						<CheckboxControl
-							onChange={ ( checked ) =>
-								setEditableAttribute( {
-									...( editableAttribute as EnhancedProductAttribute ),
-									isDefault: checked,
-								} )
-							}
-							checked={ editableAttribute?.isDefault }
-							label={ isDefaultLabel }
-						/>
-						<Tooltip text={ isDefaultTooltip } />
-					</div>
+					{ attribute.variation && (
+						<div className="woocommerce-edit-attribute-modal__option-container">
+							<CheckboxControl
+								onChange={ ( checked ) =>
+									setEditableAttribute( {
+										...( editableAttribute as EnhancedProductAttribute ),
+										isDefault: checked,
+									} )
+								}
+								checked={ editableAttribute?.isDefault }
+								label={ isDefaultLabel }
+							/>
+							<Tooltip text={ isDefaultTooltip } />
+						</div>
+					) }
 
 					<div className="woocommerce-edit-attribute-modal__option-container">
 						<CheckboxControl

--- a/packages/js/product-editor/src/hooks/use-product-attributes.ts
+++ b/packages/js/product-editor/src/hooks/use-product-attributes.ts
@@ -14,17 +14,17 @@ import { useCallback, useEffect, useState } from '@wordpress/element';
  */
 import { sift } from '../utils';
 
-type useProductAttributesProps = {
-	allAttributes: ProductAttribute[];
-	isVariationAttributes?: boolean;
-	onChange: ( attributes: ProductAttribute[] ) => void;
-	productId?: number;
-};
-
 export type EnhancedProductAttribute = ProductAttribute & {
 	isDefault?: boolean;
 	terms?: ProductAttributeTerm[];
 	visible?: boolean;
+};
+
+type useProductAttributesProps = {
+	allAttributes: ProductAttribute[];
+	isVariationAttributes?: boolean;
+	onChange: ( attributes: EnhancedProductAttribute[] ) => void;
+	productId?: number;
 };
 
 const getFilteredAttributes = (
@@ -90,7 +90,7 @@ export function useProductAttributes( {
 		} ) );
 	};
 
-	const handleChange = ( newAttributes: ProductAttribute[] ) => {
+	const handleChange = ( newAttributes: EnhancedProductAttribute[] ) => {
 		let otherAttributes = isVariationAttributes
 			? allAttributes.filter( ( attribute ) => ! attribute.variation )
 			: allAttributes.filter( ( attribute ) => !! attribute.variation );

--- a/packages/js/product-editor/src/hooks/use-product-attributes.ts
+++ b/packages/js/product-editor/src/hooks/use-product-attributes.ts
@@ -22,6 +22,7 @@ type useProductAttributesProps = {
 };
 
 export type EnhancedProductAttribute = ProductAttribute & {
+	isDefault?: boolean;
 	terms?: ProductAttributeTerm[];
 	visible?: boolean;
 };


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #39440

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure `New product editor` is turned on under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure you have at least one global attribute created under `/wp-admin/edit.php?post_type=product&page=product_attributes`
3. Visit `/wp-admin/admin.php?page=wc-admin&path=/add-product&tab=variations`
4. Then click `Add variation options` button
5. In the modal add a global attribute and more than one attribute terms as options
6. Then click the Add button of the modal
7. When the modal closes a list of Attribute options should be shown
8. Save the product by clicking the top right button of the screen
9. Click the Edit button from any table row
10. The edit attribute modal should be shown with a `Set default value` checkbox checked by default 
11. Uncheck it and click save
12. Save the product again
13. If you try to edit the same attribute, the checkbox should de unchecked in the modal
14. Close the modal
15. Remove the attribute from the list and then save the product again
16. After refresh the page, the attribute options list should be empty

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
