### PR TITLE
Bump beta tester to 2.2.2 in prep to release bugfixes

### DIFF
--- a/plugins/woocommerce-beta-tester/changelog/dev-bump-beta-tester-version
+++ b/plugins/woocommerce-beta-tester/changelog/dev-bump-beta-tester-version
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Release woocommerce-beta-tester with bugfixes from #39441

--- a/plugins/woocommerce-beta-tester/composer.json
+++ b/plugins/woocommerce-beta-tester/composer.json
@@ -6,7 +6,7 @@
 	"license": "GPL-3.0-or-later",
 	"prefer-stable": true,
 	"minimum-stability": "dev",
-	"version": "2.2.1",
+	"version": "2.2.2",
 	"require": {
 		"composer/installers": "~1.7"
 	},

--- a/plugins/woocommerce-beta-tester/package.json
+++ b/plugins/woocommerce-beta-tester/package.json
@@ -7,7 +7,7 @@
 		"url": "git://github.com/woocommerce/woocommerce-beta-tester.git"
 	},
 	"title": "WooCommerce Beta Tester",
-	"version": "2.2.1",
+	"version": "2.2.2",
 	"homepage": "http://github.com/woocommerce/woocommerce-beta-tester",
 	"devDependencies": {
 		"@types/react": "^17.0.2",

--- a/plugins/woocommerce-beta-tester/readme.txt
+++ b/plugins/woocommerce-beta-tester/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, bor0, claudiosanches, claudiulodro, kloon, mikejolley,
 Tags: woocommerce, woo commerce, beta, beta tester, bleeding edge, testing
 Requires at least: 4.7
 Tested up to: 6.0
-Stable tag: 2.2.1
+Stable tag: 2.2.2
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/plugins/woocommerce-beta-tester/woocommerce-beta-tester.php
+++ b/plugins/woocommerce-beta-tester/woocommerce-beta-tester.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Beta Tester
  * Plugin URI: https://github.com/woocommerce/woocommerce-beta-tester
  * Description: Run bleeding edge versions of WooCommerce. This will replace your installed version of WooCommerce with the latest tagged release - use with caution, and not on production sites.
- * Version: 2.2.1
+ * Version: 2.2.2
  * Author: WooCommerce
  * Author URI: http://woocommerce.com/
  * Requires at least: 5.8


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This bumps the version of beta tester to prep for a release of the bugfixes introduced in #39441 

### How to test the changes in this Pull Request:

There is nothing to test.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Release woocommerce-beta-tester with bugfixes from #39441

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
