### PR TITLE
Update TaskItem and WooPayments task

### DIFF
--- a/packages/js/data/changelog/update-task-list-item-and-woopayments-task
+++ b/packages/js/data/changelog/update-task-list-item-and-woopayments-task
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update TaskItem type to include `badge` prop.

--- a/packages/js/data/src/onboarding/types.ts
+++ b/packages/js/data/src/onboarding/types.ts
@@ -26,6 +26,7 @@ export type TaskType = {
 	eventPrefix: string;
 	level: number;
 	recordViewEvent: boolean;
+	badge?: string;
 	additionalData?: {
 		woocommerceTaxCountries?: string[];
 		taxJarActivated?: boolean;

--- a/packages/js/experimental/changelog/update-task-list-item-and-woopayments-task
+++ b/packages/js/experimental/changelog/update-task-list-item-and-woopayments-task
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update TaskItem to include a badge next to the title. Update also related components TaskList and SetupTaskList, as well as docs, storybook, and tests.

--- a/packages/js/experimental/src/experimental-list/stories/index.tsx
+++ b/packages/js/experimental/src/experimental-list/stories/index.tsx
@@ -140,6 +140,7 @@ export const TaskItemExample: Story = ( args ) => (
 			}
 			showActionButton={ false }
 			title="A high-priority task without `Primary action`"
+			badge="Badge content"
 		/>
 		<TaskItem
 			action={ () => {} }

--- a/packages/js/experimental/src/experimental-list/style.scss
+++ b/packages/js/experimental/src/experimental-list/style.scss
@@ -117,6 +117,10 @@ a.woocommerce-experimental-list__item {
 			color: $foreground-color-hover;
 		}
 
+		.woocommerce-task-list__item-badge {
+			background-color: $white;
+		}
+
 		.woocommerce-list__item-before > svg {
 			fill: $foreground-color-hover;
 		}

--- a/packages/js/experimental/src/experimental-list/task-item/README.md
+++ b/packages/js/experimental/src/experimental-list/task-item/README.md
@@ -9,6 +9,7 @@ Use `TaskItem` to display a task item.
 	action={ () => alert( '"My action" button has been clicked' ) }
 	actionLabel="My action"
 	additionalInfo="Additional task information"
+	badge="Task badge"
 	completed={ true }
 	content="Task content"
 	expandable={ false }
@@ -33,6 +34,7 @@ Use `TaskItem` to display a task item.
 | `action`           | Function | `null`  | A function to be called when the primary action is triggered |
 | `actionLabel`      | String   | `null`  | Primary action label                                         |
 | `additionalInfo`   | String   | `null`  | Additional task information                                  |
+| `badge`            | String   | `null`  | Task badge to show next to title                             |
 | `completed`        | Boolean  | `null`  | Whether the task is completed or not                         |
 | `content`          | String   | `null`  | Task content                                                 |
 | `expandable`       | Boolean  | `false` | Whether it's an expandable task                              |

--- a/packages/js/experimental/src/experimental-list/task-item/index.tsx
+++ b/packages/js/experimental/src/experimental-list/task-item/index.tsx
@@ -45,6 +45,7 @@ type TaskItemProps = {
 	onDismiss?: () => void;
 	onSnooze?: () => void;
 	onExpand?: () => void;
+	badge?: string;
 	additionalInfo?: string;
 	time?: string;
 	content: string;
@@ -107,6 +108,7 @@ const OptionalExpansionWrapper: React.FC< {
 export const TaskItem: React.FC< TaskItemProps > = ( {
 	completed,
 	title,
+	badge,
 	onDelete,
 	onCollapse,
 	onDismiss,
@@ -185,6 +187,11 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 				>
 					<span className="woocommerce-task-list__item-title">
 						{ title }
+						{ badge && (
+							<span className="woocommerce-task-list__item-badge">
+								{ badge }
+							</span>
+						) }
 					</span>
 					<OptionalExpansionWrapper
 						expandable={ expandable }

--- a/packages/js/experimental/src/experimental-list/task-item/style.scss
+++ b/packages/js/experimental/src/experimental-list/task-item/style.scss
@@ -39,6 +39,20 @@ $task-alert-yellow: #f0b849;
 
 	.woocommerce-task-list__item-title {
 		color: $foreground-color;
+		display: flex;
+		column-gap: $gap-small;
+		row-gap: $gap-smallest;
+		flex-wrap: wrap;
+	}
+
+	.woocommerce-task-list__item-badge {
+		padding: 0 10px;
+		background-color: #f6f7f7;
+		border-radius: 2px;
+		color: $gray-800;
+		font-size: 11px;
+		font-weight: 500;
+		line-height: 20px;
 	}
 
 	.woocommerce-task__additional-info,

--- a/plugins/woocommerce-admin/client/task-lists/components/task-list-item.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/components/task-list-item.tsx
@@ -57,6 +57,7 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 		isSnoozeable,
 		time,
 		title,
+		badge,
 		level,
 		additionalInfo,
 		recordViewEvent,
@@ -174,6 +175,7 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 				<TaskItem
 					key={ id }
 					title={ title }
+					badge={ badge }
 					content={ content }
 					additionalInfo={ additionalInfo }
 					time={ time }
@@ -190,7 +192,16 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 				/>
 			);
 		},
-		[ id, title, content, time, actionLabel, isExpandable, isComplete ]
+		[
+			id,
+			title,
+			badge,
+			content,
+			time,
+			actionLabel,
+			isExpandable,
+			isComplete,
+		]
 	);
 
 	return hasFills ? (

--- a/plugins/woocommerce-admin/client/task-lists/components/test/task-list-item.test.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/components/test/task-list-item.test.tsx
@@ -83,6 +83,7 @@ jest.mock( '@woocommerce/experimental', () => {
 const task: TaskType = {
 	id: 'optional',
 	title: 'This task is optional',
+	badge: 'Optional badge',
 	isComplete: false,
 	time: '1 minute',
 	isDismissable: true,

--- a/plugins/woocommerce-admin/client/task-lists/components/test/task-list.test.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/components/test/task-list.test.tsx
@@ -48,6 +48,7 @@ const tasks: { [ key: string ]: TaskType[] } = {
 		{
 			id: 'optional',
 			title: 'This task is optional',
+			badge: '',
 			isComplete: false,
 			isVisible: true,
 			time: '1 minute',
@@ -70,6 +71,7 @@ const tasks: { [ key: string ]: TaskType[] } = {
 		{
 			id: 'required',
 			title: 'This task is required',
+			badge: '',
 			isComplete: false,
 			isVisible: true,
 			time: '1 minute',
@@ -93,6 +95,7 @@ const tasks: { [ key: string ]: TaskType[] } = {
 		{
 			id: 'completed',
 			title: 'This task is completed',
+			badge: '',
 			isComplete: true,
 			isVisible: true,
 			time: '1 minute',
@@ -117,6 +120,7 @@ const tasks: { [ key: string ]: TaskType[] } = {
 		{
 			id: 'extension',
 			title: 'This task is an extension',
+			badge: '',
 			isComplete: false,
 			isVisible: true,
 			time: '1 minute',

--- a/plugins/woocommerce-admin/client/task-lists/components/test/task.test.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/components/test/task.test.tsx
@@ -11,6 +11,7 @@ import { TaskType } from '@woocommerce/data';
 const task: TaskType = {
 	id: 'optional',
 	title: 'Test',
+	badge: 'Optional badge',
 	isComplete: false,
 	time: '1 minute',
 	isDismissable: true,

--- a/plugins/woocommerce-admin/client/task-lists/setup-task-list/components/task-headers/woocommerce-payments.js
+++ b/plugins/woocommerce-admin/client/task-lists/setup-task-list/components/task-headers/woocommerce-payments.js
@@ -37,7 +37,9 @@ const connect = ( createNotice, setIsBusy ) => {
 };
 
 const WoocommercePaymentsHeader = ( { task, trackClick } ) => {
-	const incentive = getAdminSetting( 'wcpayWelcomePageIncentive' );
+	const incentive =
+		getAdminSetting( 'wcpayWelcomePageIncentive' ) ||
+		window.wcpaySettings?.connectIncentive;
 	const { createNotice } = useDispatch( 'core/notices' );
 	const [ isBusy, setIsBusy ] = useState( false );
 	const onClick = () => {

--- a/plugins/woocommerce-admin/client/task-lists/setup-task-list/components/task-headers/woocommerce-payments.js
+++ b/plugins/woocommerce-admin/client/task-lists/setup-task-list/components/task-headers/woocommerce-payments.js
@@ -14,7 +14,8 @@ import interpolateComponents from '@automattic/interpolate-components';
  * Internal dependencies
  */
 import TimerImage from './timer.svg';
-import { WC_ASSET_URL } from '~/utils/admin-settings';
+import { WC_ASSET_URL, getAdminSetting } from '~/utils/admin-settings';
+import sanitizeHTML from '~/lib/sanitize-html';
 
 const connect = ( createNotice, setIsBusy ) => {
 	const errorMessage = __(
@@ -36,6 +37,7 @@ const connect = ( createNotice, setIsBusy ) => {
 };
 
 const WoocommercePaymentsHeader = ( { task, trackClick } ) => {
+	const incentive = getAdminSetting( 'wcpayWelcomePageIncentive' );
 	const { createNotice } = useDispatch( 'core/notices' );
 	const [ isBusy, setIsBusy ] = useState( false );
 	const onClick = () => {
@@ -54,12 +56,20 @@ const WoocommercePaymentsHeader = ( { task, trackClick } ) => {
 			/>
 			<div className="woocommerce-task-header__contents">
 				<h1>{ __( "It's time to get paid", 'woocommerce' ) }</h1>
-				<p>
-					{ __(
-						"You're only one step away from getting paid. Verify your business details to start managing transactions with WooPayments.",
-						'woocommerce'
-					) }
-				</p>
+				{ incentive?.task_header_content ? (
+					<p
+						dangerouslySetInnerHTML={ sanitizeHTML(
+							incentive.task_header_content
+						) }
+					/>
+				) : (
+					<p>
+						{ __(
+							"You're only one step away from getting paid. Verify your business details to start managing transactions with WooPayments.",
+							'woocommerce'
+						) }
+					</p>
+				) }
 				<p>
 					{ interpolateComponents( {
 						mixedString: __(

--- a/plugins/woocommerce-admin/client/task-lists/setup-task-list/components/task-list-item.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/setup-task-list/components/task-list-item.tsx
@@ -33,6 +33,7 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 	const {
 		id: taskId,
 		title,
+		badge,
 		content,
 		time,
 		actionLabel,
@@ -82,6 +83,7 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 					key={ taskId }
 					className={ className }
 					title={ title }
+					badge={ badge }
 					completed={ isComplete }
 					additionalInfo={ additionalInfo }
 					content={ content }
@@ -99,7 +101,16 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 				/>
 			);
 		},
-		[ taskId, title, content, time, actionLabel, isComplete, activeTaskId ]
+		[
+			taskId,
+			title,
+			badge,
+			content,
+			time,
+			actionLabel,
+			isComplete,
+			activeTaskId,
+		]
 	);
 
 	return hasFills ? (

--- a/plugins/woocommerce-admin/client/task-lists/setup-task-list/style.scss
+++ b/plugins/woocommerce-admin/client/task-lists/setup-task-list/style.scss
@@ -159,6 +159,12 @@
 		li.is-active {
 			box-shadow: inset 0 -4px 0 0 var(--wp-admin-theme-color);
 			transition: box-shadow 0.1s linear;
+
+			.woocommerce-task-list__item-badge {
+				background-color: $white;
+				position: relative;
+				z-index: 1;
+			}
 		}
 
 		li.is-active::after {

--- a/plugins/woocommerce-admin/client/task-lists/setup-task-list/test/setup-task-list.test.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/setup-task-list/test/setup-task-list.test.tsx
@@ -59,6 +59,7 @@ const tasks: { [ key: string ]: TaskType[] } = {
 		{
 			id: 'optional',
 			title: 'This task is optional',
+			badge: '',
 			isComplete: false,
 			isVisible: true,
 			time: '1 minute',
@@ -81,6 +82,7 @@ const tasks: { [ key: string ]: TaskType[] } = {
 		{
 			id: 'required',
 			title: 'This task is required',
+			badge: '',
 			isComplete: false,
 			isVisible: true,
 			time: '1 minute',
@@ -104,6 +106,7 @@ const tasks: { [ key: string ]: TaskType[] } = {
 		{
 			id: 'completed',
 			title: 'This task is completed',
+			badge: '',
 			isComplete: true,
 			isVisible: true,
 			time: '1 minute',
@@ -128,6 +131,7 @@ const tasks: { [ key: string ]: TaskType[] } = {
 		{
 			id: 'extension',
 			title: 'This task is an extension',
+			badge: '',
 			isComplete: false,
 			isVisible: true,
 			time: '1 minute',

--- a/plugins/woocommerce/changelog/update-task-list-item-and-woopayments-task
+++ b/plugins/woocommerce/changelog/update-task-list-item-and-woopayments-task
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Display a custom WooPayments onboarding task header content, when an incentive with server based header is available.

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Task.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Task.php
@@ -178,6 +178,15 @@ abstract class Task {
 	}
 
 	/**
+	 * Badge.
+	 *
+	 * @return string
+	 */
+	public function get_badge() {
+		return '';
+	}
+
+	/**
 	 * Level.
 	 *
 	 * @deprecated 7.2.0
@@ -486,6 +495,7 @@ abstract class Task {
 			'id'              => $this->get_id(),
 			'parentId'        => $this->get_parent_id(),
 			'title'           => $this->get_title(),
+			'badge'           => $this->get_badge(),
 			'canView'         => $this->can_view(),
 			'content'         => $this->get_content(),
 			'additionalInfo'  => $this->get_additional_info(),

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/WooCommercePayments.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/WooCommercePayments.php
@@ -38,6 +38,21 @@ class WooCommercePayments extends Task {
 	}
 
 	/**
+	 * Badge.
+	 *
+	 * @return string
+	 */
+	public function get_badge() {
+		/**
+		 * Filter WooPayments onboarding task badge.
+		 *
+		 * @param string     $badge    Badge content.
+		 * @since 8.2.0
+		 */
+		return apply_filters( 'woocommerce_admin_woopayments_onboarding_task_badge', '' );
+	}
+
+	/**
 	 * Content.
 	 *
 	 * @return string

--- a/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
+++ b/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
@@ -12,7 +12,7 @@ use Automattic\WooCommerce\Admin\PageController;
  * @package Automattic\WooCommerce\Admin\Features
  */
 class WcPayWelcomePage {
-	const CACHE_TRANSIENT_NAME = 'wcpay_welcome_page_incentive';
+	const CACHE_TRANSIENT_NAME  = 'wcpay_welcome_page_incentive';
 	const HAD_WCPAY_OPTION_NAME = 'wcpay_was_in_use';
 
 	/**
@@ -45,6 +45,7 @@ class WcPayWelcomePage {
 		add_action( 'admin_menu', [ $this, 'register_payments_welcome_page' ] );
 		add_filter( 'woocommerce_admin_shared_settings', [ $this, 'shared_settings' ] );
 		add_filter( 'woocommerce_admin_allowed_promo_notes', [ $this, 'allowed_promo_notes' ] );
+		add_filter( 'woocommerce_admin_woopayments_onboarding_task_badge', [ $this, 'onboarding_task_badge' ] );
 	}
 
 	/**
@@ -187,6 +188,20 @@ class WcPayWelcomePage {
 		$promo_notes[] = $this->get_incentive()['id'];
 
 		return $promo_notes;
+	}
+
+	/**
+	 * Adds the WooPayments incentive badge to the onboarding task.
+	 *
+	 * @return string
+	 */
+	public function onboarding_task_badge(): string {
+		// Return early if the incentive must not be visible.
+		if ( ! $this->must_be_visible() ) {
+			return '';
+		}
+
+		return $this->get_incentive()['task_badge'] ?? '';
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
+++ b/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
@@ -193,15 +193,17 @@ class WcPayWelcomePage {
 	/**
 	 * Adds the WooPayments incentive badge to the onboarding task.
 	 *
+	 * @param string $badge Current badge.
+	 *
 	 * @return string
 	 */
-	public function onboarding_task_badge(): string {
+	public function onboarding_task_badge( string $badge ): string {
 		// Return early if the incentive must not be visible.
 		if ( ! $this->must_be_visible() ) {
-			return '';
+			return $badge;
 		}
 
-		return $this->get_incentive()['task_badge'] ?? '';
+		return $this->get_incentive()['task_badge'] ?? $badge;
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:
Related to https://github.com/Automattic/woocommerce-payments/issues/7036

- Display a custom WooPayments onboarding task header content, when an incentive with `task_header_content` is available.
- Update `TaskItem` experimental component to support `badge` prop. Update also related components `TaskList` and `SetupTaskList`, as well as docs, storybook, and tests.
- Add `badge` property to `OnboardingTasks/Task` abstract class.
- Add `woocommerce_admin_woopayments_onboarding_task_badge` to properly update task badge from `WcPayWelcomePage` incentive class.
- Use the filter to display the server based badge if it exists.

### How to test the changes in this Pull Request:

>[!Note]
> Snapshot builds seem to interfear with [this condition](https://github.com/woocommerce/woocommerce/blob/bd1351e265c865de9f632bfb978ebc01c8f9823a/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php#L847-L864), causing it to load generic payments task instead of WooPayments one. You can build WC locally with  `pnpm --filter=woocommerce build:zip`. Or rename the plugin folder to `woocommerce` after installing the snapshot.

- Create a new site with WC from thins PR branch.
- Skip the profiler, and pick a WooPayments supported country (e.g. US).
- Install WooPayments, but don't onboard.
- Payments (1) menu should be visible (action incentive).
- Go to WC Home and complete any WC Home task before `Set up WooPayments` until it becomes the active one.
- `Set up WooPayments` task should have the badge and the new task header, matching the attached screenshot.

### Screenshots

| Before | After |
|-|-|
|<img width="692" alt="Screenshot 2023-09-05 at 10 30 25" src="https://github.com/woocommerce/woocommerce/assets/7670276/7f813fbb-5916-4830-b604-ccd7dd0ada64">|<img width="693" alt="Screenshot 2023-09-05 at 10 24 38" src="https://github.com/woocommerce/woocommerce/assets/7670276/6187674d-a680-4fa2-9021-1910ab04254e">|