### PR TITLE
Prevent non-WC_Orders on the order received page

### DIFF
--- a/plugins/woocommerce/changelog/BL-prevent-non-orders-on-order-received-page
+++ b/plugins/woocommerce/changelog/BL-prevent-non-orders-on-order-received-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+No longer fatals on order-received page when provided with the id of a refund

--- a/plugins/woocommerce/changelog/BL-prevent-non-orders-on-order-received-page
+++ b/plugins/woocommerce/changelog/BL-prevent-non-orders-on-order-received-page
@@ -1,4 +1,4 @@
-Significance: patch
+Significance: minor
 Type: fix
 
-No longer fatals on order-received page when provided with the id of a refund
+Avoid a fatal error on the order received page if the order ID is not for a valid order.

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -271,7 +271,7 @@ class WC_Shortcode_Checkout {
 		if ( $order_id > 0 ) {
 			$order = wc_get_order( $order_id );
 
-			if ( ! $order || ! hash_equals( $order->get_order_key(), $order_key ) ) {
+			if ( ( ! $order instanceof WC_Order ) || ! hash_equals( $order->get_order_key(), $order_key ) ) {
 				$order = false;
 			}
 		}

--- a/plugins/woocommerce/includes/wc-cart-functions.php
+++ b/plugins/woocommerce/includes/wc-cart-functions.php
@@ -185,7 +185,7 @@ function wc_clear_cart_after_payment() {
 	if ( WC()->session->order_awaiting_payment > 0 ) {
 		$order = wc_get_order( WC()->session->order_awaiting_payment );
 
-		if ( $order && $order->get_id() > 0 ) {
+		if ( $order instanceof WC_Order && $order->get_id() > 0 ) {
 			// If the order has not failed, or is not pending, the order must have gone through.
 			if ( ! $order->has_status( array( 'failed', 'pending', 'cancelled' ) ) ) {
 				WC()->cart->empty_cart();

--- a/plugins/woocommerce/includes/wc-cart-functions.php
+++ b/plugins/woocommerce/includes/wc-cart-functions.php
@@ -176,7 +176,7 @@ function wc_clear_cart_after_payment() {
 		if ( $order_id > 0 ) {
 			$order = wc_get_order( $order_id );
 
-			if ( $order && hash_equals( $order->get_order_key(), $order_key ) ) {
+			if ( $order instanceof WC_Order && hash_equals( $order->get_order_key(), $order_key ) ) {
 				WC()->cart->empty_cart();
 			}
 		}


### PR DESCRIPTION
Greetings 👋 

We saw some fatal errors in our logs, that we could trace back to a WooCommerce function. I did not see an issue for what we found, so we decided to just create a community patch.

I did not see any unit tests, so did not contribute there. If they do exist, do let me know, and I'll see if I can add this particular case.

If you'd like for an issue to exist. Just point me to where to create it, and I'll act 🙂 .

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

I'm unsure how, but we were seeing visits to the order-received page, with the post id of a refund. I'd expect this to result in an unspecific order-received page. but we got a fatal error instead. I investigated on a clean install, these are my findings:

![Checkout_-_bobLocalTestSite](https://github.com/boblinthorst/woocommerce/assets/11849359/c250d0af-8e2e-4f4a-9b90-aed353049878)

![Checkout_-_bobLocalTestSite-3](https://github.com/boblinthorst/woocommerce/assets/11849359/ce557052-9b3a-4ef1-8c91-6af289ab914f)

![WordPress_›_Error](https://github.com/boblinthorst/woocommerce/assets/11849359/2446ef7e-b3d9-4517-82a8-dc38502d7414)

We think it would be better if this case respons similarly to the non-order cases, so that's what this PR is intended to achieve.

<!--- Closes # . -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

***Preconditions:***

Have performed an order and a refund of that order.

***Actions***
Visit `$site/checkout/order-received/$order_id/`, where $order_id is the post ID of the refund.

***Validation***
Before this PR, this would result in a fatal error, ensure it now results in a generic order confirmation page.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Avoid a fatal error on the order received page if the order ID is not for a valid order.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>