### PR TITLE
E2E: Remove WP Latest-2 from release tests

### DIFF
--- a/.github/workflows/smoke-test-release.yml
+++ b/.github/workflows/smoke-test-release.yml
@@ -340,6 +340,8 @@ jobs:
             - name: Launch WP Env
               working-directory: plugins/woocommerce
               run: pnpm run env:test
+              env:
+                WP_ENV_CORE: WordPress/WordPress#${{ steps.get-wp-latest-1.outputs.version }}
 
             - name: Download release zip
               env:
@@ -348,13 +350,6 @@ jobs:
 
             - name: Replace `plugins/woocommerce` with unzipped woocommerce release build
               run: unzip -d plugins -o tmp/woocommerce.zip
-
-            - name: Downgrade WordPress version to ${{ steps.get-wp-latest-1.outputs.version }}
-              working-directory: plugins/woocommerce
-              run: |
-                  pnpm exec wp-env run tests-cli -- wp core update --version=${{ steps.get-wp-latest-1.outputs.version }} --force
-                  pnpm exec wp-env run tests-cli wp core update-db
-                  pnpm exec wp-env run tests-cli wp core version
 
             - name: Run API tests
               id: run-api-composite-action

--- a/.github/workflows/smoke-test-release.yml
+++ b/.github/workflows/smoke-test-release.yml
@@ -354,6 +354,7 @@ jobs:
               run: |
                   pnpm exec wp-env run tests-cli -- wp core update --version=${{ steps.get-wp-latest-1.outputs.version }} --force
                   pnpm exec wp-env run tests-cli wp core update-db
+                  pnpm exec wp-env run tests-cli wp core version
 
             - name: Run API tests
               id: run-api-composite-action

--- a/.github/workflows/smoke-test-release.yml
+++ b/.github/workflows/smoke-test-release.yml
@@ -391,7 +391,7 @@ jobs:
                     -f run_number=${{ github.run_number }} \
                     -f release_tag=${{ needs.get-tag.outputs.tag }} \
                     -f artifact="${{ env.API_WP_LATEST_X_ARTIFACT }}" \
-                    -f env_description="WP Latest-1" \
+                    -f env_description="${{ env.ENV_DESCRIPTION }}" \
                     -f test_type="api" \
                     --repo woocommerce/woocommerce-test-reports
 

--- a/.github/workflows/smoke-test-release.yml
+++ b/.github/workflows/smoke-test-release.yml
@@ -61,251 +61,251 @@ jobs:
                   GH_TOKEN: ${{ secrets.E2E_GH_TOKEN }}
               run: echo "created=$(gh release view ${{ steps.get-tag.outputs.tag }} --json assets --jq .assets[0].createdAt --repo woocommerce/woocommerce)" >> $GITHUB_OUTPUT
 
-    # e2e-update-wc:
-    #     name: Test WooCommerce update
-    #     runs-on: ubuntu-20.04
-    #     needs: [get-tag]
-    #     permissions:
-    #         contents: read
-    #     env:
-    #         ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-report
-    #         ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-results
-    #     steps:
-    #         - uses: actions/checkout@v3
+    e2e-update-wc:
+        name: Test WooCommerce update
+        runs-on: ubuntu-20.04
+        needs: [get-tag]
+        permissions:
+            contents: read
+        env:
+            ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-report
+            ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-results
+        steps:
+            - uses: actions/checkout@v3
 
-    #         - name: Setup WooCommerce Monorepo
-    #           uses: ./.github/actions/setup-woocommerce-monorepo
-    #           with:
-    #               install-filters: woocommerce
-    #               build: false
+            - name: Setup WooCommerce Monorepo
+              uses: ./.github/actions/setup-woocommerce-monorepo
+              with:
+                  install-filters: woocommerce
+                  build: false
 
-    #         - name: Run E2E tests
-    #           id: run-e2e-composite-action
-    #           timeout-minutes: 60
-    #           uses: ./.github/actions/tests/run-e2e-tests
-    #           with:
-    #               report-name: ${{ env.E2E_UPDATE_WC_ARTIFACT }}
-    #               tests: update-woocommerce.spec.js
-    #           env:
-    #               ADMIN_PASSWORD: ${{ secrets.RELEASE_TEST_ADMIN_PASSWORD }}
-    #               ADMIN_USER: ${{ secrets.RELEASE_TEST_ADMIN_USER }}
-    #               BASE_URL: ${{ secrets.RELEASE_TEST_URL }}
-    #               CUSTOMER_PASSWORD: ${{ secrets.RELEASE_TEST_CUSTOMER_PASSWORD }}
-    #               CUSTOMER_USER: ${{ secrets.RELEASE_TEST_CUSTOMER_USER }}
-    #               DEFAULT_TIMEOUT_OVERRIDE: 120000
-    #               GITHUB_TOKEN: ${{ secrets.E2E_GH_TOKEN }}
-    #               UPDATE_WC: ${{ needs.get-tag.outputs.tag }}
+            - name: Run E2E tests
+              id: run-e2e-composite-action
+              timeout-minutes: 60
+              uses: ./.github/actions/tests/run-e2e-tests
+              with:
+                  report-name: ${{ env.E2E_UPDATE_WC_ARTIFACT }}
+                  tests: update-woocommerce.spec.js
+              env:
+                  ADMIN_PASSWORD: ${{ secrets.RELEASE_TEST_ADMIN_PASSWORD }}
+                  ADMIN_USER: ${{ secrets.RELEASE_TEST_ADMIN_USER }}
+                  BASE_URL: ${{ secrets.RELEASE_TEST_URL }}
+                  CUSTOMER_PASSWORD: ${{ secrets.RELEASE_TEST_CUSTOMER_PASSWORD }}
+                  CUSTOMER_USER: ${{ secrets.RELEASE_TEST_CUSTOMER_USER }}
+                  DEFAULT_TIMEOUT_OVERRIDE: 120000
+                  GITHUB_TOKEN: ${{ secrets.E2E_GH_TOKEN }}
+                  UPDATE_WC: ${{ needs.get-tag.outputs.tag }}
 
-    #         - name: Upload Allure artifacts to bucket
-    #           if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
-    #           uses: ./.github/actions/tests/upload-allure-files-to-bucket
-    #           with:
-    #               aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
-    #               aws-region: ${{ secrets.REPORTS_AWS_REGION }}
-    #               aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
-    #               artifact-name: ${{ env.E2E_WP_LATEST_ARTIFACT }}
-    #               s3-bucket: ${{ secrets.REPORTS_BUCKET }}
+            - name: Upload Allure artifacts to bucket
+              if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
+              uses: ./.github/actions/tests/upload-allure-files-to-bucket
+              with:
+                  aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
+                  aws-region: ${{ secrets.REPORTS_AWS_REGION }}
+                  aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
+                  artifact-name: ${{ env.E2E_WP_LATEST_ARTIFACT }}
+                  s3-bucket: ${{ secrets.REPORTS_BUCKET }}
 
-    #         - name: Publish E2E Allure report
-    #           if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
-    #           env:
-    #               GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
-    #               ENV_DESCRIPTION: wp-latest
-    #           run: |
-    #               gh workflow run publish-test-reports-release.yml \
-    #                 -f created_at="${{ needs.get-tag.outputs.created }}" \
-    #                 -f run_id=${{ github.run_id }} \
-    #                 -f run_number=${{ github.run_number }} \
-    #                 -f release_tag=${{ needs.get-tag.outputs.tag }} \
-    #                 -f artifact="${{ env.E2E_WP_LATEST_ARTIFACT }}" \
-    #                 -f env_description="${{ env.ENV_DESCRIPTION }}" \
-    #                 -f test_type="e2e" \
-    #                 --repo woocommerce/woocommerce-test-reports
+            - name: Publish E2E Allure report
+              if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
+              env:
+                  GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+                  ENV_DESCRIPTION: wp-latest
+              run: |
+                  gh workflow run publish-test-reports-release.yml \
+                    -f created_at="${{ needs.get-tag.outputs.created }}" \
+                    -f run_id=${{ github.run_id }} \
+                    -f run_number=${{ github.run_number }} \
+                    -f release_tag=${{ needs.get-tag.outputs.tag }} \
+                    -f artifact="${{ env.E2E_WP_LATEST_ARTIFACT }}" \
+                    -f env_description="${{ env.ENV_DESCRIPTION }}" \
+                    -f test_type="e2e" \
+                    --repo woocommerce/woocommerce-test-reports
 
-    #         - name: Create Slack block
-    #           if: |
-    #               success() || (
-    #                 failure() && steps.run-e2e-composite-action.outputs.result == 'failure'
-    #               )
-    #           uses: ./.github/actions/tests/slack-summary-on-release/slack-blocks
-    #           with:
-    #               test-name: WC Update test
-    #               e2e-result: ${{ steps.run-e2e-composite-action.outputs.result }}
-    #               env-slug: wp-latest
-    #               release-version: ${{ needs.get-tag.outputs.tag }}
+            - name: Create Slack block
+              if: |
+                  success() || (
+                    failure() && steps.run-e2e-composite-action.outputs.result == 'failure'
+                  )
+              uses: ./.github/actions/tests/slack-summary-on-release/slack-blocks
+              with:
+                  test-name: WC Update test
+                  e2e-result: ${{ steps.run-e2e-composite-action.outputs.result }}
+                  env-slug: wp-latest
+                  release-version: ${{ needs.get-tag.outputs.tag }}
 
-    # api-wp-latest:
-    #     name: API on WP Latest
-    #     runs-on: ubuntu-20.04
-    #     needs: [get-tag, e2e-update-wc]
-    #     permissions:
-    #         contents: read
-    #     outputs:
-    #         result: ${{ steps.run-api-composite-action.outputs.result }}
-    #     env:
-    #         ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/api-test-report/allure-report
-    #         ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/api-test-report/allure-results
-    #         API_WP_LATEST_ARTIFACT: API test on release smoke test site with WP Latest (run ${{ github.run_number }})
-    #     steps:
-    #         - uses: actions/checkout@v3
+    api-wp-latest:
+        name: API on WP Latest
+        runs-on: ubuntu-20.04
+        needs: [get-tag, e2e-update-wc]
+        permissions:
+            contents: read
+        outputs:
+            result: ${{ steps.run-api-composite-action.outputs.result }}
+        env:
+            ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/api-test-report/allure-report
+            ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/api-test-report/allure-results
+            API_WP_LATEST_ARTIFACT: API test on release smoke test site with WP Latest (run ${{ github.run_number }})
+        steps:
+            - uses: actions/checkout@v3
 
-    #         - name: Setup WooCommerce Monorepo
-    #           uses: ./.github/actions/setup-woocommerce-monorepo
-    #           with:
-    #               install-filters: woocommerce
-    #               build: false
+            - name: Setup WooCommerce Monorepo
+              uses: ./.github/actions/setup-woocommerce-monorepo
+              with:
+                  install-filters: woocommerce
+                  build: false
 
-    #         - name: Run API tests
-    #           id: run-api-composite-action
-    #           uses: ./.github/actions/tests/run-api-tests
-    #           with:
-    #               report-name: ${{ env.API_WP_LATEST_ARTIFACT }}
-    #               tests: hello
-    #           env:
-    #               API_BASE_URL: ${{ secrets.RELEASE_TEST_URL }}
-    #               USER_KEY: ${{ secrets.RELEASE_TEST_ADMIN_USER }}
-    #               USER_SECRET: ${{ secrets.RELEASE_TEST_ADMIN_PASSWORD }}
+            - name: Run API tests
+              id: run-api-composite-action
+              uses: ./.github/actions/tests/run-api-tests
+              with:
+                  report-name: ${{ env.API_WP_LATEST_ARTIFACT }}
+                  tests: hello
+              env:
+                  API_BASE_URL: ${{ secrets.RELEASE_TEST_URL }}
+                  USER_KEY: ${{ secrets.RELEASE_TEST_ADMIN_USER }}
+                  USER_SECRET: ${{ secrets.RELEASE_TEST_ADMIN_PASSWORD }}
 
-    #         - name: Upload Allure artifacts to bucket
-    #           if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
-    #           uses: ./.github/actions/tests/upload-allure-files-to-bucket
-    #           with:
-    #               aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
-    #               aws-region: ${{ secrets.REPORTS_AWS_REGION }}
-    #               aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
-    #               artifact-name: ${{ env.API_WP_LATEST_ARTIFACT }}
-    #               s3-bucket: ${{ secrets.REPORTS_BUCKET }}
+            - name: Upload Allure artifacts to bucket
+              if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
+              uses: ./.github/actions/tests/upload-allure-files-to-bucket
+              with:
+                  aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
+                  aws-region: ${{ secrets.REPORTS_AWS_REGION }}
+                  aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
+                  artifact-name: ${{ env.API_WP_LATEST_ARTIFACT }}
+                  s3-bucket: ${{ secrets.REPORTS_BUCKET }}
 
-    #         - name: Publish API Allure report
-    #           if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
-    #           env:
-    #               GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
-    #               ENV_DESCRIPTION: wp-latest
-    #           run: |
-    #               gh workflow run publish-test-reports-release.yml \
-    #                 -f created_at="${{ needs.get-tag.outputs.created }}" \
-    #                 -f run_id=${{ github.run_id }} \
-    #                 -f run_number=${{ github.run_number }} \
-    #                 -f release_tag=${{ needs.get-tag.outputs.tag }} \
-    #                 -f artifact="${{ env.API_WP_LATEST_ARTIFACT }}" \
-    #                 -f env_description="${{ env.ENV_DESCRIPTION }}" \
-    #                 -f test_type="api" \
-    #                 --repo woocommerce/woocommerce-test-reports
+            - name: Publish API Allure report
+              if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
+              env:
+                  GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+                  ENV_DESCRIPTION: wp-latest
+              run: |
+                  gh workflow run publish-test-reports-release.yml \
+                    -f created_at="${{ needs.get-tag.outputs.created }}" \
+                    -f run_id=${{ github.run_id }} \
+                    -f run_number=${{ github.run_number }} \
+                    -f release_tag=${{ needs.get-tag.outputs.tag }} \
+                    -f artifact="${{ env.API_WP_LATEST_ARTIFACT }}" \
+                    -f env_description="${{ env.ENV_DESCRIPTION }}" \
+                    -f test_type="api" \
+                    --repo woocommerce/woocommerce-test-reports
 
-    #         - name: Create Slack block
-    #           if: |
-    #               success() || (
-    #                 failure() && steps.run-api-composite-action.outputs.result == 'failure'
-    #               )
-    #           uses: ./.github/actions/tests/slack-summary-on-release/slack-blocks
-    #           with:
-    #               test-name: WP Latest
-    #               api-result: ${{ steps.run-api-composite-action.outputs.result }}
-    #               env-slug: wp-latest
-    #               release-version: ${{ needs.get-tag.outputs.tag }}
+            - name: Create Slack block
+              if: |
+                  success() || (
+                    failure() && steps.run-api-composite-action.outputs.result == 'failure'
+                  )
+              uses: ./.github/actions/tests/slack-summary-on-release/slack-blocks
+              with:
+                  test-name: WP Latest
+                  api-result: ${{ steps.run-api-composite-action.outputs.result }}
+                  env-slug: wp-latest
+                  release-version: ${{ needs.get-tag.outputs.tag }}
 
