### PR TITLE
Add migration to move incorrectly stored payment token IDS to HPOS tables

### DIFF
--- a/plugins/woocommerce/changelog/fix-35612-migration
+++ b/plugins/woocommerce/changelog/fix-35612-migration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add migration to move incorrectly stored payment token IDS to HPOS tables from postmeta.

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -240,7 +240,6 @@ class WC_Install {
 		),
 		'8.1.0' => array(
 			'wc_update_810_migrate_transactional_metadata_for_hpos',
-
 		),
 	);
 

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -238,6 +238,10 @@ class WC_Install {
 		'7.7.0' => array(
 			'wc_update_770_remove_multichannel_marketing_feature_options',
 		),
+		'8.1.0' => array(
+			'wc_update_810_migrate_transactional_metadata_for_hpos',
+
+		),
 	);
 
 	/**

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -33,7 +33,7 @@ final class WooCommerce {
 	 *
 	 * @var string
 	 */
-	public $version = '8.0.0';
+	public $version = '8.1.0';
 
 	/**
 	 * WooCommerce Schema version.

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -2575,6 +2575,25 @@ function wc_update_750_add_columns_to_order_stats_table() {
 }
 
 /**
+ * Disable the experimental product management experience.
+ *
+ * @return void
+ */
+function wc_update_750_disable_new_product_management_experience() {
+	if ( 'yes' === get_option( 'woocommerce_new_product_management_enabled' ) ) {
+		update_option( 'woocommerce_new_product_management_enabled', 'no' );
+	}
+}
+
+/**
+ * Remove the multichannel marketing feature flag and options. This feature is now enabled by default.
+ */
+function wc_update_770_remove_multichannel_marketing_feature_options() {
+	delete_option( 'woocommerce_multichannel_marketing_enabled' );
+	delete_option( 'woocommerce_marketing_overview_welcome_hidden' );
+}
+
+/**
  * Migrate transaction data which was being incorrectly stored in the postmeta table to HPOS tables.
  *
  * @return bool Whether there are pending migration recrods.
@@ -2607,7 +2626,7 @@ WHERE
 
 	// No need to get the data in application, we can insert directly. Sync setting does not matter as this data already exist in the post table. Limit the batch size to 250.
 	$query =
-	"
+		"
 INSERT INTO $orders_meta_table (order_id, meta_key, meta_value)
 $select_query
 LIMIT 250
@@ -2619,23 +2638,4 @@ LIMIT 250
 	$has_pending = $wpdb->query( "$select_query LIMIT 1;" );
 
 	return ! empty( $has_pending );
-}
-
-/**
- * Disable the experimental product management experience.
- *
- * @return void
- */
-function wc_update_750_disable_new_product_management_experience() {
-	if ( 'yes' === get_option( 'woocommerce_new_product_management_enabled' ) ) {
-		update_option( 'woocommerce_new_product_management_enabled', 'no' );
-	}
-}
-
-/**
- * Remove the multichannel marketing feature flag and options. This feature is now enabled by default.
- */
-function wc_update_770_remove_multichannel_marketing_feature_options() {
-	delete_option( 'woocommerce_multichannel_marketing_enabled' );
-	delete_option( 'woocommerce_marketing_overview_welcome_hidden' );
 }

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -21,6 +21,7 @@ defined( 'ABSPATH' ) || exit;
 use Automattic\WooCommerce\Database\Migrations\MigrationHelper;
 use Automattic\WooCommerce\Internal\Admin\Marketing\MarketingSpecs;
 use Automattic\WooCommerce\Internal\AssignDefaultCategory;
+use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer;
 use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
 use Automattic\WooCommerce\Internal\ProductAttributesLookup\DataRegenerator;
 use Automattic\WooCommerce\Internal\ProductAttributesLookup\LookupDataStore;
@@ -2571,6 +2572,53 @@ function wc_update_750_add_columns_to_order_stats_table() {
 		SET order_stats.date_completed = IFNULL(FROM_UNIXTIME(postmeta.meta_value), '0000-00-00 00:00:00');"
 	);
 
