### PR TITLE
Variation attributes can not be enabled in Attributes section and Non Variations attributes cannot be enabled in Variation Options section

### DIFF
--- a/packages/js/components/changelog/add-39499
+++ b/packages/js/components/changelog/add-39499
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add Tooltip to each list item when need it

--- a/packages/js/components/src/experimental-select-control/menu-item.tsx
+++ b/packages/js/components/src/experimental-select-control/menu-item.tsx
@@ -28,26 +28,25 @@ export const MenuItem = < ItemType, >( {
 	item,
 	tooltipText,
 }: MenuItemProps< ItemType > ) => {
+	function renderListItem() {
+		return (
+			<li
+				style={ isActive ? activeStyle : {} }
+				{ ...getItemProps( { item, index } ) }
+				className="woocommerce-experimental-select-control__menu-item"
+			>
+				{ children }
+			</li>
+		);
+	}
+
 	if ( tooltipText ) {
 		return (
 			<Tooltip text={ tooltipText } position="top center">
-				<li
-					style={ isActive ? activeStyle : {} }
-					{ ...getItemProps( { item, index } ) }
-					className="woocommerce-experimental-select-control__menu-item"
-				>
-					{ children }
-				</li>
+				{ renderListItem() }
 			</Tooltip>
 		);
 	}
-	return (
-		<li
-			style={ isActive ? activeStyle : {} }
-			{ ...getItemProps( { item, index } ) }
-			className="woocommerce-experimental-select-control__menu-item"
-		>
-			{ children }
-		</li>
-	);
+
+	return renderListItem();
 };