-    # e2e-wp-latest:
-    #     name: E2E on WP Latest
-    #     runs-on: ubuntu-20.04
-    #     needs: [get-tag, api-wp-latest]
-    #     permissions:
-    #         contents: read
-    #     env:
-    #         ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-report
-    #         ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-results
-    #     steps:
-    #         - uses: actions/checkout@v3
+    e2e-wp-latest:
+        name: E2E on WP Latest
+        runs-on: ubuntu-20.04
+        needs: [get-tag, api-wp-latest]
+        permissions:
+            contents: read
+        env:
+            ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-report
+            ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-results
+        steps:
+            - uses: actions/checkout@v3
 
-    #         - name: Setup WooCommerce Monorepo
-    #           uses: ./.github/actions/setup-woocommerce-monorepo
-    #           with:
-    #               install-filters: woocommerce
-    #               build: false
+            - name: Setup WooCommerce Monorepo
+              uses: ./.github/actions/setup-woocommerce-monorepo
+              with:
+                  install-filters: woocommerce
+                  build: false
 
-    #         - name: Run E2E tests
-    #           id: run-e2e-composite-action
-    #           timeout-minutes: 60
-    #           uses: ./.github/actions/tests/run-e2e-tests
-    #           with:
-    #               report-name: e2e-wp-latest--partial--run-${{ github.run_number }}
-    #               playwright-config: ignore-plugin-tests.playwright.config.js
-    #           env:
-    #               ADMIN_PASSWORD: ${{ secrets.RELEASE_TEST_ADMIN_PASSWORD }}
-    #               ADMIN_USER: ${{ secrets.RELEASE_TEST_ADMIN_USER }}
-    #               ADMIN_USER_EMAIL: ${{ secrets.RELEASE_TEST_ADMIN_USER_EMAIL }}
-    #               BASE_URL: ${{ secrets.RELEASE_TEST_URL }}
-    #               CUSTOMER_PASSWORD: ${{ secrets.RELEASE_TEST_CUSTOMER_PASSWORD }}
-    #               CUSTOMER_USER: ${{ secrets.RELEASE_TEST_CUSTOMER_USER }}
-    #               DEFAULT_TIMEOUT_OVERRIDE: 120000
-    #               E2E_MAX_FAILURES: 25
-    #               RESET_SITE: true
+            - name: Run E2E tests
+              id: run-e2e-composite-action
+              timeout-minutes: 60
+              uses: ./.github/actions/tests/run-e2e-tests
+              with:
+                  report-name: e2e-wp-latest--partial--run-${{ github.run_number }}
+                  playwright-config: ignore-plugin-tests.playwright.config.js
+              env:
+                  ADMIN_PASSWORD: ${{ secrets.RELEASE_TEST_ADMIN_PASSWORD }}
+                  ADMIN_USER: ${{ secrets.RELEASE_TEST_ADMIN_USER }}
+                  ADMIN_USER_EMAIL: ${{ secrets.RELEASE_TEST_ADMIN_USER_EMAIL }}
+                  BASE_URL: ${{ secrets.RELEASE_TEST_URL }}
+                  CUSTOMER_PASSWORD: ${{ secrets.RELEASE_TEST_CUSTOMER_PASSWORD }}
+                  CUSTOMER_USER: ${{ secrets.RELEASE_TEST_CUSTOMER_USER }}
+                  DEFAULT_TIMEOUT_OVERRIDE: 120000
+                  E2E_MAX_FAILURES: 25
+                  RESET_SITE: true
 
-    #         - name: Download 'e2e-update-wc' artifact
-    #           if: success() || failure()
-    #           uses: actions/download-artifact@v3
-    #           with:
-    #               name: ${{ env.E2E_UPDATE_WC_ARTIFACT }}
-    #               path: plugins/woocommerce/tmp
+            - name: Download 'e2e-update-wc' artifact
+              if: success() || failure()
+              uses: actions/download-artifact@v3
+              with:
+                  name: ${{ env.E2E_UPDATE_WC_ARTIFACT }}
+                  path: plugins/woocommerce/tmp
 
-    #         - name: Add allure-results from 'e2e-update-wc'
-    #           if: success() || failure()
-    #           working-directory: plugins/woocommerce
-    #           run: cp -r tmp/allure-results tests/e2e-pw/test-results
+            - name: Add allure-results from 'e2e-update-wc'
+              if: success() || failure()
+              working-directory: plugins/woocommerce
+              run: cp -r tmp/allure-results tests/e2e-pw/test-results
 
-    #         - name: Generate E2E Test report.
-    #           if: success() || failure()
-    #           working-directory: plugins/woocommerce
-    #           run: pnpm exec allure generate --clean ${{ env.ALLURE_RESULTS_DIR }} --output ${{ env.ALLURE_REPORT_DIR }}
+            - name: Generate E2E Test report.
+              if: success() || failure()
+              working-directory: plugins/woocommerce
+              run: pnpm exec allure generate --clean ${{ env.ALLURE_RESULTS_DIR }} --output ${{ env.ALLURE_REPORT_DIR }}
 
-    #         - name: Archive E2E test report
-    #           if: success() || failure()
-    #           uses: actions/upload-artifact@v3
-    #           with:
-    #               name: ${{ env.E2E_WP_LATEST_ARTIFACT }}
-    #               path: |
-    #                   ${{ env.ALLURE_RESULTS_DIR }}
-    #                   ${{ env.ALLURE_REPORT_DIR }}
-    #               if-no-files-found: ignore
-    #               retention-days: 5
+            - name: Archive E2E test report
+              if: success() || failure()
+              uses: actions/upload-artifact@v3
+              with:
+                  name: ${{ env.E2E_WP_LATEST_ARTIFACT }}
+                  path: |
+                      ${{ env.ALLURE_RESULTS_DIR }}
+                      ${{ env.ALLURE_REPORT_DIR }}
+                  if-no-files-found: ignore
+                  retention-days: 5
 
-    #         - name: Upload Allure artifacts to bucket
-    #           if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
-    #           uses: ./.github/actions/tests/upload-allure-files-to-bucket
-    #           with:
-    #               aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
-    #               aws-region: ${{ secrets.REPORTS_AWS_REGION }}
-    #               aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
-    #               artifact-name: ${{ env.E2E_WP_LATEST_ARTIFACT }}
-    #               s3-bucket: ${{ secrets.REPORTS_BUCKET }}
+            - name: Upload Allure artifacts to bucket
+              if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
+              uses: ./.github/actions/tests/upload-allure-files-to-bucket
+              with:
+                  aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
+                  aws-region: ${{ secrets.REPORTS_AWS_REGION }}
+                  aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
+                  artifact-name: ${{ env.E2E_WP_LATEST_ARTIFACT }}
+                  s3-bucket: ${{ secrets.REPORTS_BUCKET }}
 
-    #         - name: Publish E2E Allure report
-    #           if: success() || failure()
-    #           env:
-    #               GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
-    #               ENV_DESCRIPTION: wp-latest
-    #           run: |
-    #               gh workflow run publish-test-reports-release.yml \
-    #                 -f created_at="${{ needs.get-tag.outputs.created }}" \
-    #                 -f run_id=${{ github.run_id }} \
-    #                 -f run_number=${{ github.run_number }} \
-    #                 -f release_tag=${{ needs.get-tag.outputs.tag }} \
-    #                 -f artifact="${{ env.E2E_WP_LATEST_ARTIFACT }}" \
-    #                 -f env_description="${{ env.ENV_DESCRIPTION }}" \
-    #                 -f test_type="e2e" \
-    #                 --repo woocommerce/woocommerce-test-reports
+            - name: Publish E2E Allure report
+              if: success() || failure()
+              env:
+                  GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+                  ENV_DESCRIPTION: wp-latest
+              run: |
+                  gh workflow run publish-test-reports-release.yml \
+                    -f created_at="${{ needs.get-tag.outputs.created }}" \
+                    -f run_id=${{ github.run_id }} \
+                    -f run_number=${{ github.run_number }} \
+                    -f release_tag=${{ needs.get-tag.outputs.tag }} \
+                    -f artifact="${{ env.E2E_WP_LATEST_ARTIFACT }}" \
+                    -f env_description="${{ env.ENV_DESCRIPTION }}" \
+                    -f test_type="e2e" \
+                    --repo woocommerce/woocommerce-test-reports
 
-    #         - name: Create Slack block
-    #           if: |
-    #               success() || (
-    #                 failure() && steps.run-e2e-composite-action.outputs.result == 'failure'
-    #               )
-    #           uses: ./.github/actions/tests/slack-summary-on-release/slack-blocks
-    #           with:
-    #               test-name: WP Latest
-    #               api-result: ${{ needs.api-wp-latest.outputs.result }}
-    #               e2e-result: ${{ steps.run-e2e-composite-action.outputs.result }}
-    #               env-slug: wp-latest
-    #               release-version: ${{ needs.get-tag.outputs.tag }}
+            - name: Create Slack block
+              if: |
+                  success() || (
+                    failure() && steps.run-e2e-composite-action.outputs.result == 'failure'
+                  )
+              uses: ./.github/actions/tests/slack-summary-on-release/slack-blocks
+              with:
+                  test-name: WP Latest
+                  api-result: ${{ needs.api-wp-latest.outputs.result }}
+                  e2e-result: ${{ steps.run-e2e-composite-action.outputs.result }}
+                  env-slug: wp-latest
+                  release-version: ${{ needs.get-tag.outputs.tag }}
 
     test-wp-latest-1:
         name: Test against WP Latest-1
@@ -366,34 +366,34 @@ jobs:
                   ALLURE_RESULTS_DIR: ${{ env.API_ALLURE_RESULTS_DIR }}
                   ALLURE_REPORT_DIR: ${{ env.API_ALLURE_REPORT_DIR }}
 
-            # - name: Upload Allure artifacts to bucket
-            #   if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
-            #   uses: ./.github/actions/tests/upload-allure-files-to-bucket
-            #   env:
-            #       ALLURE_RESULTS_DIR: ${{ env.API_ALLURE_RESULTS_DIR }}
-            #       ALLURE_REPORT_DIR: ${{ env.API_ALLURE_REPORT_DIR }}
-            #   with:
-            #       aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
-            #       aws-region: ${{ secrets.REPORTS_AWS_REGION }}
-            #       aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
-            #       artifact-name: ${{ env.API_WP_LATEST_X_ARTIFACT }}
-            #       s3-bucket: ${{ secrets.REPORTS_BUCKET }}
+            - name: Upload Allure artifacts to bucket
+              if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
+              uses: ./.github/actions/tests/upload-allure-files-to-bucket
+              env:
+                  ALLURE_RESULTS_DIR: ${{ env.API_ALLURE_RESULTS_DIR }}
+                  ALLURE_REPORT_DIR: ${{ env.API_ALLURE_REPORT_DIR }}
+              with:
+                  aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
+                  aws-region: ${{ secrets.REPORTS_AWS_REGION }}
+                  aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
+                  artifact-name: ${{ env.API_WP_LATEST_X_ARTIFACT }}
+                  s3-bucket: ${{ secrets.REPORTS_BUCKET }}
 
-            # - name: Publish API Allure report
-            #   if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
-            #   env:
-            #       GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
-            #       ENV_DESCRIPTION: wp-latest-1
-            #   run: |
-            #       gh workflow run publish-test-reports-release.yml \
-            #         -f created_at="${{ needs.get-tag.outputs.created }}" \
-            #         -f run_id=${{ github.run_id }} \
-            #         -f run_number=${{ github.run_number }} \
-            #         -f release_tag=${{ needs.get-tag.outputs.tag }} \
-            #         -f artifact="${{ env.API_WP_LATEST_X_ARTIFACT }}" \
-            #         -f env_description="WP Latest-1" \
-            #         -f test_type="api" \
-            #         --repo woocommerce/woocommerce-test-reports
+            - name: Publish API Allure report
+              if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
+              env:
+                  GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+                  ENV_DESCRIPTION: wp-latest-1
+              run: |
+                  gh workflow run publish-test-reports-release.yml \
+                    -f created_at="${{ needs.get-tag.outputs.created }}" \
+                    -f run_id=${{ github.run_id }} \
+                    -f run_number=${{ github.run_number }} \
+                    -f release_tag=${{ needs.get-tag.outputs.tag }} \
+                    -f artifact="${{ env.API_WP_LATEST_X_ARTIFACT }}" \
+                    -f env_description="WP Latest-1" \
+                    -f test_type="api" \
+                    --repo woocommerce/woocommerce-test-reports
 
             - name: Run E2E tests
               id: run-e2e-composite-action
@@ -406,36 +406,35 @@ jobs:
                   DEFAULT_TIMEOUT_OVERRIDE: 120000
               with:
                   report-name: ${{ env.E2E_WP_LATEST_X_ARTIFACT }}
-                  tests: basic.spec.js # mytodo remove
 
-            # - name: Upload Allure artifacts to bucket
-            #   if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
-            #   uses: ./.github/actions/tests/upload-allure-files-to-bucket
-            #   env:
-            #       ALLURE_RESULTS_DIR: ${{ env.E2E_ALLURE_RESULTS_DIR }}
-            #       ALLURE_REPORT_DIR: ${{ env.E2E_ALLURE_REPORT_DIR }}
-            #   with:
-            #       aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
-            #       aws-region: ${{ secrets.REPORTS_AWS_REGION }}
-            #       aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
-            #       artifact-name: ${{ env.E2E_WP_LATEST_X_ARTIFACT }}
-            #       s3-bucket: ${{ secrets.REPORTS_BUCKET }}
+            - name: Upload Allure artifacts to bucket
+              if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
+              uses: ./.github/actions/tests/upload-allure-files-to-bucket
+              env:
+                  ALLURE_RESULTS_DIR: ${{ env.E2E_ALLURE_RESULTS_DIR }}
+                  ALLURE_REPORT_DIR: ${{ env.E2E_ALLURE_REPORT_DIR }}
+              with:
+                  aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
+                  aws-region: ${{ secrets.REPORTS_AWS_REGION }}
+                  aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
+                  artifact-name: ${{ env.E2E_WP_LATEST_X_ARTIFACT }}
+                  s3-bucket: ${{ secrets.REPORTS_BUCKET }}
 
