### PR TITLE
Fire 'woocommerce_process_shop_order_meta' only once when updating orders on the admin

### DIFF
--- a/plugins/woocommerce/changelog/fix-39583
+++ b/plugins/woocommerce/changelog/fix-39583
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Do not run 'woocommerce_process_shop_order_meta' for order post when HPOS is authoritative.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-meta-boxes.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-meta-boxes.php
@@ -9,6 +9,7 @@
 
 use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Internal\Admin\Orders\Edit as OrderEdit;
+use Automattic\WooCommerce\Utilities\OrderUtil;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -215,7 +216,7 @@ class WC_Admin_Meta_Boxes {
 		$post_id = absint( $post_id );
 
 		// $post_id and $post are required
-		if ( empty( $post_id ) || empty( $post ) || self::$saved_meta_boxes ) {
+		if ( empty( $post_id ) || empty( $post ) || ! is_a( $post, 'WP_Post' ) || self::$saved_meta_boxes ) {
 			return;
 		}
 
@@ -247,6 +248,10 @@ class WC_Admin_Meta_Boxes {
 
 		// Check the post type.
 		if ( in_array( $post->post_type, wc_get_order_types( 'order-meta-boxes' ), true ) ) {
+			if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
+				return;
+			}
+
 			/**
 			 * Save meta for shop order.
 			 *


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
When HPOS is authoritative and data sync is enabled, creating or updating an order on the admin results in the `woocommerce_process_shop_order_meta` hook being fired twice: one for the order object itself and then for the associated post (this one triggered by the sync).

This PR makes it so we only fire it once and instead of attempting to double-update things, we let the sync take care of things.

Closes #39583.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Drop the following snippet as a .php file inside `wp-content/mu-plugins`:
   ```php
   <?php
   add_action(
	   'woocommerce_process_shop_order_meta',
	   function( $id, $obj ) {
		   error_log(
			   '"woocommerce_process_shop_order_meta" fired for ' . get_class( $obj ) . ' [' . $id . ']'
		   );
	   },
	   10,
	   2
   );
   ```
2. Go to WC > Settings > Advanced > Features and choose "High performance order storage" as datastore. Make sure "Keep the posts and orders tables in sync (compatibility mode)" is checked.
3. Go to WC > Orders and click "Add order".
4. Enter some details for the order.
5. Click "Update" and take note of the order ID as seen in the URL.
6. Check your logs and there should be entries in the form of `"woocommerce_process_shop_order_meta" fired for WC_Order [ORDER_ID]` but there should not be any entry mentioning `WP_Post` instead of `WC_Order`.
7. To confirm that sync is working correctly, change the customer for your order and some of the shipping/billing details.
8. Use WP-CLI to confirm that the changes have propagated to the post by doing a `wp post meta list <ORDER_ID>`.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
