### PR TITLE
Fix flakiness around the `Turn off the new product form` menu item

### DIFF
--- a/plugins/woocommerce/changelog/e2e-fix-flaky-turn-off-new-product-form
+++ b/plugins/woocommerce/changelog/e2e-fix-flaky-turn-off-new-product-form
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix flakiness around the `Turn off the new product form` menu item.

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/disable-block-product-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/disable-block-product-editor.spec.js
@@ -10,8 +10,6 @@ const {
 const ALL_PRODUCTS_URL = 'wp-admin/edit.php?post_type=product';
 const NEW_EDITOR_ADD_PRODUCT_URL =
 	'wp-admin/admin.php?page=wc-admin&path=%2Fadd-product';
-const SETTINGS_URL =
-	'wp-admin/admin.php?page=wc-settings&tab=advanced&section=features';
 
 let isNewProductEditorEnabled = false;
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/disable-block-product-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/disable-block-product-editor.spec.js
@@ -6,6 +6,7 @@ const {
 	isBlockProductEditorEnabled,
 	toggleBlockProductEditor,
 } = require( '../../../../utils/simple-products' );
+const { toggleBlockProductTour } = require( '../../../../utils/tours' );
 
 const ALL_PRODUCTS_URL = 'wp-admin/edit.php?post_type=product';
 const NEW_EDITOR_ADD_PRODUCT_URL =
@@ -25,6 +26,10 @@ test.describe.configure( { mode: 'serial' } );
 
 test.describe( 'Disable block product editor', () => {
 	test.use( { storageState: process.env.ADMINSTATE } );
+
+	test.beforeAll( async ( { request } ) => {
+		await toggleBlockProductTour( request, false );
+	} );
 
 	test.beforeEach( async ( { page } ) => {
 		isNewProductEditorEnabled = await isBlockProductEditorEnabled( page );
@@ -69,6 +74,7 @@ test.describe( 'Disable block product editor', () => {
 		await dismissFeedbackModalIfShown( page );
 		await expectOldProductEditor( page );
 	} );
+
 	test( 'can be disabled from settings', async ( { page } ) => {
 		await toggleBlockProductEditor( 'disable', page );
 		await page.goto( ALL_PRODUCTS_URL );

--- a/plugins/woocommerce/tests/e2e-pw/utils/index.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/index.js
@@ -3,10 +3,13 @@ const api = require( './api' );
 const site = require( './site' );
 const variableProducts = require( './variable-products' );
 const features = require( './features' );
+const tours = require( './tours' );
+
 module.exports = {
 	onboarding,
 	api,
 	site,
 	variableProducts,
-	features
+	features,
+	tours,
 };

--- a/plugins/woocommerce/tests/e2e-pw/utils/tours.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/tours.js
@@ -6,7 +6,6 @@ const base64String = Buffer.from(
 
 const headers = {
 	Authorization: `Basic ${ base64String }`,
-	cookie: '',
 };
 
 /**

--- a/plugins/woocommerce/tests/e2e-pw/utils/tours.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/tours.js
@@ -1,0 +1,31 @@
+const { admin } = require( '../test-data/data' );
+
+const base64String = Buffer.from(
+	`${ admin.username }:${ admin.password }`
+).toString( 'base64' );
+
+const headers = {
+	Authorization: `Basic ${ base64String }`,
+	cookie: '',
+};
+
+/**
+ * Enables or disables the product editor tour.
+ *
+ * @param {import('@playwright/test').APIRequestContext} request Request context from calling function.
+ * @param {boolean} enable Set to `true` if you want to enable the block product tour. `false` if otherwise.
+ */
+const toggleBlockProductTour = async ( request, enable ) => {
+	const url = '/wp-json/wc-admin/options';
+	const params = { _locale: 'user' };
+	const toggleValue = enable ? 'no' : 'yes';
+	const data = { woocommerce_block_product_tour_shown: toggleValue };
+
+	await request.post( url, {
+		data,
+		params,
+		headers,
+	} );
+};
+
+module.exports = { toggleBlockProductTour };


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/39888.

The E2E test `merchant/products/block-editor/disable-block-product-editor.spec.js > Disable block product editor > can be disabled from the header` had been flaky recently because the menu that contains the `Turn off the new product form` option automatically closes when the _"Welcome to the new product form!"_ tour message appears. To fix this flakiness, this PR makes sure that the block product editor tour would be disabled at the start of the test.

I don't see any of the specs inside the `merchant/products/block-editor` folders to be depending on whether the block product form tour is enabled or not, so I assume it's safe to disable the tour to prevent flakiness.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Test the `can be disabled from the header` isolated

1. Checkout this branch and launch the local E2E environment.
1. Run the `can be disabled from the header` test 10 times without retries, and verify that it passes each time:
    ```bash
    pnpm test:e2e-pw -g "can be disabled from the header" --retries=0 --workers=1 --repeat-each=10
    ```

#### Run all the tests in the `merchant/products/block-editor` folder

1. Checkout this branch and launch the local E2E environment.
2. Run all the tests in the `merchant/products/block-editor` folder, repeating each test at least thrice. Allow retries this time, because other tests seem to be flaky still. They can be addressed separately in another PR.
    ```bash
    pnpm test:e2e-pw 'merchant/products/block-editor' --repeat-each=3
    ```
1. In the Playwright HTML report, filter by "Passed" tests.
1. Make sure that the three `can be disabled from the header` tests are all passing -- not flaky nor failed.

    <img width="750" alt="QfDOd0UTIv" src="https://github.com/woocommerce/woocommerce/assets/4509348/01ff8273-db68-4a5c-97a2-5ada0e4a94da">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
