### PR TITLE
Fixes for HPOS new/update order hook behavior + webhook support

### DIFF
--- a/plugins/woocommerce/changelog/fix-39079
+++ b/plugins/woocommerce/changelog/fix-39079
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Bring HPOS order hooks in line with the posts implementation.

--- a/plugins/woocommerce/includes/class-wc-webhook.php
+++ b/plugins/woocommerce/includes/class-wc-webhook.php
@@ -997,9 +997,11 @@ class WC_Webhook extends WC_Legacy_Webhook {
 			),
 			'order.deleted'    => array(
 				'wp_trash_post',
+				'woocommerce_trash_order',
 			),
 			'order.restored'   => array(
 				'untrashed_post',
+				'woocommerce_untrash_order',
 			),
 			'product.created'  => array(
 				'woocommerce_process_product_meta',

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2381,6 +2381,12 @@ FROM $order_meta_table
 			return;
 		}
 
+		// For backwards compat with CPT, trashing/untrashing and changing previously datastore-level props does not trigger the update hook.
+		if ( ( ! empty( $changes['status'] ) && in_array( 'trash', array( $changes['status'], $previous_status ), true ) )
+			|| ! array_diff_key( $changes, array_flip( $this->get_post_data_store_for_backfill()->get_internal_data_store_key_getters() ) ) ) {
+			return;
+		}
+
 		do_action( 'woocommerce_update_order', $order->get_id(), $order ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 	}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2276,6 +2276,11 @@ FROM $order_meta_table
 
 		$this->persist_save( $order );
 
