### PR TITLE
Hide empty addons menu item, fix marketplace feature toggle

### DIFF
--- a/plugins/woocommerce/client/legacy/js/admin/wc-admin-menu.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-admin-menu.js
@@ -1,0 +1,20 @@
+document.addEventListener( 'DOMContentLoaded', () => {
+
+	const adminMenu = document.getElementById( 'adminmenu' );
+	if ( ! adminMenu ) {
+		return;
+	}
+
+	const addonsSubMenuLinks = adminMenu.querySelectorAll(
+		'#toplevel_page_woocommerce' +
+		' .wp-submenu' +
+		' li a[href="admin.php?page=wc-addons"]'
+	);
+
+	addonsSubMenuLinks.forEach( ( el, index ) => {
+		if ( ! el.innerHTML ) {
+			el.parentNode.remove();
+		}
+	} );
+
+} );

--- a/plugins/woocommerce/client/legacy/js/admin/wc-admin-menu.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-admin-menu.js
@@ -1,12 +1,8 @@
 document.addEventListener( 'DOMContentLoaded', () => {
 
-	const adminMenu = document.getElementById( 'adminmenu' );
-	if ( ! adminMenu ) {
-		return;
-	}
-
-	const addonsSubMenuLinks = adminMenu.querySelectorAll(
-		'#toplevel_page_woocommerce' +
+	const addonsSubMenuLinks = document.querySelectorAll(
+		'#adminmenu' +
+		' #toplevel_page_woocommerce' +
 		' .wp-submenu' +
 		' li a[href="admin.php?page=wc-addons"]'
 	);

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -8,6 +8,7 @@
 
 use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Admin\Features\Features;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 use Automattic\WooCommerce\Internal\Admin\WCAdminAssets;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -548,6 +549,11 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					)
 				);
 				wp_enqueue_script( 'marketplace-suggestions' );
+			}
+
+			// Temporarily hide empty addons submenu item
+			if ( FeaturesUtil::feature_is_enabled( 'marketplace' ) ) {
+				wp_enqueue_script( 'wc-admin-menu', WC()->plugin_url() . '/assets/js/admin/wc-admin-menu' . $suffix . '.js', null, $version );
 			}
 
 		}

--- a/plugins/woocommerce/src/Internal/Admin/Marketplace.php
+++ b/plugins/woocommerce/src/Internal/Admin/Marketplace.php
@@ -5,7 +5,7 @@
 
 namespace Automattic\WooCommerce\Internal\Admin;
 
-use Automattic\WooCommerce\Internal\Features\FeaturesController;
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 /**
  * Contains backend logic for the Marketplace feature.
@@ -16,7 +16,9 @@ class Marketplace {
 	 * Class initialization, to be executed when the class is resolved by the container.
 	 */
 	final public function init() {
-		add_action( 'admin_menu', array( $this, 'register_pages' ), 70 );
+		if ( FeaturesUtil::feature_is_enabled( 'marketplace' ) ) {
+			add_action( 'admin_menu', array( $this, 'register_pages' ), 70 );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -149,6 +149,7 @@ class FeaturesController {
 			'analytics',
 			'new_navigation',
 			'product_block_editor',
+			'marketplace',
 			// Compatibility for COT is determined by `custom_order_tables'.
 			CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION,
 			DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes 17518-gh-Automattic/woocommerce.com.

* In https://github.com/woocommerce/woocommerce/pull/39569, we added a submenu item without a title in the WooCommerce menu for the My Subscriptions page. We don't want to show this item in the submenu, as the page is reached from the Extensions page. This PR adds some JS to remove the item till the next phase of this project, when we will rebuild My Subscriptions in React.
* While testing this change, I noticed that we were adding an extra `Extensions` submenu item to the WooCommerce menu when the `marketplace` feature was disabled. I've added a condition to `Automattic\WooCommerce\Internal\Admin\Marketplace` to ensure we only add it when the feature is enabled.
* I also discovered it was impossible to enable the feature in the WooCommerce features UI, once disabled. The feature needed to be added to the `legacy_feature_ids` array in `FeaturesController` to make the feature properly togglable. We also need this change to silence a scary warning which can appear in the plugins list. (See p7bje6-57O and https://github.com/woocommerce/woocommerce/issues/39147.)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check out the branch.
2. From the `plugins/woocommerce` folder, run `pnpm build --filter=woocommerce`.
3. If you get a fatal error, run `composer dump-autoload` to refresh the composer autoload file.
4. View wp-admin (on wp-env, it's http://localhost:10003/wp-admin).
5. Mouseover the WooCommerce menu. Note that the submenu items look as expected.
6. Go to the Extensions page of WooCommerce (http://localhost:10003/wp-admin/admin.php?page=wc-admin&path=%2Fextensions). Note there is no dodgy empty submenu item after the `Extensions` item in the WooCommerce menu.
7. Click on the `My Subscriptions` tab in the page and check you can see the My Subscriptions page.
8. Click on the `Browse Extensions` tab and check you go back to the Extensions page.
9. Disable the Marketplace feature in `WooCommerce > Settings > Advanced > Features` (http://localhost:10003/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features).
10. Check that the old version of the in-app marketplace looks normal, and the `Extensions` submenu item appears, and you can view the My Subscriptions tab from the Extensions page.

<!-- End testing instructions -->

### Screenshots

<p>
<img width="168" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1647564/0c4276d5-9fc0-4b77-9fe1-bba0fa06f0a7">
</p>

<p>
<img width="610" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1647564/cafd3397-7277-459c-a299-f59ce799b57f">
</p>

<p>
<img width="165" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1647564/ee54cb26-3d16-43fb-9a54-8b810b255037">
</p>

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>