### PR TITLE
Add customize store - fonts

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/auto-block-preview.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/auto-block-preview.tsx
@@ -272,7 +272,7 @@ function ScaledBlockPreview( {
 				</style>
 				{ contentResizeListener }
 				<MemoizedBlockList renderAppender={ false } />
-				{ /* Only load  font families when there are two font families (font-paring selection). Otherwise, it is not needed. */ }
+				{ /* Only load font families when there are two font families (font-paring selection). Otherwise, it is not needed. */ }
 				{ externalFontFamilies.length === 2 && (
 					<FontFamiliesLoader
 						fontFamilies={ externalFontFamilies }

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/constants.ts
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/constants.ts
@@ -1,0 +1,503 @@
+export const FONT_PREVIEW_LARGE_WIDTH = 136;
+export const FONT_PREVIEW_LARGE_HEIGHT = 106;
+export const FONT_PREVIEW_WIDTH = 120;
+export const FONT_PREVIEW_HEIGHT = 74;
+export const SYSTEM_FONT_SLUG = 'system-font';
+
+// Generated from /wpcom/v2/sites/{site_id}/global-styles-variation/font-pairings
+// TODO: Consider creating an API endpoint for this data
+export const FONT_PAIRINGS = [
+	{
+		title: 'Bodoni Moda + Overpass',
+		version: 2,
+		settings: {
+			typography: {
+				fontFamilies: {
+					theme: [
+						{
+							fontFamily: 'Bodoni Moda',
+							slug: 'bodoni-moda',
+						},
+						{
+							fontFamily: 'Overpass',
+							slug: 'overpass',
+						},
+					],
+				},
+			},
+		},
+		styles: {
+			elements: {
+				button: {
+					typography: {
+						fontFamily: 'var(--wp--preset--font-family--overpass)',
+						fontWeight: '400',
+						lineHeight: '1',
+					},
+				},
+				heading: {
+					typography: {
+						fontFamily:
+							'var(--wp--preset--font-family--bodoni-moda)',
+						fontStyle: 'normal',
+						fontWeight: '400',
+					},
+				},
+			},
+			blocks: {
+				'core/site-title': {
+					typography: {
+						fontFamily:
+							'var(--wp--preset--font-family--bodoni-moda)',
+					},
+				},
+				'core/post-navigation-link': {
+					typography: {
+						fontFamily:
+							'var(--wp--preset--font-family--bodoni-moda)',
+					},
+				},
+			},
+			typography: {
+				fontFamily: 'var(--wp--preset--font-family--overpass)',
+				fontSize: 'var(--wp--preset--font-size--medium)',
+				fontStyle: 'normal',
+				fontWeight: '300',
+				lineHeight: '1.6',
+			},
+		},
+	},
+	{
+		title: 'Commissioner + Crimson Pro',
+		version: 2,
+		settings: {
+			typography: {
+				fontFamilies: {
+					theme: [
+						{
+							fontFamily: 'Commissioner',
+							slug: 'commissioner',
+						},
+						{
+							fontFamily: 'Crimson Pro',
+							slug: 'crimson-pro',
+						},
+					],
+				},
+			},
+		},
+		styles: {
+			elements: {
+				button: {
+					typography: {
+						fontFamily:
+							'var(--wp--preset--font-family--commissioner)',
+						fontWeight: '400',
+						lineHeight: '1',
+					},
+				},
+				heading: {
+					typography: {
+						fontFamily:
+							'var(--wp--preset--font-family--commissioner)',
+						fontStyle: 'normal',
+						fontWeight: '300',
+					},
+				},
+			},
+			blocks: {
+				'core/site-title': {
+					typography: {
+						fontFamily:
+							'var(--wp--preset--font-family--commissioner)',
+						fontWeight: '300',
+					},
+				},
+				'core/post-navigation-link': {
+					typography: {
+						fontFamily:
+							'var(--wp--preset--font-family--commissioner)',
+					},
+				},
+			},
+			typography: {
+				fontFamily: 'var(--wp--preset--font-family--crimson-pro)',
+				fontSize: 'var(--wp--preset--font-size--medium)',
+				fontStyle: 'normal',
+				fontWeight: '400',
+				lineHeight: '1.6',
+			},
+		},
+	},
+	{
+		title: 'Libre Baskerville + DM Sans',
+		version: 2,
+		settings: {
+			typography: {
+				fontFamilies: {
+					theme: [
+						{
+							fontFamily: 'Libre Baskerville',
+							slug: 'libre-baskerville',
+						},
+						{
+							fontFamily: 'DM Sans',
+							slug: 'dm-sans',
+						},
+					],
+				},
+			},
+		},
+		styles: {
+			elements: {
+				button: {
+					typography: {
+						fontFamily: 'var(--wp--preset--font-family--dm-sans)',
+						fontWeight: '400',
+						lineHeight: '1',
+					},
+				},
+				heading: {
+					typography: {
+						fontFamily:
+							'var(--wp--preset--font-family--libre-baskerville)',
+						fontStyle: 'normal',
+						fontWeight: '700',
+					},
+				},
+			},
+			blocks: {
+				'core/site-title': {
+					typography: {
+						fontFamily:
+							'var(--wp--preset--font-family--libre-baskerville)',
+					},
+				},
+				'core/post-navigation-link': {
+					typography: {
+						fontFamily:
+							'var(--wp--preset--font-family--libre-baskerville)',
+					},
+				},
+			},
+			typography: {
+				fontFamily: 'var(--wp--preset--font-family--dm-sans)',
+				fontSize: 'var(--wp--preset--font-size--small)',
+				fontStyle: 'normal',
+				fontWeight: '400',
+				lineHeight: '1.6',
+			},
+		},
+	},
+	{
+		title: 'Libre Franklin + EB Garamond',
+		version: 2,
+		settings: {
+			typography: {
+				fontFamilies: {
+					theme: [
+						{
+							fontFamily: 'Libre Franklin',
+							slug: 'libre-franklin',
+						},
+						{
+							fontFamily: 'EB Garamond',
+							slug: 'eb-garamond',
+						},
+					],
+				},
+			},
+		},
+		styles: {
+			elements: {
+				button: {
+					typography: {
+						fontFamily:
+							'var(--wp--preset--font-family--libre-franklin)',
+						fontSize: 'var(--wp--preset--font-size--small)',
+						fontWeight: '400',
+						lineHeight: '1',
+					},
+				},
+				heading: {
+					typography: {
+						fontFamily:
+							'var(--wp--preset--font-family--libre-franklin)',
+						fontStyle: 'normal',
+						fontWeight: '700',
+					},
+				},
+			},
+			blocks: {
+				'core/site-title': {
+					typography: {
+						fontFamily:
+							'var(--wp--preset--font-family--libre-franklin)',
+						fontWeight: '500',
+					},
+				},
+				'core/post-navigation-link': {
+					typography: {
+						fontFamily:
+							'var(--wp--preset--font-family--libre-franklin)',
+					},
+				},
+			},
+			typography: {
+				fontFamily: 'var(--wp--preset--font-family--eb-garamond)',
+				fontSize: 'var(--wp--preset--font-size--medium)',
+				fontStyle: 'normal',
+				fontWeight: '400',
+				lineHeight: '1.6',
+			},
+		},
+	},
+	{
+		title: 'Montserrat + Arvo',
+		version: 2,
+		settings: {
+			typography: {
+				fontFamilies: {
+					theme: [
+						{
+							fontFamily: 'Montserrat',
+							slug: 'montserrat',
+						},
+						{
+							fontFamily: 'Arvo',
+							slug: 'arvo',
+						},
+					],
+				},
+			},
+		},
+		styles: {
+			elements: {
+				button: {
+					typography: {
+						fontFamily:
+							'var(--wp--preset--font-family--montserrat)',
+						fontStyle: 'normal',
+						fontWeight: '500',
+					},
+				},
+				heading: {
+					typography: {
+						fontFamily:
+							'var(--wp--preset--font-family--montserrat)',
+						fontStyle: 'normal',
+						fontWeight: '700',
+						lineHeight: '1.4',
+					},
+				},
+			},
+			blocks: {
+				'core/site-title': {
+					typography: {
+						fontFamily:
+							'var(--wp--preset--font-family--montserrat)',
+						fontWeight: '700',
+					},
+				},
+				'core/post-navigation-link': {
+					typography: {
+						fontFamily:
+							'var(--wp--preset--font-family--montserrat)',
+					},
+				},
+			},
+			typography: {
+				fontFamily: 'var(--wp--preset--font-family--arvo)',
+				fontSize: 'var(--wp--preset--font-size--small)',
+				fontStyle: 'normal',
+				fontWeight: '400',
+				lineHeight: '1.6',
+			},
+		},
+	},
+	{
+		title: 'Playfair Display + Fira Sans',
+		version: 2,
+		settings: {
+			typography: {
+				fontFamilies: {
+					theme: [
+						{
+							fontFamily: 'Playfair Display',
+							slug: 'playfair-display',
+						},
+						{
+							fontFamily: 'Fira Sans',
+							slug: 'fira-sans',
+						},
+					],
+				},
+			},
+		},
+		styles: {
+			elements: {
+				button: {
+					typography: {
+						fontFamily: 'var(--wp--preset--font-family--fira-sans)',
+						fontWeight: '400',
+						lineHeight: '1',
+					},
+				},
+				heading: {
+					typography: {
+						fontFamily:
+							'var(--wp--preset--font-family--playfair-display)',
+						fontStyle: 'italic',
+						fontWeight: '400',
+					},
+				},
+			},
+			blocks: {
+				'core/site-title': {
+					typography: {
+						fontFamily:
+							'var(--wp--preset--font-family--playfair-display)',
+						fontStyle: 'italic',
+						fontWeight: '400',
+					},
+				},
+				'core/post-navigation-link': {
+					typography: {
+						fontFamily:
+							'var(--wp--preset--font-family--playfair-display)',
+						fontStyle: 'italic',
+						fontWeight: '400',
+					},
+				},
+			},
+			typography: {
+				fontFamily: 'var(--wp--preset--font-family--fira-sans)',
+				fontSize: 'var(--wp--preset--font-size--medium)',
+				fontStyle: 'normal',
+				fontWeight: '400',
+				lineHeight: '1.6',
+			},
+		},
+	},
+	{
+		title: 'Rubik + Inter',
+		version: 2,
+		settings: {
+			typography: {
+				fontFamilies: {
+					theme: [
+						{
+							fontFamily: 'Rubik',
+							slug: 'rubik',
+						},
+						{
+							fontFamily: 'Inter',
+							slug: 'inter',
+						},
+					],
+				},
+			},
+		},
+		styles: {
+			elements: {
+				button: {
+					typography: {
+						fontFamily: 'var(--wp--preset--font-family--inter)',
+						fontWeight: '400',
+						lineHeight: '1',
+					},
+				},
+				heading: {
+					typography: {
+						fontFamily: 'var(--wp--preset--font-family--rubik)',
+						fontStyle: 'normal',
+						fontWeight: '800',
+					},
+				},
+			},
+			blocks: {
+				'core/site-title': {
+					typography: {
+						fontFamily: 'var(--wp--preset--font-family--rubik)',
+						fontWeight: '800',
+					},
+				},
+				'core/post-navigation-link': {
+					typography: {
+						fontFamily: 'var(--wp--preset--font-family--rubik)',
+					},
+				},
+			},
+			typography: {
+				fontFamily: 'var(--wp--preset--font-family--inter)',
+				fontSize: 'var(--wp--preset--font-size--medium)',
+				fontStyle: 'normal',
+				fontWeight: '400',
+				lineHeight: '1.6',
+			},
+		},
+	},
+	{
+		title: 'Space Mono + Roboto',
+		version: 2,
+		settings: {
+			typography: {
+				fontFamilies: {
+					theme: [
+						{
+							fontFamily: 'Space Mono',
+							slug: 'space-mono',
+						},
+						{
+							fontFamily: 'Roboto',
+							slug: 'roboto',
+						},
+					],
+				},
+			},
+		},
+		styles: {
+			elements: {
+				button: {
+					typography: {
+						fontFamily: 'var(--wp--preset--font-family--roboto)',
+						fontWeight: '400',
+						lineHeight: '1',
+					},
+				},
+				heading: {
+					typography: {
+						fontFamily:
+							'var(--wp--preset--font-family--space-mono)',
+						fontStyle: 'normal',
+						fontWeight: '400',
+						lineHeight: '1.15',
+					},
+				},
+			},
+			blocks: {
+				'core/site-title': {
+					typography: {
+						fontFamily:
+							'var(--wp--preset--font-family--space-mono)',
+						fontStyle: 'normal',
+						fontWeight: '400',
+					},
+				},
+				'core/post-navigation-link': {
+					typography: {
+						fontFamily:
+							'var(--wp--preset--font-family--space-mono)',
+					},
+				},
+			},
+			typography: {
+				fontFamily: 'var(--wp--preset--font-family--roboto)',
+				fontSize: 'var(--wp--preset--font-size--small)',
+				fontStyle: 'normal',
+				fontWeight: '400',
+				lineHeight: '1.6',
+			},
+		},
+	},
+];

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/font-families-loader.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/font-families-loader.tsx
@@ -1,0 +1,50 @@
+// Load font families from wp.com.
+
+/**
+ * External dependencies
+ */
+import { useMemo } from '@wordpress/element';
+
+export type FontFamily = {
+	fontFamily: string;
+	name: string;
+	slug: string;
+};
+
+type Props = {
+	fontFamilies: FontFamily[];
+	onLoad?: () => void;
+};
+
+// See https://developers.google.com/fonts/docs/css2
+const FONT_API_BASE = 'https://fonts-api.wp.com/css2';
+
+const FONT_AXIS = 'ital,wght@0,400;0,700;1,400;1,700';
+
+export const FontFamiliesLoader = ( { fontFamilies, onLoad }: Props ) => {
+	const params = useMemo(
+		() =>
+			new URLSearchParams( [
+				...fontFamilies.map( ( { fontFamily } ) => [
+					'family',
+					`${ fontFamily }:${ FONT_AXIS }`,
+				] ),
+				[ 'display', 'swap' ],
+			] ),
+		fontFamilies
+	);
+
+	if ( ! params.getAll( 'family' ).length ) {
+		return null;
+	}
+
+	return (
+		<link
+			rel="stylesheet"
+			type="text/css"
+			href={ `${ FONT_API_BASE }?${ params }` }
+			onLoad={ onLoad }
+			onError={ onLoad }
+		/>
+	);
+};

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/font-families-loader.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/font-families-loader.tsx
@@ -1,3 +1,4 @@
+// TODO: We should Download webfonts and host them locally on a site before launching CYS in Core.
 // Load font families from wp.com.
 
 /**

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/index.tsx
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+/* eslint-disable @woocommerce/dependency-group */
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+/**
+ * External dependencies
+ */
+// @ts-ignore No types for this exist yet.
+import { __experimentalGrid as Grid } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { FONT_PAIRINGS } from './constants';
+import { VariationContainer } from '../variation-container';
+import { FontPairingVariationPreview } from './preview';
+
+export const FontPairing = () => {
+	return (
+		<Grid
+			columns={ 2 }
+			gap={ 3 }
+			className="woocommerce-customize-store_font-pairing-container"
+		>
+			{ FONT_PAIRINGS.map( ( variation, index ) => (
+				<VariationContainer key={ index } variation={ variation }>
+					<FontPairingVariationPreview />
+				</VariationContainer>
+			) ) }
+		</Grid>
+	);
+};

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/index.tsx
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 /* eslint-disable @woocommerce/dependency-group */
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 /**

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/preview.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/preview.tsx
@@ -1,0 +1,176 @@
+// Reference: https://github.com/Automattic/wp-calypso/blob/d3c9b16fb99ce242f61baa21119b7c20f8823be6/packages/global-styles/src/components/font-pairing-variations/preview.tsx
+/* eslint-disable @woocommerce/dependency-group */
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+/**
+ * External dependencies
+ */
+import {
+	// @ts-ignore No types for this exist yet.
+	__experimentalHStack as HStack,
+	// @ts-ignore No types for this exist yet.
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { useResizeObserver, useViewportMatch } from '@wordpress/compose';
+import { useMemo, useState } from '@wordpress/element';
+import {
+	privateApis as blockEditorPrivateApis,
+	// @ts-ignore no types exist yet.
+} from '@wordpress/block-editor';
+// @ts-ignore No types for this exist yet.
+import { unlock } from '@wordpress/edit-site/build-module/lock-unlock';
+import { GlobalStylesVariationIframe } from '../global-styles-variation-iframe';
+import { FontFamiliesLoader, FontFamily } from './font-families-loader';
+import {
+	FONT_PREVIEW_LARGE_WIDTH,
+	FONT_PREVIEW_LARGE_HEIGHT,
+	FONT_PREVIEW_WIDTH,
+	FONT_PREVIEW_HEIGHT,
+	SYSTEM_FONT_SLUG,
+} from './constants';
+
+const { useGlobalStyle, useGlobalSetting } = unlock( blockEditorPrivateApis );
+
+const DEFAULT_LARGE_FONT_STYLES: React.CSSProperties = {
+	fontSize: '13vw', // 18px for min-width wide breakpoint and 15px for max-width wide
+	lineHeight: '20px',
+	color: '#000000',
+};
+
+export const FontPairingVariationPreview = () => {
+	const [ fontFamilies ] = useGlobalSetting(
+		'typography.fontFamilies.theme'
+	) as [ FontFamily[] ];
+
+	const [ textFontFamily = 'serif' ] = useGlobalStyle(
+		'typography.fontFamily'
+	);
+	const [ textFontStyle = 'normal' ] = useGlobalStyle(
+		'typography.fontStyle'
+	);
+	const [ textLetterSpacing = '-0.15px' ] = useGlobalStyle(
+		'typography.letterSpacing'
+	);
+	const [ textFontWeight = 400 ] = useGlobalStyle( 'typography.fontWeight' );
+
+	const [ headingFontFamily = textFontFamily ] = useGlobalStyle(
+		'elements.heading.typography.fontFamily'
+	);
+	const [ headingFontStyle = textFontStyle ] = useGlobalStyle(
+		'elements.heading.typography.fontStyle'
+	);
+	const [ headingFontWeight = textFontWeight ] = useGlobalStyle(
+		'elements.heading.typography.fontWeight'
+	);
+	const [ headingLetterSpacing = textLetterSpacing ] = useGlobalStyle(
+		'elements.heading.typography.letterSpacing'
+	);
+
+	const [ containerResizeListener, { width } ] = useResizeObserver();
+	const isDesktop = useViewportMatch( 'large' );
+	const defaultWidth = isDesktop
+		? FONT_PREVIEW_LARGE_WIDTH
+		: FONT_PREVIEW_WIDTH;
+	const defaultHeight = isDesktop
+		? FONT_PREVIEW_LARGE_HEIGHT
+		: FONT_PREVIEW_HEIGHT;
+	const ratio = width ? width / defaultWidth : 1;
+	const normalizedHeight = Math.ceil( defaultHeight * ratio );
+	const externalFontFamilies = fontFamilies.filter(
+		( { slug } ) => slug !== SYSTEM_FONT_SLUG
+	);
+	const [ isLoaded, setIsLoaded ] = useState( ! externalFontFamilies.length );
+	const getFontFamilyName = ( targetFontFamily: string ) => {
+		const fontFamily = fontFamilies.find(
+			( { fontFamily: _fontFamily } ) => _fontFamily === targetFontFamily
+		);
+		return fontFamily?.name || fontFamily?.fontFamily || targetFontFamily;
+	};
+
+	const textFontFamilyName = useMemo(
+		() => getFontFamilyName( textFontFamily ),
+		[ textFontFamily, fontFamilies ]
+	);
+
+	const headingFontFamilyName = useMemo(
+		() => getFontFamilyName( headingFontFamily ),
+		[ headingFontFamily, fontFamilies ]
+	);
+
+	const handleOnLoad = () => setIsLoaded( true );
+
+	return (
+		<GlobalStylesVariationIframe
+			width={ width }
+			height={ normalizedHeight }
+			containerResizeListener={ containerResizeListener }
+		>
+			<>
+				<div
+					style={ {
+						// Apply the normalized height only when the width is available
+						height: width ? normalizedHeight : 0,
+						width: '100%',
+						background: 'white',
+						cursor: 'pointer',
+					} }
+				>
+					<div
+						style={ {
+							height: '100%',
+							overflow: 'hidden',
+							opacity: isLoaded ? 1 : 0,
+						} }
+					>
+						<HStack
+							spacing={ 10 * ratio }
+							justify="flex-start"
+							style={ {
+								height: '100%',
+								overflow: 'hidden',
+							} }
+						>
+							<VStack
+								spacing={ 1 }
+								style={ {
+									margin: '10px',
+									width: '100%',
+									textAlign: isDesktop ? 'center' : 'left',
+								} }
+							>
+								<div
+									aria-label={ headingFontFamilyName }
+									style={ {
+										...DEFAULT_LARGE_FONT_STYLES,
+										letterSpacing: headingLetterSpacing,
+										fontWeight: headingFontWeight,
+										fontFamily: headingFontFamily,
+										fontStyle: headingFontStyle,
+									} }
+								>
+									{ headingFontFamilyName }
+								</div>
+								<div
+									aria-label={ textFontFamilyName }
+									style={ {
+										...DEFAULT_LARGE_FONT_STYLES,
+										fontSize: '13px',
+										letterSpacing: textLetterSpacing,
+										fontWeight: textFontWeight,
+										fontFamily: textFontFamily,
+										fontStyle: textFontStyle,
+									} }
+								>
+									{ textFontFamilyName }
+								</div>
+							</VStack>
+						</HStack>
+					</div>
+				</div>
+				<FontFamiliesLoader
+					fontFamilies={ externalFontFamilies }
+					onLoad={ handleOnLoad }
+				/>
+			</>
+		</GlobalStylesVariationIframe>
+	);
+};

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/index.ts
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/index.ts
@@ -1,2 +1,3 @@
 export { ColorPalette } from './color-palette-variations';
 export { ColorPanel } from './color-panel';
+export { FontPairing } from './font-pairing-variations';

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/variation-container.jsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/variation-container.jsx
@@ -9,10 +9,9 @@ import { __, sprintf } from '@wordpress/i18n';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { mergeBaseAndUserConfigs } from '@wordpress/edit-site/build-module/components/global-styles/global-styles-provider';
 import { unlock } from '@wordpress/edit-site/build-module/lock-unlock';
+import { isEqual } from 'lodash';
 
-const { GlobalStylesContext, areGlobalStyleConfigsEqual } = unlock(
-	blockEditorPrivateApis
-);
+const { GlobalStylesContext } = unlock( blockEditorPrivateApis );
 
 export const VariationContainer = ( { variation, children } ) => {
 	const { base, user, setUserConfig } = useContext( GlobalStylesContext );
@@ -31,8 +30,14 @@ export const VariationContainer = ( { variation, children } ) => {
 	const selectVariation = () => {
 		setUserConfig( () => {
 			return {
-				settings: variation.settings,
-				styles: variation.styles,
+				settings: mergeBaseAndUserConfigs(
+					user.settings,
+					variation.settings
+				),
+				styles: mergeBaseAndUserConfigs(
+					user.styles,
+					variation.styles
+				),
 			};
 		} );
 	};
@@ -45,7 +50,13 @@ export const VariationContainer = ( { variation, children } ) => {
 	};
 
 	const isActive = useMemo( () => {
-		return areGlobalStyleConfigsEqual( user, variation );
+		if ( variation.settings.color ) {
+			return isEqual( variation.settings.color, user.settings.color );
+		}
+		return isEqual(
+			variation.settings.typography,
+			user.settings.typography
+		);
 	}, [ user, variation ] );
 
 	let label = variation?.title;

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-typography.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-typography.tsx
@@ -1,17 +1,36 @@
+/* eslint-disable @woocommerce/dependency-group */
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 /**
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
 import { Link } from '@woocommerce/components';
+import { useSelect } from '@wordpress/data';
+// @ts-ignore no types exist yet.
+import { BlockEditorProvider } from '@wordpress/block-editor';
+import { noop } from 'lodash';
+// @ts-ignore No types for this exist yet.
+import { store as editSiteStore } from '@wordpress/edit-site/build-module/store';
+// @ts-ignore No types for this exist yet.
+import { unlock } from '@wordpress/edit-site/build-module/lock-unlock';
 
 /**
  * Internal dependencies
  */
 import { SidebarNavigationScreen } from './sidebar-navigation-screen';
 import { ADMIN_URL } from '~/utils/admin-settings';
+import { FontPairing } from './global-styles';
 
 export const SidebarNavigationScreenTypography = () => {
+	const { storedSettings } = useSelect( ( select ) => {
+		const { getSettings } = unlock( select( editSiteStore ) );
+
+		return {
+			storedSettings: getSettings( false ),
+		};
+	}, [] );
+
 	return (
 		<SidebarNavigationScreen
 			title={ __( 'Change your font', 'woocommerce' ) }
@@ -36,9 +55,15 @@ export const SidebarNavigationScreenTypography = () => {
 				}
 			) }
 			content={
-				<>
-					<div className="edit-site-sidebar-navigation-screen-patterns__group-header"></div>
-				</>
+				<div className="woocommerce-customize-store_sidebar-typography-content">
+					<BlockEditorProvider
+						settings={ storedSettings }
+						onChange={ noop }
+						onInput={ noop }
+					>
+						<FontPairing />
+					</BlockEditorProvider>
+				</div>
 			}
 		/>
 	);

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
@@ -357,6 +357,42 @@
 
 	.woocommerce-customize-store_sidebar-color-content {
 		width: 324px;
+
+		.woocommerce-customize-store_global-styles-variations_item {
+			border-radius: 2px;
+			padding: 2.5px;
+
+			.woocommerce-customize-store_global-styles-variations_item-preview {
+				border: 1px solid #dcdcde;
+				background: #fff;
+			}
+
+			&:hover,
+			&.is-active {
+				box-shadow: 0 0 0 1.5px  var(--wp-admin-theme-color), 0 0 0 2.5px #fff;
+			}
+		}
+	}
+
+	.woocommerce-customize-store_sidebar-typography-content {
+		width: 324px;
+
+		.woocommerce-customize-store_global-styles-variations_item {
+			border-radius: 2px;
+			border: 1px solid #dcdcde;
+			background: #fff;
+
+			&:hover,
+			&.is-active {
+				border-radius: 2px;
+				border: 1.5px solid var(--wp-admin-theme-color);
+				background: #fff;
+			}
+		}
+
+		.global-styles-variation-container__iframe {
+			box-shadow: none;
+		}
 	}
 
 	/* Preview Canvas */
@@ -471,20 +507,5 @@
 
 	.woocommerce-tour-kit-step-navigation .components-button.is-primary {
 		margin-left: 12px;
-	}
-}
-
-.woocommerce-customize-store_global-styles-variations_item {
-	border-radius: 2px;
-	padding: 2.5px;
-
-	.woocommerce-customize-store_global-styles-variations_item-preview {
-		border: 1px solid #dcdcde;
-		background: #fff;
-	}
-
-	&:hover,
-	&.is-active {
-		box-shadow: 0 0 0 1.5px  var(--wp-admin-theme-color), 0 0 0 2.5px #fff;
 	}
 }

--- a/plugins/woocommerce/changelog/add-cys-fonts
+++ b/plugins/woocommerce/changelog/add-cys-fonts
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add customize store - fonts


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #39717. 

Implement the customize store - fonts feature. 

Currently, fonts are loaded through [jetpack-google-fonts-provider](https://github.com/Automattic/jetpack-google-fonts-provider) from wp.com. It's okay for WooExpress. However, we'll need to download webfonts and host them locally before we launch CYS in Core.

https://github.com/woocommerce/woocommerce/assets/4344253/fa8ea017-3a64-45c7-a8ee-feb74b10620b


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Use WP 6.3 and Gutenberg [16.5.1](https://github.com/WordPress/gutenberg/releases/tag/v16.5.1)
2. Install the `WooCommerce Beta Tester` plugin
3. Install [webfonts.zip](https://github.com/woocommerce/woocommerce/files/12574060/webfonts.zip) plugin. This is needed for testing in non-wpcom environments. On wpcom, they already have a mu-plugin that registers all Google fonts. 
4. Go to /wp-admin/tools.php?page=woocommerce-admin-test-helper and enable `customize-store` feature flag
5. Go to `WooCommerce > Home`
6. Click on `Customize your store` task 
7. Click on `Assembler Hub` button
8. Click on "Change fonts"
9. Confirm the UI matches the design
10. Select a font
11. Observe that the preview frame font style should be changed.
12. Click on "save" button
13. Changes should persist when reloading the page
14. Go to the frontend page and confirm the fonts are loaded correctly. 
15. Go back to  "Change fonts" page. 
16. Select a font without saving
17. Go back to main sidebar
18. Observe that changes should be discarded.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add customize store - fonts

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
