### PR TITLE
Fix infinite category loading state

### DIFF
--- a/packages/js/product-editor/changelog/fix-infinite_categories_loading_state
+++ b/packages/js/product-editor/changelog/fix-infinite_categories_loading_state
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix infinite category loading state

--- a/packages/js/product-editor/src/blocks/taxonomy/use-taxonomy-search.ts
+++ b/packages/js/product-editor/src/blocks/taxonomy/use-taxonomy-search.ts
@@ -69,8 +69,7 @@ const useTaxonomySearch = (
 					taxonomyName
 				);
 			}
-			setIsSearching( false );
-		} catch ( e ) {
+		} finally {
 			setIsSearching( false );
 		}
 		return taxonomies;

--- a/packages/js/product-editor/src/blocks/taxonomy/use-taxonomy-search.ts
+++ b/packages/js/product-editor/src/blocks/taxonomy/use-taxonomy-search.ts
@@ -69,6 +69,7 @@ const useTaxonomySearch = (
 					taxonomyName
 				);
 			}
+			setIsSearching( false );
 		} catch ( e ) {
 			setIsSearching( false );
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

After merging [this PR](https://github.com/woocommerce/woocommerce/pull/39966) (which sends the `isLoading` prop to the [SelectTreeMenu](https://github.com/woocommerce/woocommerce/blob/trunk/packages/js/components/src/experimental-select-tree-control/select-tree.tsx#L222)) and [this PR](https://github.com/woocommerce/woocommerce/pull/39947), the category selector under `Products > Add New > Organization` never loses the `loading` state.

The problem is that the hook `useTaxonomySearch` never sets [the isLoading state to false](https://github.com/woocommerce/woocommerce/blob/trunk/packages/js/product-editor/src/blocks/taxonomy/use-taxonomy-search.ts#L57) after fetching.

This PR fixes the problem.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the product blocks editor under WooCommerce -> Settings -> Advanced -> Features.
2. Navigate to Products > Add new.
3. Press `Organization` and select the Categories dropdown menu.
4. The loading spinner should disappear after a few seconds, and it should show the categories available.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
