### PR TITLE
Add marketplace feedback component

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
@@ -9,6 +9,7 @@ import './content.scss';
 import Discover from '../discover/discover';
 import Extensions from '../extensions/extensions';
 import Footer from '../footer/footer';
+import FeedbackModal from '../feedback-modal/feedback-modal';
 
 export interface ContentProps {
 	selectedTab?: string | undefined;
@@ -31,6 +32,7 @@ export default function Content( props: ContentProps ): JSX.Element {
 				{ renderContent( selectedTab ) }
 			</div>
 			<Footer />
+			<FeedbackModal />
 		</>
 	);
 }

--- a/plugins/woocommerce-admin/client/marketplace/components/feedback-modal/feedback-modal.scss
+++ b/plugins/woocommerce-admin/client/marketplace/components/feedback-modal/feedback-modal.scss
@@ -1,0 +1,9 @@
+.woocommerce-marketplace__feedback-modal {
+	max-width: 666px;
+}
+
+.woocommerce-marketplace__feedback-modal-buttons {
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
+}

--- a/plugins/woocommerce-admin/client/marketplace/components/feedback-modal/feedback-modal.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/feedback-modal/feedback-modal.tsx
@@ -1,0 +1,246 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Modal, Button, TextareaControl } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { useState, useEffect } from '@wordpress/element';
+import { recordEvent } from '@woocommerce/tracks';
+
+/**
+ * Internal dependencies
+ */
+import './feedback-modal.scss';
+import LikertScale from '../likert-scale/likert-scale';
+import sanitizeHTML from '../../../lib/sanitize-html';
+
+export default function FeedbackModal(): JSX.Element {
+	const CUSTOMER_EFFORT_SCORE_ACTION = 'marketplace_redesign_2023';
+	const LOCALSTORAGE_KEY_DISMISSAL_COUNT =
+		'marketplace_redesign_2023_dismissals'; // ensure we don't ask for feedback if the user's already given feedback or declined to multiple times
+	const LOCALSTORAGE_KEY_LAST_REQUESTED_DATE =
+		'marketplace_redesign_2023_last_shown_date'; // ensure we don't ask for feedback more than once per day
+	const SUPPRESS_IF_DISMISSED_X_TIMES = 1; // if the user dismisses the snackbar this many times, stop asking for feedback
+	const SUPPRESS_IF_AFTER_DATE = '2024-01-01'; // if this date is reached, stop asking for feedback
+
+	// Save that we dismissed the dialog or snackbar TODAY so we don't show it again until tomorrow (if ever)
+	const dismissToday = () =>
+		localStorage.setItem(
+			LOCALSTORAGE_KEY_LAST_REQUESTED_DATE,
+			new Date().toDateString()
+		);
+
+	// Returns the number of times that the request for feedback has been dismissed
+	const dismissedTimes = () =>
+		parseInt(
+			localStorage.getItem( LOCALSTORAGE_KEY_DISMISSAL_COUNT ) || '0',
+			10
+		);
+
+	// Increment the number of times that the request for feedback has been dismissed
+	const incrementDismissedTimes = () => {
+		dismissToday();
+		localStorage.setItem(
+			LOCALSTORAGE_KEY_DISMISSAL_COUNT,
+			`${ dismissedTimes() + 1 }`
+		);
+	};
+
+	// Dismiss forever (by incrementing the number of dismissals to a high number), e.g. when feedback is provided
+	const dismissForever = () => {
+		dismissToday();
+		localStorage.setItem(
+			LOCALSTORAGE_KEY_DISMISSAL_COUNT,
+			`${ SUPPRESS_IF_DISMISSED_X_TIMES }`
+		);
+	};
+
+	// Returns true if dismissed forever (either by dismissing at least SUPPRESS_IF_DISMISSED_X_TIMES times, or by submitting feedback)
+	const isDismissedForever = () =>
+		dismissedTimes() >= SUPPRESS_IF_DISMISSED_X_TIMES;
+
+	const [ isOpen, setOpen ] = useState( false );
+	const [ thoughts, setThoughts ] = useState( '' );
+	const [ easyToFind, setEasyToFind ] = useState( 0 );
+	const [ easyToFindValidiationFailed, setEasyToFindValidiationFailed ] =
+		useState( false );
+	const [ meetsMyNeeds, setMeetsMyNeeds ] = useState( 0 );
+	const [ meetsMyNeedsValidiationFailed, setMeetsMyNeedsValidiationFailed ] =
+		useState( false );
+	const openModal = () => setOpen( true );
+	const closeModal = () => {
+		incrementDismissedTimes();
+		setOpen( false );
+	};
+	const { createNotice } = useDispatch( 'core/notices' );
+
+	function maybeShowSnackbar() {
+		// don't show if the user has already given feedback or otherwise suppressed:
+		if ( isDismissedForever() ) {
+			return;
+		}
+
+		// don't show if the user has already declined to provide feedback today:
+		const today = new Date().toDateString();
+		if (
+			today ===
+			localStorage.getItem( LOCALSTORAGE_KEY_LAST_REQUESTED_DATE )
+		) {
+			return;
+		}
+
+		createNotice(
+			'success',
+			__( 'How easy is it to find an extension?', 'woocommerce' ),
+			{
+				type: 'snackbar',
+				icon: (
+					<>
+						<svg
+							color="#fff"
+							strokeWidth="1.5"
+							viewBox="0 0 28.873 8.9823"
+							style={ { height: '8px', marginLeft: '-7px' } }
+						>
+							<path
+								className="l"
+								d="m4.1223 1.1216 19.12-0.014142 4.3982 3.38-4.3982 3.38-19.12-0.014142a3.34 3.34 0 0 1-2.39-0.97581 3.37 3.37 0 0 1 0.00707-4.773 3.34 3.34 0 0 1 2.383-0.98288z"
+								stroke="#fff"
+							/>
+							<line
+								className="l"
+								x1="6.7669"
+								x2="6.7669"
+								y1="7.8533"
+								y2="1.1216"
+								stroke="#fff"
+							/>
+							<path
+								className="l"
+								d="m23.235 1.1146 4.4053 3.3729-4.3982 3.38a6.59 6.59 0 0 1-0.89096-3.3517 6.59 6.59 0 0 1 0.88388-3.4012z"
+								stroke="#fff"
+							/>
+							<line
+								className="l"
+								x1="6.7669"
+								x2="22.323"
+								y1="4.4875"
+								y2="4.4875"
+								stroke="#fff"
+							/>
+						</svg>
+					</>
+				),
+				explicitDismiss: true,
+				onDismiss: incrementDismissedTimes,
+				actions: [
+					{
+						onClick: openModal,
+						label: 'Give feedback',
+					},
+				],
+			}
+		);
+	}
+
+	// eslint-disable-next-line react-hooks/exhaustive-deps -- [] => we only want this effect to run once, on first render
+	useEffect( maybeShowSnackbar, [] );
+
+	// We don't want the "How easy was it to find an extension?" dialog to appear forever:
+	const FEEDBACK_DIALOG_CAN_APPEAR =
+		new Date( SUPPRESS_IF_AFTER_DATE ) > new Date();
+	if ( ! FEEDBACK_DIALOG_CAN_APPEAR ) {
+		return <></>;
+	}
+
+	function easyToFindChanged( value: number ) {
+		setEasyToFindValidiationFailed( false );
+		setEasyToFind( value );
+	}
+
+	function meetsMyNeedsChanged( value: number ) {
+		setMeetsMyNeedsValidiationFailed( false );
+		setMeetsMyNeeds( value );
+	}
+
+	function submit() {
+		// Validate:
+		if ( easyToFind === 0 || meetsMyNeeds === 0 ) {
+			if ( easyToFind === 0 ) setEasyToFindValidiationFailed( true );
+			if ( meetsMyNeeds === 0 ) setMeetsMyNeedsValidiationFailed( true );
+			return;
+		}
+
+		const comments = sanitizeHTML( thoughts ).__html;
+
+		// Send event to CES:
+		recordEvent( 'ces_feedback', {
+			action: CUSTOMER_EFFORT_SCORE_ACTION,
+			score: easyToFind,
+			score_second_question: meetsMyNeeds,
+			score_combined: easyToFind + meetsMyNeeds,
+			comments,
+		} );
+		// Close the modal:
+		setOpen( false );
+		// Ensure we don't ask for feedback again:
+		dismissForever();
+	}
+
+	return (
+		<>
+			{ isOpen && (
+				<Modal
+					title={ __(
+						'How easy was it to find an extension?',
+						'woocommerce'
+					) }
+					onRequestClose={ closeModal }
+					className="woocommerce-marketplace__feedback-modal"
+				>
+					<p>
+						{ __(
+							'Your feedback will help us create a better experience for people like you! Please tell us to what extent you agree or disagree with the statements below.',
+							'woocommerce'
+						) }
+					</p>
+					<LikertScale
+						fieldName="extension_screen_easy_to_find"
+						title={ __(
+							'It was easy to find an extension',
+							'woocommerce'
+						) }
+						onValueChange={ easyToFindChanged }
+						validationFailed={ easyToFindValidiationFailed }
+					/>
+					<LikertScale
+						fieldName="extension_screen_meets_my_needs"
+						title={ __(
+							'The Extensions screen’s functionality meets my needs',
+							'woocommerce'
+						) }
+						onValueChange={ meetsMyNeedsChanged }
+						validationFailed={ meetsMyNeedsValidiationFailed }
+					/>
+					<TextareaControl
+						label={ __( 'Additional thoughts', 'woocommerce' ) }
+						value={ thoughts }
+						onChange={ ( value: string ) => setThoughts( value ) }
+					/>
+					<p className="woocommerce-marketplace__feedback-modal-buttons">
+						<Button
+							variant="tertiary"
+							onClick={ closeModal }
+							text={ __( 'Cancel', 'woocommerce' ) }
+						/>
+						<Button
+							variant="primary"
+							onClick={ submit }
+							text={ __( 'Send', 'woocommerce' ) }
+						/>
+					</p>
+				</Modal>
+			) }
+		</>
+	);
+}

