### PR TITLE
Fix onboarding payments task not completed after setting up WooPayments

### DIFF
--- a/plugins/woocommerce/changelog/fix-5769-wcpay-onboarding-payments-task-completed
+++ b/plugins/woocommerce/changelog/fix-5769-wcpay-onboarding-payments-task-completed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Onboarding payments task not completed after setting up WooPayments

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/WooCommercePayments.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/WooCommercePayments.php
@@ -109,8 +109,7 @@ class WooCommercePayments extends Task {
 
 		return ! $payments->is_complete() && // Do not re-display the task if the "add payments" task has already been completed.
 			self::is_installed() &&
-			self::is_supported() &&
-			! self::is_connected();
+			self::is_supported();
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:
Closes https://github.com/Automattic/woocommerce-payments/issues/5769

Remove `self::is_connected()` condition from `WooCommercePayments` task `can_view` method to ensure WC Home displays the WooPayments set up task as completed rather than the uncompleted Payments task, after finishing WooPayments set up.

### How to test the changes in this Pull Request:
- Create a JN site using this PR branch.
- Skip WC profiler.
- Uncompleted **Set up payments** task should be there in **WC Home** page.
- Click it and then on **Get started**
- Wait for it to be installed, refresh, and go to **WC Home** page.
- Uncompleted **Set up WooPayments** task should be there.
- Click on it and complete the onboarding.
- Go to **WC Home** again.
- **Set up WooPayments** should be completed now.
