### PR TITLE
Order confirmation page: tweak verification logic

### DIFF
--- a/plugins/woocommerce/changelog/fix-verify-email-checks
+++ b/plugins/woocommerce/changelog/fix-verify-email-checks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Make it easier to disable email verification checks for the order confirmation and order pay pages.

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -387,12 +387,6 @@ class WC_Shortcode_Checkout {
 			return false;
 		}
 
-		$email = filter_input( INPUT_POST, 'email' );
-		$nonce = filter_input( INPUT_POST, 'check_submission' );
-		if ( $email && ! wp_verify_nonce( $nonce, 'wc_verify_email' ) ) {
-			return true;
-		}
-
 		/**
 		 * Controls the grace period within which we do not require any sort of email verification step before rendering
 		 * the 'order received' or 'order pay' pages.
@@ -426,11 +420,12 @@ class WC_Shortcode_Checkout {
 			$session_email = is_array( $customer ) && isset( $customer['email'] ) ? $customer['email'] : '';
 		}
 
-		$session_email_match  = $session_email === $order->get_billing_email();
-		$supplied_email_match = isset( $_POST['email'] ) && sanitize_email( wp_unslash( $_POST['email'] ) ?? '' ) === $order->get_billing_email();
+		// Email verification is required if the user cannot be identified, or if they supplied an email address but the nonce check failed.
 		$can_view_orders      = current_user_can( 'read_private_shop_orders' );
+		$session_email_match  = $session_email === $order->get_billing_email();
+		$supplied_email_match = sanitize_email( wp_unslash( filter_input( INPUT_POST, 'email' ) ) ) === $order->get_billing_email()
+			&& wp_verify_nonce( filter_input( INPUT_POST, 'check_submission' ), 'wc_verify_email' );
 
-		// If we cannot match the order with the current user, the user should verify their email address.
 		$email_verification_required = ! $session_email_match && ! $supplied_email_match && ! $can_view_orders;
 
 		/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We recently added some protections to reduce the risk of unauthorized access to the following pages:

- The order received page (example URL: `/checkout/order-received/1234/?key=abc123`)
- The order payment page (example URL: `/checkout/order-pay/1234/?key=abc123`)

The basic principle is that if the user is not known (they are not logged in, or there is no active user session, or else we have one of those things but the referenced user does not match the customer associated with the order) then we may ask them to verify their email address before proceeding.

This may not be desirable for all merchants, or for all integrations, so we also added filter hook `woocommerce_order_email_verification_required` which was intended to provide a means of removing this verification step, via a snippet looking something like this:

```php
add_filter( 'woocommerce_order_email_verification_required', '__return_false' );
```

Based on reports in the linked issue, it seems this does not always work. On review, we were able to identify cases where the presence of certain post data fields could indeed make it so this filter is not invoked. **Specifically, the nonce check could inadvertently short-circuit things.** This PR addresses those scenarios.

Updates #39750 (but does not close, as other changes may be required).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

> 💡 In the following instructions I refer to opening a new browser context. This could mean opening a new container (Firefox) or a new private/incognito window (most other browsers) **or** a completely different browser.
>
> The important thing is that no cookies or other browser session data should be brought across. If you experience problems with the testing instructions in relation to this, please also consider explicitly clearing cookies ([Chrome](https://support.google.com/chrome/answer/95647?hl=en&co=GENIE.Platform=Desktop), [Firefox](https://support.mozilla.org/en-US/kb/clear-cookies-and-site-data-firefox)) after opening the new browsing context.

**Part 1: ensure the verification step still functions**

Start by setting up a store with some products and a standard/simple gateway (such as Direct Bank Transfer).

1. Acting as a (guest) shopper, purchase an item from the storefront.
2. After successfully checking out, you should see the order received page. Copy the URL.
3. Re-open the same page from a new browser context.
4. Assuming you run through these steps promptly (within 10 minutes of the order being placed), you should again see the order confirmation page.
5. Now simulate a scenario where more than 10 minutes have passed. You can do this by adding a snippet like the one shared below, which you should also leave in place for the following scenarios, to a suitable location (such as `mu-plugins/test-39750.php`):

```php
add_filter( 'woocommerce_order_email_verification_grace_period', '__return_zero' );
```

7. Refresh the tab (the one you opened in a different browser context).
8. You should now be asked to verify the email address used when the order was placed.
9. If you supply the wrong email address, or try to submit the form without an email address, you should not see the order confirmation page.
10. If you supply the correct email address, you should now see the order confirmation page.

**Part 2: confirm nonce protection still works**

1. Use the order confirmation page URL from the previous test.
2. Open in another browser context, so that you are again presented with the email verification form.
3. Try removing the nonce field, which you can do by entering the following JS in your browser console:

```js
document.querySelector( 'form.woocommerce-verify-email input[name="check_submission"]' ).remove()
```

4. Even if you supply the correct email address, you should not be taken to the order confirmation page.
5. Repeat, but this time change the nonce value (and, again, you should not be taken to the order confirmation page even if you supply the correct email address):

```js
document.querySelector( 'form.woocommerce-verify-email input[name="check_submission"]' ).value = 'invalid!'
```

**Part 3: ensure the check can be turned off**

1. Use the order confirmation page URL from the previous test. Add another snippet:

```php
add_filter( 'woocommerce_order_email_verification_required', '__return_false' );
```

2. Open in another browser context.
3. This time, you should go straight to the order received page (no email verification step).

Let's do a further variation of this test, simulating conditions from the reports in the linked issue. Start by creating a new page with a custom HTML block, looking something like the following ... except, the form action should be your actual order confirmation page URL:

```html
<form method="post" action="https://lab.wordpress/checkout/order-received/1234/?key=abc123">
    <input type="hidden" name="email" value="some.non.empty@string" />
    <button>Submit</button>
</form>
```

1. Publish and visit the page (from the same browser context as in the last steps).
2. You should be taken to the order received page (no email verification step). **This is a change from what you would see with the current stable release.**

**Part 4: re-test with the order payment page**

✍🏼 The same snippets you added earlier should **still be in place** at this stage.

1. As a shop manager or administrator, visit the order editor for the newly created order.
2. Change the order status to **pending payment** and save.
3. Capture the **customer payment page** URL that you should now see, and then update the form action URL from the earlier test.
4. In a new browser context, visit the form and click Submit.
5. You should be taken to the order payment page, without any email verification step.
6. **Remove** the following code snippet:

```php
add_filter( 'woocommerce_order_email_verification_required', '__return_false' );
```

7. Repeat the test, and you should be asked to verify the email address before seeing the order payment page.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
