### PR TITLE
Revert behaviour of code that was using nullish coalescing operator.

### DIFF
--- a/plugins/woocommerce/changelog/dev-fix-behaviour-of-legacy-js
+++ b/plugins/woocommerce/changelog/dev-fix-behaviour-of-legacy-js
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix an issue which was causing some attributes to default to a minimum length of 3.

--- a/plugins/woocommerce/client/legacy/js/admin/wc-enhanced-select.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-enhanced-select.js
@@ -312,7 +312,7 @@ jQuery( function( $ ) {
 					var select2_args = $.extend( {
 						allowClear        : $( this ).data( 'allow_clear' ) ? true : false,
 						placeholder       : $( this ).data( 'placeholder' ),
-						minimumInputLength: $( this ).data( 'minimum_input_length' ) ? $( this ).data( 'minimum_input_length' ) : '3',
+						minimumInputLength: $( this ).data( 'minimum_input_length' ) !== null && $( this ).data( 'minimum_input_length' ) !== undefined ? $( this ).data( 'minimum_input_length' ) : '3',
 						escapeMarkup      : function( m ) {
 							return m;
 						},
@@ -356,7 +356,7 @@ jQuery( function( $ ) {
 					var select2_args = $.extend( {
 						allowClear        : $( this ).data( 'allow_clear' ) ? true : false,
 						placeholder       : $( this ).data( 'placeholder' ),
-						minimumInputLength: $( this ).data( 'minimum_input_length' ) ? $( this ).data( 'minimum_input_length' ) : '3',
+						minimumInputLength: $( this ).data( 'minimum_input_length' ) !== null && $( this ).data( 'minimum_input_length' ) !== undefined ? $( this ).data( 'minimum_input_length' ) : '3',
 						escapeMarkup      : function( m ) {
 							return m;
 						},


### PR DESCRIPTION
### Changes proposed in this Pull Request:

A while back we removed 2 uses of nullish coalescing operator because we did not have es6 to build the legacy JS.

Unfortunately the replacement code was not functionally equivalent. `??` checks if a value is null or undefined, whereas `?:` ternary checks for falsy value. For example `''` is falsy. I'm not exactly sure what the intended behaviour is in this code, but it causes this bug: https://github.com/woocommerce/woocommerce/issues/39667

Closes #39667

### How to test the changes in this Pull Request:

Use the repro steps from the bug:

1. Products -> edit product
2. Attributes -> try to add attribute with a name like "S", "M", "L" or "XL"
3. It should **not** fail.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix an issue which was causing some attributes to default to a minimum length of 3.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
