### PR TITLE
fix: wc-connect-tax option truthiness

### DIFF
--- a/plugins/woocommerce/changelog/fix-wc-connect-tax-truthiness
+++ b/plugins/woocommerce/changelog/fix-wc-connect-tax-truthiness
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Changed Tax task completion criteria so that it considers both boolean and stringly typed values as expected

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Tax.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Tax.php
@@ -115,8 +115,8 @@ class Tax extends Task {
 	 */
 	public function is_complete() {
 		if ( $this->is_complete_result === null ) {
-			$wc_connect_taxes_enabled = get_option('wc_connect_taxes_enabled');
-			$is_wc_connect_taxes_enabled = ($wc_connect_taxes_enabled === 'yes') || ($wc_connect_taxes_enabled === true); // seems that in some places boolean is used, and other places 'yes' | 'no' is used
+			$wc_connect_taxes_enabled = get_option( 'wc_connect_taxes_enabled' );
+			$is_wc_connect_taxes_enabled = ( $wc_connect_taxes_enabled === 'yes' ) || ( $wc_connect_taxes_enabled === true ); // seems that in some places boolean is used, and other places 'yes' | 'no' is used
 
 			$this->is_complete_result = $is_wc_connect_taxes_enabled ||
 				count( TaxDataStore::get_taxes( array() ) ) > 0 ||

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Tax.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/Tax.php
@@ -115,7 +115,10 @@ class Tax extends Task {
 	 */
 	public function is_complete() {
 		if ( $this->is_complete_result === null ) {
-			$this->is_complete_result = get_option( 'wc_connect_taxes_enabled' ) ||
+			$wc_connect_taxes_enabled = get_option('wc_connect_taxes_enabled');
+			$is_wc_connect_taxes_enabled = ($wc_connect_taxes_enabled === 'yes') || ($wc_connect_taxes_enabled === true); // seems that in some places boolean is used, and other places 'yes' | 'no' is used
+
+			$this->is_complete_result = $is_wc_connect_taxes_enabled ||
 				count( TaxDataStore::get_taxes( array() ) ) > 0 ||
 				get_option( 'woocommerce_no_sales_tax' ) !== false;
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This is a symptomatic treatment of the bug which causes the Tax task to be shown as complete even on a freshly created WooExpress site. This symptom manifests because for some combinations of onboarding profile, it seems that the `wc_connect_taxes_enabled` option is set to the string 'no'. The code prior to this PR treats that as a true value, and thus the Tax task is shown as completed.

This PR defaults the completion to incomplete unless it is a boolean true or string 'yes'. 

Closes https://github.com/Automattic/wc-calypso-bridge/issues/1288.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

(For the below testing, you can set the option values using either WooCommerce Beta Tester plugin or using wp-cli. If you are using wp-env, you can access wp-cli by running `wp-env run cli bash`. To set the value, run `wp option add wc_connect_taxes_enabled "no"`)

1. Set up the WooCommerce installation as usual
2. Observe that the tax task should not show as completed
3. Set the `wc_connect_taxes_enabled` option to various values (true, false, 'yes', 'no') and observe that the completion status on the home screen should reflect correctly
4. Unset the option or set it to 'no', or false
5. Complete the tax task either by setting up WooCommerce Tax or adding tax rules or declaring no sales tax needed
6. Observe that the tax task completes successfully


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
