### PR TITLE
Add shard to the matrix name in PHP unit tests for clarity in GH UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions: {}
 
 jobs:
     test:
-        name: PHP ${{ matrix.php }} WP ${{ matrix.wp }}
+        name: PHP ${{ matrix.php }} WP ${{ matrix.wp }} - ${{ matrix.unittests }}
         timeout-minutes: 30
         runs-on: ubuntu-20.04
         permissions:

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -15,7 +15,7 @@ permissions: {}
 jobs:
     test:
         if: ${{ github.event.pull_request.user.login != 'github-actions[bot]' }}
-        name: PHP ${{ matrix.php }} WP ${{ matrix.wp }} ${{ matrix.hpos && 'HPOS' || '' }}
+        name: PHP ${{ matrix.php }} WP ${{ matrix.wp }} ${{ matrix.hpos && 'HPOS' || '' }} - ${{ matrix.unittests }}
         timeout-minutes: 30
         runs-on: ubuntu-20.04
         permissions:

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -15,7 +15,7 @@ permissions: {}
 jobs:
     test:
         if: ${{ github.event.pull_request.user.login != 'github-actions[bot]' }}
-        name: PHP ${{ matrix.php }} WP ${{ matrix.wp }} ${{ matrix.hpos && 'HPOS' || '' }} - ${{ matrix.unittests }}
+        name: PHP ${{ matrix.php }} WP ${{ matrix.wp }} - ${{ matrix.unittests }} ${{ matrix.hpos && 'HPOS' || '' }}
         timeout-minutes: 30
         runs-on: ubuntu-20.04
         permissions:


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When running unit tests in CI, the lack of shard number on the matrix run causes confusion and it appears like there are duplicate checks running. Adding the shard to the name of the matrix run should help remove that confusion.

Note: **we'll need to adjust required checks as part of this name change.**

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. See that matrix test runs show a shard name in the GH CI actions UI

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