-            # - name: Publish E2E Allure report
-            #   if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
-            #   env:
-            #       GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
-            #       ENV_DESCRIPTION: wp-latest-1
-            #   run: |
-            #       gh workflow run publish-test-reports-release.yml \
-            #         -f created_at="${{ needs.get-tag.outputs.created }}" \
-            #         -f run_id=${{ github.run_id }} \
-            #         -f run_number=${{ github.run_number }} \
-            #         -f release_tag=${{ needs.get-tag.outputs.tag }} \
-            #         -f artifact="${{ env.E2E_WP_LATEST_X_ARTIFACT }}" \
-            #         -f env_description="${{ env.ENV_DESCRIPTION }}" \
-            #         -f test_type="e2e" \
-            #         --repo woocommerce/woocommerce-test-reports
+            - name: Publish E2E Allure report
+              if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
+              env:
+                  GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+                  ENV_DESCRIPTION: wp-latest-1
+              run: |
+                  gh workflow run publish-test-reports-release.yml \
+                    -f created_at="${{ needs.get-tag.outputs.created }}" \
+                    -f run_id=${{ github.run_id }} \
+                    -f run_number=${{ github.run_number }} \
+                    -f release_tag=${{ needs.get-tag.outputs.tag }} \
+                    -f artifact="${{ env.E2E_WP_LATEST_X_ARTIFACT }}" \
+                    -f env_description="${{ env.ENV_DESCRIPTION }}" \
+                    -f test_type="e2e" \
+                    --repo woocommerce/woocommerce-test-reports
 
             - name: Create Slack block
               if: |
@@ -453,295 +452,295 @@ jobs:
                   env-slug: wp-latest-1
                   release-version: ${{ needs.get-tag.outputs.tag }}
 
-    # test-php-versions:
-    #     name: Test against PHP ${{ matrix.php_version }}
-    #     runs-on: ubuntu-20.04
-    #     needs: [get-tag]
-    #     strategy:
-    #         fail-fast: false
-    #         matrix:
-    #             php_version: ['7.4', '8.1']
-    #     env:
-    #         API_ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/test-results/allure-report
-    #         API_ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/test-results/allure-results
-    #         API_ARTIFACT: API test on wp-env with PHP ${{ matrix.php_version }} (run ${{ github.run_number }})
-    #         E2E_ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-report
-    #         E2E_ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-results
-    #         E2E_ARTIFACT: E2E test on wp-env with PHP ${{ matrix.php_version }} (run ${{ github.run_number }})
-    #     steps:
-    #         - name: Checkout
-    #           uses: actions/checkout@v3
+    test-php-versions:
+        name: Test against PHP ${{ matrix.php_version }}
+        runs-on: ubuntu-20.04
+        needs: [get-tag]
+        strategy:
+            fail-fast: false
+            matrix:
+                php_version: ['7.4', '8.1']
+        env:
+            API_ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/test-results/allure-report
+            API_ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/test-results/allure-results
+            API_ARTIFACT: API test on wp-env with PHP ${{ matrix.php_version }} (run ${{ github.run_number }})
+            E2E_ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-report
+            E2E_ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-results
+            E2E_ARTIFACT: E2E test on wp-env with PHP ${{ matrix.php_version }} (run ${{ github.run_number }})
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
 
-    #         - name: Setup WooCommerce Monorepo
-    #           uses: ./.github/actions/setup-woocommerce-monorepo
-    #           with:
-    #               build-filters: woocommerce
+            - name: Setup WooCommerce Monorepo
+              uses: ./.github/actions/setup-woocommerce-monorepo
+              with:
+                  build-filters: woocommerce
 
-    #         - name: Launch WP Env
-    #           working-directory: plugins/woocommerce
-    #           env:
-    #               WP_ENV_PHP_VERSION: ${{ matrix.php_version }}
-    #           run: pnpm run env:test
+            - name: Launch WP Env
+              working-directory: plugins/woocommerce
+              env:
+                  WP_ENV_PHP_VERSION: ${{ matrix.php_version }}
+              run: pnpm run env:test
 
-    #         - name: Verify PHP version
-    #           working-directory: .github/workflows/scripts
-    #           env:
-    #               EXPECTED_PHP_VERSION: ${{ matrix.php_version }}
-    #           run: bash verify-php-version.sh
+            - name: Verify PHP version
+              working-directory: .github/workflows/scripts
+              env:
+                  EXPECTED_PHP_VERSION: ${{ matrix.php_version }}
+              run: bash verify-php-version.sh
 
-    #         - name: Download release zip
-    #           env:
-    #               GH_TOKEN: ${{ secrets.E2E_GH_TOKEN }}
-    #           run: gh release download ${{ needs.get-tag.outputs.tag }} --dir tmp
+            - name: Download release zip
+              env:
+                  GH_TOKEN: ${{ secrets.E2E_GH_TOKEN }}
+              run: gh release download ${{ needs.get-tag.outputs.tag }} --dir tmp
 
-    #         - name: Replace `plugins/woocommerce` with unzipped woocommerce release build
-    #           run: unzip -d plugins -o tmp/woocommerce.zip
+            - name: Replace `plugins/woocommerce` with unzipped woocommerce release build
+              run: unzip -d plugins -o tmp/woocommerce.zip
 
-    #         - name: Run API tests
-    #           id: run-api-composite-action
-    #           uses: ./.github/actions/tests/run-api-tests
-    #           with:
-    #               report-name: ${{ env.API_ARTIFACT }}
-    #               tests: hello.test.js
-    #           env:
-    #               ALLURE_RESULTS_DIR: ${{ env.API_ALLURE_RESULTS_DIR }}
-    #               ALLURE_REPORT_DIR: ${{ env.API_ALLURE_REPORT_DIR }}
+            - name: Run API tests
+              id: run-api-composite-action
+              uses: ./.github/actions/tests/run-api-tests
+              with:
+                  report-name: ${{ env.API_ARTIFACT }}
+                  tests: hello.test.js
+              env:
+                  ALLURE_RESULTS_DIR: ${{ env.API_ALLURE_RESULTS_DIR }}
+                  ALLURE_REPORT_DIR: ${{ env.API_ALLURE_REPORT_DIR }}
 
-    #         - name: Upload Allure artifacts to bucket
-    #           if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
-    #           uses: ./.github/actions/tests/upload-allure-files-to-bucket
-    #           env:
-    #               ALLURE_RESULTS_DIR: ${{ env.API_ALLURE_RESULTS_DIR }}
-    #               ALLURE_REPORT_DIR: ${{ env.API_ALLURE_REPORT_DIR }}
-    #           with:
-    #               aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
-    #               aws-region: ${{ secrets.REPORTS_AWS_REGION }}
-    #               aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
-    #               artifact-name: ${{ env.API_ARTIFACT }}
-    #               s3-bucket: ${{ secrets.REPORTS_BUCKET }}
+            - name: Upload Allure artifacts to bucket
+              if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
+              uses: ./.github/actions/tests/upload-allure-files-to-bucket
+              env:
+                  ALLURE_RESULTS_DIR: ${{ env.API_ALLURE_RESULTS_DIR }}
+                  ALLURE_REPORT_DIR: ${{ env.API_ALLURE_REPORT_DIR }}
+              with:
+                  aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
+                  aws-region: ${{ secrets.REPORTS_AWS_REGION }}
+                  aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
+                  artifact-name: ${{ env.API_ARTIFACT }}
+                  s3-bucket: ${{ secrets.REPORTS_BUCKET }}
 
-    #         - name: Publish API Allure report
-    #           if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
-    #           env:
-    #               GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
-    #               ENV_DESCRIPTION: php-${{ matrix.php_version }}
-    #           run: |
-    #               gh workflow run publish-test-reports-release.yml \
-    #                 -f created_at="${{ needs.get-tag.outputs.created }}" \
-    #                 -f run_id=${{ github.run_id }} \
-    #                 -f run_number=${{ github.run_number }} \
-    #                 -f release_tag=${{ needs.get-tag.outputs.tag }} \
-    #                 -f artifact="${{ env.API_ARTIFACT }}" \
-    #                 -f env_description="${{ env.ENV_DESCRIPTION }}" \
-    #                 -f test_type="api" \
-    #                 --repo woocommerce/woocommerce-test-reports
+            - name: Publish API Allure report
+              if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
+              env:
+                  GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+                  ENV_DESCRIPTION: php-${{ matrix.php_version }}
+              run: |
+                  gh workflow run publish-test-reports-release.yml \
+                    -f created_at="${{ needs.get-tag.outputs.created }}" \
+                    -f run_id=${{ github.run_id }} \
+                    -f run_number=${{ github.run_number }} \
+                    -f release_tag=${{ needs.get-tag.outputs.tag }} \
+                    -f artifact="${{ env.API_ARTIFACT }}" \
+                    -f env_description="${{ env.ENV_DESCRIPTION }}" \
+                    -f test_type="api" \
+                    --repo woocommerce/woocommerce-test-reports
 
-    #         - name: Run E2E tests
-    #           id: run-e2e-composite-action
-    #           timeout-minutes: 60
-    #           uses: ./.github/actions/tests/run-e2e-tests
-    #           env:
-    #               ALLURE_RESULTS_DIR: ${{ env.E2E_ALLURE_RESULTS_DIR }}
-    #               ALLURE_REPORT_DIR: ${{ env.E2E_ALLURE_REPORT_DIR }}
-    #               DEFAULT_TIMEOUT_OVERRIDE: 120000
-    #               E2E_MAX_FAILURES: 15
-    #           with:
-    #               report-name: ${{ env.E2E_ARTIFACT }}
+            - name: Run E2E tests
+              id: run-e2e-composite-action
+              timeout-minutes: 60
+              uses: ./.github/actions/tests/run-e2e-tests
+              env:
+                  ALLURE_RESULTS_DIR: ${{ env.E2E_ALLURE_RESULTS_DIR }}
+                  ALLURE_REPORT_DIR: ${{ env.E2E_ALLURE_REPORT_DIR }}
+                  DEFAULT_TIMEOUT_OVERRIDE: 120000
+                  E2E_MAX_FAILURES: 15
+              with:
+                  report-name: ${{ env.E2E_ARTIFACT }}
 
-    #         - name: Upload Allure artifacts to bucket
-    #           if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
-    #           uses: ./.github/actions/tests/upload-allure-files-to-bucket
-    #           env:
-    #               ALLURE_RESULTS_DIR: ${{ env.E2E_ALLURE_RESULTS_DIR }}
-    #               ALLURE_REPORT_DIR: ${{ env.E2E_ALLURE_REPORT_DIR }}
-    #           with:
-    #               aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
-    #               aws-region: ${{ secrets.REPORTS_AWS_REGION }}
-    #               aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
-    #               artifact-name: ${{ env.E2E_ARTIFACT }}
-    #               s3-bucket: ${{ secrets.REPORTS_BUCKET }}
+            - name: Upload Allure artifacts to bucket
+              if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
+              uses: ./.github/actions/tests/upload-allure-files-to-bucket
+              env:
+                  ALLURE_RESULTS_DIR: ${{ env.E2E_ALLURE_RESULTS_DIR }}
+                  ALLURE_REPORT_DIR: ${{ env.E2E_ALLURE_REPORT_DIR }}
+              with:
+                  aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
+                  aws-region: ${{ secrets.REPORTS_AWS_REGION }}
+                  aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
+                  artifact-name: ${{ env.E2E_ARTIFACT }}
+                  s3-bucket: ${{ secrets.REPORTS_BUCKET }}
 
-    #         - name: Publish E2E Allure report
-    #           if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
-    #           env:
-    #               GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
-    #               ENV_DESCRIPTION: php-${{ matrix.php_version }}
-    #           run: |
-    #               gh workflow run publish-test-reports-release.yml \
-    #                 -f created_at="${{ needs.get-tag.outputs.created }}" \
-    #                 -f run_id=${{ github.run_id }} \
-    #                 -f run_number=${{ github.run_number }} \
-    #                 -f release_tag=${{ needs.get-tag.outputs.tag }} \
-    #                 -f artifact="${{ env.E2E_ARTIFACT }}" \
-    #                 -f env_description="${{ env.ENV_DESCRIPTION }}" \
-    #                 -f test_type="e2e" \
-    #                 --repo woocommerce/woocommerce-test-reports
+            - name: Publish E2E Allure report
+              if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
+              env:
+                  GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+                  ENV_DESCRIPTION: php-${{ matrix.php_version }}
+              run: |
+                  gh workflow run publish-test-reports-release.yml \
+                    -f created_at="${{ needs.get-tag.outputs.created }}" \
+                    -f run_id=${{ github.run_id }} \
+                    -f run_number=${{ github.run_number }} \
+                    -f release_tag=${{ needs.get-tag.outputs.tag }} \
+                    -f artifact="${{ env.E2E_ARTIFACT }}" \
+                    -f env_description="${{ env.ENV_DESCRIPTION }}" \
+                    -f test_type="e2e" \
+                    --repo woocommerce/woocommerce-test-reports
 
-    #         - name: Create Slack block
-    #           if: |
-    #               success() || (
-    #                 failure() && (
-    #                   steps.run-api-composite-action.outputs.result == 'failure' ||
-    #                   steps.run-e2e-composite-action.outputs.result == 'failure' 
-    #                 )
-    #               )
-    #           uses: ./.github/actions/tests/slack-summary-on-release/slack-blocks
-    #           with:
-    #               test-name: PHP ${{ matrix.php_version }}
-    #               api-result: ${{ steps.run-api-composite-action.outputs.result }}
-    #               e2e-result: ${{ steps.run-e2e-composite-action.outputs.result }}
-    #               env-slug: php-${{ matrix.php_version }}
-    #               release-version: ${{ needs.get-tag.outputs.tag }}
+            - name: Create Slack block
+              if: |
+                  success() || (
+                    failure() && (
+                      steps.run-api-composite-action.outputs.result == 'failure' ||
+                      steps.run-e2e-composite-action.outputs.result == 'failure' 
+                    )
+                  )
+              uses: ./.github/actions/tests/slack-summary-on-release/slack-blocks
+              with:
+                  test-name: PHP ${{ matrix.php_version }}
+                  api-result: ${{ steps.run-api-composite-action.outputs.result }}
+                  e2e-result: ${{ steps.run-e2e-composite-action.outputs.result }}
+                  env-slug: php-${{ matrix.php_version }}
+                  release-version: ${{ needs.get-tag.outputs.tag }}
 
