### PR TITLE
Use ternary instead of null coalescing operator to prevent PHP 8.1 deprecation notice

### DIFF
--- a/plugins/woocommerce/changelog/issue-php-81-conversion-of-false-to-array
+++ b/plugins/woocommerce/changelog/issue-php-81-conversion-of-false-to-array
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add defensive check to DataSourcePoller, since we cannot guarantee a transient will return the expected type.

--- a/plugins/woocommerce/src/Admin/DataSourcePoller.php
+++ b/plugins/woocommerce/src/Admin/DataSourcePoller.php
@@ -133,7 +133,10 @@ abstract class DataSourcePoller {
 			$this->merge_specs( $specs_from_data_source, $specs, $url );
 		}
 
-		$specs_group            = get_transient( $this->args['transient_name'] ) ?: array();
+		$specs_group = get_transient( $this->args['transient_name'] );
+		if ( false === $specs_group ) {
+			$specs_group = array();
+		}
 		$locale                 = get_user_locale();
 		$specs_group[ $locale ] = $specs;
 		// Persist the specs as a transient.

--- a/plugins/woocommerce/src/Admin/DataSourcePoller.php
+++ b/plugins/woocommerce/src/Admin/DataSourcePoller.php
@@ -134,7 +134,7 @@ abstract class DataSourcePoller {
 		}
 
 		$specs_group = get_transient( $this->args['transient_name'] );
-		if ( false === $specs_group ) {
+		if ( ! is_array( $specs_group ) ) {
 			$specs_group = array();
 		}
 		$locale                 = get_user_locale();

--- a/plugins/woocommerce/src/Admin/DataSourcePoller.php
+++ b/plugins/woocommerce/src/Admin/DataSourcePoller.php
@@ -133,7 +133,7 @@ abstract class DataSourcePoller {
 			$this->merge_specs( $specs_from_data_source, $specs, $url );
 		}
 
-		$specs_group            = get_transient( $this->args['transient_name'] ) ?? array();
+		$specs_group            = get_transient( $this->args['transient_name'] ) ?: array();
 		$locale                 = get_user_locale();
 		$specs_group[ $locale ] = $specs;
 		// Persist the specs as a transient.


### PR DESCRIPTION
> Deprecated: Automatic conversion of false to array is deprecated

Lots of users have been hitting this error relating to our DataPoller:

```
PHP Deprecated: Automatic conversion of false to array is deprecated in /.../plugins/woocommerce/src/Admin/DataSourcePoller.php on line 141
```

The code in question currently does something like this:

```php
$specs_group = get_transient( $this->args['transient_name'] ) ?? array();
```

However, this only guarantees an array if `get_transient()` returns `null`. Whereas, if the transient is not set, it returns `false`. This change introduces some defensive coding to account for the possibility the returned type is a non-array.

Closes #39708.

### Testing

It's probably easiest for a developer to test this, and use breakpoints to analyze what's happening. I recommend using PHP 8.1+ to see the problem.

- Start with a clean WordPress installation, then install and active WooCommerce.
- Skip setup (onboarding wizard).
- Establish a breakpoint in `src/Admin/DataSourcePoller.php:136`.
- Clear all transients using `wp transient delete-all` (or use an alternative approach if you prefer, so long as all transients are deleted).
- Visit **WooCommerce ▸ Home**.
- This should result in the breakpoint being triggered.
- Notice how, without this change, `$specs_group` will be false and assigning an array element to it results in *automatic conversion of false to array is deprecated* being emitted.
- With this change, that problem should not occur.

### Notes

- The breakpoint may be triggered within a `/wp-json` request, so tools like Query Monitor won't necessarily capture the error (so you'll need to be able to see errors being emitted some other way, whether that's by tailing the PHP error log or something else).
- There may be other 'functional' testing we can do: might need Mothra to fill in the blanks there, but I think the above should suffice.

