### PR TITLE
tweak some of the HPOS Settings UI

### DIFF
--- a/plugins/woocommerce/changelog/update-hpos-ui-tweaks
+++ b/plugins/woocommerce/changelog/update-hpos-ui-tweaks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+tweak some of the HPOS Settings UI.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -5069,6 +5069,19 @@ img.help_tip {
 }
 
 /**
+ * Settings / Advanced / Features
+ */
+.woocommerce_page_wc-settings {
+	.wc-settings-row-woocommerce_custom_orders_table_enabled td.forminp {
+		padding-bottom: 0;
+	}
+
+	.wc-settings-row-woocommerce_custom_orders_table_data_sync_enabled td.forminp {
+		padding-top: 0;
+	}
+}
+
+/**
   * Shipping
   */
 .woocommerce_page_wc-settings {

--- a/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-settings.php
@@ -240,6 +240,12 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 				if ( ! isset( $value['placeholder'] ) ) {
 					$value['placeholder'] = '';
 				}
+				if ( ! isset( $value['row_class'] ) ) {
+					$value['row_class'] = '';
+				}
+				if ( ! empty( $value['row_class'] ) && substr( $value['row_class'], 0, 16 ) !== 'wc-settings-row-' ) {
+					$value['row_class'] = 'wc-settings-row-' . $value['row_class'];
+				}
 				if ( ! isset( $value['suffix'] ) ) {
 					$value['suffix'] = '';
 				}
@@ -281,7 +287,9 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						break;
 
 					case 'info':
-						echo '<tr><th scope="row" class="titledesc"/><td style="' . esc_attr( $value['css'] ) . '">';
+						?><tr valign="top"<?php echo $value['row_class'] ? ' class="' . esc_attr( $value['row_class'] ) . '"' : '' ?>">
+							<th scope="row" class="titledesc"/><td style="<?php echo esc_attr( $value['css'] ); ?>">;
+						<?php
 						echo wp_kses_post( wpautop( wptexturize( $value['text'] ) ) );
 						echo '</td></tr>';
 						break;
@@ -312,7 +320,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 					case 'tel':
 						$option_value = $value['value'];
 
-						?><tr valign="top">
+						?><tr valign="top"<?php echo $value['row_class'] ? ' class="' . esc_attr( $value['row_class'] ) . '"' : '' ?>">
 							<th scope="row" class="titledesc">
 								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
 							</th>
@@ -337,7 +345,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						$option_value = $value['value'];
 
 						?>
-						<tr valign="top">
+						<tr valign="top"<?php echo $value['row_class'] ? ' class="' . esc_attr( $value['row_class'] ) . '"' : '' ?>">
 							<th scope="row" class="titledesc">
 								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
 							</th>
@@ -365,7 +373,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						$option_value = $value['value'];
 
 						?>
-						<tr valign="top">
+						<tr valign="top"<?php echo $value['row_class'] ? ' class="' . esc_attr( $value['row_class'] ) . '"' : '' ?>">
 							<th scope="row" class="titledesc">
 								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
 							</th>
@@ -391,7 +399,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						$option_value = $value['value'];
 
 						?>
-						<tr valign="top">
+						<tr valign="top"<?php echo $value['row_class'] ? ' class="' . esc_attr( $value['row_class'] ) . '"' : '' ?>">
 							<th scope="row" class="titledesc">
 								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
 							</th>
@@ -434,7 +442,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						$show_desc_at_end = $value['desc_at_end'] ?? false;
 
 						?>
-						<tr valign="top">
+						<tr valign="top"<?php echo $value['row_class'] ? ' class="' . esc_attr( $value['row_class'] ) . '"' : '' ?>">
 							<th scope="row" class="titledesc">
 								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
 							</th>
@@ -493,6 +501,9 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						}
 						if ( 'option' === $value['show_if_checked'] ) {
 							$visibility_class[] = 'show_options_if_checked';
+						}
+						if ( $value['row_class'] ) {
+							$visibility_class[] = $value['row_class'];
 						}
 
 						$must_disable = $value['disabled'] ?? false;
@@ -566,7 +577,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						}
 
 						?>
-						<tr valign="top">
+						<tr valign="top"<?php echo $value['row_class'] ? ' class="' . esc_attr( $value['row_class'] ) . '"' : '' ?>">
 							<th scope="row" class="titledesc">
 							<label><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html . $disabled_message; // WPCS: XSS ok. ?></label>
 						</th>
@@ -600,7 +611,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						}
 
 						?>
