### PR TITLE
Add Shipping item to the global Quick Update dropdown

### DIFF
--- a/packages/js/product-editor/changelog/add-39798
+++ b/packages/js/product-editor/changelog/add-39798
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add Shipping item to the global Quick Update dropdown

--- a/packages/js/product-editor/src/components/variations-table/shipping-menu-item/shipping-menu-item.tsx
+++ b/packages/js/product-editor/src/components/variations-table/shipping-menu-item/shipping-menu-item.tsx
@@ -5,19 +5,48 @@ import { Dropdown, MenuItem } from '@wordpress/components';
 import { createElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { chevronRight } from '@wordpress/icons';
+import { ProductVariation } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
  */
-import { ShippingMenuItemProps } from './types';
 import { TRACKS_SOURCE } from '../../../constants';
+import { VariationActionsMenuItemProps } from '../types';
+import { handlePrompt } from '../../../utils/handle-prompt';
 
 export function ShippingMenuItem( {
-	variation,
-	handlePrompt,
+	selection,
+	onChange,
 	onClose,
-}: ShippingMenuItemProps ) {
+}: VariationActionsMenuItemProps ) {
+	const ids = Array.isArray( selection )
+		? selection.map( ( { id } ) => id )
+		: selection.id;
+
+	function handleDimensionsChange(
+		value: Partial< ProductVariation[ 'dimensions' ] >
+	) {
+		if ( Array.isArray( selection ) ) {
+			onChange(
+				selection.map( ( { id, dimensions } ) => ( {
+					id,
+					dimensions: {
+						...dimensions,
+						...value,
+					},
+				} ) )
+			);
+		} else {
+			onChange( {
+				dimensions: {
+					...selection.dimensions,
+					...value,
+				},
+			} );
+		}
+	}
+
 	return (
 		<Dropdown
 			position="middle right"
@@ -26,7 +55,7 @@ export function ShippingMenuItem( {
 					onClick={ () => {
 						recordEvent( 'product_variations_menu_shipping_click', {
 							source: TRACKS_SOURCE,
-							variation_id: variation.id,
+							variation_id: ids,
 						} );
 						onToggle();
 					} }
@@ -46,24 +75,23 @@ export function ShippingMenuItem( {
 								{
 									source: TRACKS_SOURCE,
 									action: 'dimensions_length_set',
-									variation_id: variation.id,
+									variation_id: ids,
 								}
 							);
-							handlePrompt( undefined, ( value ) => {
-								recordEvent(
-									'product_variations_menu_shipping_update',
-									{
-										source: TRACKS_SOURCE,
-										action: 'dimensions_length_set',
-										variation_id: variation.id,
-									}
-								);
-								return {
-									dimensions: {
-										...variation.dimensions,
+							handlePrompt( {
+								onOk( value ) {
+									recordEvent(
+										'product_variations_menu_shipping_update',
+										{
+											source: TRACKS_SOURCE,
+											action: 'dimensions_length_set',
+											variation_id: ids,
+										}
+									);
+									handleDimensionsChange( {
 										length: value,
-									},
-								};
+									} );
+								},
 							} );
 							onClose();
 						} }
@@ -77,24 +105,23 @@ export function ShippingMenuItem( {
 								{
 									source: TRACKS_SOURCE,
 									action: 'dimensions_width_set',
-									variation_id: variation.id,
+									variation_id: ids,
 								}
 							);
-							handlePrompt( undefined, ( value ) => {
-								recordEvent(
-									'product_variations_menu_shipping_update',
-									{
-										source: TRACKS_SOURCE,
-										action: 'dimensions_width_set',
-										variation_id: variation.id,
-									}
-								);
-								return {
-									dimensions: {
-										...variation.dimensions,
+							handlePrompt( {
+								onOk( value ) {
+									recordEvent(
+										'product_variations_menu_shipping_update',
+										{
+											source: TRACKS_SOURCE,
+											action: 'dimensions_width_set',
+											variation_id: ids,
+										}
+									);
+									handleDimensionsChange( {
 										width: value,
-									},
-								};
+									} );
+								},
 							} );
 							onClose();
 						} }
@@ -108,24 +135,23 @@ export function ShippingMenuItem( {
 								{
 									source: TRACKS_SOURCE,
 									action: 'dimensions_height_set',
-									variation_id: variation.id,
+									variation_id: ids,
 								}
 							);
-							handlePrompt( undefined, ( value ) => {
-								recordEvent(
-									'product_variations_menu_shipping_update',
-									{
-										source: TRACKS_SOURCE,
-										action: 'dimensions_height_set',
-										variation_id: variation.id,
-									}
-								);
-								return {
-									dimensions: {
-										...variation.dimensions,
+							handlePrompt( {
+								onOk( value ) {
+									recordEvent(
+										'product_variations_menu_shipping_update',
+										{
+											source: TRACKS_SOURCE,
+											action: 'dimensions_height_set',
+											variation_id: ids,
+										}
+									);
+									handleDimensionsChange( {
 										height: value,
-									},
-								};
+									} );
+								},
 							} );
 							onClose();
 						} }
@@ -139,19 +165,30 @@ export function ShippingMenuItem( {
 								{
 									source: TRACKS_SOURCE,
 									action: 'weight_set',
-									variation_id: variation.id,
+									variation_id: ids,
 								}
 							);
-							handlePrompt( undefined, ( value ) => {
-								recordEvent(
-									'product_variations_menu_shipping_update',
-									{
-										source: TRACKS_SOURCE,
-										action: 'weight_set',
-										variation_id: variation.id,
+							handlePrompt( {
+								onOk( value ) {
+									recordEvent(
+										'product_variations_menu_shipping_update',
+										{
+											source: TRACKS_SOURCE,
+											action: 'weight_set',
+											variation_id: ids,
+										}
+									);
+									if ( Array.isArray( selection ) ) {
+										onChange(
+											selection.map( ( { id } ) => ( {
+												id,
+												weight: value,
+											} ) )
+										);
+									} else {
+										onChange( { weight: value } );
 									}
-								);
-								return { weight: value };
+								},
 							} );
 							onClose();
 						} }

--- a/packages/js/product-editor/src/components/variations-table/variation-actions-menu/variation-actions-menu.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variation-actions-menu/variation-actions-menu.tsx
@@ -5,7 +5,6 @@ import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { createElement, Fragment } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { moreVertical } from '@wordpress/icons';
-import { ProductVariation } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 
 /**
@@ -22,21 +21,6 @@ export function VariationActionsMenu( {
 	onChange,
 	onDelete,
 }: VariationActionsMenuProps ) {
-	function handlePrompt(
-		label: string = __( 'Enter a value', 'woocommerce' ),
-		parser: ( value: string ) => Partial< ProductVariation > | null = () =>
-			null
-	) {
-		// eslint-disable-next-line no-alert
-		const value = window.prompt( label );
-		if ( value === null ) return;
-
-		const updates = parser( value.trim() );
-		if ( updates ) {
-			onChange( updates );
-		}
-	}
-
 	return (
 		<DropdownMenu
 			icon={ moreVertical }
@@ -83,8 +67,8 @@ export function VariationActionsMenu( {
 							onClose={ onClose }
 						/>
 						<ShippingMenuItem
-							variation={ selection }
-							handlePrompt={ handlePrompt }
+							selection={ selection }
+							onChange={ onChange }
 							onClose={ onClose }
 						/>
 					</MenuGroup>

--- a/packages/js/product-editor/src/components/variations-table/variations-actions-menu/variations-actions-menu.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variations-actions-menu/variations-actions-menu.tsx
@@ -24,7 +24,7 @@ export function VariationsActionsMenu( {
 }: VariationsActionsMenuProps ) {
 	return (
 		<Dropdown
-			position="bottom right"
+			position="bottom left"
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<Button
 					disabled={ disabled }

--- a/packages/js/product-editor/src/components/variations-table/variations-actions-menu/variations-actions-menu.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variations-actions-menu/variations-actions-menu.tsx
@@ -14,6 +14,7 @@ import { UpdateStockMenuItem } from '../update-stock-menu-item';
 import { PricingMenuItem } from '../pricing-menu-item';
 import { SetListPriceMenuItem } from '../set-list-price-menu-item';
 import { InventoryMenuItem } from '../inventory-menu-item';
+import { ShippingMenuItem } from '../shipping-menu-item';
 
 export function VariationsActionsMenu( {
 	selection,
@@ -57,6 +58,11 @@ export function VariationsActionsMenu( {
 							onClose={ onClose }
 						/>
 						<InventoryMenuItem
+							selection={ selection }
+							onChange={ onChange }
+							onClose={ onClose }
+						/>
+						<ShippingMenuItem
 							selection={ selection }
 							onChange={ onChange }
 							onClose={ onClose }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #39798

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure feature `product-variation-management` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper`
3. Go to `/wp-admin/admin.php?page=wc-admin&path=/add-product&tab=variations` and click `Add variation options` button from the `Variations` tab
4. Add at many Variation attributes and at least one value. Then click `Add` button from the `Add variation options` modal.
5. Wait until the variations are generated
6. A list a variation should be shown depending on the options selected
7. In the Variations table at the top right corner a new `Quick update` dropdown menu should be shown disabled if no variations are selected.
8. When at least one variations is selected from the table then the `Quick update` dropdown menu should be enabled
9. If you expand the dropdown menu a new `Shipping` submenu should be shown.
<img width="779" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/bb672d57-ba6a-4c4b-8447-b4158ad4af4f">

10. If you click any item from the `Shipping` submenu should update all the selected variations

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
