### PR TITLE
add: url navigation to cys

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/index.tsx
@@ -97,28 +97,28 @@ function SidebarScreens() {
 	useSyncPathWithURL();
 	return (
 		<>
-			<NavigatorScreen path="/customize-store">
+			<NavigatorScreen path="/customize-store/assembler-hub">
 				<SidebarNavigationScreenMain />
 			</NavigatorScreen>
-			<NavigatorScreen path="/customize-store/color-palette">
+			<NavigatorScreen path="/customize-store/assembler-hub/color-palette">
 				<SidebarNavigationScreenColorPalette />
 			</NavigatorScreen>
-			<NavigatorScreen path="/customize-store/typography">
+			<NavigatorScreen path="/customize-store/assembler-hub/typography">
 				<SidebarNavigationScreenTypography />
 			</NavigatorScreen>
-			<NavigatorScreen path="/customize-store/header">
+			<NavigatorScreen path="/customize-store/assembler-hub/header">
 				<SidebarNavigationScreenHeader />
 			</NavigatorScreen>
-			<NavigatorScreen path="/customize-store/homepage">
+			<NavigatorScreen path="/customize-store/assembler-hub/homepage">
 				<SidebarNavigationScreenHomepage />
 			</NavigatorScreen>
-			<NavigatorScreen path="/customize-store/footer">
+			<NavigatorScreen path="/customize-store/assembler-hub/footer">
 				<SidebarNavigationScreenFooter />
 			</NavigatorScreen>
-			<NavigatorScreen path="/customize-store/pages">
+			<NavigatorScreen path="/customize-store/assembler-hub/pages">
 				<SidebarNavigationScreenPages />
 			</NavigatorScreen>
-			<NavigatorScreen path="/customize-store/logo">
+			<NavigatorScreen path="/customize-store/assembler-hub/logo">
 				<SidebarNavigationScreenLogo />
 			</NavigatorScreen>
 		</>
@@ -126,13 +126,11 @@ function SidebarScreens() {
 }
 
 function Sidebar() {
-	const { params: urlParams } = useLocation();
-	const initialPath = useRef( urlParams.path ?? '/customize-store' );
 	return (
 		<>
 			<NavigatorProvider
 				className="edit-site-sidebar__content"
-				initialPath={ initialPath.current }
+				initialPath={ '/customize-store/assembler-hub' }
 			>
 				<SidebarScreens />
 			</NavigatorProvider>

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/save-hub.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/save-hub.tsx
@@ -5,7 +5,7 @@
  * External dependencies
  */
 import { useContext, useEffect } from '@wordpress/element';
-
+import { useQuery } from '@woocommerce/navigation';
 import { useSelect, useDispatch } from '@wordpress/data';
 // @ts-ignore No types for this exist yet.
 import { Button, __experimentalHStack as HStack } from '@wordpress/components';
@@ -14,13 +14,8 @@ import { __ } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 // @ts-ignore No types for this exist yet.
 import { store as blockEditorStore } from '@wordpress/block-editor';
-
-// @ts-ignore No types for this exist yet.
-import { privateApis as routerPrivateApis } from '@wordpress/router';
 // @ts-ignore No types for this exist yet.
 import { store as noticesStore } from '@wordpress/notices';
-// @ts-ignore No types for this exist yet.
-import { unlock } from '@wordpress/edit-site/build-module/lock-unlock';
 // @ts-ignore No types for this exist yet.
 import { useEntitiesSavedStatesIsDirty as useIsDirty } from '@wordpress/editor';
 
@@ -28,8 +23,6 @@ import { useEntitiesSavedStatesIsDirty as useIsDirty } from '@wordpress/editor';
  * Internal dependencies
  */
 import { CustomizeStoreContext } from '../';
-
-const { useLocation } = unlock( routerPrivateApis );
 
 const PUBLISH_ON_SAVE_ENTITIES = [
 	{
@@ -40,7 +33,7 @@ const PUBLISH_ON_SAVE_ENTITIES = [
 
 export const SaveHub = () => {
 	const saveNoticeId = 'site-edit-save-notice';
-	const { params } = useLocation();
+	const urlParams = useQuery();
 	const { sendEvent } = useContext( CustomizeStoreContext );
 
 	// @ts-ignore No types for this exist yet.
@@ -127,7 +120,7 @@ export const SaveHub = () => {
 		} );
 		// Only run when path changes.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ params.path ] );
+	}, [ urlParams.path ] );
 
 	const save = async () => {
 		removeNotice( saveNoticeId );
@@ -168,7 +161,7 @@ export const SaveHub = () => {
 	};
 
 	const renderButton = () => {
-		if ( params.path === '/customize-store' ) {
+		if ( urlParams.path === '/customize-store/assembler-hub' ) {
 			return (
 				<Button
 					variant="primary"

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-main.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-main.tsx
@@ -61,7 +61,7 @@ export const SidebarNavigationScreenMain = () => {
 					<ItemGroup>
 						<NavigatorButton
 							as={ SidebarNavigationItem }
-							path="/customize-store/logo"
+							path="/customize-store/assembler-hub/logo"
 							withChevron
 							icon={ siteLogo }
 						>
@@ -69,7 +69,7 @@ export const SidebarNavigationScreenMain = () => {
 						</NavigatorButton>
 						<NavigatorButton
 							as={ SidebarNavigationItem }
-							path="/customize-store/color-palette"
+							path="/customize-store/assembler-hub/color-palette"
 							withChevron
 							icon={ color }
 						>
@@ -77,7 +77,7 @@ export const SidebarNavigationScreenMain = () => {
 						</NavigatorButton>
 						<NavigatorButton
 							as={ SidebarNavigationItem }
-							path="/customize-store/typography"
+							path="/customize-store/assembler-hub/typography"
 							withChevron
 							icon={ typography }
 						>
@@ -92,7 +92,7 @@ export const SidebarNavigationScreenMain = () => {
 					<ItemGroup>
 						<NavigatorButton
 							as={ SidebarNavigationItem }
-							path="/customize-store/header"
+							path="/customize-store/assembler-hub/header"
 							withChevron
 							icon={ header }
 						>
@@ -100,7 +100,7 @@ export const SidebarNavigationScreenMain = () => {
 						</NavigatorButton>
 						<NavigatorButton
 							as={ SidebarNavigationItem }
-							path="/customize-store/homepage"
+							path="/customize-store/assembler-hub/homepage"
 							withChevron
 							icon={ home }
 						>
@@ -108,7 +108,7 @@ export const SidebarNavigationScreenMain = () => {
 						</NavigatorButton>
 						<NavigatorButton
 							as={ SidebarNavigationItem }
-							path="/customize-store/footer"
+							path="/customize-store/assembler-hub/footer"
 							withChevron
 							icon={ footer }
 						>
@@ -116,7 +116,7 @@ export const SidebarNavigationScreenMain = () => {
 						</NavigatorButton>
 						<NavigatorButton
 							as={ SidebarNavigationItem }
-							path="/customize-store/pages"
+							path="/customize-store/assembler-hub/pages"
 							withChevron
 							icon={ pages }
 						>

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/actions.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/actions.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { assign } from 'xstate';
+import { getQuery, updateQueryString } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -75,10 +76,34 @@ const logAIAPIRequestError = () => {
 	console.log( 'API Request error' );
 };
 
+const updateQueryStep = (
+	_context: unknown,
+	_evt: unknown,
+	{ action }: { action: unknown }
+) => {
+	const { path } = getQuery() as { path: string };
+	const step = ( action as { step: string } ).step;
+	const pathFragments = path.split( '/' ); // [0] '', [1] 'customize-store', [2] cys step slug [3] design-with-ai step slug
+	if (
+		pathFragments[ 1 ] === 'customize-store' &&
+		pathFragments[ 2 ] === 'design-with-ai'
+	) {
+		if ( pathFragments[ 3 ] !== step ) {
+			// this state machine is only concerned with [2], so we ignore changes to [3]
+			// [1] is handled by router at root of wc-admin
+			updateQueryString(
+				{},
+				`/customize-store/design-with-ai/${ step }`
+			);
+		}
+	}
+};
+
 export const actions = {
 	assignBusinessInfoDescription,
 	assignLookAndFeel,
 	assignToneOfVoice,
 	assignLookAndTone,
 	logAIAPIRequestError,
+	updateQueryStep,
 };

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/services.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/services.ts
@@ -4,6 +4,7 @@
 import { __experimentalRequestJetpackToken as requestJetpackToken } from '@woocommerce/ai';
 import apiFetch from '@wordpress/api-fetch';
 import { recordEvent } from '@woocommerce/tracks';
+import { Sender } from 'xstate';
 
 /**
  * Internal dependencies
@@ -101,6 +102,18 @@ export const getLookAndTone = async (
 	return parseLookAndToneCompletionResponse( data );
 };
 
+const browserPopstateHandler =
+	() => ( sendBack: Sender< { type: 'EXTERNAL_URL_UPDATE' } > ) => {
+		const popstateHandler = () => {
+			sendBack( { type: 'EXTERNAL_URL_UPDATE' } );
+		};
+		window.addEventListener( 'popstate', popstateHandler );
+		return () => {
+			window.removeEventListener( 'popstate', popstateHandler );
+		};
+	};
+
 export const services = {
 	getLookAndTone,
+	browserPopstateHandler,
 };

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/types.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/types.ts
@@ -24,10 +24,7 @@ export type designWithAiStateMachineEvents =
 			type: 'TONE_OF_VOICE_COMPLETE';
 	  }
 	| {
-			type: 'API_CALL_TO_AI_SUCCCESSFUL';
-	  }
-	| {
-			type: 'API_CALL_TO_AI_FAILED';
+			type: 'EXTERNAL_URL_UPDATE';
 	  };
 
 export const VALID_LOOKS = [ 'Contemporary', 'Classic', 'Bold' ] as const;

--- a/plugins/woocommerce-admin/client/customize-store/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/index.tsx
@@ -34,9 +34,13 @@ export type customizeStoreStateMachineEvents =
 	| { type: 'AI_WIZARD_CLOSED_BEFORE_COMPLETION'; payload: { step: string } }
 	| { type: 'EXTERNAL_URL_UPDATE' };
 
-const updateQueryStep = ( _context: unknown, _evt: unknown, meta: unknown ) => {
+const updateQueryStep = (
+	_context: unknown,
+	_evt: unknown,
+	{ action }: { action: unknown }
+) => {
 	const { path } = getQuery() as { path: string };
-	const step = ( meta as { step: string } ).step;
+	const step = ( action as { step: string } ).step;
 	const pathFragments = path.split( '/' ); // [0] '', [1] 'customize-store', [2] step slug [3] design-with-ai, assembler-hub path fragments
 	if ( pathFragments[ 1 ] === 'customize-store' ) {
 		if ( pathFragments[ 2 ] !== step ) {

--- a/plugins/woocommerce-admin/client/customize-store/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/index.tsx
@@ -195,8 +195,16 @@ export const customizeStoreStateMachineDefinition = createMachine( {
 			},
 		},
 		assemblerHub: {
-			meta: {
-				component: AssemblerHub,
+			initial: 'assemblerHub',
+			states: {
+				assemblerHub: {
+					entry: [
+						{ type: 'updateQueryStep', step: 'assembler-hub' },
+					],
+					meta: {
+						component: AssemblerHub,
+					},
+				},
 			},
 			on: {
 				FINISH_CUSTOMIZATION: {

--- a/plugins/woocommerce-admin/client/customize-store/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/index.tsx
@@ -1,9 +1,10 @@
 /**
  * External dependencies
  */
-import { createMachine } from 'xstate';
+import { Sender, createMachine } from 'xstate';
 import { useEffect, useMemo, useState } from '@wordpress/element';
 import { useMachine, useSelector } from '@xstate/react';
+import { getQuery, updateQueryString } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -30,18 +31,49 @@ export type customizeStoreStateMachineEvents =
 	| introEvents
 	| designWithAiEvents
 	| assemblerHubEvents
-	| { type: 'AI_WIZARD_CLOSED_BEFORE_COMPLETION'; payload: { step: string } };
+	| { type: 'AI_WIZARD_CLOSED_BEFORE_COMPLETION'; payload: { step: string } }
+	| { type: 'EXTERNAL_URL_UPDATE' };
 
-export const customizeStoreStateMachineServices = {
-	...introServices,
+const updateQueryStep = ( _context: unknown, _evt: unknown, meta: unknown ) => {
+	const { path } = getQuery() as { path: string };
+	const step = ( meta as { step: string } ).step;
+	const pathFragments = path.split( '/' ); // [0] '', [1] 'customize-store', [2] step slug [3] design-with-ai, assembler-hub path fragments
+	if ( pathFragments[ 1 ] === 'customize-store' ) {
+		if ( pathFragments[ 2 ] !== step ) {
+			// this state machine is only concerned with [2], so we ignore changes to [3]
+			// [1] is handled by router at root of wc-admin
+			updateQueryString( {}, `/customize-store/${ step }` );
+		}
+	}
+};
+
+const browserPopstateHandler =
+	() => ( sendBack: Sender< { type: 'EXTERNAL_URL_UPDATE' } > ) => {
+		const popstateHandler = () => {
+			sendBack( { type: 'EXTERNAL_URL_UPDATE' } );
+		};
+		window.addEventListener( 'popstate', popstateHandler );
+		return () => {
+			window.removeEventListener( 'popstate', popstateHandler );
+		};
+	};
+
+export const machineActions = {
+	updateQueryStep,
 };
 
 export const customizeStoreStateMachineActions = {
 	...introActions,
+	...machineActions,
+};
+
+export const customizeStoreStateMachineServices = {
+	...introServices,
+	browserPopstateHandler,
 };
 export const customizeStoreStateMachineDefinition = createMachine( {
 	id: 'customizeStore',
-	initial: 'intro',
+	initial: 'navigate',
 	predictableActionArguments: true,
 	preserveActionOrder: true,
 	schema: {
@@ -57,7 +89,47 @@ export const customizeStoreStateMachineDefinition = createMachine( {
 			activeTheme: '',
 		},
 	} as customizeStoreStateMachineContext,
+	invoke: {
+		src: 'browserPopstateHandler',
+	},
+	on: {
+		EXTERNAL_URL_UPDATE: {
+			target: 'navigate',
+		},
+		AI_WIZARD_CLOSED_BEFORE_COMPLETION: {
+			target: 'intro',
+			actions: [ { type: 'updateQueryStep', step: 'intro' } ],
+		},
+	},
 	states: {
+		navigate: {
+			always: [
+				{
+					target: 'intro',
+					cond: {
+						type: 'hasStepInUrl',
+						step: 'intro',
+					},
+				},
+				{
+					target: 'designWithAi',
+					cond: {
+						type: 'hasStepInUrl',
+						step: 'design-with-ai',
+					},
+				},
+				{
+					target: 'assemblerHub',
+					cond: {
+						type: 'hasStepInUrl',
+						step: 'assembler-hub',
+					},
+				},
+				{
+					target: 'intro',
+				},
+			],
+		},
 		intro: {
 			id: 'intro',
 			initial: 'preIntro',
@@ -107,6 +179,9 @@ export const customizeStoreStateMachineDefinition = createMachine( {
 					meta: {
 						component: DesignWithAi,
 					},
+					entry: [
+						{ type: 'updateQueryStep', step: 'design-with-ai' },
+					],
 				},
 			},
 			on: {
@@ -131,13 +206,6 @@ export const customizeStoreStateMachineDefinition = createMachine( {
 		backToHomescreen: {},
 		appearanceTask: {},
 	},
-	on: {
-		AI_WIZARD_CLOSED_BEFORE_COMPLETION: {
-			actions: () => {
-				// TODO: when navigation has been implemented, this should navigate back to the Intro screen
-			},
-		},
-	},
 } );
 
 export const CustomizeStoreController = ( {
@@ -159,7 +227,16 @@ export const CustomizeStoreController = ( {
 				...customizeStoreStateMachineActions,
 				...actionOverrides,
 			},
-			guards: {},
+			guards: {
+				hasStepInUrl: ( _ctx, _evt, { cond }: { cond: unknown } ) => {
+					const { path = '' } = getQuery() as { path: string };
+					const pathFragments = path.split( '/' );
+					return (
+						pathFragments[ 2 ] === // [0] '', [1] 'customize-store', [2] step slug
+						( cond as { step: string | undefined } ).step
+					);
+				},
+			},
 		} );
 	}, [ actionOverrides, servicesOverrides ] );
 

--- a/plugins/woocommerce/changelog/add-cys-url-navigation
+++ b/plugins/woocommerce/changelog/add-cys-url-navigation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Added URL navigation support to customize-store feature


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This is part of the bigger customize your store feature development and does not require QA review as it is behind a feature flag.

This PR adds the ability for the user to navigate forward/backwards using the browser's forward/back button, and for the 'x' button in the design with AI wizard to bring them back to the intro screen.

Closes https://github.com/woocommerce/team-ghidorah/issues/262.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Use WP 6.3 
2. Install the `WooCommerce Beta Tester` plugin
3. Go to /wp-admin/tools.php?page=woocommerce-admin-test-helper and enable `customize-store` feature flag
4. Go to `WooCommerce > Home`
5. Click on `Customize your store` task 
6. Click on `Assembler Hub` button
7. Should see the Assembler Hub screen, and observe that the URL should reflect `path=%2Fcustomize-store%2Fassembler-hub`. 
8. Any navigation using the sidebar buttons on the left should also update the URL, and browser back/forward buttons should have the same effect.
9. You should also be able to back out of the assembler hub feature
10. Click on the `Design with AI` button
11. Should see the design with AI wizard flow, and the URL should reflect `path=%2Fcustomize-store%2Fdesign-with-ai`
12. Progressing foward in the wizard should show the URL changing, and you should be able to use the browser back/forward buttons.
13. You should be able to back out of the design with AI feature.
14. The 'x' button in the design with AI wizard should bring you back to the (currently unstyled) intro screen

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
