### PR TITLE
Update PageController.php to prevent PHP warning when menu items have no position set

### DIFF
--- a/plugins/woocommerce/changelog/trunk
+++ b/plugins/woocommerce/changelog/trunk
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixes PHP error when WooCommerce menus are created without a position and when users view the WordPress admin dashboard without having WooCommerce admin permissions.

--- a/plugins/woocommerce/src/Admin/PageController.php
+++ b/plugins/woocommerce/src/Admin/PageController.php
@@ -450,6 +450,10 @@ class PageController {
 			$options['path'] = self::PAGE_ROOT . '&path=' . $options['path'];
 		}
 
+		if ( null !== $options['position'] ) {
+			$options['position'] = intval( round( $options['position'] ) );
+		}
+
 		if ( is_null( $options['parent'] ) ) {
 			add_menu_page(
 				$options['title'],
@@ -458,7 +462,7 @@ class PageController {
 				$options['path'],
 				array( __CLASS__, 'page_wrapper' ),
 				$options['icon'],
-				intval( round( $options['position'] ) )
+				$options['position']
 			);
 		} else {
 			$parent_path = $this->get_path_from_id( $options['parent'] );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
These changes fix the PHP warning shown in https://github.com/woocommerce/woocommerce/issues/38858. Previously the default page options set $args['position'] to null, but then tries to round() this variable resulting in a PHP warning.

The pull request adds a check to ensure $args['position'] is not null before applying round() and intval() to it.

This situation can occur when a WooCommerce menu is created without a position such as when the woocommerce-home menu item is created for users without WooCommerce admin permissions (line 168 in Automattic\WooCommerce\Internal\Admin\Homescreen)

Closes https://github.com/woocommerce/woocommerce/issues/38858.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure PHP error reporting is on
2. Install WordPress (use PHP 8.2) and WooCommerce on your hosting platform
3. Once fully installed, log in to WordPress as an administrator and go To Admin > Users
4. Click Add New and enter a username, email and password for a new user
5. Under Role, select "Contributor"
6. Click Add New User
7. In an incognito browser window visit your WordPress website and log in as the newly created user
8. When viewing the WordPress dashboard without this PR applied you will see a PHP error saying "Deprecated: round(): Passing null to parameter # 1 ($num) of type int|float is deprecated..."
9. With this PR applied, no warning is shown

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Fixes PHP error when WooCommerce menus are created without a position and when users view the WordPress admin dashboard without having WooCommerce admin permissions.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
