### PR TITLE
Add filter woocommerce_hpos_enable_sync_on_read to disable sync on read with HPOS sync enabled.

### DIFF
--- a/plugins/woocommerce/changelog/add-filter-sync-on-read
+++ b/plugins/woocommerce/changelog/add-filter-sync-on-read
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add filter woocommerce_hpos_enable_sync_on_read to disable sync on read with HPOS sync enabled.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1111,6 +1111,18 @@ WHERE
 		}
 
 		$data_sync_enabled = $data_synchronizer->data_sync_is_enabled();
+		if ( $data_sync_enabled ) {
+			/**
+			 * Allow opportunity to disable sync on read, while keeping sync on write disabled. This adds another step as a large shop progresses from full sync to no sync with HPOS authoritative.
+			 * This filter is only executed if data sync is enabled from settings in the first place as it's meant to be a step between full sync -> no sync, rather than be a control for enabling just the read on sync. Sync on read without sync on write is problematic as any update will reset on the next read, but sync on write without sync on read is fine.
+			 *
+			 * @param bool $read_on_sync_enabled Whether to sync on read.
+			 *
+			 * @since 8.1.0
+			 */
+			$data_sync_enabled = apply_filters( 'woocommerce_hpos_enable_sync_on_read', $data_sync_enabled );
+		}
+
 		$load_posts_for    = array_diff( $order_ids, array_merge( self::$reading_order_ids, self::$backfilling_order_ids ) );
 		$post_orders       = $data_sync_enabled ? $this->get_post_orders_for_ids( array_intersect_key( $orders, array_flip( $load_posts_for ) ) ) : array();
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -1113,8 +1113,8 @@ WHERE
 		$data_sync_enabled = $data_synchronizer->data_sync_is_enabled();
 		if ( $data_sync_enabled ) {
 			/**
-			 * Allow opportunity to disable sync on read, while keeping sync on write disabled. This adds another step as a large shop progresses from full sync to no sync with HPOS authoritative.
-			 * This filter is only executed if data sync is enabled from settings in the first place as it's meant to be a step between full sync -> no sync, rather than be a control for enabling just the read on sync. Sync on read without sync on write is problematic as any update will reset on the next read, but sync on write without sync on read is fine.
+			 * Allow opportunity to disable sync on read, while keeping sync on write enabled. This adds another step as a large shop progresses from full sync to no sync with HPOS authoritative.
+			 * This filter is only executed if data sync is enabled from settings in the first place as it's meant to be a step between full sync -> no sync, rather than be a control for enabling just the sync on read. Sync on read without sync on write is problematic as any update will reset on the next read, but sync on write without sync on read is fine.
 			 *
 			 * @param bool $read_on_sync_enabled Whether to sync on read.
 			 *


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Allow opportunity to disable sync on read, while keeping sync on write disabled. This adds another step as a large shop progresses from full sync to no sync with HPOS authoritative.

This filter is only executed if data sync is enabled from settings in the first place as it's meant to be a step between full sync -> no sync, rather than a control for enabling just the read-on sync. Sync on read without sync on write is problematic as any update will reset on the next read, but sync on write without sync on read is fine.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set HPOS to authoritative and sync to on.
2. Add the following code snippet:
```
add_filter( 'woocommerce_hpos_enable_sync_on_read', '__return_false' );
```
3. Open WP shell, using the command `wp shell` and run the following:
```
// Create an order for our testing
$order = wc_create_order();

// Let's bypass order CRUD and add a  postmeta directly.
add_post_meta( $order->get_id(), 'test_key', 'test_value' );

// Refresh the order and test that meta is not set.
$r_order = wc_get_order( $order->get_id() );

// Should be emtpy
$r_order->get_meta( 'test_key' ); 
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
