### PR TITLE
Record plugin api and install failures to coreprofiler_install_plugin_error track

### DIFF
--- a/plugins/woocommerce/changelog/update-39699-track-plugin-failure-separately-for-core-profiler
+++ b/plugins/woocommerce/changelog/update-39699-track-plugin-failure-separately-for-core-profiler
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Records plugin API requests and installation errors to coreprofiler_install_plugin_error separately for the core profiler.

--- a/plugins/woocommerce/src/Admin/API/OnboardingPlugins.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingPlugins.php
@@ -148,6 +148,8 @@ class OnboardingPlugins extends WC_REST_Data_Controller {
 				true
 			);
 		}
+		add_action( 'woocommerce_plugins_install_error', array( $this, 'log_plugins_install_error' ), 10, 4 );
+		add_action( 'woocommerce_plugins_install_api_error', array( $this, 'log_plugins_install_api_error' ), 10, 2 );
 	}
 
 	/**
@@ -410,5 +412,42 @@ class OnboardingPlugins extends WC_REST_Data_Controller {
 				),
 			),
 		);
+	}
+
+	public function log_plugins_install_error( $slug, $api, $result, $upgrader ) {
+		$properties = array(
+			'error_message'         => sprintf(
+			/* translators: %s: plugin slug (example: woocommerce-services) */
+				__(
+					'The requested plugin `%s` could not be installed.',
+					'woocommerce'
+				),
+				$slug
+			),
+			'type'				    => 'plugin_info_api_error',
+			'slug'                  => $slug,
+			'api_version'           => $api->version,
+			'api_download_link'     => $api->download_link,
+			'upgrader_skin_message' => implode( ',', $upgrader->skin->get_upgrade_messages() ),
+			'result'                => is_wp_error( $result ) ? $result->get_error_message() : 'null',
+		);
+		wc_admin_record_tracks_event( 'coreprofiler_install_plugin_error', $properties );
+	}
+
+	public function log_plugins_install_api_error( $slug, $api ) {
+		$properties = array(
+			'error_message'     => sprintf(
+			// translators: %s: plugin slug (example: woocommerce-services).
+				__(
+					'The requested plugin `%s` could not be installed. Plugin API call failed.',
+					'woocommerce'
+				),
+				$slug
+			),
+			'type'              => 'plugin_install_error',
+			'api_error_message' => $api->get_error_message(),
+			'slug'              => $slug,
+		);
+		wc_admin_record_tracks_event( 'coreprofiler_install_plugin_error', $properties );
 	}
 }

--- a/plugins/woocommerce/src/Admin/API/OnboardingPlugins.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingPlugins.php
@@ -148,6 +148,7 @@ class OnboardingPlugins extends WC_REST_Data_Controller {
 				true
 			);
 		}
+		
 		add_action( 'woocommerce_plugins_install_error', array( $this, 'log_plugins_install_error' ), 10, 4 );
 		add_action( 'woocommerce_plugins_install_api_error', array( $this, 'log_plugins_install_api_error' ), 10, 2 );
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #39699  .

This PR records plugin API requests and installation errors to `coreprofiler_install_plugin_error` separately for the core profiler.




<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

To test this PR without manually changing the code, we'll use the following plugins. Please download and install them without activation.

1.[ Log WC_Track::record PHP requests](https://gist.github.com/moon0326/d3c41945266d8cadbbe5060fdf873402)
2. [Add -invalid to plugin slugs](https://gist.github.com/moon0326/277abdee7854881747cd29fb0ccc7158)
3. [Make an empty file in plugins/mailpoet](https://gist.github.com/moon0326/54fcc1a81616c4ad7dfaa0adc2224176) 

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

### Testing plugin_info_api_error errors

1. Create a new JN site and start the core profiler.
2. Proceed to the plugins page.
4. Activate `Add -invalid to plugin slugs` and `Log WC_Track::record PHP requests` plugins
5. Click `Continue` button.
6. Installation should fail and you see an error message.
7. Go to `WooCommerce -> Status -> Logs` and search for `wc-track-2023-MM-DD' log and click `View`
8. You should see logs with `[type] => plugin_install_error` value.

### Testing plugin_install_error errors

1. This test requires a new JN site. Please create a new JN site again.
2. Install `Log WC_Track::record PHP requests` and `Make an empty file in plugins/mailpoet` plugins, but do not activate them yet.
3. Start the core profiler and proceed to the plugins page.
4. Enable both `Log WC_Track::record PHP requests` and `Make an empty file in plugins/mailpoet` plugins.
5. Make sure to check `Mailpoet` plugin and click `Continue` button.
6. Mailpoet installation will fail and you'll see an error message.
7. Go to `WooCommerce -> Status -> Logs` and search for `wc-track-2023-MM-DD' log and click `View`
8. You should see logs with `[type] => plugin_install_error` value.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message 

Records plugin API requests and installation errors to coreprofiler_install_plugin_error separately for the core profiler. 

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
