### PR TITLE
Marketplace: Add the query parameters to product page URLs

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/product-card/product-card.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/product-card/product-card.tsx
@@ -9,7 +9,6 @@ import { Card } from '@wordpress/components';
  */
 import './product-card.scss';
 import { Product } from '../product-list/types';
-import { appendUTMParams } from '../../utils/functions';
 
 export interface ProductCardProps {
 	type?: string;
@@ -21,21 +20,14 @@ function ProductCard( props: ProductCardProps ): JSX.Element {
 	// We hardcode this for now while we only display prices in USD.
 	const currencySymbol = '$';
 
-	// Append UTM parameters to the vendor URL
-	let vendorUrl = '';
-	if ( product.vendorUrl ) {
-		vendorUrl = appendUTMParams( product.vendorUrl, [
-			[ 'utm_source', 'extensionsscreen' ],
-			[ 'utm_medium', 'product' ],
-			[ 'utm_campaign', 'wcaddons' ],
-			[ 'utm_content', 'devpartner' ],
-		] );
-	}
-
 	let productVendor: string | JSX.Element | null = product?.vendorName;
 	if ( product?.vendorName && product?.vendorUrl ) {
 		productVendor = (
-			<a href={ vendorUrl } target="_blank" rel="noopener noreferrer">
+			<a
+				href={ product.vendorUrl }
+				target="_blank"
+				rel="noopener noreferrer"
+			>
 				{ product.vendorName }
 			</a>
 		);

--- a/plugins/woocommerce-admin/client/marketplace/components/product-list-content/product-list-content.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/product-list-content/product-list-content.tsx
@@ -4,14 +4,17 @@
 import './product-list-content.scss';
 import ProductCard from '../product-card/product-card';
 import { Product } from '../product-list/types';
+import { appendURLParams } from '../../utils/functions';
+import { getAdminSetting } from '../../../utils/admin-settings';
 
 export default function ProductListContent( props: {
 	products: Product[];
 } ): JSX.Element {
-	const { products } = props;
+	const wccomHelperSettings = getAdminSetting( 'wccomHelper', {} );
+
 	return (
 		<div className="woocommerce-marketplace__product-list-content">
-			{ products.map( ( product ) => (
+			{ props.products.map( ( product ) => (
 				<ProductCard
 					key={ product.id }
 					type="classic"
@@ -19,9 +22,19 @@ export default function ProductListContent( props: {
 						title: product.title,
 						icon: product.icon,
 						vendorName: product.vendorName,
-						vendorUrl: product.vendorUrl,
+						vendorUrl: appendURLParams( product.vendorUrl, [
+							[ 'utm_source', 'extensionsscreen' ],
+							[ 'utm_medium', 'product' ],
+							[ 'utm_campaign', 'wcaddons' ],
+							[ 'utm_content', 'devpartner' ],
+						] ),
 						price: product.price,
-						url: product.url,
+						url: appendURLParams(
+							product.url,
+							Object.entries(
+								wccomHelperSettings.inAppPurchaseURLParams
+							)
+						),
 						description: product.description,
 					} }
 				/>

--- a/plugins/woocommerce-admin/client/marketplace/utils/functions.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/utils/functions.tsx
@@ -60,7 +60,7 @@ function fetchCategories(): Promise< CategoryAPIItem[] > {
 }
 
 // Append UTM parameters to a URL, being aware of existing query parameters
-const appendUTMParams = (
+const appendURLParams = (
 	url: string,
 	utmParams: Array< [ string, string ] >
 ): string => {
@@ -78,5 +78,5 @@ export {
 	fetchDiscoverPageData,
 	fetchCategories,
 	ProductGroup,
-	appendUTMParams,
+	appendURLParams,
 };

--- a/plugins/woocommerce/changelog/wccom-17911-marketplace-query-args-header
+++ b/plugins/woocommerce/changelog/wccom-17911-marketplace-query-args-header
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fixes query parameters for Marketplace URLs
+
+

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-admin.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-admin.php
@@ -45,6 +45,7 @@ class WC_Helper_Admin {
 			'userEmail'   => $auth_user_email,
 			'userAvatar'  => get_avatar_url( $auth_user_email, array( 'size' => '48' ) ),
 			'storeCountry' => wc_get_base_location()['country'],
+			'inAppPurchaseURLParams' => WC_Admin_Addons::get_in_app_purchase_url_params(),
 		);
 
 		return $settings;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:
In the old marketplace, product page URLs had certain query parameters. These are used for distinguishing merchants loading the product page from the in-app marketplace and showing a header to get them back on their store. 

On the new marketplace page, these query parameters are missing. This PR adds them back.

Closes https://github.com/Automattic/woocommerce.com/issues/17911

### How to test the changes in this Pull Request:

1. Checkout this branch
2. Run `pnpm run start` in the `packages/woocommerce-admin` folder
3. Run `composer dump-autoload` in the `packages/woocommerce` folder
4. Load [the discover page](http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fextensions) (/wp-admin/admin.php?page=wc-admin&path=%2Fextensions) and click on a product card. You should end up at WooCommerce.com and you should see the in-app header.
5. Click on **Back to Store** and confirm you go back to your store.
    - That being said, the product page opens in a new tab. So not sure how useful is the **Back to Store** button.
7. Load [the browse page](http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fextensions&tab=extensions) (/wp-admin/admin.php?page=wc-admin&path=%2Fextensions&tab=extensions) and click on a product card. You should end up at WooCommerce.com and you should see the in-app header.
8. Confirm the URL has `wccom-site`,`wccom-back`, `wccom-woo-version` and `wccom-connect-nonce` parameters
9. Click on **Back to Store** and confirm you go back to your store.
10. Click on a vendors name in the product card and confirm you end up WooCommerce.com again, with these set [as query parameters](https://github.com/woocommerce/woocommerce/pull/39901/files#diff-d33ce5ad0ffbbd53cd5beb965bbe34efd3f3dbf41a12e18c258dbd04eb02e6c2R26). 

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment 

Fixes query parameters for Marketplace URLs

</details>

#### Screenshot
![image](https://github.com/woocommerce/woocommerce/assets/10389957/db9789ca-4124-4740-8fe6-8218c491b234)