-						<tr valign="top" class="single_select_page">
+						<tr valign="top" class="single_select_page"<?php echo $value['row_class'] ? ' class="' . esc_attr( $value['row_class'] ) . '"' : '' ?>">
 							<th scope="row" class="titledesc">
 								<label><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
 							</th>
@@ -625,7 +636,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 							);
 						}
 						?>
-						<tr valign="top" class="single_select_page">
+						<tr valign="top" class="single_select_page"<?php echo $value['row_class'] ? ' class="' . esc_attr( $value['row_class'] ) . '"' : '' ?>">
 							<th scope="row" class="titledesc">
 								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></label>
 							</th>
@@ -665,7 +676,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 							$state   = '*';
 						}
 						?>
-						<tr valign="top">
+						<tr valign="top"<?php echo $value['row_class'] ? ' class="' . esc_attr( $value['row_class'] ) . '"' : '' ?>">
 							<th scope="row" class="titledesc">
 								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
 							</th>
@@ -689,7 +700,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 
 						asort( $countries );
 						?>
-						<tr valign="top">
+						<tr valign="top"<?php echo $value['row_class'] ? ' class="' . esc_attr( $value['row_class'] ) . '"' : '' ?>">
 							<th scope="row" class="titledesc">
 								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
 							</th>
@@ -718,7 +729,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						);
 						$option_value = wc_parse_relative_date_option( $value['value'] );
 						?>
