### PR TITLE
Set the orders table exist option if its not set.

### DIFF
--- a/plugins/woocommerce/changelog/fix-sync-upgrade
+++ b/plugins/woocommerce/changelog/fix-sync-upgrade
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Set the order table exist options value when its not present for smooth upgradation from lower WC versions.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -144,7 +144,7 @@ class DataSynchronizer implements BatchProcessorInterface {
 		switch ( $table_exists ) {
 			case 'no':
 			case 'yes':
-				return $table_exists === 'yes';
+				return 'yes' === $table_exists;
 			default:
 				return $this->check_orders_table_exists();
 		}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -155,10 +155,7 @@ class DataSynchronizer implements BatchProcessorInterface {
 	 */
 	public function create_database_tables() {
 		$this->database_util->dbdelta( $this->data_store->get_database_schema() );
-		if ( ! $this->check_orders_table_exists() ) {
-			return;
-		}
-		update_option( self::ORDERS_TABLE_CREATED, 'yes' );
+		$this->check_orders_table_exists();
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds the logic to set the `ORDERS_TABLE_CREATED` to either `yes` or `no` when it's not set. Since we added this option in 8.0 itself if someone upgrades from 7.9 to 8.0, then this option will not be set for them. The logic for updating this option executes when toggling the sync or COT feature, so if someone has already enabled it, then this option won't be set for them unless they toggle it again.

We fix the behavior by checking if order tables are created when the option value is null, and then set to `yes` or `no` accordingly.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

We will do two different testing:

Testing#1

1. Start with a store on WC 7.9, and set the sync to on. Testing instructions work both for HPOS or posts authoritative, but sync should be enabled.
2. Create one order from the admin so that we have something synced. Go to WooCommerce > Settings > Advanced > Custom data store to verify that there are no orders pending sync.
3. Upgrade WC to this build, and check the sync setting again, by going to WooCommerce > Settings > Advanced > Features and verify that there are still no orders pending sync.

Testing#2
1. On this WC build, set the HPOS sync to on by going to WooCommerce > Settings > Advanced > Features. Create at least one order.
2. Delete the orders creating option by running `wp option delete woocommerce_custom_orders_table_created` in CLI.
3. Refresh the page, verify that it still shows that there are no pending orders to be synced (i.e. no message is displayed).
4. Verify that the `woocommerce_custom_orders_table_created` is set, by running `wp option get woocommerce_custom_orders_table_created` .

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
