### PR TITLE
add: customize your store xstate scaffolding

### DIFF
--- a/plugins/woocommerce-admin/client/core-profiler/types.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/types.tsx
@@ -6,7 +6,7 @@ import { CoreProfilerStateMachineContext } from '.';
 export type ComponentMeta = {
 	/** React component that is rendered when state matches the location this meta key is defined */
 	component: ( arg0: ComponentProps ) => JSX.Element;
-	/** number between 0 - 100 */
+	/** Number between 0 - 100 */
 	progress: number;
 };
 

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/index.tsx
@@ -1,0 +1,1 @@
+export type events = { type: 'FINISH_CUSTOMIZATION' };

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/index.tsx
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies
+ */
+import { CustomizeStoreComponent } from '../types';
+
+export type events = { type: 'THEME_SUGGESTED' };
+export const DesignWithAi: CustomizeStoreComponent = ( { sendEvent } ) => {
+	return (
+		<>
+			<h1>Design with AI</h1>
+			<button onClick={ () => sendEvent( { type: 'THEME_SUGGESTED' } ) }>
+				Back to intro
+			</button>
+		</>
+	);
+};

--- a/plugins/woocommerce-admin/client/customize-store/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/index.tsx
@@ -1,0 +1,193 @@
+/**
+ * External dependencies
+ */
+import { createMachine } from 'xstate';
+import { useEffect, useMemo, useState } from '@wordpress/element';
+import { useMachine, useSelector } from '@xstate/react';
+
+/**
+ * Internal dependencies
+ */
+import { useFullScreen } from '~/utils';
+import {
+	Intro,
+	events as introEvents,
+	services as introServices,
+	actions as introActions,
+} from './intro';
+import { DesignWithAi, events as designWithAiEvents } from './design-with-ai';
+import { events as assemblerHubEvents } from './assembler-hub';
+import { findComponentMeta } from '~/utils/xstate/find-component';
+import {
+	CustomizeStoreComponentMeta,
+	CustomizeStoreComponent,
+	customizeStoreStateMachineContext,
+} from './types';
+import { ThemeCard } from './intro/theme-cards';
+
+export type customizeStoreStateMachineEvents =
+	| introEvents
+	| designWithAiEvents
+	| assemblerHubEvents;
+
+export const customizeStoreStateMachineServices = {
+	...introServices,
+};
+
+export const customizeStoreStateMachineActions = {
+	...introActions,
+};
+export const customizeStoreStateMachineDefinition = createMachine( {
+	id: 'customizeStore',
+	initial: 'intro',
+	predictableActionArguments: true,
+	preserveActionOrder: true,
+	schema: {
+		context: {} as customizeStoreStateMachineContext,
+		events: {} as customizeStoreStateMachineEvents,
+		services: {} as {
+			fetchThemeCards: { data: ThemeCard[] };
+		},
+	},
+	context: {
+		intro: {
+			themeCards: [] as ThemeCard[],
+			activeTheme: '',
+		},
+	} as customizeStoreStateMachineContext,
+	states: {
+		intro: {
+			id: 'intro',
+			initial: 'preIntro',
+			states: {
+				preIntro: {
+					invoke: {
+						src: 'fetchThemeCards',
+						onDone: {
+							target: 'intro',
+							actions: [ 'assignThemeCards' ],
+						},
+					},
+				},
+				intro: {
+					meta: {
+						component: Intro,
+					},
+				},
+			},
+			on: {
+				DESIGN_WITH_AI: {
+					target: 'designWithAi',
+				},
+				SELECTED_ACTIVE_THEME: {
+					target: 'assemblerHub',
+				},
+				CLICKED_ON_BREADCRUMB: {
+					target: 'backToHomescreen',
+				},
+				SELECTED_NEW_THEME: {
+					target: '? Appearance Task ?',
+				},
+				SELECTED_BROWSE_ALL_THEMES: {
+					target: '? Appearance Task ?',
+				},
+			},
+		},
+		designWithAi: {
+			initial: 'preDesignWithAi',
+			states: {
+				preDesignWithAi: {
+					always: {
+						target: 'designWithAi',
+					},
+				},
+				designWithAi: {
+					meta: {
+						component: DesignWithAi,
+					},
+				},
+			},
+			on: {
+				THEME_SUGGESTED: {
+					target: 'assemblerHub',
+				},
+			},
+		},
+		assemblerHub: {
+			on: {
+				FINISH_CUSTOMIZATION: {
+					target: 'backToHomescreen',
+				},
+			},
+		},
+		backToHomescreen: {},
+		'? Appearance Task ?': {},
+	},
+} );
+
+export const CustomizeStoreController = ( {
+	actionOverrides,
+	servicesOverrides,
+}: {
+	actionOverrides: Partial< typeof customizeStoreStateMachineActions >;
+	servicesOverrides: Partial< typeof customizeStoreStateMachineServices >;
+} ) => {
+	useFullScreen( [ 'woocommerce-customize-store' ] );
+
+	const augmentedStateMachine = useMemo( () => {
+		return customizeStoreStateMachineDefinition.withConfig( {
+			services: {
+				...customizeStoreStateMachineServices,
+				...servicesOverrides,
+			},
+			actions: {
+				...customizeStoreStateMachineActions,
+				...actionOverrides,
+			},
+			guards: {},
+		} );
+	}, [ actionOverrides, servicesOverrides ] );
+
+	const [ state, send, service ] = useMachine( augmentedStateMachine, {
+		devTools: process.env.NODE_ENV === 'development',
+	} );
+
+	// eslint-disable-next-line react-hooks/exhaustive-deps -- false positive due to function name match, this isn't from react std lib
+	const currentNodeMeta = useSelector( service, ( currentState ) =>
+		findComponentMeta< CustomizeStoreComponentMeta >(
+			currentState?.meta ?? undefined
+		)
+	);
+
+	const [ CurrentComponent, setCurrentComponent ] =
+		useState< CustomizeStoreComponent | null >( null );
+	useEffect( () => {
+		if ( currentNodeMeta?.component ) {
+			setCurrentComponent( () => currentNodeMeta?.component );
+		}
+	}, [ CurrentComponent, currentNodeMeta?.component ] );
+
+	const currentNodeCssLabel =
+		state.value instanceof Object
+			? Object.keys( state.value )[ 0 ]
+			: state.value;
+
+	return (
+		<>
+			<div
+				className={ `woocommerce-profile-wizard__container woocommerce-profile-wizard__step-${ currentNodeCssLabel }` }
+			>
+				{ CurrentComponent ? (
+					<CurrentComponent
+						sendEvent={ send }
+						context={ state.context }
+					/>
+				) : (
+					<div />
+				) }
+			</div>
+		</>
+	);
+};
+
+export default CustomizeStoreController;