--- a/plugins/woocommerce-admin/client/marketplace/components/footer/footer.scss
+++ b/plugins/woocommerce-admin/client/marketplace/components/footer/footer.scss
@@ -3,7 +3,7 @@
 .woocommerce-admin-page__extensions .woocommerce-layout__footer {
 	background: #f6f7f7;
 	// Undo default fixed footer style used in WC Admin
-	position: unset;
+	position: relative;
 	width: 100%;
 }
 

--- a/plugins/woocommerce-admin/client/marketplace/components/header-search-button/header-search-button.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/header-search-button/header-search-button.tsx
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+
+export default function HeaderSearchButton() {
+	return (
+		<button className="woocommerce-marketplace__header-search-button">
+			<svg
+				width="24"
+				height="24"
+				viewBox="0 0 24 24"
+				fill="none"
+				xmlns="http://www.w3.org/2000/svg"
+			>
+				<path
+					id="Union"
+					fillRule="evenodd"
+					clipRule="evenodd"
+					d="M19.0001 11C19.0001 14.3137 16.3138 17 13.0001 17C11.6135 17 10.3369 16.5297 9.32086 15.7399L5.53039 19.5304L4.46973 18.4697L8.26019 14.6793C7.47038 13.6632 7.00006 12.3865 7.00006 11C7.00006 7.68629 9.68635 5 13.0001 5C16.3138 5 19.0001 7.68629 19.0001 11ZM17.5001 11C17.5001 13.4853 15.4853 15.5 13.0001 15.5C10.5148 15.5 8.50006 13.4853 8.50006 11C8.50006 8.51472 10.5148 6.5 13.0001 6.5C15.4853 6.5 17.5001 8.51472 17.5001 11Z"
+					fill="#1E1E1E"
+				/>
+			</svg>
+			<span className="screen-reader-text">
+				{ __( 'Search', 'woocommerce' ) }
+			</span>
+		</button>
+	);
+}