-    # test-plugins:
-    #     name: With ${{ matrix.plugin }}
-    #     runs-on: ubuntu-20.04
-    #     needs: [get-tag]
-    #     env:
-    #         ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/allure-results
-    #         ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/allure-report
-    #         ARTIFACT_NAME: E2E test on wp-env with ${{ matrix.plugin }} installed (run ${{ github.run_number }})
-    #     strategy:
-    #         fail-fast: false
-    #         matrix:
-    #             include:
-    #                 - plugin: 'WooCommerce Payments'
-    #                   repo: 'automattic/woocommerce-payments'
-    #                   env_description: 'woocommerce-payments'
-    #                 - plugin: 'WooCommerce PayPal Payments'
-    #                   repo: 'woocommerce/woocommerce-paypal-payments'
-    #                   env_description: 'woocommerce-paypal-payments'
-    #                 - plugin: 'WooCommerce Shipping & Tax'
-    #                   repo: 'automattic/woocommerce-services'
-    #                   env_description: 'woocommerce-shipping-&-tax'
-    #                 - plugin: 'WooCommerce Subscriptions'
-    #                   repo: WC_SUBSCRIPTIONS_REPO
-    #                   private: true
-    #                   env_description: 'woocommerce-subscriptions'
-    #                 - plugin: 'Gutenberg'
-    #                   repo: 'WordPress/gutenberg'
-    #                   env_description: 'gutenberg'
-    #                 - plugin: 'Gutenberg - Nightly'
-    #                   repo: 'bph/gutenberg'
-    #                   env_description: 'gutenberg-nightly'
-    #     steps:
-    #         - name: Checkout
-    #           uses: actions/checkout@v3
+    test-plugins:
+        name: With ${{ matrix.plugin }}
+        runs-on: ubuntu-20.04
+        needs: [get-tag]
+        env:
+            ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/allure-results
+            ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/allure-report
+            ARTIFACT_NAME: E2E test on wp-env with ${{ matrix.plugin }} installed (run ${{ github.run_number }})
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - plugin: 'WooCommerce Payments'
+                      repo: 'automattic/woocommerce-payments'
+                      env_description: 'woocommerce-payments'
+                    - plugin: 'WooCommerce PayPal Payments'
+                      repo: 'woocommerce/woocommerce-paypal-payments'
+                      env_description: 'woocommerce-paypal-payments'
+                    - plugin: 'WooCommerce Shipping & Tax'
+                      repo: 'automattic/woocommerce-services'
+                      env_description: 'woocommerce-shipping-&-tax'
+                    - plugin: 'WooCommerce Subscriptions'
+                      repo: WC_SUBSCRIPTIONS_REPO
+                      private: true
+                      env_description: 'woocommerce-subscriptions'
+                    - plugin: 'Gutenberg'
+                      repo: 'WordPress/gutenberg'
+                      env_description: 'gutenberg'
+                    - plugin: 'Gutenberg - Nightly'
+                      repo: 'bph/gutenberg'
+                      env_description: 'gutenberg-nightly'
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
 
-    #         - name: Setup WooCommerce Monorepo
-    #           uses: ./.github/actions/setup-woocommerce-monorepo
-    #           with:
-    #               build-filters: woocommerce
+            - name: Setup WooCommerce Monorepo
+              uses: ./.github/actions/setup-woocommerce-monorepo
+              with:
+                  build-filters: woocommerce
 
-    #         - name: Launch WP Env
-    #           working-directory: plugins/woocommerce
-    #           run: pnpm run env:test
+            - name: Launch WP Env
+              working-directory: plugins/woocommerce
+              run: pnpm run env:test
 
-    #         - name: Download release zip
-    #           env:
-    #               GH_TOKEN: ${{ secrets.E2E_GH_TOKEN }}
-    #           run: gh release download ${{ needs.get-tag.outputs.tag }} --dir tmp
+            - name: Download release zip
+              env:
+                  GH_TOKEN: ${{ secrets.E2E_GH_TOKEN }}
+              run: gh release download ${{ needs.get-tag.outputs.tag }} --dir tmp
 
-    #         - name: Replace `plugins/woocommerce` with unzipped woocommerce release build
-    #           run: unzip -d plugins -o tmp/woocommerce.zip
+            - name: Replace `plugins/woocommerce` with unzipped woocommerce release build
+              run: unzip -d plugins -o tmp/woocommerce.zip
 
-    #         - name: Run 'Upload plugin' test
-    #           id: run-upload-test
-    #           timeout-minutes: 60
-    #           uses: ./.github/actions/tests/run-e2e-tests
-    #           with:
-    #               report-name: ${{ env.ARTIFACT_NAME }}
-    #               tests: upload-plugin.spec.js
-    #           env:
-    #               GITHUB_TOKEN: ${{ secrets.E2E_GH_TOKEN }}
-    #               PLUGIN_NAME: ${{ matrix.plugin }}
-    #               PLUGIN_REPOSITORY: ${{ matrix.private && secrets[matrix.repo] || matrix.repo }}
+            - name: Run 'Upload plugin' test
+              id: run-upload-test
+              timeout-minutes: 60
+              uses: ./.github/actions/tests/run-e2e-tests
+              with:
+                  report-name: ${{ env.ARTIFACT_NAME }}
+                  tests: upload-plugin.spec.js
+              env:
+                  GITHUB_TOKEN: ${{ secrets.E2E_GH_TOKEN }}
+                  PLUGIN_NAME: ${{ matrix.plugin }}
+                  PLUGIN_REPOSITORY: ${{ matrix.private && secrets[matrix.repo] || matrix.repo }}
 
-    #         - name: Run the rest of E2E tests
-    #           id: run-e2e-composite-action
-    #           timeout-minutes: 60
-    #           uses: ./.github/actions/tests/run-e2e-tests
-    #           with:
-    #               playwright-config: ignore-plugin-tests.playwright.config.js
-    #               report-name: ${{ env.ARTIFACT_NAME }}
-    #           env:
-    #               E2E_MAX_FAILURES: 15
+            - name: Run the rest of E2E tests
+              id: run-e2e-composite-action
+              timeout-minutes: 60
+              uses: ./.github/actions/tests/run-e2e-tests
+              with:
+                  playwright-config: ignore-plugin-tests.playwright.config.js
+                  report-name: ${{ env.ARTIFACT_NAME }}
+              env:
+                  E2E_MAX_FAILURES: 15
 
-    #         - name: Upload Allure artifacts to bucket
-    #           if: |
-    #               success() || 
-    #               ( failure() && 
-    #               ( steps.run-upload-test.conclusion == 'failure' || steps.run-e2e-composite-action.conclusion == 'failure' ) )
-    #           uses: ./.github/actions/tests/upload-allure-files-to-bucket
-    #           with:
-    #               aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
-    #               aws-region: ${{ secrets.REPORTS_AWS_REGION }}
-    #               aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
-    #               artifact-name: ${{ env.ARTIFACT_NAME }}
-    #               s3-bucket: ${{ secrets.REPORTS_BUCKET }}
+            - name: Upload Allure artifacts to bucket
+              if: |
+                  success() || 
+                  ( failure() && 
+                  ( steps.run-upload-test.conclusion == 'failure' || steps.run-e2e-composite-action.conclusion == 'failure' ) )
+              uses: ./.github/actions/tests/upload-allure-files-to-bucket
+              with:
+                  aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
+                  aws-region: ${{ secrets.REPORTS_AWS_REGION }}
+                  aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
+                  artifact-name: ${{ env.ARTIFACT_NAME }}
+                  s3-bucket: ${{ secrets.REPORTS_BUCKET }}
 
-    #         - name: Publish E2E Allure report
-    #           if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
-    #           env:
-    #               GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
-    #           run: |
-    #               gh workflow run publish-test-reports-release.yml \
-    #                 -f created_at="${{ needs.get-tag.outputs.created }}" \
-    #                 -f run_id=${{ github.run_id }} \
-    #                 -f run_number=${{ github.run_number }} \
-    #                 -f release_tag=${{ needs.get-tag.outputs.tag }} \
-    #                 -f artifact="${{ env.ARTIFACT_NAME }}" \
-    #                 -f env_description="${{ matrix.env_description }}" \
-    #                 -f test_type="e2e" \
-    #                 --repo woocommerce/woocommerce-test-reports
+            - name: Publish E2E Allure report
+              if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
+              env:
+                  GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+              run: |
+                  gh workflow run publish-test-reports-release.yml \
+                    -f created_at="${{ needs.get-tag.outputs.created }}" \
+                    -f run_id=${{ github.run_id }} \
+                    -f run_number=${{ github.run_number }} \
+                    -f release_tag=${{ needs.get-tag.outputs.tag }} \
+                    -f artifact="${{ env.ARTIFACT_NAME }}" \
+                    -f env_description="${{ matrix.env_description }}" \
+                    -f test_type="e2e" \
+                    --repo woocommerce/woocommerce-test-reports
 
-    #         - name: Create Slack block
-    #           if: |
-    #               success() || (
-    #                 failure() && steps.run-e2e-composite-action.outputs.result == 'failure' )
-    #           uses: ./.github/actions/tests/slack-summary-on-release/slack-blocks
-    #           with:
-    #               test-name: With ${{ matrix.plugin }}
-    #               e2e-result: ${{ steps.run-e2e-composite-action.outputs.result }}
-    #               env-slug: ${{ matrix.env_description }}
-    #               release-version: ${{ needs.get-tag.outputs.tag }}
+            - name: Create Slack block
+              if: |
+                  success() || (
+                    failure() && steps.run-e2e-composite-action.outputs.result == 'failure' )
+              uses: ./.github/actions/tests/slack-summary-on-release/slack-blocks
+              with:
+                  test-name: With ${{ matrix.plugin }}
+                  e2e-result: ${{ steps.run-e2e-composite-action.outputs.result }}
+                  env-slug: ${{ matrix.env_description }}
+                  release-version: ${{ needs.get-tag.outputs.tag }}
 
-    # post-slack-summary:
-    #     name: Post Slack summary
-    #     runs-on: ubuntu-20.04
-    #     permissions:
-    #         contents: read
-    #     if: |
-    #         success() || (
-    #           failure() && contains( needs.*.result, 'failure' )
-    #         )
-    #     needs:
-    #         - e2e-wp-latest
-    #         - get-tag
-    #         - test-php-versions
-    #         - test-plugins
-    #         - test-wp-latest-1
-    #     steps:
-    #         - uses: actions/checkout@v3
+    post-slack-summary:
+        name: Post Slack summary
+        runs-on: ubuntu-20.04
+        permissions:
+            contents: read
+        if: |
+            success() || (
+              failure() && contains( needs.*.result, 'failure' )
+            )
+        needs:
+            - e2e-wp-latest
+            - get-tag
+            - test-php-versions
+            - test-plugins
+            - test-wp-latest-1
+        steps:
+            - uses: actions/checkout@v3
 
-    #         - name: Download all slack blocks
-    #           id: download-slack-blocks
-    #           uses: actions/download-artifact@v3
-    #           with:
-    #               name: ${{ env.SLACK_BLOCKS_ARTIFACT }}
-    #               path: /tmp/slack-payload
+            - name: Download all slack blocks
+              id: download-slack-blocks
+              uses: actions/download-artifact@v3
+              with:
+                  name: ${{ env.SLACK_BLOCKS_ARTIFACT }}
+                  path: /tmp/slack-payload
 
-    #         - name: Construct payload from all blocks
-    #           id: run-payload-action
-    #           uses: ./.github/actions/tests/slack-summary-on-release/slack-payload
-    #           with:
-    #               release-version: ${{ needs.get-tag.outputs.tag }}
-    #               blocks-dir: ${{ steps.download-slack-blocks.outputs.download-path }}
+            - name: Construct payload from all blocks
+              id: run-payload-action
+              uses: ./.github/actions/tests/slack-summary-on-release/slack-payload
+              with:
+                  release-version: ${{ needs.get-tag.outputs.tag }}
+                  blocks-dir: ${{ steps.download-slack-blocks.outputs.download-path }}
 
-    #         - name: Send Slack message
-    #           uses: slackapi/slack-github-action@v1.23.0
-    #           with:
-    #               channel-id: ${{ secrets.RELEASE_TEST_SLACK_CHANNEL }}
-    #               payload: ${{ steps.run-payload-action.outputs.payload }}
-    #           env:
-    #               SLACK_BOT_TOKEN: ${{ secrets.E2E_SLACK_TOKEN }}
+            - name: Send Slack message
+              uses: slackapi/slack-github-action@v1.23.0
+              with:
+                  channel-id: ${{ secrets.RELEASE_TEST_SLACK_CHANNEL }}
+                  payload: ${{ steps.run-payload-action.outputs.payload }}
+              env:
+                  SLACK_BOT_TOKEN: ${{ secrets.E2E_SLACK_TOKEN }}

--- a/.github/workflows/smoke-test-release.yml
+++ b/.github/workflows/smoke-test-release.yml
@@ -355,14 +355,6 @@ jobs:
                   pnpm exec wp-env run tests-cli -- wp core update --version=${{ steps.get-wp-latest-1.outputs.version }} --force
                   pnpm exec wp-env run tests-cli wp core update-db
 
-            - name: Verify environment details
-              working-directory: plugins/woocommerce
-              run: |
-                  pnpm exec wp-env run tests-cli wp core version
-                  pnpm exec wp-env run tests-cli wp plugin list
-                  pnpm exec wp-env run tests-cli wp theme list
-                  pnpm exec wp-env run tests-cli wp user list
-
             - name: Run API tests
               id: run-api-composite-action
               uses: ./.github/actions/tests/run-api-tests

--- a/.github/workflows/smoke-test-release.yml
+++ b/.github/workflows/smoke-test-release.yml
@@ -61,310 +61,277 @@ jobs:
                   GH_TOKEN: ${{ secrets.E2E_GH_TOKEN }}
               run: echo "created=$(gh release view ${{ steps.get-tag.outputs.tag }} --json assets --jq .assets[0].createdAt --repo woocommerce/woocommerce)" >> $GITHUB_OUTPUT
 
