### PR TITLE
Speed up the lint and test task by doing pnpm install instead of full setup

### DIFF
--- a/.github/workflows/pr-lint-js.yml
+++ b/.github/workflows/pr-lint-js.yml
@@ -22,8 +22,10 @@ jobs:
         steps:
             - uses: actions/checkout@v3
 
-            - name: Setup WooCommerce Monorepo
-              uses: ./.github/actions/setup-woocommerce-monorepo
+            - name: Install prerequisites
+              run: |
+                  # ignore scripts is faster, and postinstall should not be needed for lint.
+                  pnpm install --ignore-scripts
 
             - name: Lint
               run: pnpm run -r --filter='release-posts' --filter='woocommerce/client/admin...' --filter='@woocommerce/monorepo-utils' --filter='!@woocommerce/e2e*' --filter='!@woocommerce/api' --color lint

--- a/.github/workflows/pr-lint-js.yml
+++ b/.github/workflows/pr-lint-js.yml
@@ -22,6 +22,18 @@ jobs:
         steps:
             - uses: actions/checkout@v3
 
+            - name: Setup PNPM
+              uses: pnpm/action-setup@c3b53f6a16e57305370b4ae5a540c2077a1d50dd
+              with:
+                  version: '8.6.7'
+
+            - name: Setup Node
+              uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
+              with:
+                  node-version-file: .nvmrc
+                  cache: pnpm
+                  registry-url: 'https://registry.npmjs.org'
+
             - name: Install prerequisites
               run: |
                   # ignore scripts is faster, and postinstall should not be needed for lint.

--- a/.github/workflows/pr-test-js.yml
+++ b/.github/workflows/pr-test-js.yml
@@ -19,8 +19,22 @@ jobs:
         steps:
             - uses: actions/checkout@v3
 
-            - name: Setup WooCommerce Monorepo
-              uses: ./.github/actions/setup-woocommerce-monorepo
+            - name: Setup PNPM
+              uses: pnpm/action-setup@c3b53f6a16e57305370b4ae5a540c2077a1d50dd
+              with:
+                  version: '8.6.7'
+
+            - name: Setup Node
+              uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
+              with:
+                  node-version-file: .nvmrc
+                  cache: pnpm
+                  registry-url: 'https://registry.npmjs.org'
+
+            - name: Install prerequisites
+              run: |
+                  # ignore scripts is faster, and postinstall should not be needed for test.
+                  pnpm install --ignore-scripts
 
             - name: Test
               run: pnpm run test --filter='woocommerce/client/admin...' --filter='@woocommerce/monorepo-utils' --filter='!@woocommerce/e2e*' --filter='@woocommerce/monorepo-utils' --filter='!@woocommerce/api' --color

--- a/.github/workflows/pr-test-js.yml
+++ b/.github/workflows/pr-test-js.yml
@@ -1,4 +1,4 @@
-name: Lint and tests for JS packages and woocommerce-admin/client
+name: Run tests for JS packages and woocommerce-admin/client
 
 on:
     pull_request:
@@ -11,7 +11,7 @@ concurrency:
 permissions: {}
 
 jobs:
-    lint-test-js:
+    test-js:
         name: Run JS Tests
         runs-on: ubuntu-20.04
         permissions:
@@ -33,7 +33,7 @@ jobs:
 
             - name: Install prerequisites
               run: |
-                  # ignore scripts is faster, and postinstall should not be needed for test.
+                  # ignore scripts is faster, and postinstall should not be needed for tests.
                   pnpm install --ignore-scripts
 
             - name: Test


### PR DESCRIPTION
### Changes proposed in this Pull Request:

1. Remove monorepo setup from lint:

In a recent PR #39746 we removed redundant dependencies from woocommerce-admin, which were blocking running lint without a build because it caused an error with an e2e package that needs to be built to reference an import.

2. Remove monorepo setup from test:

Because test already depends on turbo:build this meant we were building twice for this task, once when we run monorepo setup and once in the test task. Now it just builds when tests are run. In future we might be able to provide a slimmed down build that just builds the `packages/js`, because I think we just need the build for TS types in most cases.

3. Fix up the title of the test workflow which I missed fixing up in #39704 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. You can just compare CI runs of lint and test workflows in this PR to other PRs, you'll see that losing the `Setup WooCommerce Monorepo` step shaves approx 5-7 minutes off the runs of these tasks

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
