### PR TITLE
Fix "Move to Trash" link in order edit screen

### DIFF
--- a/plugins/woocommerce/changelog/fix-hpos-order-edit-trash-link
+++ b/plugins/woocommerce/changelog/fix-hpos-order-edit-trash-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Restore moving to trash functionality within HPOS order edit screen.

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
@@ -103,7 +103,7 @@ class WC_Meta_Box_Order_Actions {
 			$trash_order_url = add_query_arg(
 				array(
 					'action'           => 'trash',
-					'order'            => array( $order_id ),
+					'id'            => array( $order_id ),
 					'_wp_http_referer' => $order_list_url,
 				),
 				$order_list_url


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
After #39524 we renamed the query string arguments in HPOS from `order` to `id`, but apparently the "Move to trash" link that appears in the edit screen was missed.

This PR brings it inline with the other logic so that you can properly trash orders from the edit screen.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable HPOS by going to WC > Settings > Advanced > Features and choosing "High performance order storage (new)" as "Data storage for orders".
2. Go to WC > Orders.
3. Create a few orders (if you don't have any).
4. Choose one of the orders in the list and click on it.
5. Click the "Move to trash" link that appears in the "Order actions" metabox on the right side.
6. You should be back at the list of orders.
7. Make sure the order is no longer visible and confirm that it appears when clicking the "Trash" filter.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fix "Move to trash" URL in HPOS edit screen.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
