### PR TITLE
Rollback condition from delete flow as causes issues with no HPOS tables

### DIFF
--- a/plugins/woocommerce/changelog/fix-delete_db_issue
+++ b/plugins/woocommerce/changelog/fix-delete_db_issue
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Partial rollback of an earlier PR.
+
+

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -667,10 +667,12 @@ ORDER BY orders.id ASC
 			return;
 		}
 
+		if ( ! $this->get_table_exists() ) {
+			return;
+		}
+
 		if ( $this->data_sync_is_enabled() ) {
-			if ( $this->get_table_exists() ) {
-				$this->data_store->delete_order_data_from_custom_order_tables( $postid );
-			}
+			$this->data_store->delete_order_data_from_custom_order_tables( $postid );
 		} elseif ( $this->custom_orders_table_is_authoritative() ) {
 			return;
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR partially rollback #39616 around the part where we were returning if the table didn't exist. In cases where HPOS tables are not created, we would have gotten to the part where `SELECT EXISTS` checks happen which would cause DB error with message `Table {wpdb->prefix}wc_orders don't exist.`. Note that since `$wpdb` would hide these errors, it would just return false and order would be deleted as expected, however for stores that have configured to log DB errors, we would end up adding to their logs whenever they would delete an order.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set posts to authoritative, sync to off, and delete the custom order tables if already created by going to WooCommerce > Status > Tools.
2. Create an order and move it to trash.
3. Add the following code snippet to surface the error ($wpdb will hide it by default, so things will work as expected without this snippet):
```php
add_filter( 'deleted_post', function () {
	global $wpdb;
	$last_error = $wpdb->last_error;
	if ( '' === $last_error ) {
		return;
	}
	die( "<pre>$last_error</pre>" );
}, 99 );
```
6. Go to the order trash list, and delete the recently trashed order. Check that the `die` didn't triggered and order was deleted as expected.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
