### PR TITLE
Optimize customize store preview frame resize performance

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/auto-block-preview.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/auto-block-preview.tsx
@@ -12,13 +12,15 @@ import {
 	__unstableEditorStyles as EditorStyles,
 	__unstableIframe as Iframe,
 	BlockList,
-	MemoizedBlockList,
 	// @ts-ignore No types for this exist yet.
 } from '@wordpress/block-editor';
 
 const MAX_HEIGHT = 2000;
 // @ts-ignore No types for this exist yet.
 const { Provider: DisabledProvider } = Disabled.Context;
+
+// This is used to avoid rendering the block list if the sizes change.
+let MemoizedBlockList: typeof BlockList | undefined;
 
 export type ScaledBlockPreviewProps = {
 	viewportWidth?: number;
@@ -59,7 +61,7 @@ function ScaledBlockPreview( {
 	}, [ settings.styles ] );
 
 	// Initialize on render instead of module top level, to avoid circular dependency issues.
-	const RenderedBlockList = MemoizedBlockList || pure( BlockList );
+	MemoizedBlockList = MemoizedBlockList || pure( BlockList );
 	const scale = containerWidth / viewportWidth;
 
 	return (
@@ -223,7 +225,7 @@ function ScaledBlockPreview( {
 					` }
 				</style>
 				{ contentResizeListener }
-				<RenderedBlockList renderAppender={ false } />
+				<MemoizedBlockList renderAppender={ false } />
 			</Iframe>
 		</DisabledProvider>
 	);

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/layout.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/layout.tsx
@@ -51,8 +51,6 @@ export const Layout = () => {
 	const disableMotion = useReducedMotion();
 	const [ canvasResizer, canvasSize ] = useResizeObserver();
 	const isEditorLoading = useIsSiteEditorLoading();
-	const [ isResizableFrameOversized, setIsResizableFrameOversized ] =
-		useState( false );
 	const [ backgroundColor ] = useGlobalStyle( 'color.background' );
 	const [ gradientValue ] = useGlobalStyle( 'color.gradient' );
 
@@ -67,7 +65,7 @@ export const Layout = () => {
 					variants={ {
 						view: { x: 0 },
 					} }
-					isTransparent={ isResizableFrameOversized }
+					isTransparent={ false }
 					className="edit-site-layout__hub"
 				/>
 			</motion.div>
@@ -113,11 +111,7 @@ export const Layout = () => {
 								initial={ false }
 								layout="position"
 								className={ classnames(
-									'edit-site-layout__canvas',
-									{
-										'is-right-aligned':
-											isResizableFrameOversized,
-									}
+									'edit-site-layout__canvas'
 								) }
 								transition={ {
 									type: 'tween',
@@ -137,12 +131,7 @@ export const Layout = () => {
 												24 /* $canvas-padding */,
 											height: canvasSize.height,
 										} }
-										isOversized={
-											isResizableFrameOversized
-										}
-										setIsOversized={
-											setIsResizableFrameOversized
-										}
+										isOversized={ false }
 										innerContentStyle={ {
 											background:
 												gradientValue ??

--- a/plugins/woocommerce/changelog/update-optimize-cys-frame-resizing
+++ b/plugins/woocommerce/changelog/update-optimize-cys-frame-resizing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Optimize customize store preview frame resize performance


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #39929.

I thought MemoizedBlockList was a specific component in a previous PR, but didn't realize it was just a variable for performance issues to [avoid re-rendering if size changes](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/block-preview/auto.js#L18).

The frame resizing performance has been improved drastically in this PR

https://github.com/woocommerce/woocommerce/assets/4344253/328de6b4-f7de-4429-b510-702e79636519

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Use WP 6.3 
2. Install the `WooCommerce Beta Tester` plugin
3. Go to /wp-admin/tools.php?page=woocommerce-admin-test-helper and enable `customize-store` feature flag
4. Go to `WooCommerce > Home`
5. Click on `Customize your store` task 
6. Click on `Assembler Hub` button
7. You should see the Assembler Hub screen
8. Try to resize the preview frame by hovering the frame and dragging the resizing handler.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Optimize customize store preview frame resize performance

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