-    e2e-update-wc:
-        name: Test WooCommerce update
+    # e2e-update-wc:
+    #     name: Test WooCommerce update
+    #     runs-on: ubuntu-20.04
+    #     needs: [get-tag]
+    #     permissions:
+    #         contents: read
+    #     env:
+    #         ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-report
+    #         ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-results
+    #     steps:
+    #         - uses: actions/checkout@v3
+
+    #         - name: Setup WooCommerce Monorepo
+    #           uses: ./.github/actions/setup-woocommerce-monorepo
+    #           with:
+    #               install-filters: woocommerce
+    #               build: false
+
+    #         - name: Run E2E tests
+    #           id: run-e2e-composite-action
+    #           timeout-minutes: 60
+    #           uses: ./.github/actions/tests/run-e2e-tests
+    #           with:
+    #               report-name: ${{ env.E2E_UPDATE_WC_ARTIFACT }}
+    #               tests: update-woocommerce.spec.js
+    #           env:
+    #               ADMIN_PASSWORD: ${{ secrets.RELEASE_TEST_ADMIN_PASSWORD }}
+    #               ADMIN_USER: ${{ secrets.RELEASE_TEST_ADMIN_USER }}
+    #               BASE_URL: ${{ secrets.RELEASE_TEST_URL }}
+    #               CUSTOMER_PASSWORD: ${{ secrets.RELEASE_TEST_CUSTOMER_PASSWORD }}
+    #               CUSTOMER_USER: ${{ secrets.RELEASE_TEST_CUSTOMER_USER }}
+    #               DEFAULT_TIMEOUT_OVERRIDE: 120000
+    #               GITHUB_TOKEN: ${{ secrets.E2E_GH_TOKEN }}
+    #               UPDATE_WC: ${{ needs.get-tag.outputs.tag }}
+
+    #         - name: Upload Allure artifacts to bucket
+    #           if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
+    #           uses: ./.github/actions/tests/upload-allure-files-to-bucket
+    #           with:
+    #               aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
+    #               aws-region: ${{ secrets.REPORTS_AWS_REGION }}
+    #               aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
+    #               artifact-name: ${{ env.E2E_WP_LATEST_ARTIFACT }}
+    #               s3-bucket: ${{ secrets.REPORTS_BUCKET }}
+
+    #         - name: Publish E2E Allure report
+    #           if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
+    #           env:
+    #               GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+    #               ENV_DESCRIPTION: wp-latest
+    #           run: |
+    #               gh workflow run publish-test-reports-release.yml \
+    #                 -f created_at="${{ needs.get-tag.outputs.created }}" \
+    #                 -f run_id=${{ github.run_id }} \
+    #                 -f run_number=${{ github.run_number }} \
+    #                 -f release_tag=${{ needs.get-tag.outputs.tag }} \
+    #                 -f artifact="${{ env.E2E_WP_LATEST_ARTIFACT }}" \
+    #                 -f env_description="${{ env.ENV_DESCRIPTION }}" \
+    #                 -f test_type="e2e" \
+    #                 --repo woocommerce/woocommerce-test-reports
+
+    #         - name: Create Slack block
+    #           if: |
+    #               success() || (
+    #                 failure() && steps.run-e2e-composite-action.outputs.result == 'failure'
+    #               )
+    #           uses: ./.github/actions/tests/slack-summary-on-release/slack-blocks
+    #           with:
+    #               test-name: WC Update test
+    #               e2e-result: ${{ steps.run-e2e-composite-action.outputs.result }}
+    #               env-slug: wp-latest
+    #               release-version: ${{ needs.get-tag.outputs.tag }}
+
+    # api-wp-latest:
+    #     name: API on WP Latest
+    #     runs-on: ubuntu-20.04
+    #     needs: [get-tag, e2e-update-wc]
+    #     permissions:
+    #         contents: read
+    #     outputs:
+    #         result: ${{ steps.run-api-composite-action.outputs.result }}
+    #     env:
+    #         ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/api-test-report/allure-report
+    #         ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/api-test-report/allure-results
+    #         API_WP_LATEST_ARTIFACT: API test on release smoke test site with WP Latest (run ${{ github.run_number }})
+    #     steps:
+    #         - uses: actions/checkout@v3
+
+    #         - name: Setup WooCommerce Monorepo
+    #           uses: ./.github/actions/setup-woocommerce-monorepo
+    #           with:
+    #               install-filters: woocommerce
+    #               build: false
+
+    #         - name: Run API tests
+    #           id: run-api-composite-action
+    #           uses: ./.github/actions/tests/run-api-tests
+    #           with:
+    #               report-name: ${{ env.API_WP_LATEST_ARTIFACT }}
+    #               tests: hello
+    #           env:
+    #               API_BASE_URL: ${{ secrets.RELEASE_TEST_URL }}
+    #               USER_KEY: ${{ secrets.RELEASE_TEST_ADMIN_USER }}
+    #               USER_SECRET: ${{ secrets.RELEASE_TEST_ADMIN_PASSWORD }}
+
+    #         - name: Upload Allure artifacts to bucket
+    #           if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
+    #           uses: ./.github/actions/tests/upload-allure-files-to-bucket
+    #           with:
+    #               aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
+    #               aws-region: ${{ secrets.REPORTS_AWS_REGION }}
+    #               aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
+    #               artifact-name: ${{ env.API_WP_LATEST_ARTIFACT }}
+    #               s3-bucket: ${{ secrets.REPORTS_BUCKET }}
+
+    #         - name: Publish API Allure report
+    #           if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
+    #           env:
+    #               GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+    #               ENV_DESCRIPTION: wp-latest
+    #           run: |
+    #               gh workflow run publish-test-reports-release.yml \
+    #                 -f created_at="${{ needs.get-tag.outputs.created }}" \
+    #                 -f run_id=${{ github.run_id }} \
+    #                 -f run_number=${{ github.run_number }} \
+    #                 -f release_tag=${{ needs.get-tag.outputs.tag }} \
+    #                 -f artifact="${{ env.API_WP_LATEST_ARTIFACT }}" \
+    #                 -f env_description="${{ env.ENV_DESCRIPTION }}" \
+    #                 -f test_type="api" \
+    #                 --repo woocommerce/woocommerce-test-reports
+
+    #         - name: Create Slack block
+    #           if: |
+    #               success() || (
+    #                 failure() && steps.run-api-composite-action.outputs.result == 'failure'
+    #               )
+    #           uses: ./.github/actions/tests/slack-summary-on-release/slack-blocks
+    #           with:
+    #               test-name: WP Latest
+    #               api-result: ${{ steps.run-api-composite-action.outputs.result }}
+    #               env-slug: wp-latest
+    #               release-version: ${{ needs.get-tag.outputs.tag }}
+
+    # e2e-wp-latest:
+    #     name: E2E on WP Latest
+    #     runs-on: ubuntu-20.04
+    #     needs: [get-tag, api-wp-latest]
+    #     permissions:
+    #         contents: read
+    #     env:
+    #         ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-report
+    #         ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-results
+    #     steps:
+    #         - uses: actions/checkout@v3
+
+    #         - name: Setup WooCommerce Monorepo
+    #           uses: ./.github/actions/setup-woocommerce-monorepo
+    #           with:
+    #               install-filters: woocommerce
+    #               build: false
+
+    #         - name: Run E2E tests
+    #           id: run-e2e-composite-action
+    #           timeout-minutes: 60
+    #           uses: ./.github/actions/tests/run-e2e-tests
+    #           with:
+    #               report-name: e2e-wp-latest--partial--run-${{ github.run_number }}
+    #               playwright-config: ignore-plugin-tests.playwright.config.js
+    #           env:
+    #               ADMIN_PASSWORD: ${{ secrets.RELEASE_TEST_ADMIN_PASSWORD }}
+    #               ADMIN_USER: ${{ secrets.RELEASE_TEST_ADMIN_USER }}
+    #               ADMIN_USER_EMAIL: ${{ secrets.RELEASE_TEST_ADMIN_USER_EMAIL }}
+    #               BASE_URL: ${{ secrets.RELEASE_TEST_URL }}
+    #               CUSTOMER_PASSWORD: ${{ secrets.RELEASE_TEST_CUSTOMER_PASSWORD }}
+    #               CUSTOMER_USER: ${{ secrets.RELEASE_TEST_CUSTOMER_USER }}
+    #               DEFAULT_TIMEOUT_OVERRIDE: 120000
+    #               E2E_MAX_FAILURES: 25
+    #               RESET_SITE: true
+
+    #         - name: Download 'e2e-update-wc' artifact
+    #           if: success() || failure()
+    #           uses: actions/download-artifact@v3
+    #           with:
+    #               name: ${{ env.E2E_UPDATE_WC_ARTIFACT }}
+    #               path: plugins/woocommerce/tmp
+
+    #         - name: Add allure-results from 'e2e-update-wc'
+    #           if: success() || failure()
+    #           working-directory: plugins/woocommerce
+    #           run: cp -r tmp/allure-results tests/e2e-pw/test-results
+
+    #         - name: Generate E2E Test report.
+    #           if: success() || failure()
+    #           working-directory: plugins/woocommerce
+    #           run: pnpm exec allure generate --clean ${{ env.ALLURE_RESULTS_DIR }} --output ${{ env.ALLURE_REPORT_DIR }}
+
+    #         - name: Archive E2E test report
+    #           if: success() || failure()
+    #           uses: actions/upload-artifact@v3
+    #           with:
+    #               name: ${{ env.E2E_WP_LATEST_ARTIFACT }}
+    #               path: |
+    #                   ${{ env.ALLURE_RESULTS_DIR }}
+    #                   ${{ env.ALLURE_REPORT_DIR }}
+    #               if-no-files-found: ignore
+    #               retention-days: 5
+
+    #         - name: Upload Allure artifacts to bucket
+    #           if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
+    #           uses: ./.github/actions/tests/upload-allure-files-to-bucket
+    #           with:
+    #               aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
+    #               aws-region: ${{ secrets.REPORTS_AWS_REGION }}
+    #               aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
+    #               artifact-name: ${{ env.E2E_WP_LATEST_ARTIFACT }}
+    #               s3-bucket: ${{ secrets.REPORTS_BUCKET }}
+
+    #         - name: Publish E2E Allure report
+    #           if: success() || failure()
+    #           env:
+    #               GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+    #               ENV_DESCRIPTION: wp-latest
+    #           run: |
+    #               gh workflow run publish-test-reports-release.yml \
+    #                 -f created_at="${{ needs.get-tag.outputs.created }}" \
+    #                 -f run_id=${{ github.run_id }} \
+    #                 -f run_number=${{ github.run_number }} \
+    #                 -f release_tag=${{ needs.get-tag.outputs.tag }} \
+    #                 -f artifact="${{ env.E2E_WP_LATEST_ARTIFACT }}" \
+    #                 -f env_description="${{ env.ENV_DESCRIPTION }}" \
+    #                 -f test_type="e2e" \
+    #                 --repo woocommerce/woocommerce-test-reports
+
+    #         - name: Create Slack block
+    #           if: |
+    #               success() || (
+    #                 failure() && steps.run-e2e-composite-action.outputs.result == 'failure'
+    #               )
+    #           uses: ./.github/actions/tests/slack-summary-on-release/slack-blocks
+    #           with:
+    #               test-name: WP Latest
+    #               api-result: ${{ needs.api-wp-latest.outputs.result }}
+    #               e2e-result: ${{ steps.run-e2e-composite-action.outputs.result }}
+    #               env-slug: wp-latest
+    #               release-version: ${{ needs.get-tag.outputs.tag }}
+
+    test-wp-latest-1:
+        name: Test against WP Latest-1
         runs-on: ubuntu-20.04
