### PR TITLE
[New Blocks Editor]: Update product experiment name.

### DIFF
--- a/plugins/woocommerce-admin/client/task-lists/fills/products/use-create-product-by-type.ts
+++ b/plugins/woocommerce-admin/client/task-lists/fills/products/use-create-product-by-type.ts
@@ -38,7 +38,7 @@ export const useCreateProductByType = () => {
 			}
 
 			const assignment = await loadExperimentAssignment(
-				'woocommerce_product_creation_experience_202306_v2'
+				'woocommerce_product_creation_experience_202308_v3'
 			);
 
 			if ( assignment.variationName === 'treatment' ) {

--- a/plugins/woocommerce/changelog/update-38624_new_experiment_name
+++ b/plugins/woocommerce/changelog/update-38624_new_experiment_name
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: This only updates the experiment name of the product block editor, this does not need to be listed in the changelog.
+
+


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Updates the product block editor experiment name for the new release.

Related to https://github.com/woocommerce/woocommerce/issues/38624


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

   - Verify the experiment name
   - Install the WooCommerce Beta Tester and go to Tools > WCA Test Helper > Experiments and toggle woocommerce_product_creation_experience_202308_v3 to treatment ( you may have to go to the Add product task first for it to show up, or just add it )
   -  Then go to the Add product task list and click Physical product
   -  You should be redirected to the new product editing experience with the feature flag auto-enabled (you can check that in the Advanced Feature settings )
   -   Go to the Add product task list and select another product type- verify the redirection to the legacy editor.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.
