### PR TITLE
Add CLI commands to enable or disable HPOS.

### DIFF
--- a/plugins/woocommerce/changelog/fix-cli-hpos-activate
+++ b/plugins/woocommerce/changelog/fix-cli-hpos-activate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add CLI commands to enable or disable HPOS.

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -257,6 +257,7 @@ class CLIRunner {
 	}
 
 	/**
+	 * [Deprecated] Use `wp wc cot sync` instead.
 	 * Copy order data into the postmeta table.
 	 *
 	 * Note that this could dramatically increase the size of your postmeta table, but is recommended
@@ -685,11 +686,7 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 	}
 
 	/**
-	 * Set custom order tables (HPOS) to authoritative if:
-	 * 1. HPOS and posts tables are in sync, or,
-	 * 2. This is a new shop (in this case also create tables).
-	 * and
-	 * 3. All installed WC plugins are compatible.
+	 * Set custom order tables (HPOS) to authoritative if: 1). HPOS and posts tables are in sync, or, 2). This is a new shop (in this case also create tables). Additionally, all installed WC plugins should be compatible.
 	 *
 	 * ## OPTIONS
 	 *

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\DataBase\Migrations\CustomOrderTable;
 use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
 use Automattic\WooCommerce\Internal\DataStores\Orders\DataSynchronizer;
 use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
+use Automattic\WooCommerce\Internal\Features\FeaturesController;
 use WP_CLI;
 
 /**
@@ -60,6 +61,8 @@ class CLIRunner {
 		WP_CLI::add_command( 'wc cot migrate', array( $this, 'migrate' ) );
 		WP_CLI::add_command( 'wc cot sync', array( $this, 'sync' ) );
 		WP_CLI::add_command( 'wc cot verify_cot_data', array( $this, 'verify_cot_data' ) );
+		WP_CLI::add_command( 'wc cot enable', array( $this, 'enable' ) );
+		WP_CLI::add_command( 'wc cot disable', array( $this, 'disable' ) );
 	}
 
 	/**
@@ -669,6 +672,183 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 			$clubbed_data[ $row['entity_id'] ][ $row['meta_key'] ][] = $row['meta_value'];
 		}
 		return $clubbed_data;
+	}
+
+	/**
+	 * Set custom order tables (HPOS) to authoritative if:
+	 * 1. HPOS and posts tables are in sync, or,
+	 * 2. This is a new shop (in this case also create tables).
+	 * and
+	 * 3. All installed WC plugins are compatible.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--for-new-shop]
+	 * : Enable only if this is a new shop, irrespective of whether tables are in sync.
+	 * ---
+	 * default: false
+	 * ---
+	 *
+	 * [--with-sync]
+	 * : Also enables sync (if it's currently not enabled).
+	 * ---
+	 * default: false
+	 * ---
+	 *
+	 * ### EXAMPLES
+	 *
+	 *      # Enable HPOS on new shops.
+	 *      wp wc cot enable --for-new-shop
+	 *
+	 * @param array $args Positional arguments passed to the command.
+	 * @param array $assoc_args Associative arguments (options) passed to the command.
+	 *
+	 * @return void
+	 */
+	public function enable( array $args = array(), array $assoc_args = array() ) {
+		$assoc_args = wp_parse_args(
+			$assoc_args,
+			array(
+				'for-new-shop' => false,
+				'with-sync'    => false,
+			)
+		);
+
+		$enable_hpos = true;
+		WP_CLI::log( __( 'Running pre-enable checks...', 'woocommerce' ) );
+
+		$is_new_shop = \WC_Install::is_new_install();
+		if ( $assoc_args['for-new-shop'] && ! $is_new_shop ) {
+			WP_CLI::warning( __( '[Failed] This is not a new shop, but --for-new-shop flag was passed.', 'woocommerce' ) );
+			$enable_hpos = false;
+		}
+
+		/** Feature controller instance @var FeaturesController $feature_controller */
+		$feature_controller = wc_get_container()->get( FeaturesController::class );
+		$plugin_info        = $feature_controller->get_compatible_plugins_for_feature( 'custom_order_tables', true );
+		if ( count( array_merge( $plugin_info['uncertain'], $plugin_info['incompatible'] ) ) > 0 ) {
+			WP_CLI::warning( __( '[Failed] Some installed plugins are incompatible. Please review the plugins by going to WooCommerce > Settings > Advanced > Features and see the Data storage for orders section.', 'woocommerce' ) );
+			$enable_hpos = false;
+		}
+
+		/** DataSynchronizer instance @var DataSynchronizer $data_synchronizer */
+		$data_synchronizer = wc_get_container()->get( DataSynchronizer::class );
+		$pending_orders    = $data_synchronizer->get_total_pending_count();
+		$table_exists      = $data_synchronizer->check_orders_table_exists();
+
+		if ( ! $table_exists ) {
+			WP_CLI::warning( __( 'Orders table does not exist. Creating...', 'woocommerce' ) );
+			if ( $is_new_shop || 0 === $pending_orders ) {
+				$data_synchronizer->create_database_tables();
+				if ( $data_synchronizer->check_orders_table_exists() ) {
+					WP_CLI::log( __( 'Orders table created.', 'woocommerce' ) );
+					$table_exists = true;
+				} else {
+					WP_CLI::warning( __( '[Failed] Orders table could not be created.', 'woocommerce' ) );
+					$enable_hpos = false;
+				}
+			} else {
+				WP_CLI::warning( __( '[Failed] The orders table does not exist and this is not a new shop. Please create the table by going to WooCommerce > Settings > Advanced > Features and enabling sync.', 'woocommerce' ) );
+				$enable_hpos = false;
+			}
+		}
+
+		if ( $pending_orders > 0 ) {
+			WP_CLI::warning(
+				sprintf(
+					// translators: %s is the command to run (wp wc cot sync).
+					__( '[Failed] There are orders pending sync. Please run `%s` to sync pending orders.', 'woocommerce' ),
+					'wp wc cot sync',
+				)
+			);
+			$enable_hpos = false;
+		}
+
+		if ( $assoc_args['with-sync'] && $table_exists ) {
+			if ( $data_synchronizer->data_sync_is_enabled() ) {
+				WP_CLI::warning( __( 'Sync is already enabled.', 'woocommerce' ) );
+			} else {
+				$feature_controller->change_feature_enable( DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION, true );
+				WP_CLI::log( __( 'Sync enabled.', 'woocommerce' ) );
+			}
+		}
+
+		if ( ! $enable_hpos ) {
+			WP_CLI::error( __( 'HPOS could not be enabled, see the errors above', 'woocommerce' ) );
+			return;
+		}
+
+		/** CustomOrdersTableController instance @var CustomOrdersTableController $cot_status */
+		$cot_status = wc_get_container()->get( CustomOrdersTableController::class );
+		if ( $cot_status->custom_orders_table_usage_is_enabled() ) {
+			WP_CLI::warning( __( 'HPOS is already enabled.', 'woocommerce' ) );
+		} else {
+			$feature_controller->change_feature_enable( 'custom_order_tables', true );
+			WP_CLI::log( __( 'HPOS enabled.', 'woocommerce' ) );
+		}
+	}
+
+	/**
+	 * Disables custom order tables (HPOS) and posts to authoritative if HPOS and post tables are in sync.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--with-sync]
+	 * : Also disables sync (if it's currently enabled).
+	 * ---
+	 * default: false
+	 * ---
+	 *
+	 * ### EXAMPLES
+	 *
+	 *  # Disable HPOS.
+	 *  wp wc cot disable
+	 *
+	 * @param array $args Positional arguments passed to the command.
+	 * @param array $assoc_args Associative arguments (options) passed to the command.
+	 */
+	public function disable( $args, $assoc_args ) {
+		$assoc_args = wp_parse_args(
+			$assoc_args,
+			array(
+				'with-sync' => false,
+			)
+		);
+
+		WP_CLI::log( __( 'Running pre-disable checks...', 'woocommerce' ) );
+
+		/** DataSynchronizer instance @var DataSynchronizer $data_synchronizer */
+		$data_synchronizer = wc_get_container()->get( DataSynchronizer::class );
+		$pending_orders    = $data_synchronizer->get_total_pending_count();
+		if ( $pending_orders > 0 ) {
+			return WP_CLI::error(
+				sprintf(
+					// translators: %s is the command to run (wp wc cot sync).
+					__( '[Failed] There are orders pending sync. Please run `%s` to sync pending orders.', 'woocommerce' ),
+					'wp wc cot sync',
+				)
+			);
+		}
+
+		/** FeaturesController instance @var FeaturesController $feature_controller */
+		$feature_controller = wc_get_container()->get( FeaturesController::class );
+
+		/** CustomOrdersTableController instance @var CustomOrdersTableController $cot_status */
+		$cot_status = wc_get_container()->get( CustomOrdersTableController::class );
+		if ( ! $cot_status->custom_orders_table_usage_is_enabled() ) {
+			WP_CLI::warning( __( 'HPOS is already disabled.', 'woocommerce' ) );
+		} else {
+			$feature_controller->change_feature_enable( 'custom_order_tables', false );
+			WP_CLI::log( __( 'HPOS disabled.', 'woocommerce' ) );
+		}
+
+		if ( $assoc_args['with-sync'] ) {
+			if ( ! $data_synchronizer->data_sync_is_enabled() ) {
+				return WP_CLI::warning( __( 'Sync is already enabled.', 'woocommerce' ) );
+			}
+			$feature_controller->change_feature_enable( DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION, false );
+			WP_CLI::log( __( 'Sync disabled.', 'woocommerce' ) );
+		}
 	}
 
 }

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -469,6 +469,7 @@ class CustomOrdersTableController {
 		$plugin_incompat_warning = $this->plugin_util->generate_incompatible_plugin_feature_warning( 'custom_order_tables', $plugin_info );
 		$sync_complete           = 0 === $sync_status['current_pending_count'];
 		$disabled_option         = array();
+		// Changing something here? might also want to look at `enable|disable` functions in CLIRunner.
 		if ( count( array_merge( $plugin_info['uncertain'], $plugin_info['incompatible'] ) ) > 0 ) {
 			$disabled_option = array( 'yes' );
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR introduces two new CLI commands to enable and disable and HPOS:

1. `wp wc cot enable`: Enables the HPOS after checking that there are no orders pending sync and that there is no incompatible plugin installed. Supports two params: `--for-new-shop` for enabling only if this is a new shop (useful for hosts who wants to rollout HPOS on new shops only) and `--with-sync` which also enables sync along with HPOS.
2. `wp wc cot disable`: Disables HPOS after checking that there are no orders pending sync. Also supports `--with-sync` param that also disables sync.

These CLI commands are useful for hosts (such as us) who plans to do gradual rollout.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Start with posts authoritative and sync off. Create one order so that there is at least one order pending sync.
1. Run `wp wc cot enable --for-new-shop`. This should show an error that this is not a new shop.
1. Run `wp wc cot enable`. This should show an error that there are orders pending sync.
1. Add an incompatible plugin, such as [smooth generator 1.0.4](https://github.com/woocommerce/wc-smooth-generator/releases/tag/1.0.4) and run `wp wc cot enable`. This should show an error that incompatible plugins are installed.
1. Deactivate smooth generator and run `wp wc cot sync` to sync orders. Run `wp wc cot enable`, this time it will be enabled, but without sync.
2. Run `wp wc cot enable --with-sync`, it should say that HPOS is already enabled, and sync will be enabled.
3. Run `wp wc cot disable`, this should disable HPOS.
4. Run ` wp wc cot disable --with-sync`, this should say that HPOS is already disabled, and sync will be disabled.

1. On a new shop, run `wp wc cot enable --for-new-shop`, this should enable HPOS without sync (and will create orders table in the process.
2. On the same new shop, running `wp wc cot disable` should disable HPOS again.
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
