### PR TITLE
In-App Marketplace: Improve Product Card Clickability

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/product-card/product-card.scss
+++ b/plugins/woocommerce-admin/client/marketplace/components/product-card/product-card.scss
@@ -61,7 +61,9 @@
 		}
 
 		&__link {
-			&, &:hover, &:active {
+			&,
+			&:hover,
+			&:active {
 				color: $gray-900;
 				text-decoration: none;
 			}
@@ -69,7 +71,7 @@
 			/* Use the ::after trick to make the whole card clickable: */
 			&::after {
 				bottom: 0;
-				content: "";
+				content: '';
 				left: 0;
 				position: absolute;
 				right: 0;

--- a/plugins/woocommerce-admin/client/marketplace/components/product-card/product-card.scss
+++ b/plugins/woocommerce-admin/client/marketplace/components/product-card/product-card.scss
@@ -6,6 +6,10 @@
 		border-radius: $grid-unit-05 !important;
 		margin-top: $large-gap;
 
+		&:hover {
+			outline: 1.5px solid var(--wc-blue);
+		}
+
 		&__content {
 			display: grid;
 			align-items: flex-start;
@@ -56,11 +60,30 @@
 			text-overflow: ellipsis;
 		}
 
+		&__link {
+			&, &:hover, &:active {
+				color: $gray-900;
+				text-decoration: none;
+			}
+
+			/* Use the ::after trick to make the whole card clickable: */
+			&::after {
+				bottom: 0;
+				content: "";
+				left: 0;
+				position: absolute;
+				right: 0;
+				top: 0;
+			}
+		}
+
 		&__vendor {
 			display: flex;
 			gap: $grid-unit-05;
 			margin: 0;
 			padding: 0;
+			/* Allow vendor link to "punch through" the "whole card clickable" trick: */
+			position: relative;
 		}
 
 		&__vendor a {

--- a/plugins/woocommerce-admin/client/marketplace/components/product-card/product-card.scss
+++ b/plugins/woocommerce-admin/client/marketplace/components/product-card/product-card.scss
@@ -7,7 +7,7 @@
 		margin-top: $large-gap;
 
 		&:hover {
-			outline: 1.5px solid var(--wc-blue);
+			outline: 1.5px solid var(--wp-admin-theme-color);
 		}
 
 		&__content {

--- a/plugins/woocommerce-admin/client/marketplace/components/product-card/product-card.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/product-card/product-card.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button, Card } from '@wordpress/components';
+import { Card } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -55,7 +55,12 @@ function ProductCard( props: ProductCardProps ): JSX.Element {
 						) }
 						<div className="woocommerce-marketplace__product-card__meta">
 							<h2 className="woocommerce-marketplace__product-card__title">
-								<a className="woocommerce-marketplace__product-card__link" href={ product.url } target="_blank" rel="noopener noreferrer">
+								<a
+									className="woocommerce-marketplace__product-card__link"
+									href={ product.url }
+									target="_blank"
+									rel="noopener noreferrer"
+								>
 									{ product.title }
 								</a>
 							</h2>

--- a/plugins/woocommerce-admin/client/marketplace/components/product-card/product-card.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/product-card/product-card.tsx
@@ -55,7 +55,9 @@ function ProductCard( props: ProductCardProps ): JSX.Element {
 						) }
 						<div className="woocommerce-marketplace__product-card__meta">
 							<h2 className="woocommerce-marketplace__product-card__title">
-								{ product.title }
+								<a className="woocommerce-marketplace__product-card__link" href={ product.url } target="_blank" rel="noopener noreferrer">
+									{ product.title }
+								</a>
 							</h2>
 							{ productVendor && (
 								<p className="woocommerce-marketplace__product-card__vendor">
@@ -69,12 +71,7 @@ function ProductCard( props: ProductCardProps ): JSX.Element {
 				<p className="woocommerce-marketplace__product-card__description">
 					{ product.description }
 				</p>
-				<Button
-					className="woocommerce-marketplace__product-card__price"
-					href={ product.url }
-					target="_blank"
-					variant="link"
-				>
+				<div className="woocommerce-marketplace__product-card__price">
 					<span>
 						{ product.price === 0 || product.price === '0'
 							? __( 'Free download', 'woocommerce' )
@@ -85,7 +82,7 @@ function ProductCard( props: ProductCardProps ): JSX.Element {
 							? ''
 							: __( ' annually', 'woocommerce' ) }
 					</span>
-				</Button>
+				</div>
 			</div>
 		</Card>
 	);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes [WCCOM#17831 "Ensure Product Card product titles are clickable"](https://github.com/Automattic/woocommerce.com/issues/17831) and [WCCOM#17792 "Make whole card clickable"](https://github.com/Automattic/woocommerce.com/issues/17792).

Design refinements to the In-App Marketplace indicate that:
- The entire product card, including but not limited to its title, should be clickable
  - However, clicking the vendor link on the product card should continue to point to the vendor's profile page
- Hovering over the product card should give appropriate feedback

This PR aims to achieve this.

### How to test the changes in this Pull Request:

1. Build WooCommerce Admin on your local environment e.g.: cd plugins/woocommerce-admin then nvm use && pnpm start.
2. Visit [WooCommerce > Marketplace > Extensions](http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fextensions&tab=extensions)
3. Test links to products and vendors, including their hover effect
4. See no `"can't embed <a> in <a>"` errors in your debug console

In the video below, watch the status bar in the bottom right to see that the link destination differs between the card and vendor link. Note that the double-encoded price issue is believed to be separate (something to do with [this WCCOM PR](https://github.com/Automattic/woocommerce.com/pull/17850), I presume). @poligilad-auto does this meet your expectations?

https://github.com/woocommerce/woocommerce/assets/53293/c58fc24d-a68e-48a5-93c0-fe7afaefebfe

