### PR TITLE
Add a notice to "track inventory" toggle

### DIFF
--- a/packages/js/product-editor/changelog/dev-39152_add_notice_to_track_inventory_toggle
+++ b/packages/js/product-editor/changelog/dev-39152_add_notice_to_track_inventory_toggle
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add notice to "track inventory" toggle #40011

--- a/packages/js/product-editor/src/blocks/style.scss
+++ b/packages/js/product-editor/src/blocks/style.scss
@@ -19,3 +19,4 @@
 @import 'variation-items/editor.scss';
 @import 'variation-options/editor.scss';
 @import 'taxonomy/editor.scss';
+@import 'toggle/editor.scss';

--- a/packages/js/product-editor/src/blocks/toggle/block.json
+++ b/packages/js/product-editor/src/blocks/toggle/block.json
@@ -18,6 +18,10 @@
 		"disabled": {
 			"type": "boolean",
 			"default": false
+		},
+		"disabledCopy": {
+			"type": "string",
+			"__experimentalRole": "content"
 		}
 	},
 	"supports": {

--- a/packages/js/product-editor/src/blocks/toggle/edit.tsx
+++ b/packages/js/product-editor/src/blocks/toggle/edit.tsx
@@ -24,10 +24,6 @@ export function Edit( {
 		property
 	);
 
-	console.log( 'attributes', attributes );
-	console.log( 'blockProps', blockProps );
-	console.log( 'disabledCopy', disabledCopy );
-
 	return (
 		<div { ...blockProps }>
 			<ToggleControl

--- a/packages/js/product-editor/src/blocks/toggle/edit.tsx
+++ b/packages/js/product-editor/src/blocks/toggle/edit.tsx
@@ -11,17 +11,22 @@ import { ToggleControl } from '@wordpress/components';
  * Internal dependencies
  */
 import { ToggleBlockAttributes } from './types';
+import { sanitizeHTML } from '../../utils/sanitize-html';
 
 export function Edit( {
 	attributes,
 }: BlockEditProps< ToggleBlockAttributes > ) {
 	const blockProps = useBlockProps();
-	const { label, property, disabled } = attributes;
+	const { label, property, disabled, disabledCopy } = attributes;
 	const [ value, setValue ] = useEntityProp< boolean >(
 		'postType',
 		'product',
 		property
 	);
+
+	console.log( 'attributes', attributes );
+	console.log( 'blockProps', blockProps );
+	console.log( 'disabledCopy', disabledCopy );
 
 	return (
 		<div { ...blockProps }>
@@ -31,6 +36,12 @@ export function Edit( {
 				disabled={ disabled }
 				onChange={ setValue }
 			/>
+			{ disabled && (
+				<p
+					className="wp-block-woocommerce-product-toggle__disable-copy"
+					dangerouslySetInnerHTML={ sanitizeHTML( disabledCopy ) }
+				/>
+			) }
 		</div>
 	);
 }

--- a/packages/js/product-editor/src/blocks/toggle/editor.scss
+++ b/packages/js/product-editor/src/blocks/toggle/editor.scss
@@ -1,0 +1,6 @@
+.wp-block-woocommerce-product-toggle__disable-copy {
+	margin: $gap-small 0 0;
+	font-size: 12px;
+	color: $gray-700;
+	line-height: 1.5;
+}

--- a/plugins/woocommerce/changelog/dev-39152_add_notice_to_track_inventory_toggle
+++ b/plugins/woocommerce/changelog/dev-39152_add_notice_to_track_inventory_toggle
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add notice to "track inventory" toggle #40011

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -555,7 +555,7 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 					'disabledCopy' => sprintf(
 						/* translators: %1$s: Learn more link opening tag. %2$s: Learn more link closing tag.*/
 							__( 'Per your %1$sstore settings%2$s, inventory management is <strong>disabled</strong>.', 'woocommerce' ),
-							'<a href="http://blue.local/wp-admin/admin.php?page=wc-settings&tab=products&section=inventory" target="_blank" rel="noreferrer">',
+							'<a href="' . admin_url( 'admin.php?page=wc-settings&tab=products&section=inventory' ) . '" target="_blank" rel="noreferrer">',
 							'</a>'
 						),
 				],

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -552,6 +552,12 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 					'label'    => __( 'Track stock quantity for this product', 'woocommerce' ),
 					'property' => 'manage_stock',
 					'disabled' => 'yes' !== get_option( 'woocommerce_manage_stock' ),
+					'disabledCopy' => sprintf(
+						/* translators: %1$s: Learn more link opening tag. %2$s: Learn more link closing tag.*/
+							__( 'Per your %1$sstore settings%2$s, inventory management is <strong>disabled</strong>.', 'woocommerce' ),
+							'<a href="http://blue.local/wp-admin/admin.php?page=wc-settings&tab=products&section=inventory" target="_blank" rel="noreferrer">',
+							'</a>'
+						),
 				],
 			]
 		);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR introduces a notification to the "Track Inventory" toggle.

When stock management is disabled, a message reading `Per your store settings, inventory management is disabled.` will appear below the `Track stock quantity for this product` toggle within the Inventory section of the Products > Add New screen.

Closes #39152.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the product blocks editor under `WooCommerce` > `Settings` > `Advanced` > `Features`.
2. Go to `WooCommerce` > `Settings` > `Products` > `Inventory` and disable the stock management checkbox.
3. Navigate to `Product` > `Add New` > `Inventory`.
4. Verify the presence of the message: `Per your store settings, inventory management is disabled.`. This message should include a link leading to `WooCommerce` > `Settings` > `Products` > `Inventory`.

![Screenshot 2023-09-04 at 10 28 33](https://github.com/woocommerce/woocommerce/assets/1314156/fcb717fe-7d2a-4ee3-a893-9a646bf0961b)

5. Return to `WooCommerce` > `Settings` > `Products` > `Inventory` and re-enable the stock management checkbox.
6. Navigate to `Product` > `Add New` > `Inventory`.
7. Confirm that the message is no longer visible.

![Screenshot 2023-09-04 at 10 26 51](https://github.com/woocommerce/woocommerce/assets/1314156/9b8b702a-5b3b-4253-93f3-be75d06966ce)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
