### PR TITLE
Make `Link type="external"` use `@worpress/components.ExternalLink`

### DIFF
--- a/packages/js/components/changelog/update-wp-externallink
+++ b/packages/js/components/changelog/update-wp-externallink
@@ -1,0 +1,4 @@
+Significance: major
+Type: update
+
+Make `Link type="external"` use `@wordpress/components.ExternalLink` to use the "external" icon, and make UI consistent.

--- a/packages/js/components/src/link/index.tsx
+++ b/packages/js/components/src/link/index.tsx
@@ -3,6 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import { partial } from 'lodash';
+import { ExternalLink } from '@wordpress/components';
 import { createElement } from '@wordpress/element';
 import { getHistory } from '@woocommerce/navigation';
 import React from 'react';
@@ -80,10 +81,12 @@ export const Link = ( {
 		passProps.onClick = partial( wcAdminLinkHandler, passProps.onClick );
 	}
 
+	const LinkElement = type === 'external' ? ExternalLink : 'a';
+
 	return (
-		<a href={ href } { ...passProps }>
+		<LinkElement href={ href } { ...passProps }>
 			{ children }
-		</a>
+		</LinkElement>
 	);
 };
 

--- a/packages/js/components/src/link/test/index.tsx
+++ b/packages/js/components/src/link/test/index.tsx
@@ -19,10 +19,34 @@ describe( 'Link', () => {
 
 		expect( container.firstChild ).toMatchInlineSnapshot( `
 			<a
+			  class="components-external-link"
 			  data-link-type="external"
 			  href="https://woocommerce.com"
+			  rel="external noreferrer noopener"
+			  target="_blank"
 			>
 			  WooCommerce.com
+			  <span
+			    class="components-visually-hidden css-1mm2cvy-View em57xhy0"
+			    data-wp-c16t="true"
+			    data-wp-component="VisuallyHidden"
+			    style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
+			  >
+			    (opens in a new tab)
+			  </span>
+			  <svg
+			    aria-hidden="true"
+			    class="components-external-link__icon css-16iaek2-StyledIcon etxm6pv0"
+			    focusable="false"
+			    height="24"
+			    viewBox="0 0 24 24"
+			    width="24"
+			    xmlns="http://www.w3.org/2000/svg"
+			  >
+			    <path
+			      d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z"
+			    />
+			  </svg>
 			</a>
 		` );
 	} );
@@ -87,7 +111,7 @@ describe( 'Link', () => {
 				href="https://woocommerce.com"
 				type="external"
 				className="foo"
-				target="bar"
+				title="bar"
 			>
 				WooCommerce.com
 			</Link>
@@ -95,12 +119,35 @@ describe( 'Link', () => {
 
 		expect( container.firstChild ).toMatchInlineSnapshot( `
 			<a
-			  class="foo"
+			  class="components-external-link foo"
 			  data-link-type="external"
 			  href="https://woocommerce.com"
-			  target="bar"
+			  rel="external noreferrer noopener"
+			  target="_blank"
+			  title="bar"
 			>
 			  WooCommerce.com
+			  <span
+			    class="components-visually-hidden css-1mm2cvy-View em57xhy0"
+			    data-wp-c16t="true"
+			    data-wp-component="VisuallyHidden"
+			    style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
+			  >
+			    (opens in a new tab)
+			  </span>
+			  <svg
+			    aria-hidden="true"
+			    class="components-external-link__icon css-16iaek2-StyledIcon etxm6pv0"
+			    focusable="false"
+			    height="24"
+			    viewBox="0 0 24 24"
+			    width="24"
+			    xmlns="http://www.w3.org/2000/svg"
+			  >
+			    <path
+			      d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z"
+			    />
+			  </svg>
 			</a>
 		` );
 	} );

--- a/packages/js/components/src/list/test/index.js
+++ b/packages/js/components/src/list/test/index.js
@@ -86,12 +86,14 @@ describe( 'List', () => {
 					.dataset.linkType
 			).toBe( 'wc-admin' );
 			expect(
-				screen.getByRole( 'menuitem', { name: 'WooCommerce.com' } )
-					.dataset.linkType
+				screen.getByRole( 'menuitem', {
+					name: 'WooCommerce.com (opens in a new tab)',
+				} ).dataset.linkType
 			).toBe( 'external' );
 			expect(
-				screen.getByRole( 'menuitem', { name: 'WordPress.org' } )
-					.dataset.linkType
+				screen.getByRole( 'menuitem', {
+					name: 'WordPress.org (opens in a new tab)',
+				} ).dataset.linkType
 			).toBe( 'external' );
 		} );
 
@@ -132,12 +134,14 @@ describe( 'List', () => {
 					.dataset.listItemTag
 			).toBe( 'marketing' );
 			expect(
-				screen.getByRole( 'menuitem', { name: 'WooCommerce.com' } )
-					.dataset.listItemTag
+				screen.getByRole( 'menuitem', {
+					name: 'WooCommerce.com (opens in a new tab)',
+				} ).dataset.listItemTag
 			).toBe( 'woocommerce.com-site' );
 			expect(
-				screen.getByRole( 'menuitem', { name: 'WordPress.org' } )
-					.dataset.listItemTag
+				screen.getByRole( 'menuitem', {
+					name: 'WordPress.org (opens in a new tab)',
+				} ).dataset.listItemTag
 			).toBeUndefined();
 		} );
 	} );

