### PR TITLE
Don't pass lint if it fails, but still run annotate.

### DIFF
--- a/.github/workflows/pr-lint-js.yml
+++ b/.github/workflows/pr-lint-js.yml
@@ -1,4 +1,4 @@
-name: Lint JS packages
+name: Lint packages
 
 on:
     pull_request:
@@ -39,16 +39,16 @@ jobs:
                   # ignore scripts is faster, and postinstall should not be needed for lint.
                   pnpm install --ignore-scripts
 
-            - name: Lint
+            - name: Lint JS
               run: pnpm run -r --filter='release-posts' --filter='woocommerce/client/admin...' --filter='@woocommerce/monorepo-utils' --filter='!@woocommerce/e2e*' --filter='!@woocommerce/api' --color lint
-              continue-on-error: true
 
             - name: Collect and Combine Eslint Reports
+              if: ${{ github.event.pull_request.head.repo.fork != true && always() }}
               run: node ./.github/workflows/scripts/collect-eslint-reports.js
 
             - name: Annotate Code Linting Results
               uses: ataylorme/eslint-annotate-action@a1bf7cb320a18aa53cb848a267ce9b7417221526
-              if: github.event.pull_request.head.repo.fork != true
+              if: ${{ github.event.pull_request.head.repo.fork != true && always() }}
               with:
                   repo-token: '${{ secrets.GITHUB_TOKEN }}'
                   report-json: 'combined_eslint_report.json'

--- a/.github/workflows/pr-lint-js.yml
+++ b/.github/workflows/pr-lint-js.yml
@@ -39,7 +39,7 @@ jobs:
                   # ignore scripts is faster, and postinstall should not be needed for lint.
                   pnpm install --ignore-scripts
 
-            - name: Lint JS
+            - name: Lint JS and CSS
               run: pnpm run -r --filter='release-posts' --filter='woocommerce/client/admin...' --filter='@woocommerce/monorepo-utils' --filter='!@woocommerce/e2e*' --filter='!@woocommerce/api' --color lint
 
             - name: Collect and Combine Eslint Reports


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The continue-on-error approach to running annotations was flawed because it passes the lint job even on failure. This should ensure the annotate still runs but fails if lint fails.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

See the failing CI lint check, but that the subsequent steps are still running: https://github.com/woocommerce/woocommerce/actions/runs/6009598842/job/16299353738?pr=39943

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
