### PR TITLE
Improve existing E2E test page loads to verify one more element on the pages

### DIFF
--- a/plugins/woocommerce/changelog/improve-page-loads-test
+++ b/plugins/woocommerce/changelog/improve-page-loads-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Improve the existing E2E test to verify one more element on each page load.

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/page-loads.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/page-loads.spec.js
@@ -41,34 +41,68 @@ const wcPages = [
 			{
 				name: 'Settings',
 				heading: 'General',
-				element:
-					'.select2-woocommerce_default_customer_address-container',
-				text: 'Shop country/region',
+				element: '#store_address-description',
+				text: 'This is where your business is located. Tax rates and shipping rates will use this address.',
 			},
 			{
 				name: 'Status',
 				heading: 'System status',
-				element: 'h2',
-				text: 'WordPress environment',
+				element: '.nav-tab-active',
+				text: 'System status',
 			},
 		],
 	},
 	{
 		name: 'Products',
 		subpages: [
-			{ name: 'All Products', heading: 'Products' },
-			{ name: 'Add New', heading: 'Add New' },
-			{ name: 'Categories', heading: 'Product categories' },
-			{ name: 'Tags', heading: 'Product tags' },
-			{ name: 'Attributes', heading: 'Attributes' },
+			{
+				name: 'All Products',
+				heading: 'Products',
+				element: '.woocommerce-BlankState-cta.button-primary',
+				text: 'Create Product',
+			},
+			{
+				name: 'Add New',
+				heading: 'Add New',
+				element: '.general_options > a > span',
+				text: 'General',
+			},
+			{
+				name: 'Categories',
+				heading: 'Product categories',
+				element: '.row-title',
+				text: 'Uncategorized',
+			},
+			{
+				name: 'Tags',
+				heading: 'Product tags',
+				element: '.no-items > td',
+				text: 'No tags found',
+			},
+			{
+				name: 'Attributes',
+				heading: 'Attributes',
+				element: '.alternate > td',
+				text: 'No attributes currently exist.',
+			},
 		],
 	},
 	// analytics is handled through a separate test
 	{
 		name: 'Marketing',
 		subpages: [
-			{ name: 'Overview', heading: 'Overview' },
-			{ name: 'Coupons', heading: 'Coupons' },
+			{
+				name: 'Overview',
+				heading: 'Overview',
+				element: '.woocommerce-marketing-card-header-description',
+				text: 'Start by adding a channel to your store',
+			},
+			{
+				name: 'Coupons',
+				heading: 'Coupons',
+				element: '.woocommerce-BlankState-cta.button-primary',
+				text: 'Create your first coupon',
+			},
 		],
 	},
 ];

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/page-loads.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/page-loads.spec.js
@@ -7,13 +7,50 @@ const wcPages = [
 	{
 		name: 'WooCommerce',
 		subpages: [
-			{ name: 'Home', heading: 'Home' },
-			{ name: 'Orders', heading: 'Orders' },
-			{ name: 'Customers', heading: 'Customers' },
-			{ name: 'Coupons', heading: 'Coupons' },
-			{ name: 'Reports', heading: 'Orders' },
-			{ name: 'Settings', heading: 'General' },
-			{ name: 'Status', heading: 'System status' },
+			{
+				name: 'Home',
+				heading: 'Home',
+				element:
+					'.wooocommerce-inbox-card__header > .components-truncate',
+				text: 'Inbox',
+			},
+			{
+				name: 'Orders',
+				heading: 'Orders',
+				element: '.woocommerce-BlankState-message',
+				text: 'When you receive a new order, it will appear here.',
+			},
+			{
+				name: 'Customers',
+				heading: 'Customers',
+				element: '.woocommerce-table__empty-item',
+				text: 'No data to display',
+			},
+			{
+				name: 'Coupons',
+				heading: 'Coupons',
+				element: '.woocommerce-table__empty-item',
+				text: 'No data to display',
+			},
+			{
+				name: 'Reports',
+				heading: 'Orders',
+				element: '.nav-tab-wrapper > .nav-tab-active',
+				text: 'Orders',
+			},
+			{
+				name: 'Settings',
+				heading: 'General',
+				element:
+					'.select2-woocommerce_default_customer_address-container',
+				text: 'Shop country/region',
+			},
+			{
+				name: 'Status',
+				heading: 'System status',
+				element: 'h2',
+				text: 'WordPress environment',
+			},
 		],
 	},
 	{
@@ -104,6 +141,10 @@ for ( const currentPage of wcPages ) {
 				await expect(
 					page.locator( 'h1.components-text' )
 				).toContainText( currentPage.subpages[ i ].heading );
+
+				await expect(
+					page.locator( currentPage.subpages[ i ].element )
+				).toContainText( currentPage.subpages[ i ].text );
 			} );
 		}
 	} );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/page-loads.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/page-loads.spec.js
@@ -17,8 +17,8 @@ const wcPages = [
 			{
 				name: 'Orders',
 				heading: 'Orders',
-				element: '.woocommerce-BlankState-message',
-				text: 'When you receive a new order, it will appear here.',
+				element: '.select2-selection__placeholder',
+				text: 'Filter by registered customer',
 			},
 			{
 				name: 'Customers',
@@ -58,14 +58,14 @@ const wcPages = [
 			{
 				name: 'All Products',
 				heading: 'Products',
-				element: '.woocommerce-BlankState-cta.button-primary',
-				text: 'Create Product',
+				element: '.product_cat.column-product_cat',
+				text: 'Uncategorized',
 			},
 			{
 				name: 'Add New',
 				heading: 'Add New',
-				element: '.general_options > a > span',
-				text: 'General',
+				element: '.duplication',
+				text: 'Copy to a new draft',
 			},
 			{
 				name: 'Categories',

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/page-loads.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/page-loads.spec.js
@@ -110,14 +110,14 @@ const wcPages = [
 let productId, orderId;
 const productName = 'Simple Product Name';
 const productPrice = '15.99';
-const randomNum = new Date().getTime().toString();
-const customer = {
-	username: `customer${ randomNum }`,
-	password: 'password',
-	email: `customer${ randomNum }@woocommercecoree2etestsuite.com`,
-};
 
 for ( const currentPage of wcPages ) {
+	const randomNum = new Date().getTime().toString();
+	const customer = {
+		username: `customer${ randomNum }`,
+		password: 'password',
+		email: `customer${ randomNum }@woocommercecoree2etestsuite.com`,
+	};
 	test.describe( `WooCommerce Page Load > Load ${ currentPage.name } sub pages`, () => {
 		test.use( { storageState: process.env.ADMINSTATE } );
 
@@ -232,6 +232,10 @@ for ( const currentPage of wcPages ) {
 				await expect(
 					page.locator( 'h1.components-text' )
 				).toContainText( currentPage.subpages[ i ].heading );
+
+				await expect(
+					page.locator( currentPage.subpages[ i ].element )
+				).toBeVisible();
 
 				await expect(
 					page.locator( currentPage.subpages[ i ].element )


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # [665](https://github.com/woocommerce/woocommerce-quality/issues/665) in Woo Quality

Updated existing test to add one more check for every page load so we ensure the page is loaded more rigorously than verifying just the page title. Checking for one more element on the page is enough to say the page loaded with all its elements. We have other tests verifying the full functionality of the page.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout this branch and launch the local E2E environment.
2. cd into plugins/woocommerce
3. Run the e2e tests with pnpm test:e2e-pw
4. Ensure the updated tests ./tests/e2e-pw/tests/merchant/page-loads.spec.js pass

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
