### PR TITLE
Fixup to prevent migration loop from 39724

### DIFF
--- a/plugins/woocommerce/changelog/fix-39381-2
+++ b/plugins/woocommerce/changelog/fix-39381-2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: This is a fixup for exisiting change, not a meaningful change of its own.
+
+

--- a/plugins/woocommerce/includes/wc-update-functions.php
+++ b/plugins/woocommerce/includes/wc-update-functions.php
@@ -2603,7 +2603,7 @@ function wc_update_810_migrate_transactional_metadata_for_hpos() {
 
 	$data_synchronizer = wc_get_container()->get( DataSynchronizer::class );
 	if ( ! $data_synchronizer->get_table_exists() ) {
-		return true;
+		return false;
 	}
 
 	$orders_table      = OrdersTableDataStore::get_orders_table_name();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes a regression from #39724 , where when orders table are present, we were incorrectly returning true instead of false. Returning true would tell the runner that there is more stuff pending and it would schedule the migration again, resulting in a migration loop.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set posts tables to authoritative, and sync to off. Delete the custom order tables by going to WooCommerce > Status > Tools and selecting the delete custom order table tools. (Or start with a new shop).
2. Manually set the WC version and DB option to trigger update like so:
```
wp option update  woocommerce_db_version 7.9.0
 wp option update woocommerce_version 7.9.0
```
4. Refresh any admin page, it will say that DB update is pending. Start the migration, and check that it completes successfully (and is not always pending)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