--- a/packages/js/components/src/experimental-select-control/menu-item.tsx
+++ b/packages/js/components/src/experimental-select-control/menu-item.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { Tooltip } from '@wordpress/components';
 import { createElement, CSSProperties, ReactElement } from 'react';
 
 /**
@@ -15,6 +16,7 @@ export type MenuItemProps< ItemType > = {
 	children: ReactElement | string;
 	getItemProps: getItemPropsType< ItemType >;
 	activeStyle?: CSSProperties;
+	tooltipText?: string;
 };
 
 export const MenuItem = < ItemType, >( {
@@ -24,7 +26,21 @@ export const MenuItem = < ItemType, >( {
 	isActive,
 	activeStyle = { backgroundColor: '#bde4ff' },
 	item,
+	tooltipText,
 }: MenuItemProps< ItemType > ) => {
+	if ( tooltipText ) {
+		return (
+			<Tooltip text={ tooltipText } position="top center">
+				<li
+					style={ isActive ? activeStyle : {} }
+					{ ...getItemProps( { item, index } ) }
+					className="woocommerce-experimental-select-control__menu-item"
+				>
+					{ children }
+				</li>
+			</Tooltip>
+		);
+	}
 	return (
 		<li
 			style={ isActive ? activeStyle : {} }

--- a/packages/js/product-editor/changelog/add-39499
+++ b/packages/js/product-editor/changelog/add-39499
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Disable attributes used in different sections

--- a/packages/js/product-editor/src/blocks/variation-options/edit.tsx
+++ b/packages/js/product-editor/src/blocks/variation-options/edit.tsx
@@ -170,8 +170,8 @@ export function Edit() {
 						'Remove variation option',
 						'woocommerce'
 					),
-					attributeRemoveConfirmationMessage: __(
-						'Remove this variation option?',
+					attributeRemoveConfirmationModalMessage: __(
+						'If you continue, some variations of this product will be deleted and customers will no longer be able to purchase them.',
 						'woocommerce'
 					),
 				} }

--- a/packages/js/product-editor/src/blocks/variation-options/edit.tsx
+++ b/packages/js/product-editor/src/blocks/variation-options/edit.tsx
@@ -139,6 +139,9 @@ export function Edit() {
 						product_block_variable_options_notice_dismissed: 'yes',
 					} )
 				}
+				disabledAttributeIds={ entityAttributes
+					.filter( ( attr ) => ! attr.variation )
+					.map( ( attr ) => attr.id ) }
 				uiStrings={ {
 					notice,
 					globalAttributeHelperMessage: '',
@@ -167,8 +170,8 @@ export function Edit() {
 						'Remove variation option',
 						'woocommerce'
 					),
-					attributeRemoveConfirmationModalMessage: __(
-						'If you continue, some variations of this product will be deleted and customers will no longer be able to purchase them.',
+					attributeRemoveConfirmationMessage: __(
+						'Remove this variation option?',
 						'woocommerce'
 					),
 				} }

--- a/packages/js/product-editor/src/blocks/variations/edit.tsx
+++ b/packages/js/product-editor/src/blocks/variations/edit.tsx
@@ -158,6 +158,9 @@ export function Edit( {
 					selectedAttributeIds={ variationOptions.map(
 						( attr ) => attr.id
 					) }
+					disabledAttributeIds={ productAttributes
+						.filter( ( attr ) => ! attr.variation )
+						.map( ( attr ) => attr.id ) }
 				/>
 			) }
 		</div>

--- a/packages/js/product-editor/src/components/attribute-control/attribute-control.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/attribute-control.tsx
@@ -7,8 +7,6 @@ import {
 	createElement,
 	Fragment,
 	createInterpolateElement,
-	useMemo,
-	useEffect,
 } from '@wordpress/element';
 import { Button, Notice } from '@wordpress/components';
 import { ProductAttribute } from '@woocommerce/data';
@@ -50,6 +48,7 @@ type AttributeControlProps = {
 	onNoticeDismiss?: () => void;
 	createNewAttributesAsGlobal?: boolean;
 	useRemoveConfirmationModal?: boolean;
+	disabledAttributeIds?: number[];
 	uiStrings?: {
 		notice?: string | React.ReactElement;
 		emptyStateSubtitle?: string;
@@ -61,7 +60,8 @@ type AttributeControlProps = {
 		attributeRemoveLabel?: string;
 		attributeRemoveConfirmationMessage?: string;
 		attributeRemoveConfirmationModalMessage?: string;
-		globalAttributeHelperMessage: string;
+		globalAttributeHelperMessage?: string;
+		disabledAttributeMessage?: string;
 	};
 };
 
@@ -82,6 +82,7 @@ export const AttributeControl: React.FC< AttributeControlProps > = ( {
 	uiStrings,
 	createNewAttributesAsGlobal = false,
 	useRemoveConfirmationModal = false,
+	disabledAttributeIds = [],
 } ) => {
 	uiStrings = {
 		newAttributeListItemLabel: __( 'Add new', 'woocommerce' ),
@@ -213,21 +214,6 @@ export const AttributeControl: React.FC< AttributeControlProps > = ( {
 		( attr ) => getAttributeId( attr ) === currentAttributeId
 	);
 
-	const disabledAttributeIds = useMemo(
-		() =>
-			value
-				.filter( ( attr ) => ! attr.variation )
-				.map( ( attr ) => attr.id ),
-		[ value, isNewModalVisible ]
-	);
-
-	useEffect( () => {
-		console.log( 'AttributeControl', {
-			value,
-			disabledAttributeIds,
-		} );
-	}, [ disabledAttributeIds, isNewModalVisible ] );
-
 	return (
 		<div className="woocommerce-attribute-field">
 			<Button
@@ -297,6 +283,9 @@ export const AttributeControl: React.FC< AttributeControlProps > = ( {
 					selectedAttributeIds={ value.map( ( attr ) => attr.id ) }
 					createNewAttributesAsGlobal={ createNewAttributesAsGlobal }
 					disabledAttributeIds={ disabledAttributeIds }
+					disabledAttributeMessage={
+						uiStrings.disabledAttributeMessage
+					}
 				/>
 			) }
 			<SelectControlMenuSlot />
@@ -310,22 +299,26 @@ export const AttributeControl: React.FC< AttributeControlProps > = ( {
 					customAttributeHelperMessage={
 						uiStrings.customAttributeHelperMessage
 					}
-					globalAttributeHelperMessage={ createInterpolateElement(
-						uiStrings.globalAttributeHelperMessage,
-						{
-							link: (
-								<Link
-									href={ getAdminLink(
-										'edit.php?post_type=product&page=product_attributes'
-									) }
-									target="_blank"
-									type="wp-admin"
-								>
-									<></>
-								</Link>
-							),
-						}
-					) }
+					globalAttributeHelperMessage={
+						uiStrings.globalAttributeHelperMessage
+							? createInterpolateElement(
+									uiStrings.globalAttributeHelperMessage,
+									{
+										link: (
+											<Link
+												href={ getAdminLink(
+													'edit.php?post_type=product&page=product_attributes'
+												) }
+												target="_blank"
+												type="wp-admin"
+											>
+												<></>
+											</Link>
+										),
+									}
+							  )
+							: undefined
+					}
 					onCancel={ () => {
 						closeEditModal( currentAttribute );
 						onEditModalCancel( currentAttribute );

--- a/packages/js/product-editor/src/components/attribute-control/attribute-control.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/attribute-control.tsx
@@ -7,6 +7,8 @@ import {
 	createElement,
 	Fragment,
 	createInterpolateElement,
+	useMemo,
+	useEffect,
 } from '@wordpress/element';
 import { Button, Notice } from '@wordpress/components';
 import { ProductAttribute } from '@woocommerce/data';
@@ -211,6 +213,21 @@ export const AttributeControl: React.FC< AttributeControlProps > = ( {
 		( attr ) => getAttributeId( attr ) === currentAttributeId
 	);
 
+	const disabledAttributeIds = useMemo(
+		() =>
+			value
+				.filter( ( attr ) => ! attr.variation )
+				.map( ( attr ) => attr.id ),
+		[ value, isNewModalVisible ]
+	);
+
+	useEffect( () => {
+		console.log( 'AttributeControl', {
+			value,
+			disabledAttributeIds,
+		} );
+	}, [ disabledAttributeIds, isNewModalVisible ] );
+
 	return (
 		<div className="woocommerce-attribute-field">
 			<Button
@@ -279,6 +296,7 @@ export const AttributeControl: React.FC< AttributeControlProps > = ( {
 					onAdd={ handleAdd }
 					selectedAttributeIds={ value.map( ( attr ) => attr.id ) }
 					createNewAttributesAsGlobal={ createNewAttributesAsGlobal }
+					disabledAttributeIds={ disabledAttributeIds }
 				/>
 			) }
 			<SelectControlMenuSlot />

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
@@ -92,7 +92,7 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 	createNewAttributesAsGlobal = false,
 	disabledAttributeIds = [],
 	disabledAttributeMessage = __(
-		'(Already used in Attributes)',
+		'Already used in Attributes',
 		'woocommerce'
 	),
 } ) => {

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
@@ -56,6 +56,7 @@ type NewAttributeModalProps = {
 	selectedAttributeIds?: number[];
 	createNewAttributesAsGlobal?: boolean;
 	disabledAttributeIds?: number[];
+	disabledAttributeMessage?: string;
 };
 
 type AttributeForm = {
@@ -90,6 +91,10 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 	selectedAttributeIds = [],
 	createNewAttributesAsGlobal = false,
 	disabledAttributeIds = [],
+	disabledAttributeMessage = __(
+		'(Already used in Attributes)',
+		'woocommerce'
+	),
 } ) => {
 	const scrollAttributeIntoView = ( index: number ) => {
 		setTimeout( () => {
@@ -321,6 +326,9 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 															}
 															disabledAttributeIds={
 																disabledAttributeIds
+															}
+															disabledAttributeMessage={
+																disabledAttributeMessage
 															}
 														/>
 													</td>

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
@@ -55,6 +55,7 @@ type NewAttributeModalProps = {
 	onAdd: ( newCategories: EnhancedProductAttribute[] ) => void;
 	selectedAttributeIds?: number[];
 	createNewAttributesAsGlobal?: boolean;
+	disabledAttributeIds?: number[];
 };
 
 type AttributeForm = {
@@ -88,6 +89,7 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 	onAdd,
 	selectedAttributeIds = [],
 	createNewAttributesAsGlobal = false,
+	disabledAttributeIds = [],
 } ) => {
 	const scrollAttributeIntoView = ( index: number ) => {
 		setTimeout( () => {
@@ -316,6 +318,9 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 															] }
 															createNewAttributesAsGlobal={
 																createNewAttributesAsGlobal
+															}
+															disabledAttributeIds={
+																disabledAttributeIds
 															}
 														/>
 													</td>

--- a/packages/js/product-editor/src/components/attribute-input-field/attribute-input-field.scss
+++ b/packages/js/product-editor/src/components/attribute-input-field/attribute-input-field.scss
@@ -8,3 +8,10 @@
 		margin-right: $gap-small;
 	}
 }
+
+.woocommerce-experimental-select-control__popover-menu-container {
+	.woocommerce-experimental-select-control__menu-item[disabled] {
+		pointer-events: none;
+		opacity: 0.6;
+	}
+}

--- a/packages/js/product-editor/src/components/attribute-input-field/attribute-input-field.scss
+++ b/packages/js/product-editor/src/components/attribute-input-field/attribute-input-field.scss
@@ -14,4 +14,7 @@
 		pointer-events: none;
 		color: $gray-600;
 	}
+	.disabled-element-wrapper {
+		cursor: not-allowed;
+	}
 }

--- a/packages/js/product-editor/src/components/attribute-input-field/attribute-input-field.scss
+++ b/packages/js/product-editor/src/components/attribute-input-field/attribute-input-field.scss
@@ -12,6 +12,6 @@
 .woocommerce-experimental-select-control__popover-menu-container {
 	.woocommerce-experimental-select-control__menu-item[disabled] {
 		pointer-events: none;
-		opacity: 0.6;
+		color: $gray-600;
 	}
 }

--- a/packages/js/product-editor/src/components/attribute-input-field/attribute-input-field.tsx
+++ b/packages/js/product-editor/src/components/attribute-input-field/attribute-input-field.tsx
@@ -3,9 +3,9 @@
  */
 import { sprintf, __ } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { Spinner, Icon } from '@wordpress/components';