-        needs: [get-tag]
-        permissions:
-            contents: read
-        env:
-            ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-report
-            ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-results
-        steps:
-            - uses: actions/checkout@v3
-
-            - name: Setup WooCommerce Monorepo
-              uses: ./.github/actions/setup-woocommerce-monorepo
-              with:
-                  install-filters: woocommerce
-                  build: false
-
-            - name: Run E2E tests
-              id: run-e2e-composite-action
-              timeout-minutes: 60
-              uses: ./.github/actions/tests/run-e2e-tests
-              with:
-                  report-name: ${{ env.E2E_UPDATE_WC_ARTIFACT }}
-                  tests: update-woocommerce.spec.js
-              env:
-                  ADMIN_PASSWORD: ${{ secrets.RELEASE_TEST_ADMIN_PASSWORD }}
-                  ADMIN_USER: ${{ secrets.RELEASE_TEST_ADMIN_USER }}
-                  BASE_URL: ${{ secrets.RELEASE_TEST_URL }}
-                  CUSTOMER_PASSWORD: ${{ secrets.RELEASE_TEST_CUSTOMER_PASSWORD }}
-                  CUSTOMER_USER: ${{ secrets.RELEASE_TEST_CUSTOMER_USER }}
-                  DEFAULT_TIMEOUT_OVERRIDE: 120000
-                  GITHUB_TOKEN: ${{ secrets.E2E_GH_TOKEN }}
-                  UPDATE_WC: ${{ needs.get-tag.outputs.tag }}
-
-            - name: Upload Allure artifacts to bucket
-              if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
-              uses: ./.github/actions/tests/upload-allure-files-to-bucket
-              with:
-                  aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
-                  aws-region: ${{ secrets.REPORTS_AWS_REGION }}
-                  aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
-                  artifact-name: ${{ env.E2E_WP_LATEST_ARTIFACT }}
-                  s3-bucket: ${{ secrets.REPORTS_BUCKET }}
-
-            - name: Publish E2E Allure report
-              if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
-              env:
-                  GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
-                  ENV_DESCRIPTION: wp-latest
-              run: |
-                  gh workflow run publish-test-reports-release.yml \
-                    -f created_at="${{ needs.get-tag.outputs.created }}" \
-                    -f run_id=${{ github.run_id }} \
-                    -f run_number=${{ github.run_number }} \
-                    -f release_tag=${{ needs.get-tag.outputs.tag }} \
-                    -f artifact="${{ env.E2E_WP_LATEST_ARTIFACT }}" \
-                    -f env_description="${{ env.ENV_DESCRIPTION }}" \
-                    -f test_type="e2e" \
-                    --repo woocommerce/woocommerce-test-reports
-
-            - name: Create Slack block
-              if: |
-                  success() || (
-                    failure() && steps.run-e2e-composite-action.outputs.result == 'failure'
-                  )
-              uses: ./.github/actions/tests/slack-summary-on-release/slack-blocks
-              with:
-                  test-name: WC Update test
-                  e2e-result: ${{ steps.run-e2e-composite-action.outputs.result }}
-                  env-slug: wp-latest
-                  release-version: ${{ needs.get-tag.outputs.tag }}
-
-    api-wp-latest:
-        name: API on WP Latest
-        runs-on: ubuntu-20.04
-        needs: [get-tag, e2e-update-wc]
-        permissions:
-            contents: read
-        outputs:
-            result: ${{ steps.run-api-composite-action.outputs.result }}
-        env:
-            ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/api-test-report/allure-report
-            ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/api-test-report/allure-results
-            API_WP_LATEST_ARTIFACT: API test on release smoke test site with WP Latest (run ${{ github.run_number }})
-        steps:
-            - uses: actions/checkout@v3
-
-            - name: Setup WooCommerce Monorepo
-              uses: ./.github/actions/setup-woocommerce-monorepo
-              with:
-                  install-filters: woocommerce
-                  build: false
-
-            - name: Run API tests
-              id: run-api-composite-action
-              uses: ./.github/actions/tests/run-api-tests
-              with:
-                  report-name: ${{ env.API_WP_LATEST_ARTIFACT }}
-                  tests: hello
-              env:
-                  API_BASE_URL: ${{ secrets.RELEASE_TEST_URL }}
-                  USER_KEY: ${{ secrets.RELEASE_TEST_ADMIN_USER }}
-                  USER_SECRET: ${{ secrets.RELEASE_TEST_ADMIN_PASSWORD }}
-
-            - name: Upload Allure artifacts to bucket
-              if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
-              uses: ./.github/actions/tests/upload-allure-files-to-bucket
-              with:
-                  aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
-                  aws-region: ${{ secrets.REPORTS_AWS_REGION }}
-                  aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
-                  artifact-name: ${{ env.API_WP_LATEST_ARTIFACT }}
-                  s3-bucket: ${{ secrets.REPORTS_BUCKET }}
-
-            - name: Publish API Allure report
-              if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
-              env:
-                  GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
-                  ENV_DESCRIPTION: wp-latest
-              run: |
-                  gh workflow run publish-test-reports-release.yml \
-                    -f created_at="${{ needs.get-tag.outputs.created }}" \
-                    -f run_id=${{ github.run_id }} \
-                    -f run_number=${{ github.run_number }} \
-                    -f release_tag=${{ needs.get-tag.outputs.tag }} \
-                    -f artifact="${{ env.API_WP_LATEST_ARTIFACT }}" \
-                    -f env_description="${{ env.ENV_DESCRIPTION }}" \
-                    -f test_type="api" \
-                    --repo woocommerce/woocommerce-test-reports
-
-            - name: Create Slack block
-              if: |
-                  success() || (
-                    failure() && steps.run-api-composite-action.outputs.result == 'failure'
-                  )
-              uses: ./.github/actions/tests/slack-summary-on-release/slack-blocks
-              with:
-                  test-name: WP Latest
-                  api-result: ${{ steps.run-api-composite-action.outputs.result }}
-                  env-slug: wp-latest
-                  release-version: ${{ needs.get-tag.outputs.tag }}
-
-    e2e-wp-latest:
-        name: E2E on WP Latest
-        runs-on: ubuntu-20.04
-        needs: [get-tag, api-wp-latest]
-        permissions:
-            contents: read
-        env:
-            ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-report
-            ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-results
-        steps:
-            - uses: actions/checkout@v3
-
-            - name: Setup WooCommerce Monorepo
-              uses: ./.github/actions/setup-woocommerce-monorepo
-              with:
-                  install-filters: woocommerce
-                  build: false
-
-            - name: Run E2E tests
-              id: run-e2e-composite-action
-              timeout-minutes: 60
-              uses: ./.github/actions/tests/run-e2e-tests
-              with:
-                  report-name: e2e-wp-latest--partial--run-${{ github.run_number }}
-                  playwright-config: ignore-plugin-tests.playwright.config.js
-              env:
-                  ADMIN_PASSWORD: ${{ secrets.RELEASE_TEST_ADMIN_PASSWORD }}
-                  ADMIN_USER: ${{ secrets.RELEASE_TEST_ADMIN_USER }}
-                  ADMIN_USER_EMAIL: ${{ secrets.RELEASE_TEST_ADMIN_USER_EMAIL }}
-                  BASE_URL: ${{ secrets.RELEASE_TEST_URL }}
-                  CUSTOMER_PASSWORD: ${{ secrets.RELEASE_TEST_CUSTOMER_PASSWORD }}
-                  CUSTOMER_USER: ${{ secrets.RELEASE_TEST_CUSTOMER_USER }}
-                  DEFAULT_TIMEOUT_OVERRIDE: 120000
-                  E2E_MAX_FAILURES: 25
-                  RESET_SITE: true
-
-            - name: Download 'e2e-update-wc' artifact
-              if: success() || failure()
-              uses: actions/download-artifact@v3
-              with:
-                  name: ${{ env.E2E_UPDATE_WC_ARTIFACT }}
-                  path: plugins/woocommerce/tmp
-
-            - name: Add allure-results from 'e2e-update-wc'
-              if: success() || failure()
-              working-directory: plugins/woocommerce
-              run: cp -r tmp/allure-results tests/e2e-pw/test-results
-
-            - name: Generate E2E Test report.
-              if: success() || failure()
-              working-directory: plugins/woocommerce
-              run: pnpm exec allure generate --clean ${{ env.ALLURE_RESULTS_DIR }} --output ${{ env.ALLURE_REPORT_DIR }}
-
-            - name: Archive E2E test report
-              if: success() || failure()
-              uses: actions/upload-artifact@v3
-              with:
-                  name: ${{ env.E2E_WP_LATEST_ARTIFACT }}
-                  path: |
-                      ${{ env.ALLURE_RESULTS_DIR }}
-                      ${{ env.ALLURE_REPORT_DIR }}
-                  if-no-files-found: ignore
-                  retention-days: 5
-
-            - name: Upload Allure artifacts to bucket
-              if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
-              uses: ./.github/actions/tests/upload-allure-files-to-bucket
-              with:
-                  aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
-                  aws-region: ${{ secrets.REPORTS_AWS_REGION }}
-                  aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
-                  artifact-name: ${{ env.E2E_WP_LATEST_ARTIFACT }}
-                  s3-bucket: ${{ secrets.REPORTS_BUCKET }}
-
-            - name: Publish E2E Allure report
-              if: success() || failure()
-              env:
-                  GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
-                  ENV_DESCRIPTION: wp-latest
-              run: |
-                  gh workflow run publish-test-reports-release.yml \
-                    -f created_at="${{ needs.get-tag.outputs.created }}" \
-                    -f run_id=${{ github.run_id }} \
-                    -f run_number=${{ github.run_number }} \
-                    -f release_tag=${{ needs.get-tag.outputs.tag }} \
-                    -f artifact="${{ env.E2E_WP_LATEST_ARTIFACT }}" \
-                    -f env_description="${{ env.ENV_DESCRIPTION }}" \
-                    -f test_type="e2e" \
-                    --repo woocommerce/woocommerce-test-reports
-
-            - name: Create Slack block
-              if: |
-                  success() || (
-                    failure() && steps.run-e2e-composite-action.outputs.result == 'failure'
-                  )
-              uses: ./.github/actions/tests/slack-summary-on-release/slack-blocks
-              with:
-                  test-name: WP Latest
-                  api-result: ${{ needs.api-wp-latest.outputs.result }}
-                  e2e-result: ${{ steps.run-e2e-composite-action.outputs.result }}
-                  env-slug: wp-latest
-                  release-version: ${{ needs.get-tag.outputs.tag }}
-
-    get-wp-versions:
-        name: Get WP L-1 & L-2 version numbers
-        needs: [get-tag]
-        runs-on: ubuntu-20.04
-        permissions:
-            contents: read
-        outputs:
-            matrix: ${{ steps.get-versions.outputs.versions }}
-            tag: ${{ needs.get-tag.outputs.tag }}
-            created: ${{ needs.get-tag.outputs.created }}
-        steps:
-            - name: Create dirs
-              run: |
-                  mkdir script
-                  mkdir repo
-
-            - name: Checkout
-              uses: actions/checkout@v3
-              with:
-                  path: repo
-
-            - name: Copy script to get previous WP versions
-              run: cp repo/plugins/woocommerce/tests/e2e-pw/utils/wordpress.js script
-
-            - name: Install axios
-              working-directory: script
-              run: npm install axios
-
-            - name: Get version numbers
-              id: get-versions
-              uses: actions/github-script@v6
-              with:
-                  script: |
-                      const { getPreviousTwoVersions } = require('./script/wordpress');
-                      const versions = await getPreviousTwoVersions();
-                      console.log(versions);
-                      core.setOutput('versions', versions);
-
-    test-wp-versions:
-        name: Test against ${{ matrix.version.description }} (${{ matrix.version.number }})
-        runs-on: ubuntu-20.04
-        needs: [get-wp-versions]
-        strategy:
-            fail-fast: false
-            matrix: ${{ fromJSON(needs.get-wp-versions.outputs.matrix) }}
+        needs: [ get-tag ]
         env:
             API_ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/api/allure-report
             API_ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/api/allure-results
-            API_WP_LATEST_X_ARTIFACT: API test on wp-env with WordPress ${{ matrix.version.number }} (run ${{ github.run_number }})
+            API_WP_LATEST_X_ARTIFACT: API test on wp-env with WordPress L-1 (run ${{ github.run_number }})
             E2E_ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/e2e/allure-report
             E2E_ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/e2e/allure-results
-            E2E_WP_LATEST_X_ARTIFACT: E2E test on wp-env with WordPress ${{ matrix.version.number }} (run ${{ github.run_number }})
+            E2E_WP_LATEST_X_ARTIFACT: E2E test on wp-env with WordPress L-1 (run ${{ github.run_number }})
         permissions:
             contents: read
         steps:
             - name: Checkout WooCommerce repo
               uses: actions/checkout@v3
 
+            - name: Get WP Latest-1 version number
+              id: get-wp-latest-1
+              uses: actions/github-script@v6
+              with:
+                  script: |
+                      const { getVersionWPLatestMinusOne } = require( './plugins/woocommerce/tests/e2e-pw/utils/wordpress' );
+                      await getVersionWPLatestMinusOne( { core, github } );
+                      
             - name: Setup WooCommerce Monorepo
               uses: ./.github/actions/setup-woocommerce-monorepo
               with:
@@ -377,15 +344,15 @@ jobs:
             - name: Download release zip
               env:
                   GH_TOKEN: ${{ secrets.E2E_GH_TOKEN }}
-              run: gh release download ${{ needs.get-wp-versions.outputs.tag }} --dir tmp
+              run: gh release download ${{ steps.get-wp-latest-1.outputs.version }} --dir tmp
 
             - name: Replace `plugins/woocommerce` with unzipped woocommerce release build
               run: unzip -d plugins -o tmp/woocommerce.zip
 
-            - name: Downgrade WordPress version to ${{ matrix.version.number }}
+            - name: Downgrade WordPress version to ${{ steps.get-wp-latest-1.outputs.version }}
               working-directory: plugins/woocommerce
               run: |
-                  pnpm exec wp-env run tests-cli -- wp core update --version=${{ matrix.version.number }} --force
+                  pnpm exec wp-env run tests-cli -- wp core update --version=${{ steps.get-wp-latest-1.outputs.version }} --force
                   pnpm exec wp-env run tests-cli wp core update-db
 
             - name: Verify environment details
@@ -406,34 +373,34 @@ jobs:
                   ALLURE_RESULTS_DIR: ${{ env.API_ALLURE_RESULTS_DIR }}
                   ALLURE_REPORT_DIR: ${{ env.API_ALLURE_REPORT_DIR }}
 
-            - name: Upload Allure artifacts to bucket
-              if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
-              uses: ./.github/actions/tests/upload-allure-files-to-bucket
-              env:
-                  ALLURE_RESULTS_DIR: ${{ env.API_ALLURE_RESULTS_DIR }}
-                  ALLURE_REPORT_DIR: ${{ env.API_ALLURE_REPORT_DIR }}
-              with:
-                  aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
-                  aws-region: ${{ secrets.REPORTS_AWS_REGION }}
-                  aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
-                  artifact-name: ${{ env.API_WP_LATEST_X_ARTIFACT }}
-                  s3-bucket: ${{ secrets.REPORTS_BUCKET }}
+            # - name: Upload Allure artifacts to bucket
+            #   if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
+            #   uses: ./.github/actions/tests/upload-allure-files-to-bucket
+            #   env:
+            #       ALLURE_RESULTS_DIR: ${{ env.API_ALLURE_RESULTS_DIR }}
+            #       ALLURE_REPORT_DIR: ${{ env.API_ALLURE_REPORT_DIR }}
+            #   with:
+            #       aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
+            #       aws-region: ${{ secrets.REPORTS_AWS_REGION }}
+            #       aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
+            #       artifact-name: ${{ env.API_WP_LATEST_X_ARTIFACT }}
+            #       s3-bucket: ${{ secrets.REPORTS_BUCKET }}
 
-            - name: Publish API Allure report
-              if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
-              env:
-                  GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
-                  ENV_DESCRIPTION: ${{ matrix.version.env_description }}
-              run: |
-                  gh workflow run publish-test-reports-release.yml \
-                    -f created_at="${{ needs.get-wp-versions.outputs.created }}" \
-                    -f run_id=${{ github.run_id }} \
-                    -f run_number=${{ github.run_number }} \
-                    -f release_tag=${{ needs.get-wp-versions.outputs.tag }} \
-                    -f artifact="${{ env.API_WP_LATEST_X_ARTIFACT }}" \
-                    -f env_description="${{ env.ENV_DESCRIPTION }}" \
-                    -f test_type="api" \
-                    --repo woocommerce/woocommerce-test-reports
+            # - name: Publish API Allure report
+            #   if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
+            #   env:
+            #       GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+            #       ENV_DESCRIPTION: wp-latest-1
+            #   run: |
+            #       gh workflow run publish-test-reports-release.yml \
+            #         -f created_at="${{ needs.get-tag.outputs.created }}" \
+            #         -f run_id=${{ github.run_id }} \
+            #         -f run_number=${{ github.run_number }} \
+            #         -f release_tag=${{ needs.get-tag.outputs.tag }} \
+            #         -f artifact="${{ env.API_WP_LATEST_X_ARTIFACT }}" \
+            #         -f env_description="WP Latest-1" \
+            #         -f test_type="api" \
+            #         --repo woocommerce/woocommerce-test-reports
 
             - name: Run E2E tests
               id: run-e2e-composite-action
@@ -446,35 +413,36 @@ jobs:
                   DEFAULT_TIMEOUT_OVERRIDE: 120000
               with:
                   report-name: ${{ env.E2E_WP_LATEST_X_ARTIFACT }}
+                  tests: basic.spec.js # mytodo remove
 
-            - name: Upload Allure artifacts to bucket
-              if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
-              uses: ./.github/actions/tests/upload-allure-files-to-bucket
-              env:
-                  ALLURE_RESULTS_DIR: ${{ env.E2E_ALLURE_RESULTS_DIR }}
-                  ALLURE_REPORT_DIR: ${{ env.E2E_ALLURE_REPORT_DIR }}
-              with:
-                  aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
-                  aws-region: ${{ secrets.REPORTS_AWS_REGION }}
-                  aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
-                  artifact-name: ${{ env.E2E_WP_LATEST_X_ARTIFACT }}
-                  s3-bucket: ${{ secrets.REPORTS_BUCKET }}
+            # - name: Upload Allure artifacts to bucket
+            #   if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
+            #   uses: ./.github/actions/tests/upload-allure-files-to-bucket
+            #   env:
+            #       ALLURE_RESULTS_DIR: ${{ env.E2E_ALLURE_RESULTS_DIR }}
+            #       ALLURE_REPORT_DIR: ${{ env.E2E_ALLURE_REPORT_DIR }}
+            #   with:
+            #       aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
+            #       aws-region: ${{ secrets.REPORTS_AWS_REGION }}
+            #       aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
+            #       artifact-name: ${{ env.E2E_WP_LATEST_X_ARTIFACT }}
+            #       s3-bucket: ${{ secrets.REPORTS_BUCKET }}
 
-            - name: Publish E2E Allure report
-              if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
-              env:
-                  GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
-                  ENV_DESCRIPTION: ${{ matrix.version.env_description }}
-              run: |
-                  gh workflow run publish-test-reports-release.yml \
-                    -f created_at="${{ needs.get-wp-versions.outputs.created }}" \
-                    -f run_id=${{ github.run_id }} \
-                    -f run_number=${{ github.run_number }} \
-                    -f release_tag=${{ needs.get-wp-versions.outputs.tag }} \
-                    -f artifact="${{ env.E2E_WP_LATEST_X_ARTIFACT }}" \
-                    -f env_description="${{ env.ENV_DESCRIPTION }}" \
-                    -f test_type="e2e" \
-                    --repo woocommerce/woocommerce-test-reports
+            # - name: Publish E2E Allure report
+            #   if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
+            #   env:
+            #       GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+            #       ENV_DESCRIPTION: wp-latest-1
+            #   run: |
+            #       gh workflow run publish-test-reports-release.yml \
+            #         -f created_at="${{ needs.get-tag.outputs.created }}" \
+            #         -f run_id=${{ github.run_id }} \
+            #         -f run_number=${{ github.run_number }} \
+            #         -f release_tag=${{ needs.get-tag.outputs.tag }} \
+            #         -f artifact="${{ env.E2E_WP_LATEST_X_ARTIFACT }}" \
+            #         -f env_description="${{ env.ENV_DESCRIPTION }}" \
+            #         -f test_type="e2e" \
+            #         --repo woocommerce/woocommerce-test-reports
 
             - name: Create Slack block
               if: |
@@ -486,301 +454,301 @@ jobs:
                   )
               uses: ./.github/actions/tests/slack-summary-on-release/slack-blocks
               with:
