### PR TITLE
Add code snippet to add a currency and symbol

### DIFF
--- a/docs/snippets/README.md
+++ b/docs/snippets/README.md
@@ -3,5 +3,6 @@
 Various code snippets you can add to your site to enable custom functionality:
 
 - [Add a message above the login / register form](./before-login--register-form.md)
+- [Add a currency and symbol](./add-a-currency-symbol.md)
 - [Change number of related products output](./number-of-products-per-row.md)
 - [Unhook and remove WooCommerce emails](./unhook--remove-woocommerce-emails.md)

--- a/docs/snippets/add-a-currency-symbol.md
+++ b/docs/snippets/add-a-currency-symbol.md
@@ -1,7 +1,5 @@
 # Add a currency and symbol
 
-> This is a **Developer level** doc. If you are unfamiliar with code and resolving potential conflicts, select a [WooExpert or Developer](https://woocommerce.com/customizations/) for assistance. We are unable to provide support for customizations under our [Support Policy](http://www.woocommerce.com/support-policy/).
-
 Add this code to your child theme’s `functions.php` file or via a plugin that allows custom functions to be added, such as the [Code Snippets](https://wordpress.org/plugins/code-snippets/) plugin. Avoid adding custom code directly to your parent theme’s functions.php file, as this will be wiped entirely when you update the theme.
 
 ```php

--- a/docs/snippets/add-a-currency-symbol.md
+++ b/docs/snippets/add-a-currency-symbol.md
@@ -1,0 +1,40 @@
+# Add a currency and symbol
+
+> This is a **Developer level** doc. If you are unfamiliar with code and resolving potential conflicts, select a [WooExpert or Developer](https://woocommerce.com/customizations/) for assistance. We are unable to provide support for customizations under our [Support Policy](http://www.woocommerce.com/support-policy/).
+
+Add this code to your child theme’s `functions.php` file or via a plugin that allows custom functions to be added, such as the [Code Snippets](https://wordpress.org/plugins/code-snippets/) plugin. Avoid adding custom code directly to your parent theme’s functions.php file, as this will be wiped entirely when you update the theme.
+
+```php
+if ( ! function_exists( 'YOUR_PREFIX_add_currency_name' ) ) {
+  /**
+   * Add custom currency
+   * 
+   * @param array $currencies Existing currencies.
+   * @return array $currencies Updated currencies.
+   */
+  function YOUR_PREFIX_add_currency_name( $currencies ) {
+    $currencies['ABC'] = __( 'Currency name', 'YOUR-TEXTDOMAIN' );
+
+    return $currencies;
+  }
+  add_filter( 'woocommerce_currencies', 'YOUR_PREFIX_add_currency_name' );
+}
+
+if ( ! function_exists( 'YOUR_PREFIX_add_currency_symbol' ) ) {
+  /**
+   * Add custom currency symbol
+   * 
+   * @param string $currency_symbol Existing currency symbols.
+   * @param string $currency Currency code.
+   * @return string $currency_symbol Updated currency symbol(s).
+   */
+  function YOUR_PREFIX_add_currency_symbol( $currency_symbol, $currency ) {
+    switch( $currency ) {
+      case 'ABC': $currency_symbol = '$'; break;
+    }
+
+    return $currency_symbol;
+  }
+  add_filter('woocommerce_currency_symbol', 'YOUR_PREFIX_add_currency_symbol', 10, 2);
+}
+```


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woodocs/issues/100

This PR adds the code snippet [Add a currency and symbol](http://www.woocommerce.com/document/add-a-custom-currency-symbol/) to the Woo docs.

### How to test the changes in this Pull Request:

1. Compare the content of the file docs/snippets/add-a-currency-symbol.md with the content on http://www.woocommerce.com/document/add-a-custom-currency-symbol/.
2. Verify that the new link within docs/snippets/README.md points to the newly added code snippet.