### PR TITLE
Marketplace: update discover page card counts

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/product-list-content/product-list-content.scss
+++ b/plugins/woocommerce-admin/client/marketplace/components/product-list-content/product-list-content.scss
@@ -20,6 +20,12 @@
 			gap: $large-gap;
 			grid-template-columns: repeat(2, 1fr);
 		}
+		// Hide third and fourth product cards on Discover page due to API result count
+		// These are progressively displayed at larger screen sizes.
+		&__discover .woocommerce-marketplace__product-card:nth-child(3),
+		&__discover .woocommerce-marketplace__product-card:nth-child(4) {
+			display: none;
+		}
 	}
 }
 
@@ -29,6 +35,9 @@
 			gap: $large-gap;
 			grid-template-columns: repeat(3, 1fr);
 		}
+		&__discover .woocommerce-marketplace__product-card:nth-child(3) {
+			display: block;
+		}
 	}
 }
 
@@ -36,6 +45,9 @@
 	.woocommerce-marketplace {
 		&__product-list-content {
 			grid-template-columns: repeat(4, 1fr);
+		}
+		&__discover .woocommerce-marketplace__product-card:nth-child(4) {
+			display: block;
 		}
 	}
 }

--- a/plugins/woocommerce-admin/client/marketplace/components/product-list-content/product-list-content.scss
+++ b/plugins/woocommerce-admin/client/marketplace/components/product-list-content/product-list-content.scss
@@ -20,10 +20,9 @@
 			gap: $large-gap;
 			grid-template-columns: repeat(2, 1fr);
 		}
-		// Hide third and fourth product cards on Discover page due to API result count
+		// Hide third and above product cards on Discover page due to API result count
 		// These are progressively displayed at larger screen sizes.
-		&__discover .woocommerce-marketplace__product-card:nth-child(3),
-		&__discover .woocommerce-marketplace__product-card:nth-child(4) {
+		&__discover .woocommerce-marketplace__product-card:nth-child(n+3){
 			display: none;
 		}
 	}

--- a/plugins/woocommerce-admin/client/marketplace/components/product-list-content/product-list-content.scss
+++ b/plugins/woocommerce-admin/client/marketplace/components/product-list-content/product-list-content.scss
@@ -22,7 +22,7 @@
 		}
 		// Hide third and above product cards on Discover page due to API result count
 		// These are progressively displayed at larger screen sizes.
-		&__discover .woocommerce-marketplace__product-card:nth-child(n+3){
+		&__discover .woocommerce-marketplace__product-card:nth-child(n+3) {
 			display: none;
 		}
 	}

--- a/plugins/woocommerce/changelog/fix-wccom-18030-discover-card-count
+++ b/plugins/woocommerce/changelog/fix-wccom-18030-discover-card-count
@@ -1,4 +1,5 @@
 Significance: patch
 Type: update
+Comment: CSS to render correct number of columns in marketplace Discover screen.
 
-CSS to render correct number of columns in marketplace Discover screen.
+

--- a/plugins/woocommerce/changelog/fix-wccom-18030-discover-card-count
+++ b/plugins/woocommerce/changelog/fix-wccom-18030-discover-card-count
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+CSS to render correct number of columns in marketplace Discover screen.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR addresses In-app marketplace feedback. The Discover page API returns results for each section that don't fit neatly in the new design. To resolve this, the PR hides extra product cards on some screen sizes.

Closes 18030-gh-Automattic/woocommerce.com

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout this branch locally and from `plugins/woocommerce-admin` run `pnpm run build`
2. Visit WooCommerce > Extensions from your development site (**wp-env**: http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fextensions)
3. See that on mobile (one-column) all cards display
4. See that on 2-column layouts only 2 cards display per section
5. See that on 3-column layouts only 3 cards display per section
6. See that on larger screen sizes over 1920px that 4 cards display on the “Discover our Favourites” section (other sections only return 3 results in the API)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

CSS to render correct number of columns in marketplace Discover screen.

</details>