### PR TITLE
Add a filter to OrdersTableQuery to allow overriding of HPOS queries

### DIFF
--- a/plugins/woocommerce/changelog/add-filter-hpos-query-override
+++ b/plugins/woocommerce/changelog/add-filter-hpos-query-override
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a filter to OrdersTableQuery to allow overriding of HPOS queries.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -218,7 +218,7 @@ class OrdersTableQuery {
 		 * Return a non-null value to bypass the HPOS default order queries.
 		 *
 		 * If the query includes limits via the `limit`, `page`, or `offset` arguments, we
-		 * require the `found_orders` and `max_num_pages` properties to also be set.
+		 * encourage the `found_orders` and `max_num_pages` properties to also be set.
 		 *
 		 * @since 8.2.0
 		 *

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -230,6 +230,7 @@ class OrdersTableQuery {
 		 *     @type int   $max_num_pages The number of pages.
 		 * }
 		 * @param OrdersTableQuery   $query The OrdersTableQuery instance.
+		 * @param string             $sql The OrdersTableQuery instance.
 		 */
 		list( $this->orders, $this->found_orders, $this->max_num_pages ) = apply_filters( 'woocommerce_hpos_pre_query', null, $this, $this->sql );
 		// If the filter set the orders, make sure the others values are set as well and skip running the query.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -201,7 +201,17 @@ class OrdersTableQuery {
 		$require_limit_data = ( $this->arg_isset( 'limit' ) || $this->arg_isset( 'page' ) || $this->arg_isset( 'offset' ) );
 
 		$this->build_query();
+		if ( ! $this->maybe_override_query() ) {
+			$this->run_query();
+		}
+	}
 