-                  test-name: ${{ matrix.version.description }} (${{ matrix.version.number }})
+                  test-name: WP Latest-1 (${{ steps.get-wp-latest-1.outputs.version }})
                   api-result: ${{ steps.run-api-composite-action.outputs.result }}
                   e2e-result: ${{ steps.run-e2e-composite-action.outputs.result }}
-                  env-slug: ${{ matrix.version.env_description }}
-                  release-version: ${{ needs.get-wp-versions.outputs.tag }}
-
-    test-php-versions:
-        name: Test against PHP ${{ matrix.php_version }}
-        runs-on: ubuntu-20.04
-        needs: [get-tag]
-        strategy:
-            fail-fast: false
-            matrix:
-                php_version: ['7.4', '8.1']
-        env:
-            API_ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/test-results/allure-report
-            API_ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/test-results/allure-results
-            API_ARTIFACT: API test on wp-env with PHP ${{ matrix.php_version }} (run ${{ github.run_number }})
-            E2E_ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-report
-            E2E_ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-results
-            E2E_ARTIFACT: E2E test on wp-env with PHP ${{ matrix.php_version }} (run ${{ github.run_number }})
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v3
-
-            - name: Setup WooCommerce Monorepo
-              uses: ./.github/actions/setup-woocommerce-monorepo
-              with:
-                  build-filters: woocommerce
-
-            - name: Launch WP Env
-              working-directory: plugins/woocommerce
-              env:
-                  WP_ENV_PHP_VERSION: ${{ matrix.php_version }}
-              run: pnpm run env:test
-
-            - name: Verify PHP version
-              working-directory: .github/workflows/scripts
-              env:
-                  EXPECTED_PHP_VERSION: ${{ matrix.php_version }}
-              run: bash verify-php-version.sh
-
-            - name: Download release zip
-              env:
-                  GH_TOKEN: ${{ secrets.E2E_GH_TOKEN }}
-              run: gh release download ${{ needs.get-tag.outputs.tag }} --dir tmp
-
-            - name: Replace `plugins/woocommerce` with unzipped woocommerce release build
-              run: unzip -d plugins -o tmp/woocommerce.zip
-
-            - name: Run API tests
-              id: run-api-composite-action
-              uses: ./.github/actions/tests/run-api-tests
-              with:
-                  report-name: ${{ env.API_ARTIFACT }}
-                  tests: hello.test.js
-              env:
-                  ALLURE_RESULTS_DIR: ${{ env.API_ALLURE_RESULTS_DIR }}
-                  ALLURE_REPORT_DIR: ${{ env.API_ALLURE_REPORT_DIR }}
-
-            - name: Upload Allure artifacts to bucket
-              if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
-              uses: ./.github/actions/tests/upload-allure-files-to-bucket
-              env:
-                  ALLURE_RESULTS_DIR: ${{ env.API_ALLURE_RESULTS_DIR }}
-                  ALLURE_REPORT_DIR: ${{ env.API_ALLURE_REPORT_DIR }}
-              with:
-                  aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
-                  aws-region: ${{ secrets.REPORTS_AWS_REGION }}
-                  aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
-                  artifact-name: ${{ env.API_ARTIFACT }}
-                  s3-bucket: ${{ secrets.REPORTS_BUCKET }}
-
-            - name: Publish API Allure report
-              if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
-              env:
-                  GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
-                  ENV_DESCRIPTION: php-${{ matrix.php_version }}
-              run: |
-                  gh workflow run publish-test-reports-release.yml \
-                    -f created_at="${{ needs.get-tag.outputs.created }}" \
-                    -f run_id=${{ github.run_id }} \
-                    -f run_number=${{ github.run_number }} \
-                    -f release_tag=${{ needs.get-tag.outputs.tag }} \
-                    -f artifact="${{ env.API_ARTIFACT }}" \
-                    -f env_description="${{ env.ENV_DESCRIPTION }}" \
-                    -f test_type="api" \
-                    --repo woocommerce/woocommerce-test-reports
-
-            - name: Run E2E tests
-              id: run-e2e-composite-action
-              timeout-minutes: 60
-              uses: ./.github/actions/tests/run-e2e-tests
-              env:
-                  ALLURE_RESULTS_DIR: ${{ env.E2E_ALLURE_RESULTS_DIR }}
-                  ALLURE_REPORT_DIR: ${{ env.E2E_ALLURE_REPORT_DIR }}
-                  DEFAULT_TIMEOUT_OVERRIDE: 120000
-                  E2E_MAX_FAILURES: 15
-              with:
-                  report-name: ${{ env.E2E_ARTIFACT }}
-
-            - name: Upload Allure artifacts to bucket
-              if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
-              uses: ./.github/actions/tests/upload-allure-files-to-bucket
-              env:
-                  ALLURE_RESULTS_DIR: ${{ env.E2E_ALLURE_RESULTS_DIR }}
-                  ALLURE_REPORT_DIR: ${{ env.E2E_ALLURE_REPORT_DIR }}
-              with:
-                  aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
-                  aws-region: ${{ secrets.REPORTS_AWS_REGION }}
-                  aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
-                  artifact-name: ${{ env.E2E_ARTIFACT }}
-                  s3-bucket: ${{ secrets.REPORTS_BUCKET }}
-
-            - name: Publish E2E Allure report
-              if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
-              env:
-                  GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
-                  ENV_DESCRIPTION: php-${{ matrix.php_version }}
-              run: |
-                  gh workflow run publish-test-reports-release.yml \
-                    -f created_at="${{ needs.get-tag.outputs.created }}" \
-                    -f run_id=${{ github.run_id }} \
-                    -f run_number=${{ github.run_number }} \
-                    -f release_tag=${{ needs.get-tag.outputs.tag }} \
-                    -f artifact="${{ env.E2E_ARTIFACT }}" \
-                    -f env_description="${{ env.ENV_DESCRIPTION }}" \
-                    -f test_type="e2e" \
-                    --repo woocommerce/woocommerce-test-reports
-
-            - name: Create Slack block
-              if: |
-                  success() || (
-                    failure() && (
-                      steps.run-api-composite-action.outputs.result == 'failure' ||
-                      steps.run-e2e-composite-action.outputs.result == 'failure' 
-                    )
-                  )
-              uses: ./.github/actions/tests/slack-summary-on-release/slack-blocks
-              with:
-                  test-name: PHP ${{ matrix.php_version }}
-                  api-result: ${{ steps.run-api-composite-action.outputs.result }}
-                  e2e-result: ${{ steps.run-e2e-composite-action.outputs.result }}
-                  env-slug: php-${{ matrix.php_version }}
+                  env-slug: wp-latest-1
                   release-version: ${{ needs.get-tag.outputs.tag }}
 
-    test-plugins:
-        name: With ${{ matrix.plugin }}
-        runs-on: ubuntu-20.04
-        needs: [get-tag]
-        env:
-            ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/allure-results
-            ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/allure-report
-            ARTIFACT_NAME: E2E test on wp-env with ${{ matrix.plugin }} installed (run ${{ github.run_number }})
-        strategy:
-            fail-fast: false
-            matrix:
-                include:
-                    - plugin: 'WooCommerce Payments'
-                      repo: 'automattic/woocommerce-payments'
-                      env_description: 'woocommerce-payments'
-                    - plugin: 'WooCommerce PayPal Payments'
-                      repo: 'woocommerce/woocommerce-paypal-payments'
-                      env_description: 'woocommerce-paypal-payments'
-                    - plugin: 'WooCommerce Shipping & Tax'
-                      repo: 'automattic/woocommerce-services'
-                      env_description: 'woocommerce-shipping-&-tax'
-                    - plugin: 'WooCommerce Subscriptions'
-                      repo: WC_SUBSCRIPTIONS_REPO
-                      private: true
-                      env_description: 'woocommerce-subscriptions'
-                    - plugin: 'Gutenberg'
-                      repo: 'WordPress/gutenberg'
-                      env_description: 'gutenberg'
-                    - plugin: 'Gutenberg - Nightly'
-                      repo: 'bph/gutenberg'
-                      env_description: 'gutenberg-nightly'
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v3
+    # test-php-versions:
+    #     name: Test against PHP ${{ matrix.php_version }}
+    #     runs-on: ubuntu-20.04
+    #     needs: [get-tag]
+    #     strategy:
+    #         fail-fast: false
+    #         matrix:
+    #             php_version: ['7.4', '8.1']
+    #     env:
+    #         API_ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/test-results/allure-report
+    #         API_ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/api-core-tests/test-results/allure-results
+    #         API_ARTIFACT: API test on wp-env with PHP ${{ matrix.php_version }} (run ${{ github.run_number }})
+    #         E2E_ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-report
+    #         E2E_ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/test-results/allure-results
+    #         E2E_ARTIFACT: E2E test on wp-env with PHP ${{ matrix.php_version }} (run ${{ github.run_number }})
+    #     steps:
+    #         - name: Checkout
+    #           uses: actions/checkout@v3
 
-            - name: Setup WooCommerce Monorepo
-              uses: ./.github/actions/setup-woocommerce-monorepo
-              with:
-                  build-filters: woocommerce
+    #         - name: Setup WooCommerce Monorepo
+    #           uses: ./.github/actions/setup-woocommerce-monorepo
+    #           with:
+    #               build-filters: woocommerce
 
-            - name: Launch WP Env
-              working-directory: plugins/woocommerce
-              run: pnpm run env:test
+    #         - name: Launch WP Env
+    #           working-directory: plugins/woocommerce
+    #           env:
+    #               WP_ENV_PHP_VERSION: ${{ matrix.php_version }}
+    #           run: pnpm run env:test
 
-            - name: Download release zip
-              env:
-                  GH_TOKEN: ${{ secrets.E2E_GH_TOKEN }}
-              run: gh release download ${{ needs.get-tag.outputs.tag }} --dir tmp
+    #         - name: Verify PHP version
+    #           working-directory: .github/workflows/scripts
+    #           env:
+    #               EXPECTED_PHP_VERSION: ${{ matrix.php_version }}
+    #           run: bash verify-php-version.sh
 
-            - name: Replace `plugins/woocommerce` with unzipped woocommerce release build
-              run: unzip -d plugins -o tmp/woocommerce.zip
+    #         - name: Download release zip
+    #           env:
+    #               GH_TOKEN: ${{ secrets.E2E_GH_TOKEN }}
+    #           run: gh release download ${{ needs.get-tag.outputs.tag }} --dir tmp
 
-            - name: Run 'Upload plugin' test
-              id: run-upload-test
-              timeout-minutes: 60
-              uses: ./.github/actions/tests/run-e2e-tests
-              with:
-                  report-name: ${{ env.ARTIFACT_NAME }}
-                  tests: upload-plugin.spec.js
-              env:
-                  GITHUB_TOKEN: ${{ secrets.E2E_GH_TOKEN }}
-                  PLUGIN_NAME: ${{ matrix.plugin }}
-                  PLUGIN_REPOSITORY: ${{ matrix.private && secrets[matrix.repo] || matrix.repo }}
+    #         - name: Replace `plugins/woocommerce` with unzipped woocommerce release build
+    #           run: unzip -d plugins -o tmp/woocommerce.zip
 
-            - name: Run the rest of E2E tests
-              id: run-e2e-composite-action
-              timeout-minutes: 60
-              uses: ./.github/actions/tests/run-e2e-tests
-              with:
-                  playwright-config: ignore-plugin-tests.playwright.config.js
-                  report-name: ${{ env.ARTIFACT_NAME }}
-              env:
-                  E2E_MAX_FAILURES: 15
+    #         - name: Run API tests
+    #           id: run-api-composite-action
+    #           uses: ./.github/actions/tests/run-api-tests
+    #           with:
+    #               report-name: ${{ env.API_ARTIFACT }}
+    #               tests: hello.test.js
+    #           env:
+    #               ALLURE_RESULTS_DIR: ${{ env.API_ALLURE_RESULTS_DIR }}
+    #               ALLURE_REPORT_DIR: ${{ env.API_ALLURE_REPORT_DIR }}
 
-            - name: Upload Allure artifacts to bucket
-              if: |
-                  success() || 
-                  ( failure() && 
-                  ( steps.run-upload-test.conclusion == 'failure' || steps.run-e2e-composite-action.conclusion == 'failure' ) )
-              uses: ./.github/actions/tests/upload-allure-files-to-bucket
-              with:
-                  aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
-                  aws-region: ${{ secrets.REPORTS_AWS_REGION }}
-                  aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
-                  artifact-name: ${{ env.ARTIFACT_NAME }}
-                  s3-bucket: ${{ secrets.REPORTS_BUCKET }}
+    #         - name: Upload Allure artifacts to bucket
+    #           if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
+    #           uses: ./.github/actions/tests/upload-allure-files-to-bucket
+    #           env:
+    #               ALLURE_RESULTS_DIR: ${{ env.API_ALLURE_RESULTS_DIR }}
+    #               ALLURE_REPORT_DIR: ${{ env.API_ALLURE_REPORT_DIR }}
+    #           with:
+    #               aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
+    #               aws-region: ${{ secrets.REPORTS_AWS_REGION }}
+    #               aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
+    #               artifact-name: ${{ env.API_ARTIFACT }}
+    #               s3-bucket: ${{ secrets.REPORTS_BUCKET }}
 
-            - name: Publish E2E Allure report
-              if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
-              env:
-                  GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
-              run: |
-                  gh workflow run publish-test-reports-release.yml \
-                    -f created_at="${{ needs.get-tag.outputs.created }}" \
-                    -f run_id=${{ github.run_id }} \
-                    -f run_number=${{ github.run_number }} \
-                    -f release_tag=${{ needs.get-tag.outputs.tag }} \
-                    -f artifact="${{ env.ARTIFACT_NAME }}" \
-                    -f env_description="${{ matrix.env_description }}" \
-                    -f test_type="e2e" \
-                    --repo woocommerce/woocommerce-test-reports
+    #         - name: Publish API Allure report
+    #           if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )
+    #           env:
+    #               GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+    #               ENV_DESCRIPTION: php-${{ matrix.php_version }}
+    #           run: |
+    #               gh workflow run publish-test-reports-release.yml \
+    #                 -f created_at="${{ needs.get-tag.outputs.created }}" \
+    #                 -f run_id=${{ github.run_id }} \
+    #                 -f run_number=${{ github.run_number }} \
+    #                 -f release_tag=${{ needs.get-tag.outputs.tag }} \
+    #                 -f artifact="${{ env.API_ARTIFACT }}" \
+    #                 -f env_description="${{ env.ENV_DESCRIPTION }}" \
+    #                 -f test_type="api" \
+    #                 --repo woocommerce/woocommerce-test-reports
 
-            - name: Create Slack block
-              if: |
-                  success() || (
-                    failure() && steps.run-e2e-composite-action.outputs.result == 'failure' )
-              uses: ./.github/actions/tests/slack-summary-on-release/slack-blocks
-              with:
-                  test-name: With ${{ matrix.plugin }}
-                  e2e-result: ${{ steps.run-e2e-composite-action.outputs.result }}
-                  env-slug: ${{ matrix.env_description }}
-                  release-version: ${{ needs.get-tag.outputs.tag }}
+    #         - name: Run E2E tests
+    #           id: run-e2e-composite-action
+    #           timeout-minutes: 60
+    #           uses: ./.github/actions/tests/run-e2e-tests
+    #           env:
+    #               ALLURE_RESULTS_DIR: ${{ env.E2E_ALLURE_RESULTS_DIR }}
+    #               ALLURE_REPORT_DIR: ${{ env.E2E_ALLURE_REPORT_DIR }}
+    #               DEFAULT_TIMEOUT_OVERRIDE: 120000
+    #               E2E_MAX_FAILURES: 15
+    #           with:
+    #               report-name: ${{ env.E2E_ARTIFACT }}
 
