### PR TITLE
Temporary solution to avoid extra queries from WooPayments incentives

### DIFF
--- a/plugins/woocommerce/changelog/fix-wcpay-incentive-dismissed-queries
+++ b/plugins/woocommerce/changelog/fix-wcpay-incentive-dismissed-queries
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Temporary fix to WooPayments incentives logic to do extra order queries when an incentive has been dismissed.
+
+

--- a/plugins/woocommerce/changelog/fix-wcpay-incentive-dismissed-queries
+++ b/plugins/woocommerce/changelog/fix-wcpay-incentive-dismissed-queries
@@ -1,5 +1,5 @@
 Significance: patch
 Type: fix
-Comment: Temporary fix to WooPayments incentives logic to do extra order queries when an incentive has been dismissed.
+Comment: Temporary fix to avoid doing extra order queries when a WooPayments incentive has been dismissed.
 
 

--- a/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
+++ b/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
@@ -69,7 +69,7 @@ class WcPayWelcomePage {
 		}
 
 		// Temporary solution until we improve the dismiss and cache logic.
-		if (false !== get_option( 'wcpay_welcome_page_incentives_dismissed', false )) {
+		if ( false !== get_option( 'wcpay_welcome_page_incentives_dismissed', false ) ) {
 			return false;
 		}
 
@@ -160,7 +160,7 @@ class WcPayWelcomePage {
 		}
 
 		// Return early if the incentive must not be visible.
-		if ( !$this->must_be_visible() ) {
+		if ( ! $this->must_be_visible() ) {
 			return $settings;
 		}
 
@@ -177,7 +177,7 @@ class WcPayWelcomePage {
 	 */
 	public function allowed_promo_notes( $promo_notes = [] ): array {
 		// Return early if the incentive must not be visible.
-		if ( !$this->must_be_visible() ) {
+		if ( ! $this->must_be_visible() ) {
 			return $promo_notes;
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
+++ b/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
@@ -68,6 +68,11 @@ class WcPayWelcomePage {
 			return false;
 		}
 
+		// Temporary solution until we improve the dismiss and cache logic.
+		if (false !== get_option( 'wcpay_welcome_page_incentives_dismissed', false )) {
+			return false;
+		}
+
 		// The WooPayments plugin must not be active.
 		if ( $this->is_wcpay_active() ) {
 			return false;
@@ -154,8 +159,8 @@ class WcPayWelcomePage {
 			return $settings;
 		}
 
-		// Return early if there is no eligible incentive.
-		if ( empty( $this->get_incentive() ) ) {
+		// Return early if the incentive must not be visible.
+		if ( !$this->must_be_visible() ) {
 			return $settings;
 		}
 
@@ -171,8 +176,8 @@ class WcPayWelcomePage {
 	 * @return array
 	 */
 	public function allowed_promo_notes( $promo_notes = [] ): array {
-		// Return early if there is no eligible incentive.
-		if ( empty( $this->get_incentive() ) ) {
+		// Return early if the incentive must not be visible.
+		if ( !$this->must_be_visible() ) {
 			return $promo_notes;
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

After dismissing a WooPayments incentive we still do some WC order queries while checking for dismissed and cached incentives. This temporary solution skip that when any incentive has been dismissed. Preventing any performance issue for sites with plenty of orders.

Adds an early check for `wcpay_welcome_page_incentives_dismissed` in `must_be_visible`, and updates both `shared_settings` and `allowed_promo_notes` to use `must_be_visible` rather than `get_incentive` for early exit, avoiding any unnecessary SQL query.

This temporary fix is intended to target WooCommerce 8.0.3, while we work on a better solution for 8.1.

### How to test the changes in this Pull Request:

>[!Note]
>We need to check the existance of a SQL query, you can use [Query Monitor](https://wordpress.org/plugins/query-monitor/) or any other similar option.

#### No more order queries after dismissing an incentive
- Create a new JN site with WC from thins PR branch.
- **Payments (1)** menu should be visible.
- The following SQL query **should be** in the logs.
- Dismiss the incentive by clicking on `No thanks`, and wait for the page to reload.
- Refresh, and confirm that the following SQL query **has not been** executed.

#### Incentive applied as expected
- Remove `wcpay_welcome_page_incentives_dismissed` option to get the incentive again.
- Go to **Payments (1)** and finish the onboarding process by following [test onboarding instructions](https://woocommerce.com/document/woopayments/testing-and-troubleshooting/dev-mode/).
- Confirm that the incentive fee is applied by checking **Active discounts** under **Payments > Overview**.

**SQL query:**
Searching for `_payment_method` should be enough to find it in the monitor.
```sql
SELECT wp_posts.ID
FROM wp_posts INNER JOIN wp_postmeta ON ( wp_posts.ID = wp_postmeta.post_id )
WHERE 1=1 AND ( 
( wp_postmeta.meta_key = '_payment_method' AND wp_postmeta.meta_value = 'woocommerce_payments' )
) AND wp_posts.post_type IN ('shop_order', 'shop_order_refund') AND ((wp_posts.post_status = 'wc-pending' OR wp_posts.post_status = 'wc-processing' OR wp_posts.post_status = 'wc-on-hold' OR wp_posts.post_status = 'wc-completed' OR wp_posts.post_status = 'wc-cancelled' OR wp_posts.post_status = 'wc-refunded' OR wp_posts.post_status = 'wc-failed' OR wp_posts.post_status = 'wc-checkout-draft'))
GROUP BY wp_posts.ID
ORDER BY wp_posts.post_date DESC
LIMIT 0, 1
```