--- a/plugins/woocommerce-admin/client/customize-store/intro/actions.ts
+++ b/plugins/woocommerce-admin/client/customize-store/intro/actions.ts
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import { assign, DoneInvokeEvent } from 'xstate';
+
+/**
+ * Internal dependencies
+ */
+import { customizeStoreStateMachineEvents } from '..';
+
+/**
+ * Internal dependencies
+ */
+import { customizeStoreStateMachineContext } from '../types';
+import { ThemeCard } from './theme-cards';
+
+export const assignThemeCards = assign<
+	customizeStoreStateMachineContext,
+	customizeStoreStateMachineEvents // this is actually the wrong type for the event but I still don't know how to type this properly
+>( {
+	intro: ( context, event ) => {
+		const themeCards = ( event as DoneInvokeEvent< ThemeCard[] > ).data; // type coercion workaround for now
+		return { ...context.intro, themeCards };
+	},
+} );

--- a/plugins/woocommerce-admin/client/customize-store/intro/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/intro/index.tsx
@@ -1,0 +1,42 @@
+/**
+ * Internal dependencies
+ */
+import { CustomizeStoreComponent } from '../types';
+
+export type events =
+	| { type: 'DESIGN_WITH_AI' }
+	| { type: 'CLICKED_ON_BREADCRUMB' }
+	| { type: 'SELECTED_BROWSE_ALL_THEMES' }
+	| { type: 'SELECTED_ACTIVE_THEME' }
+	| { type: 'SELECTED_NEW_THEME'; payload: { theme: string } };
+
+export * as actions from './actions';
+export * as services from './services';
+
+export const Intro: CustomizeStoreComponent = ( { sendEvent, context } ) => {
+	const {
+		intro: { themeCards, activeTheme },
+	} = context;
+	return (
+		<>
+			<h1>Intro</h1>
+			<div>Active theme: { activeTheme }</div>
+			{ themeCards?.map( ( themeCard ) => (
+				<button
+					key={ themeCard.name }
+					onClick={ () =>
+						sendEvent( {
+							type: 'SELECTED_NEW_THEME',
+							payload: { theme: themeCard.name },
+						} )
+					}
+				>
+					{ themeCard.name }
+				</button>
+			) ) }
+			<button onClick={ () => sendEvent( { type: 'DESIGN_WITH_AI' } ) }>
+				Design with AI
+			</button>
+		</>
+	);
+};