--- a/packages/js/onboarding/changelog/update-wp-externallink
+++ b/packages/js/onboarding/changelog/update-wp-externallink
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Remove redundant attributes from `Link type="external"`.

--- a/packages/js/onboarding/src/components/WCPayBanner/WCPayBanner.tsx
+++ b/packages/js/onboarding/src/components/WCPayBanner/WCPayBanner.tsx
@@ -39,20 +39,12 @@ export const WCPayBannerText: React.VFC< {
 } > = ( { actionButton, isWooPayEligible } ) => {
 	const links = {
 		tosLink: (
-			<Link
-				href="https://wordpress.com/tos/"
-				type="external"
-				target="_blank"
-			>
+			<Link href="https://wordpress.com/tos/" type="external">
 				<></>
 			</Link>
 		),
 		privacyLink: (
-			<Link
-				href="https://automattic.com/privacy/"
-				type="external"
-				target="_blank"
-			>
+			<Link href="https://automattic.com/privacy/" type="external">
 				<></>
 			</Link>
 		),
@@ -60,7 +52,6 @@ export const WCPayBannerText: React.VFC< {
 			<Link
 				href="https://wordpress.com/tos/#more-woopay-specifically"
 				type="external"
-				target="_blank"
 			>
 				<></>
 			</Link>

--- a/packages/js/onboarding/src/components/WCPayCard/WCPayCard.tsx
+++ b/packages/js/onboarding/src/components/WCPayCard/WCPayCard.tsx
@@ -51,9 +51,7 @@ export const WCPayCardBody: React.VFC< WCPayCardBodyProps > = ( {
 			{ description }
 			<br />
 			<Link
-				target="_blank"
 				type="external"
-				rel="noreferrer"
 				href="https://woocommerce.com/payments/?utm_medium=product"
 				onClick={ onLinkClick }
 			>

--- a/packages/js/product-editor/changelog/update-wp-externallink
+++ b/packages/js/product-editor/changelog/update-wp-externallink
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Remove redundant attributes from `Link type="external"`.

--- a/packages/js/product-editor/src/blocks/inventory-email/edit.tsx
+++ b/packages/js/product-editor/src/blocks/inventory-email/edit.tsx
@@ -84,7 +84,6 @@ export function Edit( {
 												href={ `${ getSetting(
 													'adminUrl'
 												) }admin.php?page=wc-settings&tab=products&section=inventory` }
-												target="_blank"
 												type="external"
 											></Link>
 										),

--- a/packages/js/product-editor/src/components/details-feature-field/details-feature-field.tsx
+++ b/packages/js/product-editor/src/components/details-feature-field/details-feature-field.tsx
@@ -40,7 +40,6 @@ export const DetailsFeatureField = () => {
 								moreLink: (
 									<Link
 										href="https://woocommerce.com/document/woocommerce-shortcodes/#products"
-										target="_blank"
 										type="external"
 										onClick={ () =>
 											recordEvent(

--- a/plugins/woo-ai/changelog/update-wp-externallink
+++ b/plugins/woo-ai/changelog/update-wp-externallink
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Remove redundant attributes from `Link type="external"`.

--- a/plugins/woo-ai/src/product-name/powered-by-link.tsx
+++ b/plugins/woo-ai/src/product-name/powered-by-link.tsx
@@ -18,7 +18,6 @@ export const PoweredByLink = () => (
 				link: (
 					<Link
 						href="https://automattic.com/ai-guidelines"
-						target="_blank"
 						type="external"
 						onClick={ () => {
 							recordNameTracks( 'learn_more_click' );

--- a/plugins/woocommerce-admin/client/core-profiler/test/__snapshots__/core-profiler-machine.test.tsx.snap
+++ b/plugins/woocommerce-admin/client/core-profiler/test/__snapshots__/core-profiler-machine.test.tsx.snap
@@ -451,7 +451,7 @@ Object {
                     class="components-checkbox-control__label"
                     for="inspector-checkbox-control-1"
                   >
-                    I agree to share my data to tailor my store setup experience and get more relevant content (WooCommerce will never rent or sell your data, and you can opt out at any time in WooCommerce settings. 
+                    I agree to share my data to tailor my store setup experience and get more relevant content (WooCommerce will never rent or sell your data, and you can opt out at any time in WooCommerce settings.
                     <a
                       data-link-type="external"
                       href="https://woocommerce.com/usage-tracking?utm_medium=product"
@@ -596,7 +596,7 @@ Object {
                   class="components-checkbox-control__label"
                   for="inspector-checkbox-control-1"
                 >
-                  I agree to share my data to tailor my store setup experience and get more relevant content (WooCommerce will never rent or sell your data, and you can opt out at any time in WooCommerce settings. 
+                  I agree to share my data to tailor my store setup experience and get more relevant content (WooCommerce will never rent or sell your data, and you can opt out at any time in WooCommerce settings.
                   <a
                     data-link-type="external"
                     href="https://woocommerce.com/usage-tracking?utm_medium=product"
@@ -971,7 +971,7 @@ Object {
                     class="components-checkbox-control__label"
                     for="inspector-checkbox-control-3"
                   >
-                    I agree to share my data to tailor my store setup experience and get more relevant content (WooCommerce will never rent or sell your data, and you can opt out at any time in WooCommerce settings. 
+                    I agree to share my data to tailor my store setup experience and get more relevant content (WooCommerce will never rent or sell your data, and you can opt out at any time in WooCommerce settings.
                     <a
                       data-link-type="external"
                       href="https://woocommerce.com/usage-tracking?utm_medium=product"
@@ -1116,7 +1116,7 @@ Object {
                   class="components-checkbox-control__label"
                   for="inspector-checkbox-control-3"
                 >
-                  I agree to share my data to tailor my store setup experience and get more relevant content (WooCommerce will never rent or sell your data, and you can opt out at any time in WooCommerce settings. 
+                  I agree to share my data to tailor my store setup experience and get more relevant content (WooCommerce will never rent or sell your data, and you can opt out at any time in WooCommerce settings.
                   <a
                     data-link-type="external"
                     href="https://woocommerce.com/usage-tracking?utm_medium=product"
@@ -1878,7 +1878,7 @@ Object {
                     class="components-checkbox-control__label"
                     for="inspector-checkbox-control-2"
                   >
-                    I agree to share my data to tailor my store setup experience and get more relevant content (WooCommerce will never rent or sell your data, and you can opt out at any time in WooCommerce settings. 
+                    I agree to share my data to tailor my store setup experience and get more relevant content (WooCommerce will never rent or sell your data, and you can opt out at any time in WooCommerce settings.
                     <a
                       data-link-type="external"
                       href="https://woocommerce.com/usage-tracking?utm_medium=product"
@@ -2023,7 +2023,7 @@ Object {
                   class="components-checkbox-control__label"
                   for="inspector-checkbox-control-2"
                 >
-                  I agree to share my data to tailor my store setup experience and get more relevant content (WooCommerce will never rent or sell your data, and you can opt out at any time in WooCommerce settings. 
+                  I agree to share my data to tailor my store setup experience and get more relevant content (WooCommerce will never rent or sell your data, and you can opt out at any time in WooCommerce settings.
                   <a
                     data-link-type="external"
                     href="https://woocommerce.com/usage-tracking?utm_medium=product"

--- a/plugins/woocommerce-admin/client/core-profiler/test/__snapshots__/core-profiler-machine.test.tsx.snap
+++ b/plugins/woocommerce-admin/client/core-profiler/test/__snapshots__/core-profiler-machine.test.tsx.snap
@@ -451,13 +451,36 @@ Object {
                     class="components-checkbox-control__label"
                     for="inspector-checkbox-control-1"
                   >
-                    I agree to share my data to tailor my store setup experience and get more relevant content (WooCommerce will never rent or sell your data, and you can opt out at any time in WooCommerce settings.
+                    I agree to share my data to tailor my store setup experience and get more relevant content (WooCommerce will never rent or sell your data, and you can opt out at any time in WooCommerce settings. 
                     <a
+                      class="components-external-link"
                       data-link-type="external"
                       href="https://woocommerce.com/usage-tracking?utm_medium=product"
+                      rel="external noreferrer noopener"
                       target="_blank"
                     >
                       Learn more about usage tracking.
+                      <span
+                        class="components-visually-hidden css-1mm2cvy-View em57xhy0"
+                        data-wp-c16t="true"
+                        data-wp-component="VisuallyHidden"
+                        style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
+                      >
+                        (opens in a new tab)
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        class="components-external-link__icon css-16iaek2-StyledIcon etxm6pv0"
+                        focusable="false"
+                        height="24"
+                        viewBox="0 0 24 24"
+                        width="24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z"
+                        />
+                      </svg>
                     </a>
                     )
                   </label>
@@ -596,13 +619,36 @@ Object {
                   class="components-checkbox-control__label"
                   for="inspector-checkbox-control-1"
                 >
-                  I agree to share my data to tailor my store setup experience and get more relevant content (WooCommerce will never rent or sell your data, and you can opt out at any time in WooCommerce settings.
+                  I agree to share my data to tailor my store setup experience and get more relevant content (WooCommerce will never rent or sell your data, and you can opt out at any time in WooCommerce settings. 
                   <a
+                    class="components-external-link"
                     data-link-type="external"
                     href="https://woocommerce.com/usage-tracking?utm_medium=product"
+                    rel="external noreferrer noopener"
                     target="_blank"
                   >
                     Learn more about usage tracking.
+                    <span
+                      class="components-visually-hidden css-1mm2cvy-View em57xhy0"
+                      data-wp-c16t="true"
+                      data-wp-component="VisuallyHidden"
+                      style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
+                    >
+                      (opens in a new tab)
+                    </span>
+                    <svg
+                      aria-hidden="true"
+                      class="components-external-link__icon css-16iaek2-StyledIcon etxm6pv0"
+                      focusable="false"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z"
+                      />
+                    </svg>
                   </a>
                   )
                 </label>
@@ -971,13 +1017,36 @@ Object {
                     class="components-checkbox-control__label"
                     for="inspector-checkbox-control-3"
                   >
-                    I agree to share my data to tailor my store setup experience and get more relevant content (WooCommerce will never rent or sell your data, and you can opt out at any time in WooCommerce settings.
+                    I agree to share my data to tailor my store setup experience and get more relevant content (WooCommerce will never rent or sell your data, and you can opt out at any time in WooCommerce settings. 
                     <a
+                      class="components-external-link"
                       data-link-type="external"
                       href="https://woocommerce.com/usage-tracking?utm_medium=product"
+                      rel="external noreferrer noopener"
                       target="_blank"
                     >
                       Learn more about usage tracking.
+                      <span
+                        class="components-visually-hidden css-1mm2cvy-View em57xhy0"
+                        data-wp-c16t="true"
+                        data-wp-component="VisuallyHidden"
+                        style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
+                      >
+                        (opens in a new tab)
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        class="components-external-link__icon css-16iaek2-StyledIcon etxm6pv0"
+                        focusable="false"
+                        height="24"
+                        viewBox="0 0 24 24"
+                        width="24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z"
+                        />
+                      </svg>
                     </a>
                     )
                   </label>
@@ -1116,13 +1185,36 @@ Object {
                   class="components-checkbox-control__label"
                   for="inspector-checkbox-control-3"
                 >
-                  I agree to share my data to tailor my store setup experience and get more relevant content (WooCommerce will never rent or sell your data, and you can opt out at any time in WooCommerce settings.
+                  I agree to share my data to tailor my store setup experience and get more relevant content (WooCommerce will never rent or sell your data, and you can opt out at any time in WooCommerce settings. 
                   <a
+                    class="components-external-link"
                     data-link-type="external"
                     href="https://woocommerce.com/usage-tracking?utm_medium=product"
+                    rel="external noreferrer noopener"
                     target="_blank"
                   >
                     Learn more about usage tracking.
+                    <span
+                      class="components-visually-hidden css-1mm2cvy-View em57xhy0"
+                      data-wp-c16t="true"
+                      data-wp-component="VisuallyHidden"
+                      style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
+                    >
+                      (opens in a new tab)
+                    </span>
+                    <svg
+                      aria-hidden="true"
+                      class="components-external-link__icon css-16iaek2-StyledIcon etxm6pv0"
+                      focusable="false"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z"
+                      />
+                    </svg>
                   </a>
                   )
                 </label>
@@ -1878,13 +1970,36 @@ Object {
                     class="components-checkbox-control__label"
                     for="inspector-checkbox-control-2"
                   >
-                    I agree to share my data to tailor my store setup experience and get more relevant content (WooCommerce will never rent or sell your data, and you can opt out at any time in WooCommerce settings.
+                    I agree to share my data to tailor my store setup experience and get more relevant content (WooCommerce will never rent or sell your data, and you can opt out at any time in WooCommerce settings. 
                     <a
+                      class="components-external-link"
                       data-link-type="external"
                       href="https://woocommerce.com/usage-tracking?utm_medium=product"
+                      rel="external noreferrer noopener"
                       target="_blank"
                     >
                       Learn more about usage tracking.
+                      <span
+                        class="components-visually-hidden css-1mm2cvy-View em57xhy0"
+                        data-wp-c16t="true"
+                        data-wp-component="VisuallyHidden"
+                        style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
+                      >
+                        (opens in a new tab)
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        class="components-external-link__icon css-16iaek2-StyledIcon etxm6pv0"
+                        focusable="false"
+                        height="24"
+                        viewBox="0 0 24 24"
+                        width="24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z"
+                        />
+                      </svg>
                     </a>
                     )
                   </label>
@@ -2023,13 +2138,36 @@ Object {
                   class="components-checkbox-control__label"
                   for="inspector-checkbox-control-2"
                 >
-                  I agree to share my data to tailor my store setup experience and get more relevant content (WooCommerce will never rent or sell your data, and you can opt out at any time in WooCommerce settings.
+                  I agree to share my data to tailor my store setup experience and get more relevant content (WooCommerce will never rent or sell your data, and you can opt out at any time in WooCommerce settings. 
                   <a
+                    class="components-external-link"
                     data-link-type="external"
                     href="https://woocommerce.com/usage-tracking?utm_medium=product"
+                    rel="external noreferrer noopener"
                     target="_blank"
                   >
                     Learn more about usage tracking.
+                    <span
+                      class="components-visually-hidden css-1mm2cvy-View em57xhy0"
+                      data-wp-c16t="true"
+                      data-wp-component="VisuallyHidden"
+                      style="border: 0px; clip: rect(1px, 1px, 1px, 1px); clip-path: inset( 50% ); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; word-wrap: normal;"
+                    >
+                      (opens in a new tab)
+                    </span>
+                    <svg
+                      aria-hidden="true"
+                      class="components-external-link__icon css-16iaek2-StyledIcon etxm6pv0"
+                      focusable="false"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z"
+                      />
+                    </svg>
                   </a>
                   )
                 </label>

--- a/plugins/woocommerce-admin/client/homescreen/activity-panel/reviews/test/index.js
+++ b/plugins/woocommerce-admin/client/homescreen/activity-panel/reviews/test/index.js
@@ -76,7 +76,11 @@ describe( 'ReviewsPanel', () => {
 			/>
 		);
 
-		expect( getByTextWithMarkup( 'Reviewer reviewed Cap' ) ).not.toBeNull();
+		expect(
+			getByTextWithMarkup(
+				'Reviewer(opens in a new tab) reviewed Cap(opens in a new tab)'
+			)
+		).not.toBeNull();
 	} );
 
 	it( 'should render checkmark circle icon in the review title, if review is verfied owner', () => {

--- a/plugins/woocommerce-admin/client/homescreen/welcome-from-calypso-modal/welcome-from-calypso-modal.js
+++ b/plugins/woocommerce-admin/client/homescreen/welcome-from-calypso-modal/welcome-from-calypso-modal.js
@@ -34,7 +34,6 @@ const page = {
 						<Link
 							href="https://wordpress.com/support/new-woocommerce-experience-on-wordpress-dot-com/"
 							type="external"
-							target="_blank"
 						/>
 					),
 				},

--- a/plugins/woocommerce-admin/client/marketing/components/ReadBlogMessage.js
+++ b/plugins/woocommerce-admin/client/marketing/components/ReadBlogMessage.js
@@ -16,7 +16,6 @@ const ReadBlogMessage = () => {
 				<Link
 					type="external"
 					href="https://woocommerce.com/blog/marketing/coupons/?utm_medium=product"
-					target="_blank"
 				/>
 			),
 		},

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/business-details/flows/selective-bundle/selective-extensions-bundle/index.js
@@ -123,7 +123,6 @@ const renderBusinessExtensionHelpText = ( values, isInstallingActivating ) => {
 							link: (
 								<Link
 									href="https://wordpress.com/tos/"
-									target="_blank"
 									type="external"
 								/>
 							),

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/product-types/label.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/product-types/label.js
@@ -59,7 +59,6 @@ export default function ProductTypeLabel( {
 							moreLink: moreUrl ? (
 								<Link
 									href={ moreUrl }
-									target="_blank"
 									type="external"
 									onClick={ () =>
 										recordEvent(

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/product-types/product-type.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/product-types/product-type.js
@@ -57,7 +57,6 @@ export default function ProductType( {
 							moreLink: moreUrl ? (
 								<Link
 									href={ moreUrl }
-									target="_blank"
 									type="external"
 									onClick={ () =>
 										recordEvent(

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/product-types/test/product-type.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/product-types/test/product-type.js
@@ -51,7 +51,7 @@ describe( 'ProductType', () => {
 		const learnMoreLink = popover.querySelector( 'a' );
 		expect( popover ).not.toBeNull();
 		expect( popover.textContent ).toBe(
-			defaultProps.description + ' Learn more'
+			defaultProps.description + ' Learn more(opens in a new tab)'
 		);
 		expect( learnMoreLink.href ).toBe( defaultProps.moreUrl );
 	} );

--- a/plugins/woocommerce-admin/client/profile-wizard/steps/usage-modal.js
+++ b/plugins/woocommerce-admin/client/profile-wizard/steps/usage-modal.js
@@ -117,7 +117,6 @@ class UsageModal extends Component {
 					link: (
 						<Link
 							href="https://woocommerce.com/usage-tracking?utm_medium=product"
-							target="_blank"
 							type="external"
 						/>
 					),

--- a/plugins/woocommerce-admin/client/store-management-links/quick-link/index.js
+++ b/plugins/woocommerce-admin/client/store-management-links/quick-link/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from '@wordpress/element';
-import { external, Icon } from '@wordpress/icons';
+import { Icon } from '@wordpress/icons';
 import { Link } from '@woocommerce/components';
 import { Text } from '@woocommerce/experimental';
 
@@ -12,15 +12,12 @@ import { Text } from '@woocommerce/experimental';
 import './style.scss';
 
 export const QuickLink = ( { icon, title, href, linkType, onClick } ) => {
-	const isExternal = linkType === 'external';
-
 	return (
 		<div className="woocommerce-quick-links__item">
 			<Link
 				onClick={ onClick }
 				href={ href }
 				type={ linkType }
-				target={ isExternal ? '_blank' : null }
 				className="woocommerce-quick-links__item-link"
 			>
 				<Icon
@@ -37,7 +34,6 @@ export const QuickLink = ( { icon, title, href, linkType, onClick } ) => {
 				>
 					{ title }
 				</Text>
-				{ isExternal && <Icon icon={ external } /> }
 			</Link>
 		</div>
 	);

--- a/plugins/woocommerce-admin/client/task-lists/fills/PaymentGatewaySuggestions/components/WCPay/UsageModal.js
+++ b/plugins/woocommerce-admin/client/task-lists/fills/PaymentGatewaySuggestions/components/WCPay/UsageModal.js
@@ -39,7 +39,6 @@ export const UsageModal = () => {
 			link: (
 				<Link
 					href="https://woocommerce.com/usage-tracking?utm_medium=product"
-					target="_blank"
 					type="external"
 				/>
 			),

--- a/plugins/woocommerce-admin/client/task-lists/fills/shipping/index.js
+++ b/plugins/woocommerce-admin/client/task-lists/fills/shipping/index.js
@@ -233,7 +233,7 @@ export class Shipping extends Component {
 					name
 				),
 				components: {
-					link: <Link href={ url } target="_blank" type="external" />,
+					link: <Link href={ url } type="external" />,
 				},
 			} );
 		};
@@ -319,7 +319,6 @@ export class Shipping extends Component {
 								link: (
 									<Link
 										href="https://woocommerce.com/products/shipstation-integration?utm_medium=product"
-										target="_blank"
 										type="external"
 									/>
 								),
@@ -596,7 +595,6 @@ export class Shipping extends Component {
 														href={
 															'https://wordpress.com/tos/'
 														}
-														target="_blank"
 														type="external"
 													>
 														<></>

--- a/plugins/woocommerce-admin/client/task-lists/setup-task-list/components/task-headers/woocommerce-payments.js
+++ b/plugins/woocommerce-admin/client/task-lists/setup-task-list/components/task-headers/woocommerce-payments.js
@@ -70,9 +70,7 @@ const WoocommercePaymentsHeader = ( { task, trackClick } ) => {
 							link: (
 								<Link
 									href="https://wordpress.com/tos/"
-									target="_blank"
 									type="external"
-									rel="noreferrer"
 								/>
 							),
 						},

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -416,14 +416,12 @@ export class ShippingBanner extends Component {
 									tosLink: (
 										<ExternalLink
 											href="https://wordpress.com/tos"
-											target="_blank"
 											type="external"
 										/>
 									),
 									wcsLink: (
 										<ExternalLink
 											href="https://woocommerce.com/products/shipping/?utm_medium=product"
-											target="_blank"
 											type="external"
 											onClick={
 												this

--- a/plugins/woocommerce/changelog/update-wp-externallink
+++ b/plugins/woocommerce/changelog/update-wp-externallink
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Remove redundant attributes from `Link type="external"`.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
- [Make Link type="external" use @worpress/components.ExternalLink](https://github.com/woocommerce/woocommerce/commit/e0fdf1a4a81cc1fd956e77993620fc0e939218b6) 
   to make the UI consistent.
   Fixes https://github.com/woocommerce/woocommerce/issues/32236.
- [Remove redundant target & rel atts from Link type="external"s](https://github.com/woocommerce/woocommerce/commit/783a407a3a5209436607dfd286b3d7636f8ab980)
- [Add changelog entries](https://github.com/woocommerce/woocommerce/commit/1b689df43ed707dd468166dce583f067457de74d)
<!-- Begin testing instructions -->

:warning: From visual and `@woocommerce/components` API perspective this is a breaking change.
1. an "external" icon will appear next to **all** external links, even for the links created by **other extensions**
2. `Link` component will ignore any `target` property given, and render always `_blank`  

![image](https://github.com/woocommerce/woocommerce/assets/17435/57562031-8803-4c37-aa3a-c111e525b59e)

![image](https://github.com/woocommerce/woocommerce/assets/17435/af8959d9-443b-43c5-bac9-acdbc60fa45c)



### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Open any page that uses `Link type="external"` (link `/wp-admin/admin.php?page=wc-admin&task=payments`) and check that an external icon is added there

**Regression**
3. Open all usages of `Link type="external"` and check that the external icon does not break the layout


### Additional notes

1. We can revisit all use cases when we use just `<ExternalLink>`, `Icon icon="external">`, and `<a target="_blank">` if they should be converted to `<Link type="external"`

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
