### PR TITLE
WC Telemetry: add `first_used` and `installation_date` data to WCTracker

### DIFF
--- a/plugins/woocommerce/changelog/wcios-10406-telemetry-add-metrics
+++ b/plugins/woocommerce/changelog/wcios-10406-telemetry-add-metrics
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Support `first_used` and `installation_date` mobile usage data for WCTracker.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Telemetry/class-wc-rest-telemetry-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Telemetry/class-wc-rest-telemetry-controller.php
@@ -131,7 +131,7 @@ class WC_REST_Telemetry_Controller extends WC_REST_Controller {
 			'platform'          => sanitize_text_field( $platform ),
 			'version'           => sanitize_text_field( $version ),
 			'last_used'         => gmdate( 'c' ),
-			'installation_date' => $installation_date,
+			'installation_date' => get_gmt_from_date( $installation_date, 'c' ),
 		);
 	}
 

--- a/plugins/woocommerce/includes/rest-api/Controllers/Telemetry/class-wc-rest-telemetry-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Telemetry/class-wc-rest-telemetry-controller.php
@@ -82,14 +82,23 @@ class WC_REST_Telemetry_Controller extends WC_REST_Controller {
 
 		$platform = $new['platform'];
 
-		// Only sets `first_used` when this and `last_used` haven't been set before.
-		if ( ! $data[ $platform ]['first_used'] && ! $data[ $platform ]['last_used'] ) {
-			$new['first_used'] = $new['last_used'];
-		}
+        if ( isset($data[ $platform ]) ) {
+            $existing_usage = $data[ $platform ];
 
-		if ( ! $data[ $platform ] || version_compare( $new['version'], $data[ $platform ]['version'], '>=' ) ) {
-			$data[ $platform ] = $new;
-		}
+            // Sets the installation date only if it has not been set before.
+            if ( !isset($existing_usage['installation_date']) ) {
+                $data[ $platform ]['installation_date'] = $new['installation_date'];
+            }
+
+            if ( version_compare( $new['version'], $existing_usage['version'], '>=' ) ) {
+                $data[ $platform ]['version'] = $new['version'];
+                $data[ $platform ]['last_used'] = $new['last_used'];
+            }
+        } else {
+            // Only sets `first_used` when the platform usage data hasn't been set before.
+            $new['first_used'] = $new['last_used'];
+            $data[ $platform ] = $new;
+        }
 
 		update_option( 'woocommerce_mobile_app_usage', $data );
 	}
@@ -150,7 +159,8 @@ class WC_REST_Telemetry_Controller extends WC_REST_Controller {
 			'installation_date'  => array(
 				'description'       => __( 'Installation date of the WooCommerce mobile app.', 'woocommerce' ),
 				'required'          => false, // For backward compatibility.
-				'type'              => 'date-time',
+				'type'               => 'string',
+                'format'             => 'date-time',
 				'validate_callback' => 'rest_validate_request_arg',
 			),
 		);

