### PR TITLE
bump WooCommerce blocks version to 10.6.5

### DIFF
--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-10.6.5
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-10.6.5
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+bump WooCommerce Blocks to 10.6.5

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -23,7 +23,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.6.1",
-		"woocommerce/woocommerce-blocks": "10.6.4"
+		"woocommerce/woocommerce-blocks": "10.6.5"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.3.0",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ec3a4ac00d0f17e7656229a2efe18a88",
+    "content-hash": "e680b0914f7ff2b18d7d8afd52c99d2d",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1004,16 +1004,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "10.6.4",
+            "version": "10.6.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "5ff77faccb8b52f95ec0a4a166722d3ed8010314"
+                "reference": "e05df5d2d7cd6c273ff10cbec424d446be1dbc88"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/5ff77faccb8b52f95ec0a4a166722d3ed8010314",
-                "reference": "5ff77faccb8b52f95ec0a4a166722d3ed8010314",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/e05df5d2d7cd6c273ff10cbec424d446be1dbc88",
+                "reference": "e05df5d2d7cd6c273ff10cbec424d446be1dbc88",
                 "shasum": ""
             },
             "require": {
@@ -1059,9 +1059,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v10.6.4"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v10.6.5"
             },
-            "time": "2023-08-04T15:41:33+00:00"
+            "time": "2023-08-09T08:15:17+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 10.6.5. This is intended to be merged into WooCommerce 8.0.

## Blocks 10.6.5

* [Release PR](https://github.com/woocommerce/woocommerce-blocks/pull/10510)
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/1065.md)

### Changelog entry

#### Bug Fixes

- Avoid to cache script data in a transient. ([10509](https://github.com/woocommerce/woocommerce-blocks/pull/10509))

****