--- a/plugins/woocommerce-admin/client/marketplace/components/header-search/header-search.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/header-search/header-search.tsx
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export default function HeaderSearch() {
+	return (
+		<form className="woocommerce-marketplace__header-search">
+			<input
+				type="search"
+				className="woocommerce-marketplace__header-search-field"
+				placeholder={ __(
+					'Search extensions and themes',
+					'woocommerce'
+				) }
+			/>
+			<button className="woocommerce-marketplace__header-search-button">
+				<svg
+					width="24"
+					height="24"
+					viewBox="0 0 24 24"
+					fill="none"
+					xmlns="http://www.w3.org/2000/svg"
+				>
+					<path
+						id="Union"
+						fillRule="evenodd"
+						clipRule="evenodd"
+						d="M19.0001 11C19.0001 14.3137 16.3138 17 13.0001 17C11.6135 17 10.3369 16.5297 9.32086 15.7399L5.53039 19.5304L4.46973 18.4697L8.26019 14.6793C7.47038 13.6632 7.00006 12.3865 7.00006 11C7.00006 7.68629 9.68635 5 13.0001 5C16.3138 5 19.0001 7.68629 19.0001 11ZM17.5001 11C17.5001 13.4853 15.4853 15.5 13.0001 15.5C10.5148 15.5 8.50006 13.4853 8.50006 11C8.50006 8.51472 10.5148 6.5 13.0001 6.5C15.4853 6.5 17.5001 8.51472 17.5001 11Z"
+						fill="#1E1E1E"
+					/>
+				</svg>
+				<span className="screen-reader-text">
+					{ __( 'Search', 'woocommerce' ) }
+				</span>
+			</button>
+		</form>
+	);
+}

