### PR TITLE
Execute order update logic earlier in the request

### DIFF
--- a/plugins/woocommerce/changelog/fix-39585
+++ b/plugins/woocommerce/changelog/fix-39585
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+When HPOS is authoritative, execute order update logic earlier during the request.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
@@ -290,11 +290,6 @@ class PageController {
 		switch ( $this->current_action ) {
 			case 'edit_order':
 			case 'new_order':
-				if ( ! isset( $this->order_edit_form ) ) {
-					$this->order_edit_form = new Edit();
-					$this->order_edit_form->setup( $this->order );
-				}
-				$this->order_edit_form->set_current_action( $this->current_action );
 				$this->order_edit_form->display();
 				break;
 			case 'list_orders':
@@ -341,6 +336,22 @@ class PageController {
 	}
 
 	/**
+	 * Prepares the order edit form for creating or editing an order.
+	 *
+	 * @see \Automattic\WooCommerce\Internal\Admin\Orders\Edit.
+	 * @since 8.1.0
+	 */
+	private function prepare_order_edit_form(): void {
+		if ( ! $this->order || ! in_array( $this->current_action, array( 'new_order', 'edit_order' ), true ) ) {
+			return;
+		}
+
+		$this->order_edit_form = $this->order_edit_form ?? new Edit();
+		$this->order_edit_form->setup( $this->order );
+		$this->order_edit_form->set_current_action( $this->current_action );
+	}
+
+	/**
 	 * Handles initialization of the orders edit form.
 	 *
 	 * @return void
@@ -351,6 +362,8 @@ class PageController {
 		$this->verify_edit_permission();
 		$this->handle_edit_lock();
 		$theorder = $this->order;
+
+		$this->prepare_order_edit_form();
 	}
 
 	/**
@@ -380,6 +393,8 @@ class PageController {
 		}
 
 		$theorder = $this->order;
+
+		$this->prepare_order_edit_form();
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
When HPOS is authoritative, order data is updated via `woocommerce_process_shop_order_meta` inside a hook (`woocommerce_page_wc-orders`) that is meant to only output the content of the admin page.
Proof of that is that, for example, `admin_notices` gets fired before this logic is executed, which can be problematic for 3rd party code.

This PR changes our edit order logic to be executed inside `load-woocommerce_page_wc-orders` instead, which is [allowed by the `PageController` class](https://github.com/woocommerce/woocommerce/blob/d64e1c24dd69cb58518e0a8ceeb3e9ae6ec77bb8/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php#L155C37-L155C37).

The actual rendering of the page (metaboxes, etc.) does occur at a later stage as expected.

Closes #39585.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. As explained in #39585, a good way to make sure that hooks are fired in the correct order is to use a snippet to log when they are called.
   In particular, the following snippet will do the trick. It can be dropped inside `wp-content/mu-plugins/` as a .php file:
   ```php
   <?php
   foreach ( [ 'load-woocommerce_page_wc-orders', 'woocommerce_page_wc-orders', 'woocommerce_process_shop_order_meta', 'admin_notices' ] as $hook ) {
	   add_action(
		   $hook,
		   static function() {
			   error_log( current_action() );
		   }
	   );
   }
   ```
2. Go to WC > Settings > Advanced > Features.
3. Make sure "High performance order storage" is selected. Update settings if necessary.
4. Go to WC > Orders.
5. Create a new order by clicking "Add order".
6. Enter order details and click "Update".
7. Check your logs and confirm that entries that were logged by the snippet are in the correct order. That is: `load-woocommerce_page_wc-orders` -> `woocommerce_process_shop_order_meta` -> `woocommerce_page_wc-orders`.
In particular, `admin_notices` should not appear _before_ `woocommerce_process_shop_order_meta` (for any given request).
8. Repeat steps 6 and 7 after making further changes to the order and confirm that those changes have been saved.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
When HPOS is authoritative, execute order update logic earlier during the request.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
