### PR TITLE
Fix description toolbar

### DIFF
--- a/packages/js/product-editor/changelog/fix-39868_description_toolbar
+++ b/packages/js/product-editor/changelog/fix-39868_description_toolbar
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix positioning of fixed block toolbar in IFrame editor used for product description, to make work with latest WordPress versions.

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.scss
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.scss
@@ -1,39 +1,40 @@
 .woocommerce-iframe-editor__header-toolbar {
-    height: 60px;
-    border: 0;
-    border-bottom: 1px solid $gray-400;
-    display: flex;
-    align-items: center;
+	height: 60px;
+	border: 0;
+	border-bottom: 1px solid $gray-400;
+	display: flex;
+	align-items: center;
 	justify-content: space-between;
 
-    .woocommerce-iframe-editor__header-toolbar-inserter-toggle.components-button.has-icon {
-        height: 32px;
-        margin-right: 8px;
-        min-width: 32px;
-        padding: 0;
-        width: 32px;
+	.woocommerce-iframe-editor__header-toolbar-inserter-toggle.components-button.has-icon {
+		height: 32px;
+		margin-right: 8px;
+		min-width: 32px;
+		padding: 0;
+		width: 32px;
 
-        svg {
-            transition: transform .2s cubic-bezier(.165,.84,.44,1);
-        }
+		svg {
+			transition: transform 0.2s cubic-bezier(0.165, 0.84, 0.44, 1);
+		}
 
-        &.is-pressed:before {
-            width: 100%;
-            left: 0;
-        }
+		&.is-pressed:before {
+			width: 100%;
+			left: 0;
+		}
 
-        &.is-pressed svg {
-            transform: rotate(45deg);
-        }
-    }
+		&.is-pressed svg {
+			transform: rotate(45deg);
+		}
+	}
 
-    &-left {
-        padding-left: $gap-small;
-    }
+	&-left {
+		padding-left: $gap-small;
+	}
 	&-right {
 		display: flex;
 		justify-content: center;
 		align-items: center;
+		gap: $gap-smaller;
 		> .components-dropdown-menu {
 			margin-right: $gap-small;
 			width: 48px;
@@ -47,8 +48,7 @@
 		}
 		button.woocommerce-modal-actions__done-button,
 		button.woocommerce-modal-actions__cancel-button {
-			margin-left: $gap-smaller;
 			height: $gap-larger - $gap-smallest;
 		}
-    }
+	}
 }

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
@@ -7,7 +7,6 @@ import { __ } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
 import {
 	createElement,
-	Fragment,
 	useRef,
 	useCallback,
 	useContext,
@@ -46,7 +45,6 @@ export function HeaderToolbar( {
 }: HeaderToolbarProps ) {
 	const { isInserterOpened, setIsInserterOpened } =
 		useContext( EditorContext );
-	const isWideViewport = useViewportMatch( 'wide' );
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const inserterButton = useRef< HTMLButtonElement | null >( null );
 	const { isInserterEnabled, isTextModeEnabled } = useSelect( ( select ) => {

--- a/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/header-toolbar/header-toolbar.tsx
@@ -115,19 +115,15 @@ export function HeaderToolbar( {
 					}
 					showTooltip
 				/>
-				{ isWideViewport && (
-					<>
-						{ isLargeViewport && (
-							<ToolbarItem
-								as={ ToolSelector }
-								disabled={ isTextModeEnabled }
-							/>
-						) }
-						<ToolbarItem as={ EditorHistoryUndo } />
-						<ToolbarItem as={ EditorHistoryRedo } />
-						<ToolbarItem as={ DocumentOverview } />
-					</>
+				{ isLargeViewport && (
+					<ToolbarItem
+						as={ ToolSelector }
+						disabled={ isTextModeEnabled }
+					/>
 				) }
+				<ToolbarItem as={ EditorHistoryUndo } />
+				<ToolbarItem as={ EditorHistoryRedo } />
+				<ToolbarItem as={ DocumentOverview } />
 			</div>
 			<div className="woocommerce-iframe-editor__header-toolbar-right">
 				<ToolbarItem

--- a/packages/js/product-editor/src/components/iframe-editor/iframe-editor.scss
+++ b/packages/js/product-editor/src/components/iframe-editor/iframe-editor.scss
@@ -1,8 +1,8 @@
 .woocommerce-iframe-editor {
 	box-sizing: border-box;
 	display: flex;
-    flex-direction: column;
-    height: 100%;
+	flex-direction: column;
+	height: 100%;
 
 	&__main {
 		align-items: flex-start;
@@ -55,5 +55,15 @@
 		border-bottom: 1px solid $gray-400;
 		border-right: 1px solid $gray-400;
 		box-sizing: border-box;
+		margin-left: 0px;
+		width: 100%;
+		> .block-editor-block-toolbar.is-showing-movers:before {
+			display: none;
+		}
+
+		.block-editor-block-toolbar__group-expand-fixed-toolbar,
+		.block-editor-block-toolbar__group-collapse-fixed-toolbar {
+			display: none;
+		}
 	}
 }

--- a/packages/js/product-editor/src/components/iframe-editor/iframe-editor.scss
+++ b/packages/js/product-editor/src/components/iframe-editor/iframe-editor.scss
@@ -57,6 +57,7 @@
 		box-sizing: border-box;
 		margin-left: 0px;
 		width: 100%;
+		min-height: 47px;
 		> .block-editor-block-toolbar.is-showing-movers:before {
 			display: none;
 		}

--- a/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import classNames from 'classnames';
 import { BlockInstance } from '@wordpress/blocks';
 import { Popover } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -90,11 +89,7 @@ export function IframeEditor( {
 	const settings = __settings || parentEditorSettings;
 
 	return (
-		<div
-			className={ classNames( 'woocommerce-iframe-editor', {
-				'has-fixed-toolbar': true,
-			} ) }
-		>
+		<div className="woocommerce-iframe-editor">
 			<EditorContext.Provider
 				value={ {
 					hasRedo,

--- a/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
+++ b/packages/js/product-editor/src/components/iframe-editor/iframe-editor.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classNames from 'classnames';
 import { BlockInstance } from '@wordpress/blocks';
 import { Popover } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -89,7 +90,11 @@ export function IframeEditor( {
 	const settings = __settings || parentEditorSettings;
 
 	return (
-		<div className="woocommerce-iframe-editor">
+		<div
+			className={ classNames( 'woocommerce-iframe-editor', {
+				'has-fixed-toolbar': true,
+			} ) }
+		>
 			<EditorContext.Provider
 				value={ {
 					hasRedo,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Before:
<img width="1315" alt="Screenshot 2023-08-22 at 2 05 16 PM" src="https://github.com/woocommerce/woocommerce/assets/2240960/f00c98b7-4c81-4b0d-8611-f4c73e9b0fb3">

After:
<img width="653" alt="Screenshot 2023-08-23 at 5 25 23 PM" src="https://github.com/woocommerce/woocommerce/assets/2240960/732f818a-74b9-49b0-adaa-d627049f57d1">


### Changes proposed in this Pull Request:

This fixes an CSS conflict with WP 6.3 where the fixed block toolbar got moved up to the add block toolbar. Instead of using this same approach, I decided to go with our original view and make sure it still shows up underneath the other header instead of inline.
Reasons why I didn't adjust to the new WP 6.3 approach (for now):
- We have to use `absolute` for our header because it is in a Modal, while WP uses `fixed`. This causes a couple issues:
     - The parent element contains `overflow: hidden`, so we have to set it to `visible` in order to have the toolbar show. The `overflow: hidden` does seem to have a purpose and may surface some old bugs if we change it to `visible`.
     - We have to re-align the toolbar `left` css when either the 'add block' or 'document overview' panels are open on the left side. This is not an issue in WP, as it uses `fixed`.
- Using `fixed` seems unreliable, as we display it within a Modal and I was getting slightly different alignments between Chrome & Safari.

Closes #39868  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Load a new website with WP 6.3 and this branch
2. Enable the **New Product Block Editor** Under **WooCommerce > Settings > Advanced > Features**
3. Go to **Products > Add New**
4. Scroll down to description and click **Add description**
5. A empty header should show underneath the `Add block` header
6. Click inside of one of the paragraphs, the block tools should correctly show up within that header now.
7. Now install the **WP Downgrade** plugin and activate it
8. Click **Settings** on the **WP Downgrade** list and set WP to 6.2.2
9. Go to **Dashboard Updates** and re-install, so 6.2.2 gets installed
10. Go back to the **Add description** modal, the block toolbar header should still look and act the same.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