+import { Spinner, Icon, Tooltip } from '@wordpress/components';
 import { plus } from '@wordpress/icons';
-import { createElement, useMemo } from '@wordpress/element';
+import { createElement, Fragment, useMemo } from '@wordpress/element';
 import {
 	EXPERIMENTAL_PRODUCT_ATTRIBUTES_STORE_NAME,
 	QueryProductAttribute,
@@ -42,6 +42,7 @@ type AttributeInputFieldProps = {
 	placeholder?: string;
 	disabled?: boolean;
 	disabledAttributeIds?: number[];
+	disabledAttributeMessage?: string;
 	ignoredAttributeIds?: number[];
 	createNewAttributesAsGlobal?: boolean;
 };
@@ -57,6 +58,7 @@ export const AttributeInputField: React.FC< AttributeInputFieldProps > = ( {
 	label,
 	disabled,
 	disabledAttributeIds = [],
+	disabledAttributeMessage,
 	ignoredAttributeIds = [],
 	createNewAttributesAsGlobal = false,
 } ) => {
@@ -195,21 +197,10 @@ export const AttributeInputField: React.FC< AttributeInputFieldProps > = ( {
 									index={ index }
 									isActive={ highlightedIndex === index }
 									item={ item }
-									getItemProps={ ( options ) => {
-										console.log(
-											'getItemProps',
-											getItemProps( options )
-										);
-										return {
-											...getItemProps( options ),
-											disabled:
-												item.isDisabled || undefined,
-											onKeyDown( event: KeyboardEvent ) {
-												if ( item.isDisabled )
-													event.stopPropagation();
-											},
-										};
-									} }
+									getItemProps={ ( options ) => ( {
+										...getItemProps( options ),
+										disabled: item.isDisabled || undefined,
+									} ) }
 								>
 									{ isNewAttributeListItem( item ) ? (
 										<div className="woocommerce-attribute-input-field__add-new">
@@ -230,7 +221,12 @@ export const AttributeInputField: React.FC< AttributeInputFieldProps > = ( {
 											</span>
 										</div>
 									) : (
-										item.name
+										<>
+											{ item.name }
+											{ item.isDisabled &&
+												disabledAttributeMessage &&
+												` ${ disabledAttributeMessage }` }
+										</>
 									) }
 								</MenuItem>
 							) )

--- a/packages/js/product-editor/src/components/attribute-input-field/attribute-input-field.tsx
+++ b/packages/js/product-editor/src/components/attribute-input-field/attribute-input-field.tsx
@@ -3,9 +3,9 @@
  */
 import { sprintf, __ } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { Spinner, Icon, Tooltip } from '@wordpress/components';
+import { Spinner, Icon } from '@wordpress/components';
 import { plus } from '@wordpress/icons';
-import { createElement, Fragment, useMemo } from '@wordpress/element';
+import { createElement, useMemo } from '@wordpress/element';
 import {
 	EXPERIMENTAL_PRODUCT_ATTRIBUTES_STORE_NAME,
 	QueryProductAttribute,
@@ -201,6 +201,11 @@ export const AttributeInputField: React.FC< AttributeInputFieldProps > = ( {
 										...getItemProps( options ),
 										disabled: item.isDisabled || undefined,
 									} ) }
+									tooltipText={
+										item.isDisabled
+											? disabledAttributeMessage
+											: undefined
+									}
 								>
 									{ isNewAttributeListItem( item ) ? (
 										<div className="woocommerce-attribute-input-field__add-new">
@@ -221,12 +226,7 @@ export const AttributeInputField: React.FC< AttributeInputFieldProps > = ( {
 											</span>
 										</div>
 									) : (
-										<>
-											{ item.name }
-											{ item.isDisabled &&
-												disabledAttributeMessage &&
-												` ${ disabledAttributeMessage }` }
-										</>
+										item.name
 									) }
 								</MenuItem>
 							) )

--- a/packages/js/product-editor/src/components/attributes/attributes.tsx
+++ b/packages/js/product-editor/src/components/attributes/attributes.tsx
@@ -3,6 +3,7 @@
  */
 import { createElement } from '@wordpress/element';
 import { ProductAttribute } from '@woocommerce/data';
+import { __ } from '@wordpress/i18n';
 import { recordEvent } from '@woocommerce/tracks';
 
 /**
@@ -10,7 +11,6 @@ import { recordEvent } from '@woocommerce/tracks';
  */
 import { AttributeControl } from '../attribute-control';
 import { useProductAttributes } from '../../hooks/use-product-attributes';
-import { __ } from '@wordpress/i18n';
 
 type AttributesProps = {
 	value: ProductAttribute[];

--- a/packages/js/product-editor/src/components/attributes/attributes.tsx
+++ b/packages/js/product-editor/src/components/attributes/attributes.tsx
@@ -37,7 +37,7 @@ export const Attributes: React.FC< AttributesProps > = ( {
 				.map( ( attr ) => attr.id ) }
 			uiStrings={ {
 				disabledAttributeMessage: __(
-					'(Already used in Variations)',
+					'Already used in Variations',
 					'woocommerce'
 				),
 			} }

--- a/packages/js/product-editor/src/components/attributes/attributes.tsx
+++ b/packages/js/product-editor/src/components/attributes/attributes.tsx
@@ -10,6 +10,7 @@ import { recordEvent } from '@woocommerce/tracks';
  */
 import { AttributeControl } from '../attribute-control';
 import { useProductAttributes } from '../../hooks/use-product-attributes';
+import { __ } from '@wordpress/i18n';
 
 type AttributesProps = {
 	value: ProductAttribute[];
@@ -31,6 +32,15 @@ export const Attributes: React.FC< AttributesProps > = ( {
 	return (
 		<AttributeControl
 			value={ attributes }
+			disabledAttributeIds={ value
+				.filter( ( attr ) => !! attr.variation )
+				.map( ( attr ) => attr.id ) }
+			uiStrings={ {
+				disabledAttributeMessage: __(
+					'(Already used in Variations)',
+					'woocommerce'
+				),
+			} }
 			onAdd={ () => {
 				recordEvent( 'product_add_attributes_modal_add_button_click' );
 			} }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #39499

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure feature `product-variation-management` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper`
3. Go to `/wp-admin/admin.php?page=wc-admin&path=/add-product&tab=organization` and click `Add new` button under `Attributes` section
4. Select or create a new attribute from the modal
5. Go to `/wp-admin/admin.php?page=wc-admin&path=/add-product&tab=variations` and click `Add variation options` button from the `Variations` tab
6. In the `Attributes` dropdown list, the attribute you selected in the point 4 should be shown disabled and when hovering it a Tooltip saying `Already used in Attributes` should be shown too
7. Select or create another attribute and add it as a variation
8. If you go back to `Organization` tab and try to add another attribute there, a similar Tooltip should be shown `Already used in Variations` for the attribute you selected in point 7

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
