### PR TITLE
Fix customize your store task header button

### DIFF
--- a/plugins/woocommerce-admin/client/task-lists/setup-task-list/components/task-headers/customize-store.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/setup-task-list/components/task-headers/customize-store.tsx
@@ -4,6 +4,7 @@
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { TaskType } from '@woocommerce/data';
+import { getAdminLink } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -12,7 +13,6 @@ import { WC_ASSET_URL } from '../../../../utils/admin-settings';
 
 const CustomizeStoreHeader = ( {
 	task,
-	goToTask,
 }: {
 	task: TaskType;
 	goToTask: React.MouseEventHandler;
@@ -40,7 +40,12 @@ const CustomizeStoreHeader = ( {
 				<Button
 					isSecondary={ task.isComplete }
 					isPrimary={ ! task.isComplete }
-					onClick={ goToTask }
+					onClick={ () => {
+						// We need to use window.location.href instead of navigateTo because we need to initiate a full page refresh to ensure that all dependencies are loaded.
+						window.location.href = getAdminLink(
+							'admin.php?page=wc-admin&path=%2Fcustomize-store'
+						);
+					} }
 				>
 					{ __( 'Start customizing', 'woocommerce' ) }
 				</Button>

--- a/plugins/woocommerce/changelog/fix-cys-task-header-button
+++ b/plugins/woocommerce/changelog/fix-cys-task-header-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix customize your store task header button


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #40032.

This PR fixes the customize your store task header button. Previously, it's not working and goes to a blank screen.

![Screenshot 2023-09-05 at 15 51 25](https://github.com/woocommerce/woocommerce/assets/4344253/ae055886-a8e6-465e-a491-91cb8e2e4ceb)


https://github.com/woocommerce/woocommerce/assets/4344253/6362eb4f-cc9f-42ca-b400-845ff5c6278f


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Use WP 6.3
2. Install the `WooCommerce Beta Tester` plugin
3. Go to /wp-admin/tools.php?page=woocommerce-admin-test-helper and enable `customize-store` feature flag
4. Go to `WooCommerce > Home`
5. Click on `Start customizing` in task header
6. Should see the customize your store  screen


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix customize your store task header button

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