--- a/plugins/woocommerce-admin/client/customize-store/intro/services.ts
+++ b/plugins/woocommerce-admin/client/customize-store/intro/services.ts
@@ -1,0 +1,14 @@
+// placeholder xstate async service that returns a set of theme cards
+
+export const fetchThemeCards = async () => {
+	return [
+		{
+			name: 'Twenty Twenty One',
+			description: 'The default theme for WordPress.',
+		},
+		{
+			name: 'Twenty Twenty',
+			description: 'The previous default theme for WordPress.',
+		},
+	];
+};

--- a/plugins/woocommerce-admin/client/customize-store/intro/theme-cards.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/intro/theme-cards.tsx
@@ -1,0 +1,6 @@
+export type ThemeCard = {
+	// placeholder props, possibly take reference from https://github.com/Automattic/wp-calypso/blob/1f1b79210c49ef0d051f8966e24122229a334e29/packages/design-picker/src/components/theme-card/index.tsx#L32
+	name: string;
+	description: string;
+	image: string;
+};

--- a/plugins/woocommerce-admin/client/customize-store/types.ts
+++ b/plugins/woocommerce-admin/client/customize-store/types.ts
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import { Sender } from 'xstate';
+
+/**
+ * Internal dependencies
+ */
+import { customizeStoreStateMachineEvents } from '.';
+import { ThemeCard } from './intro/theme-cards';
+
+export type CustomizeStoreComponent = ( props: {
+	sendEvent: Sender< customizeStoreStateMachineEvents >;
+	context: customizeStoreStateMachineContext;
+} ) => React.ReactElement | null;
+
+export type CustomizeStoreComponentMeta = {
+	component: CustomizeStoreComponent;
+};
+
+export type customizeStoreStateMachineContext = {
+	themeConfiguration: Record< string, unknown >; // placeholder for theme configuration until we know what it looks like
+	intro: {
+		themeCards: ThemeCard[];
+		activeTheme: string;
+	};
+};

--- a/plugins/woocommerce-admin/client/layout/controller.js
+++ b/plugins/woocommerce-admin/client/layout/controller.js
@@ -74,6 +74,10 @@ const WCPaymentsWelcomePage = lazy( () =>
 	)
 );
 
