### PR TITLE
Product Block Editor: add tracks to the Variations tab

### DIFF
--- a/packages/js/product-editor/changelog/add-39831
+++ b/packages/js/product-editor/changelog/add-39831
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add tracking events to add edit and update attribute

--- a/packages/js/product-editor/src/blocks/variation-options/edit.tsx
+++ b/packages/js/product-editor/src/blocks/variation-options/edit.tsx
@@ -74,7 +74,6 @@ export function Edit() {
 		productId: useEntityId( 'postType', 'product' ),
 		onChange( values ) {
 			setEntityAttributes( values );
-			setEntityDefaultAttributes( manageDefaultAttributes( values ) );
 			generateProductVariations( values );
 		},
 	} );
@@ -131,7 +130,12 @@ export function Edit() {
 					attributes,
 					entityDefaultAttributes,
 				] ) }
-				onChange={ handleChange }
+				onChange={ ( values ) => {
+					handleChange( values );
+					setEntityDefaultAttributes(
+						manageDefaultAttributes( values )
+					);
+				} }
 				createNewAttributesAsGlobal={ true }
 				useRemoveConfirmationModal={ true }
 				onNoticeDismiss={ () =>

--- a/packages/js/product-editor/src/blocks/variations/edit.tsx
+++ b/packages/js/product-editor/src/blocks/variations/edit.tsx
@@ -6,6 +6,7 @@ import type { BlockEditProps } from '@wordpress/blocks';
 import { Button } from '@wordpress/components';
 import { Link } from '@woocommerce/components';
 import { Product, ProductAttribute } from '@woocommerce/data';
+import { recordEvent } from '@woocommerce/tracks';
 import {
 	createElement,
 	useState,
@@ -36,6 +37,7 @@ import {
 import { getAttributeId } from '../../components/attribute-control/utils';
 import { useProductVariationsHelper } from '../../hooks/use-product-variations-helper';
 import { hasAttributesUsedForVariations } from '../../utils';
+import { TRACKS_SOURCE } from '../../constants';
 
 function getFirstOptionFromEachAttribute(
 	attributes: Product[ 'attributes' ]
@@ -101,15 +103,22 @@ export function Edit( {
 	};
 
 	const handleAdd = ( newOptions: EnhancedProductAttribute[] ) => {
-		handleChange( [
-			...newOptions.filter(
-				( newAttr ) =>
-					! variationOptions.find(
-						( attr: ProductAttribute ) =>
-							getAttributeId( newAttr ) === getAttributeId( attr )
-					)
-			),
-		] );
+		const addedAttributesOnly = newOptions.filter(
+			( newAttr ) =>
+				! variationOptions.some(
+					( attr: ProductAttribute ) =>
+						getAttributeId( newAttr ) === getAttributeId( attr )
+				)
+		);
+		recordEvent( 'product_options_add', {
+			source: TRACKS_SOURCE,
+			options: addedAttributesOnly.map( ( attribute ) => ( {
+				attribute: attribute.name,
+				values: attribute.options,
+			} ) ),
+		} );
+
+		handleChange( addedAttributesOnly );
 		closeNewModal();
 	};
 

--- a/packages/js/product-editor/src/components/attribute-control/attribute-control.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/attribute-control.tsx
@@ -191,7 +191,16 @@ export const AttributeControl: React.FC< AttributeControlProps > = ( {
 		closeNewModal();
 	};
 
-	const handleEdit = ( updatedAttribute: ProductAttribute ) => {
+	const handleEdit = ( updatedAttribute: EnhancedProductAttribute ) => {
+		recordEvent( 'product_options_update', {
+			source: TRACKS_SOURCE,
+			attribute: updatedAttribute.name,
+			values: updatedAttribute.options,
+			default: updatedAttribute.isDefault,
+			visible: updatedAttribute.visible,
+			filter: true, // default true until attribute filter gets implemented
+		} );
+
 		const updatedAttributes = value.map( ( attr ) => {
 			if (
 				getAttributeId( attr ) === getAttributeId( updatedAttribute )

--- a/packages/js/product-editor/src/components/attribute-control/attribute-control.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/attribute-control.tsx
@@ -158,6 +158,10 @@ export const AttributeControl: React.FC< AttributeControlProps > = ( {
 	};
 
 	const openEditModal = ( attribute: ProductAttribute ) => {
+		recordEvent( 'product_options_edit', {
+			source: TRACKS_SOURCE,
+			attribute: attribute.name,
+		} );
 		setCurrentAttributeId( getAttributeId( attribute ) );
 		onEditModalOpen( attribute );
 	};

--- a/packages/js/product-editor/src/components/attribute-control/attribute-control.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/attribute-control.tsx
@@ -31,6 +31,7 @@ import {
 import { AttributeListItem } from '../attribute-list-item';
 import { NewAttributeModal } from './new-attribute-modal';
 import { RemoveConfirmationModal } from './remove-confirmation-modal';
+import { TRACKS_SOURCE } from '../../constants';
 
 type AttributeControlProps = {
 	value: EnhancedProductAttribute[];
@@ -167,16 +168,21 @@ export const AttributeControl: React.FC< AttributeControlProps > = ( {
 	};
 
 	const handleAdd = ( newAttributes: EnhancedProductAttribute[] ) => {
-		handleChange( [
-			...value,
-			...newAttributes.filter(
-				( newAttr ) =>
-					! value.find(
-						( attr ) =>
-							getAttributeId( newAttr ) === getAttributeId( attr )
-					)
-			),
-		] );
+		const addedAttributesOnly = newAttributes.filter(
+			( newAttr ) =>
+				! value.some(
+					( current: ProductAttribute ) =>
+						getAttributeId( newAttr ) === getAttributeId( current )
+				)
+		);
+		recordEvent( 'product_options_add', {
+			source: TRACKS_SOURCE,
+			options: addedAttributesOnly.map( ( attribute ) => ( {
+				attribute: attribute.name,
+				values: attribute.options,
+			} ) ),
+		} );
+		handleChange( [ ...value, ...addedAttributesOnly ] );
 		onAdd( newAttributes );
 		closeNewModal();
 	};

--- a/packages/js/product-editor/src/components/attribute-control/attribute-control.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/attribute-control.tsx
@@ -240,7 +240,9 @@ export const AttributeControl: React.FC< AttributeControlProps > = ( {
 				className="woocommerce-add-attribute-list-item__add-button"
 				onClick={ () => {
 					openNewModal();
-					recordEvent( 'product_add_attributes_click' );
+					recordEvent( 'product_options_add_button_click', {
+						source: TRACKS_SOURCE,
+					} );
 				} }
 			>
 				{ uiStrings.newAttributeListItemLabel }

--- a/packages/js/product-editor/src/components/attribute-control/attribute-control.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/attribute-control.tsx
@@ -195,7 +195,7 @@ export const AttributeControl: React.FC< AttributeControlProps > = ( {
 		recordEvent( 'product_options_update', {
 			source: TRACKS_SOURCE,
 			attribute: updatedAttribute.name,
-			values: updatedAttribute.options,
+			values: updatedAttribute.terms?.map( ( term ) => term.name ),
 			default: updatedAttribute.isDefault,
 			visible: updatedAttribute.visible,
 			filter: true, // default true until attribute filter gets implemented

--- a/plugins/woocommerce/changelog/add-39831
+++ b/plugins/woocommerce/changelog/add-39831
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Add Variation options section back to the product blocks template

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -725,13 +725,19 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 				],
 			]
 		);
-		$variation_fields->add_block(
+		$variation_options_section = $variation_fields->add_block(
 			[
-				'id'         => 'product-variation-options',
-				'blockName'  => 'woocommerce/product-variations-options-field',
+				'id'         => 'product-variation-options-section',
+				'blockName'  => 'woocommerce/product-section',
 				'attributes' => [
 					'title' => __( 'Variation options', 'woocommerce' ),
 				],
+			]
+		);
+		$variation_options_section->add_block(
+			[
+				'id'        => 'product-variation-options',
+				'blockName' => 'woocommerce/product-variations-options-field',
 			]
 		);
 		$variation_section = $variation_fields->add_block(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/39831

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure `Enable tracking` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com`
3. Make sure feature `product-variation-management` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper`
4. Run `Enable wc-admin Tracking` under `Tools` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper`
5. Open the browser DevTools Console
6. Go to `/wp-admin/admin.php?page=wc-admin&path=/add-product&tab=variations` and click `Add variation options` button from the `Variations` tab
9. Add at least one Variation attribute and at least one value. Then click `Add` button from the `Add variation options` modal.
10. A tracking event should be sent and shown in the Console like follow
<img width="568" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/279b285f-b2a3-4fb8-bcef-ecacbc86cb87">

12. In the attribute option list click the `Edit` link from any option
13. A tracking event should be sent and shown in the Console like follow
<img width="561" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/e98157e5-7d91-4f0d-a57f-66f70b7940a1">

15. The `Edit` option modal should be shown
16. Change the values of the option and then click the `Update` button
17. A tracking event should be sent and shown in the Console like follow
<img width="553" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/3e683d9c-0934-4039-9495-7a81a2c60a11">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>