### PR TITLE
Auto select one or more attribute terms when selecting an attribute

### DIFF
--- a/packages/js/product-editor/changelog/add-39892
+++ b/packages/js/product-editor/changelog/add-39892
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Auto select one or more attribute terms when selecting an attribute

--- a/packages/js/product-editor/src/blocks/variation-options/edit.tsx
+++ b/packages/js/product-editor/src/blocks/variation-options/edit.tsx
@@ -120,6 +120,7 @@ export function Edit() {
 				disabledAttributeIds={ entityAttributes
 					.filter( ( attr ) => ! attr.variation )
 					.map( ( attr ) => attr.id ) }
+				termsAutoselection="all"
 				uiStrings={ {
 					notice,
 					globalAttributeHelperMessage: '',

--- a/packages/js/product-editor/src/blocks/variation-options/edit.tsx
+++ b/packages/js/product-editor/src/blocks/variation-options/edit.tsx
@@ -120,7 +120,7 @@ export function Edit() {
 				disabledAttributeIds={ entityAttributes
 					.filter( ( attr ) => ! attr.variation )
 					.map( ( attr ) => attr.id ) }
-				termsAutoselection="all"
+				termsAutoSelection="all"
 				uiStrings={ {
 					notice,
 					globalAttributeHelperMessage: '',

--- a/packages/js/product-editor/src/blocks/variations/edit.tsx
+++ b/packages/js/product-editor/src/blocks/variations/edit.tsx
@@ -158,6 +158,7 @@ export function Edit( {
 					disabledAttributeIds={ productAttributes
 						.filter( ( attr ) => ! attr.variation )
 						.map( ( attr ) => attr.id ) }
+					termsAutoselection="all"
 				/>
 			) }
 		</div>

--- a/packages/js/product-editor/src/blocks/variations/edit.tsx
+++ b/packages/js/product-editor/src/blocks/variations/edit.tsx
@@ -158,7 +158,7 @@ export function Edit( {
 					disabledAttributeIds={ productAttributes
 						.filter( ( attr ) => ! attr.variation )
 						.map( ( attr ) => attr.id ) }
-					termsAutoselection="all"
+					termsAutoSelection="all"
 				/>
 			) }
 		</div>

--- a/packages/js/product-editor/src/components/attribute-control/attribute-control.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/attribute-control.tsx
@@ -50,6 +50,7 @@ type AttributeControlProps = {
 	createNewAttributesAsGlobal?: boolean;
 	useRemoveConfirmationModal?: boolean;
 	disabledAttributeIds?: number[];
+	termsAutoselection?: 'first' | 'all';
 	uiStrings?: {
 		notice?: string | React.ReactElement;
 		emptyStateSubtitle?: string;
@@ -84,6 +85,7 @@ export const AttributeControl: React.FC< AttributeControlProps > = ( {
 	createNewAttributesAsGlobal = false,
 	useRemoveConfirmationModal = false,
 	disabledAttributeIds = [],
+	termsAutoselection,
 } ) => {
 	uiStrings = {
 		newAttributeListItemLabel: __( 'Add new', 'woocommerce' ),
@@ -307,6 +309,7 @@ export const AttributeControl: React.FC< AttributeControlProps > = ( {
 					disabledAttributeMessage={
 						uiStrings.disabledAttributeMessage
 					}
+					termsAutoselection={ termsAutoselection }
 				/>
 			) }
 			<SelectControlMenuSlot />

--- a/packages/js/product-editor/src/components/attribute-control/attribute-control.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/attribute-control.tsx
@@ -50,7 +50,7 @@ type AttributeControlProps = {
 	createNewAttributesAsGlobal?: boolean;
 	useRemoveConfirmationModal?: boolean;
 	disabledAttributeIds?: number[];
-	termsAutoselection?: 'first' | 'all';
+	termsAutoSelection?: 'first' | 'all';
 	uiStrings?: {
 		notice?: string | React.ReactElement;
 		emptyStateSubtitle?: string;
@@ -85,7 +85,7 @@ export const AttributeControl: React.FC< AttributeControlProps > = ( {
 	createNewAttributesAsGlobal = false,
 	useRemoveConfirmationModal = false,
 	disabledAttributeIds = [],
-	termsAutoselection,
+	termsAutoSelection,
 } ) => {
 	uiStrings = {
 		newAttributeListItemLabel: __( 'Add new', 'woocommerce' ),
@@ -309,7 +309,7 @@ export const AttributeControl: React.FC< AttributeControlProps > = ( {
 					disabledAttributeMessage={
 						uiStrings.disabledAttributeMessage
 					}
-					termsAutoselection={ termsAutoselection }
+					termsAutoSelection={ termsAutoSelection }
 				/>
 			) }
 			<SelectControlMenuSlot />

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
@@ -291,8 +291,7 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 											...selectedAttribute,
 										} );
 										focusValueField( index );
-									} )
-									.catch( () => {} );
+									} );
 							} else {
 								setValue(
 									'attributes[' + index + ']',

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
@@ -62,7 +62,7 @@ type NewAttributeModalProps = {
 	createNewAttributesAsGlobal?: boolean;
 	disabledAttributeIds?: number[];
 	disabledAttributeMessage?: string;
-	termsAutoselection?: 'first' | 'all';
+	termsAutoSelection?: 'first' | 'all';
 };
 
 type AttributeForm = {
@@ -101,7 +101,7 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 		'Already used in Attributes',
 		'woocommerce'
 	),
-	termsAutoselection,
+	termsAutoSelection,
 } ) => {
 	const scrollAttributeIntoView = ( index: number ) => {
 		setTimeout( () => {
@@ -259,7 +259,7 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 								| string
 						) {
 							if (
-								termsAutoselection &&
+								termsAutoSelection &&
 								value &&
 								! ( typeof value === 'string' )
 							) {
@@ -280,7 +280,7 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 											getProductAttributeObject(
 												value
 											) as EnhancedProductAttribute;
-										if ( termsAutoselection === 'all' ) {
+										if ( termsAutoSelection === 'all' ) {
 											selectedAttribute.terms = terms;
 										} else if ( terms.length > 0 ) {
 											selectedAttribute.terms = [

--- a/packages/js/product-editor/src/components/attributes/attributes.tsx
+++ b/packages/js/product-editor/src/components/attributes/attributes.tsx
@@ -67,7 +67,7 @@ export const Attributes: React.FC< AttributesProps > = ( {
 					'product_remove_attribute_confirmation_cancel_click'
 				)
 			}
-			termsAutoselection="first"
+			termsAutoSelection="first"
 		/>
 	);
 };

--- a/packages/js/product-editor/src/components/attributes/attributes.tsx
+++ b/packages/js/product-editor/src/components/attributes/attributes.tsx
@@ -67,6 +67,7 @@ export const Attributes: React.FC< AttributesProps > = ( {
 					'product_remove_attribute_confirmation_cancel_click'
 				)
 			}
+			termsAutoselection="first"
 		/>
 	);
 };


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #39892

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure feature `product-variation-management` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper`
3. Create at least 2 global attributes with mora than one terms under `/wp-admin/edit.php?post_type=product&page=product_attributes`
4. Go to `/wp-admin/admin.php?page=wc-admin&path=/add-product&tab=variations` and click `Add variation options` button from the `Variations` tab
5. When one global attribute is selected all the terms related to it should be auto selected too in the Values field
6. Go to `/wp-admin/admin.php?page=wc-admin&path=/add-product&tab=organization` and click `Add new` button from the `Organization` tab and under `Attributes` section
7. When one global attribute is selected the first term related to it should be auto selected too in the Values field

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
