### PR TITLE
Make sure we also save default attributes prior to variation generation

### DIFF
--- a/packages/js/data/changelog/fix-39840_product_editor_variations_auto_save_bug
+++ b/packages/js/data/changelog/fix-39840_product_editor_variations_auto_save_bug
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update generateProductVariations action to add support for default_attributes and allowing to disable the product saving.

--- a/packages/js/data/src/product-variations/actions.ts
+++ b/packages/js/data/src/product-variations/actions.ts
@@ -63,10 +63,9 @@ export const generateProductVariations = function* (
 	const { key } = parseId( idQuery, urlParameters );
 	yield generateProductVariationsRequest( key );
 
-	let updatedProduct: Product | undefined = undefined;
 	if ( saveAttributes ) {
 		try {
-			updatedProduct = yield controls.dispatch(
+			yield controls.dispatch(
 				'core',
 				'saveEntityRecord',
 				'postType',

--- a/packages/js/data/src/product-variations/actions.ts
+++ b/packages/js/data/src/product-variations/actions.ts
@@ -17,11 +17,7 @@ import type {
 	GenerateRequest,
 } from './types';
 import CRUD_ACTIONS from './crud-actions';
-import {
-	Product,
-	ProductAttribute,
-	ProductDefaultAttribute,
-} from '../products/types';
+import { ProductAttribute, ProductDefaultAttribute } from '../products/types';
 
 export function generateProductVariationsError( key: IdType, error: unknown ) {
 	return {
@@ -54,7 +50,7 @@ export const generateProductVariations = function* (
 		default_attributes?: ProductDefaultAttribute[];
 	},
 	data: GenerateRequest,
-	saveAttributes: boolean = true
+	saveAttributes = true
 ) {
 	const urlParameters = getUrlParameters(
 		WC_PRODUCT_VARIATIONS_NAMESPACE,

--- a/packages/js/data/src/product-variations/actions.ts
+++ b/packages/js/data/src/product-variations/actions.ts
@@ -17,7 +17,11 @@ import type {
 	GenerateRequest,
 } from './types';
 import CRUD_ACTIONS from './crud-actions';
-import { ProductAttribute } from '../products/types';
+import {
+	Product,
+	ProductAttribute,
+	ProductDefaultAttribute,
+} from '../products/types';
 
 export function generateProductVariationsError( key: IdType, error: unknown ) {
 	return {
@@ -47,8 +51,10 @@ export const generateProductVariations = function* (
 	productData: {
 		type?: string;
 		attributes: ProductAttribute[];
+		default_attributes?: ProductDefaultAttribute[];
 	},
-	data: GenerateRequest
+	data: GenerateRequest,
+	saveAttributes: boolean = true
 ) {
 	const urlParameters = getUrlParameters(
 		WC_PRODUCT_VARIATIONS_NAMESPACE,
@@ -57,20 +63,23 @@ export const generateProductVariations = function* (
 	const { key } = parseId( idQuery, urlParameters );
 	yield generateProductVariationsRequest( key );
 
-	try {
-		yield controls.dispatch(
-			'core',
-			'saveEntityRecord',
-			'postType',
-			'product',
-			{
-				id: urlParameters[ 0 ],
-				...productData,
-			}
-		);
-	} catch ( error ) {
-		yield generateProductVariationsError( key, error );
-		throw error;
+	let updatedProduct: Product | undefined = undefined;
+	if ( saveAttributes ) {
+		try {
+			updatedProduct = yield controls.dispatch(
+				'core',
+				'saveEntityRecord',
+				'postType',
+				'product',
+				{
+					id: urlParameters[ 0 ],
+					...productData,
+				}
+			);
+		} catch ( error ) {
+			yield generateProductVariationsError( key, error );
+			throw error;
+		}
 	}
 
 	try {
@@ -83,7 +92,6 @@ export const generateProductVariations = function* (
 			method: 'POST',
 			data,
 		} );
-
 		yield generateProductVariationsSuccess( key );
 		return result;
 	} catch ( error ) {

--- a/packages/js/product-editor/changelog/fix-39840_product_editor_variations_auto_save_bug
+++ b/packages/js/product-editor/changelog/fix-39840_product_editor_variations_auto_save_bug
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix bug where the form was dirty still after adding product variations for the first time.

--- a/packages/js/product-editor/src/blocks/variation-options/edit.tsx
+++ b/packages/js/product-editor/src/blocks/variation-options/edit.tsx
@@ -29,25 +29,6 @@ import {
 import { AttributeControl } from '../../components/attribute-control';
 import { useProductVariationsHelper } from '../../hooks/use-product-variations-helper';
 
-function manageDefaultAttributes( values: EnhancedProductAttribute[] ) {
-	return values.reduce< Product[ 'default_attributes' ] >(
-		( prevDefaultAttributes, currentAttribute ) => {
-			if ( currentAttribute.isDefault ) {
-				return [
-					...prevDefaultAttributes,
-					{
-						id: currentAttribute.id,
-						name: currentAttribute.name,
-						option: currentAttribute.options[ 0 ],
-					},
-				];
-			}
-			return prevDefaultAttributes;
-		},
-		[]
-	);
-}
-
 export function Edit() {
 	const blockProps = useBlockProps();
 	const { generateProductVariations } = useProductVariationsHelper();

--- a/packages/js/product-editor/src/blocks/variation-options/edit.tsx
+++ b/packages/js/product-editor/src/blocks/variation-options/edit.tsx
@@ -22,10 +22,7 @@ import { useEntityProp, useEntityId } from '@wordpress/core-data';
 /**
  * Internal dependencies
  */
-import {
-	EnhancedProductAttribute,
-	useProductAttributes,
-} from '../../hooks/use-product-attributes';
+import { useProductAttributes } from '../../hooks/use-product-attributes';
 import { AttributeControl } from '../../components/attribute-control';
 import { useProductVariationsHelper } from '../../hooks/use-product-variations-helper';
 

--- a/packages/js/product-editor/src/blocks/variation-options/edit.tsx
+++ b/packages/js/product-editor/src/blocks/variation-options/edit.tsx
@@ -72,9 +72,10 @@ export function Edit() {
 		allAttributes: entityAttributes,
 		isVariationAttributes: true,
 		productId: useEntityId( 'postType', 'product' ),
-		onChange( values ) {
+		onChange( values, defaultAttributes ) {
 			setEntityAttributes( values );
-			generateProductVariations( values );
+			setEntityDefaultAttributes( defaultAttributes );
+			generateProductVariations( values, defaultAttributes );
 		},
 	} );
 
@@ -130,12 +131,7 @@ export function Edit() {
 					attributes,
 					entityDefaultAttributes,
 				] ) }
-				onChange={ ( values ) => {
-					handleChange( values );
-					setEntityDefaultAttributes(
-						manageDefaultAttributes( values )
-					);
-				} }
+				onChange={ handleChange }
 				createNewAttributesAsGlobal={ true }
 				useRemoveConfirmationModal={ true }
 				onNoticeDismiss={ () =>

--- a/packages/js/product-editor/src/blocks/variations/edit.tsx
+++ b/packages/js/product-editor/src/blocks/variations/edit.tsx
@@ -70,10 +70,10 @@ export function Edit( {
 			productId: useEntityId( 'postType', 'product' ),
 			onChange( values ) {
 				setProductAttributes( values );
-				setDefaultProductAttributes(
-					getFirstOptionFromEachAttribute( values )
-				);
-				generateProductVariations( values );
+				const defaultAttributes =
+					getFirstOptionFromEachAttribute( values );
+				setDefaultProductAttributes( defaultAttributes );
+				generateProductVariations( values, defaultAttributes );
 			},
 		}
 	);

--- a/packages/js/product-editor/src/blocks/variations/edit.tsx
+++ b/packages/js/product-editor/src/blocks/variations/edit.tsx
@@ -39,16 +39,6 @@ import { useProductVariationsHelper } from '../../hooks/use-product-variations-h
 import { hasAttributesUsedForVariations } from '../../utils';
 import { TRACKS_SOURCE } from '../../constants';
 
-function getFirstOptionFromEachAttribute(
-	attributes: Product[ 'attributes' ]
-): Product[ 'default_attributes' ] {
-	return attributes.map( ( attribute ) => ( {
-		id: attribute.id,
-		name: attribute.name,
-		option: attribute.options[ 0 ],
-	} ) );
-}
-
 export function Edit( {
 	attributes,
 }: BlockEditProps< VariationsBlockAttributes > ) {
@@ -68,10 +58,8 @@ export function Edit( {
 			allAttributes: productAttributes,
 			isVariationAttributes: true,
 			productId: useEntityId( 'postType', 'product' ),
-			onChange( values ) {
+			onChange( values, defaultAttributes ) {
 				setProductAttributes( values );
-				const defaultAttributes =
-					getFirstOptionFromEachAttribute( values );
 				setDefaultProductAttributes( defaultAttributes );
 				generateProductVariations( values, defaultAttributes );
 			},

--- a/packages/js/product-editor/src/hooks/test/use-product-attributes.test.ts
+++ b/packages/js/product-editor/src/hooks/test/use-product-attributes.test.ts
@@ -172,15 +172,18 @@ describe( 'useProductAttributes', () => {
 			jest.runOnlyPendingTimers();
 			await waitForNextUpdate();
 			result.current.handleChange( [
-				allAttributes[ 0 ],
-				allAttributes[ 1 ],
-				{ ...testAttributes[ 0 ] },
+				{ ...allAttributes[ 0 ], isDefault: false },
+				{ ...allAttributes[ 1 ], isDefault: false },
+				{ ...testAttributes[ 0 ], isDefault: false },
 			] );
-			expect( onChange ).toHaveBeenCalledWith( [
-				{ ...allAttributes[ 0 ], position: 0 },
-				{ ...allAttributes[ 1 ], position: 1 },
-				{ ...testAttributes[ 0 ], variation: false, position: 2 },
-			] );
+			expect( onChange ).toHaveBeenCalledWith(
+				[
+					{ ...allAttributes[ 0 ], position: 0 },
+					{ ...allAttributes[ 1 ], position: 1 },
+					{ ...testAttributes[ 0 ], variation: false, position: 2 },
+				],
+				[]
+			);
 		} );
 
 		it( 'should keep both variable and non variable as part of the onChange list, when isVariation is false', async () => {
@@ -202,12 +205,17 @@ describe( 'useProductAttributes', () => {
 			);
 			jest.runOnlyPendingTimers();
 			await waitForNextUpdate();
-			result.current.handleChange( [ { ...testAttributes[ 0 ] } ] );
-			expect( onChange ).toHaveBeenCalledWith( [
-				{ ...testAttributes[ 0 ], variation: false, position: 0 },
-				{ ...allAttributes[ 0 ], position: 1 },
-				{ ...allAttributes[ 1 ], position: 2 },
+			result.current.handleChange( [
+				{ ...testAttributes[ 0 ], isDefault: false },
 			] );
+			expect( onChange ).toHaveBeenCalledWith(
+				[
+					{ ...testAttributes[ 0 ], variation: false, position: 0 },
+					{ ...allAttributes[ 0 ], position: 1 },
+					{ ...allAttributes[ 1 ], position: 2 },
+				],
+				[]
+			);
 		} );
 
 		it( 'should keep both variable and non variable as part of the onChange list, when isVariation is true', async () => {
@@ -229,12 +237,17 @@ describe( 'useProductAttributes', () => {
 			);
 			jest.runOnlyPendingTimers();
 			await waitForNextUpdate();
-			result.current.handleChange( [ { ...testAttributes[ 0 ] } ] );
-			expect( onChange ).toHaveBeenCalledWith( [
-				{ ...allAttributes[ 0 ], position: 0 },
-				{ ...allAttributes[ 1 ], position: 1 },
-				{ ...testAttributes[ 0 ], variation: true, position: 2 },
+			result.current.handleChange( [
+				{ ...testAttributes[ 0 ], isDefault: false },
 			] );
+			expect( onChange ).toHaveBeenCalledWith(
+				[
+					{ ...allAttributes[ 0 ], position: 0 },
+					{ ...allAttributes[ 1 ], position: 1 },
+					{ ...testAttributes[ 0 ], variation: true, position: 2 },
+				],
+				[]
+			);
 		} );
 
 		it( 'should remove duplicate globals', async () => {
@@ -256,11 +269,16 @@ describe( 'useProductAttributes', () => {
 			);
 			jest.runOnlyPendingTimers();
 			await waitForNextUpdate();
-			result.current.handleChange( [ { ...testAttributes[ 1 ] } ] );
-			expect( onChange ).toHaveBeenCalledWith( [
-				{ ...allAttributes[ 1 ], position: 0 },
-				{ ...allAttributes[ 0 ], position: 1, variation: true },
+			result.current.handleChange( [
+				{ ...testAttributes[ 1 ], isDefault: false },
 			] );
+			expect( onChange ).toHaveBeenCalledWith(
+				[
+					{ ...allAttributes[ 1 ], position: 0 },
+					{ ...allAttributes[ 0 ], position: 1, variation: true },
+				],
+				[]
+			);
 		} );
 
 		it( 'should remove duplicate locals by name', async () => {
@@ -282,11 +300,94 @@ describe( 'useProductAttributes', () => {
 			);
 			jest.runOnlyPendingTimers();
 			await waitForNextUpdate();
-			result.current.handleChange( [ { ...testAttributes[ 0 ] } ] );
-			expect( onChange ).toHaveBeenCalledWith( [
-				{ ...allAttributes[ 1 ], position: 0 },
-				{ ...allAttributes[ 0 ], position: 1, variation: true },
+			result.current.handleChange( [
+				{ ...testAttributes[ 0 ], isDefault: false },
 			] );
+			expect( onChange ).toHaveBeenCalledWith(
+				[
+					{ ...allAttributes[ 1 ], position: 0 },
+					{ ...allAttributes[ 0 ], position: 1, variation: true },
+				],
+				[]
+			);
+		} );
+
+		it( 'should pass default attributes as second param, defaulting to true when isDefault is not defined', async () => {
+			const allAttributes = [
+				{ ...testAttributes[ 0 ] },
+				{ ...testAttributes[ 1 ] },
+			];
+			const onChange = jest.fn();
+			const { result, waitForNextUpdate } = renderHook(
+				useProductAttributes,
+				{
+					initialProps: {
+						allAttributes,
+						onChange,
+						isVariationAttributes: true,
+						productId: 123,
+					},
+				}
+			);
+			jest.runOnlyPendingTimers();
+			await waitForNextUpdate();
+			result.current.handleChange( [ { ...testAttributes[ 0 ] } ] );
+			expect( onChange ).toHaveBeenCalledWith(
+				[
+					{ ...allAttributes[ 1 ], position: 0 },
+					{ ...allAttributes[ 0 ], position: 1, variation: true },
+				],
+				[
+					{
+						id: testAttributes[ 0 ].id,
+						name: testAttributes[ 0 ].name,
+						option: testAttributes[ 0 ].options[ 0 ],
+					},
+				]
+			);
+		} );
+
+		it( 'should pass default attributes as second param, when isDefault is true', async () => {
+			const allAttributes = [
+				{ ...testAttributes[ 0 ] },
+				{ ...testAttributes[ 1 ] },
+			];
+			const onChange = jest.fn();
+			const { result, waitForNextUpdate } = renderHook(
+				useProductAttributes,
+				{
+					initialProps: {
+						allAttributes,
+						onChange,
+						isVariationAttributes: true,
+						productId: 123,
+					},
+				}
+			);
+			jest.runOnlyPendingTimers();
+			await waitForNextUpdate();
+			result.current.handleChange( [
+				{ ...testAttributes[ 0 ], isDefault: true },
+				{ ...testAttributes[ 1 ], isDefault: true },
+			] );
+			expect( onChange ).toHaveBeenCalledWith(
+				[
+					{ ...allAttributes[ 0 ], position: 0, variation: true },
+					{ ...allAttributes[ 1 ], position: 1, variation: true },
+				],
+				[
+					{
+						id: testAttributes[ 0 ].id,
+						name: testAttributes[ 0 ].name,
+						option: testAttributes[ 0 ].options[ 0 ],
+					},
+					{
+						id: testAttributes[ 1 ].id,
+						name: testAttributes[ 1 ].name,
+						option: testAttributes[ 1 ].options[ 0 ],
+					},
+				]
+			);
 		} );
 	} );
 

--- a/packages/js/product-editor/src/hooks/use-product-attributes.ts
+++ b/packages/js/product-editor/src/hooks/use-product-attributes.ts
@@ -3,8 +3,10 @@
  */
 import {
 	EXPERIMENTAL_PRODUCT_ATTRIBUTE_TERMS_STORE_NAME,
+	Product,
 	ProductAttribute,
 	ProductAttributeTerm,
+	ProductDefaultAttribute,
 } from '@woocommerce/data';
 import { resolveSelect } from '@wordpress/data';
 import { useCallback, useEffect, useState } from '@wordpress/element';
@@ -23,7 +25,10 @@ export type EnhancedProductAttribute = ProductAttribute & {
 type useProductAttributesProps = {
 	allAttributes: ProductAttribute[];
 	isVariationAttributes?: boolean;
-	onChange: ( attributes: ProductAttribute[] ) => void;
+	onChange: (
+		attributes: ProductAttribute[],
+		defaultAttributes: ProductDefaultAttribute[]
+	) => void;
 	productId?: number;
 };
 
@@ -35,6 +40,29 @@ const getFilteredAttributes = (
 		? attr.filter( ( attribute ) => !! attribute.variation )
 		: attr.filter( ( attribute ) => ! attribute.variation );
 };
+
+function manageDefaultAttributes( values: EnhancedProductAttribute[] ) {
+	return values.reduce< Product[ 'default_attributes' ] >(
+		( prevDefaultAttributes, currentAttribute ) => {
+			if (
+				// defaults to true.
+				currentAttribute.isDefault === undefined ||
+				currentAttribute.isDefault === true
+			) {
+				return [
+					...prevDefaultAttributes,
+					{
+						id: currentAttribute.id,
+						name: currentAttribute.name,
+						option: currentAttribute.options[ 0 ],
+					},
+				];
+			}
+			return prevDefaultAttributes;
+		},
+		[]
+	);
+}
 
 export function useProductAttributes( {
 	allAttributes = [],
@@ -83,7 +111,7 @@ export function useProductAttributes( {
 		variation: boolean,
 		startPosition: number
 	): ProductAttribute[] => {
-		return atts.map( ( { terms, ...attribute }, index ) => ( {
+		return atts.map( ( { isDefault, terms, ...attribute }, index ) => ( {
 			...attribute,
 			variation,
 			position: startPosition + index,
@@ -91,6 +119,7 @@ export function useProductAttributes( {
 	};
 
 	const handleChange = ( newAttributes: EnhancedProductAttribute[] ) => {
+		const defaultAttributes = manageDefaultAttributes( newAttributes );
 		let otherAttributes = isVariationAttributes
 			? allAttributes.filter( ( attribute ) => ! attribute.variation )
 			: allAttributes.filter( ( attribute ) => !! attribute.variation );
@@ -126,15 +155,15 @@ export function useProductAttributes( {
 		);
 
 		if ( isVariationAttributes ) {
-			onChange( [
-				...otherAugmentedAttributes,
-				...newAugmentedAttributes,
-			] );
+			onChange(
+				[ ...otherAugmentedAttributes, ...newAugmentedAttributes ],
+				defaultAttributes
+			);
 		} else {
-			onChange( [
-				...newAugmentedAttributes,
-				...otherAugmentedAttributes,
-			] );
+			onChange(
+				[ ...newAugmentedAttributes, ...otherAugmentedAttributes ],
+				defaultAttributes
+			);
 		}
 	};
 

--- a/packages/js/product-editor/src/hooks/use-product-attributes.ts
+++ b/packages/js/product-editor/src/hooks/use-product-attributes.ts
@@ -83,7 +83,7 @@ export function useProductAttributes( {
 		variation: boolean,
 		startPosition: number
 	): ProductAttribute[] => {
-		return atts.map( ( { isDefault, terms, ...attribute }, index ) => ( {
+		return atts.map( ( { terms, ...attribute }, index ) => ( {
 			...attribute,
 			variation,
 			position: startPosition + index,

--- a/packages/js/product-editor/src/hooks/use-product-variations-helper.ts
+++ b/packages/js/product-editor/src/hooks/use-product-variations-helper.ts
@@ -4,7 +4,10 @@
 import { useDispatch } from '@wordpress/data';
 import { useEntityProp } from '@wordpress/core-data';
 import { useCallback, useState } from '@wordpress/element';
-import { EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME } from '@woocommerce/data';
+import {
+	EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME,
+	ProductDefaultAttribute,
+} from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -25,7 +28,10 @@ export function useProductVariationsHelper() {
 	const [ isGenerating, setIsGenerating ] = useState( false );
 
 	const generateProductVariations = useCallback(
-		async ( attributes: EnhancedProductAttribute[] ) => {
+		async (
+			attributes: EnhancedProductAttribute[],
+			defaultAttributes?: ProductDefaultAttribute[]
+		) => {
 			setIsGenerating( true );
 
 			const hasVariableAttribute = attributes.some(
@@ -42,6 +48,7 @@ export function useProductVariationsHelper() {
 				{
 					type: hasVariableAttribute ? 'variable' : 'simple',
 					attributes,
+					default_attributes: defaultAttributes,
 				},
 				{
 					delete: true,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This fixes a bug where the dirty state was still present after creating a brand new product with variations.
This was because of the default attributes still being present, they were also broken.

Closes #39840  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

**Requires feature flag: `product-variation-management`**

1. Load this branch and enable the new product editor under **WooCommerce > Settings > Advanced > Features**
2. Install the WooCommerce Beta tester plugin and enable the `product-variation-management` feature under **Tools > WCA Test Helper > Features**
3. Go to Products > Add New
4. Add a name.
5. This step is important: save the product as draft.
6. Go to the Variations tab
7. Click Add variation options and add a couple variations and click Add
8. Variations should be auto created. 
9. Refresh the page, Notice how it refreshes fine without the loose your changes confirmation, that shows up after making some edits without saving.
10. Now click **Edit** on one of the variation options and toggle the **Set default value** and click **Update**
11. Refresh the page, the **Set default value** should persist correctly when editing the same default value again.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