-						<tr valign="top">
+						<tr valign="top"<?php echo $value['row_class'] ? ' class="' . esc_attr( $value['row_class'] ) . '"' : '' ?>">
 							<th scope="row" class="titledesc">
 								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
 							</th>

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -723,7 +723,7 @@ ORDER BY $meta_table.order_id ASC, $meta_table.meta_key ASC;
 		$feature_controller = wc_get_container()->get( FeaturesController::class );
 		$plugin_info        = $feature_controller->get_compatible_plugins_for_feature( 'custom_order_tables', true );
 		if ( count( array_merge( $plugin_info['uncertain'], $plugin_info['incompatible'] ) ) > 0 ) {
-			WP_CLI::warning( __( '[Failed] Some installed plugins are incompatible. Please review the plugins by going to WooCommerce > Settings > Advanced > Features and see the Data storage for orders section.', 'woocommerce' ) );
+			WP_CLI::warning( __( '[Failed] Some installed plugins are incompatible. Please review the plugins by going to WooCommerce > Settings > Advanced > Features and see the "Order data storage" section.', 'woocommerce' ) );
 			$enable_hpos = false;
 		}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -455,7 +455,7 @@ class CustomOrdersTableController {
 			'type'        => 'radio',
 			'options'     => array(
 				'no'  => __( 'WordPress posts storage (legacy)', 'woocommerce' ),
-				'yes' => __( 'High-Performance Order Storage (new)', 'woocommerce' ),
+				'yes' => __( 'High-performance order storage (recommended)', 'woocommerce' ),
 			),
 			'value'       => $hpos_enabled ? 'yes' : 'no',
 			'disabled'    => $disabled_option,

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -485,8 +485,8 @@ class CustomOrdersTableController {
 			$sync_message = sprintf(
 				// translators: %d: number of pending orders.
 				_n(
-					'%d order pending to be synchronized. You can switch order data storage only when the posts and orders tables are in sync.',
-					'%d orders pending to be synchronized. You can switch order data storage only when the posts and orders tables are in sync.',
+					'%d order pending to be synchronized. You can switch order data storage <strong>only when the posts and orders tables are in sync</strong>.',
+					'%d orders pending to be synchronized. You can switch order data storage <strong>only when the posts and orders tables are in sync</strong>.',
 					$sync_status['current_pending_count'],
 					'woocommerce'
 				),

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -451,11 +451,11 @@ class CustomOrdersTableController {
 
 		return array(
 			'id'          => self::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION,
-			'title'       => __( 'Data storage for orders', 'woocommerce' ),
+			'title'       => __( 'Order data storage', 'woocommerce' ),
 			'type'        => 'radio',
 			'options'     => array(
 				'no'  => __( 'WordPress post tables', 'woocommerce' ),
-				'yes' => __( 'High performance order storage (new)', 'woocommerce' ),
+				'yes' => __( 'High-Performance Order Storage (new)', 'woocommerce' ),
 			),
 			'value'       => $hpos_enabled ? 'yes' : 'no',
 			'disabled'    => $disabled_option,
@@ -485,8 +485,8 @@ class CustomOrdersTableController {
 			$sync_message = sprintf(
 				// translators: %d: number of pending orders.
 				_n(
-					'Sync %d pending order. You can switch data storage for orders only when posts and orders table are in sync.',
-					'Sync %d pending orders. You can switch data storage for orders only when posts and orders table are in sync.',
+					'%d order pending to be synchronized. You can switch order data storage only when the posts and orders tables are in sync.',
+					'%d orders pending to be synchronized. You can switch order data storage only when the posts and orders tables are in sync.',
 					$sync_status['current_pending_count'],
 					'woocommerce'
 				),
@@ -498,7 +498,7 @@ class CustomOrdersTableController {
 			'id'       => DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION,
 			'title'    => '',
 			'type'     => 'checkbox',
-			'desc'     => __( 'Keep the posts and orders tables in sync (compatibility mode).', 'woocommerce' ),
+			'desc'     => __( 'Enable compatibility mode (synchronizes orders to the posts table).', 'woocommerce' ),
 			'value'    => $sync_enabled,
 			'desc_tip' => $sync_message,
 		);

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -454,7 +454,7 @@ class CustomOrdersTableController {
 			'title'       => __( 'Order data storage', 'woocommerce' ),
 			'type'        => 'radio',
 			'options'     => array(
-				'no'  => __( 'WordPress post tables', 'woocommerce' ),
+				'no'  => __( 'WordPress posts storage (legacy)', 'woocommerce' ),
 				'yes' => __( 'High-Performance Order Storage (new)', 'woocommerce' ),
 			),
 			'value'       => $hpos_enabled ? 'yes' : 'no',

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -461,6 +461,7 @@ class CustomOrdersTableController {
 			'disabled'    => $disabled_option,
 			'desc'        => $plugin_incompat_warning,
 			'desc_at_end' => true,
+			'row_class' => self::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION,
 		);
 	}
 
@@ -495,12 +496,13 @@ class CustomOrdersTableController {
 		}
 
 		return array(
-			'id'       => DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION,
-			'title'    => '',
-			'type'     => 'checkbox',
-			'desc'     => __( 'Enable compatibility mode (synchronizes orders to the posts table).', 'woocommerce' ),
-			'value'    => $sync_enabled,
-			'desc_tip' => $sync_message,
+			'id'        => DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION,
+			'title'     => '',
+			'type'      => 'checkbox',
+			'desc'      => __( 'Enable compatibility mode (synchronizes orders to the posts table).', 'woocommerce' ),
+			'value'     => $sync_enabled,
+			'desc_tip'  => $sync_message,
+			'row_class' => DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION,
 		);
 	}
 }

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -114,12 +114,12 @@ class FeaturesController {
 				'disable_ui'      => false,
 			),
 			// Options for HPOS features are added in CustomOrdersTableController to keep the logic in same place.
-			'custom_order_tables'  => array( // This exists for back-compat only, otherwise it's value is superseded by $hpos_authoritative option.
-				'name'               => __( 'High-Performance order storage (COT)', 'woocommerce' ),
+			'custom_order_tables'    => array( // This exists for back-compat only, otherwise it's value is superseded by $hpos_authoritative option.
+				'name'               => __( 'High-Performance Order Storage (HPOS)', 'woocommerce' ),
 				'enabled_by_default' => false,
 			),
 			$hpos_authoritative    => array(
-				'name'            => __( 'High performance order storage', 'woocommerce' ),
+				'name'             => __( 'High-Performance Order Storage', 'woocommerce' ),
 			),
 			$hpos_enable_sync      => array(
 				'name'            => '',

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -120,9 +120,11 @@ class FeaturesController {
 			),
 			$hpos_authoritative    => array(
 				'name'             => __( 'High-Performance Order Storage', 'woocommerce' ),
+				'order'            => 10,
 			),
 			$hpos_enable_sync      => array(
 				'name'            => '',
+				'order'            => 9,
 			),
 			'cart_checkout_blocks' => array(
 				'name'            => __( 'Cart & Checkout Blocks', 'woocommerce' ),
@@ -592,6 +594,15 @@ class FeaturesController {
 		$features = $this->get_features( true );
 
 		$feature_ids              = array_keys( $features );
+		usort( $feature_ids, function( $feature_id_a, $feature_id_b ) use ( $features ) {
+			if ( ! isset( $features[ $feature_id_a ]['order'] ) ) {
+				$features[ $feature_id_a ]['order'] = 0;
+			}
+			if ( ! isset( $features[ $feature_id_b ]['order'] ) ) {
+				$features[ $feature_id_b ]['order'] = 0;
+			}
+			return $features[ $feature_id_b ]['order'] <=> $features[ $feature_id_a ]['order'];
+		} );
 		$experimental_feature_ids = array_filter(
 			$feature_ids,
 			function( $feature_id ) use ( $features ) {

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -595,13 +595,7 @@ class FeaturesController {
 
 		$feature_ids              = array_keys( $features );
 		usort( $feature_ids, function( $feature_id_a, $feature_id_b ) use ( $features ) {
-			if ( ! isset( $features[ $feature_id_a ]['order'] ) ) {
-				$features[ $feature_id_a ]['order'] = 0;
-			}
-			if ( ! isset( $features[ $feature_id_b ]['order'] ) ) {
-				$features[ $feature_id_b ]['order'] = 0;
-			}
-			return $features[ $feature_id_b ]['order'] <=> $features[ $feature_id_a ]['order'];
+			return ( $features[ $feature_id_b ]['order'] ?? 0 ) <=> ( $features[ $feature_id_a ]['order'] ?? 0 );
 		} );
 		$experimental_feature_ids = array_filter(
 			$feature_ids,

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -96,14 +96,14 @@ class FeaturesController {
 		$features           = array(
 			'analytics'            => array(
 				'name'               => __( 'Analytics', 'woocommerce' ),
-				'description'        => __( 'Enables WooCommerce Analytics', 'woocommerce' ),
+				'description'        => __( 'Enable WooCommerce Analytics', 'woocommerce' ),
 				'is_experimental'    => false,
 				'enabled_by_default' => true,
 				'disable_ui'         => false,
 			),
 			'new_navigation'       => array(
 				'name'            => __( 'Navigation', 'woocommerce' ),
-				'description'     => __( 'Adds the new WooCommerce navigation experience to the dashboard', 'woocommerce' ),
+				'description'     => __( 'Add the new WooCommerce navigation experience to the dashboard', 'woocommerce' ),
 				'is_experimental' => false,
 				'disable_ui'      => false,
 			),

--- a/plugins/woocommerce/tests/api-core-tests/tests/settings/settings-crud.test.js
+++ b/plugins/woocommerce/tests/api-core-tests/tests/settings/settings-crud.test.js
@@ -1941,7 +1941,7 @@ test.describe.serial( 'Settings API tests: CRUD', () => {
 					expect.objectContaining( {
 						id: 'woocommerce_analytics_enabled',
 						label: 'Analytics',
-						description: 'Enables WooCommerce Analytics',
+						description: 'Enable WooCommerce Analytics',
 						type: 'checkbox',
 						default: 'yes',
 						value: 'yes',
@@ -1954,7 +1954,7 @@ test.describe.serial( 'Settings API tests: CRUD', () => {
 						id: 'woocommerce_navigation_enabled',
 						label: 'Navigation',
 						description: expect.stringContaining(
-							'Adds the new WooCommerce navigation experience to the dashboard'
+							'Add the new WooCommerce navigation experience to the dashboard'
 						),
 						type: 'checkbox',
 						value: expect.any( String ),

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
@@ -580,6 +580,6 @@ class DataSynchronizerTests extends HposTestCase {
 		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- This is a test.
 		$sync_setting = apply_filters( 'woocommerce_feature_setting', array(), $this->sut::ORDERS_DATA_SYNC_ENABLED_OPTION );
 		$this->assertEquals( $sync_setting['value'], 'no' );
-		$this->assertTrue( str_contains( $sync_setting['desc_tip'], 'Sync 1 pending order' ) );
+		$this->assertTrue( str_contains( $sync_setting['desc_tip'], '1 order pending to be synchronized' ) );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR tweaks a few things on the Settings / Advanced / Features page, especially around the HPOS settings. 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

0. you will probably need to run `pnpm run --filter=woocommerce/client/legacy build` before being able to observe this PR's changes
1. visit the `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features` page and observe tweaked wording and less padding between the two HPOS settings
2. observe that the HPOS settings have been moved to the top
3. install and activate a plugin that is incompatible with HPOS and observe the wording and styling of the warning on the `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features` page

A few of these tweaks are my suggestions, while others have been previously discussed and decided. Happy to adjust. Screenshot of what to expect: 

![Screenshot 2023-08-25 at 18 56 46](https://github.com/woocommerce/woocommerce/assets/23619/acd22d7f-9411-46bf-96e2-40a4a2b125c2)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
