### PR TITLE
Fix incentive cache-busting edge case performance issues

### DIFF
--- a/plugins/woocommerce/changelog/fix-incentive-performance-issues
+++ b/plugins/woocommerce/changelog/fix-incentive-performance-issues
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix edgecase performance issues around incentives caching.

--- a/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
+++ b/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
@@ -52,6 +52,11 @@ class WcPayWelcomePage {
 	 * @return boolean
 	 */
 	public function must_be_visible(): bool {
+		// The WooPayments plugin must not be active.
+		if ( $this->is_wcpay_active() ) {
+			return false;
+		}
+
 		// Suggestions not disabled via a setting.
 		if ( get_option( 'woocommerce_show_marketplace_suggestions', 'yes' ) === 'no' ) {
 			return false;
@@ -68,17 +73,7 @@ class WcPayWelcomePage {
 			return false;
 		}
 
-		// Temporary solution until we improve the dismiss and cache logic.
-		if ( false !== get_option( 'wcpay_welcome_page_incentives_dismissed', false ) ) {
-			return false;
-		}
-
-		// The WooPayments plugin must not be active.
-		if ( $this->is_wcpay_active() ) {
-			return false;
-		}
-
-		// Incentive is available.
+		// An incentive must be available.
 		if ( empty( $this->get_incentive() ) ) {
 			return false;
 		}

--- a/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
+++ b/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
@@ -246,14 +246,21 @@ class WcPayWelcomePage {
 	 * @return boolean
 	 */
 	private function is_incentive_dismissed(): bool {
+		$dismissed_incentives = get_option( 'wcpay_welcome_page_incentives_dismissed', [] );
+
+		// If there are no dismissed incentives, return early.
+		if ( empty( $dismissed_incentives ) ) {
+			return false;
+		}
+
 		// Return early if there is no eligible incentive.
-		if ( empty( $this->get_incentive() ) ) {
+		$incentive = $this->get_incentive();
+		if ( empty( $incentive ) ) {
 			return true;
 		}
 
-		$dismissed_incentives = get_option( 'wcpay_welcome_page_incentives_dismissed', [] );
-
-		if ( in_array( $this->get_incentive()['id'], $dismissed_incentives, true ) ) {
+		// Search the incentive ID in the dismissed incentives list.
+		if ( in_array( $incentive['id'], $dismissed_incentives, true ) ) {
 			return true;
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
+++ b/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
@@ -133,11 +133,17 @@ class WcPayWelcomePage {
 		}
 
 		// Add badge.
+		$badge = ' <span class="wcpay-menu-badge awaiting-mod count-1"><span class="plugin-count">1</span></span>';
 		foreach ( $menu as $index => $menu_item ) {
-			if ( 'wc-admin&path=/wc-pay-welcome-page' === $menu_item[2]
-					|| 'admin.php?page=wc-admin&path=/wc-pay-welcome-page' === $menu_item[2] ) {
-				//phpcs:ignore
-				$menu[ $index ][0] .= ' <span class="wcpay-menu-badge awaiting-mod count-1"><span class="plugin-count">1</span></span>';
+			// Only add the badge markup if not already present and the menu item is the WooPayments menu item.
+			if ( false === strpos( $menu_item[0], $badge )
+				&& ( 'wc-admin&path=/wc-pay-welcome-page' === $menu_item[2]
+					|| 'admin.php?page=wc-admin&path=/wc-pay-welcome-page' === $menu_item[2] )
+			) {
+				$menu[ $index ][0] .= $badge; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+				// One menu item with a badge is more than enough.
+				break;
 			}
 		}
 	}

--- a/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
+++ b/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
@@ -290,17 +290,6 @@ class WcPayWelcomePage {
 			return $this->incentive;
 		}
 
-		// If we have a transient cache that is not expired, use it if it is not older than an hour
-		// without checking for the store context hash.
-		// This is a safeguard to avoid making, at every WP admin page load,
-		// the store context SQL queries that might be expensive/slow in some cases
-		// (mostly sites with a huge number of orders and no HPOS).
-		if ( false !== $cache && ! empty( $cache['timestamp'] ) && intval( $cache['timestamp'] ) > time() - HOUR_IN_SECONDS ) {
-			$this->incentive = $cache['incentive'] ?? [];
-
-			return $this->incentive;
-		}
-
 		// Gather the store context data.
 		$store_context = [
 			// Store ISO-2 country code, e.g. `US`.

--- a/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
+++ b/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
@@ -190,13 +190,13 @@ class WcPayWelcomePage {
 	}
 
 	/**
-	 * Check if the WooPayments payment gateway is active and set up,
+	 * Check if the WooPayments payment gateway is active and set up or was at some point,
 	 * or there are orders processed with it, at some moment.
 	 *
 	 * @return boolean
 	 */
 	private function has_wcpay(): bool {
-		// First, get the store value, if it exists.
+		// First, get the stored value, if it exists.
 		// This way we avoid costly DB queries and API calls.
 		// Basically, we only want to know if WooPayments was in use in the past.
 		// Since the past can't be changed, neither can this value.
@@ -210,7 +210,8 @@ class WcPayWelcomePage {
 		$had_wcpay = false;
 
 		// We consider the store to have WooPayments if there is meaningful account data in the WooPayments account cache.
-		// This implies that WooPayments is or was active at some point and that it was connected.
+		// This implies that WooPayments was active at some point and that it was connected.
+		// If WooPayments is active right now, we will not get to this point since the plugin is active check is done first.
 		if ( $this->has_wcpay_account_data() ) {
 			$had_wcpay = true;
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The temporary changes introduced in https://github.com/woocommerce/woocommerce/pull/39882 have been partially reverted, and new logic has been introduced:
- Store the value of whether the store had WooPayments in use in the past (that causes the SQL queries) and only compute it once since the past can't be changed :) 
- Generate the store context as late as possible.
- Avoid getting the incentives as much as possible (e.g., no need for incentives when testing for dismissal if there are no dismissed incentives).
- Attach the incentives API fetch timestamp to the cached data so we can know when we last fetched.

I think this solves the performance issues and provides an even more performant solution.

Plus, I've fixed the caching logic around API errors: we now store a `WP_Error` serialized object because null will not be stored as such, but as an empty string by the `set_transient()` function.

### How to test the changes in this Pull Request:

>[!Note]
>We need to check the existence of an SQL query. You can use [Query Monitor](https://wordpress.org/plugins/query-monitor/) or any other similar option.

#### Only one order query by payment method, ever
- Create a new JN site with WC from this PR branch.
- **Payments (1)** menu should be visible.
- The bellow SQL query **should be** in the logs.
- Refresh the page as many times as you want and confirm that the following SQL query **has not been** executed.
- Check that the `wcpay_was_in_use` option is present in the DB with a `no` value.
- Remove the `_transient_wcpay_welcome_page_incentive` and `wcpay_was_in_use` options, refresh the page, and the bellow SQL query **should be** in the logs.
- Continue to refresh and it shouldn't be again.

#### Incentive applied as expected
- Remove the `wcpay_welcome_page_incentives_dismissed` option to get the incentive again.
- Go to **Payments (1)** and finish the onboarding process by following [test onboarding instructions](https://woocommerce.com/document/woopayments/testing-and-troubleshooting/dev-mode/).
- Confirm that the incentive fee is applied by checking **Active discounts** under **Payments > Overview**.

**SQL query:**
Searching for `_payment_method` with the Query Monitor panel opened should be enough to find it in the Database queries tab. This is the full SQL query we are after:

```sql
SELECT wp_posts.ID
FROM wp_posts INNER JOIN wp_postmeta ON ( wp_posts.ID = wp_postmeta.post_id )
WHERE 1=1 AND ( 
( wp_postmeta.meta_key = '_payment_method' AND wp_postmeta.meta_value = 'woocommerce_payments' )
) AND wp_posts.post_type IN ('shop_order', 'shop_order_refund') AND ((wp_posts.post_status = 'wc-pending' OR wp_posts.post_status = 'wc-processing' OR wp_posts.post_status = 'wc-on-hold' OR wp_posts.post_status = 'wc-completed' OR wp_posts.post_status = 'wc-cancelled' OR wp_posts.post_status = 'wc-refunded' OR wp_posts.post_status = 'wc-failed' OR wp_posts.post_status = 'wc-checkout-draft'))
GROUP BY wp_posts.ID
ORDER BY wp_posts.post_date DESC
LIMIT 0, 1
```

Related to: https://github.com/woocommerce/woocommerce/issues/39668 https://github.com/woocommerce/woocommerce/issues/39742