### PR TITLE
Add quick actions dropdown menu per variation item 

### DIFF
--- a/packages/js/product-editor/changelog/add-39787
+++ b/packages/js/product-editor/changelog/add-39787
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add quick actions dropdown menu to variation items

--- a/packages/js/product-editor/src/components/variations-table/styles.scss
+++ b/packages/js/product-editor/src/components/variations-table/styles.scss
@@ -49,7 +49,7 @@
 		align-items: center;
 		justify-content: flex-end;
 
-		&--trash {
+		&--delete {
 			&.components-button.components-menu-item__button.is-link {
 				text-decoration: none;
 			}

--- a/packages/js/product-editor/src/components/variations-table/styles.scss
+++ b/packages/js/product-editor/src/components/variations-table/styles.scss
@@ -49,6 +49,12 @@
 		align-items: center;
 		justify-content: flex-end;
 
+		&--trash {
+			&.components-button.components-menu-item__button.is-link {
+				text-decoration: none;
+			}
+		}
+
 		.components-button {
 			position: relative;
 			color: var(--wp-admin-theme-color);
@@ -63,8 +69,14 @@
 			}
 		}
 
-		.components-button svg {
-			fill: none;
+		.components-button {
+			&.components-dropdown-menu__toggle.has-icon svg {
+				fill: inherit;
+			}
+
+			svg {
+				fill: none;
+			}
 		}
 
 		.components-button--visible {

--- a/packages/js/product-editor/src/components/variations-table/variations-table.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variations-table.tsx
@@ -14,14 +14,7 @@ import {
 	EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME,
 	ProductVariation,
 } from '@woocommerce/data';
-import {
-	Link,
-	ListItem,
-	Pagination,
-	Sortable,
-	Tag,
-} from '@woocommerce/components';
-import { getNewPath } from '@woocommerce/navigation';
+import { ListItem, Pagination, Sortable, Tag } from '@woocommerce/components';
 import {
 	useContext,
 	useState,
@@ -29,6 +22,7 @@ import {
 	Fragment,
 } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { moreVertical } from '@wordpress/icons';
 import classnames from 'classnames';
 import truncate from 'lodash/truncate';
 import { CurrencyContext } from '@woocommerce/currency';
@@ -47,7 +41,6 @@ import {
 	DEFAULT_PER_PAGE_OPTION,
 	PRODUCT_VARIATION_TITLE_LIMIT,
 } from '../../constants';
-import { moreVertical } from '@wordpress/icons';
 
 const NOT_VISIBLE_TEXT = __( 'Not visible to customers', 'woocommerce' );
 const VISIBLE_TEXT = __( 'Visible to customers', 'woocommerce' );
@@ -290,7 +283,9 @@ export function VariationsTable() {
 												'Variation Id: '
 											) } ${ variation.id }` }
 										>
-											<MenuItem onClick={ onClose }>
+											<MenuItem
+												href={ variation.permalink }
+											>
 												{ __(
 													'Preview',
 													'woocommerce'

--- a/packages/js/product-editor/src/components/variations-table/variations-table.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variations-table.tsx
@@ -93,7 +93,7 @@ export function VariationsTable() {
 			[ currentPage, perPage, productId ]
 		);
 
-	const { updateProductVariation } = useDispatch(
+	const { updateProductVariation, deleteProductVariation } = useDispatch(
 		EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME
 	);
 
@@ -123,6 +123,23 @@ export function VariationsTable() {
 			{ product_id: productId, id: variationId },
 			{ status }
 		).finally( () =>
+			setIsUpdating( ( prevState ) => ( {
+				...prevState,
+				[ variationId ]: false,
+			} ) )
+		);
+	}
+
+	function handleDeleteVariationClick( variationId: number ) {
+		if ( isUpdating[ variationId ] ) return;
+		setIsUpdating( ( prevState ) => ( {
+			...prevState,
+			[ variationId ]: true,
+		} ) );
+		deleteProductVariation< Promise< ProductVariation > >( {
+			product_id: productId,
+			id: variationId,
+		} ).finally( () =>
 			setIsUpdating( ( prevState ) => ( {
 				...prevState,
 				[ variationId ]: false,
@@ -296,10 +313,18 @@ export function VariationsTable() {
 											<MenuItem
 												isDestructive
 												variant="link"
-												onClick={ onClose }
-												className="woocommerce-product-variations__actions--trash"
+												onClick={ () => {
+													handleDeleteVariationClick(
+														variation.id
+													);
+													onClose();
+												} }
+												className="woocommerce-product-variations__actions--delete"
 											>
-												{ __( 'Trash', 'woocommerce' ) }
+												{ __(
+													'Delete',
+													'woocommerce'
+												) }
 											</MenuItem>
 										</MenuGroup>
 									</>

--- a/packages/js/product-editor/src/components/variations-table/variations-table.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variations-table.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import {
 	Button,
 	DropdownMenu,
@@ -296,9 +296,14 @@ export function VariationsTable() {
 								{ ( { onClose } ) => (
 									<>
 										<MenuGroup
-											label={ `${ __(
-												'Variation Id: '
-											) } ${ variation.id }` }
+											label={ sprintf(
+												/** Translators: Variation ID */
+												__(
+													'Variation Id: %s',
+													'woocommerce'
+												),
+												variation.id
+											) }
 										>
 											<MenuItem
 												href={ variation.permalink }

--- a/packages/js/product-editor/src/components/variations-table/variations-table.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variations-table.tsx
@@ -14,6 +14,7 @@ import {
 	EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME,
 	ProductVariation,
 } from '@woocommerce/data';
+import { recordEvent } from '@woocommerce/tracks';
 import { ListItem, Pagination, Sortable, Tag } from '@woocommerce/components';
 import {
 	useContext,
@@ -40,6 +41,7 @@ import { getProductStockStatus, getProductStockStatusClass } from '../../utils';
 import {
 	DEFAULT_PER_PAGE_OPTION,
 	PRODUCT_VARIATION_TITLE_LIMIT,
+	TRACKS_SOURCE,
 } from '../../constants';
 
 const NOT_VISIBLE_TEXT = __( 'Not visible to customers', 'woocommerce' );
@@ -139,12 +141,18 @@ export function VariationsTable() {
 		deleteProductVariation< Promise< ProductVariation > >( {
 			product_id: productId,
 			id: variationId,
-		} ).finally( () =>
-			setIsUpdating( ( prevState ) => ( {
-				...prevState,
-				[ variationId ]: false,
-			} ) )
-		);
+		} )
+			.then( () => {
+				recordEvent( 'product_variations_delete', {
+					source: TRACKS_SOURCE,
+				} );
+			} )
+			.finally( () =>
+				setIsUpdating( ( prevState ) => ( {
+					...prevState,
+					[ variationId ]: false,
+				} ) )
+			);
 	}
 
 	return (
@@ -292,6 +300,16 @@ export function VariationsTable() {
 							<DropdownMenu
 								icon={ moreVertical }
 								label={ __( 'Actions', 'woocommerce' ) }
+								toggleProps={ {
+									onClick() {
+										recordEvent(
+											'product_variations_menu_view',
+											{
+												source: TRACKS_SOURCE,
+											}
+										);
+									},
+								} }
 							>
 								{ ( { onClose } ) => (
 									<>
@@ -307,6 +325,14 @@ export function VariationsTable() {
 										>
 											<MenuItem
 												href={ variation.permalink }
+												onClick={ () => {
+													recordEvent(
+														'product_variations_preview',
+														{
+															source: TRACKS_SOURCE,
+														}
+													);
+												} }
 											>
 												{ __(
 													'Preview',

--- a/packages/js/product-editor/src/components/variations-table/variations-table.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variations-table.tsx
@@ -2,7 +2,14 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button, Spinner, Tooltip } from '@wordpress/components';
+import {
+	Button,
+	DropdownMenu,
+	MenuGroup,
+	MenuItem,
+	Spinner,
+	Tooltip,
+} from '@wordpress/components';
 import {
 	EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME,
 	ProductVariation,
@@ -15,7 +22,12 @@ import {
 	Tag,
 } from '@woocommerce/components';
 import { getNewPath } from '@woocommerce/navigation';
-import { useContext, useState, createElement } from '@wordpress/element';
+import {
+	useContext,
+	useState,
+	createElement,
+	Fragment,
+} from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import classnames from 'classnames';
 import truncate from 'lodash/truncate';
@@ -35,6 +47,7 @@ import {
 	DEFAULT_PER_PAGE_OPTION,
 	PRODUCT_VARIATION_TITLE_LIMIT,
 } from '../../constants';
+import { moreVertical } from '@wordpress/icons';
 
 const NOT_VISIBLE_TEXT = __( 'Not visible to customers', 'woocommerce' );
 const VISIBLE_TEXT = __( 'Visible to customers', 'woocommerce' );
@@ -266,17 +279,37 @@ export function VariationsTable() {
 								</Tooltip>
 							) }
 
-							<Link
-								href={ getNewPath(
-									{},
-									`/product/${ productId }/variation/${ variation.id }`,
-									{}
-								) }
-								type="wc-admin"
-								className="components-button"
+							<DropdownMenu
+								icon={ moreVertical }
+								label={ __( 'Actions', 'woocommerce' ) }
 							>
-								{ __( 'Edit', 'woocommerce' ) }
-							</Link>
+								{ ( { onClose } ) => (
+									<>
+										<MenuGroup
+											label={ `${ __(
+												'Variation Id: '
+											) } ${ variation.id }` }
+										>
+											<MenuItem onClick={ onClose }>
+												{ __(
+													'Preview',
+													'woocommerce'
+												) }
+											</MenuItem>
+										</MenuGroup>
+										<MenuGroup>
+											<MenuItem
+												isDestructive
+												variant="link"
+												onClick={ onClose }
+												className="woocommerce-product-variations__actions--trash"
+											>
+												{ __( 'Trash', 'woocommerce' ) }
+											</MenuItem>
+										</MenuGroup>
+									</>
+								) }
+							</DropdownMenu>
 						</div>
 					</ListItem>
 				) ) }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #39787

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure feature `product-variation-management` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper`
3. Go to `/wp-admin/admin.php?page=wc-admin&path=/add-product&tab=variations` and click `Add variation options` button from the `Variations` tab
4. Add at least one Variation attribute and at least one value. Then click `Add` button from the `Add variation options` modal.
5. Wait until the variations are generated
6. A list a variation should be shown depending on the options selected
7. In the Variations table, each row should have a dropdown icon button at the right most place
8. When clicking a dropdown menu should be shown
9. From the menu, the group label should show the Variation Id
10. A `Preview` menu item should be shown and when clicking it should redirect to the storefront page related to that variation product.
11. A `Delete` menu item should be shown and when clicking it should delete the variation item so that variation row should disappear from the table

<img width="699" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/ef7d12f5-4ea8-4f04-849d-4fe7fe678552">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
