### PR TITLE
add: made look and tone ai api call more robust

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/actions.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/actions.ts
@@ -9,19 +9,19 @@ import { assign } from 'xstate';
 import {
 	designWithAiStateMachineContext,
 	designWithAiStateMachineEvents,
-	completionAPIResponse,
 } from './types';
 import {
 	businessInfoDescriptionCompleteEvent,
 	lookAndFeelCompleteEvent,
 	toneOfVoiceCompleteEvent,
 } from './pages';
+import { LookAndToneCompletionResponse } from './services';
 
 const assignBusinessInfoDescription = assign<
 	designWithAiStateMachineContext,
 	designWithAiStateMachineEvents
 >( {
-	businessInfoDescription: ( context, event: unknown ) => {
+	businessInfoDescription: ( _context, event: unknown ) => {
 		return {
 			descriptionText: ( event as businessInfoDescriptionCompleteEvent )
 				.payload,
@@ -33,7 +33,7 @@ const assignLookAndFeel = assign<
 	designWithAiStateMachineContext,
 	designWithAiStateMachineEvents
 >( {
-	lookAndFeel: ( context, event: unknown ) => {
+	lookAndFeel: ( _context, event: unknown ) => {
 		return {
 			choice: ( event as lookAndFeelCompleteEvent ).payload,
 		};
@@ -44,7 +44,7 @@ const assignToneOfVoice = assign<
 	designWithAiStateMachineContext,
 	designWithAiStateMachineEvents
 >( {
-	toneOfVoice: ( context, event: unknown ) => {
+	toneOfVoice: ( _context, event: unknown ) => {
 		return {
 			choice: ( event as toneOfVoiceCompleteEvent ).payload,
 		};
@@ -55,14 +55,16 @@ const assignLookAndTone = assign<
 	designWithAiStateMachineContext,
 	designWithAiStateMachineEvents
 >( {
-	lookAndFeel: ( context, event: unknown ) => {
+	lookAndFeel: ( _context, event: unknown ) => {
 		return {
-			choice: ( event as { data: completionAPIResponse } ).data.look,
+			choice: ( event as { data: LookAndToneCompletionResponse } ).data
+				.look,
 		};
 	},
-	toneOfVoice: ( context, event: unknown ) => {
+	toneOfVoice: ( _context, event: unknown ) => {
 		return {
-			choice: ( event as { data: completionAPIResponse } ).data.tone,
+			choice: ( event as { data: LookAndToneCompletionResponse } ).data
+				.tone,
 		};
 	},
 } );

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/pages/LookAndFeel.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/pages/LookAndFeel.tsx
@@ -9,14 +9,14 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { designWithAiStateMachineContext } from '../types';
+import { Look, designWithAiStateMachineContext } from '../types';
 import { Choice } from '../components/choice/choice';
 import { CloseButton } from '../components/close-button/close-button';
 import { aiWizardClosedBeforeCompletionEvent } from '../events';
 
 export type lookAndFeelCompleteEvent = {
 	type: 'LOOK_AND_FEEL_COMPLETE';
-	payload: string;
+	payload: Look;
 };
 
 export const LookAndFeel = ( {
@@ -31,6 +31,7 @@ export const LookAndFeel = ( {
 	const choices = [
 		{
 			title: __( 'Contemporary', 'woocommerce' ),
+			key: 'Contemporary' as const,
 			subtitle: __(
 				'Clean lines, neutral colors, sleek and modern look',
 				'woocommerce'
@@ -38,6 +39,7 @@ export const LookAndFeel = ( {
 		},
 		{
 			title: __( 'Classic', 'woocommerce' ),
+			key: 'Classic' as const,
 			subtitle: __(
 				'Elegant and timeless look with nostalgic touch.',
 				'woocommerce'
@@ -45,15 +47,16 @@ export const LookAndFeel = ( {
 		},
 		{
 			title: __( 'Bold', 'woocommerce' ),
+			key: 'Bold' as const,
 			subtitle: __(
 				'Vibrant look with eye-catching colors and visuals.',
 				'woocommerce'
 			),
 		},
 	];
-	const [ look, setLook ] = useState< string >(
+	const [ look, setLook ] = useState< Look >(
 		context.lookAndFeel.choice === ''
-			? choices[ 0 ].title
+			? choices[ 0 ].key
 			: context.lookAndFeel.choice
 	);
 	return (
@@ -80,17 +83,17 @@ export const LookAndFeel = ( {
 						) }
 					</h1>
 					<div className="choices">
-						{ choices.map( ( { title, subtitle } ) => {
+						{ choices.map( ( { title, subtitle, key } ) => {
 							return (
 								<Choice
-									key={ title }
+									key={ key }
 									name="user-profile-choice"
 									title={ title }
 									subtitle={ subtitle }
-									selected={ look === title }
-									value={ title }
-									onChange={ ( _title ) => {
-										setLook( _title );
+									selected={ look === key }
+									value={ key }
+									onChange={ ( _key ) => {
+										setLook( _key as Look );
 									} }
 								/>
 							);

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/pages/ToneOfVoice.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/pages/ToneOfVoice.tsx
@@ -9,14 +9,14 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { designWithAiStateMachineContext } from '../types';
+import { Tone, designWithAiStateMachineContext } from '../types';
 import { Choice } from '../components/choice/choice';
 import { CloseButton } from '../components/close-button/close-button';
 import { aiWizardClosedBeforeCompletionEvent } from '../events';
 
 export type toneOfVoiceCompleteEvent = {
 	type: 'TONE_OF_VOICE_COMPLETE';
-	payload: string;
+	payload: Tone;
 };
 
 export const ToneOfVoice = ( {
@@ -31,6 +31,7 @@ export const ToneOfVoice = ( {
 	const choices = [
 		{
 			title: __( 'Informal', 'woocommerce' ),
+			key: 'Informal' as const,
 			subtitle: __(
 				'Relaxed and friendly, like a conversation with a friend.',
 				'woocommerce'
@@ -38,6 +39,7 @@ export const ToneOfVoice = ( {
 		},
 		{
 			title: __( 'Neutral', 'woocommerce' ),
+			key: 'Neutral' as const,
 			subtitle: __(
 				'Impartial tone with casual expressions without slang.',
 				'woocommerce'
@@ -45,15 +47,16 @@ export const ToneOfVoice = ( {
 		},
 		{
 			title: __( 'Formal', 'woocommerce' ),
+			key: 'Formal' as const,
 			subtitle: __(
 				'Direct yet respectful, serious and professional.',
 				'woocommerce'
 			),
 		},
 	];
-	const [ sound, setSound ] = useState< string >(
+	const [ sound, setSound ] = useState< Tone >(
 		context.toneOfVoice.choice === ''
-			? choices[ 0 ].title
+			? choices[ 0 ].key
 			: context.toneOfVoice.choice
 	);
 	return (
@@ -77,7 +80,7 @@ export const ToneOfVoice = ( {
 						{ __( 'How would you like to sound?', 'woocommerce' ) }
 					</h1>
 					<div className="choices">
-						{ choices.map( ( { title, subtitle } ) => {
+						{ choices.map( ( { title, subtitle, key } ) => {
 							return (
 								<Choice
 									key={ title }
@@ -85,9 +88,9 @@ export const ToneOfVoice = ( {
 									title={ title }
 									subtitle={ subtitle }
 									selected={ sound === title }
-									value={ title }
-									onChange={ ( _title ) => {
-										setSound( _title );
+									value={ key }
+									onChange={ ( _key ) => {
+										setSound( _key as Tone );
 									} }
 								/>
 							);

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/pages/ToneOfVoice.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/pages/ToneOfVoice.tsx
@@ -83,11 +83,11 @@ export const ToneOfVoice = ( {
 						{ choices.map( ( { title, subtitle, key } ) => {
 							return (
 								<Choice
-									key={ title }
+									key={ key }
 									name="user-profile-choice"
 									title={ title }
 									subtitle={ subtitle }
-									selected={ sound === title }
+									selected={ sound === key }
 									value={ key }
 									onChange={ ( _key ) => {
 										setSound( _key as Tone );

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/services.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/services.ts
@@ -69,8 +69,10 @@ export const getLookAndTone = async (
 	const prompt = [
 		'You are a WordPress theme expert.',
 		'Analyze the following store description and determine the look and tone of the theme.',
-		'For look, you can choose between Contemporary, Classic, and Bold.',
-		'For tone of the description, you can choose between Informal, Neutral, and Formal.',
+		`For look, you can choose between ${ VALID_LOOKS.join( ',' ) }.`,
+		`For tone of the description, you can choose between ${ VALID_TONES.join(
+			','
+		) }.`,
 		'Your response should be in json with look and tone values.',
 		'\n',
 		context.businessInfoDescription.descriptionText,

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/state-machine.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/state-machine.tsx
@@ -30,7 +30,6 @@ export const designWithAiStateMachineDefinition = createMachine(
 		context: {
 			businessInfoDescription: {
 				descriptionText: '',
-				isMakignRequest: false,
 			},
 
 			lookAndFeel: {
@@ -58,10 +57,7 @@ export const designWithAiStateMachineDefinition = createMachine(
 						},
 						on: {
 							BUSINESS_INFO_DESCRIPTION_COMPLETE: {
-								actions: [
-									'assignBusinessInfoDescription',
-									'assignAIAPIRequestStarted',
-								],
+								actions: [ 'assignBusinessInfoDescription' ],
 								target: 'postBusinessInfoDescription',
 							},
 						},
@@ -70,17 +66,11 @@ export const designWithAiStateMachineDefinition = createMachine(
 						invoke: {
 							src: 'getLookAndTone',
 							onError: {
-								actions: [
-									'assignAIAPIRequestFinished',
-									'logAIAPIRequestError',
-								],
+								actions: [ 'logAIAPIRequestError' ],
 								target: '#lookAndFeel',
 							},
 							onDone: {
-								actions: [
-									'assignAIAPIRequestFinished',
-									'assignLookAndTone',
-								],
+								actions: [ 'assignLookAndTone' ],
 								target: '#lookAndFeel',
 							},
 						},

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/tests/services.test.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/tests/services.test.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { recordEvent } from '@woocommerce/tracks'; // Replace 'eventModule' with the actual module where recordEvent is defined
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/tests/services.test.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/tests/services.test.ts
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+import { recordEvent } from '@woocommerce/tracks'; // Replace 'eventModule' with the actual module where recordEvent is defined
+
+/**
+ * Internal dependencies
+ */
+import {
+	parseLookAndToneCompletionResponse,
+	LookAndToneCompletionResponse,
+} from '../services';
+
+jest.mock( '@woocommerce/tracks', () => ( {
+	recordEvent: jest.fn(),
+} ) );
+
+describe( 'parseLookAndToneCompletionResponse', () => {
+	beforeEach( () => {
+		( recordEvent as jest.Mock ).mockClear();
+	} );
+
+	it( 'should return a valid object when given valid JSON', () => {
+		const validObj = {
+			completion: '{"look": "Contemporary", "tone": "Neutral"}',
+		};
+		const result = parseLookAndToneCompletionResponse( validObj );
+		const expected: LookAndToneCompletionResponse = {
+			look: 'Contemporary',
+			tone: 'Neutral',
+		};
+		expect( result ).toEqual( expected );
+		expect( recordEvent ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should throw an error and record an event for JSON parse error', () => {
+		const invalidObj = { completion: 'invalid JSON' };
+		expect( () =>
+			parseLookAndToneCompletionResponse( invalidObj )
+		).toThrow( 'Could not parse Look and Tone completion response.' );
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'customize_your_store_look_and_tone_ai_completion_response_error',
+			{
+				error_type: 'json_parse_error',
+				response: JSON.stringify( invalidObj ),
+			}
+		);
+	} );
+
+	it( 'should throw an error and record an event for valid JSON but invalid values', () => {
+		const invalidValuesObj = {
+			completion: '{"look": "Invalid", "tone": "Invalid"}',
+		};
+		expect( () =>
+			parseLookAndToneCompletionResponse( invalidValuesObj )
+		).toThrow( 'Could not parse Look and Tone completion response.' );
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'customize_your_store_look_and_tone_ai_completion_response_error',
+			{
+				error_type: 'valid_json_invalid_values',
+				response: JSON.stringify( invalidValuesObj ),
+			}
+		);
+	} );
+} );

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/types.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/types.ts
@@ -4,10 +4,10 @@ export type designWithAiStateMachineContext = {
 		isMakignRequest?: boolean;
 	};
 	lookAndFeel: {
-		choice: string;
+		choice: Look | '';
 	};
 	toneOfVoice: {
-		choice: string;
+		choice: Tone | '';
 	};
 	// If we require more data from options, previously provided core profiler details,
 	// we can retrieve them in preBusinessInfoDescription and then assign them here
@@ -35,3 +35,8 @@ export type completionAPIResponse = {
 	look: string;
 	tone: string;
 };
+
+export const VALID_LOOKS = [ 'Contemporary', 'Classic', 'Bold' ] as const;
+export const VALID_TONES = [ 'Informal', 'Neutral', 'Formal' ] as const;
+export type Look = ( typeof VALID_LOOKS )[ number ];
+export type Tone = ( typeof VALID_TONES )[ number ];

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/types.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/types.ts
@@ -1,7 +1,6 @@
 export type designWithAiStateMachineContext = {
 	businessInfoDescription: {
 		descriptionText: string;
-		isMakignRequest?: boolean;
 	};
 	lookAndFeel: {
 		choice: Look | '';
@@ -30,11 +29,6 @@ export type designWithAiStateMachineEvents =
 	| {
 			type: 'API_CALL_TO_AI_FAILED';
 	  };
-
-export type completionAPIResponse = {
-	look: string;
-	tone: string;
-};
 
 export const VALID_LOOKS = [ 'Contemporary', 'Classic', 'Bold' ] as const;
 export const VALID_TONES = [ 'Informal', 'Neutral', 'Formal' ] as const;

--- a/plugins/woocommerce/changelog/add-look-and-tone-api
+++ b/plugins/woocommerce/changelog/add-look-and-tone-api
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Made ai completion for look and tone more robust and added tracks


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

As mentioned in https://github.com/woocommerce/team-ghidorah/issues/261, there's a chance of exceeding the HTTP specs when appending the JWT and prompt + user input to the URL search params.

This PR moves it into the POST body of the API call thus mitigating the mentioned issues.

This PR also makes the handling of the response more robust, by asserting that the AI's response makes sense and recording a tracks event if it doesn't.

Closes https://github.com/woocommerce/team-ghidorah/issues/261.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

This feature is part of the larger customize your store development and behind a feature flag, hence QA review can be deferred until the call for testing before release.

Make sure you are testing this with a Jetpack connected instance of WooCommerce, as the AI text completion endpoint can only be called with a Jetpack connected account.

1. Create a new WooCommerce installation with this version.
2. Make sure to enable `customize-store` feature flag
3. Go to `WooCommerce -> Home` and click `Customize Store` task
4. Click `Design with AI` button
5. Test that the AI text suggestion feature works (the choices should be correctly highlighted in the next two pages), some examples of known answer/response pairings:

"test" -> Contemporary + Neutral
"we sell old timey antique furniture" -> Classic + Informal
"we sell bold cartoony art pieces" -> Bold + Informal

6. Might be worth testing with languages other than english, although I believe the release plan indicates that we won't be supporting non-english locales for now. Cursory testing shows that it worked ok....
7. I don't really know how to get the AI to send an invalid response, please share if you do! However, the test cases should provide some assurance that the tracks event will be sent when invalid responses happen.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