+	/**
+	 * Lets the `woocommerce_hpos_pre_query` filter override the query.
+	 *
+	 * @return boolean Whether the query was overridden or not.
+	 */
+	private function maybe_override_query(): bool {
 		/**
 		 * Filters the orders array before the query takes place.
 		 *
@@ -233,9 +243,9 @@ class OrdersTableQuery {
 				}
 				$this->max_num_pages = (int) ceil( $this->found_orders / $this->args['limit'] );
 			}
-		} else {
-			$this->run_query();
+			return true;
 		}
+		return false;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -222,7 +222,7 @@ class OrdersTableQuery {
 		 *
 		 * @since 8.2.0
 		 *
-		 * @param array $order_data {
+		 * @param array|null $order_data {
 		 *     An array of order data.
 		 *     @type int[] $orders        Return an array of order IDs data to short-circuit the HPOS query,
 		 *                                or null to allow HPOS to run its normal query.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -198,8 +198,6 @@ class OrdersTableQuery {
 		// TODO: args to be implemented.
 		unset( $this->args['customer_note'], $this->args['name'] );
 
-		$require_limit_data = ( $this->arg_isset( 'limit' ) || $this->arg_isset( 'page' ) || $this->arg_isset( 'offset' ) );
-
 		$this->build_query();
 		if ( ! $this->maybe_override_query() ) {
 			$this->run_query();

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
@@ -335,7 +335,6 @@ class OrdersTableQueryTests extends WC_Unit_Test_Case {
 		};
 		add_filter( 'woocommerce_hpos_pre_query', $callback, 10, 3 );
 
-		echo 'setting limit arg to 5. ';
 		$query = new OrdersTableQuery(
 			array(
 				'limit' => 5,

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
@@ -237,9 +237,9 @@ class OrdersTableQueryTests extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox The pre-query escape hook allows replacing the order query.
+	 * @testdox The pre-query escape hook allows replacing the order query. The callback does not return pagination information.
 	 */
-	public function test_pre_query_escape_hook() {
+	public function test_pre_query_escape_hook_simple() {
 		$order1 = new \WC_Order();
 		$order1->set_date_created( time() - HOUR_IN_SECONDS );
 		$order1->save();
@@ -252,13 +252,58 @@ class OrdersTableQueryTests extends WC_Unit_Test_Case {
 		$this->assertEquals( 2, $query->found_orders );
 		$this->assertEquals( 0, $query->max_num_pages );
 
-		$callback = function( $query ) use ( $order1 ) {
+		$callback = function( $result, $query_object, $sql ) use ( $order1 ) {
+			$this->assertNull( $result );
+			$this->assertInstanceOf( OrdersTableQuery::class, $query_object );
+			$this->assertStringContainsString( 'SELECT ', $sql );
+
+			// Only return one of the orders to show that we are replacing the query result.
+			// Do not return found_orders or max_num_pages to show we're setting defaults.
+			$order_ids = array( $order1->get_id() );
+			return array( $order_ids, null, null );
+		};
+		add_filter( 'woocommerce_hpos_pre_query', $callback, 10, 3 );
+
+		$query = new OrdersTableQuery( array() );
+		$this->assertCount( 1, $query->orders );
+		$this->assertEquals( 1, $query->found_orders );
+		$this->assertEquals( 1, $query->max_num_pages );
+		$this->assertEquals( $order1->get_id(), $query->orders[0] );
+
+		$orders = wc_get_orders( array() );
+		$this->assertCount( 1, $orders );
+		$this->assertEquals( $order1->get_id(), $orders[0]->get_id() );
+
+		remove_all_filters( 'woocommerce_hpos_pre_query' );
+	}
+
+	/**
+	 * @testdox The pre-query escape hook allows replacing the order query. The callback returns pagination information.
+	 */
+	public function test_pre_query_escape_hook_with_pagination() {
+		$order1 = new \WC_Order();
+		$order1->set_date_created( time() - HOUR_IN_SECONDS );
+		$order1->save();
+
+		$order2 = new \WC_Order();
+		$order2->save();
+
+		$query = new OrdersTableQuery( array() );
+		$this->assertCount( 2, $query->orders );
+		$this->assertEquals( 2, $query->found_orders );
+		$this->assertEquals( 0, $query->max_num_pages );
+
+		$callback = function( $result, $query_object, $sql ) use ( $order1 ) {
+			$this->assertNull( $result );
+			$this->assertInstanceOf( OrdersTableQuery::class, $query_object );
+			$this->assertStringContainsString( 'SELECT ', $sql );
+
 			// Only return one of the orders to show that we are replacing the query result.
 			$order_ids = array( $order1->get_id() );
-			// These are made up to show that we are actually replacing the values. 
-			$found_orders = 17;
+			// These are made up to show that we are actually replacing the values.
+			$found_orders  = 17;
 			$max_num_pages = 23;
-			return [ $order_ids, $found_orders, $max_num_pages ];
+			return array( $order_ids, $found_orders, $max_num_pages );
 		};
 		add_filter( 'woocommerce_hpos_pre_query', $callback, 10, 3 );
 
@@ -275,4 +320,31 @@ class OrdersTableQueryTests extends WC_Unit_Test_Case {
 		remove_all_filters( 'woocommerce_hpos_pre_query' );
 	}
 
+	/**
+	 * @testdox The pre-query escape hook uses the limit arg if it is set.
+	 */
+	public function test_pre_query_escape_hook_pass_limit() {
+		$order1 = new \WC_Order();
+		$order1->set_date_created( time() - HOUR_IN_SECONDS );
+		$order1->save();
+
+		$callback = function( $result, $query_object, $sql ) use ( $order1 ) {
+			// Do not return found_orders or max_num_pages so as to provoke a warning.
+			$order_ids = array( $order1->get_id() );
+			return array( $order_ids, 10, null );
+		};
+		add_filter( 'woocommerce_hpos_pre_query', $callback, 10, 3 );
+
+		echo 'setting limit arg to 5. ';
+		$query = new OrdersTableQuery(
+			array(
+				'limit' => 5,
+			)
+		);
+		$this->assertCount( 1, $query->orders );
+		$this->assertEquals( 10, $query->found_orders );
+		$this->assertEquals( 2, $query->max_num_pages );
+
+		remove_all_filters( 'woocommerce_hpos_pre_query' );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
@@ -347,4 +347,52 @@ class OrdersTableQueryTests extends WC_Unit_Test_Case {
 
 		remove_all_filters( 'woocommerce_hpos_pre_query' );
 	}
+
+	/**
+	 * @testdox A regular query will still work even if the pre-query escape hook returns null for the whole 3-tuple.
+	 */
+	public function test_pre_query_escape_hook_return_null() {
+		$order1 = new \WC_Order();
+		$order1->set_date_created( time() - HOUR_IN_SECONDS );
+		$order1->save();
+
+		$callback = function( $result, $query_object, $sql ) use ( $order1 ) {
+			// Just return null.
+			return null;
+		};
+		add_filter( 'woocommerce_hpos_pre_query', $callback, 10, 3 );
+
+		$query = new OrdersTableQuery();
+		$this->assertCount( 1, $query->orders );
+		$this->assertEquals( 1, $query->found_orders );
+		$this->assertEquals( null, $query->max_num_pages );
+
+		remove_all_filters( 'woocommerce_hpos_pre_query' );
+	}
+
+	/**
+	 * @testdox A regular query with a limit will still work even if the pre-query escape hook returns null for the whole 3-tuple.
+	 */
+	public function test_pre_query_escape_hook_return_null_limit() {
+		$order1 = new \WC_Order();
+		$order1->set_date_created( time() - HOUR_IN_SECONDS );
+		$order1->save();
+
+		$callback = function( $result, $query_object, $sql ) use ( $order1 ) {
+			// Just return null.
+			return null;
+		};
+		add_filter( 'woocommerce_hpos_pre_query', $callback, 10, 3 );
+
+		$query = new OrdersTableQuery(
+			array(
+				'limit' => 5,
+			)
+		);
+		$this->assertCount( 1, $query->orders );
+		$this->assertEquals( 1, $query->found_orders );
+		$this->assertEquals( 1, $query->max_num_pages );
+
+		remove_all_filters( 'woocommerce_hpos_pre_query' );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds a filter to the `OrdersTableQuery` class to allow for the overriding of HPOS queries. 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create four orders and note their IDs.
2. Add a filter snippet to, for example, `woocommerce.php`, so that an HPOS-based order query will only return those IDs. Example: 
```php
$callback = function( $result, $query_object, $sql ) {
	// an array of the order IDs to return, the number of orders, and the number of pages
	// for this test, simply replace the two order IDs with the ones you noted down
	return array( array( 15, 18 ), 2, 1 );
};
add_filter( 'woocommerce_hpos_pre_query', $callback, 10, 3 );

```
3. Go to the order list screen and verify that all four orders are displayed.
4. Go to Settings / Features and activate HPOS
5. Go to the order list screen and verify that only the two orders returned by the callback are displayed.

<!-- End testing instructions -→

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -→

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -→

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -→

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -→

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -→

</details>
