### PR TITLE
bump WooCommerce blocks version to 10.6.4

### DIFF
--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-10.6.4
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-10.6.4
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update WooCommerce Blocks to 10.6.4

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -23,7 +23,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.6.1",
-		"woocommerce/woocommerce-blocks": "10.6.3"
+		"woocommerce/woocommerce-blocks": "10.6.4"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.3.0",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7b144c7ab609140c435100a30d38d195",
+    "content-hash": "ec3a4ac00d0f17e7656229a2efe18a88",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1004,16 +1004,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "10.6.3",
+            "version": "10.6.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "38f548b4756c1a39ecac63c0ac1f3da66124edf7"
+                "reference": "5ff77faccb8b52f95ec0a4a166722d3ed8010314"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/38f548b4756c1a39ecac63c0ac1f3da66124edf7",
-                "reference": "38f548b4756c1a39ecac63c0ac1f3da66124edf7",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/5ff77faccb8b52f95ec0a4a166722d3ed8010314",
+                "reference": "5ff77faccb8b52f95ec0a4a166722d3ed8010314",
                 "shasum": ""
             },
             "require": {
@@ -1059,9 +1059,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v10.6.3"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v10.6.4"
             },
-            "time": "2023-08-03T07:34:20+00:00"
+            "time": "2023-08-04T15:41:33+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 10.6.4. This is intended to be merged into WooCommerce 8.0.

## Blocks 10.6.4

* [Release PR](https://github.com/woocommerce/woocommerce-blocks/pull/10480)
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/1064.md)

### Changelog entry

#### Bug Fixes

- Classic Template block registration: Add defensive type handling. ([10475](https://github.com/woocommerce/woocommerce-blocks/pull/10475))
- Fixed an issue where modifications to the Cart/Checkout templates made in the site editor would not be visible on the front end. [#10462](https://github.com/woocommerce/woocommerce-blocks/pull/10462)

****