### PR TITLE
HPOS: Add background sync

### DIFF
--- a/plugins/woocommerce/changelog/fix-39626-pending-order-syncs
+++ b/plugins/woocommerce/changelog/fix-39626-pending-order-syncs
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Add a recurring event when HPOS compatibility mode is enabled to check for unsynced orders and sync them. Also add a button on the Features screen to trigger an order sync manually.
+Add a background sync that can run independently of the normal real-time HPOS data sync. Also add a button on the Features screen to trigger an order sync manually.

--- a/plugins/woocommerce/changelog/fix-39626-pending-order-syncs
+++ b/plugins/woocommerce/changelog/fix-39626-pending-order-syncs
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add a recurring event when HPOS compatibility mode is enabled to check for unsynced orders and sync them. Also add a button on the Features screen to trigger an order sync manually.

--- a/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
+++ b/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
@@ -99,14 +99,25 @@ class BatchProcessingController {
 	 * @param bool $unique     Whether to make the action unique.
 	 */
 	private function schedule_watchdog_action( bool $with_delay = false, bool $unique = false ): void {
-		$time = $with_delay ? time() + HOUR_IN_SECONDS : time();
-		as_schedule_single_action(
-			$time,
-			self::WATCHDOG_ACTION_NAME,
-			array(),
-			self::ACTION_GROUP,
-			$unique
-		);
+		$time = time();
+		if ( $with_delay ) {
+			/**
+			 * Modify the delay interval for the batch processor's watchdog events.
+			 *
+			 * @param int $delay Time, in seconds, before the watchdog process will run. Defaults to 3600 (1 hour).
+			 */
+			$time += apply_filters( 'woocommerce_batch_processor_watchdog_delay_seconds', HOUR_IN_SECONDS );
+		}
+
+		if ( ! as_has_scheduled_action( self::WATCHDOG_ACTION_NAME ) ) {
+			as_schedule_single_action(
+				$time,
+				self::WATCHDOG_ACTION_NAME,
+				array(),
+				self::ACTION_GROUP,
+				$unique
+			);
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
+++ b/plugins/woocommerce/src/Internal/BatchProcessing/BatchProcessingController.php
@@ -104,6 +104,8 @@ class BatchProcessingController {
 			/**
 			 * Modify the delay interval for the batch processor's watchdog events.
 			 *
+			 * @since 8.2.0
+			 *
 			 * @param int $delay Time, in seconds, before the watchdog process will run. Defaults to 3600 (1 hour).
 			 */
 			$time += apply_filters( 'woocommerce_batch_processor_watchdog_delay_seconds', HOUR_IN_SECONDS );

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -374,8 +374,13 @@ class CustomOrdersTableController {
 			return;
 		}
 
-		if ( ! as_has_scheduled_action( self::SYNC_CHECK_EVENT_HOOK ) ) {
-			as_schedule_recurring_action(
+		$has_scheduled_action = WC()->queue()->search( array(
+			'hook'   => self::SYNC_CHECK_EVENT_HOOK,
+			'status' => array( 'in-progress', 'pending' ),
+		) );
+
+		if ( ! $has_scheduled_action ) {
+			WC()->queue()->schedule_recurring(
 				time() + HOUR_IN_SECONDS,
 				6 * HOUR_IN_SECONDS,
 				self::SYNC_CHECK_EVENT_HOOK
@@ -395,7 +400,7 @@ class CustomOrdersTableController {
 			return;
 		}
 
-		as_unschedule_all_actions( self::SYNC_CHECK_EVENT_HOOK );
+		WC()->queue()->cancel_all( self::SYNC_CHECK_EVENT_HOOK );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -592,10 +592,10 @@ class CustomOrdersTableController {
 			);
 
 			$sync_message .= sprintf(
-				'<br /><br /><a href="%1$s" class="button button-secondary">%2$s</a>',
+				'<br /><a href="%1$s" class="button button-link">%2$s</a>',
 				esc_url( $sync_now_url ),
 				sprintf(
-				// translators: %d: number of pending orders.
+					// translators: %d: number of pending orders.
 					_n(
 						'Sync %d pending order',
 						'Sync %d pending orders',

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -586,10 +586,10 @@ class CustomOrdersTableController {
 				wc_get_container()->get( FeaturesController::class )->get_features_page_url()
 			);
 
-			$sync_message .= esc_html__(
+			$sync_message .= wp_kses_data( __(
 				'You can switch order data storage <strong>only when the posts and orders tables are in sync</strong>.',
 				'woocommerce'
-			);
+			) );
 
 			$sync_message .= sprintf(
 				'<br /><a href="%1$s" class="button button-link">%2$s</a>',
@@ -597,12 +597,12 @@ class CustomOrdersTableController {
 				sprintf(
 					// translators: %d: number of pending orders.
 					_n(
-						'Sync %d pending order',
-						'Sync %d pending orders',
+						'Sync %s pending order',
+						'Sync %s pending orders',
 						$sync_status['current_pending_count'],
 						'woocommerce'
 					),
-					$sync_status['current_pending_count']
+					number_format_i18n( $sync_status['current_pending_count'] )
 				)
 			);
 		}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -379,10 +379,17 @@ class CustomOrdersTableController {
 			'status' => array( 'in-progress', 'pending' ),
 		) );
 
+		/**
+		 * Modify the time interval for the recurring event to check for pending order syncs.
+		 *
+		 * @param int $sync_check_interval The time, in seconds, between sync checks. Defaults to 21600 (6 hours).
+		 */
+		$interval = apply_filters( 'woocommerce_custom_orders_table_sync_check_interval', 6 * HOUR_IN_SECONDS );
+
 		if ( ! $has_scheduled_action ) {
 			WC()->queue()->schedule_recurring(
 				time() + HOUR_IN_SECONDS,
-				6 * HOUR_IN_SECONDS,
+				$interval,
 				self::SYNC_CHECK_EVENT_HOOK
 			);
 		}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -423,8 +423,8 @@ class CustomOrdersTableController {
 			return;
 		}
 
-		$sync_status = $this->data_synchronizer->get_sync_status();
-		if ( $sync_status['current_pending_count'] <= 0 ) {
+		$pending_count = $this->data_synchronizer->get_total_pending_count();
+		if ( $pending_count <= 0 ) {
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -483,6 +483,10 @@ class CustomOrdersTableController {
 		$sync_enabled     = $this->data_synchronizer->data_sync_is_enabled();
 		$sync_message     = array();
 
+		if ( ! $sync_enabled && $this->data_synchronizer->background_sync_is_enabled() ) {
+			$sync_message[] = __( 'Background sync is enabled.', 'woocommerce' );
+		}
+
 		if ( $sync_in_progress && $sync_status['current_pending_count'] > 0 ) {
 			$sync_message[] = sprintf(
 				// translators: %d: number of pending orders.
@@ -516,10 +520,6 @@ class CustomOrdersTableController {
 					number_format_i18n( $sync_status['current_pending_count'] )
 				)
 			);
-		}
-
-		if ( $this->data_synchronizer->background_sync_is_enabled() ) {
-			$sync_message[] = __( 'Background sync is enabled.', 'woocommerce' );
 		}
 
 		return array(

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -47,6 +47,8 @@ class DataSynchronizer implements BatchProcessorInterface {
 
 	private const BACKGROUND_SYNC_EVENT_HOOK                = 'woocommerce_custom_orders_table_background_sync';
 	private const BACKGROUND_SYNC_SCHEDULE_STATUS_CACHE_KEY = 'woocommerce_custom_orders_table_background_sync_scheduled';
+	private const BACKGROUND_SYNC_MODE_INTERVAL             = 'interval';
+	private const BACKGROUND_SYNC_MODE_CONTINUOUS           = 'continuous';
 
 	/**
 	 * The data store object to use.
@@ -325,15 +327,15 @@ class DataSynchronizer implements BatchProcessorInterface {
 		 *
 		 * @param string $mode The mode for background sync. 'interval' or 'continuous'. Defaults to 'interval'.
 		 */
-		$mode = apply_filters( 'woocommerce_custom_orders_table_background_sync_mode', 'interval' );
+		$mode = apply_filters( 'woocommerce_custom_orders_table_background_sync_mode', self::BACKGROUND_SYNC_MODE_INTERVAL );
 
 		switch ( $mode ) {
-			case 'interval':
+			case self::BACKGROUND_SYNC_MODE_INTERVAL:
 			default:
 				$this->schedule_background_sync();
 				break;
 
-			case 'continuous':
+			case self::BACKGROUND_SYNC_MODE_CONTINUOUS:
 				// This method already checks if a processor is enqueued before adding it to avoid duplication.
 				$this->batch_processing_controller->enqueue_processor( self::class );
 				$this->unschedule_background_sync();

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -8,7 +8,7 @@ namespace Automattic\WooCommerce\Internal\DataStores\Orders;
 use Automattic\WooCommerce\Caches\OrderCache;
 use Automattic\WooCommerce\Caches\OrderCacheController;
 use Automattic\WooCommerce\Database\Migrations\CustomOrderTable\PostsToOrdersMigrationController;
-use Automattic\WooCommerce\Internal\BatchProcessing\BatchProcessorInterface;
+use Automattic\WooCommerce\Internal\BatchProcessing\{ BatchProcessingController, BatchProcessorInterface };
 use Automattic\WooCommerce\Internal\Features\FeaturesController;
 use Automattic\WooCommerce\Internal\Traits\AccessiblePrivateMethods;
 use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
@@ -81,6 +81,13 @@ class DataSynchronizer implements BatchProcessorInterface {
 	private $order_cache_controller;
 
 	/**
+	 * The batch processing controller.
+	 *
+	 * @var BatchProcessingController
+	 */
+	private $batch_processing_controller;
+
+	/**
 	 * Class constructor.
 	 */
 	public function __construct() {
@@ -101,6 +108,7 @@ class DataSynchronizer implements BatchProcessorInterface {
 	 * @param PostsToOrdersMigrationController $posts_to_cot_migrator The posts to COT migration class to use.
 	 * @param LegacyProxy                      $legacy_proxy The legacy proxy instance to use.
 	 * @param OrderCacheController             $order_cache_controller The order cache controller instance to use.
+	 * @param BatchProcessingController        $batch_processing_controller The batch processing controller to use.
 	 * @internal
 	 */
 	final public function init(
@@ -108,13 +116,15 @@ class DataSynchronizer implements BatchProcessorInterface {
 		DatabaseUtil $database_util,
 		PostsToOrdersMigrationController $posts_to_cot_migrator,
 		LegacyProxy $legacy_proxy,
-		OrderCacheController $order_cache_controller
+		OrderCacheController $order_cache_controller,
+		BatchProcessingController $batch_processing_controller
 	) {
-		$this->data_store             = $data_store;
-		$this->database_util          = $database_util;
-		$this->posts_to_cot_migrator  = $posts_to_cot_migrator;
-		$this->error_logger           = $legacy_proxy->call_function( 'wc_get_logger' );
-		$this->order_cache_controller = $order_cache_controller;
+		$this->data_store                  = $data_store;
+		$this->database_util               = $database_util;
+		$this->posts_to_cot_migrator       = $posts_to_cot_migrator;
+		$this->error_logger                = $legacy_proxy->call_function( 'wc_get_logger' );
+		$this->order_cache_controller      = $order_cache_controller;
+		$this->batch_processing_controller = $batch_processing_controller;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -45,10 +45,10 @@ class DataSynchronizer implements BatchProcessorInterface {
 	public const ID_TYPE_DELETED_FROM_ORDERS_TABLE = 3;
 	public const ID_TYPE_DELETED_FROM_POSTS_TABLE  = 4;
 
-	private const BACKGROUND_SYNC_EVENT_HOOK                = 'woocommerce_custom_orders_table_background_sync';
+	public const BACKGROUND_SYNC_EVENT_HOOK                 = 'woocommerce_custom_orders_table_background_sync';
 	private const BACKGROUND_SYNC_SCHEDULE_STATUS_CACHE_KEY = 'woocommerce_custom_orders_table_background_sync_scheduled';
-	private const BACKGROUND_SYNC_MODE_INTERVAL             = 'interval';
-	private const BACKGROUND_SYNC_MODE_CONTINUOUS           = 'continuous';
+	public const BACKGROUND_SYNC_MODE_INTERVAL              = 'interval';
+	public const BACKGROUND_SYNC_MODE_CONTINUOUS            = 'continuous';
 
 	/**
 	 * The data store object to use.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -249,7 +249,7 @@ class DataSynchronizer implements BatchProcessorInterface {
 	 * @return void
 	 */
 	private function unschedule_background_sync() {
-		WC()->queue()->cancel_all( self::BACKGROUND_SYNC_EVENT_HOOK );as_unschedule_all_actions();
+		WC()->queue()->cancel_all( self::BACKGROUND_SYNC_EVENT_HOOK );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -244,13 +244,22 @@ class DataSynchronizer implements BatchProcessorInterface {
 	}
 
 	/**
+	 * Remove any pending background sync events.
+	 *
+	 * @return void
+	 */
+	private function unschedule_background_sync() {
+		WC()->queue()->cancel_all( self::BACKGROUND_SYNC_EVENT_HOOK );as_unschedule_all_actions();
+	}
+
+	/**
 	 * Keep background sync running, if it's enabled.
 	 *
 	 * @return void
 	 */
 	private function handle_background_sync() {
 		if ( ! $this->background_sync_is_enabled() ) {
-			WC()->queue()->cancel_all( self::BACKGROUND_SYNC_EVENT_HOOK );
+			$this->unschedule_background_sync();
 			return;
 		}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -279,6 +279,7 @@ class DataSynchronizer implements BatchProcessorInterface {
 			case 'continuous':
 				// This method already checks if a processor is enqueued before adding it to avoid duplication.
 				$this->batch_processing_controller->enqueue_processor( self::class );
+				$this->unschedule_background_sync();
 				break;
 		}
 	}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -206,6 +206,8 @@ class DataSynchronizer implements BatchProcessorInterface {
 		 *
 		 * This allows for background sync to be enabled even when real-time sync is disabled.
 		 *
+		 * @since 8.2.0
+		 *
 		 * @param bool $enabled True to enabled background sync.
 		 */
 		return apply_filters( 'woocommerce_custom_orders_table_background_sync_enabled', $enabled );
@@ -228,6 +230,8 @@ class DataSynchronizer implements BatchProcessorInterface {
 			 *
 			 * Note that the background sync mode must first be set to 'interval' using the
 			 * 'woocommerce_custom_orders_table_background_sync_mode' filter hook before this will work.
+			 *
+			 * @since 8.2.0
 			 *
 			 * @param int $interval The time interval, in seconds, between background syncs. Defaults to 3600 (1 hour).
 			 */
@@ -265,6 +269,8 @@ class DataSynchronizer implements BatchProcessorInterface {
 
 		/**
 		 * Modify the background sync mode.
+		 *
+		 * @since 8.2.0
 		 *
 		 * @param string $mode The mode for background sync. 'interval' or 'continuous'. Defaults to 'interval'.
 		 */

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -101,7 +101,7 @@ class DataSynchronizer implements BatchProcessorInterface {
 		self::add_action( 'woocommerce_refund_created', array( $this, 'handle_updated_order' ), 100 );
 		self::add_action( 'woocommerce_update_order', array( $this, 'handle_updated_order' ), 100 );
 		self::add_action( 'wp_scheduled_auto_draft_delete', array( $this, 'delete_auto_draft_orders' ), 9 );
-		self::add_action( 'init', array( $this, 'handle_background_sync' ) );
+		self::add_action( 'shutdown', array( $this, 'handle_background_sync' ) );
 		self::add_action( self::BACKGROUND_SYNC_EVENT_HOOK, array( $this, 'maybe_enqueue_data_sync' ) );
 
 		self::add_filter( 'woocommerce_feature_description_tip', array( $this, 'handle_feature_description_tip' ), 10, 3 );

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/OrdersDataStoreServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/OrdersDataStoreServiceProvider.php
@@ -58,6 +58,7 @@ class OrdersDataStoreServiceProvider extends AbstractServiceProvider {
 				PostsToOrdersMigrationController::class,
 				LegacyProxy::class,
 				OrderCacheController::class,
+				BatchProcessingController::class,
 			)
 		);
 		$this->share( OrdersTableRefundDataStore::class )->addArguments( array( OrdersTableDataStoreMeta::class, DatabaseUtil::class, LegacyProxy::class ) );

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -1053,7 +1053,7 @@ class FeaturesController {
 	 *
 	 * @return string
 	 */
-	private function get_features_page_url(): string {
+	public function get_features_page_url(): string {
 		return admin_url( 'admin.php?page=wc-settings&tab=advanced&section=features' );
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
@@ -580,6 +580,6 @@ class DataSynchronizerTests extends HposTestCase {
 		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- This is a test.
 		$sync_setting = apply_filters( 'woocommerce_feature_setting', array(), $this->sut::ORDERS_DATA_SYNC_ENABLED_OPTION );
 		$this->assertEquals( $sync_setting['value'], 'no' );
-		$this->assertTrue( str_contains( $sync_setting['desc_tip'], '1 order pending to be synchronized' ) );
+		$this->assertTrue( str_contains( $sync_setting['desc_tip'], 'Sync 1 pending order' ) );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/DataSynchronizerTests.php
@@ -699,6 +699,7 @@ class DataSynchronizerTests extends HposTestCase {
 		$this->assertTrue( wc_get_container()->get( BatchProcessingController::class )->is_enqueued( DataSynchronizer::class ) );
 		$this->assertFalse( as_has_scheduled_action( $this->sut::BACKGROUND_SYNC_EVENT_HOOK ) );
 
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment -- This is a test.
 		do_action( wc_get_container()->get( BatchProcessingController::class )::PROCESS_SINGLE_BATCH_ACTION_NAME, get_class( $this->sut ) );
 		$this->assertFalse( wc_get_container()->get( BatchProcessingController::class )->is_enqueued( DataSynchronizer::class ) );
 		$handler_method->invoke( $this->sut );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds a "Background Sync" feature that can run in parallel with, or in place of the "real-time" order data sync that is enabled by the "Compatibility Mode" checkbox on the WC Features screen. For now, the background sync mode has no UI of its own, it is either activated by simply having the normal data sync mode also enabled, or if that is disabled, it can be activated separately using a filter hook.

Background Sync can either be run at a set interval, or in "continuous" mode, where the data synchronizer is always enqueued in the batch processor so that it will always catch changes to order data as they come in (but still process them asynchronously so that order operations remain performant).

Also changes the "Sync x pending orders" message to a button that, when clicked, will immediately start a syncing process for those orders.

Fixes #39626

### How to test the changes in this Pull Request:

There are several different modes to test in this PR, but the action you perform for each test is essentially the same. As described in the reproduction steps in #39626, you just delete an order from the wc_orders table using a raw SQL query so that you bypass the hooks and filters that would normally run when you delete an order through the WC API. WooCommerce will then detect that the posts and orders tables are out of sync. What it does after that is what we're testing here.

#### Real-time sync on, background sync on

1. After checking this branch out, go to _WP Admin > WooCommerce > Settings > Advanced > Features_, and make sure that **Order data storage** is set to "legacy" (i.e. posts table) and the compatibility mode box is checked (i.e. data sync is _on_). In a separate tab, open up _WP Admin > Tools > Scheduled Actions_ and run any pending actions named `wc_schedule_pending_batch_processes` so there aren't any left in the queue.
2. As in #39626, manually delete an order and then refresh the Features screen. You should see the message that you can't switch authoritative tables until the data is in sync, and a button saying "Sync 1 order".
3. Switch to the Scheduled Actions tab and refresh. You should see a scheduled event named `woocommerce_custom_orders_table_background_sync` that will run in about an hour. Click the row action to run the event now. That should spawn a new `wc_schedule_pending_batch_processes` event, which may run immediately, or may be delayed by up to a minute (this is how Action Scheduler works, not part of this PR)
4. Back on the Features screen, you should now see a "Currently syncing" message, or nothing if the sync has already completed.
5. The orders should be back in sync now, so the one you deleted should be restored at this point.
6. Delete the order again and refresh the Features screen. This time, click the "Sync 1 order" button. The message should change to "Currently syncing". On the Scheduled Actions screen, you should see the `wc_schedule_pending_batch_processes` event queued up to run immediately.
7. Once the event has finished, the Features screen should show that everything is back in sync.

#### Real-time sync **off**, background sync on, "interval" mode

Ok, so now we're going to test background sync by itself, while the regular sync is disabled. Background sync has two active modes, "interval" and "continuous". "interval" is the default, so we'll test that first.

1. On the Features screen, uncheck the compatibility mode checkbox and save your changes. On the Scheduled Actions screen, the `woocommerce_custom_orders_table_background_sync` event should now be gone. All syncing is now disabled.
2. To re-enable just background sync, run the following WP CLI command:
    ```bash
   wp option update woocommerce_custom_orders_table_background_sync_mode interval
    ```
3. Now on the Features screen, it should say "Background sync enabled" and on the Scheduled Actions screen, the `woocommerce_custom_orders_table_background_sync` event should be there again.
4. Run through steps 2-7 from the previous section again to test syncing with the scheduled event and syncing with the button. You should get the same results.

#### Real-time sync **off**, background sync on, "continuous" mode

1. Now run this WP CLI command:
    ```bash
    wp option update woocommerce_custom_orders_table_background_sync_mode continuous
    ```
2. On the Scheduled Actions screen, there should be a `wc_schedule_pending_batch_processes` event queued up, even though the orders are currently in sync.
3. Delete the order again, and immediately refresh the Features screen. Rather than showing the "Sync 1 order" button, it should have skipped directly to "Currently syncing".
4. Even after the event has completed and everything is back in sync, there should be another `wc_schedule_pending_batch_processes` event queued up.

#### Turn background sync back off

1. Run this WP CLI command:
    ```bash
    wp option update woocommerce_custom_orders_table_background_sync_mode off
    ```
    or this one:
    ```bash
    wp option delete woocommerce_custom_orders_table_background_sync_mode
    ```
2. There should not be a `woocommerce_custom_orders_table_background_sync` event in Scheduled Actions, nor a `wc_schedule_pending_batch_processes` event.
3. The "Background sync enabled" message should be gone.
4. If you delete the order again, you should still see a "Sync 1 order" button that you can click to manually sync the order.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message

Add a "background" sync that can run independently of the normal "real-time" HPOS data sync. Also add a button on the Features screen to trigger an order sync manually.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