+		// Do not fire 'woocommerce_new_order' for draft statuses for backwards compatibility.
+		if ( 'auto-draft' === $order->get_status( 'edit') ) {
+			return;
+		}
+
 		/**
 		 * Fires when a new order is created.
 		 *

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2339,6 +2339,9 @@ FROM $order_meta_table
 	 * @param \WC_Order $order Order object.
 	 */
 	public function update( &$order ) {
+		$previous_status = ArrayUtil::get_value_or_default( $order->get_data(), 'status' );
+		$changes         = $order->get_changes();
+
 		// Before updating, ensure date paid is set if missing.
 		if (
 			! $order->get_date_paid( 'edit' )
@@ -2371,6 +2374,12 @@ FROM $order_meta_table
 
 		$order->apply_changes();
 		$this->clear_caches( $order );
+
+		// For backwards compatibility, moving an auto-draft order to a valid status triggers the 'woocommerce_new_order' hook.
+		if ( ! empty( $changes['status'] ) && 'auto-draft' === $previous_status ) {
+			do_action( 'woocommerce_new_order', $order->get_id(), $order ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+			return;
+		}
 
 		do_action( 'woocommerce_update_order', $order->get_id(), $order ); // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -2618,4 +2618,79 @@ class OrdersTableDataStoreTests extends HposTestCase {
 		$this->assertTrue( $order->get_download_permissions_granted() );
 		$this->assertEquals( 'test_value', $r_order->get_meta( 'test_key', true ) );
 	}
+
+	/**
+	 * @testDox Checks that order new/updated hooks are fired at appropriate times in HPOS (vs CPT).
+	 * @testWith [true]
+	 *           [false]
+	 * @param bool $cot_is_authoritative True to test with the orders table as authoritative, false to test with the posts table as authoritative.
+	 */
+	public function test_order_hooks_vs_cpt( $cot_is_authoritative = true ) {
+		$this->toggle_cot_authoritative( $cot_is_authoritative );
+		$this->disable_cot_sync();
+
+		$new_count = $update_count = 0;
+
+		$callback = function( $order_id ) use ( &$new_count, &$update_count ) {
+			$new_count    += 'woocommerce_new_order' === current_action() ? 1 : 0;
+			$update_count += 'woocommerce_update_order' === current_action() ? 1 : 0;
+		};
+
+		add_action( 'woocommerce_new_order', $callback );
+		add_action( 'woocommerce_update_order', $callback );
+
+		// Creating a new order should trigger 'woocommerce_new_order' but not 'woocommerce_update_order'.
+		$order = new WC_Order();
+		$order->save();
+		$this->assertEquals( 1, $new_count );
+		$this->assertEquals( 0, $update_count );
+
+		// An update to the order should only trigger 'woocommerce_update_order'.
+		$order->set_billing_city( 'Los Angeles' );
+		$order->save();
+		$this->assertEquals( 1, $new_count );
+		$this->assertEquals( 1, $update_count );
+
+		// Updating datastore-level props should not trigger anything.
+		$order->get_data_store()->set_download_permissions_granted( $order->get_id(), true );
+		$this->assertEquals( 1, $new_count );
+		$this->assertEquals( 1, $update_count );
+
+		// Trashing should not fire an update.
+		$order->get_data_store()->delete( $order );
+		$this->assertEquals( $order->get_status(), 'trash' );
+		$this->assertEquals( 1, $update_count );
+
+		// Untrashing should not fire an update.
+		if ( $cot_is_authoritative ) {
+			$order = wc_get_order( $order->get_id() ); // Refresh order.
+			$order->get_data_store()->untrash_order( $order );
+		} else {
+			wp_untrash_post( $order->get_id() );
+			$order = wc_get_order( $order->get_id() ); // Refresh order.
+		}
+		$this->assertNotEquals( $order->get_status(), 'trash' );
+		$this->assertEquals( 1, $update_count );
+
+		// An auto-draft order should not trigger 'woocommerce_new_order' until first saved with a valid status.
+		if ( $cot_is_authoritative ) {
+			$order = new WC_Order();
+			$order->set_status( 'auto-draft' );
+			$order->save();
+
+			$this->assertEquals( 1, $new_count );
+			$this->assertEquals( 1, $update_count );
+
+			$order->set_status( 'on-hold' );
+			$order->save();
+
+			$this->assertEquals( 2, $new_count );
+			$this->assertEquals( 1, $update_count );
+		}
+
+		remove_action( 'woocommerce_new_order', $callback );
+		remove_action( 'woocommerce_update_order', $callback );
+	}
+
+
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR adds support to webhooks for order trashing and untrashing when HPOS is active.

While testing I noticed (as the customer in #39079 also did) that HPOS triggers the `woocommerce_update_order` hook more frequently (and thus the webhooks associated to it) than the CPT implementation. That's because certain operations with CPT orders bypass the `WC_Order::save()` method:

- Creating a new order from the admin actually creates an `auto-draft` post that is "invisible" to the CPT datastore until the first save.
- Trashing and untrashing happens via WP functions.
- Changes to datastore-level properties such as `download_permissions_granted` happens via `update_post_meta()`.

In order to bring everything in line, this PR also changes the way we deal with those changes in HPOS. In particular:

- An `auto-draft` order won't trigger the `woocommerce_new_order` hook until it is first saved with an order status, even though it (obviously) already exists in the db.
- Changes to properties that were datastore-level in CPT are silently made without triggering `woocommerce_update_order`.
- Trashing/untrashing, despite involving a `save()`, won't trigger `woocommerce_update_order`.

Whether HPOS or CPT is more correct is up for discussion, but I decided to go with backwards compatibility for now as that reduces the noise the user from #39079 was seeing (with trashing/untrashing triggering the `order.updated` webhook, for example). I'd be more than happy to change the code if the new behavior is deemed preferable.

Closes #39079.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Changes to the way we handle `auto-draft` orders are covered by unit tests added with this PR. The following instructions are only to confirm that webhooks are working as expected.

1. Drop the following snippet as .php file in `wp-content/mu-plugins/` which will allow us to log when webhooks are scheduled, as to not have to wait until A-S handles actual delivery:
   ```php
   add_action(
	   'woocommerce_webhook_process_delivery',
	   function( $webhook, $arg ) {
		   error_log( $webhook->get_topic() . ' ' . ( is_object( $arg ) ? $arg->get_id() : absint( $arg ) ) );
   
	   },
	   10,
	   2
   );
   ```
2. Go to WC > Settings > Advanced > Webhooks.
3. Create webhooks for topics "Order created", "Order updated", "Order deleted", "Order restored".

   Any valid URL can be used as delivery URL as we're using the snippet above for faster testing. If delivery is to be tested, I suggest using a [Request Bin](https://pipedream.com/requestbin) URL as delivery URL.
4. Go to WC > Settings > Advanced > Features and make sure HPOS is enabled: that is, **Data storage for orders** is set to **High performance order storage (new)**.
5. Go to WC > Orders and
   1. Create a new empty order by clicking **Add order** and then **Create**. Take note of the order ID.
   2. Make some changes to the order and click **Update**.
   3. Click **Move to trash** to send the order to the trash.
   4. You should be back in the list table view.
   5. Go to **Trash**.
   6. Click the checkbox next to your order, select the **Restore** option in the bulk actions drop-down and click **Apply**.
6. Check your site logs, and you should have entries like the following in this exact order and with the ID of your order:
   > [11-Aug-2023 21:48:31 UTC] order.created ORDER_ID
   > [11-Aug-2023 21:48:34 UTC] order.updated ORDER_ID
   > [11-Aug-2023 21:48:38 UTC] order.deleted ORDER_ID
   > [11-Aug-2023 21:48:48 UTC] order.restored ORDER_ID
8. Repeat steps 5-6 with **Keep the posts and orders tables in sync** and with **WordPress post tables** as **Data storage for orders**. These settings can be changed from WC > Settings > Advanced > Features, as usual. Make sure the output (step 6) is identical in every case.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
