### PR TITLE
Fix child keys error in `Tabs` component and and remove unnecessary `sanitizeHTML` call from `FeedbackModal` component

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/feedback-modal/feedback-modal.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/feedback-modal/feedback-modal.tsx
@@ -12,7 +12,6 @@ import { recordEvent } from '@woocommerce/tracks';
  */
 import './feedback-modal.scss';
 import LikertScale from '../likert-scale/likert-scale';
-import sanitizeHTML from '../../../lib/sanitize-html';
 
 export default function FeedbackModal(): JSX.Element {
 	const CUSTOMER_EFFORT_SCORE_ACTION = 'marketplace_redesign_2023';
@@ -171,15 +170,13 @@ export default function FeedbackModal(): JSX.Element {
 			return;
 		}
 
-		const comments = sanitizeHTML( thoughts ).__html;
-
 		// Send event to CES:
 		recordEvent( 'ces_feedback', {
 			action: CUSTOMER_EFFORT_SCORE_ACTION,
 			score: easyToFind,
 			score_second_question: meetsMyNeeds,
 			score_combined: easyToFind + meetsMyNeeds,
-			comments,
+			thoughts,
 		} );
 		// Close the modal:
 		setOpen( false );

--- a/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx
@@ -68,38 +68,36 @@ const renderTabs = ( props: TabsProps ) => {
 	const tabContent = [];
 	for ( const tabKey in tabs ) {
 		tabContent.push(
-			<>
-				{ tabs[ tabKey ]?.href ? (
-					<a
-						className={ classNames(
-							'woocommerce-marketplace__tab-button',
-							'components-button',
-							`woocommerce-marketplace__tab-${ tabKey }`
-						) }
-						href={ tabs[ tabKey ]?.href }
-						key={ tabKey }
-					>
-						{ tabs[ tabKey ]?.title }
-					</a>
-				) : (
-					<Button
-						className={ classNames(
-							'woocommerce-marketplace__tab-button',
-							`woocommerce-marketplace__tab-${ tabKey }`,
-							{
-								'is-active': tabKey === selectedTab,
-							}
-						) }
-						onClick={ () => {
-							setSelectedTab( tabKey );
-							setUrlTabParam( tabKey );
-						} }
-						key={ tabKey }
-					>
-						{ tabs[ tabKey ]?.title }
-					</Button>
-				) }
-			</>
+			tabs[ tabKey ]?.href ? (
+				<a
+					className={ classNames(
+						'woocommerce-marketplace__tab-button',
+						'components-button',
+						`woocommerce-marketplace__tab-${ tabKey }`
+					) }
+					href={ tabs[ tabKey ]?.href }
+					key={ tabKey }
+				>
+					{ tabs[ tabKey ]?.title }
+				</a>
+			) : (
+				<Button
+					className={ classNames(
+						'woocommerce-marketplace__tab-button',
+						`woocommerce-marketplace__tab-${ tabKey }`,
+						{
+							'is-active': tabKey === selectedTab,
+						}
+					) }
+					onClick={ () => {
+						setSelectedTab( tabKey );
+						setUrlTabParam( tabKey );
+					} }
+					key={ tabKey }
+				>
+					{ tabs[ tabKey ]?.title }
+				</Button>
+			)
 		);
 	}
 	return tabContent;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

- Fixed issue with missing keys in `Tabs` component children. We were outputting fragments without keys.
- Removed unnecessary `sanitizeHTML` call in `FeedbackModal`. This sanitization is easily worked around in the browser, and may lead to a false sense of security. See [discussion](p1691995091671139-slack-C04182G03V2) for more details.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Child keys

- Check out this branch and run `pnpm run build` from `plugins/woocommerce-admin`.
- Open dev tools and view the in-app marketplace browse extensions page. (If you're using wp-env, it's http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fextensions.)
- Note that you don't see an error about missing child keys in the console.

#### Feedback modal

These steps are from https://github.com/woocommerce/woocommerce/pull/39609.

- You should see a snackbar at the bottom of the same page prompting you to provide feedback.
- Click the link and fill in the form, providing a comment.
- Observe that a Tracks event would be sent in a way that's compatible with internal documentation (FG "Importing CES Feedback").

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>