### PR TITLE
Add Inventory item to the global Quick Update dropdown

### DIFF
--- a/packages/js/product-editor/changelog/add-39797
+++ b/packages/js/product-editor/changelog/add-39797
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add Inventory item to the global Quick Update dropdown

--- a/packages/js/product-editor/src/components/variations-table/variation-actions-menu/variation-actions-menu.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variation-actions-menu/variation-actions-menu.tsx
@@ -78,8 +78,7 @@ export function VariationActionsMenu( {
 							onClose={ onClose }
 						/>
 						<InventoryMenuItem
-							variation={ selection }
-							handlePrompt={ handlePrompt }
+							selection={ selection }
 							onChange={ onChange }
 							onClose={ onClose }
 						/>

--- a/packages/js/product-editor/src/components/variations-table/variations-actions-menu/variations-actions-menu.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variations-actions-menu/variations-actions-menu.tsx
@@ -13,6 +13,7 @@ import { VariationsActionsMenuProps } from './types';
 import { UpdateStockMenuItem } from '../update-stock-menu-item';
 import { PricingMenuItem } from '../pricing-menu-item';
 import { SetListPriceMenuItem } from '../set-list-price-menu-item';
+import { InventoryMenuItem } from '../inventory-menu-item';
 
 export function VariationsActionsMenu( {
 	selection,
@@ -51,6 +52,11 @@ export function VariationsActionsMenu( {
 					</MenuGroup>
 					<MenuGroup>
 						<PricingMenuItem
+							selection={ selection }
+							onChange={ onChange }
+							onClose={ onClose }
+						/>
+						<InventoryMenuItem
 							selection={ selection }
 							onChange={ onChange }
 							onClose={ onClose }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #39797

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure feature `product-variation-management` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper`
3. Go to `/wp-admin/admin.php?page=wc-admin&path=/add-product&tab=variations` and click `Add variation options` button from the `Variations` tab
4. Add at many Variation attributes and at least one value. Then click `Add` button from the `Add variation options` modal.
5. Wait until the variations are generated
6. A list a variation should be shown depending on the options selected
7. In the Variations table at the top right corner a new `Quick update` dropdown menu should be shown disabled if no variations are selected.
8. When at least one variations is selected from the table then the `Quick update` dropdown menu should be enabled
9. If you expand the dropdown menu a new `Inventory` submenu should be shown. 
<img width="788" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/7266b2af-1eb3-43ce-a366-30f3657ebbf3">

10. If you click any item from the `Inventory` submenu should update all the selected variations

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
