### PR TITLE
Remove marketplace tour temporarily

### DIFF
--- a/plugins/woocommerce-admin/client/guided-tours/wc-addons-tour/get-config.ts
+++ b/plugins/woocommerce-admin/client/guided-tours/wc-addons-tour/get-config.ts
@@ -30,7 +30,7 @@ export const getTourConfig = ( {
 				spotlight: {
 					interactivity: {
 						enabled: true,
-						rootElementSelector: '.woocommerce.wc-addons-wrap',
+						rootElementSelector: '.woocommerce-marketplace',
 					},
 				},
 				autoScroll: {
@@ -39,21 +39,6 @@ export const getTourConfig = ( {
 				},
 			},
 			popperModifiers: [
-				{
-					name: 'arrow',
-					options: {
-						padding: ( {
-							popper,
-						}: {
-							popper: { width: number };
-						} ) => {
-							return {
-								// Align the arrow to the left of the popper.
-								right: popper.width - 34,
-							};
-						},
-					},
-				},
 				{
 					name: 'offset',
 					options: {

--- a/plugins/woocommerce-admin/client/guided-tours/wc-addons-tour/get-steps.ts
+++ b/plugins/woocommerce-admin/client/guided-tours/wc-addons-tour/get-steps.ts
@@ -10,13 +10,15 @@ export const getSteps = (): TourKitTypes.WooStep[] => {
 	return [
 		{
 			referenceElements: {
-				desktop: '#adminmenu a[href="admin.php?page=wc-addons"]',
+				desktop:
+					'#adminmenu a[href="admin.php?page=wc-admin&path=%2Fextensions"]',
 			},
 			focusElement: {
-				desktop: '#adminmenu a[href="admin.php?page=wc-addons"]',
+				desktop:
+					'#adminmenu a[href="admin.php?page=wc-admin&path=%2Fextensions"]',
 			},
 			meta: {
-				name: 'wc-addons-menu-item',
+				name: 'wc-extensions-menu-item',
 				heading: __(
 					'Welcome to the WooCommerce Marketplace',
 					'woocommerce'
@@ -24,7 +26,7 @@ export const getSteps = (): TourKitTypes.WooStep[] => {
 				descriptions: {
 					desktop: createInterpolateElement(
 						__(
-							'Power up your store by adding extra functionality using extensions, find a fresh new look with themes, or integrate your store with other software and services.<br/><br/>The WooCommerce Marketplace is your go-to for all of the above, and the only place you’ll find products that have been reviewed and approved by the WooCommerce team.<br/><br/>Whether you’re looking to improve your store or grow your business, you can find a solution here. There are hundreds of options available, and new products are added regularly.<br/><br/>The WooCommerce Marketplace is also available at WooCommerce.com.',
+							"Power up your store by adding extra functionality with extensions or integrate your store with other software and services.<br/><br/>Here you'll find hundreds of trusted solutions for your store — all reviewed and approved by the Woo team.<br/><br/>You can also browse the Woo Marketplace at WooCommerce.com.",
 							'woocommerce'
 						),
 						{
@@ -36,17 +38,17 @@ export const getSteps = (): TourKitTypes.WooStep[] => {
 		},
 		{
 			referenceElements: {
-				desktop: '.marketplace-header__search-form',
+				desktop: '.woocommerce-marketplace__search',
 			},
 			focusElement: {
-				desktop: '.marketplace-header__search-form',
+				desktop: '.woocommerce-marketplace__search',
 			},
 			meta: {
-				name: 'wc-addons-search',
+				name: 'wc-extensions-search',
 				heading: __( 'Find exactly what you need', 'woocommerce' ),
 				descriptions: {
 					desktop: __(
-						'Use the search box to find specific products or solutions.',
+						'Use the search box to find specific extensions or solutions.',
 						'woocommerce'
 					),
 				},
@@ -54,10 +56,10 @@ export const getSteps = (): TourKitTypes.WooStep[] => {
 		},
 		{
 			referenceElements: {
-				desktop: '#marketplace-current-section-dropdown',
+				desktop: '.woocommerce-marketplace__tab-browse',
 			},
 			focusElement: {
-				desktop: '#marketplace-current-section-dropdown',
+				desktop: '.woocommerce-marketplace__tab-browse',
 			},
 			meta: {
 				name: 'wc-addons-categories',
@@ -65,7 +67,7 @@ export const getSteps = (): TourKitTypes.WooStep[] => {
 				descriptions: {
 					desktop: createInterpolateElement(
 						__(
-							'Or browse all available products by category.',
+							"Or if you're not sure exactly what you need, you can browse all available extensions by category.",
 							'woocommerce'
 						),
 						{
@@ -77,18 +79,18 @@ export const getSteps = (): TourKitTypes.WooStep[] => {
 		},
 		{
 			referenceElements: {
-				desktop: '.addon-product-group:first-child',
+				desktop: '.woocommerce-marketplace__discover:first-child',
 			},
 			focusElement: {
-				desktop: '.addon-product-group:first-child',
+				desktop: '.woocommerce-marketplace__discover:first-child',
 			},
 			meta: {
 				name: 'wc-addons-featured',
-				heading: __( 'Learn more about products', 'woocommerce' ),
+				heading: __( 'Learn more about each product', 'woocommerce' ),
 				descriptions: {
 					desktop: createInterpolateElement(
 						__(
-							'Scroll down to see all available products for a search or selected category.<br/><br/>Click on any product to see more information about it, including features, requirements, and available documentation.',
+							'Scroll down to see all of the relevant extensions and solutions.<br/><br/>Click on any solution to learn more about its features, any installation requirements, and available documentation.',
 							'woocommerce'
 						),
 						{
@@ -100,10 +102,10 @@ export const getSteps = (): TourKitTypes.WooStep[] => {
 		},
 		{
 			referenceElements: {
-				desktop: '.marketplace-header__tab-link_helper',
+				desktop: '.woocommerce-marketplace__header-meta',
 			},
 			focusElement: {
-				desktop: '.marketplace-header__tab-link_helper',
+				desktop: '.woocommerce-marketplace__header-meta',
 			},
 			meta: {
 				name: 'wc-addons-my-subscriptions',
@@ -111,7 +113,7 @@ export const getSteps = (): TourKitTypes.WooStep[] => {
 				descriptions: {
 					desktop: createInterpolateElement(
 						__(
-							"Products purchased from the WooCommerce Marketplace can be managed in My Subscriptions, either here or on WooCommerce.com.<br/><br/>Every purchase is backed by our <a1>30-day money-back guarantee</a1>, and includes <a2>email and live chat support</a2>.<br/><br/>That's it! We hope the WooCommerce Marketplace helps you build the business of your dreams.",
+							"All of your Woo Marketplace purchases can be found here, or on WooCommerce.com.<br/><br/>Every purchase is backed by our <a1>30-day money-back guarantee</a1>, and includes <a2>email and live chat support</a2>.<br/><br/>That's it! You're now ready to power up your store.",
 							'woocommerce'
 						),
 						{

--- a/plugins/woocommerce-admin/client/guided-tours/wc-addons-tour/index.tsx
+++ b/plugins/woocommerce-admin/client/guided-tours/wc-addons-tour/index.tsx
@@ -16,7 +16,7 @@ import { scrollPopperToVisibleAreaIfNeeded } from './utils';
 import { getSteps } from './get-steps';
 
 const WCAddonsTour = () => {
-	const [ showTour, setShowTour ] = useState( false );
+	const [ showTour, setShowTour ] = useState( true );
 
 	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
 
@@ -62,7 +62,7 @@ const WCAddonsTour = () => {
 			const timeoutId = setTimeout( showPopper, 500 );
 
 			const intervalId = observePositionChange(
-				'.wc-addons-wrap',
+				'.woocommerce-marketplace',
 				showPopper,
 				150
 			);

--- a/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx
@@ -71,7 +71,11 @@ const renderTabs = ( props: TabsProps ) => {
 			<>
 				{ tabs[ tabKey ]?.href ? (
 					<a
-						className="woocommerce-marketplace__tab-button components-button"
+						className={ classNames(
+							'woocommerce-marketplace__tab-button',
+							'components-button',
+							`woocommerce-marketplace__tab-${ tabKey }`
+						) }
 						href={ tabs[ tabKey ]?.href }
 						key={ tabKey }
 					>
@@ -81,6 +85,7 @@ const renderTabs = ( props: TabsProps ) => {
 					<Button
 						className={ classNames(
 							'woocommerce-marketplace__tab-button',
+							`woocommerce-marketplace__tab-${ tabKey }`,
 							{
 								'is-active': tabKey === selectedTab,
 							}

--- a/plugins/woocommerce-admin/client/marketplace/index.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/index.tsx
@@ -10,6 +10,7 @@ import './marketplace.scss';
 import { DEFAULT_TAB_KEY } from './components/constants';
 import Header from './components/header/header';
 import Content from './components/content/content';
+import WCAddonsTour from '~/guided-tours/wc-addons-tour/index';
 
 export default function Marketplace() {
 	const [ selectedTab, setSelectedTab ] = useState( DEFAULT_TAB_KEY );
@@ -21,6 +22,7 @@ export default function Marketplace() {
 				setSelectedTab={ setSelectedTab }
 			/>
 			<Content selectedTab={ selectedTab } />
+			<WCAddonsTour />
 		</div>
 	);
 }

--- a/plugins/woocommerce-admin/client/marketplace/index.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/index.tsx
@@ -10,7 +10,6 @@ import './marketplace.scss';
 import { DEFAULT_TAB_KEY } from './components/constants';
 import Header from './components/header/header';
 import Content from './components/content/content';
-import WCAddonsTour from '~/guided-tours/wc-addons-tour/index';
 
 export default function Marketplace() {
 	const [ selectedTab, setSelectedTab ] = useState( DEFAULT_TAB_KEY );
@@ -22,7 +21,6 @@ export default function Marketplace() {
 				setSelectedTab={ setSelectedTab }
 			/>
 			<Content selectedTab={ selectedTab } />
-			<WCAddonsTour />
 		</div>
 	);
 }

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/TaskLists.php
@@ -9,7 +9,6 @@ use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\DeprecatedExtendedTask;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\ReviewShippingOptions;
-use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\TourInAppMarketplace;
 /**
  * Task Lists class.
  */
@@ -56,7 +55,6 @@ class TaskLists {
 		'AdditionalPayments',
 		'ReviewShippingOptions',
 		'GetMobileApp',
-		'TourInAppMarketplace',
 	);
 
 	/**
@@ -195,11 +193,6 @@ class TaskLists {
 					'visible'      => false,
 				)
 			);
-		}
-
-		if ( ! wp_is_mobile() ) { // Permit In-App Marketplace Tour on desktops only.
-			$tour_task = new TourInAppMarketplace();
-			self::add_task( 'extended', $tour_task );
 		}
 
 		if ( has_filter( 'woocommerce_admin_experimental_onboarding_tasklists' ) ) {

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/TourInAppMarketplace.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/TourInAppMarketplace.php
@@ -24,7 +24,7 @@ class TourInAppMarketplace extends Task {
 	 */
 	public function get_title() {
 		return __(
-			'Discover where to find powerful store add-ons and integrations, with a WooCommerce Marketplace tour',
+			'Discover ways of extending your store with a tour of the Woo Marketplace',
 			'woocommerce'
 		);
 	}
@@ -62,7 +62,7 @@ class TourInAppMarketplace extends Task {
 	 * @return string
 	 */
 	public function get_action_url() {
-		return admin_url( 'admin.php?page=wc-addons&tutorial=true' );
+		return admin_url( 'admin.php?page=wc-admin&path=%2Fextensions&tutorial=true' );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/Automattic/woocommerce.com/issues/17611

This PR temporarily disables the In-App Marketplace tour. 

The tour will be reconfigured at a later stage, but there is currently a bug that prevents the site option for marking that a tour is dismissed or completed from being saved. This means the tour, and its associated task, can't be dismissed. To prevent issues for now, we're disabling the tour altogether until the redesign can handle this bug.

Note that this PR does include some content changes for the tour since the decision to remove it was made after the redesign was started. Rather than remove those, it seemed logical to save work for later.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout this branch locally and from `plugins/woocommerce-admin` run `pnpm run build`
2. Visit the WooCommerce “Home” screen – (`wp-env` URL: http://localhost:8888/wp-admin/admin.php?page=wc-admin)
3. Look for the "Things to do next" section and notice that the marketplace tour task isn't displayed
4. Visit the URL that would trigger the tour and see that no tour appears (`wp-env` URL: localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fextensions&tutorial=true)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
