### PR TITLE
Fix font color in tasklist description

### DIFF
--- a/plugins/woocommerce-admin/client/task-lists/setup-task-list/style.scss
+++ b/plugins/woocommerce-admin/client/task-lists/setup-task-list/style.scss
@@ -267,7 +267,7 @@
 		max-width: 70%;
 		p,
 		span {
-			color: $gray-600;
+			color: $gray-700;
 		}
 
 		p:first-of-type {

--- a/plugins/woocommerce/changelog/fix-tasklist-fix-description-color
+++ b/plugins/woocommerce/changelog/fix-tasklist-fix-description-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Tweak tasklist description color to darker


### PR DESCRIPTION
Fix p1691680546530629-slack-C01SFMVEYAK

### Changes proposed in this Pull Request:

Tweak tasklist description color to #757575 from #949494;

<!-- Begin testing instructions -->

1. Go to WooCommerce > Home
2. Observe tasklist description color is darker

Before:

<img width="500" alt="image" src="https://github.com/woocommerce/woocommerce/assets/3747241/d9feda33-9324-4362-9e8d-412cc9ebaf84">

After:

<img width="500" alt="image" src="https://github.com/woocommerce/woocommerce/assets/3747241/35c59742-9808-435e-b2d8-8bd3d26bc5f4">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>