+const CustomizeStore = lazy( () =>
+	import( /* webpackChunkName: "customize-store" */ '../customize-store' )
+);
+
 export const PAGES_FILTER = 'woocommerce_admin_pages_list';
 
 export const getPages = () => {
@@ -285,6 +289,18 @@ export const getPages = () => {
 			breadcrumbs: [
 				...initialBreadcrumbs,
 				__( 'Profiler', 'woocommerce' ),
+			],
+			capability: 'manage_woocommerce',
+		} );
+	}
+
+	if ( window.wcAdminFeatures[ 'customize-store' ] ) {
+		pages.push( {
+			container: CustomizeStore,
+			path: '/customize-store',
+			breadcrumbs: [
+				...initialBreadcrumbs,
+				__( 'Customize Your Store', 'woocommerce' ),
 			],
 			capability: 'manage_woocommerce',
 		} );

--- a/plugins/woocommerce-admin/client/utils/xstate/find-component.tsx
+++ b/plugins/woocommerce-admin/client/utils/xstate/find-component.tsx
@@ -4,17 +4,30 @@
  * @template T - The type of the component meta object
  */
 export function findComponentMeta< T >(
-	obj: Record< string, unknown >
+	obj: Record< string, unknown >,
+	visited = new Set< Record< string, unknown > >()
 ): T | undefined {
+	if ( visited.has( obj ) ) {
+		return undefined;
+	}
+
+	visited.add( obj );
+
 	for ( const key in obj ) {
-		if ( key === 'component' ) {
-			return obj as T;
-		} else if ( typeof obj[ key ] === 'object' && obj[ key ] !== null ) {
-			const found = findComponentMeta< T >(
-				obj[ key ] as Record< string, unknown >
-			);
-			if ( found !== undefined ) {
-				return found;
+		if ( obj.hasOwnProperty( key ) ) {
+			if ( key === 'component' ) {
+				return obj as T;
+			} else if (
+				typeof obj[ key ] === 'object' &&
+				obj[ key ] !== null
+			) {
+				const found = findComponentMeta< T >(
+					obj[ key ] as Record< string, unknown >,
+					visited
+				);
+				if ( found !== undefined ) {
+					return found;
+				}
 			}
 		}
 	}

--- a/plugins/woocommerce-admin/client/utils/xstate/test/find-component.test.tsx
+++ b/plugins/woocommerce-admin/client/utils/xstate/test/find-component.test.tsx
@@ -61,4 +61,58 @@ describe( 'findComponentMeta', () => {
 			progress: 100,
 		} );
 	} );
+
+	it( 'should return undefined if there are circular references and no component', () => {
+		const objA: Record< string, unknown > = {};
+		const objB: Record< string, unknown > = { other: objA };
+		objA.self = objA; // Creating a cyclic reference within objA
+		objA.another = objB; // Adding another object to traverse
+
+		const result = findComponentMeta( objA );
+		expect( result ).toBeUndefined();
+	} );
+
+	it( 'should work correctly with mixed types', () => {
+		const mixedObject = {
+			number: 42,
+			string: 'test',
+			array: [ 1, 2, 3 ],
+			nested: { component: 'found' },
+		};
+
+		const result = findComponentMeta( mixedObject );
+		expect( result ).toEqual( { component: 'found' } );
+	} );
+
+	it( 'should work correctly with null and undefined values', () => {
+		const objectWithNullAndUndefined = {
+			key1: null,
+			key2: undefined,
+			nested: { component: 'found' },
+		};
+
+		const result = findComponentMeta( objectWithNullAndUndefined );
+		expect( result ).toEqual( { component: 'found' } );
+	} );
+
+	it( 'should return the first component meta even if there are deeper ones', () => {
+		const sparseComponentObject = {
+			level1: {
+				component: 'found',
+				level2: {
+					level3: { component: 'not this one' },
+					otherLevel3: { component: 'not this one either' },
+				},
+			},
+		};
+
+		const result = findComponentMeta( sparseComponentObject );
+		expect( result ).toEqual( {
+			component: 'found',
+			level2: {
+				level3: { component: 'not this one' },
+				otherLevel3: { component: 'not this one either' },
+			},
+		} );
+	} );
 } );

--- a/plugins/woocommerce/changelog/add-customize-your-store-xstate
+++ b/plugins/woocommerce/changelog/add-customize-your-store-xstate
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Added xstate scaffolding for customize your store feature


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR introduces the xstate scaffolding for part of the Customize Your Store feature.
- it covers mostly the states for the intro screen, but also has the placeholder states for design-with-ai and assembler-hub
- design-with-ai and assembler-hub should be their own xstate machines that are self contained within their respective components that will be rendered in this one. Their xstate machines will be introduced in a follow up
- this PR attempts to introduce a more organised structure for each state, such that the index.tsx for each component/state should also export its events, services, and actions.
- most of the implementation details are placeholders and should be changed when there are more concrete details

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

This PR should not be externally tested on it's own as its only laying the groundwork for the Customize Your Store feature.

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Run WooCommerce, with the customize-store feature flag enabled
2. Reach the customize your store feature through the task list
3. Test around this

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
