### PR TITLE
Run A/B test on the core profiler plugins page with Jetpack and Jetpack Boost

### DIFF
--- a/plugins/woocommerce-admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/index.tsx
@@ -344,7 +344,19 @@ const redirectToJetpackAuthPage = (
 	_context: CoreProfilerStateMachineContext,
 	event: { data: { url: string } }
 ) => {
-	window.location.href = event.data.url + '&installed_ext_success=1';
+	const url = new URL( event.data.url );
+	url.searchParams.set( 'installed_ext_success', '1' );
+	const selectedPlugin = _context.pluginsSelected.find(
+		( plugin ) => plugin === 'jetpack' || plugin === 'jetpack-boost'
+	);
+
+	if ( selectedPlugin ) {
+		const pluginName =
+			selectedPlugin === 'jetpack' ? 'jetpack-ai' : 'jetpack-boost';
+		url.searchParams.set( 'plugin_name', pluginName );
+	}
+
+	window.location.href = url.toString();
 };
 
 const updateTrackingOption = async (

--- a/plugins/woocommerce/changelog/update-39629-jetpack-ab-test-on-plugins-page
+++ b/plugins/woocommerce/changelog/update-39629-jetpack-ab-test-on-plugins-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Run A/B test on the core profiler plugins page -- suggest Jetpack or Jetpack Boost

--- a/plugins/woocommerce/src/Admin/API/OnboardingFreeExtensions.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingFreeExtensions.php
@@ -103,7 +103,7 @@ class OnboardingFreeExtensions extends WC_REST_Data_Controller {
 	}
 
 	private function replace_jetpack_with_jetpack_boost_for_treatment( array $extensions ) {
-		$is_treatment = \WooCommerce\Admin\Experimental_Abtest::in_treatment( 'coreprofiler_jetpack_or_jetpack_boost' );
+		$is_treatment = \WooCommerce\Admin\Experimental_Abtest::in_treatment( 'woocommerce_jetpack_copy' );
 
 		if ( ! $is_treatment ) {
 			return $extensions;

--- a/plugins/woocommerce/src/Admin/API/OnboardingFreeExtensions.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingFreeExtensions.php
@@ -97,7 +97,37 @@ class OnboardingFreeExtensions extends WC_REST_Data_Controller {
 			}
 		}
 
+		$extensions = $this->replace_jetpack_with_jetpack_boost_for_treatment( $extensions );
+
 		return new WP_REST_Response( $extensions );
 	}
 
+	private function replace_jetpack_with_jetpack_boost_for_treatment( array $extensions ) {
+		$is_treatment = \WooCommerce\Admin\Experimental_Abtest::in_treatment( 'coreprofiler_jetpack_or_jetpack_boost' );
+
+		if ( ! $is_treatment ) {
+			return $extensions;
+		}
+
+		$has_core_profiler = array_search( 'obw/core-profiler', array_column( $extensions, 'key' ) );
+
+		if ( $has_core_profiler === false ) {
+			return $extensions;
+		}
+
+		$has_jetpack = array_search( 'jetpack', array_column( $extensions[ $has_core_profiler ]['plugins'], 'key' ) );
+
+		if ( $has_jetpack === false ) {
+			return $extensions;
+		}
+
+		$jetpack                  = &$extensions[ $has_core_profiler ]['plugins'][ $has_jetpack ];
+		$jetpack->key             = 'jetpack-boost';
+		$jetpack->name            = 'Jetpack Boost';
+		$jetpack->label           = __( 'Optimize store performance with Jetpack Boost', 'woocommerce' );
+		$jetpack->description     = __( 'Speed up your store and improve your SEO with performance-boosting tools from Jetpack. Learn more', 'woocommerce' );
+		$jetpack->learn_more_link = 'https://jetpack.com/boost/';
+
+		return $extensions;
+	}
 }

--- a/plugins/woocommerce/src/Admin/API/OnboardingProfile.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingProfile.php
@@ -391,6 +391,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 				'items'             => array(
 					'enum' => array(
 						'jetpack',
+						'jetpack-boost',
 						'woocommerce-services',
 						'woocommerce-payments',
 						'mailchimp-for-woocommerce',

--- a/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
+++ b/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
@@ -875,9 +875,9 @@ class DefaultFreeExtensions {
 				'install_priority' => 3,
 			),
 			'jetpack'                       => array(
-				'label'            => __( 'Enhance security with Jetpack', 'woocommerce' ),
+				'label'            => __( 'Boost content creation with Jetpack AI Assistant', 'woocommerce' ),
 				'image_url'        => plugins_url( '/assets/images/core-profiler/logo-jetpack.svg', WC_PLUGIN_FILE ),
-				'description'      => __( 'Get auto real-time backups, malware scans, and spam protection.', 'woocommerce' ),
+				'description'      => __( 'Save time on content creation — unlock high-quality blog posts and pages using AI.', 'woocommerce' ),
 				'learn_more_link'  => 'https://woocommerce.com/products/jetpack',
 				'install_priority' => 8,
 			),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #39629 

This PR adds ExPlat on the core profiler plugins page for conducting A/B tests with Jetpack and Jetpack Boost.

control: Jetpack with AI copy update
treatment: Jetpack Boost


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Temp: Go to `WooCommerce -> Settings -> Advanced -> WooCommerce.com` and turn off `Show Suggestions`. This is temporary until we release the same change in woocommerc.com

1. Install and activate WooCommerce Test Helper plugin.
2. Start the core profiler and proceed to the plugins page.
3. Confirm you're suggested with `Jetpack with AI`. 
4. Confirm the copy changes (refer to the issue)
5. Open a new tab and go to `Tools -> WCA Test Helper -> Experiments`
6. Toggle `woocommerce_jetpack_copy` to treatment
7. Refresh the plugins page.
8. Confirm you're suggested with `Jetpack Boost`


Click the continue button for both cases and confirm the plugins are installable. 
Click the continue button and confirm the URL has `plugin_name` when you're on Jetpack Connection page. `plugin_name` should be either `jetpack-ai` or `jetpack-boost`.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
