### PR TITLE
Update marketplace product card for updated WCCOM search API

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/product-card/product-card.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/product-card/product-card.tsx
@@ -9,7 +9,6 @@ import { Button, Card } from '@wordpress/components';
  */
 import './product-card.scss';
 import { Product } from '../product-list/types';
-import { getAdminSetting } from '../../../../client/utils/admin-settings';
 import { appendUTMParams } from '../../utils/functions';
 
 export interface ProductCardProps {
@@ -19,7 +18,8 @@ export interface ProductCardProps {
 
 function ProductCard( props: ProductCardProps ): JSX.Element {
 	const { product } = props;
-	const currencySymbol = getAdminSetting( 'currency' )?.symbol;
+	// We hardcode this for now while we only display prices in USD.
+	const currencySymbol = '$';
 
 	// Append UTM parameters to the vendor URL
 	let vendorUrl = '';
@@ -76,12 +76,15 @@ function ProductCard( props: ProductCardProps ): JSX.Element {
 					variant="link"
 				>
 					<span>
-						{ product.price === 0 || product.price === '0'
-							? __( 'Free download', 'woocommerce' )
-							: currencySymbol + product.price }
+						{
+							// '0' is a free product
+							product.price === 0
+								? __( 'Free download', 'woocommerce' )
+								: currencySymbol + product.price
+						}
 					</span>
 					<span className="woocommerce-marketplace__product-card__price-billing">
-						{ product.price === 0 || product.price === '0'
+						{ product.price === 0
 							? ''
 							: __( ' annually', 'woocommerce' ) }
 					</span>

--- a/plugins/woocommerce-admin/client/marketplace/components/product-list/types.ts
+++ b/plugins/woocommerce-admin/client/marketplace/components/product-list/types.ts
@@ -5,6 +5,7 @@ export type SearchAPIProductType = {
 	link: string;
 	demo_url: string;
 	price: string;
+	raw_price: number;
 	hash: string;
 	slug: string;
 	id: number;
@@ -23,9 +24,8 @@ export interface Product {
 	vendorUrl: string;
 	icon: string;
 	url: string;
-	price: string | number;
+	price: number;
 	productType?: string;
 	averageRating?: number | null;
 	reviewsCount?: number | null;
-	currency?: string;
 }

--- a/plugins/woocommerce-admin/client/marketplace/contexts/product-list-context.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/contexts/product-list-context.tsx
@@ -78,10 +78,10 @@ export function ProductListContextProvider(
 							vendorUrl: product.vendor_url,
 							icon: product.icon,
 							url: product.link,
-							price: product.price,
+							// Due to backwards compatibility, raw_price is from search API, price is from featured API
+							price: product.raw_price ?? product.price,
 							averageRating: product.rating ?? 0,
 							reviewsCount: product.reviews_count ?? 0,
-							currency: '',
 						};
 					}
 				);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

As part of https://github.com/Automattic/woocommerce.com/issues/17829 we need to ensure that the product cards display the correct currency symbol and price for both the Discover page, and the search results.

This PR updates to using the values from the new API endpoint changes on `woocommerce.com` that include pricing and currency symbols in the correct format.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout this branch locally 
2. Update [this line](https://github.com/woocommerce/woocommerce/blob/4d8fd6378c3eb91d5fc3ac437f35f89670c3c6a7/plugins/woocommerce-admin/client/marketplace/components/constants.ts#L3C3-L3C3) to `export const MARKETPLACE_URL = 'https://woocommerce.test';`
3. From `plugins/woocommerce-admin` run `pnpm run build`
4. Visit the Discovery page (wp-env URL: http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fextensions)
5. Check that the product cards correctly display as either "Free download" or with a rounded price.
    - Note: there is a separate issue to deal with an encoding issue so the price currently displays with an entity code for the currency symbol at the start. This means seeing `&#36;29 annually` is to be expected and should appear in the API response. It is the equivalent of `$29 annually`

<img width="1515" alt="Screenshot 2023-08-14 at 16 04 05" src="https://github.com/woocommerce/woocommerce/assets/22053773/62433065-54ff-4b0b-9ad2-19a887101b9b">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
