### PR TITLE
Avoing string to int comparison and add the id clause only when available

### DIFF
--- a/plugins/woocommerce/changelog/fix-cust_bought_product_query_cache
+++ b/plugins/woocommerce/changelog/fix-cust_bought_product_query_cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Avoid string<>int comparison in products bought query to avoid results with customer_id = 0.

--- a/plugins/woocommerce/includes/wc-user-functions.php
+++ b/plugins/woocommerce/includes/wc-user-functions.php
@@ -362,6 +362,10 @@ function wc_customer_bought_product( $customer_email, $user_id, $product_id ) {
 				$statuses
 			);
 			$order_table = OrdersTableDataStore::get_orders_table_name();
+			$user_id_clause = '';
+			if ( $user_id ) {
+				$user_id_clause = 'OR o.customer_id = ' . absint( $user_id );
+			}
 			$sql = "
 SELECT im.meta_value FROM $order_table AS o
 INNER JOIN {$wpdb->prefix}woocommerce_order_items AS i ON o.id = i.order_id
@@ -369,8 +373,7 @@ INNER JOIN {$wpdb->prefix}woocommerce_order_itemmeta AS im ON i.order_item_id = 
 WHERE o.status IN ('" . implode( "','", $statuses ) . "')
 AND im.meta_key IN ('_product_id', '_variation_id' )
 AND im.meta_value != 0
-AND ( o.customer_id IN ('" . implode( "','", $customer_data ) . "') OR o.billing_email IN ('" . implode( "','", $customer_data ) . "') )
-
+AND ( o.billing_email IN ('" . implode( "','", $customer_data ) . "') $user_id_clause )
 ";
 			$result = $wpdb->get_col( $sql );
 		} else {

--- a/plugins/woocommerce/tests/php/includes/wc-user-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-user-functions-test.php
@@ -51,6 +51,10 @@ class WC_User_Functions_Tests extends WC_Unit_Test_Case {
 		$order_3->set_billing_email( 'test@example.com' );
 		$order_3->set_status( 'pending' );
 		$order_3->save();
+		$order_4 = wc_create_order();
+		$order_4->add_product( $product_1 );
+		$order_4->set_status( 'completed' );
+		$order_4->save();
 
 		$this->assertTrue( wc_customer_bought_product( 'test@example.com', $customer_id_1, $product_id_1 ) );
 		$this->assertTrue( wc_customer_bought_product( '', $customer_id_1, $product_id_1 ) );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes a bug where we were comparing string against an int column, which unfortunately would also include results for orders with customer_id = 0. This is a remnant from post tables where since the meta_value was the string, this comparison was valid. Now we only compare the ID (and not email) against the customer_id column.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Unit tests adequately capture the bug and the fix, however, to test:
1. Set HPOS as authoritative.
2. Create two new products, let's say their IDs are X and Y.
3. Create an order with a guest user with product X. (for example, from checkout).
4. Create a new user, let's say its ID is Z.
5. Create another order with this user, this time with product Y.

Open wp shell, to test usages of `wc_customer_bought_product` function:
```
wc_customer_bought_product( '', Z, Y); // should be true
wc_customer_bought_product( '', Z, X); // should be false
```


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
