### PR TITLE
Update WooCommerce Blocks to 10.9.3

### DIFF
--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-10.9.3
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-10.9.3
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update WooCommerce Blocks to 10.9.3

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -23,7 +23,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.6.2",
-		"woocommerce/woocommerce-blocks": "10.9.2"
+		"woocommerce/woocommerce-blocks": "10.9.3"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.3.0",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "43fee812be15bb01611597d4aee7b721",
+    "content-hash": "0fbbf35adfe8924174d461ce53cfe1c6",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1004,16 +1004,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "10.9.2",
+            "version": "10.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "ce9c852dc5d468a45e6e6ea3868ee86cfc05ac74"
+                "reference": "c9b6f46758f446b21cfd9f98ae1d2ca714effbc3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/ce9c852dc5d468a45e6e6ea3868ee86cfc05ac74",
-                "reference": "ce9c852dc5d468a45e6e6ea3868ee86cfc05ac74",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/c9b6f46758f446b21cfd9f98ae1d2ca714effbc3",
+                "reference": "c9b6f46758f446b21cfd9f98ae1d2ca714effbc3",
                 "shasum": ""
             },
             "require": {
@@ -1062,9 +1062,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v10.9.2"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v10.9.3"
             },
-            "time": "2023-08-21T16:51:12+00:00"
+            "time": "2023-08-24T20:50:04+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 10.9.3. This is intended to be merged into WooCommerce 8.1.

## Blocks 10.9.3

* https://github.com/woocommerce/woocommerce-blocks/pull/10725
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/v10.9.3/docs/internal-developers/testing/releases/1093.md)

### Changelog entry

#### Bug Fixes

- Add to Cart: fix the problem that variable products couldn't be added to cart (https://github.com/woocommerce/woocommerce-blocks/pull/10723)

****