--- a/plugins/woocommerce-admin/client/marketplace/components/likert-scale/likert-scale.scss
+++ b/plugins/woocommerce-admin/client/marketplace/components/likert-scale/likert-scale.scss
@@ -1,0 +1,52 @@
+.woocommerce-marketplace__likert-scale {
+	display: flex;
+	list-style: none;
+	margin: 0;
+	border: 2px solid transparent;
+
+	&.validation-failed {
+		border-color: $alert-red;
+	}
+}
+
+.woocommerce-marketplace__likert-scale-item {
+	margin: 0;
+	width: 100%;
+	font-size: 11px;
+
+	label {
+		align-items: center;
+		aspect-ratio: 91.6 / 48;
+		border: 1.5px solid transparent;
+		box-sizing: border-box;
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		justify-content: center;
+		padding: 16px 8px;
+		text-align: center;
+	}
+
+	input:checked + label {
+		border-color: var(--wp-admin-theme-color-darker-10);
+		background: #e6f1f5;
+	}
+
+	// Improve a11y (especially keyboard navigation) by transferring the outline from the (now hidden) checkbox to its label
+	input:focus {
+		margin-top: -99px;
+
+		& + label {
+			outline: 2px solid var(--wp-admin-theme-color);
+			outline-offset: 2px;
+		}
+	}
+}
+
+.woocommerce-marketplace__likert-scale-icon {
+	font-size: 24px;
+}
+
+.woocommerce-marketplace__likert-scale-text {
+	font-size: 11px;
+}