--- a/plugins/woocommerce/includes/rest-api/Controllers/Telemetry/class-wc-rest-telemetry-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Telemetry/class-wc-rest-telemetry-controller.php
@@ -86,7 +86,7 @@ class WC_REST_Telemetry_Controller extends WC_REST_Controller {
 			$existing_usage = $data[ $platform ];
 
 			// Sets the installation date only if it has not been set before.
-			if ( ! isset( $existing_usage['installation_date'] ) ) {
+			if ( isset( $new['installation_date'] ) && ! isset( $existing_usage['installation_date'] ) ) {
 				$data[ $platform ]['installation_date'] = $new['installation_date'];
 			}
 
@@ -127,12 +127,14 @@ class WC_REST_Telemetry_Controller extends WC_REST_Controller {
 		// The installation date could be null from earlier mobile client versions.
 		$installation_date = $request->get_param( 'installation_date' );
 
-		return array(
+		return array_filter(array(
 			'platform'          => sanitize_text_field( $platform ),
 			'version'           => sanitize_text_field( $version ),
 			'last_used'         => gmdate( 'c' ),
-			'installation_date' => get_gmt_from_date( $installation_date, 'c' ),
-		);
+			'installation_date' => isset($installation_date) ? get_gmt_from_date( $installation_date, 'c' ) : null,
+		), function($value) {
+			return $value !== null;
+		});
 	}
 
 	/**

--- a/plugins/woocommerce/includes/rest-api/Controllers/Telemetry/class-wc-rest-telemetry-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Telemetry/class-wc-rest-telemetry-controller.php
@@ -82,23 +82,23 @@ class WC_REST_Telemetry_Controller extends WC_REST_Controller {
 
 		$platform = $new['platform'];
 
-        if ( isset($data[ $platform ]) ) {
-            $existing_usage = $data[ $platform ];
+		if ( isset( $data[ $platform ] ) ) {
+			$existing_usage = $data[ $platform ];
 
-            // Sets the installation date only if it has not been set before.
-            if ( !isset($existing_usage['installation_date']) ) {
-                $data[ $platform ]['installation_date'] = $new['installation_date'];
-            }
+			// Sets the installation date only if it has not been set before.
+			if ( ! isset( $existing_usage['installation_date'] ) ) {
+				$data[ $platform ]['installation_date'] = $new['installation_date'];
+			}
 
-            if ( version_compare( $new['version'], $existing_usage['version'], '>=' ) ) {
-                $data[ $platform ]['version'] = $new['version'];
-                $data[ $platform ]['last_used'] = $new['last_used'];
-            }
-        } else {
-            // Only sets `first_used` when the platform usage data hasn't been set before.
-            $new['first_used'] = $new['last_used'];
-            $data[ $platform ] = $new;
-        }
+			if ( version_compare( $new['version'], $existing_usage['version'], '>=' ) ) {
+				$data[ $platform ]['version']   = $new['version'];
+				$data[ $platform ]['last_used'] = $new['last_used'];
+			}
+		} else {
+			// Only sets `first_used` when the platform usage data hasn't been set before.
+			$new['first_used'] = $new['last_used'];
+			$data[ $platform ] = $new;
+		}
 
 		update_option( 'woocommerce_mobile_app_usage', $data );
 	}
@@ -128,9 +128,9 @@ class WC_REST_Telemetry_Controller extends WC_REST_Controller {
 		$installation_date = $request->get_param( 'installation_date' );
 
 		return array(
-			'platform'  => sanitize_text_field( $platform ),
-			'version'   => sanitize_text_field( $version ),
-			'last_used' => gmdate( 'c' ),
+			'platform'          => sanitize_text_field( $platform ),
+			'version'           => sanitize_text_field( $version ),
+			'last_used'         => gmdate( 'c' ),
 			'installation_date' => $installation_date,
 		);
 	}
@@ -142,25 +142,25 @@ class WC_REST_Telemetry_Controller extends WC_REST_Controller {
 	 */
 	public function get_collection_params() {
 		return array(
-			'platform' => array(
+			'platform'          => array(
 				'description'       => __( 'Platform to track.', 'woocommerce' ),
 				'required'          => true,
 				'type'              => 'string',
 				'sanitize_callback' => 'sanitize_text_field',
 				'validate_callback' => 'rest_validate_request_arg',
 			),
-			'version'  => array(
+			'version'           => array(
 				'description'       => __( 'Platform version to track.', 'woocommerce' ),
 				'required'          => true,
 				'type'              => 'string',
 				'sanitize_callback' => 'sanitize_text_field',
 				'validate_callback' => 'rest_validate_request_arg',
 			),
-			'installation_date'  => array(
+			'installation_date' => array(
 				'description'       => __( 'Installation date of the WooCommerce mobile app.', 'woocommerce' ),
 				'required'          => false, // For backward compatibility.
-				'type'               => 'string',
-                'format'             => 'date-time',
+				'type'              => 'string',
+				'format'            => 'date-time',
 				'validate_callback' => 'rest_validate_request_arg',
 			),
 		);

--- a/plugins/woocommerce/includes/rest-api/Controllers/Telemetry/class-wc-rest-telemetry-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Telemetry/class-wc-rest-telemetry-controller.php
@@ -127,14 +127,17 @@ class WC_REST_Telemetry_Controller extends WC_REST_Controller {
 		// The installation date could be null from earlier mobile client versions.
 		$installation_date = $request->get_param( 'installation_date' );
 
-		return array_filter(array(
-			'platform'          => sanitize_text_field( $platform ),
-			'version'           => sanitize_text_field( $version ),
-			'last_used'         => gmdate( 'c' ),
-			'installation_date' => isset($installation_date) ? get_gmt_from_date( $installation_date, 'c' ) : null,
-		), function($value) {
-			return $value !== null;
-		});
+		return array_filter(
+			array(
+				'platform'          => sanitize_text_field( $platform ),
+				'version'           => sanitize_text_field( $version ),
+				'last_used'         => gmdate( 'c' ),
+				'installation_date' => isset( $installation_date ) ? get_gmt_from_date( $installation_date, 'c' ) : null,
+			),
+			function( $value ) {
+				return null !== $value;
+			}
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/includes/rest-api/Controllers/Telemetry/class-wc-rest-telemetry-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Telemetry/class-wc-rest-telemetry-controller.php
@@ -81,6 +81,12 @@ class WC_REST_Telemetry_Controller extends WC_REST_Controller {
 		}
 
 		$platform = $new['platform'];
+
+		// Only sets `first_used` when this and `last_used` haven't been set before.
+		if ( ! $data[ $platform ]['first_used'] && ! $data[ $platform ]['last_used'] ) {
+			$new['first_used'] = $new['last_used'];
+		}
+
 		if ( ! $data[ $platform ] || version_compare( $new['version'], $data[ $platform ]['version'], '>=' ) ) {
 			$data[ $platform ] = $new;
 		}
@@ -109,10 +115,14 @@ class WC_REST_Telemetry_Controller extends WC_REST_Controller {
 			return;
 		}
 
+		// The installation date could be null from earlier mobile client versions.
+		$installation_date = $request->get_param( 'installation_date' );
+
 		return array(
 			'platform'  => sanitize_text_field( $platform ),
 			'version'   => sanitize_text_field( $version ),
 			'last_used' => gmdate( 'c' ),
+			'installation_date' => $installation_date,
 		);
 	}
 

--- a/plugins/woocommerce/includes/rest-api/Controllers/Telemetry/class-wc-rest-telemetry-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Telemetry/class-wc-rest-telemetry-controller.php
@@ -147,6 +147,12 @@ class WC_REST_Telemetry_Controller extends WC_REST_Controller {
 				'sanitize_callback' => 'sanitize_text_field',
 				'validate_callback' => 'rest_validate_request_arg',
 			),
+			'installation_date'  => array(
+				'description'       => __( 'Installation date of the WooCommerce mobile app.', 'woocommerce' ),
+				'required'          => false, // For backward compatibility.
+				'type'              => 'date-time',
+				'validate_callback' => 'rest_validate_request_arg',
+			),
 		);
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Telemetry/TelemetryControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Telemetry/TelemetryControllerTest.php
@@ -12,9 +12,9 @@ use WC_REST_Unit_Test_Case;
 use WP_REST_Request;
 
 /**
- * OnboardingPlugins API controller test.
+ * Telemetry API controller test.
  *
- * @class OnboardingPluginsTest.
+ * @class TelemetryControllerTest.
  */
 class TelemetryControllerTest extends WC_REST_Unit_Test_Case {
     /**

--- a/plugins/woocommerce/tests/php/src/Internal/Telemetry/TelemetryControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Telemetry/TelemetryControllerTest.php
@@ -178,6 +178,35 @@ class TelemetryControllerTest extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Test to confirm that `installation_date` is not set when it is not included in the request.
+	 *
+	 * @return void
+	 */
+	public function test_WCTracker_mobile_usage_installation_date_is_not_set_when_it_is_not_in_the_request() {
+		// Given.
+		$existing_data = array(
+			'ios' => array(
+				'version'           => '14.8',
+			),
+		);
+		update_option( self::MOBILE_USAGE_OPTION_KEY, $existing_data );
+
+		// When.
+		$this->request(
+			array(
+				'platform'          => 'ios',
+				'version'           => '14.7',
+			)
+		)->get_data();
+
+		// Then.
+		$new_data = get_option( self::MOBILE_USAGE_OPTION_KEY );
+		$this->assertTrue( isset( $new_data['ios'] ) );
+		$this->assertFalse( isset( $new_data['ios']['installation_date'] ) );
+		$this->assertFalse( isset( $new_data['android'] ) );
+	}
+
+	/**
 	 * Test to confirm that `first_used` is only set once per platform.
 	 *
 	 * @return void

--- a/plugins/woocommerce/tests/php/src/Internal/Telemetry/TelemetryControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Telemetry/TelemetryControllerTest.php
@@ -69,9 +69,9 @@ class TelemetryControllerTest extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
-	 * Request to install-async endpoint.
+	 * Request to the telemetry endpoint.
 	 *
-	 * @param $body_params
+	 * @param array $body_params Parameters in the request body.
 	 * @return mixed
 	 */
 	private function request( $body_params ) {
@@ -89,7 +89,7 @@ class TelemetryControllerTest extends WC_REST_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_response_is_null_on_success() {
-		// When
+		// When.
 		$data = $this->request(
 			array(
 				'platform'          => 'ios',
@@ -98,7 +98,7 @@ class TelemetryControllerTest extends WC_REST_Unit_Test_Case {
 			)
 		)->get_data();
 
-		// Then
+		// Then.
 		$this->assertNull( $data );
 	}
 
@@ -108,10 +108,10 @@ class TelemetryControllerTest extends WC_REST_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_401_is_returned_without_logged_in_user() {
-		// Given
+		// Given.
 		$this->useWithoutUser();
 
-		// When
+		// When.
 		$response = $this->request(
 			array(
 				'platform' => 'ios',
@@ -119,7 +119,7 @@ class TelemetryControllerTest extends WC_REST_Unit_Test_Case {
 			)
 		);
 
-		// Then
+		// Then.
 		$this->assertEquals( 401, $response->get_status() );
 	}
 
@@ -129,7 +129,7 @@ class TelemetryControllerTest extends WC_REST_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_WCTracker_mobile_usage_data_fields_are_all_set_for_the_first_time() {
-		// When
+		// When.
 		$this->request(
 			array(
 				'platform'          => 'ios',
@@ -138,7 +138,7 @@ class TelemetryControllerTest extends WC_REST_Unit_Test_Case {
 			)
 		)->get_data();
 
-		// Then
+		// Then.
 		$new_data = get_option( self::MOBILE_USAGE_OPTION_KEY );
 		$this->assertEquals( '2023-08-08T03:38:50Z', $new_data['ios']['installation_date'] );
 		$this->assertEquals( '14.7', $new_data['ios']['version'] );
@@ -152,7 +152,7 @@ class TelemetryControllerTest extends WC_REST_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_WCTracker_mobile_usage_installation_date_is_not_overwritten_when_it_was_previously_set() {
-		// Given
+		// Given.
 		$existing_data = array(
 			'ios' => array(
 				'version'           => '14.8',
@@ -161,7 +161,7 @@ class TelemetryControllerTest extends WC_REST_Unit_Test_Case {
 		);
 		update_option( self::MOBILE_USAGE_OPTION_KEY, $existing_data );
 
-		// When
+		// When.
 		$this->request(
 			array(
 				'platform'          => 'ios',
@@ -170,7 +170,7 @@ class TelemetryControllerTest extends WC_REST_Unit_Test_Case {
 			)
 		)->get_data();
 
-		// Then
+		// Then.
 		$new_data = get_option( self::MOBILE_USAGE_OPTION_KEY );
 		$this->assertEquals( '2023-08-08T03:38:50Z', $new_data['ios']['installation_date'] );
 		$this->assertFalse( isset( $new_data['android'] ) );
@@ -182,7 +182,7 @@ class TelemetryControllerTest extends WC_REST_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_WCTracker_mobile_usage_first_used_is_not_overwritten_when_it_was_previously_set() {
-		// Given
+		// Given.
 		$existing_data = array(
 			'ios' => array(
 				'version'           => '14.8',
@@ -192,7 +192,7 @@ class TelemetryControllerTest extends WC_REST_Unit_Test_Case {
 		);
 		update_option( self::MOBILE_USAGE_OPTION_KEY, $existing_data );
 
-		// When
+		// When.
 		$this->request(
 			array(
 				'platform' => 'ios',
@@ -200,7 +200,7 @@ class TelemetryControllerTest extends WC_REST_Unit_Test_Case {
 			)
 		)->get_data();
 
-		// Then
+		// Then.
 		$new_data = get_option( self::MOBILE_USAGE_OPTION_KEY );
 		$this->assertEquals( '2023-08-08T14:58:33+00:00', $new_data['ios']['first_used'] );
 		$this->assertFalse( isset( $new_data['android'] ) );
@@ -212,7 +212,7 @@ class TelemetryControllerTest extends WC_REST_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_WCTracker_mobile_usage_last_used_and_version_are_updated_when_they_were_previously_set_and_version_is_higher() {
-		// Given
+		// Given.
 		$existing_data = array(
 			'ios' => array(
 				'version'           => '14.8',
@@ -222,7 +222,7 @@ class TelemetryControllerTest extends WC_REST_Unit_Test_Case {
 		);
 		update_option( self::MOBILE_USAGE_OPTION_KEY, $existing_data );
 
-		// When
+		// When.
 		$this->request(
 			array(
 				'platform' => 'ios',
@@ -230,7 +230,7 @@ class TelemetryControllerTest extends WC_REST_Unit_Test_Case {
 			)
 		)->get_data();
 
-		// Then
+		// Then.
 		$new_data = get_option( self::MOBILE_USAGE_OPTION_KEY );
 		$this->assertEquals( '14.9', $new_data['ios']['version'] );
 		$this->assertGreaterThan( new \DateTime( '2023-08-06T14:58:33+00:00' ), new \DateTime( $new_data['ios']['last_used'] ) );
@@ -243,7 +243,7 @@ class TelemetryControllerTest extends WC_REST_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_WCTracker_mobile_usage_last_used_and_version_are_not_updated_when_they_were_previously_set_and_version_is_lower() {
-		// Given
+		// Given.
 		$existing_data = array(
 			'ios' => array(
 				'version'           => '14.8',
@@ -253,7 +253,7 @@ class TelemetryControllerTest extends WC_REST_Unit_Test_Case {
 		);
 		update_option( self::MOBILE_USAGE_OPTION_KEY, $existing_data );
 
-		// When
+		// When.
 		$this->request(
 			array(
 				'platform' => 'ios',
@@ -261,7 +261,7 @@ class TelemetryControllerTest extends WC_REST_Unit_Test_Case {
 			)
 		)->get_data();
 
-		// Then
+		// Then.
 		$new_data = get_option( self::MOBILE_USAGE_OPTION_KEY );
 		$this->assertEquals( '14.8', $new_data['ios']['version'] );
 		$this->assertEquals( '2023-08-06T14:58:33+00:00', $new_data['ios']['last_used'] );

--- a/plugins/woocommerce/tests/php/src/Internal/Telemetry/TelemetryControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Telemetry/TelemetryControllerTest.php
@@ -1,0 +1,270 @@
+<?php
+/**
+ * Test the API controller class that handles the telemetry REST endpoints.
+ *
+ * @package WooCommerce\Admin\Tests\Internal\Telemetry
+ */
+
+namespace Automattic\WooCommerce\Tests\Internal\Telemetry;
+
+use Nette\Utils\DateTime;
+use WC_REST_Unit_Test_Case;
+use WP_REST_Request;
+
+/**
+ * OnboardingPlugins API controller test.
+ *
+ * @class OnboardingPluginsTest.
+ */
+class TelemetryControllerTest extends WC_REST_Unit_Test_Case {
+    /**
+     * Endpoint.
+     *
+     * @var string
+     */
+    const ENDPOINT = '/wc-telemetry/tracker';
+
+    const MOBILE_USAGE_OPTION_KEY = 'woocommerce_mobile_app_usage';
+
+    /**
+     * Set up.
+     */
+    public function setUp(): void {
+        parent::setUp();
+        $this->useAdmin();
+        $this->resetMobileUsageData();
+    }
+
+    /**
+     * Use a user with administrator role.
+     *
+     * @return void
+     */
+    public function useAdmin() {
+        // Register an administrator user and log in.
+        $this->user = $this->factory->user->create(
+            array(
+                'role' => 'administrator',
+            )
+        );
+        wp_set_current_user( $this->user );
+    }
+
+    /**
+     * Use a user without any permissions.
+     *
+     * @return void
+     */
+    public function useWithoutUser() {
+        wp_set_current_user( null );
+    }
+
+    /**
+     * Use a user without any permissions.
+     *
+     * @return void
+     */
+    public function resetMobileUsageData() {
+        update_option( self::MOBILE_USAGE_OPTION_KEY, null );
+    }
+
+    /**
+     * Request to install-async endpoint.
+     *
+     * @param $body_params
+     * @return mixed
+     */
+    private function request( $body_params ) {
+        $request = new WP_REST_Request( 'POST', self::ENDPOINT );
+        $request->set_header( 'content-type', 'application/json' );
+        $request->set_body_params( $body_params );
+        $response = $this->server->dispatch( $request );
+
+        return $response;
+    }
+
+    /**
+     * Test to confirm that null is returned on success.
+     *
+     * @return void
+     */
+    public function test_response_is_null_on_success() {
+        // When
+        $data = $this->request(
+            array(
+                'platform' => 'ios',
+                'version' => '14.8',
+                'installation_date' => '2023-08-08T03:38:50Z'
+            )
+        )->get_data();
+
+        // Then
+        $this->assertNull( $data );
+    }
+
+    /**
+     * Test 401 error is thrown when there is no logged in user.
+     *
+     * @return void
+     */
+    public function test_401_is_returned_without_logged_in_user() {
+        // Given
+        $this->useWithoutUser();
+
+        // When
+        $response = $this->request(
+            array(
+                'platform' => 'ios',
+                'version' => '14.8',
+            )
+        );
+
+        // Then
+        $this->assertEquals( 401, $response->get_status() );
+    }
+
+    /**
+     * Test to confirm all the data fields are set for the first time.
+     *
+     * @return void
+     */
+    public function test_WCTracker_mobile_usage_data_fields_are_all_set_for_the_first_time() {
+        // When
+        $this->request(
+            array(
+                'platform' => 'ios',
+                'version' => '14.7',
+                'installation_date' => '2023-08-08T03:38:50Z'
+            )
+        )->get_data();
+
+        // Then
+        $new_data = get_option( self::MOBILE_USAGE_OPTION_KEY );
+        $this->assertEquals( '2023-08-08T03:38:50Z',  $new_data['ios']['installation_date'] );
+        $this->assertEquals( '14.7',  $new_data['ios']['version'] );
+        $this->assertEquals( $new_data['ios']['last_used'],  $new_data['ios']['first_used'] );
+        $this->assertFalse( isset($new_data['android']) );
+    }
+
+    /**
+     * Test to confirm that `installation_date` is only set once per platform.
+     *
+     * @return void
+     */
+    public function test_WCTracker_mobile_usage_installation_date_is_not_overwritten_when_it_was_previously_set() {
+        // Given
+        $existing_data = array(
+            'ios' => array(
+                'version' => '14.8',
+                'installation_date' => '2023-08-08T03:38:50Z'
+            )
+        );
+        update_option( self::MOBILE_USAGE_OPTION_KEY, $existing_data );
+
+        // When
+        $this->request(
+            array(
+                'platform' => 'ios',
+                'version' => '14.7',
+                'installation_date' => '2023-03-08T03:38:50Z'
+            )
+        )->get_data();
+
+        // Then
+        $new_data = get_option( self::MOBILE_USAGE_OPTION_KEY );
+        $this->assertEquals( '2023-08-08T03:38:50Z',  $new_data['ios']['installation_date'] );
+        $this->assertFalse( isset($new_data['android']) );
+    }
+
+    /**
+     * Test to confirm that `first_used` is only set once per platform.
+     *
+     * @return void
+     */
+    public function test_WCTracker_mobile_usage_first_used_is_not_overwritten_when_it_was_previously_set() {
+        // Given
+        $existing_data = array(
+            'ios' => array(
+                'version' => '14.8',
+                'installation_date' => '2023-08-08T03:38:50Z',
+                'first_used' => '2023-08-08T14:58:33+00:00'
+            )
+        );
+        update_option( self::MOBILE_USAGE_OPTION_KEY, $existing_data );
+
+        // When
+        $this->request(
+            array(
+                'platform' => 'ios',
+                'version' => '14.9'
+            )
+        )->get_data();
+
+        // Then
+        $new_data = get_option( self::MOBILE_USAGE_OPTION_KEY );
+        $this->assertEquals( '2023-08-08T14:58:33+00:00',  $new_data['ios']['first_used'] );
+        $this->assertFalse( isset($new_data['android']) );
+    }
+
+    /**
+     * Test to confirm that `last_used` and `version` are updated when the new data has a higher version.
+     *
+     * @return void
+     */
+    public function test_WCTracker_mobile_usage_last_used_and_version_are_updated_when_they_were_previously_set_and_version_is_higher() {
+        // Given
+        $existing_data = array(
+            'ios' => array(
+                'version' => '14.8',
+                'installation_date' => '2023-08-08T03:38:50Z',
+                'last_used' => '2023-08-06T14:58:33+00:00'
+            )
+        );
+        update_option( self::MOBILE_USAGE_OPTION_KEY, $existing_data );
+
+        // When
+        $this->request(
+            array(
+                'platform' => 'ios',
+                'version' => '14.9'
+            )
+        )->get_data();
+
+        // Then
+        $new_data = get_option( self::MOBILE_USAGE_OPTION_KEY );
+        $this->assertEquals( '14.9', $new_data['ios']['version'] );
+        $this->assertGreaterThan( new \DateTime('2023-08-06T14:58:33+00:00' ),  new \DateTime( $new_data['ios']['last_used'] ) );
+        $this->assertFalse( isset($new_data['android']) );
+    }
+
+    /**
+     * Test to confirm that `last_used` and `version` are not updated when the new data has a lower version.
+     *
+     * @return void
+     */
+    public function test_WCTracker_mobile_usage_last_used_and_version_are_not_updated_when_they_were_previously_set_and_version_is_lower() {
+        // Given
+        $existing_data = array(
+            'ios' => array(
+                'version' => '14.8',
+                'installation_date' => '2023-08-08T03:38:50Z',
+                'last_used' => '2023-08-06T14:58:33+00:00'
+            )
+        );
+        update_option( self::MOBILE_USAGE_OPTION_KEY, $existing_data );
+
+        // When
+        $this->request(
+            array(
+                'platform' => 'ios',
+                'version' => '14.7'
+            )
+        )->get_data();
+
+        // Then
+        $new_data = get_option( self::MOBILE_USAGE_OPTION_KEY );
+        $this->assertEquals( '14.8', $new_data['ios']['version'] );
+        $this->assertEquals( '2023-08-06T14:58:33+00:00', $new_data['ios']['last_used'] );
+        $this->assertFalse( isset($new_data['android']) );
+    }
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Telemetry/TelemetryControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Telemetry/TelemetryControllerTest.php
@@ -140,7 +140,8 @@ class TelemetryControllerTest extends WC_REST_Unit_Test_Case {
 
 		// Then.
 		$new_data = get_option( self::MOBILE_USAGE_OPTION_KEY );
-		$this->assertEquals( '2023-08-08T03:38:50Z', $new_data['ios']['installation_date'] );
+		// The installation date should be converted to the GMT date format 'c' to match other date fields.
+		$this->assertEquals( '2023-08-08T03:38:50+00:00', $new_data['ios']['installation_date'] );
 		$this->assertEquals( '14.7', $new_data['ios']['version'] );
 		$this->assertEquals( $new_data['ios']['last_used'], $new_data['ios']['first_used'] );
 		$this->assertFalse( isset( $new_data['android'] ) );
@@ -156,7 +157,7 @@ class TelemetryControllerTest extends WC_REST_Unit_Test_Case {
 		$existing_data = array(
 			'ios' => array(
 				'version'           => '14.8',
-				'installation_date' => '2023-08-08T03:38:50Z',
+				'installation_date' => '2023-08-08T03:38:50+00:00',
 			),
 		);
 		update_option( self::MOBILE_USAGE_OPTION_KEY, $existing_data );
@@ -172,7 +173,7 @@ class TelemetryControllerTest extends WC_REST_Unit_Test_Case {
 
 		// Then.
 		$new_data = get_option( self::MOBILE_USAGE_OPTION_KEY );
-		$this->assertEquals( '2023-08-08T03:38:50Z', $new_data['ios']['installation_date'] );
+		$this->assertEquals( '2023-08-08T03:38:50+00:00', $new_data['ios']['installation_date'] );
 		$this->assertFalse( isset( $new_data['android'] ) );
 	}
 
@@ -186,7 +187,6 @@ class TelemetryControllerTest extends WC_REST_Unit_Test_Case {
 		$existing_data = array(
 			'ios' => array(
 				'version'           => '14.8',
-				'installation_date' => '2023-08-08T03:38:50Z',
 				'first_used'        => '2023-08-08T14:58:33+00:00',
 			),
 		);
@@ -216,7 +216,6 @@ class TelemetryControllerTest extends WC_REST_Unit_Test_Case {
 		$existing_data = array(
 			'ios' => array(
 				'version'           => '14.8',
-				'installation_date' => '2023-08-08T03:38:50Z',
 				'last_used'         => '2023-08-06T14:58:33+00:00',
 			),
 		);
@@ -247,7 +246,6 @@ class TelemetryControllerTest extends WC_REST_Unit_Test_Case {
 		$existing_data = array(
 			'ios' => array(
 				'version'           => '14.8',
-				'installation_date' => '2023-08-08T03:38:50Z',
 				'last_used'         => '2023-08-06T14:58:33+00:00',
 			),
 		);

--- a/plugins/woocommerce/tests/php/src/Internal/Telemetry/TelemetryControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Telemetry/TelemetryControllerTest.php
@@ -186,7 +186,7 @@ class TelemetryControllerTest extends WC_REST_Unit_Test_Case {
 		// Given.
 		$existing_data = array(
 			'ios' => array(
-				'version'           => '14.8',
+				'version' => '14.8',
 			),
 		);
 		update_option( self::MOBILE_USAGE_OPTION_KEY, $existing_data );
@@ -194,8 +194,8 @@ class TelemetryControllerTest extends WC_REST_Unit_Test_Case {
 		// When.
 		$this->request(
 			array(
-				'platform'          => 'ios',
-				'version'           => '14.7',
+				'platform' => 'ios',
+				'version'  => '14.7',
 			)
 		)->get_data();
 
@@ -215,8 +215,8 @@ class TelemetryControllerTest extends WC_REST_Unit_Test_Case {
 		// Given.
 		$existing_data = array(
 			'ios' => array(
-				'version'           => '14.8',
-				'first_used'        => '2023-08-08T14:58:33+00:00',
+				'version'    => '14.8',
+				'first_used' => '2023-08-08T14:58:33+00:00',
 			),
 		);
 		update_option( self::MOBILE_USAGE_OPTION_KEY, $existing_data );
@@ -244,8 +244,8 @@ class TelemetryControllerTest extends WC_REST_Unit_Test_Case {
 		// Given.
 		$existing_data = array(
 			'ios' => array(
-				'version'           => '14.8',
-				'last_used'         => '2023-08-06T14:58:33+00:00',
+				'version'   => '14.8',
+				'last_used' => '2023-08-06T14:58:33+00:00',
 			),
 		);
 		update_option( self::MOBILE_USAGE_OPTION_KEY, $existing_data );
@@ -274,8 +274,8 @@ class TelemetryControllerTest extends WC_REST_Unit_Test_Case {
 		// Given.
 		$existing_data = array(
 			'ios' => array(
-				'version'           => '14.8',
-				'last_used'         => '2023-08-06T14:58:33+00:00',
+				'version'   => '14.8',
+				'last_used' => '2023-08-06T14:58:33+00:00',
 			),
 		);
 		update_option( self::MOBILE_USAGE_OPTION_KEY, $existing_data );

--- a/plugins/woocommerce/tests/php/src/Internal/Telemetry/TelemetryControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Telemetry/TelemetryControllerTest.php
@@ -17,254 +17,254 @@ use WP_REST_Request;
  * @class TelemetryControllerTest.
  */
 class TelemetryControllerTest extends WC_REST_Unit_Test_Case {
-    /**
-     * Endpoint.
-     *
-     * @var string
-     */
-    const ENDPOINT = '/wc-telemetry/tracker';
+	/**
+	 * Endpoint.
+	 *
+	 * @var string
+	 */
+	const ENDPOINT = '/wc-telemetry/tracker';
 
-    const MOBILE_USAGE_OPTION_KEY = 'woocommerce_mobile_app_usage';
+	const MOBILE_USAGE_OPTION_KEY = 'woocommerce_mobile_app_usage';
 
-    /**
-     * Set up.
-     */
-    public function setUp(): void {
-        parent::setUp();
-        $this->useAdmin();
-        $this->resetMobileUsageData();
-    }
+	/**
+	 * Set up.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->useAdmin();
+		$this->resetMobileUsageData();
+	}
 
-    /**
-     * Use a user with administrator role.
-     *
-     * @return void
-     */
-    public function useAdmin() {
-        // Register an administrator user and log in.
-        $this->user = $this->factory->user->create(
-            array(
-                'role' => 'administrator',
-            )
-        );
-        wp_set_current_user( $this->user );
-    }
+	/**
+	 * Use a user with administrator role.
+	 *
+	 * @return void
+	 */
+	public function useAdmin() {
+		// Register an administrator user and log in.
+		$this->user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+		wp_set_current_user( $this->user );
+	}
 
-    /**
-     * Use a user without any permissions.
-     *
-     * @return void
-     */
-    public function useWithoutUser() {
-        wp_set_current_user( null );
-    }
+	/**
+	 * Use a user without any permissions.
+	 *
+	 * @return void
+	 */
+	public function useWithoutUser() {
+		wp_set_current_user( null );
+	}
 
-    /**
-     * Use a user without any permissions.
-     *
-     * @return void
-     */
-    public function resetMobileUsageData() {
-        update_option( self::MOBILE_USAGE_OPTION_KEY, null );
-    }
+	/**
+	 * Use a user without any permissions.
+	 *
+	 * @return void
+	 */
+	public function resetMobileUsageData() {
+		update_option( self::MOBILE_USAGE_OPTION_KEY, null );
+	}
 
-    /**
-     * Request to install-async endpoint.
-     *
-     * @param $body_params
-     * @return mixed
-     */
-    private function request( $body_params ) {
-        $request = new WP_REST_Request( 'POST', self::ENDPOINT );
-        $request->set_header( 'content-type', 'application/json' );
-        $request->set_body_params( $body_params );
-        $response = $this->server->dispatch( $request );
+	/**
+	 * Request to install-async endpoint.
+	 *
+	 * @param $body_params
+	 * @return mixed
+	 */
+	private function request( $body_params ) {
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body_params( $body_params );
+		$response = $this->server->dispatch( $request );
 
-        return $response;
-    }
+		return $response;
+	}
 
-    /**
-     * Test to confirm that null is returned on success.
-     *
-     * @return void
-     */
-    public function test_response_is_null_on_success() {
-        // When
-        $data = $this->request(
-            array(
-                'platform' => 'ios',
-                'version' => '14.8',
-                'installation_date' => '2023-08-08T03:38:50Z'
-            )
-        )->get_data();
+	/**
+	 * Test to confirm that null is returned on success.
+	 *
+	 * @return void
+	 */
+	public function test_response_is_null_on_success() {
+		// When
+		$data = $this->request(
+			array(
+				'platform'          => 'ios',
+				'version'           => '14.8',
+				'installation_date' => '2023-08-08T03:38:50Z',
+			)
+		)->get_data();
 
-        // Then
-        $this->assertNull( $data );
-    }
+		// Then
+		$this->assertNull( $data );
+	}
 
-    /**
-     * Test 401 error is thrown when there is no logged in user.
-     *
-     * @return void
-     */
-    public function test_401_is_returned_without_logged_in_user() {
-        // Given
-        $this->useWithoutUser();
+	/**
+	 * Test 401 error is thrown when there is no logged in user.
+	 *
+	 * @return void
+	 */
+	public function test_401_is_returned_without_logged_in_user() {
+		// Given
+		$this->useWithoutUser();
 
-        // When
-        $response = $this->request(
-            array(
-                'platform' => 'ios',
-                'version' => '14.8',
-            )
-        );
+		// When
+		$response = $this->request(
+			array(
+				'platform' => 'ios',
+				'version'  => '14.8',
+			)
+		);
 
-        // Then
-        $this->assertEquals( 401, $response->get_status() );
-    }
+		// Then
+		$this->assertEquals( 401, $response->get_status() );
+	}
 
-    /**
-     * Test to confirm all the data fields are set for the first time.
-     *
-     * @return void
-     */
-    public function test_WCTracker_mobile_usage_data_fields_are_all_set_for_the_first_time() {
-        // When
-        $this->request(
-            array(
-                'platform' => 'ios',
-                'version' => '14.7',
-                'installation_date' => '2023-08-08T03:38:50Z'
-            )
-        )->get_data();
+	/**
+	 * Test to confirm all the data fields are set for the first time.
+	 *
+	 * @return void
+	 */
+	public function test_WCTracker_mobile_usage_data_fields_are_all_set_for_the_first_time() {
+		// When
+		$this->request(
+			array(
+				'platform'          => 'ios',
+				'version'           => '14.7',
+				'installation_date' => '2023-08-08T03:38:50Z',
+			)
+		)->get_data();
 
-        // Then
-        $new_data = get_option( self::MOBILE_USAGE_OPTION_KEY );
-        $this->assertEquals( '2023-08-08T03:38:50Z',  $new_data['ios']['installation_date'] );
-        $this->assertEquals( '14.7',  $new_data['ios']['version'] );
-        $this->assertEquals( $new_data['ios']['last_used'],  $new_data['ios']['first_used'] );
-        $this->assertFalse( isset($new_data['android']) );
-    }
+		// Then
+		$new_data = get_option( self::MOBILE_USAGE_OPTION_KEY );
+		$this->assertEquals( '2023-08-08T03:38:50Z', $new_data['ios']['installation_date'] );
+		$this->assertEquals( '14.7', $new_data['ios']['version'] );
+		$this->assertEquals( $new_data['ios']['last_used'], $new_data['ios']['first_used'] );
+		$this->assertFalse( isset( $new_data['android'] ) );
+	}
 
-    /**
-     * Test to confirm that `installation_date` is only set once per platform.
-     *
-     * @return void
-     */
-    public function test_WCTracker_mobile_usage_installation_date_is_not_overwritten_when_it_was_previously_set() {
-        // Given
-        $existing_data = array(
-            'ios' => array(
-                'version' => '14.8',
-                'installation_date' => '2023-08-08T03:38:50Z'
-            )
-        );
-        update_option( self::MOBILE_USAGE_OPTION_KEY, $existing_data );
+	/**
+	 * Test to confirm that `installation_date` is only set once per platform.
+	 *
+	 * @return void
+	 */
+	public function test_WCTracker_mobile_usage_installation_date_is_not_overwritten_when_it_was_previously_set() {
+		// Given
+		$existing_data = array(
+			'ios' => array(
+				'version'           => '14.8',
+				'installation_date' => '2023-08-08T03:38:50Z',
+			),
+		);
+		update_option( self::MOBILE_USAGE_OPTION_KEY, $existing_data );
 
-        // When
-        $this->request(
-            array(
-                'platform' => 'ios',
-                'version' => '14.7',
-                'installation_date' => '2023-03-08T03:38:50Z'
-            )
-        )->get_data();
+		// When
+		$this->request(
+			array(
+				'platform'          => 'ios',
+				'version'           => '14.7',
+				'installation_date' => '2023-03-08T03:38:50Z',
+			)
+		)->get_data();
 
-        // Then
-        $new_data = get_option( self::MOBILE_USAGE_OPTION_KEY );
-        $this->assertEquals( '2023-08-08T03:38:50Z',  $new_data['ios']['installation_date'] );
-        $this->assertFalse( isset($new_data['android']) );
-    }
+		// Then
+		$new_data = get_option( self::MOBILE_USAGE_OPTION_KEY );
+		$this->assertEquals( '2023-08-08T03:38:50Z', $new_data['ios']['installation_date'] );
+		$this->assertFalse( isset( $new_data['android'] ) );
+	}
 
-    /**
-     * Test to confirm that `first_used` is only set once per platform.
-     *
-     * @return void
-     */
-    public function test_WCTracker_mobile_usage_first_used_is_not_overwritten_when_it_was_previously_set() {
-        // Given
-        $existing_data = array(
-            'ios' => array(
-                'version' => '14.8',
-                'installation_date' => '2023-08-08T03:38:50Z',
-                'first_used' => '2023-08-08T14:58:33+00:00'
-            )
-        );
-        update_option( self::MOBILE_USAGE_OPTION_KEY, $existing_data );
+	/**
+	 * Test to confirm that `first_used` is only set once per platform.
+	 *
+	 * @return void
+	 */
+	public function test_WCTracker_mobile_usage_first_used_is_not_overwritten_when_it_was_previously_set() {
+		// Given
+		$existing_data = array(
+			'ios' => array(
+				'version'           => '14.8',
+				'installation_date' => '2023-08-08T03:38:50Z',
+				'first_used'        => '2023-08-08T14:58:33+00:00',
+			),
+		);
+		update_option( self::MOBILE_USAGE_OPTION_KEY, $existing_data );
 
-        // When
-        $this->request(
-            array(
-                'platform' => 'ios',
-                'version' => '14.9'
-            )
-        )->get_data();
+		// When
+		$this->request(
+			array(
+				'platform' => 'ios',
+				'version'  => '14.9',
+			)
+		)->get_data();
 
-        // Then
-        $new_data = get_option( self::MOBILE_USAGE_OPTION_KEY );
-        $this->assertEquals( '2023-08-08T14:58:33+00:00',  $new_data['ios']['first_used'] );
-        $this->assertFalse( isset($new_data['android']) );
-    }
+		// Then
+		$new_data = get_option( self::MOBILE_USAGE_OPTION_KEY );
+		$this->assertEquals( '2023-08-08T14:58:33+00:00', $new_data['ios']['first_used'] );
+		$this->assertFalse( isset( $new_data['android'] ) );
+	}
 
-    /**
-     * Test to confirm that `last_used` and `version` are updated when the new data has a higher version.
-     *
-     * @return void
-     */
-    public function test_WCTracker_mobile_usage_last_used_and_version_are_updated_when_they_were_previously_set_and_version_is_higher() {
-        // Given
-        $existing_data = array(
-            'ios' => array(
-                'version' => '14.8',
-                'installation_date' => '2023-08-08T03:38:50Z',
-                'last_used' => '2023-08-06T14:58:33+00:00'
-            )
-        );
-        update_option( self::MOBILE_USAGE_OPTION_KEY, $existing_data );
+	/**
+	 * Test to confirm that `last_used` and `version` are updated when the new data has a higher version.
+	 *
+	 * @return void
+	 */
+	public function test_WCTracker_mobile_usage_last_used_and_version_are_updated_when_they_were_previously_set_and_version_is_higher() {
+		// Given
+		$existing_data = array(
+			'ios' => array(
+				'version'           => '14.8',
+				'installation_date' => '2023-08-08T03:38:50Z',
+				'last_used'         => '2023-08-06T14:58:33+00:00',
+			),
+		);
+		update_option( self::MOBILE_USAGE_OPTION_KEY, $existing_data );
 
-        // When
-        $this->request(
-            array(
-                'platform' => 'ios',
-                'version' => '14.9'
-            )
-        )->get_data();
+		// When
+		$this->request(
+			array(
+				'platform' => 'ios',
+				'version'  => '14.9',
+			)
+		)->get_data();
 
-        // Then
-        $new_data = get_option( self::MOBILE_USAGE_OPTION_KEY );
-        $this->assertEquals( '14.9', $new_data['ios']['version'] );
-        $this->assertGreaterThan( new \DateTime('2023-08-06T14:58:33+00:00' ),  new \DateTime( $new_data['ios']['last_used'] ) );
-        $this->assertFalse( isset($new_data['android']) );
-    }
+		// Then
+		$new_data = get_option( self::MOBILE_USAGE_OPTION_KEY );
+		$this->assertEquals( '14.9', $new_data['ios']['version'] );
+		$this->assertGreaterThan( new \DateTime( '2023-08-06T14:58:33+00:00' ), new \DateTime( $new_data['ios']['last_used'] ) );
+		$this->assertFalse( isset( $new_data['android'] ) );
+	}
 
-    /**
-     * Test to confirm that `last_used` and `version` are not updated when the new data has a lower version.
-     *
-     * @return void
-     */
-    public function test_WCTracker_mobile_usage_last_used_and_version_are_not_updated_when_they_were_previously_set_and_version_is_lower() {
-        // Given
-        $existing_data = array(
-            'ios' => array(
-                'version' => '14.8',
-                'installation_date' => '2023-08-08T03:38:50Z',
-                'last_used' => '2023-08-06T14:58:33+00:00'
-            )
-        );
-        update_option( self::MOBILE_USAGE_OPTION_KEY, $existing_data );
+	/**
+	 * Test to confirm that `last_used` and `version` are not updated when the new data has a lower version.
+	 *
+	 * @return void
+	 */
+	public function test_WCTracker_mobile_usage_last_used_and_version_are_not_updated_when_they_were_previously_set_and_version_is_lower() {
+		// Given
+		$existing_data = array(
+			'ios' => array(
+				'version'           => '14.8',
+				'installation_date' => '2023-08-08T03:38:50Z',
+				'last_used'         => '2023-08-06T14:58:33+00:00',
+			),
+		);
+		update_option( self::MOBILE_USAGE_OPTION_KEY, $existing_data );
 
-        // When
-        $this->request(
-            array(
-                'platform' => 'ios',
-                'version' => '14.7'
-            )
-        )->get_data();
+		// When
+		$this->request(
+			array(
+				'platform' => 'ios',
+				'version'  => '14.7',
+			)
+		)->get_data();
 
-        // Then
-        $new_data = get_option( self::MOBILE_USAGE_OPTION_KEY );
-        $this->assertEquals( '14.8', $new_data['ios']['version'] );
-        $this->assertEquals( '2023-08-06T14:58:33+00:00', $new_data['ios']['last_used'] );
-        $this->assertFalse( isset($new_data['android']) );
-    }
+		// Then
+		$new_data = get_option( self::MOBILE_USAGE_OPTION_KEY );
+		$this->assertEquals( '14.8', $new_data['ios']['version'] );
+		$this->assertEquals( '2023-08-06T14:58:33+00:00', $new_data['ios']['last_used'] );
+		$this->assertFalse( isset( $new_data['android'] ) );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

- [x] I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
- [x] I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- [x] Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Part of https://github.com/woocommerce/woocommerce-ios/issues/10406

After the initial implementation of the telemetry endpoint https://github.com/woocommerce/woocommerce/pull/30415, this PR adds tracking for `first_used` and `installation_date` that are sent to WCTracker for a better understanding of the Woo mobile merchants.

#### `first_used`

When saving the mobile usage data for the first time, `first_used` field is set to be the same as `last_used` (the time of the request). For stores that already have the mobile usage data (`last_used` has been set), they won't have a `first_used` date so that we can track the usage more accurately.

#### `installation_date`

This is an optional field since earlier mobile versions don't track and send the installation date. It's set once when the field hasn't been set before, whether the store has existing mobile usage data or not.

💬  @shiki feel free to suggest a different definition based on the business requirements.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Prerequisite: the site hasn't had any mobile usage data tracked yet (like a brand new site), and supports https so that it can use the [REST API key & secret](https://woocommerce.com/document/woocommerce-rest-api/) to make API requests. I personally use [Local](https://localwp.com/) for development for the ease of adding SSL to the site.

1. Send a POST request to the `/wp-json/wc-telemetry/tracker` endpoint with body: `{ "platform": "ios", "version": "1.2", "installation_date": "2023-08-08T03:48:50Z" }`. The response should have a `200` status, but no response body.
2. Via WP-CLI or similar, execute `WC_Tracker::get_tracking_data()` --> `wc_mobile_usage` should show an entry for `ios`, and the data underneath should include `version: 1.2`, `installation_date: 2023-08-08T03:48:50+00:00`, and the same `first_used` and `last used` dates in ISO 8601 format
    * Example:  `wp eval "var_dump(WC_Tracker::get_tracking_data()['wc_mobile_usage']);"`
3. Send another POST request to the telemetry endpoint with body: `{ "platform": "ios", "version": "1.2", "installation_date": "2023-08-10T03:48:50Z" }` --> in WCTracker from WP-CLI, `wc_mobile_usage` should show an entry for `ios`, and the data underneath should include `version: 1.2`, `installation_date: 2023-08-08T03:48:50+00:00` (same as the previous value), and the `first_used` date should not be changed from the previous value while `last used` should be updated to the latest request time.
4. You can "reset" the mobile usage data for further testing by deleting the relevant option:
    * `wp option delete woocommerce_mobile_app_usage`

Note: If using `wp shell` to test, you may have to close the shell session and re-open if the option value is cached.

<!-- End testing instructions -->