-    post-slack-summary:
-        name: Post Slack summary
-        runs-on: ubuntu-20.04
-        permissions:
-            contents: read
-        if: |
-            success() || (
-              failure() && contains( needs.*.result, 'failure' )
-            )
-        needs:
-            - e2e-wp-latest
-            - get-tag
-            - test-php-versions
-            - test-plugins
-            - test-wp-versions
-        steps:
-            - uses: actions/checkout@v3
+    #         - name: Upload Allure artifacts to bucket
+    #           if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
+    #           uses: ./.github/actions/tests/upload-allure-files-to-bucket
+    #           env:
+    #               ALLURE_RESULTS_DIR: ${{ env.E2E_ALLURE_RESULTS_DIR }}
+    #               ALLURE_REPORT_DIR: ${{ env.E2E_ALLURE_REPORT_DIR }}
+    #           with:
+    #               aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
+    #               aws-region: ${{ secrets.REPORTS_AWS_REGION }}
+    #               aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
+    #               artifact-name: ${{ env.E2E_ARTIFACT }}
+    #               s3-bucket: ${{ secrets.REPORTS_BUCKET }}
 
-            - name: Download all slack blocks
-              id: download-slack-blocks
-              uses: actions/download-artifact@v3
-              with:
-                  name: ${{ env.SLACK_BLOCKS_ARTIFACT }}
-                  path: /tmp/slack-payload
+    #         - name: Publish E2E Allure report
+    #           if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
+    #           env:
+    #               GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+    #               ENV_DESCRIPTION: php-${{ matrix.php_version }}
+    #           run: |
+    #               gh workflow run publish-test-reports-release.yml \
+    #                 -f created_at="${{ needs.get-tag.outputs.created }}" \
+    #                 -f run_id=${{ github.run_id }} \
+    #                 -f run_number=${{ github.run_number }} \
+    #                 -f release_tag=${{ needs.get-tag.outputs.tag }} \
+    #                 -f artifact="${{ env.E2E_ARTIFACT }}" \
+    #                 -f env_description="${{ env.ENV_DESCRIPTION }}" \
+    #                 -f test_type="e2e" \
+    #                 --repo woocommerce/woocommerce-test-reports
 
-            - name: Construct payload from all blocks
-              id: run-payload-action
-              uses: ./.github/actions/tests/slack-summary-on-release/slack-payload
-              with:
-                  release-version: ${{ needs.get-tag.outputs.tag }}
-                  blocks-dir: ${{ steps.download-slack-blocks.outputs.download-path }}
+    #         - name: Create Slack block
+    #           if: |
+    #               success() || (
+    #                 failure() && (
+    #                   steps.run-api-composite-action.outputs.result == 'failure' ||
+    #                   steps.run-e2e-composite-action.outputs.result == 'failure' 
+    #                 )
+    #               )
+    #           uses: ./.github/actions/tests/slack-summary-on-release/slack-blocks
+    #           with:
+    #               test-name: PHP ${{ matrix.php_version }}
+    #               api-result: ${{ steps.run-api-composite-action.outputs.result }}
+    #               e2e-result: ${{ steps.run-e2e-composite-action.outputs.result }}
+    #               env-slug: php-${{ matrix.php_version }}
+    #               release-version: ${{ needs.get-tag.outputs.tag }}
 
-            - name: Send Slack message
-              uses: slackapi/slack-github-action@v1.23.0
-              with:
-                  channel-id: ${{ secrets.RELEASE_TEST_SLACK_CHANNEL }}
-                  payload: ${{ steps.run-payload-action.outputs.payload }}
-              env:
-                  SLACK_BOT_TOKEN: ${{ secrets.E2E_SLACK_TOKEN }}
+    # test-plugins:
+    #     name: With ${{ matrix.plugin }}
+    #     runs-on: ubuntu-20.04
+    #     needs: [get-tag]
+    #     env:
+    #         ALLURE_RESULTS_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/allure-results
+    #         ALLURE_REPORT_DIR: ${{ github.workspace }}/plugins/woocommerce/tests/e2e-pw/allure-report
+    #         ARTIFACT_NAME: E2E test on wp-env with ${{ matrix.plugin }} installed (run ${{ github.run_number }})
+    #     strategy:
+    #         fail-fast: false
+    #         matrix:
+    #             include:
+    #                 - plugin: 'WooCommerce Payments'
+    #                   repo: 'automattic/woocommerce-payments'
+    #                   env_description: 'woocommerce-payments'
+    #                 - plugin: 'WooCommerce PayPal Payments'
+    #                   repo: 'woocommerce/woocommerce-paypal-payments'
+    #                   env_description: 'woocommerce-paypal-payments'
+    #                 - plugin: 'WooCommerce Shipping & Tax'
+    #                   repo: 'automattic/woocommerce-services'
+    #                   env_description: 'woocommerce-shipping-&-tax'
+    #                 - plugin: 'WooCommerce Subscriptions'
+    #                   repo: WC_SUBSCRIPTIONS_REPO
+    #                   private: true
+    #                   env_description: 'woocommerce-subscriptions'
+    #                 - plugin: 'Gutenberg'
+    #                   repo: 'WordPress/gutenberg'
+    #                   env_description: 'gutenberg'
+    #                 - plugin: 'Gutenberg - Nightly'
+    #                   repo: 'bph/gutenberg'
+    #                   env_description: 'gutenberg-nightly'
+    #     steps:
+    #         - name: Checkout
+    #           uses: actions/checkout@v3
+
+    #         - name: Setup WooCommerce Monorepo
+    #           uses: ./.github/actions/setup-woocommerce-monorepo
+    #           with:
+    #               build-filters: woocommerce
+
+    #         - name: Launch WP Env
+    #           working-directory: plugins/woocommerce
+    #           run: pnpm run env:test
+
+    #         - name: Download release zip
+    #           env:
+    #               GH_TOKEN: ${{ secrets.E2E_GH_TOKEN }}
+    #           run: gh release download ${{ needs.get-tag.outputs.tag }} --dir tmp
+
+    #         - name: Replace `plugins/woocommerce` with unzipped woocommerce release build
+    #           run: unzip -d plugins -o tmp/woocommerce.zip
+
+    #         - name: Run 'Upload plugin' test
+    #           id: run-upload-test
+    #           timeout-minutes: 60
+    #           uses: ./.github/actions/tests/run-e2e-tests
+    #           with:
+    #               report-name: ${{ env.ARTIFACT_NAME }}
+    #               tests: upload-plugin.spec.js
+    #           env:
+    #               GITHUB_TOKEN: ${{ secrets.E2E_GH_TOKEN }}
+    #               PLUGIN_NAME: ${{ matrix.plugin }}
+    #               PLUGIN_REPOSITORY: ${{ matrix.private && secrets[matrix.repo] || matrix.repo }}
+
+    #         - name: Run the rest of E2E tests
+    #           id: run-e2e-composite-action
+    #           timeout-minutes: 60
+    #           uses: ./.github/actions/tests/run-e2e-tests
+    #           with:
+    #               playwright-config: ignore-plugin-tests.playwright.config.js
+    #               report-name: ${{ env.ARTIFACT_NAME }}
+    #           env:
+    #               E2E_MAX_FAILURES: 15
+
+    #         - name: Upload Allure artifacts to bucket
+    #           if: |
+    #               success() || 
+    #               ( failure() && 
+    #               ( steps.run-upload-test.conclusion == 'failure' || steps.run-e2e-composite-action.conclusion == 'failure' ) )
+    #           uses: ./.github/actions/tests/upload-allure-files-to-bucket
+    #           with:
+    #               aws-access-key-id: ${{ secrets.REPORTS_AWS_ACCESS_KEY_ID }}
+    #               aws-region: ${{ secrets.REPORTS_AWS_REGION }}
+    #               aws-secret-access-key: ${{ secrets.REPORTS_AWS_SECRET_ACCESS_KEY }}
+    #               artifact-name: ${{ env.ARTIFACT_NAME }}
+    #               s3-bucket: ${{ secrets.REPORTS_BUCKET }}
+
+    #         - name: Publish E2E Allure report
+    #           if: success() || ( failure() && steps.run-e2e-composite-action.conclusion == 'failure' )
+    #           env:
+    #               GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+    #           run: |
+    #               gh workflow run publish-test-reports-release.yml \
+    #                 -f created_at="${{ needs.get-tag.outputs.created }}" \
+    #                 -f run_id=${{ github.run_id }} \
+    #                 -f run_number=${{ github.run_number }} \
+    #                 -f release_tag=${{ needs.get-tag.outputs.tag }} \
+    #                 -f artifact="${{ env.ARTIFACT_NAME }}" \
+    #                 -f env_description="${{ matrix.env_description }}" \
+    #                 -f test_type="e2e" \
+    #                 --repo woocommerce/woocommerce-test-reports
+
+    #         - name: Create Slack block
+    #           if: |
+    #               success() || (
+    #                 failure() && steps.run-e2e-composite-action.outputs.result == 'failure' )
+    #           uses: ./.github/actions/tests/slack-summary-on-release/slack-blocks
+    #           with:
+    #               test-name: With ${{ matrix.plugin }}
+    #               e2e-result: ${{ steps.run-e2e-composite-action.outputs.result }}
+    #               env-slug: ${{ matrix.env_description }}
+    #               release-version: ${{ needs.get-tag.outputs.tag }}
+
+    # post-slack-summary:
+    #     name: Post Slack summary
+    #     runs-on: ubuntu-20.04
+    #     permissions:
+    #         contents: read
+    #     if: |
+    #         success() || (
+    #           failure() && contains( needs.*.result, 'failure' )
+    #         )
+    #     needs:
+    #         - e2e-wp-latest
+    #         - get-tag
+    #         - test-php-versions
+    #         - test-plugins
+    #         - test-wp-latest-1
+    #     steps:
+    #         - uses: actions/checkout@v3
+
+    #         - name: Download all slack blocks
+    #           id: download-slack-blocks
+    #           uses: actions/download-artifact@v3
+    #           with:
+    #               name: ${{ env.SLACK_BLOCKS_ARTIFACT }}
+    #               path: /tmp/slack-payload
+
+    #         - name: Construct payload from all blocks
+    #           id: run-payload-action
+    #           uses: ./.github/actions/tests/slack-summary-on-release/slack-payload
+    #           with:
+    #               release-version: ${{ needs.get-tag.outputs.tag }}
+    #               blocks-dir: ${{ steps.download-slack-blocks.outputs.download-path }}
+
+    #         - name: Send Slack message
+    #           uses: slackapi/slack-github-action@v1.23.0
+    #           with:
+    #               channel-id: ${{ secrets.RELEASE_TEST_SLACK_CHANNEL }}
+    #               payload: ${{ steps.run-payload-action.outputs.payload }}
+    #           env:
+    #               SLACK_BOT_TOKEN: ${{ secrets.E2E_SLACK_TOKEN }}

--- a/plugins/woocommerce/changelog/e2e-release-remove-wp-latest-2
+++ b/plugins/woocommerce/changelog/e2e-release-remove-wp-latest-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Remove "WP Latest-2" from release tests.

--- a/plugins/woocommerce/tests/e2e-pw/utils/wordpress.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/wordpress.js
@@ -1,12 +1,8 @@
-const axios = require( 'axios' ).default;
+const getVersionWPLatestMinusOne = async ( { core, github } ) => {
+	const URL_WP_STABLE_VERSION_CHECK =
+		'https://api.wordpress.org/core/stable-check/1.0/';
 
-const getPreviousTwoVersions = async () => {
-	const response = await axios
-		.get( 'http://api.wordpress.org/core/stable-check/1.0/' )
-		.catch( ( error ) => {
-			console.log( error.toJSON() );
-			throw new Error( error.message );
-		} );
+	const response = await github.request( URL_WP_STABLE_VERSION_CHECK );
 
 	const body = response.data;
 	const allVersions = Object.keys( body );
@@ -22,34 +18,7 @@ const getPreviousTwoVersions = async () => {
 		( version ) => ! version.startsWith( latestMajorAndMinorNumbers )
 	);
 
-	const latestMinus1MajorAndMinorNumbers = latestMinus1.match(
-		/^\d+.\d+/
-	)[ 0 ];
-
-	const latestMinus2 = previousStableVersions.find(
-		( version ) =>
-			! (
-				version.startsWith( latestMajorAndMinorNumbers ) ||
-				version.startsWith( latestMinus1MajorAndMinorNumbers )
-			)
-	);
-
-	const matrix = {
-		version: [
-			{
-				number: latestMinus1,
-				description: 'WP Latest-1',
-				env_description: 'wp-latest-1',
-			},
-			{
-				number: latestMinus2,
-				description: 'WP Latest-2',
-				env_description: 'wp-latest-2',
-			},
-		],
-	};
-
-	return matrix;
+	core.setOutput( 'version', latestMinus1 );
 };
 
-module.exports = { getPreviousTwoVersions };
+module.exports = { getVersionWPLatestMinusOne };


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR removes "WP Latest-2" from the list of environments being tested during release tests. WooCommerce now only supports up to WP Latest-1 so we need to make this appropriate adjustment to our release tests.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to [Smoke test release](https://github.com/woocommerce/woocommerce/actions/workflows/smoke-test-release.yml).
2. Select this branch ( `e2e/remove-wp-l-2` ).
1. Select any recent valid release version.
2. Run the workflow. Wait for it to finish.
3. In the list of jobs, verify that you see the job "Test against WP Latest-1". There should be no "Test against WP Latest-2" job.
    <img width="224" alt="buQLejuy4C" src="https://github.com/woocommerce/woocommerce/assets/4509348/67d33754-fc11-4d7e-a8ab-3bf1cfa42851">
4. Click on the "Test against WP Latest-1" job.
1. Look for the step `Launch WP Env` and expand it.
2. Expand the `Run pnpm run env:test` command to see the environment variables passed onto it.
3. Verify that the value for the `WP_ENV_CORE` variable is `WordPress/WordPress#6.2.2`. The number after the `#` character should be the correct WP L-1 version, currently 6.2.2.
    <img width="592" alt="Iy9difP5ia" src="https://github.com/woocommerce/woocommerce/assets/4509348/3ac5e7ab-e3cc-4763-8d3c-421a03d63eae">
1. In the Slack notification for release tests, verify that the `WP Latest-1` section shows the correct L-1 version. Also verify that there's no `WP Latest-2` section.
    <img width="290" alt="OOQFdgMfdA" src="https://github.com/woocommerce/woocommerce/assets/4509348/c5c8c173-3f82-45d6-964d-a5774626c8c5">



<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
