### PR TITLE
Support git worktrees

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"clean": "pnpm store prune && git clean -fx **/node_modules && pnpm i",
 		"preinstall": "npx only-allow pnpm",
 		"postinstall": "pnpm git:update-hooks",
-		"git:update-hooks": "rm -r .git/hooks && mkdir -p .git/hooks && husky install",
+		"git:update-hooks": "if test -d .git; then rm -r .git/hooks && mkdir -p .git/hooks && husky install; else husky install; fi",
 		"create-extension": "node ./tools/create-extension/index.js",
 		"cherry-pick": "node ./tools/cherry-pick/bin/run",
 		"sync-dependencies": "pnpm exec syncpack -- fix-mismatches",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

As described in https://github.com/woocommerce/woocommerce/issues/32568,  `pnpm install` fails if you work with a git worktree due to `.git` being a file not a directory when in a worktree. This ensures that we don't try update hooks when you're working in a worktree.

Closes  #32568 
<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Checkout this branch on your local repository.
2. Add a worktree based on this branch `git worktree add ../pnpm-install-should-work dev/support-worktrees`
3. Run `pnpm i`
4. It should pass.
5. Now from the original branch also run `pnpm i`. it should also work.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
