### PR TITLE
Try: Template API filter and action to handle dependent block addition and block removal

### DIFF
--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/AbstractProductFormTemplate.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/AbstractProductFormTemplate.php
@@ -51,7 +51,7 @@ abstract class AbstractProductFormTemplate extends AbstractBlockTemplate impleme
 	 *
 	 * @param array $block_config The block data.
 	 */
-	public function add_group( array $block_config ): GroupInterface {
+	public function add_group( array $block_config ): ?GroupInterface {
 		$block = new Group( $block_config, $this->get_root_template(), $this );
 		return $this->add_inner_block( $block );
 	}

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/Group.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/Group.php
@@ -42,7 +42,7 @@ class Group extends ProductBlock implements GroupInterface {
 	 *
 	 * @param array $block_config The block data.
 	 */
-	public function add_section( array $block_config ): SectionInterface {
+	public function add_section( array $block_config ): ?SectionInterface {
 		$block = new Section( $block_config, $this->get_root_template(), $this );
 		return $this->add_inner_block( $block );
 	}

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/GroupInterface.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/GroupInterface.php
@@ -16,12 +16,12 @@ interface GroupInterface extends BlockContainerInterface {
 	 * @param array $block_config block config.
 	 * @return SectionInterface new block section.
 	 */
-	public function add_section( array $block_config ): SectionInterface;
+	public function add_section( array $block_config ): ?SectionInterface;
 
 	/**
 	 * Adds a new block to the section block.
 	 *
 	 * @param array $block_config block config.
 	 */
-	public function add_block( array $block_config ): BlockInterface;
+	public function add_block( array $block_config ): ?BlockInterface;
 }

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/ProductBlock.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/ProductBlock.php
@@ -20,7 +20,7 @@ class ProductBlock extends AbstractBlock implements ContainerInterface {
 	 *
 	 * @param array $block_config The block data.
 	 */
-	public function &add_block( array $block_config ): BlockInterface {
+	public function &add_block( array $block_config ): ?BlockInterface {
 		$block = new ProductBlock( $block_config, $this->get_root_template(), $this );
 		return $this->add_inner_block( $block );
 	}

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/ProductFormTemplateInterface.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/ProductFormTemplateInterface.php
@@ -16,7 +16,7 @@ interface ProductFormTemplateInterface extends BlockTemplateInterface {
 	 * @param array $block_config block config.
 	 * @return BlockInterface new block section.
 	 */
-	public function add_group( array $block_config ): GroupInterface;
+	public function add_group( array $block_config ): ?GroupInterface;
 
 	/**
 	 * Gets Group block by id.

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/Section.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/Section.php
@@ -36,7 +36,7 @@ class Section extends ProductBlock implements SectionInterface {
 	 *
 	 * @param array $block_config The block data.
 	 */
-	public function add_section( array $block_config ): SectionInterface {
+	public function add_section( array $block_config ): ?SectionInterface {
 		$block = new Section( $block_config, $this->get_root_template(), $this );
 		return $this->add_inner_block( $block );
 	}

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/SectionInterface.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/SectionInterface.php
@@ -17,12 +17,12 @@ interface SectionInterface extends BlockContainerInterface {
 	 * @param array $block_config block config.
 	 * @return SectionInterface new block section.
 	 */
-	public function add_section( array $block_config ): SectionInterface;
+	public function add_section( array $block_config ): ?SectionInterface;
 
 	/**
 	 * Adds a new block to the section block.
 	 *
 	 * @param array $block_config block config.
 	 */
-	public function add_block( array $block_config ): BlockInterface;
+	public function add_block( array $block_config ): ?BlockInterface;
 }

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplates/Block.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplates/Block.php
@@ -17,7 +17,7 @@ class Block extends AbstractBlock implements BlockContainerInterface {
 	 *
 	 * @param array $block_config The block data.
 	 */
-	public function &add_block( array $block_config ): BlockInterface {
+	public function &add_block( array $block_config ): ?BlockInterface {
 		$block = new Block( $block_config, $this->get_root_template(), $this );
 		return $this->add_inner_block( $block );
 	}

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockContainerTrait.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockContainerTrait.php
@@ -37,6 +37,16 @@ trait BlockContainerTrait {
 			throw new \UnexpectedValueException( 'The block container is not the parent of the block.' );
 		}
 
+		/**
+		 * Filter called before a block is added to the block container.
+		 *
+		 * This filter can be used to prevent a block from being added to the block container by returning false.
+		 *
+		 * @param bool           $should_add_block Whether the block should be added to the block container.
+		 * @param BlockInterface $block            The block.
+		 *
+		 * @since 8.2.0
+		 */
 		$should_add_block = apply_filters( 'woocommerce_block_template_before_add_block', true, $block );
 
 		if ( ! $should_add_block ) {
@@ -47,6 +57,14 @@ trait BlockContainerTrait {
 		$root_template->cache_block( $block );
 		$this->inner_blocks[] = &$block;
 
+		/**
+		 * Action called after a block is added to the block container.
+		 *
+		 * This action can be used to perform actions after a block is added to the block container,
+		 * such as adding a dependent block.
+		 *
+		 * @param BlockInterface $block The block.
+		 */
 		do_action( 'woocommerce_block_template_after_add_block', $block );
 
 		return $block;

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockContainerTrait.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockContainerTrait.php
@@ -22,13 +22,13 @@ trait BlockContainerTrait {
 	/**
 	 * Add a block to the block container.
 	 *
-	 * @param BlockInterface $block The block.
+	 * @param BlockInterface|null $block The block.
 	 *
 	 * @throws \ValueError If the block configuration is invalid.
 	 * @throws \ValueError If a block with the specified ID already exists in the template.
 	 * @throws \UnexpectedValueException If the block container is not the parent of the block.
 	 */
-	protected function &add_inner_block( BlockInterface $block ): BlockInterface {
+	protected function &add_inner_block( BlockInterface $block ): ?BlockInterface {
 		if ( ! $block instanceof BlockInterface ) {
 			throw new \UnexpectedValueException( 'The block must return an instance of BlockInterface.' );
 		}
@@ -37,9 +37,18 @@ trait BlockContainerTrait {
 			throw new \UnexpectedValueException( 'The block container is not the parent of the block.' );
 		}
 
+		$should_add_block = apply_filters( 'woocommerce_block_template_before_add_block', true, $block );
+
+		if ( ! $should_add_block ) {
+			return null;
+		}
+
 		$root_template = $block->get_root_template();
 		$root_template->cache_block( $block );
 		$this->inner_blocks[] = &$block;
+
+		do_action( 'woocommerce_block_template_after_add_block', $block );
+
 		return $block;
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockTemplate.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockTemplate.php
@@ -22,7 +22,7 @@ class BlockTemplate extends AbstractBlockTemplate {
 	 *
 	 * @param array $block_config The block data.
 	 */
-	public function add_block( array $block_config ): BlockInterface {
+	public function add_block( array $block_config ): ?BlockInterface {
 		$block = new Block( $block_config, $this->get_root_template(), $this );
 		return $this->add_inner_block( $block );
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR tries an approach to improve the scenario where a block to be added by an extension depends on another block in the template (such as one provided by core, or by another extension).

A new action, `woocommerce_block_template_after_add_block`, is available. This action can be hooked into to perform actions after a block is added to the block container. Some examples of common actions:

* Adding a dependent block
* Setting up conditional hiding of the block (future)

A new filter, `woocommerce_block_template_before_add_block`, is available. This filter can be hooked into to perform actions before a block is added to the block container. Some examples of common actions:

* preventing a block from being added, by returning `false` (the `remove_block()`/`remove_blocks()` API methods will be removed if this approach is agreed upon, and this will be the only way to remove a block)
* replacing a block

Not included in this PR (will be added if we agree to go forward with this approach):

* Updating `SimpleProductTemplate` to handle when blocks are not added
* Removal of the `remove_block()` and `remove_blocks()` methods
* Updated unit tests

Part of #40022.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Test the `woocommerce_block_template_after_add_block` action with code similar to the following (put it in a plugin/mu-plugin).

```php
if ( ! function_exists( 'YOUR_PREFIX_block_template_after_add_block' ) ) {
	function YOUR_PREFIX_block_template_after_add_block( BlockInterface $block ) {
		$block_id = $block->get_id();

		if ( 'product-summary' === $block_id ) {
			// Add a toggle after the summary field
			$parent = $block->get_parent();

			if ( method_exists( $parent, 'add_block' ) ) {
				$parent->add_block(
					[
						'id'         => 'your-prefix-summary-show-toggle',
						'blockName'  => 'woocommerce/product-toggle-field',
						'order'	     => $block->get_order() + 5,
						'attributes' => [
							'label'    => __( 'Show summary', 'woocommerce' ),
						],
					]
				);
			}
		}
	}	

	add_action( 'woocommerce_block_template_after_add_block', 'YOUR_PREFIX_block_template_after_add_block' );
}
```

2. Test the `woocommerce_block_template_before_add_block` filter with code similar to the following (put it in a plugin/mu-plugin).

```php
f ( ! function_exists( 'YOUR_PREFIX_block_template_before_add_block' ) ) {
	function YOUR_PREFIX_block_template_before_add_block( bool $should_add_block, BlockInterface $block ) {
		$block_id = $block->get_id();

		if ( 'product-summary' === $block_id ) {
			// Remove the summary field (uncomment to remove the field and see how the `woocommerce_block_template_after_add_block` doesn't get called for this field)
			//$should_add_block = false;
		} else if ( 'product-sale-price' === $block_id ) {
			// Remove the sale price field and replace it with a toggle
			$should_add_block = false;

			$parent = $block->get_parent();

			if ( method_exists( $parent, 'add_block' ) ) {
				$parent->add_block(
					[
						'id'         => 'your-prefix-sale-price-toggle',
						'blockName'  => 'woocommerce/product-toggle-field',
						'order'	     => $block->get_order(),
						'attributes' => [
							'label'    => __( 'On sale', 'woocommerce' ),
						],
					]
				);
			}
		}

		return $should_add_block;
	}

	add_filter( 'woocommerce_block_template_before_add_block', 'YOUR_PREFIX_block_template_before_add_block', 10, 2 );
}
```

Additional sample code that can be used for testing can be found here:

https://gist.github.com/mattsherman/a613580a841eba5b5c402389dbcea88f

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
