### PR TITLE
Update woocommerce/create-product-editor-block to use template API

### DIFF
--- a/packages/js/create-product-editor-block/changelog/update-create-product-editor-block-api
+++ b/packages/js/create-product-editor-block/changelog/update-create-product-editor-block-api
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update to use the template API.

--- a/packages/js/create-product-editor-block/plugin-templates/$slug.php.mustache
+++ b/packages/js/create-product-editor-block/plugin-templates/$slug.php.mustache
@@ -31,6 +31,9 @@
  * @package              {{namespace}}
  */
 
+use Automattic\WooCommerce\Admin\BlockTemplates\BlockTemplateInterface;
+use Automattic\WooCommerce\Admin\Features\ProductBlockEditor\ProductTemplates\ProductFormTemplateInterface;
+
 /**
  * Registers the block using the metadata loaded from the `block.json` file.
  * Behind the scenes, it registers also all assets so they can be enqueued
@@ -45,53 +48,22 @@ function {{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init() {
 }
 add_action( 'init', '{{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init' );
 
-function {{namespaceSnakeCase}}_{{slugSnakeCase}}_add_block_to_product_editor( $args ) {
-	// if the product block editor is not enabled, return the args as-is
-	if ( ! class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) ||
-			! \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_block_editor' ) ) {
-		return $args;
-	}
+function {{namespaceSnakeCase}}_{{slugSnakeCase}}_add_block_to_product_editor( BlockTemplateInterface $template ) {
+	if ( $template instanceof ProductFormTemplateInterface && 'simple-product' === $template->get_id() ) {
+		$basic_details = $template->get_section_by_id( 'basic-details' );
 
-	// if the template is not set or is not an array, return the args as-is
-	if ( ! isset( $args['template'] ) || ! is_array( $args['template'] ) ) {
-		return $args;
-	}
-
-	$template = $args['template'];
-
-	// find the 'Basic details' section and add our block to the end of it
-	foreach ( $template as $tab_index => $tab ) {
-		$tab_properties = $tab[1];
-
-		if ( 'general' === $tab_properties['id'] ) {
-			$tab_sections = $tab[2];
-
-			foreach ( $tab_sections as $section_index => $section ) {
-				$section_properties = $section[1];
-
-				// TODO: this is not the right way to do this, since it is checking a localized string.
-				if ( 'Basic details' === $section_properties['title'] ) {
-					$section_fields = $section[2];
-
-					// add our block to the end of the section
-					$section_fields[] = [
-						'{{namespace}}/{{slug}}',
-						[
-							'message' => '{{title}}',
-						]
-					];
-
-					// update the template with our new block
-					$args[ 'template' ][ $tab_index ][2][ $section_index ][2] = $section_fields;
-
-					break;
-				}
-			}
-
-			break;
+		if ( $basic_details ) {
+			$basic_details->add_block(
+				[
+					'id' 	     => '{{namespaceSnakeCase}}-{{slugSnakeCase}}',
+					'order'	     => 40,
+					'blockName'  => '{{namespaceSnakeCase}}/{{slugSnakeCase}}',
+					'attributes' => [
+						'message' => '{{title}}',
+					]
+				]
+			);
 		}
 	}
-
-	return $args;
 }
-add_filter( 'woocommerce_register_post_type_product', '{{namespaceSnakeCase}}_{{slugSnakeCase}}_add_block_to_product_editor', 100 );
+add_filter( 'woocommerce_block_template_register', '{{namespaceSnakeCase}}_{{slugSnakeCase}}_add_block_to_product_editor', 100 );

--- a/packages/js/create-product-editor-block/plugin-templates/$slug.php.mustache
+++ b/packages/js/create-product-editor-block/plugin-templates/$slug.php.mustache
@@ -55,9 +55,9 @@ function {{namespaceSnakeCase}}_{{slugSnakeCase}}_add_block_to_product_editor( B
 		if ( $basic_details ) {
 			$basic_details->add_block(
 				[
-					'id' 	     => '{{namespaceSnakeCase}}-{{slugSnakeCase}}',
+					'id' 	     => '{{namespace}}-{{slug}}',
 					'order'	     => 40,
-					'blockName'  => '{{namespaceSnakeCase}}/{{slugSnakeCase}}',
+					'blockName'  => '{{namespace}}/{{slug}}',
 					'attributes' => [
 						'message' => '{{title}}',
 					]


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR updates the `woocommerce/create-product-editor-block` package to use the template API in the generated skeleton code.

_Note: `woocommerce/create-product-editor-block` may eventually be superseded by a broader, more comprehensive tool. However, until that point, it is valuable to keep this tool up-to-date with the template API and best practices._

Closes #39536.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Follow the instructions in the package's README.md (note, since you are testing a version of the package that hasn't been published yet, you will need to use the `npx @wordpress/create-block --template ./path/to/woocommerce/packages/js/create-product-editor-block my-extension-name` form of the command, with a local path to the template)
2. Verify that the generated skeleton project can be used, with the built-in `wp-env` support, to render the example block in the block-based product form, with no modifications of any files or any commands other than those mentioned in the README.md.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
