### PR TITLE
Update class-wc-order.php

### DIFF
--- a/plugins/woocommerce/includes/class-wc-order.php
+++ b/plugins/woocommerce/includes/class-wc-order.php
@@ -392,7 +392,7 @@ class WC_Order extends WC_Abstract_Order {
 
 		if ( $status_transition ) {
 			try {
-				do_action( 'woocommerce_order_status_' . $status_transition['to'], $this->get_id(), $this );
+				do_action( 'woocommerce_order_status_' . $status_transition['to'], $this->get_id(), $this, $status_transition );
 
 				if ( ! empty( $status_transition['from'] ) ) {
 					/* translators: 1: old order status 2: new order status */


### PR DESCRIPTION
this hook is important as this is the place where we can make changes to the order data based on previous order status that will be reflected in the state change email notification 

with this change we will be able to access the old status of the order and whether the event was triggered manually or automated in this hook.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

We want to regenerate estimate date for the order based on the order status change

for this we need old state and if the event was auto triggered and we need the changes to reflect in the outgoing email as well

but as of now we can't do that as the old state data and manual trigger data is not present in the hook 

so with this change that data will be available 


### Testing instructions

- Code review as this is adding a parameter to an existing hook





