### PR TITLE
Remote Inbox Notifications: Add `in` and `!in` comparison operators

### DIFF
--- a/plugins/woocommerce/changelog/add-RIN-in-not-in-comparison
+++ b/plugins/woocommerce/changelog/add-RIN-in-not-in-comparison
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update Remote Inbox Notifications to add in and !in comparison operators for comparing values against arrays

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/ComparisonOperation.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/ComparisonOperation.php
@@ -42,6 +42,16 @@ class ComparisonOperation {
 					return ! in_array( $right_operand, $left_operand, true );
 				}
 				return strpos( $right_operand, $left_operand ) === false;
+			case 'in':
+				if ( is_array( $right_operand ) && is_string( $left_operand ) ) {
+					return in_array( $left_operand, $right_operand, true );
+				}
+				return strpos( $left_operand, $right_operand ) !== false;
+			case '!in':
+				if ( is_array( $right_operand ) && is_string( $left_operand ) ) {
+					return ! in_array( $left_operand, $right_operand, true );
+				}
+				return strpos( $left_operand, $right_operand ) === false;
 		}
 
 		return false;

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/DataSourcePoller.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/DataSourcePoller.php
@@ -15,7 +15,8 @@ defined( 'ABSPATH' ) || exit;
 class DataSourcePoller extends \Automattic\WooCommerce\Admin\DataSourcePoller {
 	const ID           = 'remote_inbox_notifications';
 	const DATA_SOURCES = array(
-		'https://woocommerce.com/wp-json/wccom/inbox-notifications/1.0/notifications.json',
+		// 'https://woocommerce.com/wp-json/wccom/inbox-notifications/1.0/notifications.json',
+		'https://gist.githubusercontent.com/psealock/bde9264b5fdda289d5988cde10146f69/raw/a1db34f0a6df07f738b3e2ed6865cbaeae4f40fb/notifications.json',
 	);
 	/**
 	 * Class instance.

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/DataSourcePoller.php
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/DataSourcePoller.php
@@ -15,8 +15,7 @@ defined( 'ABSPATH' ) || exit;
 class DataSourcePoller extends \Automattic\WooCommerce\Admin\DataSourcePoller {
 	const ID           = 'remote_inbox_notifications';
 	const DATA_SOURCES = array(
-		// 'https://woocommerce.com/wp-json/wccom/inbox-notifications/1.0/notifications.json',
-		'https://gist.githubusercontent.com/psealock/bde9264b5fdda289d5988cde10146f69/raw/a1db34f0a6df07f738b3e2ed6865cbaeae4f40fb/notifications.json',
+		'https://woocommerce.com/wp-json/wccom/inbox-notifications/1.0/notifications.json',
 	);
 	/**
 	 * Class instance.

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/README.md
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/README.md
@@ -167,6 +167,20 @@ onboarding profile:
 }
 ```
 
+`in` and `!in` allow checking if a value is found (or not found) in a provided array. For example, using the `in` comparison operator to check if the base country location value is found in a given array, as below. This rule matches if the `base_location_country` is `US`, `NZ`, or `ZA`.
+
+```json
+{
+	"type": "base_location_country",
+  	"value": [
+		"US",
+		"NZ",
+		"ZA"
+	],
+	"operation": "in"
+}
+```
+
 ### Plugins activated
 
 This passes if all of the listed plugins are installed and activated.

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/README.md
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/README.md
@@ -169,7 +169,7 @@ onboarding profile:
 }
 ```
 
-`in` and `!in` allow checking if a value is found (or not found) in a provided array. For example, using the `in` comparison operator to check if the base country location value is found in a given array, as below. This rule matches if the `base_location_country` is `US`, `NZ`, or `ZA`. **NOTE** These comparisons were added in WooCommerce 8.2.0. If the spec is read by an older version of WooCommerce, the rule will evaluate to `false`.
+`in` and `!in` allow checking if a value is found (or not found) in a provided array. For example, using the `in` comparison operator to check if the base country location value is found in a given array, as below. This rule matches if the `base_location_country` is `US`, `NZ`, or `ZA`. **NOTE:** These comparisons were added in **WooCommerce 8.2.0**. If the spec is read by an older version of WooCommerce, the rule will evaluate to `false`.
 
 ```json
 {

--- a/plugins/woocommerce/src/Admin/RemoteInboxNotifications/README.md
+++ b/plugins/woocommerce/src/Admin/RemoteInboxNotifications/README.md
@@ -151,6 +151,8 @@ values. The following operations are implemented:
 -   `!=`
 -   `contains`
 -   `!contains`
+-   `in` (Added in WooCommerce 8.2.0)
+-   `!in` (Added in WooCommerce 8.2.0)
 
 `contains` and `!contains` allow checking if the provided value is present (or
 not present) in the haystack value. An example of this is using the
@@ -167,7 +169,7 @@ onboarding profile:
 }
 ```
 
-`in` and `!in` allow checking if a value is found (or not found) in a provided array. For example, using the `in` comparison operator to check if the base country location value is found in a given array, as below. This rule matches if the `base_location_country` is `US`, `NZ`, or `ZA`.
+`in` and `!in` allow checking if a value is found (or not found) in a provided array. For example, using the `in` comparison operator to check if the base country location value is found in a given array, as below. This rule matches if the `base_location_country` is `US`, `NZ`, or `ZA`. **NOTE** These comparisons were added in WooCommerce 8.2.0. If the spec is read by an older version of WooCommerce, the rule will evaluate to `false`.
 
 ```json
 {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Often times we need to compare a value to an array of values in order to determine if a Remote Inbox Notification should be shown. Currently this would involve a comparison rule for each possible value, resulting in a very verbose spec.

This PR introduces the `in` and `!in` comparison operators to specify an array of values to compare against.

A rule to return `true` for base country location matching an array of values looks like this:

```
{
  "type": "base_location_country",
  "value": [
    "US",
    "NZ",
    "ZA"
  ],
  "operation": "in"
}
```
Alternatively, to return `true` for any currency NOT matching an array of values looks like so:

```
{
  "type": "option",
  "option_name": "woocommerce_currency",
  "value": [
    "USD",
    "NZD",
    "ZAR"
  ],
  "operation": "!in"
}
```

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Prep your notes

1. Remove any cached specs
```
DELETE from wp_options WHERE option_name LIKE '_transient_timeout_woocommerce_admin_remote_inbox_notifications_specs';
DELETE from wp_options WHERE option_name LIKE '_transient_woocommerce_admin_remote_inbox_notifications_specs';
```
2. Remove notes (to make things easier)
```
DELETE FROM wp_wc_admin_notes;
```
3. Point to a custom spec I've written with the examples from above. Replace the url in [this line](https://github.com/woocommerce/woocommerce/blob/850523284653ef66ce671815f12d4fa4e6f2cf50/plugins/woocommerce/src/Admin/RemoteInboxNotifications/DataSourcePoller.php#L18) with a gist I created. Be sure to check it out and make sure it is sensible.
```
https://gist.githubusercontent.com/psealock/bde9264b5fdda289d5988cde10146f69/raw/a1db34f0a6df07f738b3e2ed6865cbaeae4f40fb/notifications.json
```
#### Test the notes

1. Go to `Tools > WCA Test Helper > Tools` and press the `Run` button for the `wc_admin_daily job` cron job.
2. Go to WooCommerce > Home and you should see a note if your store is based in US, NZ, or SA. You should see a second note if your store's currency is NOT USD, NZD, or ZAR.
3. Next play with your store's settings to change the conditions to meet/not meet these criteria.
4. You'll need to delete your notes (`DELETE FROM wp_wc_admin_notes;`) and re-run the `wc_admin_daily job` cron job between each iteration.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Update Remote Inbox Notifications to add in and !in comparison operators for comparing values against arrays

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