+}
+
+/**
+ * Migrate transaction data which was being incorrectly stored in the postmeta table to HPOS tables.
+ *
+ * @return bool Whether there are pending migration recrods.
+ */
+function wc_update_810_migrate_transactional_metadata_for_hpos() {
+	global $wpdb;
+
+	$data_synchronizer = wc_get_container()->get( DataSynchronizer::class );
+	if ( ! $data_synchronizer->get_table_exists() ) {
+		return true;
+	}
+
+	$orders_table      = OrdersTableDataStore::get_orders_table_name();
+	$orders_meta_table = OrdersTableDataStore::get_meta_table_name();
+
+	/**
+	 * We are migrating payment_tokens meta that is stored in wp_postmeta table to the HPOS table. To do this with minimum db ops:
+	 * 1. We join postmeta table with wc_orders table directly, this filters out orders that are yet to be migrated and any post with non-order post type.
+	 * 2. A combination of filter on wc_orders_meta.meta_key = _payment_tokens in the join condition itself, along with a null check in a WHERE condition, allows us to only get the orders where the meta is not yet migrated.
+	 */
+	$select_query = "
+SELECT post_id, '_payment_tokens', {$wpdb->postmeta}.meta_value
+FROM {$wpdb->postmeta}
+JOIN $orders_table ON {$wpdb->postmeta}.post_id = $orders_table.id
+LEFT JOIN $orders_meta_table ON $orders_meta_table.order_id = $orders_table.id AND $orders_meta_table.meta_key = '_payment_tokens'
+WHERE
+	{$wpdb->postmeta}.meta_key = '_payment_tokens'
+	AND $orders_meta_table.order_id IS NULL
+	";
+
+	// No need to get the data in application, we can insert directly. Sync setting does not matter as this data already exist in the post table. Limit the batch size to 250.
+	$query =
+	"
+INSERT INTO $orders_meta_table (order_id, meta_key, meta_value)
+$select_query
+LIMIT 250
+";
+	// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- No user input in the query, everything hardcoded.
+	$wpdb->query( $query );
+
+	// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- No user input in the query, everything hardcoded.
+	$has_pending = $wpdb->query( "$select_query LIMIT 1;" );
+
+	return ! empty( $has_pending );
 }
 
 /**


### PR DESCRIPTION

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This is a follow-up from #39381 and adds a migration to move over _payments_token meta to the order meta table. Note that we already have a "hot migration" in place, i.e. every time we get payment token meta, we also check the post meta table if the orders table is empty, so migration being complete should not be a prerequisite for orders payment tokens to work.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Since nothing uses payment token in vanilla WooCommerce, we will be using CLI to run this migration.

1. Set HPOS to Authoritative and sync to off. Switch to WC 8.0, and then open the wp shell by running `wp shell` and run following commands:
```php
/ Let's create a new order first and save it. Note the order ID, let's say its ORDER_ID
$order = wc_create_order();
$order->save();

// Add some payment token for this order.
$token = new WC_Payment_Token_ECheck();
$token->set_last4( 1234 );
$token->set_token( time() );
$token->save();

// Add the token to order
$order->add_payment_token( $token );
```
2. Make sure you note down the ORDER_ID of this newly created order.
3. Close the shell and switch over to WC 8.1 (or WC dev build that includes this PR).
4. Set the WooCommerce version into the database to a lower version, so that DB update gets triggered like so: `wp option update woocommerce_version 8.0.0`
5. Refresh any admin page in WC, you should be prompted to do a DB update. Run the migration from the UX and wait for it to complete.
6. Verify that the above token is stored in order meta table, by running the following SQL query:
```
wp db query "SELECT * FROM wp_wc_orders_meta WHERE order_id = ORDER_ID and meta_key = '_payment_tokens';"
```
You should see a serialized value, for example, if the value when getting from code is [1], then the serialized will be a:1:{i:0;i:1;}.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
