### PR TITLE
POC: Add contextual block and block component wrapper

### DIFF
--- a/packages/js/product-editor/src/blocks/name/index.ts
+++ b/packages/js/product-editor/src/blocks/name/index.ts
@@ -1,9 +1,10 @@
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils';
+import { registerWooBlock } from '../../utils';
 import metadata from './block.json';
 import { Edit } from './edit';
+import { Edit as ListEdit } from './list/edit';
 
 const { name } = metadata;
 
@@ -11,11 +12,14 @@ export { metadata, name };
 
 export const settings = {
 	example: {},
-	edit: Edit,
+	edit: {
+		list: ListEdit,
+		default: Edit
+	},
 };
 
 export const init = () =>
-	initBlock( {
+	registerWooBlock( {
 		name,
 		metadata: metadata as never,
 		settings,

--- a/packages/js/product-editor/src/blocks/name/list/edit.tsx
+++ b/packages/js/product-editor/src/blocks/name/list/edit.tsx
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { BlockEditProps } from '@wordpress/blocks';
+import { createElement } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { NameBlockAttributes } from '../types';
+
+export function Edit( { attributes }: BlockEditProps< NameBlockAttributes > ) {
+	return <div>list view</div>;
+}

--- a/packages/js/product-editor/src/blocks/name/list/edit.tsx
+++ b/packages/js/product-editor/src/blocks/name/list/edit.tsx
@@ -10,6 +10,7 @@ import { createElement } from '@wordpress/element';
  */
 import { NameBlockAttributes } from '../types';
 
-export function Edit( { attributes }: BlockEditProps< NameBlockAttributes > ) {
-	return <div>list view</div>;
+// @ts-ignore
+export function Edit( { attributes, context }: BlockEditProps< NameBlockAttributes > ) {
+	return <div>Product name list view: { context.product.name }</div>;
 }

--- a/packages/js/product-editor/src/blocks/section/edit.tsx
+++ b/packages/js/product-editor/src/blocks/section/edit.tsx
@@ -5,6 +5,8 @@ import classNames from 'classnames';
 import { createElement } from '@wordpress/element';
 import type { BlockEditProps } from '@wordpress/blocks';
 import {
+	// @ts-expect-error no exported member.
+	BlockContextProvider,
 	useBlockProps,
 	// @ts-expect-error no exported member.
 	useInnerBlocksProps,
@@ -51,7 +53,11 @@ export function Edit( {
 				</HeadingTagName>
 			) }
 
-			<div { ...innerBlockProps } />
+			<BlockContextProvider value={ {
+				uiContext: 'default'
+			} }>
+				<div { ...innerBlockProps } />
+			</BlockContextProvider>
 		</SectionTagName>
 	);
 }

--- a/packages/js/product-editor/src/components/block-editor/block-editor.tsx
+++ b/packages/js/product-editor/src/components/block-editor/block-editor.tsx
@@ -48,7 +48,7 @@ type BlockEditorProps = {
 export function BlockEditor( {
 	context,
 	settings: _settings,
-	product,
+	product: persistedProduct,
 }: BlockEditorProps ) {
 	useConfirmUnsavedProductChanges();
 
@@ -84,7 +84,7 @@ export function BlockEditor( {
 	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
 		'postType',
 		'product',
-		{ id: product.id }
+		{ id: persistedProduct.id }
 	);
 
 	useLayoutEffect( () => {
@@ -92,7 +92,15 @@ export function BlockEditor( {
 			synchronizeBlocksWithTemplate( [], _settings?.template ),
 			{}
 		);
-	}, [ product.id ] );
+	}, [ persistedProduct.id ] );
+
+	const product: Product = useSelect( ( select ) =>
+		select( 'core' ).getEditedEntityRecord(
+			'postType',
+			'product',
+			persistedProduct.id
+		)
+	);
 
 	if ( ! blocks ) {
 		return null;
@@ -100,7 +108,7 @@ export function BlockEditor( {
 
 	return (
 		<div className="woocommerce-product-block-editor">
-			<BlockContextProvider value={ context }>
+			<BlockContextProvider value={ { ...context, product, persistedProduct } }>
 				<BlockEditorProvider
 					value={ blocks }
 					onInput={ onInput }

--- a/packages/js/product-editor/src/components/editor/editor.tsx
+++ b/packages/js/product-editor/src/components/editor/editor.tsx
@@ -80,6 +80,7 @@ export function Editor( { product, settings }: EditorProps ) {
 													selectedTab,
 													postType: 'product',
 													postId: product.id,
+													uiContext: 'list',
 												} }
 											/>
 											{ /* @ts-expect-error 'scope' does exist. @types/wordpress__plugins is outdated. */ }

--- a/packages/js/product-editor/src/utils/index.ts
+++ b/packages/js/product-editor/src/utils/index.ts
@@ -24,6 +24,7 @@ import { isValidEmail } from './validate-email';
 export * from './create-ordered-children';
 export * from './sort-fills-by-order';
 export * from './init-block';
+export * from './register-woo-block';
 export * from './product-apifetch-middleware';
 export * from './sift';
 

--- a/packages/js/product-editor/src/utils/register-woo-block.tsx
+++ b/packages/js/product-editor/src/utils/register-woo-block.tsx
@@ -49,6 +49,24 @@ function getEditComponent< T extends Record< string, any > = Record< string, any
 }
 
 /**
+ * Get the block metadata, including any Woo related context or support properties.
+ *
+ * @param metadata Original block metadata.
+ * @returns Updated block metadata.
+ */
+export function getParsedMetadata< T extends Record< string, any >>( metadata: BlockConfiguration< T > ): BlockConfiguration< T > {
+	return {
+		...metadata,
+		usesContext: [
+			...( metadata.usesContext || [] ),
+			'uiContext',
+			'product',
+			'persistedProduct',
+		],
+	}
+}
+
+/**
  * Function to register an individual block.
  *
  * @param block The block to be registered.
@@ -64,5 +82,6 @@ export function registerWooBlock<
 	const { metadata, settings, name } = block;
 	const { edit } = settings;
 	const editComponent = getEditComponent< T >( edit );
-	return registerBlockType< T >( { name, ...metadata }, { ...settings, edit: editComponent } );
+	const parsedMetadata = getParsedMetadata( metadata );
+	return registerBlockType< T >( { name, ...parsedMetadata }, { ...settings, edit: editComponent } );
 }

--- a/packages/js/product-editor/src/utils/register-woo-block.tsx
+++ b/packages/js/product-editor/src/utils/register-woo-block.tsx
@@ -1,0 +1,68 @@
+/**
+ * External dependencies
+ */
+import {
+	Block,
+	BlockConfiguration,
+	registerBlockType,
+} from '@wordpress/blocks';
+import { createElement } from '@wordpress/element';
+import { ComponentType } from 'react';
+
+import type { BlockEditProps } from '@wordpress/blocks';
+
+interface BlockRepresentation< T extends Record< string, object > > {
+	name?: string;
+	metadata: BlockConfiguration< T >;
+	settings: Omit< Partial< BlockConfiguration< T > >, 'edit'> & {
+		edit?: EditContexts<T> | EditComponent<T>
+	};
+}
+
+type EditComponent<T extends Record< string, any > = Record< string, any >> = ComponentType<BlockEditProps<T>>;
+
+interface EditContexts<T extends Record< string, any > = Record< string, any >> {
+    [name: string]: EditComponent<T>;
+}
+
+function getEditComponent< T extends Record< string, any > = Record< string, any >>( edit?: EditContexts<T> | EditComponent<T> ): EditComponent<T> {
+	if ( typeof edit === 'function' ) {
+		return edit;
+	}
+
+	return ( props: BlockEditProps<T> ) => {
+		if ( ! edit ) {
+			return null;
+		}
+
+		// @ts-ignore Context should exist.
+        const { uiContext } = props.context;
+	
+		if ( edit.hasOwnProperty( uiContext as string ) ) {
+			const Component = edit[ uiContext as string ];
+			return <Component { ...props } />;
+		}
+
+		const DefaultComponent = edit.default;
+		return <DefaultComponent { ...props } />;
+	}
+}
+
+/**
+ * Function to register an individual block.
+ *
+ * @param block The block to be registered.
+ * @return The block, if it has been successfully registered; otherwise `undefined`.
+ */
+export function registerWooBlock<
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	T extends Record< string, any > = Record< string, any >
+>( block: BlockRepresentation< T > ): Block< T > | undefined {
+	if ( ! block ) {
+		return;
+	}
+	const { metadata, settings, name } = block;
+	const { edit } = settings;
+	const editComponent = getEditComponent< T >( edit );
+	return registerBlockType< T >( { name, ...metadata }, { ...settings, edit: editComponent } );
+}

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -135,6 +135,17 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 				],
 			]
 		);
+		$general_group->add_block(
+			[
+				'id'         => 'product-name-list',
+				'blockName'  => 'woocommerce/product-name-field',
+				'order'      => 10,
+				'attributes' => [
+					'name'      => 'Product name',
+					'autoFocus' => true,
+				],
+			]
+		);
 		$basic_details->add_block(
 			[
 				'id'         => 'product-name',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

This PR adds a `registerWooBlock` method that adds in context to blocks, modifies the render of blocks based on context, and generally assists with parsing blocks in the client.

<img width="725" alt="Screen Shot 2023-09-07 at 2 12 15 PM" src="https://github.com/woocommerce/woocommerce/assets/10561050/358acaf6-c0dd-47b6-a43b-d96e2efcd631">

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure the new product editing experience is enabled under WooCommerce -> Settings -> Advanced -> Features.
2. Navigate to the Add product page
3. Note that the product name block is added in 2 places, but rendered in different ways depending on the block context it resides under

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
