### PR TITLE
Fixes WooCommerce knowledge base API returning empty posts

### DIFF
--- a/plugins/woocommerce/changelog/fix-knowledge-base-posts-api
+++ b/plugins/woocommerce/changelog/fix-knowledge-base-posts-api
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fixes WooCommerce knowledge base API returning empty posts.

--- a/plugins/woocommerce/src/Internal/Admin/Marketing/MarketingSpecs.php
+++ b/plugins/woocommerce/src/Internal/Admin/Marketing/MarketingSpecs.php
@@ -150,7 +150,7 @@ class MarketingSpecs {
 				'taxonomy' => 'post_tag',
 				'term_id'  => 1377,
 				'argument' => 'tags',
-			)
+			),
 		);
 
 		// Default to the marketing category (if no term is set on the kb component).

--- a/plugins/woocommerce/src/Internal/Admin/Marketing/MarketingSpecs.php
+++ b/plugins/woocommerce/src/Internal/Admin/Marketing/MarketingSpecs.php
@@ -136,34 +136,41 @@ class MarketingSpecs {
 	/**
 	 * Load knowledge base posts from WooCommerce.com
 	 *
-	 * @param string|null $category Category of posts to retrieve.
+	 * @param string|null $term Term of posts to retrieve.
 	 * @return array
 	 */
-	public function get_knowledge_base_posts( ?string $category ): array {
-		$kb_transient = self::KNOWLEDGE_BASE_TRANSIENT;
-
-		$categories = array(
-			'marketing' => 1744,
-			'coupons'   => 25202,
+	public function get_knowledge_base_posts( ?string $term ): array {
+		$terms = array(
+			'marketing' => array(
+				'taxonomy' => 'category',
+				'term_id'  => 1744,
+				'argument' => 'categories',
+			),
+			'coupons'   => array(
+				'taxonomy' => 'post_tag',
+				'term_id'  => 1377,
+				'argument' => 'tags',
+			)
 		);
 
-		// Default to marketing category (if no category set on the kb component).
-		if ( ! empty( $category ) && array_key_exists( $category, $categories ) ) {
-			$category_id  = $categories[ $category ];
-			$kb_transient = $kb_transient . '_' . strtolower( $category );
-		} else {
-			$category_id = $categories['marketing'];
+		// Default to the marketing category (if no term is set on the kb component).
+		if ( empty( $term ) || ! array_key_exists( $term, $terms ) ) {
+			$term = 'marketing';
 		}
+
+		$term_id      = $terms[ $term ]['term_id'];
+		$argument     = $terms[ $term ]['argument'];
+		$kb_transient = self::KNOWLEDGE_BASE_TRANSIENT . '_' . strtolower( $term );
 
 		$posts = get_transient( $kb_transient );
 
 		if ( false === $posts ) {
 			$request_url = add_query_arg(
 				array(
-					'categories' => $category_id,
-					'page'       => 1,
-					'per_page'   => 8,
-					'_embed'     => 1,
+					$argument  => $term_id,
+					'page'     => 1,
+					'per_page' => 8,
+					'_embed'   => 1,
 				),
 				'https://woocommerce.com/wp-json/wp/v2/posts?utm_medium=product'
 			);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #39808.

The WooCommerce.com blog posts categories were recently restructured. The `coupons` category was removed and added as a tag in that restructuring. The WooCommerce knowledge base API uses the `coupons` category ID to fetch the posts from this category. In this PR, we'll fetch the posts tagged to `coupons` tag when a request is made to `coupons` term.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. On a fresh installation, verify WooCommerce is installed and activated.
3. Navigate to `Marketing > Coupons`.
4. Scroll to the bottom of the page to the `WooCommerce knowledge base` section.
5. Verify no posts are displayed in the section.
6. Checkout this PR.
7. Navigate to `WooCommerce > Status > Tools`.
8. Click on `Clear Transients` to clear all WooCommerce transients.
9. Navigate to `Marketing > Coupons`.
10. Verify the [posts tagged as `coupons` in WooCommerce.com](https://woocommerce.com/posts/tag/coupons/) are displayed in this section.

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fixes WooCommerce knowledge base API returning empty posts.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
