### PR TITLE
Skip eslint annotate on fork PRs

### DIFF
--- a/.github/workflows/pr-lint-js.yml
+++ b/.github/workflows/pr-lint-js.yml
@@ -48,7 +48,7 @@ jobs:
 
             - name: Annotate Code Linting Results
               uses: ataylorme/eslint-annotate-action@a1bf7cb320a18aa53cb848a267ce9b7417221526
-
+              if: github.event.pull_request.head.repo.fork != true
               with:
                   repo-token: '${{ secrets.GITHUB_TOKEN }}'
                   report-json: 'combined_eslint_report.json'


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Eslint checks are required but the annotate step fails on community fork PRs. This skips annotation on those PRs so that the required check can pass. We use the "fork" property to check this (buried in [this doc](https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request)).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Testing this is a bit tricky due to the nature of having to have a fork PR and have this branch merged. I suggest that it's probably not worth it to test beyond seeing that the regular lint check still annotates on this PR.

If there are follow up problems we can address them in another PR but I don't foresee that being an issue.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
