### PR TITLE
Allow users to select multiple items from the media library while adding images

### DIFF
--- a/packages/js/components/changelog/dev-38345_allow_select_multiple_items
+++ b/packages/js/components/changelog/dev-38345_allow_select_multiple_items
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Allow users to select multiple items from the media library while adding images #39741

--- a/packages/js/components/src/media-uploader/media-uploader.tsx
+++ b/packages/js/components/src/media-uploader/media-uploader.tsx
@@ -24,7 +24,7 @@ type MediaUploaderProps = {
 	MediaUploadComponent?: < T extends boolean = false >(
 		props: MediaUpload.Props< T >
 	) => JSX.Element;
-	multipleSelect?: boolean;
+	multipleSelect?: boolean | string;
 	onSelect?: (
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		value: ( { id: number } & { [ k: string ]: any } ) | MediaItem[]
@@ -96,7 +96,8 @@ export const MediaUploader = ( {
 						<MediaUploadComponent
 							onSelect={ onSelect }
 							allowedTypes={ allowedMediaTypes }
-							multiple={ multipleSelect }
+							// eslint-disable-next-line @typescript-eslint/no-explicit-any
+							multiple={ multipleSelect as any }
 							render={ ( { open } ) => (
 								<Button
 									variant="secondary"

--- a/packages/js/components/src/media-uploader/media-uploader.tsx
+++ b/packages/js/components/src/media-uploader/media-uploader.tsx
@@ -96,8 +96,8 @@ export const MediaUploader = ( {
 						<MediaUploadComponent
 							onSelect={ onSelect }
 							allowedTypes={ allowedMediaTypes }
-							// eslint-disable-next-line @typescript-eslint/no-explicit-any
-							multiple={ multipleSelect as any }
+							// @ts-expect-error - TODO multiple also accepts string.
+							multiple={ multipleSelect }
 							render={ ( { open } ) => (
 								<Button
 									variant="secondary"

--- a/packages/js/product-editor/changelog/dev-38345_allow_select_multiple_items
+++ b/packages/js/product-editor/changelog/dev-38345_allow_select_multiple_items
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Allow users to select multiple items from the media library while adding images #39741

--- a/packages/js/product-editor/src/blocks/images/edit.tsx
+++ b/packages/js/product-editor/src/blocks/images/edit.tsx
@@ -84,7 +84,7 @@ export function Edit() {
 					</div>
 				) : (
 					<MediaUploader
-						multipleSelect={ true }
+						multipleSelect={ 'add' }
 						onError={ () => null }
 						onFileUploadChange={ onFileUpload }
 						onMediaGalleryOpen={ () => {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR introduces the necessary code to enable users to select multiple images within the Images block of the new product form.

![Screen Capture on 2023-08-15 at 14-33-10](https://github.com/woocommerce/woocommerce/assets/1314156/34819c35-5b6a-44a8-9aee-2d704868feeb)

Closes #38345.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the product blocks editor under WooCommerce -> Settings -> Advanced -> Features.
2. Navigate to the add product page.
3. Press `Images` and access the Media Library.
4. Select multiple items without holding down the `Shift` key.

![Screenshot 2023-08-15 at 14 39 13](https://github.com/woocommerce/woocommerce/assets/1314156/cf066363-602b-4607-a120-1867e83738a9)

5. Additionally, press the `Shift` key and select multiple items. It should work well.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
