### PR TITLE
Remove redundant deps on e2e in wc-admin

### DIFF
--- a/plugins/woocommerce-admin/babel.config.js
+++ b/plugins/woocommerce-admin/babel.config.js
@@ -1,14 +1,16 @@
-const {
-	babelConfig: e2eBabelConfig,
-} = require( '@woocommerce/e2e-environment' );
-
 module.exports = function ( api ) {
 	api.cache( true );
 
 	return {
-		...e2eBabelConfig,
 		presets: [
-			...e2eBabelConfig.presets,
+			[
+				'@babel/preset-env',
+				{
+					targets: {
+						node: 'current',
+					},
+				},
+			],
 			'@babel/preset-typescript',
 			'@wordpress/babel-preset-default',
 		],

--- a/plugins/woocommerce-admin/package.json
+++ b/plugins/woocommerce-admin/package.json
@@ -55,8 +55,6 @@
 		"@react-spring/web": "^9.4.3",
 		"@types/wordpress__blocks": "^11.0.7",
 		"@woocommerce/api": "^0.2.0",
-		"@woocommerce/e2e-environment": "^0.3.0",
-		"@woocommerce/e2e-utils": "^0.2.0",
 		"@wordpress/a11y": "wp-6.0",
 		"@wordpress/api-fetch": "wp-6.0",
 		"@wordpress/base-styles": "wp-6.0",

--- a/plugins/woocommerce/changelog/dev-remove-e2e-dep-in-wc-admin
+++ b/plugins/woocommerce/changelog/dev-remove-e2e-dep-in-wc-admin
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Remove dependency on e2e-environment and e2e-utils in wc-admin.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2711,12 +2711,6 @@ importers:
       '@woocommerce/api':
         specifier: ^0.2.0
         version: 0.2.0
-      '@woocommerce/e2e-environment':
-        specifier: ^0.3.0
-        version: link:../../packages/js/e2e-environment
-      '@woocommerce/e2e-utils':
-        specifier: ^0.2.0
-        version: link:../../packages/js/e2e-utils
       '@wordpress/a11y':
         specifier: wp-6.0
         version: 3.6.1
@@ -22044,10 +22038,10 @@ packages:
     peerDependencies:
       eslint: '>= 4.12.1'
     dependencies:
-      '@babel/code-frame': 7.18.6
-      '@babel/parser': 7.21.3
-      '@babel/traverse': 7.21.3
-      '@babel/types': 7.22.4
+      '@babel/code-frame': 7.16.7
+      '@babel/parser': 7.17.8
+      '@babel/traverse': 7.17.3
+      '@babel/types': 7.17.0
       eslint: 7.32.0
       eslint-visitor-keys: 1.3.0
       resolve: 1.20.0
@@ -41566,7 +41560,7 @@ packages:
       sass: 1.60.0
       schema-utils: 3.1.1
       semver: 7.5.0
-      webpack: 5.76.3(webpack-cli@4.9.2)
+      webpack: 5.76.3(webpack-cli@3.3.12)
     dev: true
 
   /sass-loader@12.6.0(sass@1.60.0)(webpack@5.76.3):


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When trying to run some tasks in the monorepo currently without a build, (such as linting) I ran into a blocker because wc-admin depends on e2e packages and sadly some of those packages must be built to function properly.

This turns out not to be a blocker though because there is no reason to depend on these packages in wc-admin. e2e-utils was not used and e2e-environment is not needed, we can just declare our own babel config in wc-admin (I've copy pasted the one preset that we were getting from e2e-environment). Frankly it makes little sense wc-admin to get it's babel config from an e2e testing package.

With these deps gone we should be able to lint the codebase without a build which will save minutes on every CI check we run.

### How to test the changes in this Pull Request:

1. See CI passes
2. Smoke test WooCommerce, on this branch ensure `pnpm install` has been run, then `pnpm build` 
3. build should succeed
4. Smoke test WooCommerce loads JS pages in your local environment.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message 
Remove dependency on e2e-environment and e2e-utils in wc-admin.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
