### PR TITLE
Fix toolbar button text not showing in WP 6.3

### DIFF
--- a/packages/js/product-editor/changelog/fix-39543
+++ b/packages/js/product-editor/changelog/fix-39543
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix toolbar button text not showing in WP 6.3

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
@@ -135,17 +135,15 @@ export function HeaderToolbar( {
 					variant="tertiary"
 					className="woocommerce-modal-actions__cancel-button"
 					onClick={ onCancel }
-				>
-					{ __( 'Cancel', 'woocommerce' ) }
-				</ToolbarItem>
+					text={ __( 'Cancel', 'woocommerce' ) }
+				/>
 				<ToolbarItem
 					as={ Button }
 					variant="primary"
 					className="woocommerce-modal-actions__done-button"
 					onClick={ onSave }
-				>
-					{ __( 'Done', 'woocommerce' ) }
-				</ToolbarItem>
+					text={ __( 'Done', 'woocommerce' ) }
+				/>
 				<ToolbarItem
 					as={ ShowBlockInspectorPanel }
 					className="woocommerce-show-block-inspector-panel"


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Gutenberg recently updated toolbar items to use [Ariakit instead of Reakit](https://github.com/WordPress/gutenberg/pull/51623).  This PR removed the children prop from the render of toolbar items.

I think it's likely that this is unexpected behavior, so I'll open an issue and fix upstream, but in the meantime this is a workaround that allows buttons to work.

<img width="354" alt="Screen Shot 2023-08-03 at 1 29 12 PM" src="https://github.com/woocommerce/woocommerce/assets/10561050/878c19aa-7eb7-4ef3-8e60-83188a0fd187">


Closes #39543  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the new product editing experience under WooCommerce -> Settings -> Advanced -> Features.
2. Navigate to the Add Product page.
3. Click on "Add description"
4. Note that the "Cancel" and "Done" buttons and text are visible in the modal toolbar
5. Update to WP 6.3
6. Check that the buttons and text are still visible in the description modal toolbar

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
