### PR TITLE
Show sale price and list price in each variation row when the variation is on sale

### DIFF
--- a/packages/js/product-editor/changelog/add-40044
+++ b/packages/js/product-editor/changelog/add-40044
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Show sale price and list price in each variation row when the variation is on sale

--- a/packages/js/product-editor/src/components/variations-table/styles.scss
+++ b/packages/js/product-editor/src/components/variations-table/styles.scss
@@ -48,6 +48,18 @@ $table-row-height: calc($grid-unit * 9);
 		}
 	}
 
+	&__price {
+		text-align: right;
+		padding-right: $grid-unit-40;
+	}
+
+	&__regular-price--on-sale {
+		text-decoration: line-through;
+		color: $gray-600;
+		margin-left: 6px;
+		word-wrap: normal;
+	}
+
 	&__status-dot {
 		margin-right: $gap-smaller;
 		&.green {

--- a/packages/js/product-editor/src/components/variations-table/variations-table.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variations-table.tsx
@@ -378,7 +378,22 @@ export function VariationsTable() {
 								}
 							) }
 						>
-							{ formatAmount( variation.price ) }
+							{ variation.on_sale && (
+								<span className="woocommerce-product-variations__sale-price">
+									{ formatAmount( variation.sale_price ) }
+								</span>
+							) }
+							<span
+								className={ classnames(
+									'woocommerce-product-variations__regular-price',
+									{
+										'woocommerce-product-variations__regular-price--on-sale':
+											variation.on_sale,
+									}
+								) }
+							>
+								{ formatAmount( variation.regular_price ) }
+							</span>
 						</div>
 						<div
 							className={ classnames(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #40044

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure feature `product-variation-management` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper`
3. Go to `/wp-admin/admin.php?page=wc-admin&path=/add-product&tab=variations` and click `Add variation options` button from the `Variations` tab
4. Add many Variation attributes and at least one value. Then click `Add` button from the `Add variation options` modal.
5. Wait until the variations are generated
6. A list a variation should be shown depending on the options selected
7. In the Variations table add list price and sale price to any variation using the quick action menu to the right of each row
8. Once both prices are set, their values should render like follow within the variation row 
<img width="651" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/8b62f2e6-ca92-4277-8e59-b0fef121af4b">

9. The list price should be line through and light gray and both aligned to the right of the column

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
