### PR TITLE
Add block template registry and controller

### DIFF
--- a/plugins/woocommerce/changelog/add-template-registry-controller
+++ b/plugins/woocommerce/changelog/add-template-registry-controller
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add block template registry and controller

--- a/plugins/woocommerce/src/Admin/BlockTemplates/BlockTemplateInterface.php
+++ b/plugins/woocommerce/src/Admin/BlockTemplates/BlockTemplateInterface.php
@@ -7,6 +7,26 @@ namespace Automattic\WooCommerce\Admin\BlockTemplates;
  */
 interface BlockTemplateInterface extends ContainerInterface {
 	/**
+	 * Get the template ID.
+	 */
+	public function get_id(): string;
+
+	/**
+	 * Get the template title.
+	 */
+	public function get_title(): string;
+
+	/**
+	 * Get the template description.
+	 */
+	public function get_description(): string;
+
+	/**
+	 * Get the template area.
+	 */
+	public function get_area(): string;
+
+	/**
 	 * Get a block by ID.
 	 *
 	 * @param string $block_id The block ID.

--- a/plugins/woocommerce/src/Container.php
+++ b/plugins/woocommerce/src/Container.php
@@ -24,6 +24,7 @@ use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\Proxie
 use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\RestockRefundedItemsAdjusterServiceProvider;
 use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\UtilsClassesServiceProvider;
 use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\BatchProcessingServiceProvider;
+use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\BlockTemplatesServiceProvider;
 
 /**
  * PSR11 compliant dependency injection container for WooCommerce.
@@ -67,6 +68,7 @@ final class Container {
 		OrderAdminServiceProvider::class,
 		FeaturesServiceProvider::class,
 		MarketingServiceProvider::class,
+		BlockTemplatesServiceProvider::class,
 	);
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplateRegistry/BlockTemplateRegistry.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplateRegistry/BlockTemplateRegistry.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Automattic\WooCommerce\Internal\Admin\BlockTemplateRegistry;
+
+/**
+ * Block template registry.
+ */
+final class BlockTemplateRegistry {
+
+    /**
+	 * Class instance.
+	 *
+	 * @var BlockTemplateRegistry|null
+	 */
+	private static $instance = null;
+
+    /**
+     * Templates.
+     */
+    protected $templates = array();
+
+    /**
+	 * Get the instance of the class.
+	 */
+	public static function get_instance(): BlockTemplateRegistry {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+    /**
+     * Register a single template.
+     *
+     * @param array $template Template layout.
+     */
+    public function register( $template_class ) {
+        $template = new $template_class();
+        $this->templates[ $template->get_id() ] = $template;
+    }
+
+    /**
+     * Get the registered templates.
+     */
+    public function get_all_registered(): array {
+        return $this->templates;
+    }
+
+    /**
+     * Get a single registered template.
+     *
+     * @param string $id ID of the template
+     */
+    public function get_registered( $id ): array {
+        return isset( $this->templates[ $id ] ) ? $this->templates[ $id ] : null;
+    }
+
+}

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplateRegistry/BlockTemplateRegistry.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplateRegistry/BlockTemplateRegistry.php
@@ -2,6 +2,8 @@
 
 namespace Automattic\WooCommerce\Internal\Admin\BlockTemplateRegistry;
 
+use Automattic\WooCommerce\Admin\BlockTemplates\BlockTemplateInterface;
+
 /**
  * Block template registry.
  */
@@ -33,11 +35,17 @@ final class BlockTemplateRegistry {
     /**
      * Register a single template.
      *
-     * @param array $template Template layout.
+     * @param string $id Template ID.
+     * @param array  $template Template layout.
      */
-    public function register( $template_class ) {
+    public function register( string $id, string $template_class ) {
         $template = new $template_class();
-        $this->templates[ $template->get_id() ] = $template;
+
+        if ( isset( $this->templates[ $id ] ) ) {
+			throw new \ValueError( 'A template with the specified ID already exists in the registry.' );
+		}
+
+        $this->templates[ $id ] = $template;
     }
 
     /**
@@ -52,7 +60,7 @@ final class BlockTemplateRegistry {
      *
      * @param string $id ID of the template
      */
-    public function get_registered( $id ): array {
+    public function get_registered( $id ): BlockTemplateInterface {
         return isset( $this->templates[ $id ] ) ? $this->templates[ $id ] : null;
     }
 

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplateRegistry/BlockTemplateRegistry.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplateRegistry/BlockTemplateRegistry.php
@@ -38,8 +38,8 @@ final class BlockTemplateRegistry {
      * @param string $id Template ID.
      * @param array  $template Template layout.
      */
-    public function register( string $id, string $template_class ) {
-        $template = new $template_class();
+    public function register( BlockTemplateInterface $template ) {
+        $id = $template->get_id();
 
         if ( isset( $this->templates[ $id ] ) ) {
 			throw new \ValueError( 'A template with the specified ID already exists in the registry.' );

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplateRegistry/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplateRegistry/BlockTemplatesController.php
@@ -39,7 +39,6 @@ class BlockTemplatesController {
         foreach ( $templates as $template ) {
             add_filter( 'pre_get_block_templates', function( $query_result, $query, $template_type ) use( $template ) {
                 if ( ! isset( $query['area'] ) || $query['area'] !== $template->get_area() ) {
-                    wp_die($template->get_area());
                     return $query_result;
                 }
 

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplateRegistry/BlockTemplatesController.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplateRegistry/BlockTemplatesController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Automattic\WooCommerce\Internal\Admin\BlockTemplateRegistry;
+
+/**
+ * Block template controller.
+ */
+class BlockTemplatesController {
+
+    /**
+     * Block template registry
+     *
+     * @var BlockTemplateRegistry
+     */
+    private $block_template_registry;
+
+    /**
+     * Block template transformer.
+     *
+     * @var TemplateTransformer
+     */
+    private $template_transformer;
+
+    /**
+     * Init.
+     */
+    public function init( $block_template_registry, $template_transformer ) {
+        $this->block_template_registry = $block_template_registry;
+        $this->template_transformer    = $template_transformer;
+        add_action( 'rest_api_init', array( $this, 'register_templates' ) );
+    }
+
+    /**
+     * Register templates in the blocks endpoint.
+     */
+    public function register_templates() {
+        $templates = $this->block_template_registry->get_all_registered();
+
+        foreach ( $templates as $template ) {
+            add_filter( 'pre_get_block_templates', function( $query_result, $query, $template_type ) use( $template ) {
+                if ( ! isset( $query['area'] ) || $query['area'] !== $template->get_area() ) {
+                    wp_die($template->get_area());
+                    return $query_result;
+                }
+
+                $wp_block_template = $this->template_transformer->transform( $template );
+                $query_result[]    = $wp_block_template;
+        
+                return $query_result;
+            }, 10, 3 );
+        }
+    }
+
+}

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplateRegistry/TemplateTransformer.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplateRegistry/TemplateTransformer.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Automattic\WooCommerce\Internal\Admin\BlockTemplateRegistry;
+
+/**
+ * Template transformer.
+ */
+class TemplateTransformer {
+
+    /**
+	 * Transform the WooCommerceBlockTemplate to a WP_Block_Template.
+	 *
+	 * @param object $block_template The product template.
+	 */
+	public function transform( $block_template ): \WP_Block_Template {
+		$template                 = new \WP_Block_Template();
+		$template->id             = $block_template->get_id();
+		$template->theme          = 'woocommerce/woocommerce';
+		$template->content        = $block_template->get_formatted_template();
+		$template->source         = 'plugin';
+		$template->slug           = $block_template->get_id();
+		$template->type           = 'wp_template';
+		$template->title          = $block_template->get_title();
+		$template->description    = $block_template->get_description();
+		$template->status         = 'publish';
+		$template->has_theme_file = true;
+		$template->origin         = 'plugin';
+		$template->is_custom      = false; // Templates loaded from the filesystem aren't custom, ones that have been edited and loaded from the DB are.
+		$template->post_types     = array(); // Don't appear in any Edit Post template selector dropdown.
+		$template->area           = $block_template->get_area();
+
+		return $template;
+	}
+
+}

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplateRegistry/TemplateTransformer.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplateRegistry/TemplateTransformer.php
@@ -2,6 +2,8 @@
 
 namespace Automattic\WooCommerce\Internal\Admin\BlockTemplateRegistry;
 
+use Automattic\WooCommerce\Admin\BlockTemplates\BlockTemplateInterface;
+
 /**
  * Template transformer.
  */
@@ -12,7 +14,7 @@ class TemplateTransformer {
 	 *
 	 * @param object $block_template The product template.
 	 */
-	public function transform( $block_template ): \WP_Block_Template {
+	public function transform( BlockTemplateInterface $block_template ): \WP_Block_Template {
 		$template                 = new \WP_Block_Template();
 		$template->id             = $block_template->get_id();
 		$template->theme          = 'woocommerce/woocommerce';

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplates/AbstractBlockTemplate.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplates/AbstractBlockTemplate.php
@@ -13,6 +13,32 @@ abstract class AbstractBlockTemplate implements BlockTemplateInterface {
 	use BlockContainerTrait;
 
 	/**
+	 * Get the template ID.
+	 */
+	public abstract function get_id(): string;
+
+	/**
+	 * Get the template title.
+	 */
+	public function get_title(): string {
+		return '';
+	}
+
+	/**
+	 * Get the template description.
+	 */
+	public function get_description(): string {
+		return '';
+	}
+
+	/**
+	 * Get the template area.
+	 */
+	public function get_area(): string {
+		return 'uncategorized';
+	}
+
+	/**
 	 * The block cache.
 	 *
 	 * @var BlockInterface[]

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockTemplate.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockTemplate.php
@@ -11,6 +11,13 @@ use Automattic\WooCommerce\Admin\BlockTemplates\BlockTemplateInterface;
  */
 class BlockTemplate extends AbstractBlockTemplate {
 	/**
+	 * Get the template ID.
+	 */
+	public function get_id(): string {
+		return 'woocommerce-block-template';
+	}
+
+	/**
 	 * Generate a block ID based on a base.
 	 *
 	 * @param array $block_config The block data.

--- a/plugins/woocommerce/src/Internal/Admin/Loader.php
+++ b/plugins/woocommerce/src/Internal/Admin/Loader.php
@@ -8,6 +8,7 @@ namespace Automattic\WooCommerce\Internal\Admin;
 use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Admin\PageController;
 use Automattic\WooCommerce\Admin\PluginsHelper;
+use Automattic\WooCommerce\Internal\Admin\BlockTemplateRegistry\BlockTemplatesController;
 use Automattic\WooCommerce\Internal\Admin\ProductReviews\Reviews;
 use Automattic\WooCommerce\Internal\Admin\ProductReviews\ReviewsCommentsOverrides;
 use Automattic\WooCommerce\Internal\Admin\Settings;
@@ -72,6 +73,7 @@ class Loader {
 
 		wc_get_container()->get( Reviews::class );
 		wc_get_container()->get( ReviewsCommentsOverrides::class );
+		wc_get_container()->get( BlockTemplatesController::class );
 
 		add_filter( 'admin_body_class', array( __CLASS__, 'add_admin_body_classes' ) );
 		add_filter( 'admin_title', array( __CLASS__, 'update_admin_title' ) );

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/BlockTemplatesServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/BlockTemplatesServiceProvider.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * BlockTemplatesServiceProvider class file.
+ */
+
+namespace Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders;
+
+use Automattic\WooCommerce\Internal\DependencyManagement\AbstractServiceProvider;
+use Automattic\WooCommerce\Internal\Admin\BlockTemplateRegistry\BlockTemplatesController;
+use Automattic\WooCommerce\Internal\Admin\BlockTemplateRegistry\BlockTemplateRegistry;
+use Automattic\WooCommerce\Internal\Admin\BlockTemplateRegistry\TemplateTransformer;
+
+/**
+ * Service provider for the block templates controller classes in the Automattic\WooCommerce\Internal\BlockTemplateRegistry namespace.
+ */
+class BlockTemplatesServiceProvider extends AbstractServiceProvider {
+
+	/**
+	 * The classes/interfaces that are serviced by this service provider.
+	 *
+	 * @var array
+	 */
+	protected $provides = array(
+		BlockTemplateRegistry::class,
+		BlockTemplatesController::class,
+		TemplateTransformer::class,
+	);
+
+	/**
+	 * Register the classes.
+	 */
+	public function register() {
+		$this->share( TemplateTransformer::class );
+		$this->share( BlockTemplateRegistry::class );
+        $this->share( BlockTemplatesController::class )->addArguments(
+			array(
+                BlockTemplateRegistry::class,
+				TemplateTransformer::class,
+			)
+		);
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplateRegistry/BlockTemplateRegistryTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplateRegistry/BlockTemplateRegistryTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Automattic\WooCommerce\Tests\Internal\Admin\BlockTemplates;
+
+use Automattic\WooCommerce\Internal\Admin\BlockTemplates\Block;
+use Automattic\WooCommerce\Internal\Admin\BlockTemplates\BlockTemplate;
+use Automattic\WooCommerce\Internal\Admin\BlockTemplateRegistry\BlockTemplateRegistry;
+
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the BlockTemplateRegistryTest class.
+ */
+class BlockTemplateRegistryTest extends WC_Unit_Test_Case {
+	/**
+	 * Block template registry.
+	 *
+	 * @var BlockTemplateRegistry
+	 */
+	protected $block_template_registry;
+
+	/**
+	 * Runs before each test.
+	 */
+	public function setUp(): void {
+		$this->block_template_registry = new BlockTemplateRegistry();
+		$this->block_template_registry->register( 'custom-block-template', CustomBlockTemplate::class );
+		$this->block_template_registry->register( 'my-block-template', BlockTemplate::class );
+	}
+
+	/**
+	 * Test getting all registered templates.
+	 */
+	public function test_get_all_registered() {
+		$registered_templates = $this->block_template_registry->get_all_registered();
+		$this->assertCount( 2, $registered_templates );
+		$this->assertInstanceOf( CustomBlockTemplate::class, $registered_templates['custom-block-template'] );
+		$this->assertInstanceOf( BlockTemplate::class, $registered_templates['my-block-template'] );
+	}
+
+	/**
+	 * Test registering a template with an existing ID.
+	 */
+	public function test_register_duplicate_id() {
+		$this->expectException( \ValueError::class );
+		$registered_templates = $this->block_template_registry->register( 'my-block-template', BlockTemplate::class );
+	}
+
+	/**
+	 * Test getting a single template by ID.
+	 */
+	public function test_get_registered() {
+		$my_block_template = $this->block_template_registry->get_registered( 'my-block-template' );
+		$this->assertInstanceOf( BlockTemplate::class, $my_block_template );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplateRegistry/BlockTemplateRegistryTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplateRegistry/BlockTemplateRegistryTest.php
@@ -24,8 +24,8 @@ class BlockTemplateRegistryTest extends WC_Unit_Test_Case {
 	 */
 	public function setUp(): void {
 		$this->block_template_registry = new BlockTemplateRegistry();
-		$this->block_template_registry->register( 'custom-block-template', CustomBlockTemplate::class );
-		$this->block_template_registry->register( 'my-block-template', BlockTemplate::class );
+		$this->block_template_registry->register( new CustomBlockTemplate() );
+		$this->block_template_registry->register( new BlockTemplate() );
 	}
 
 	/**
@@ -35,7 +35,7 @@ class BlockTemplateRegistryTest extends WC_Unit_Test_Case {
 		$registered_templates = $this->block_template_registry->get_all_registered();
 		$this->assertCount( 2, $registered_templates );
 		$this->assertInstanceOf( CustomBlockTemplate::class, $registered_templates['custom-block-template'] );
-		$this->assertInstanceOf( BlockTemplate::class, $registered_templates['my-block-template'] );
+		$this->assertInstanceOf( BlockTemplate::class, $registered_templates['woocommerce-block-template'] );
 	}
 
 	/**
@@ -43,14 +43,14 @@ class BlockTemplateRegistryTest extends WC_Unit_Test_Case {
 	 */
 	public function test_register_duplicate_id() {
 		$this->expectException( \ValueError::class );
-		$registered_templates = $this->block_template_registry->register( 'my-block-template', BlockTemplate::class );
+		$registered_templates = $this->block_template_registry->register( new BlockTemplate() );
 	}
 
 	/**
 	 * Test getting a single template by ID.
 	 */
 	public function test_get_registered() {
-		$my_block_template = $this->block_template_registry->get_registered( 'my-block-template' );
-		$this->assertInstanceOf( BlockTemplate::class, $my_block_template );
+		$custom_block_template = $this->block_template_registry->get_registered( 'custom-block-template' );
+		$this->assertInstanceOf( CustomBlockTemplate::class, $custom_block_template );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplateRegistry/BlockTemplatesControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplateRegistry/BlockTemplatesControllerTest.php
@@ -34,7 +34,7 @@ class BlockTemplatesControllerTest extends WC_REST_Unit_Test_Case {
 	public static function setUpBeforeClass(): void {
         parent::setUpBeforeClass();
 		$block_template_registry = wc_get_container()->get( BlockTemplateRegistry::class );
-		$block_template_registry->register( 'custom-block-template', CustomBlockTemplate::class );
+		$block_template_registry->register( new CustomBlockTemplate() );
 	}
 
     /**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplateRegistry/BlockTemplatesControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplateRegistry/BlockTemplatesControllerTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Automattic\WooCommerce\Tests\Internal\Admin\BlockTemplates;
+
+use Automattic\WooCommerce\Internal\Admin\BlockTemplates\Block;
+use Automattic\WooCommerce\Internal\Admin\BlockTemplates\BlockTemplate;
+use Automattic\WooCommerce\Internal\Admin\BlockTemplateRegistry\BlockTemplateRegistry;
+use Automattic\WooCommerce\Internal\Admin\BlockTemplateRegistry\BlockTemplatesController;
+use Automattic\WooCommerce\Internal\Admin\BlockTemplateRegistry\TemplateTransformer;
+
+use WC_REST_Unit_Test_Case;
+
+/**
+ * Tests for the BlockTemplatesControllerTest class.
+ */
+class BlockTemplatesControllerTest extends WC_REST_Unit_Test_Case {
+	/**
+	 * Block template registry.
+	 *
+	 * @var BlockTemplateRegistry
+	 */
+	protected $block_template_registry;
+
+    /**
+	 * Block templates controller.
+	 *
+	 * @var BlockTemplatesController
+	 */
+	protected $block_templates_controller;
+
+	/**
+	 * Runs before suite initialization.
+	 */
+	public static function setUpBeforeClass(): void {
+        parent::setUpBeforeClass();
+		$block_template_registry = wc_get_container()->get( BlockTemplateRegistry::class );
+		$block_template_registry->register( 'custom-block-template', CustomBlockTemplate::class );
+	}
+
+    /**
+	 * Runs before each test.
+	 */
+	public function setUp(): void {
+        parent::setUp();
+
+        $admin_user = wp_insert_user(
+			array(
+				'user_login' => uniqid(),
+				'role'       => 'administrator',
+				'user_pass'  => 'x',
+			)
+		);
+		wp_set_current_user( $admin_user );
+	}
+
+	/**
+	 * Test getting a registered template when area is specififed.
+	 */
+	public function test_get_template_by_area() {
+		$request  = new \WP_REST_Request( 'GET', '/wp/v2/templates' );
+        $request->set_param( 'area', 'test-area' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertCount( 1, $data );
+		$this->assertEquals( 'custom-block-template', $data[0]['id'] );
+	}
+
+    /**
+	 * Test that getting default templates works as expected and does not show the custom templates.
+	 */
+	public function test_get_template_without_area() {
+		$request  = new \WP_REST_Request( 'GET', '/wp/v2/templates' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+        $found_registery_template = false;
+        foreach ( $data as $template ) {
+            if ( $template['id'] === 'custom-block-template' ) {
+                $found_registery_template = true;
+            }
+        }
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertFalse( $found_registery_template );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplateRegistry/BlockTemplatesControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplateRegistry/BlockTemplatesControllerTest.php
@@ -33,6 +33,7 @@ class BlockTemplatesControllerTest extends WC_REST_Unit_Test_Case {
 	 */
 	public static function setUpBeforeClass(): void {
         parent::setUpBeforeClass();
+		wc_get_container()->get( BlockTemplatesController::class );
 		$block_template_registry = wc_get_container()->get( BlockTemplateRegistry::class );
 		$block_template_registry->register( new CustomBlockTemplate() );
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplateRegistry/TemplateTransformerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplateRegistry/TemplateTransformerTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Automattic\WooCommerce\Tests\Internal\Admin\BlockTemplates;
+
+use Automattic\WooCommerce\Internal\Admin\BlockTemplateRegistry\TemplateTransformer;
+use Automattic\WooCommerce\Tests\Internal\Admin\BlockTemplates\CustomBlockTemplate;
+
+use WC_Unit_Test_Case;
+
+/**
+ * Tests for the BlockTemplatesControllerTest class.
+ */
+class TemplateTransformerTest extends WC_Unit_Test_Case {
+    /**
+	 * Template transformer instance.
+	 *
+	 * @var TemplateTransformer
+	 */
+	protected $template_transformer;
+
+	/**
+	 * Runs before each test.
+	 */
+	public function setUp(): void {
+        parent::setUp();
+		$this->template_transformer = new TemplateTransformer();
+	}
+
+	/**
+	 * Test transforming a template returns a valid WP_Block_Template.
+	 */
+	public function test_transform() {
+        $custom_block_template = new CustomBlockTemplate();
+        $wp_block_template     = $this->template_transformer->transform( $custom_block_template );
+        $this->assertInstanceOf( \WP_Block_Template::class, $wp_block_template );
+        $this->assertEquals( 'custom-block-template', $wp_block_template->id );
+        $this->assertEquals( 'Custom Block Template', $wp_block_template->title );
+        $this->assertEquals( 'A custom block template for testing.', $wp_block_template->description );
+        $this->assertEquals( 'test-area', $wp_block_template->area );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/CustomBlockTemplate.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/CustomBlockTemplate.php
@@ -10,6 +10,34 @@ use Automattic\WooCommerce\Internal\Admin\BlockTemplates\AbstractBlockTemplate;
  */
 class CustomBlockTemplate extends AbstractBlockTemplate {
 	/**
+	 * Get the template ID.
+	 */
+	public function get_id(): string {
+		return 'custom-block-template';
+	}
+
+	/**
+	 * Get the template title.
+	 */
+	public function get_title(): string {
+		return 'Custom Block Template';
+	}
+
+	/**
+	 * Get the template description.
+	 */
+	public function get_description(): string {
+		return 'A custom block template for testing.';
+	}
+
+	/**
+	 * Get the template area.
+	 */
+	public function get_area(): string {
+		return 'test-area';
+	}
+
+	/**
 	 * Add a custom block type to this template.
 	 *
 	 * @param array $block_config The block data.

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/CustomBlockTemplateTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/CustomBlockTemplateTest.php
@@ -15,6 +15,30 @@ use WC_Unit_Test_Case;
  */
 class CustomBlockTemplateTest extends WC_Unit_Test_Case {
 	/**
+	 * Test getting the template ID.
+	 */
+	public function test_get_id() {
+		$template = new CustomBlockTemplate();
+		$this->assertEquals( $template->get_id(), 'custom-block-template' );
+	}
+
+	/**
+	 * Test getting the template ID.
+	 */
+	public function test_get_title() {
+		$template = new CustomBlockTemplate();
+		$this->assertEquals( $template->get_title(), 'Custom Block Template' );
+	}
+
+	/**
+	 * Test getting the template ID.
+	 */
+	public function test_get_description() {
+		$template = new CustomBlockTemplate();
+		$this->assertEquals( $template->get_description(), 'A custom block template for testing.' );
+	}
+
+	/**
 	 * Test that the add_block method does not exist by default on templates.
 	 */
 	public function test_add_block_does_not_exist() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds:

* A block template registry that can be used to add or retrieve registered templates from a single repository, allowing third party templates to be added
* A controller that extends the WP core template REST API to include registered templates when the `area` query property matches that of any registered templates.

I will open a discussion around the choice to extend the existing WP template REST API as opposed to spinning up our own, but the short is that this lowers maintenance and grants us access to a bunch of client data store utils for fetching templates.

If we agree with this approach, the next steps are:

1.  Add some tests around the features in this PR
2. Explore enhancing the template API when needed for custom template logic that may be necessary for block visibility.  `register_rest_field` is probably a good candidate for this.

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check out this branch
2. Install and activate [this plugin](https://github.com/joshuatf/woocommerce-block-template-extensibility) on your site
3. Using postman, make a `GET` request to `/wp-json/wp/v2/templates?area=woocommerce/admin/product/edit`
4. Note that the template with `namespace/my-custom-template` is shown in the response
5. Remove the `area` query and request again
6. Make sure the WP templates are returned and no regressions have occurred

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
