### PR TITLE
Marketplace: cache Discover page content in a transient 

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/discover/discover.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/discover/discover.tsx
@@ -8,21 +8,29 @@ import { useEffect, useState } from '@wordpress/element';
  */
 import ProductList from '../product-list/product-list';
 import { fetchDiscoverPageData, ProductGroup } from '../../utils/functions';
+import ProductLoader from '../product-loader/product-loader';
 import './discover.scss';
 
 export default function Discover(): JSX.Element | null {
 	const [ productGroups, setProductGroups ] = useState<
 		Array< ProductGroup >
 	>( [] );
+	const [ isLoading, setIsLoading ] = useState( false );
 
 	useEffect( () => {
-		fetchDiscoverPageData().then( ( products: Array< ProductGroup > ) => {
-			setProductGroups( products );
-		} );
+		setIsLoading( true );
+
+		fetchDiscoverPageData()
+			.then( ( products: Array< ProductGroup > ) => {
+				setProductGroups( products );
+			} )
+			.finally( () => {
+				setIsLoading( false );
+			} );
 	}, [] );
 
-	if ( ! productGroups.length ) {
-		return null;
+	if ( isLoading ) {
+		return <ProductLoader />;
 	}
 
 	const groupsList = productGroups.flatMap( ( group ) => group );

--- a/plugins/woocommerce-admin/client/marketplace/components/product-list-content/no-results.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/product-list-content/no-results.tsx
@@ -25,6 +25,8 @@ export default function NoResults(): JSX.Element {
 	useEffect( () => {
 		if ( query.term ) {
 			setNoResultsTerm( query.term );
+
+			return;
 		}
 
 		if ( query.category ) {
@@ -42,7 +44,7 @@ export default function NoResults(): JSX.Element {
 		setisLoadingProductGroup( true );
 
 		fetchDiscoverPageData()
-			.then( ( products: Array< ProductGroup > ) => {
+			.then( ( products: ProductGroup[] ) => {
 				const mostPopularGroup = products.find(
 					( group ) => group.id === 'most-popular'
 				);

--- a/plugins/woocommerce-admin/client/marketplace/contexts/product-list-context.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/contexts/product-list-context.tsx
@@ -23,15 +23,9 @@ export const ProductListContext = createContext< ProductListContextType >( {
 	isLoading: false,
 } );
 
-type ProductListContextProviderProps = {
+export function ProductListContextProvider( props: {
 	children: JSX.Element;
-	country?: string;
-	locale?: string;
-};
-
-export function ProductListContextProvider(
-	props: ProductListContextProviderProps
-): JSX.Element {
+} ): JSX.Element {
 	const [ isLoading, setIsLoading ] = useState( false );
 	const [ productList, setProductList ] = useState< Product[] >( [] );
 
@@ -47,9 +41,9 @@ export function ProductListContextProvider(
 
 		const params = new URLSearchParams();
 
-		params.append( 'term', query.term ?? '' );
-		params.append( 'country', props.country ?? '' );
-		params.append( 'locale', props.locale ?? '' );
+		if ( query.term ) {
+			params.append( 'term', query.term );
+		}
 
 		if ( query.category ) {
 			params.append( 'category', query.category );
@@ -94,7 +88,7 @@ export function ProductListContextProvider(
 			.finally( () => {
 				setIsLoading( false );
 			} );
-	}, [ query, props.country, props.locale ] );
+	}, [ query ] );
 
 	return (
 		<ProductListContext.Provider value={ contextValue }>

--- a/plugins/woocommerce-admin/client/marketplace/utils/functions.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/utils/functions.tsx
@@ -1,9 +1,15 @@
 /**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
  * Internal dependencies
  */
 import { Product } from '../components/product-list/types';
 import { MARKETPLACE_URL } from '../components/constants';
 import { CategoryAPIItem } from '../components/category-selector/types';
+import { LOCALE } from '../../utils/admin-settings';
 
 interface ProductGroup {
 	id: string;
@@ -13,26 +19,28 @@ interface ProductGroup {
 }
 
 // Fetch data for the discover page from the WooCommerce.com API
-const fetchDiscoverPageData = async (): Promise< Array< ProductGroup > > => {
-	const fetchUrl = MARKETPLACE_URL + '/wp-json/wccom-extensions/2.0/featured';
+async function fetchDiscoverPageData(): Promise< ProductGroup[] > {
+	let url = '/wc/v3/marketplace/featured';
 
-	return fetch( fetchUrl )
-		.then( ( response ) => {
-			if ( ! response.ok ) {
-				throw new Error( response.statusText );
-			}
-			return response.json();
-		} )
-		.then( ( json ) => {
-			return json;
-		} )
-		.catch( () => {
-			return [];
-		} );
-};
+	if ( LOCALE.userLocale ) {
+		url = `${ url }?locale=${ LOCALE.userLocale }`;
+	}
+
+	try {
+		return await apiFetch( { path: url.toString() } );
+	} catch ( error ) {
+		return [];
+	}
+}
 
 function fetchCategories(): Promise< CategoryAPIItem[] > {
-	return fetch( MARKETPLACE_URL + '/wp-json/wccom-extensions/1.0/categories' )
+	let url = MARKETPLACE_URL + '/wp-json/wccom-extensions/1.0/categories';
+
+	if ( LOCALE.userLocale ) {
+		url = `${ url }?locale=${ LOCALE.userLocale }`;
+	}
+
+	return fetch( url.toString() )
 		.then( ( response ) => {
 			if ( ! response.ok ) {
 				throw new Error( response.statusText );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:
Currently, we're hitting the WCCOM API directly from the front end. However, that limits us in terms of caching and reducing the load on WCCOM.

To prevent that, we added a REST API endpoint. This endpoint fetches discover page content from WCCOM and puts in a transient. This is actually how the page works in the previous version. So we were able to reuse a lot of the code.

The same transient data can work for both the old page and the new page. So when users disable the new marketplace page, the old page will still load using the cached data.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout this branch and build woocommerce admin assets
2. Visit [the Discover page](http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fextensions) and confirm it loads
3. Check it saved a transient using `wp transient get wc_addons_featured` command
    - If you are using `wp-env` you can run it as `wp-env run cli wp transient get wc_addons_featured`
4. Go to search page and search for a term without any results. Confirm you get the **Most popular** section with products displayed
    - Most popular section uses the discover page and therefore it's also cached. 
5. Go to **WooCommerce > Settings > Advanced > Features** and uncheck **New, faster way to find extensions and themes for your WooCommerce store**. This will enable the old Marketplace page.
6. Visit [the old Marketplace page](http://localhost:8888/wp-admin/admin.php?page=wc-addons) and confirm it loads
7. Delete the transient using `wp transient delete wc_addons_featured` command
    -  If you are using `wp-env` you can run it as `wp-env run cli wp transient delete wc_addons_featured`
8. Reload [the old Marketplace page] and confirm it works
9. Go to **WooCommerce > Settings > Advanced > Features** and check **New, faster way to find extensions and themes for your WooCommerce store**. This will enable the new Marketplace page.
10. Go to **Settings > General > Site Language** and change it to French, Spanish or Portoguese. 
11. Go to the new Search page and confirm the categories are now translated. 
    - WCCOM serves the translations and therefore might have missing text. 
    - Translations only work for the category endpoint. 
    - We pass the locale data to the category and discover endpoints. Discover endpoint expects a locale but doesn't translate the results. 
    - Search endpoint doesn't accept any locale information. 

### To-Do
- [x] Search endpoint expects a `country` parameter. Previously we sent the `WC()->countries->get_base_country()` data. I have yet to find a JavaScript equivalent to that.
- [ ] We must show the error messages on the discover page, if API calls fail. 