### PR TITLE
Remove legacy PHP version checks

### DIFF
--- a/plugins/woocommerce/changelog/remove-legacy-php-version-checks
+++ b/plugins/woocommerce/changelog/remove-legacy-php-version-checks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Remove legacy PHP version update checks

--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -36,7 +36,6 @@ class WC_Admin_Notices {
 		'regenerating_thumbnails'            => 'regenerating_thumbnails_notice',
 		'regenerating_lookup_table'          => 'regenerating_lookup_table_notice',
 		'no_secure_connection'               => 'secure_connection_notice',
-		WC_PHP_MIN_REQUIREMENTS_NOTICE       => 'wp_php_min_requirements_notice',
 		'maxmind_license_key'                => 'maxmind_missing_license_key_notice',
 		'redirect_download_method'           => 'redirect_download_method_notice',
 		'uploads_directory_is_unprotected'   => 'uploads_directory_is_unprotected_notice',
@@ -425,46 +424,13 @@ class WC_Admin_Notices {
 
 	/**
 	 * Notice about WordPress and PHP minimum requirements.
+	 * 
+	 * @deprecated 8.2.0 WordPress and PHP minimum requirements notices are no longer shown.
 	 *
 	 * @since 3.6.5
 	 * @return void
 	 */
 	public static function wp_php_min_requirements_notice() {
-		if ( apply_filters( 'woocommerce_hide_php_wp_nag', get_user_meta( get_current_user_id(), 'dismissed_' . WC_PHP_MIN_REQUIREMENTS_NOTICE . '_notice', true ) ) ) {
-			self::remove_notice( WC_PHP_MIN_REQUIREMENTS_NOTICE );
-			return;
-		}
-
-		$old_php = version_compare( phpversion(), WC_NOTICE_MIN_PHP_VERSION, '<' );
-		$old_wp  = version_compare( get_bloginfo( 'version' ), WC_NOTICE_MIN_WP_VERSION, '<' );
-
-		// Both PHP and WordPress up to date version => no notice.
-		if ( ! $old_php && ! $old_wp ) {
-			return;
-		}
-
-		if ( $old_php && $old_wp ) {
-			$msg = sprintf(
-				/* translators: 1: Minimum PHP version 2: Minimum WordPress version */
-				__( 'Update required: WooCommerce will soon require PHP version %1$s and WordPress version %2$s or newer.', 'woocommerce' ),
-				WC_NOTICE_MIN_PHP_VERSION,
-				WC_NOTICE_MIN_WP_VERSION
-			);
-		} elseif ( $old_php ) {
-			$msg = sprintf(
-				/* translators: %s: Minimum PHP version */
-				__( 'Update required: WooCommerce will soon require PHP version %s or newer.', 'woocommerce' ),
-				WC_NOTICE_MIN_PHP_VERSION
-			);
-		} elseif ( $old_wp ) {
-			$msg = sprintf(
-				/* translators: %s: Minimum WordPress version */
-				__( 'Update required: WooCommerce will soon require WordPress version %s or newer.', 'woocommerce' ),
-				WC_NOTICE_MIN_WP_VERSION
-			);
-		}
-
-		include dirname( __FILE__ ) . '/views/html-notice-wp-php-minimum-requirements.php';
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-page-status-report.php
@@ -244,25 +244,7 @@ $untested_plugins   = $plugin_updates->get_untested_plugins( WC()->version, Cons
 			<td data-export-label="PHP Version"><?php esc_html_e( 'PHP version', 'woocommerce' ); ?>:</td>
 			<td class="help"><?php echo wc_help_tip( esc_html__( 'The version of PHP installed on your hosting server.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td>
-				<?php
-				if ( version_compare( $environment['php_version'], '7.2', '>=' ) ) {
-					echo '<mark class="yes">' . esc_html( $environment['php_version'] ) . '</mark>';
-				} else {
-					$update_link = ' <a href="https://docs.woocommerce.com/document/how-to-update-your-php-version/" target="_blank">' . esc_html__( 'How to update your PHP version', 'woocommerce' ) . '</a>';
-					$class       = 'error';
-
-					if ( version_compare( $environment['php_version'], '5.4', '<' ) ) {
-						$notice = '<span class="dashicons dashicons-warning"></span> ' . __( 'WooCommerce will run under this version of PHP, however, some features such as geolocation are not compatible. Support for this version will be dropped in the next major release. We recommend using PHP version 7.2 or above for greater performance and security.', 'woocommerce' ) . $update_link;
-					} elseif ( version_compare( $environment['php_version'], '5.6', '<' ) ) {
-						$notice = '<span class="dashicons dashicons-warning"></span> ' . __( 'WooCommerce will run under this version of PHP, however, it has reached end of life. We recommend using PHP version 7.2 or above for greater performance and security.', 'woocommerce' ) . $update_link;
-					} elseif ( version_compare( $environment['php_version'], '7.2', '<' ) ) {
-						$notice = __( 'We recommend using PHP version 7.2 or above for greater performance and security.', 'woocommerce' ) . $update_link;
-						$class  = 'recommendation';
-					}
-
-					echo '<mark class="' . esc_attr( $class ) . '">' . esc_html( $environment['php_version'] ) . ' - ' . wp_kses_post( $notice ) . '</mark>';
-				}
-				?>
+				<?php echo '<mark class="yes">' . esc_html( $environment['php_version'] ) . '</mark>'; ?>
 			</td>
 		</tr>
 		<?php if ( function_exists( 'ini_get' ) ) : ?>

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -315,9 +315,12 @@ final class WooCommerce {
 		$this->define( 'WC_LOG_DIR', $upload_dir['basedir'] . '/wc-logs/' );
 		$this->define( 'WC_SESSION_CACHE_GROUP', 'wc_session_id' );
 		$this->define( 'WC_TEMPLATE_DEBUG_MODE', false );
+		
+		// These three are kept defined for compatibility, but are no longer used.
 		$this->define( 'WC_NOTICE_MIN_PHP_VERSION', '7.2' );
 		$this->define( 'WC_NOTICE_MIN_WP_VERSION', '5.2' );
 		$this->define( 'WC_PHP_MIN_REQUIREMENTS_NOTICE', 'wp_php_min_requirements_' . WC_NOTICE_MIN_PHP_VERSION . '_' . WC_NOTICE_MIN_WP_VERSION );
+
 		/** Define if we're checking against major, minor or no versions in the following places:
 		 *   - plugin screen in WP Admin (displaying extra warning when updating to new major versions)
 		 *   - System Status Report ('Installed version not tested with active version of WooCommerce' warning)

--- a/plugins/woocommerce/includes/export/abstract-wc-csv-exporter.php
+++ b/plugins/woocommerce/includes/export/abstract-wc-csv-exporter.php
@@ -477,33 +477,13 @@ abstract class WC_CSV_Exporter {
 	}
 
 	/**
-	 * Write to the CSV file, ensuring escaping works across versions of
-	 * PHP.
+	 * Write to the CSV file.
 	 *
-	 * PHP 5.5.4 uses '\' as the default escape character. This is not RFC-4180 compliant.
-	 * \0 disables the escape character.
-	 *
-	 * @see https://bugs.php.net/bug.php?id=43225
-	 * @see https://bugs.php.net/bug.php?id=50686
-	 * @see https://github.com/woocommerce/woocommerce/issues/19514
 	 * @since 3.4.0
-	 * @see https://github.com/woocommerce/woocommerce/issues/24579
-	 * @since 3.9.0
 	 * @param resource $buffer Resource we are writing to.
 	 * @param array    $export_row Row to export.
 	 */
 	protected function fputcsv( $buffer, $export_row ) {
-
-		if ( version_compare( PHP_VERSION, '5.5.4', '<' ) ) {
-			ob_start();
-			$temp = fopen( 'php://output', 'w' ); // @codingStandardsIgnoreLine
-    		fputcsv( $temp, $export_row, $this->get_delimiter(), '"' ); // @codingStandardsIgnoreLine
-			fclose( $temp ); // @codingStandardsIgnoreLine
-			$row = ob_get_clean();
-			$row = str_replace( '\\"', '\\""', $row );
-			fwrite( $buffer, $row ); // @codingStandardsIgnoreLine
-		} else {
-			fputcsv( $buffer, $export_row, $this->get_delimiter(), '"', "\0" ); // @codingStandardsIgnoreLine
-		}
+		fputcsv( $buffer, $export_row, $this->get_delimiter(), '"', "\0" ); // @codingStandardsIgnoreLine
 	}
 }

--- a/plugins/woocommerce/includes/legacy/api/v1/class-wc-api-server.php
+++ b/plugins/woocommerce/includes/legacy/api/v1/class-wc-api-server.php
@@ -619,22 +619,7 @@ class WC_API_Server {
 	 * @return string
 	 */
 	public function get_raw_data() {
-		// @codingStandardsIgnoreStart
-		// $HTTP_RAW_POST_DATA is deprecated on PHP 5.6.
-		if ( function_exists( 'phpversion' ) && version_compare( phpversion(), '5.6', '>=' ) ) {
-			return file_get_contents( 'php://input' );
-		}
-
-		global $HTTP_RAW_POST_DATA;
-
-		// A bug in PHP < 5.2.2 makes $HTTP_RAW_POST_DATA not set by default,
-		// but we can do it ourself.
-		if ( ! isset( $HTTP_RAW_POST_DATA ) ) {
-			$HTTP_RAW_POST_DATA = file_get_contents( 'php://input' );
-		}
-
-		return $HTTP_RAW_POST_DATA;
-		// @codingStandardsIgnoreEnd
+		return file_get_contents( 'php://input' );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/legacy/api/v2/class-wc-api-server.php
+++ b/plugins/woocommerce/includes/legacy/api/v2/class-wc-api-server.php
@@ -656,22 +656,7 @@ class WC_API_Server {
 	 * @return string
 	 */
 	public function get_raw_data() {
-		// @codingStandardsIgnoreStart
-		// $HTTP_RAW_POST_DATA is deprecated on PHP 5.6.
-		if ( function_exists( 'phpversion' ) && version_compare( phpversion(), '5.6', '>=' ) ) {
-			return file_get_contents( 'php://input' );
-		}
-
-		global $HTTP_RAW_POST_DATA;
-
-		// A bug in PHP < 5.2.2 makes $HTTP_RAW_POST_DATA not set by default,
-		// but we can do it ourself.
-		if ( ! isset( $HTTP_RAW_POST_DATA ) ) {
-			$HTTP_RAW_POST_DATA = file_get_contents( 'php://input' );
-		}
-
-		return $HTTP_RAW_POST_DATA;
-		// @codingStandardsIgnoreEnd
+		return file_get_contents( 'php://input' );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/legacy/api/v3/class-wc-api-server.php
+++ b/plugins/woocommerce/includes/legacy/api/v3/class-wc-api-server.php
@@ -658,22 +658,7 @@ class WC_API_Server {
 	 * @return string
 	 */
 	public function get_raw_data() {
-		// @codingStandardsIgnoreStart
-		// $HTTP_RAW_POST_DATA is deprecated on PHP 5.6.
-		if ( function_exists( 'phpversion' ) && version_compare( phpversion(), '5.6', '>=' ) ) {
-			return file_get_contents( 'php://input' );
-		}
-
-		global $HTTP_RAW_POST_DATA;
-
-		// A bug in PHP < 5.2.2 makes $HTTP_RAW_POST_DATA not set by default,
-		// but we can do it ourself.
-		if ( ! isset( $HTTP_RAW_POST_DATA ) ) {
-			$HTTP_RAW_POST_DATA = file_get_contents( 'php://input' );
-		}
-
-		return $HTTP_RAW_POST_DATA;
-		// @codingStandardsIgnoreEnd
+		return file_get_contents( 'php://input' );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1094,11 +1094,7 @@ function wc_setcookie( $name, $value, $expire = 0, $secure = false, $httponly = 
 			$value
 		);
 
-		if ( version_compare( PHP_VERSION, '7.3.0', '>=' ) ) {
-			setcookie( $name, $value, $options );
-		} else {
-			setcookie( $name, $value, $options['expires'], $options['path'], $options['domain'], $options['secure'], $options['httponly'] );
-		}
+		setcookie( $name, $value, $options );
 	} elseif ( Constants::is_true( 'WP_DEBUG' ) ) {
 		headers_sent( $file, $line );
 		trigger_error( "{$name} cookie cannot be set - headers already sent by {$file} on line {$line}", E_USER_NOTICE ); // @codingStandardsIgnoreLine
@@ -2507,15 +2503,7 @@ function wc_decimal_to_fraction( $decimal ) {
  * @return float
  */
 function wc_round_discount( $value, $precision ) {
-	if ( version_compare( PHP_VERSION, '5.3.0', '>=' ) ) {
-		return NumberUtil::round( $value, $precision, WC_DISCOUNT_ROUNDING_MODE ); // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctionParameters.round_modeFound
-	}
-
-	if ( PHP_ROUND_HALF_DOWN === WC_DISCOUNT_ROUNDING_MODE ) {
-		return wc_legacy_round_half_down( $value, $precision );
-	}
-
-	return NumberUtil::round( $value, $precision );
+	return NumberUtil::round( $value, $precision, WC_DISCOUNT_ROUNDING_MODE ); // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctionParameters.round_modeFound
 }
 
 /**

--- a/plugins/woocommerce/includes/wc-formatting-functions.php
+++ b/plugins/woocommerce/includes/wc-formatting-functions.php
@@ -233,14 +233,7 @@ function wc_trim_zeros( $price ) {
  */
 function wc_round_tax_total( $value, $precision = null ) {
 	$precision = is_null( $precision ) ? wc_get_price_decimals() : intval( $precision );
-
-	if ( version_compare( PHP_VERSION, '5.3.0', '>=' ) ) {
-		$rounded_tax = NumberUtil::round( $value, $precision, wc_get_tax_rounding_mode() ); // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctionParameters.round_modeFound
-	} elseif ( 2 === wc_get_tax_rounding_mode() ) {
-		$rounded_tax = wc_legacy_round_half_down( $value, $precision );
-	} else {
-		$rounded_tax = NumberUtil::round( $value, $precision );
-	}
+	$rounded_tax = NumberUtil::round( $value, $precision, wc_get_tax_rounding_mode() ); // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctionParameters.round_modeFound
 
 	return apply_filters( 'wc_round_tax_total', $rounded_tax, $value, $precision, WC_TAX_ROUNDING_MODE );
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Remove PHP version checks that were needed due to differences in the behavior of different language or runtime versions, but are no longer relevant because all the checked versions are below 7.4 (the minimum supported PHP version now):

- In the status report (server PHP version display)
- In the abstract CSV exporter (`fputcsv` function)
- In the legacy REST API controllers (`get_raw_data` function)
- In the `wc_setcookie` function
- In the `wc_round_tax_total` function

Also, removed the infrastructure for displaying notices for outdated WordPress and PHP versions (the hardcoded checked versions were quite old anyway).

### How to test the changes in this Pull Request:

##### The wc_round_tax_total function

Run this from the command line and verify that the result is correct and no errors are shown:

```
wp eval "echo wc_round_tax_total(123.45678);"
wp eval "echo wc_round_tax_total(123.45678, 3);"
```

##### The wc_setcookie function

Log out and in from the admin area in your WordPress instance, make sure that everything continues working as usual.


##### The legacy API controllers

First you need to enable the legacy API if you haven't done it already, it's a setting in WooCommerce - Settings - Advanced - Legacy API.

Next, add this to your WooCommerce instance to easily sort out authentication (assuming the admin user id is 1, adjust if that's not the case):

```php
add_filter('woocommerce_api_check_authentication', fn() => get_user_by('id',1));
```

Now run this in the command line and verify that no errors are returned and the coupon is effectively created:

```
curl -X POST http://localhost/wc-api/v3/coupons \
    -H "Content-Type: application/json" \
    -d '{
  "coupon": {
    "code": "new-coupon-2",
    "type": "percent",
    "amount": 10,
    "individual_use": true,
    "product_ids": [],
    "exclude_product_ids": [],
    "usage_limit": "",
    "usage_limit_per_user": "",
    "limit_usage_to_x_items": "",
    "expiry_date": "",
    "enable_free_shipping": false,
    "product_category_ids": [],
    "exclude_product_category_ids": [],
    "exclude_sale_items": true,
    "minimum_amount": "100.00",
    "maximum_amount": "0.00",
    "customer_emails": [],
    "description": ""
  }
}'
```


##### The CSV exporter

Go to Products, click the "Export" button, go through the export process and verify that the generated CSV file is correct.


##### The status report

Go to WooCommerce - Status and verify that the page is rendered properly, in particular the "PHP version" field in "Server environment".


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Remove legacy PHP version update checks

#### Comment

</details>
