### PR TITLE
Checkout: show "thank you" message regardless of verification status

### DIFF
--- a/plugins/woocommerce/changelog/try-order-thankyou-reorg-2
+++ b/plugins/woocommerce/changelog/try-order-thankyou-reorg-2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+On the order confirmation screen, show the 'thank you' message regardless of whether the viewer is verified or not.

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -301,6 +301,7 @@ class WC_Shortcode_Checkout {
 
 		// For non-guest orders, require the user to be logged in before showing this page.
 		if ( $order_customer_id && get_current_user_id() !== $order_customer_id ) {
+			wc_get_template( 'checkout/order-received.php', array( 'order' => false ) );
 			wc_print_notice( esc_html__( 'Please log in to your account to view this order.', 'woocommerce' ), 'notice' );
 			woocommerce_login_form( array( 'redirect' => $order->get_checkout_order_received_url() ) );
 			return;
@@ -308,6 +309,7 @@ class WC_Shortcode_Checkout {
 
 		// For guest orders, request they verify their email address (unless we can identify them via the active user session).
 		if ( self::guest_should_verify_email( $order, 'order-received' ) ) {
+			wc_get_template( 'checkout/order-received.php', array( 'order' => false ) );
 			wc_get_template(
 				'checkout/form-verify-email.php',
 				array(

--- a/plugins/woocommerce/templates/checkout/order-received.php
+++ b/plugins/woocommerce/templates/checkout/order-received.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * "Order received" message.
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/checkout/thankyou.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce\Templates
+ * @version 8.1.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/** @var WC_Order|false $order */
+?>
+
+<p class="woocommerce-notice woocommerce-notice--success woocommerce-thankyou-order-received">
+	<?php
+	/**
+	 * Filter the message shown after a checkout is complete.
+	 *
+	 * @param string         $message The message.
+	 * @param WC_Order|false $order   The order created during checkout, or false if order data is not available.
+	 */
+	$message = apply_filters(
+		'woocommerce_thankyou_order_received_text',
+		__( 'Thank you. Your order has been received.', 'woocommerce' ),
+		$order
+	);
+
+	echo esc_html( $message );
+	?>
+</p>

--- a/plugins/woocommerce/templates/checkout/order-received.php
+++ b/plugins/woocommerce/templates/checkout/order-received.php
@@ -13,17 +13,19 @@
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
  * @version 8.1.0
+ *
+ * @var WC_Order|false $order
  */
 
 defined( 'ABSPATH' ) || exit;
-
-/** @var WC_Order|false $order */
 ?>
 
 <p class="woocommerce-notice woocommerce-notice--success woocommerce-thankyou-order-received">
 	<?php
 	/**
 	 * Filter the message shown after a checkout is complete.
+	 *
+	 * @since 2.2.0
 	 *
 	 * @param string         $message The message.
 	 * @param WC_Order|false $order   The order created during checkout, or false if order data is not available.

--- a/plugins/woocommerce/templates/checkout/thankyou.php
+++ b/plugins/woocommerce/templates/checkout/thankyou.php
@@ -13,11 +13,11 @@
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
  * @version 8.1.0
+ *
+ * @var WC_Order $order
  */
 
 defined( 'ABSPATH' ) || exit;
-
-/** @var WC_Order $order */
 ?>
 
 <div class="woocommerce-order">

--- a/plugins/woocommerce/templates/checkout/thankyou.php
+++ b/plugins/woocommerce/templates/checkout/thankyou.php
@@ -12,10 +12,12 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 3.7.0
+ * @version 8.1.0
  */
 
 defined( 'ABSPATH' ) || exit;
+
+/** @var WC_Order $order */
 ?>
 
 <div class="woocommerce-order">
@@ -39,7 +41,7 @@ defined( 'ABSPATH' ) || exit;
 
 		<?php else : ?>
 
-			<p class="woocommerce-notice woocommerce-notice--success woocommerce-thankyou-order-received"><?php echo apply_filters( 'woocommerce_thankyou_order_received_text', esc_html__( 'Thank you. Your order has been received.', 'woocommerce' ), $order ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></p>
+			<?php wc_get_template( 'checkout/order-received.php', array( 'order' => $order ) ); ?>
 
 			<ul class="woocommerce-order-overview woocommerce-thankyou-order-details order_details">
 
@@ -81,7 +83,7 @@ defined( 'ABSPATH' ) || exit;
 
 	<?php else : ?>
 
-		<p class="woocommerce-notice woocommerce-notice--success woocommerce-thankyou-order-received"><?php echo apply_filters( 'woocommerce_thankyou_order_received_text', esc_html__( 'Thank you. Your order has been received.', 'woocommerce' ), null ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></p>
+		<?php wc_get_template( 'checkout/order-received.php', array( 'order' => false ) ); ?>
 
 	<?php endif; ?>
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

As an alternative to #39406, this tries to solve the same issue in a simpler way: break the "thank you" message out into its own small template file and just include it in more places, so that no matter the context, the order confirmation screen will always say thank you, acknowledging that the order data has been received.

 ⚠️ Note that if this is approved and merged, #39406 should be closed without merging.

### How to test the changes in this Pull Request:

As with #39406, the testing instructions in #39191 apply to this PR as well. The only change should be that the "Thank you. Your order has been received." message should be shown even when viewed as an unverified customer.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

On the order confirmation screen, show the 'thank you' message regardless of whether the viewer is verified or not.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
