### PR TITLE
Add Shipping item to the Quick Actions menu per Variation item

### DIFF
--- a/packages/js/product-editor/changelog/add-39790
+++ b/packages/js/product-editor/changelog/add-39790
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add Shipping item to the Quick Actions menu per Variation item

--- a/packages/js/product-editor/src/components/variations-table/shipping-menu-item/index.ts
+++ b/packages/js/product-editor/src/components/variations-table/shipping-menu-item/index.ts
@@ -1,0 +1,2 @@
+export * from './shipping-menu-item';
+export * from './types';

--- a/packages/js/product-editor/src/components/variations-table/shipping-menu-item/shipping-menu-item.tsx
+++ b/packages/js/product-editor/src/components/variations-table/shipping-menu-item/shipping-menu-item.tsx
@@ -50,7 +50,7 @@ export function ShippingMenuItem( {
 								}
 							);
 							handlePrompt(
-								'dimensions.length',
+								'dimensions',
 								undefined,
 								( value ) => {
 									recordEvent(
@@ -61,7 +61,10 @@ export function ShippingMenuItem( {
 											variation_id: variation.id,
 										}
 									);
-									return value;
+									return {
+										...variation.dimensions,
+										length: value,
+									};
 								}
 							);
 							onClose();
@@ -80,7 +83,7 @@ export function ShippingMenuItem( {
 								}
 							);
 							handlePrompt(
-								'dimensions.width',
+								'dimensions',
 								undefined,
 								( value ) => {
 									recordEvent(
@@ -91,7 +94,10 @@ export function ShippingMenuItem( {
 											variation_id: variation.id,
 										}
 									);
-									return value;
+									return {
+										...variation.dimensions,
+										width: value,
+									};
 								}
 							);
 							onClose();
@@ -110,7 +116,7 @@ export function ShippingMenuItem( {
 								}
 							);
 							handlePrompt(
-								'dimensions.height',
+								'dimensions',
 								undefined,
 								( value ) => {
 									recordEvent(
@@ -121,7 +127,10 @@ export function ShippingMenuItem( {
 											variation_id: variation.id,
 										}
 									);
-									return value;
+									return {
+										...variation.dimensions,
+										height: value,
+									};
 								}
 							);
 							onClose();

--- a/packages/js/product-editor/src/components/variations-table/shipping-menu-item/shipping-menu-item.tsx
+++ b/packages/js/product-editor/src/components/variations-table/shipping-menu-item/shipping-menu-item.tsx
@@ -1,0 +1,162 @@
+/**
+ * External dependencies
+ */
+import { Dropdown, MenuItem } from '@wordpress/components';
+import { createElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { chevronRight } from '@wordpress/icons';
+import { recordEvent } from '@woocommerce/tracks';
+
+/**
+ * Internal dependencies
+ */
+import { ShippingMenuItemProps } from './types';
+import { TRACKS_SOURCE } from '../../../constants';
+
+export function ShippingMenuItem( {
+	variation,
+	handlePrompt,
+	onClose,
+}: ShippingMenuItemProps ) {
+	return (
+		<Dropdown
+			position="middle right"
+			renderToggle={ ( { isOpen, onToggle } ) => (
+				<MenuItem
+					onClick={ () => {
+						recordEvent( 'product_variations_menu_shipping_click', {
+							source: TRACKS_SOURCE,
+							variation_id: variation.id,
+						} );
+						onToggle();
+					} }
+					aria-expanded={ isOpen }
+					icon={ chevronRight }
+					iconPosition="right"
+				>
+					{ __( 'Shipping', 'woocommerce' ) }
+				</MenuItem>
+			) }
+			renderContent={ () => (
+				<div className="components-dropdown-menu__menu">
+					<MenuItem
+						onClick={ () => {
+							recordEvent(
+								'product_variations_menu_shipping_select',
+								{
+									source: TRACKS_SOURCE,
+									action: 'dimensions_length_set',
+									variation_id: variation.id,
+								}
+							);
+							handlePrompt(
+								'dimensions.length',
+								undefined,
+								( value ) => {
+									recordEvent(
+										'product_variations_menu_shipping_update',
+										{
+											source: TRACKS_SOURCE,
+											action: 'dimensions_length_set',
+											variation_id: variation.id,
+										}
+									);
+									return value;
+								}
+							);
+							onClose();
+						} }
+					>
+						{ __( 'Set length', 'woocommerce' ) }
+					</MenuItem>
+					<MenuItem
+						onClick={ () => {
+							recordEvent(
+								'product_variations_menu_shipping_select',
+								{
+									source: TRACKS_SOURCE,
+									action: 'dimensions_width_set',
+									variation_id: variation.id,
+								}
+							);
+							handlePrompt(
+								'dimensions.width',
+								undefined,
+								( value ) => {
+									recordEvent(
+										'product_variations_menu_shipping_update',
+										{
+											source: TRACKS_SOURCE,
+											action: 'dimensions_width_set',
+											variation_id: variation.id,
+										}
+									);
+									return value;
+								}
+							);
+							onClose();
+						} }
+					>
+						{ __( 'Set width', 'woocommerce' ) }
+					</MenuItem>
+					<MenuItem
+						onClick={ () => {
+							recordEvent(
+								'product_variations_menu_shipping_select',
+								{
+									source: TRACKS_SOURCE,
+									action: 'dimensions_height_set',
+									variation_id: variation.id,
+								}
+							);
+							handlePrompt(
+								'dimensions.height',
+								undefined,
+								( value ) => {
+									recordEvent(
+										'product_variations_menu_shipping_update',
+										{
+											source: TRACKS_SOURCE,
+											action: 'dimensions_height_set',
+											variation_id: variation.id,
+										}
+									);
+									return value;
+								}
+							);
+							onClose();
+						} }
+					>
+						{ __( 'Set height', 'woocommerce' ) }
+					</MenuItem>
+					<MenuItem
+						onClick={ () => {
+							recordEvent(
+								'product_variations_menu_shipping_select',
+								{
+									source: TRACKS_SOURCE,
+									action: 'weight_set',
+									variation_id: variation.id,
+								}
+							);
+							handlePrompt( 'weight', undefined, ( value ) => {
+								recordEvent(
+									'product_variations_menu_shipping_update',
+									{
+										source: TRACKS_SOURCE,
+										action: 'weight_set',
+										variation_id: variation.id,
+									}
+								);
+								return value;
+							} );
+							onClose();
+						} }
+					>
+						{ __( 'Set weight', 'woocommerce' ) }
+					</MenuItem>
+				</div>
+			) }
+		/>
+	);
+}

--- a/packages/js/product-editor/src/components/variations-table/shipping-menu-item/types.ts
+++ b/packages/js/product-editor/src/components/variations-table/shipping-menu-item/types.ts
@@ -1,0 +1,14 @@
+/**
+ * External dependencies
+ */
+import { ProductVariation } from '@woocommerce/data';
+
+export type ShippingMenuItemProps = {
+	variation: ProductVariation;
+	handlePrompt(
+		propertyName: keyof ProductVariation,
+		label?: string,
+		parser?: ( value: string ) => unknown
+	): void;
+	onClose(): void;
+};

--- a/packages/js/product-editor/src/components/variations-table/variation-actions-menu/variation-actions-menu.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variation-actions-menu/variation-actions-menu.tsx
@@ -18,6 +18,7 @@ import { recordEvent } from '@woocommerce/tracks';
  */
 import { VariationActionsMenuProps } from './types';
 import { TRACKS_SOURCE } from '../../../constants';
+import { ShippingMenuItem } from '../shipping-menu-item';
 
 function isPercentage( value: string ) {
 	return value.endsWith( '%' );
@@ -444,6 +445,12 @@ export function VariationActionsMenu( {
 									</MenuGroup>
 								</div>
 							) }
+						/>
+
+						<ShippingMenuItem
+							variation={ variation }
+							handlePrompt={ handlePrompt }
+							onClose={ onClose }
 						/>
 					</MenuGroup>
 					<MenuGroup>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #39790

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure feature `product-variation-management` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper`
3. Go to `/wp-admin/admin.php?page=wc-admin&path=/add-product&tab=variations` and click `Add variation options` button from the `Variations` tab
4. Add at least one Variation attribute and at least one value. Then click `Add` button from the `Add variation options` modal.
5. Wait until the variations are generated
6. A list a variation should be shown depending on the options selected
7. In the Variations table, each row should have a dropdown icon button at the right most place
8. When clicking a dropdown menu should be shown
9. From the menu a `Shipping` item should be shown
10. When clicking the `Shipping` a sub menu should be shown 
<img width="703" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/3764abd5-34d5-4c8d-b777-d289d4f144c5">

11. `Set length` should let you change the dimension length of the variation by the amount you enter in the window prompt
12. `Set width` should let you change the dimension width of the variation by the amount you enter in the window prompt
13. `Set height` should let you change the dimension height of the variation by the amount you enter in the window prompt
14. `Set weight` should let you change the weight of the variation by the amount you enter in the window prompt
15. All the changes can be checked from the variation preview page

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