--- a/plugins/woocommerce-admin/client/marketplace/components/likert-scale/likert-scale.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/likert-scale/likert-scale.tsx
@@ -1,0 +1,96 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import './likert-scale.scss';
+
+export interface LikertScaleProps {
+	title: string;
+	fieldName: string;
+	onValueChange: ( value: number ) => void;
+	validationFailed?: boolean;
+}
+
+export interface LikertChangeEvent {
+	target: {
+		value: number;
+	};
+}
+
+export default function LikertScale( props: LikertScaleProps ): JSX.Element {
+	const { title, fieldName, onValueChange, validationFailed } = props;
+	const scaleOptions = [
+		{
+			value: 1,
+			emoji: '😔',
+			label: __( 'Strongly disagree', 'woocommerce' ),
+		},
+		{
+			value: 2,
+			emoji: '🙁',
+			label: __( 'Disagree', 'woocommerce' ),
+		},
+		{
+			value: 3,
+			emoji: '😐',
+			label: __( 'Neutral', 'woocommerce' ),
+		},
+		{
+			value: 4,
+			emoji: '🙂',
+			label: __( 'Agree', 'woocommerce' ),
+		},
+		{
+			value: 5,
+			emoji: '😍',
+			label: __( 'Strongly agree', 'woocommerce' ),
+		},
+	];
+
+	const classes = classnames( 'woocommerce-marketplace__likert-scale', {
+		'validation-failed': validationFailed,
+	} );
+
+	function valueChanged( e: React.ChangeEvent< HTMLInputElement > ) {
+		onValueChange( parseInt( e.target.value, 10 ) );
+	}
+
+	return (
+		<>
+			<h2>{ title }</h2>
+			<ol className={ classes }>
+				{ scaleOptions.map( ( option ) => {
+					const key = `${ fieldName }_${ option.value }`;
+					return (
+						<li
+							key={ key }
+							className="woocommerce-marketplace__likert-scale-item"
+						>
+							<input
+								type="radio"
+								name={ fieldName }
+								value={ option.value }
+								id={ key }
+								onChange={ valueChanged }
+								className="screen-reader-text"
+							/>
+							<label htmlFor={ key }>
+								<div className="woocommerce-marketplace__likert-scale-icon">
+									{ option.emoji }
+								</div>
+								<div className="woocommerce-marketplace__likert-scale-text">
+									{ option.label }
+								</div>
+							</label>
+						</li>
+					);
+				} ) }
+			</ol>
+		</>
+	);
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Closes [WCCOM #17602.](https://github.com/Automattic/woocommerce.com/issues/17602) by adding a component that requests feedback on the new marketplace.

### How to test the changes in this Pull Request:

#### Happy Path

1. Visit http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fextensions&tab=extensions and see a snackbar prompt you to provide feedback.
2. Click the link and fill the form.
3. Observe that a Tracks event would be sent in a way that's compatible with internal documentation (FG "Importing CES Feedback")
4. Refresh the page and see that the prompt does not reappear

#### Sad Paths

- If dismissed either using the "Cancel" button on the model or using the "cross" icon on the snackbar, the snackbar should not reappear ~until tomorrow (i.e. no more than once per day); you can check/change the "date on which you last dismissed it" for testing purposes with `localStorage.getItem('marketplace_redesign_2023_last_shown_date')` / `localStorage.setItem('marketplace_redesign_2023_last_shown_date', ' ... ')`~
- ~If dismissed a total of two times OR feedback is submitted, the snackbar should not reappear ever again; you can check/change the "number of dismissals" for testing purposes with  `localStorage.getItem('marketplace_redesign_2023_dismissals')` / `localStorage.setItem('marketplace_redesign_2023_dismissals', ' ... ')`~
- After 2023, you should never be prompted for feedback; ideally the user would upgrade WC to a version in which this feature is removed, but we need a time-based check in case the user DOESN'T upgrade (we don't want to keep nagging them for feedback for years!); you can change this date by modifying `SUPPRESS_IF_AFTER_DATE` in `plugins/woocommerce-admin/client/marketplace/components/feedback-modal/feedback-modal.tsx`
- If either of the mandatory fields (the likert scales) are not answered, a border appears as a validation warning and submission does not continue

### Impact/significance

Part of a feature branch.
