### PR TITLE
Ensure menu order does not have duplicated WC-related items

### DIFF
--- a/plugins/woocommerce/changelog/fix-39599
+++ b/plugins/woocommerce/changelog/fix-39599
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Ensure menu order does not have duplicated WC-related items

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -243,7 +243,7 @@ class WC_Admin_Menus {
 				$woocommerce_menu_order[] = 'edit.php?post_type=product';
 				unset( $menu_order[ $woocommerce_separator ] );
 				unset( $menu_order[ $woocommerce_product ] );
-			} elseif ( ! in_array( $item, array( 'separator-woocommerce' ), true ) ) {
+			} elseif ( ! in_array( $item, array( 'separator-woocommerce', 'edit.php?post_type=product' ), true ) ) {
 				$woocommerce_menu_order[] = $item;
 			}
 		}

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -228,24 +228,26 @@ class WC_Admin_Menus {
 		// Initialize our custom order array.
 		$woocommerce_menu_order = array();
 
-		// Get the index of our custom separator.
-		$woocommerce_separator = array_search( 'separator-woocommerce', $menu_order, true );
-
-		// Get index of product menu.
-		$woocommerce_product = array_search( 'edit.php?post_type=product', $menu_order, true );
+		// Remove menu items that we will set manually.
+		$ignored_items = array(
+			array_search( 'separator-woocommerce', $menu_order, true ),
+			array_search( 'edit.php?post_type=product', $menu_order, true ),
+		);
 
 		// Loop through menu order and do some rearranging.
 		foreach ( $menu_order as $index => $item ) {
-
 			if ( 'woocommerce' === $item ) {
 				$woocommerce_menu_order[] = 'separator-woocommerce';
 				$woocommerce_menu_order[] = $item;
 				$woocommerce_menu_order[] = 'edit.php?post_type=product';
-				unset( $menu_order[ $woocommerce_separator ] );
-				unset( $menu_order[ $woocommerce_product ] );
-			} elseif ( ! in_array( $item, array( 'separator-woocommerce', 'edit.php?post_type=product' ), true ) ) {
-				$woocommerce_menu_order[] = $item;
+				continue;
 			}
+
+			if ( in_array( $index, $ignored_items, true ) ) {
+				continue;
+			}
+
+			$woocommerce_menu_order[] = $item;
 		}
 
 		// Return order.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In `WC_Admin_Menus::menu_order()`, it manipulates the array of admin menu items to get the WooCommerce items into a specific order. However, in doing so, it duplicates the Products menu item, because it doesn't remove the original item after it adds a new one in a specific location. This must get de-duplicated later, since we don't see "Products" twice in the menu, but it makes things more complicated for anyone else who wants to the filter the menu order and make customizations.

This PR simply ensures that menu items that are added manually for WooCommerce are not added a second time later.

Closes #39599

### How to test the changes in this Pull Request:

Add this snippet to your test site, for example, in a file in mu-plugins:

```php
// https://github.com/woocommerce/woocommerce/pull/39601
add_action(
	'menu_order',
	function( $menu_order ) {
		echo '<pre>';
		var_dump( $menu_order );
		echo '</pre>';
		wp_die();
	},
	99
);
```

1. While still on the trunk branch, point your browser at any admin page of your test site. The above snippet will output an array of the admin menu items, and then prevent the rest of the admin from loading. You should see that `edit.php?post_type=product` appears in the list twice.
2. Check out this branch and reload your browser tab. Now the `edit.php?post_type=product` should only appear once, in the correct place beneath `woocommerce`.
3. Don't forget to remove the snippet when you're done testing, since it breaks the admin!

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Ensure menu order does not have duplicated WC-related items

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>