### PR TITLE
Show in product details feature under Edit attribute modal

### DIFF
--- a/packages/js/product-editor/changelog/add-39893
+++ b/packages/js/product-editor/changelog/add-39893
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add 'Show in product details' checkbox under Edit attribute modal

--- a/packages/js/product-editor/src/components/attribute-control/attribute-control.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/attribute-control.tsx
@@ -51,6 +51,7 @@ type AttributeControlProps = {
 	useRemoveConfirmationModal?: boolean;
 	disabledAttributeIds?: number[];
 	termsAutoSelection?: 'first' | 'all';
+	defaultVisibility?: boolean;
 	uiStrings?: {
 		notice?: string | React.ReactElement;
 		emptyStateSubtitle?: string;
@@ -86,6 +87,7 @@ export const AttributeControl: React.FC< AttributeControlProps > = ( {
 	useRemoveConfirmationModal = false,
 	disabledAttributeIds = [],
 	termsAutoSelection,
+	defaultVisibility = false,
 } ) => {
 	uiStrings = {
 		newAttributeListItemLabel: __( 'Add new', 'woocommerce' ),
@@ -310,6 +312,7 @@ export const AttributeControl: React.FC< AttributeControlProps > = ( {
 						uiStrings.disabledAttributeMessage
 					}
 					termsAutoSelection={ termsAutoSelection }
+					defaultVisibility={ defaultVisibility }
 				/>
 			) }
 			<SelectControlMenuSlot />

--- a/packages/js/product-editor/src/components/attribute-control/edit-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/edit-attribute-modal.tsx
@@ -65,9 +65,9 @@ export const EditAttributeModal: React.FC< EditAttributeModalProps > = ( {
 		'Check to allow customers to search and filter by this option in your store.',
 		'woocommerce'
 	),
-	visibleLabel = __( 'Visible to customers', 'woocommerce' ),
+	visibleLabel = __( 'Show in product details', 'woocommerce' ),
 	visibleTooltip = __(
-		'Show or hide this attribute on the product page',
+		'Check to show this option and its values in the product details section on the product page.',
 		'woocommerce'
 	),
 	cancelAccessibleLabel = __( 'Cancel', 'woocommerce' ),

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
@@ -63,6 +63,7 @@ type NewAttributeModalProps = {
 	disabledAttributeIds?: number[];
 	disabledAttributeMessage?: string;
 	termsAutoSelection?: 'first' | 'all';
+	defaultVisibility?: boolean;
 };
 
 type AttributeForm = {
@@ -102,6 +103,7 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 		'woocommerce'
 	),
 	termsAutoSelection,
+	defaultVisibility = false,
 } ) => {
 	const scrollAttributeIntoView = ( index: number ) => {
 		setTimeout( () => {
@@ -159,7 +161,7 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 	};
 
 	const getVisibleOrTrue = ( attribute: EnhancedProductAttribute ) =>
-		attribute.visible !== undefined ? attribute.visible : true;
+		attribute.visible !== undefined ? attribute.visible : defaultVisibility;
 
 	const onAddingAttributes = ( values: AttributeForm ) => {
 		const newAttributesToAdd: EnhancedProductAttribute[] = [];

--- a/packages/js/product-editor/src/components/attributes/attributes.tsx
+++ b/packages/js/product-editor/src/components/attributes/attributes.tsx
@@ -68,6 +68,7 @@ export const Attributes: React.FC< AttributesProps > = ( {
 				)
 			}
 			termsAutoSelection="first"
+			defaultVisibility={ true }
 		/>
 	);
 };


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #39893

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure feature `product-variation-management` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper`
3. Go to `/wp-admin/admin.php?page=wc-admin&path=/add-product&tab=variations` and click `Add variation options` button from the `Variations` tab
4. In the modal, if you add any attribute, it is marked at non visible in product details page
5. After added it if you click edit from the variation options table row, under the edit modal the `Show in product details` checkbox should has that label and it should be unchecked
<img width="706" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/7e38e0e0-885d-49f5-b567-3c833aa6085e">

6. The Variation options table should has an eye icon indicating which is the option non visible 
<img width="693" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/0e3ab0db-5706-4151-aca5-3374bd5fa08e">
 
7. Moving to Organization tab, if you add a new attribute, by default it should be marked as visible. So you should not see the eye icon in the table and when edit it the `Show in product details` checkbox should be checked by default. 
<img width="666" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/68134be9-4d82-422e-a2d7-ccaa88d2073c">
 
8. If click on the exclamation icon to the right of the `Show in product details` checkbox label, the tooltip should say `Check to show this option and its values in the product details section on the product page.` 
<img width="696" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/8efdeab0-513f-48bb-bc73-593fef84e5b2">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
