### PR TITLE
If `geo_hash` is known and correct, avoid an unnecessary redirect

### DIFF
--- a/plugins/woocommerce/changelog/fix-29873-geolocate-redirect
+++ b/plugins/woocommerce/changelog/fix-29873-geolocate-redirect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Eliminate an unnecessary redirect when the geo hash isalready set to the correct value.

--- a/plugins/woocommerce/client/legacy/js/frontend/geolocation.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/geolocation.js
@@ -84,7 +84,7 @@ jQuery( function( $ ) {
 		Cookies.set( 'woocommerce_geo_hash', hash, { expires: 1 / 24 } );
 
 		const urlQuery     = new URL( window.location ).searchParams;
-		const existingHash = urlQuery.get( 'v' )
+		const existingHash = urlQuery.get( 'v' );
 
 		// If the current URL does not contain the expected hash, redirect.
 		if ( existingHash !== hash ) {

--- a/plugins/woocommerce/client/legacy/js/frontend/geolocation.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/geolocation.js
@@ -83,17 +83,14 @@ jQuery( function( $ ) {
 		// Updates our (cookie-based) cache of the hash value. Expires in 1 hour.
 		Cookies.set( 'woocommerce_geo_hash', hash, { expires: 1 / 24 } );
 
-		var this_page = window.location.toString();
+		const urlQuery     = new URL( window.location ).searchParams;
+		const existingHash = urlQuery.get( 'v' )
 
-		if ( this_page.indexOf( '?v=' ) > 0 || this_page.indexOf( '&v=' ) > 0 ) {
-			this_page = this_page.replace( /v=[^&]+/, 'v=' + hash );
-		} else if ( this_page.indexOf( '?' ) > 0 ) {
-			this_page = this_page + '&v=' + hash;
-		} else {
-			this_page = this_page + '?v=' + hash;
+		// If the current URL does not contain the expected hash, redirect.
+		if ( existingHash !== hash ) {
+			urlQuery.set( 'v', hash );
+			window.location.search = '?' + urlQuery.toString();
 		}
-
-		window.location = this_page;
 	};
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

If **WooCommerce ▸ Settings ▸ General ▸ Default customer location** is set to **Geolocate (with page caching support)**, then a hash looking like `?v=abc12345` will be appended to storefront URLs (the actual value of the hash varies according to the shopper's current location).

For example, suppose a visitor lands on a single product page:

```
https://store.front/product/a-product
```

The URL does not contain the geo hash, so we try to determine what that is and append it to the URL via a redirect to:

```
https://store.front/product/a-product?v=abc12345
```

Note that the value of the hash is also stored in a cookie named `woocommerce_geo_hash`. However, as described in the linked issue, the problem is that if that cookie no longer exists, we still perform a redirect *even if the URL already contains the correct geo hash.* Reloading the same page unnecessarily is of course an unwelcome performance hit.

Closes #29873.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

While testing, I recommend you use your browser's dev tools to monitor network requests. You may also wish to enable *'Persist/Preserve Logs'.*

1. Start by enabling **Geolocate (with page caching support)** (as described in the above description).
2. Visit the storefront (could be a single product page, or the main catalog page). You should see that a geo hash like `?v=abc12345` is appended to the URL.
3. Reload the page: there should be no redirect (this is unchanged, we're just checking this part continues to work as previously).
4. Using your browser's dev tools, delete the `woocommerce_geo_hash` cookie then reload the page (before you do this, you may also want to delete any network logs that have already been gathered). **You should not observe a redirect.** Whereas, *before* this PR, you should be able to observe a redirect back to the same URL you just arrived at.
5. Modify the URL and change the hash. For example, if it is `?v=abc12345` try changing it to `?v=xyz9876`. After entering this, you should be redirected back to the same hash as previously (again, this is unchanged, we're just checking this part continues to work as previously).

**Testing notes**

- If you are testing via a local clone of the repo, and especially if you are comparing `trunk` and this branch, remember to rebuild assets after switching branches: `pnpm run --filter='woocommerce/client/legacy' build`
- It is worth noting that the redirects can be triggered at one of two different levels: server-side and client-side. The redirect we've eliminated from step 4 was a client-side redirect, and happens after the page starts to load. I'm flagging this because, if you try replicating the problem without this PR, you should be aware that quite a large number of network requests will be logged before you see the redirect. Example:

<div align="center"><img width="700" alt="clientsideredirect" src="https://github.com/woocommerce/woocommerce/assets/3594411/53ba54c9-c180-462f-9526-ff27c0c44127"></div>


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
