### PR TITLE
Update modified date when a metadata is saved for HPOS.

### DIFF
--- a/plugins/woocommerce/changelog/fix-cache_data_store
+++ b/plugins/woocommerce/changelog/fix-cache_data_store
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update modified date when a metadata is saved for HPOS.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2785,8 +2785,8 @@ CREATE TABLE $meta_table (
 	/**
 	 * Deletes meta based on meta ID.
 	 *
-	 * @param  WC_Data  $object WC_Data object.
-	 * @param  stdClass $meta (containing at least ->id).
+	 * @param WC_Data  $object WC_Data object.
+	 * @param \stdClass $meta (containing at least ->id).
 	 *
 	 * @return bool
 	 */
@@ -2806,13 +2806,13 @@ CREATE TABLE $meta_table (
 	/**
 	 * Add new piece of meta.
 	 *
-	 * @param  WC_Data  $object WC_Data object.
-	 * @param  stdClass $meta (containing ->key and ->value).
+	 * @param WC_Data  $object WC_Data object.
+	 * @param \stdClass $meta (containing ->key and ->value).
 	 *
 	 * @return int|bool  meta ID or false on failure
 	 */
 	public function add_meta( &$object, $meta ) {
-		$meta->id = $this->data_store_meta->add_meta( $object, $meta );
+		$add_meta = $this->data_store_meta->add_meta( $object, $meta );
 		$this->after_meta_change( $object, $meta );
 
 		if ( $object instanceof WC_Abstract_Order && $this->should_backfill_post_record() ) {
@@ -2821,14 +2821,14 @@ CREATE TABLE $meta_table (
 			self::$backfilling_order_ids = array_diff( self::$backfilling_order_ids, array( $object->get_id() ) );
 		}
 
-		return $meta->id;
+		return $add_meta;
 	}
 
 	/**
 	 * Update meta.
 	 *
-	 * @param  WC_Data       $object WC_Data object.
-	 * @param  \WC_Meta_Data $meta (containing ->id, ->key and ->value).
+	 * @param WC_Data   $object WC_Data object.
+	 * @param \stdClass $meta (containing ->id, ->key and ->value).
 	 *
 	 * @return
 	 */
@@ -2852,7 +2852,7 @@ CREATE TABLE $meta_table (
 	 * @param \WC_Meta_Data     $meta  Metadata object.
 	 */
 	protected function after_meta_change( &$order, $meta ) {
-		$current_date_time = new \WC_DateTime( current_time( 'mysql'), new \DateTimeZone( 'GMT' ) );
+		$current_date_time = new \WC_DateTime( current_time( 'mysql', 1 ), new \DateTimeZone( 'GMT' ) );
 		method_exists( $meta, 'apply_changes' ) && $meta->apply_changes();
 		$this->clear_caches( $order );
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2853,7 +2853,7 @@ CREATE TABLE $meta_table (
 	 */
 	protected function after_meta_change( &$order, $meta ) {
 		$current_date_time = new \WC_DateTime( 'now', new \DateTimeZone( 'GMT' ) );
-		$meta->apply_changes();
+		method_exists( $meta, 'apply_changes' ) && $meta->apply_changes();
 		$this->clear_caches( $order );
 
 		// Prevent this happening multiple time in same request.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2852,7 +2852,7 @@ CREATE TABLE $meta_table (
 	 * @param \WC_Meta_Data     $meta  Metadata object.
 	 */
 	protected function after_meta_change( &$order, $meta ) {
-		$current_date_time = new \WC_DateTime( 'now', new \DateTimeZone( 'GMT' ) );
+		$current_date_time = new \WC_DateTime( current_time( 'mysql'), new \DateTimeZone( 'GMT' ) );
 		method_exists( $meta, 'apply_changes' ) && $meta->apply_changes();
 		$this->clear_caches( $order );
 

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -2743,6 +2743,7 @@ class OrdersTableDataStoreTests extends HposTestCase {
 	/**
 	 * @testDox Stale data is not read when sync is off, but then switched on again after a while.
 	 * @testWith [true]
+	 *           [false]
 	 *
 	 * @param bool $different_request Whether to simulate different requests (as much as we can in a unit test)
 	 */

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -2740,5 +2740,67 @@ class OrdersTableDataStoreTests extends HposTestCase {
 		remove_action( 'woocommerce_update_order', $callback );
 	}
 
+	/**
+	 * @testDox Stale data is not read when sync is off, but then switched on again after a while.
+	 * @testWith [true]
+	 *
+	 * @param bool $different_request Whether to simulate different requests (as much as we can in a unit test)
+	 */
+	public function test_stale_data_is_not_read_sync_off_on( $different_request ) {
+		$this->toggle_cot_authoritative( true );
+		$this->enable_cot_sync();
 
+		$cot_store = wc_get_container()->get( OrdersTableDataStore::class );
+
+		$order = OrderHelper::create_order();
+		$order->set_customer_id( 1 ); // Change a custom table column.
+		$order->set_billing_address_1( 'test' ); // Change an address column and a meta row.
+		$order->set_download_permissions_granted( true ); // Change an operational data column.
+		$order->save();
+
+		$different_request && $this->reset_order_data_store_state( $cot_store );
+
+		$order->add_meta_data( 'test_key', 'test_value' );
+		$order->save_meta_data();
+
+		$different_request && $this->reset_order_data_store_state( $cot_store );
+
+		$r_order = wc_get_order( $order->get_id() );
+		$this->assertEquals( 1, $r_order->get_customer_id() );
+		$this->assertEquals( 'test', $r_order->get_billing_address_1() );
+		$this->assertTrue( $order->get_download_permissions_granted() );
+		$this->assertEquals( 'test_value', $r_order->get_meta( 'test_key', true ) );
+
+		$different_request && $this->reset_order_data_store_state( $cot_store );
+		sleep(2);
+
+		$this->disable_cot_sync();
+		$r_order->update_meta_data( 'test_key', 'test_value_updated' );
+		$r_order->add_meta_data( 'test_key2', 'test_value2' );
+		$r_order->save_meta_data();
+
+		$different_request && $this->reset_order_data_store_state( $cot_store );
+
+		$this->enable_cot_sync();
+		$r_order = wc_get_order( $order->get_id() );
+		$this->assertEquals( 1, $r_order->get_customer_id() );
+		$this->assertEquals( 'test', $r_order->get_billing_address_1() );
+		$this->assertTrue( $order->get_download_permissions_granted() );
+		$this->assertEquals( 'test_value_updated', $r_order->get_meta( 'test_key', true ) );
+		$this->assertEquals( 'test_value2', $r_order->get_meta( 'test_key2', true ) );
+	}
+
+	/**
+	 * Helper method to reset order data store state (to help simulate multiple requests).
+	 *
+	 * @param OrdersTableDataStore $sut System under test.
+	 */
+	private function reset_order_data_store_state( $sut ) {
+		$reset_state = function () use ( $sut ) {
+			self::$backfilling_order_ids = [];
+			self::$reading_order_ids = [];
+		};
+		$reset_state->call( $sut );
+		wp_cache_flush();
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

When using a `$order->save_meta_data()` method, we have a gap in our sync logic that we do not update the `date_updated_gmt` column. The consequence here is that it will become non-deterministic for code to figure whether posts or order is more updated when there is a difference between them. To prevent this, we also update the modified date when updating the metadata via save_metadata.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Note that we will be using wp shell to test this as it's not possible in the UI only to reproduce the bug.

1. Set HPOS as authoritative. Create a new order and note it's ID (or use an existing order with ID XXX).
2.  Open a new `wp shell` and test following:
```php
// Let's fetch the order 
$order = wc_get_order( XXX );

// Note it's current modified date
$order->get_date_modified();

// Add a new meta.
$order->add_meta_data( 'test1', 'new_value');
$order->save_meta_data();

// Note the current modified date, it should be updated.
$order->get_date_modified();

// Update the metadata.
$order->update_meta_data( 'test1', 'updated_value');
$order->save_meta_data();

// Note the current modified again, it should be updated
$order->get_date_modified();

// Delete the metadata
$order->delete_meta_data( 'test1' );
$order->save_meta_data();

// Note the current modified again, it should be updated
$order->get_date_modified();
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
