### PR TITLE
Remove COT enable requirement from sync and verify command.

### DIFF
--- a/plugins/woocommerce/changelog/fix-cli-improvs
+++ b/plugins/woocommerce/changelog/fix-cli-improvs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove COT enable requirement from sync and verify command.

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -102,10 +102,6 @@ class CLIRunner {
 	 * @return int The number of orders to be migrated.*
 	 */
 	public function count_unmigrated( $args = array(), $assoc_args = array() ) : int {
-		if ( ! $this->is_enabled() ) {
-			return 0;
-		}
-
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		$order_count = $this->synchronizer->get_current_orders_pending_sync_count();
 
@@ -152,10 +148,6 @@ class CLIRunner {
 	 * @param array $assoc_args Associative arguments (options) passed to the command.
 	 */
 	public function sync( $args = array(), $assoc_args = array() ) {
-		if ( ! $this->is_enabled() ) {
-			return;
-		}
-
 		if ( ! $this->synchronizer->check_orders_table_exists() ) {
 			WP_CLI::warning( __( 'Custom order tables does not exist, creating...', 'woocommerce' ) );
 			$this->synchronizer->create_database_tables();
@@ -324,7 +316,9 @@ class CLIRunner {
 	 */
 	public function verify_cot_data( $args = array(), $assoc_args = array() ) {
 		global $wpdb;
-		if ( ! $this->is_enabled() ) {
+
+		if ( ! $this->synchronizer->check_orders_table_exists() ) {
+			WP_CLI::error( __( 'Orders table does not exist.', 'woocommerce' ) );
 			return;
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This removes the requirement from the sync and verify command to have HPOS enabled in the first place. This is reminiscent of a previous version where we had a dedicated setting page for HPOS, which needs to be enabled (not the feature itself) to be able to run sync. Now that the page itself is removed, this check is not needed anymore (and sync will create the table if they are not created already).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Disable HPOS by running `wp wc cot disable --with-sync`. If you get a "[Failed] There are orders pending sync" error, run sync with `wp wc cot sync` and try again.
2. Run sync with `wp wc cot sync`. It should run, and should not throw an error that HPOS is not enabled. (if there are no orders to sync then it will say no orders to sync, this is expected).

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
