### PR TITLE
Fix customize store whitescreen in WP 6.3

### DIFF
--- a/plugins/woocommerce-admin/client/task-lists/setup-task-list/components/task-headers/customize-store.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/setup-task-list/components/task-headers/customize-store.tsx
@@ -4,6 +4,7 @@
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { TaskType } from '@woocommerce/data';
+import { getAdminLink } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -12,7 +13,6 @@ import { WC_ASSET_URL } from '../../../../utils/admin-settings';
 
 const CustomizeStoreHeader = ( {
 	task,
-	goToTask,
 }: {
 	task: TaskType;
 	goToTask: React.MouseEventHandler;
@@ -40,7 +40,12 @@ const CustomizeStoreHeader = ( {
 				<Button
 					isSecondary={ task.isComplete }
 					isPrimary={ ! task.isComplete }
-					onClick={ goToTask }
+					onClick={ () => {
+						// We need to use window.location.href instead of navigateTo because we need to initiate a full page refresh to ensure that all dependencies are loaded.
+						window.location.href = getAdminLink(
+							'admin.php?page=wc-admin&path=%2Fcustomize-store'
+						);
+					} }
 				>
 					{ __( 'Start customizing', 'woocommerce' ) }
 				</Button>

--- a/plugins/woocommerce-admin/webpack.config.js
+++ b/plugins/woocommerce-admin/webpack.config.js
@@ -217,12 +217,6 @@ const webpackConfig = {
 						return null;
 					}
 
-					if ( request === '@wordpress/router' ) {
-						// The external wp.router does not exist in WP 6.2 and below, so we need to skip requesting to external here.
-						// We use the router in the customize store. We can remove this once our minimum support is WP 6.3.
-						return null;
-					}
-
 					if ( request.startsWith( '@wordpress/edit-site' ) ) {
 						// The external wp.editSite does not include edit-site components, so we need to skip requesting to external here. We can remove this once the edit-site components are exported in the external wp.editSite.
 						// We use the edit-site components in the customize store.

--- a/plugins/woocommerce/changelog/fix-cys-task-header-button
+++ b/plugins/woocommerce/changelog/fix-cys-task-header-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix customize your store task header button

--- a/plugins/woocommerce/changelog/fix-cys-wp-6-3-router-bug
+++ b/plugins/woocommerce/changelog/fix-cys-wp-6-3-router-bug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix customize store white screen bug in WP 6.3

--- a/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php
@@ -297,6 +297,13 @@ class WCAdminAssets {
 				$script_assets_filename = self::get_script_asset_filename( $script_path_name, 'index' );
 				$script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . $script_path_name . '/' . $script_assets_filename;
 
+				global $wp_version;
+				if ( 'app' === $script_path_name && version_compare( $wp_version, '6.3', '<' ) ) {
+					// Remove wp-router dependency for WordPress versions < 6.3 because wp-router is not included in those versions. We only use wp-router in customize store pages and the feature is only available in WordPress 6.3+.
+					// We can remove this once our minimum support is WP 6.3.
+					$script_assets['dependencies'] = array_diff( $script_assets['dependencies'], array( 'wp-router' ) );
+				}
+
 				wp_register_script(
 					$script,
 					self::get_url( $script_path_name . '/index', 'js' ),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->


The `__dangerousOptInToUnstableAPIsOnlyForCoreModules` throws an error when a script is [called more than once in the WP Core environment](https://github.com/WordPress/gutenberg/blob/482e28c93b3379781e94e06c123902350289bd38/packages/private-apis/src/implementation.js#L63)(without Gutenberg). This is because after we fixed https://github.com/woocommerce/woocommerce/pull/39995, there were two wp-routers in the environment. This PR better fixes the previous empty page issue so that we don't need to bundle the router into our pluigin..


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**WP 6.3**

1. Use WP 6.3 without Gutenberg plugin
2. Install the `WooCommerce Beta Tester` plugin
3. Go to /wp-admin/tools.php?page=woocommerce-admin-test-helper and enable `customize-store` feature flag
4. Go to `WooCommerce > Home`
5. Click on `Customize your store` task
6. The page should be loaded properly.
7. Click on `Assembler Hub` button
8. You Should see the Assembler Hub screen 

**WP 6.2**

1. Install WP 6.2.2. (or downgrad to WP 6.2.2)
2. Go to any of the WC Admin pages
3. Confirm the pages are loaded properly.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix customize store white screen bug in WP 6.3

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>