### PR TITLE
HPOS: Ensure refund meta data is saved correctly (alternative approach)

### DIFF
--- a/plugins/woocommerce/changelog/fix-39215-alternative-refund-meta-keys
+++ b/plugins/woocommerce/changelog/fix-39215-alternative-refund-meta-keys
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Ensure refund meta data is saved correctly when HPOS is enabled.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2358,9 +2358,9 @@ FROM $order_meta_table
 			$order->set_date_modified( current_time( 'mysql' ) );
 		}
 
-		$this->update_order_meta( $order );
-
 		$this->persist_order_to_db( $order, $force_all_fields );
+
+		$this->update_order_meta( $order );
 
 		$order->save_meta_data();
 		$order->apply_changes();

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableRefundDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableRefundDataStoreTests.php
@@ -102,10 +102,15 @@ class OrdersTableRefundDataStoreTests extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testDox Test that refund props are set as expected.
+	 * @testDox Test that refund props are set as expected with HPOS enabled.
 	 */
 	public function test_refund_data_is_set() {
-		$order  = OrderHelper::create_order();
+		$this->toggle_cot_feature_and_usage( true );
+
+		$order = OrderHelper::create_order();
+		$user  = $this->factory()->user->create_and_get( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user->ID );
+
 		$refund = wc_create_refund(
 			array(
 				'order_id' => $order->get_id(),
@@ -119,6 +124,7 @@ class OrdersTableRefundDataStoreTests extends WC_Unit_Test_Case {
 		$this->assertEquals( $refund->get_id(), $refreshed_refund->get_id() );
 		$this->assertEquals( 10, $refreshed_refund->get_data()['amount'] );
 		$this->assertEquals( 'Test', $refreshed_refund->get_data()['reason'] );
+		$this->assertEquals( $user->ID, $refreshed_refund->get_data()['refunded_by'] );
 	}
 
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is an alternative to #39466, as a way to ensure that refund meta data gets saved correctly. Instead of overriding the meta data setter methods, this approach sets the meta data directly in the `update_order_meta` method, using the recent (#39381) `get_metadata_by_key` data store method.

Pros:
* Avoids class overrides in the refund CRUD object.

Cons:
* Requires a small change to the save routine in the OrdersTableDataStore parent class, which could have unintended side effects (but hopefully not).
* Completely side steps the system in CRUD objects for managing meta data, which feels like it might create more technical debt than it actually mitigates.

Fixes #39215

### How to test the changes in this Pull Request:

The testing instructions in #39466 apply here as well.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Ensure refund meta data is saved correctly when HPOS is enabled.

#### Comment

</details>