### PR TITLE
Add added|updated|deleted_order_meta actions.

### DIFF
--- a/plugins/woocommerce/changelog/fix-duplicate-meta-handling
+++ b/plugins/woocommerce/changelog/fix-duplicate-meta-handling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+[HPOS]Fix duplicate meta handling by passing meta_value|unique in post calls

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
@@ -683,15 +683,67 @@ abstract class WC_Data {
 		foreach ( $this->meta_data as $array_key => $meta ) {
 			if ( is_null( $meta->value ) ) {
 				if ( ! empty( $meta->id ) ) {
+					/**
+					 * Trigger action before saving to the DB. Allows you to adjust order props before save.
+					 *
+					 * @param WC_Data          $this The object being saved.
+					 * @param WC_Data_Store_WP $data_store THe data store persisting the data.
+					 */
+					do_action( 'woocommerce_before_' . $this->object_type . '_object_save', $this, $this->data_store );
+
 					$this->data_store->delete_meta( $this, $meta );
+
+					/**
+					 * Trigger action before saving to the DB. Allows you to adjust order props before save.
+					 *
+					 * @param WC_Data          $this The object being saved.
+					 * @param WC_Data_Store_WP $data_store THe data store persisting the data.
+					 */
+					do_action( 'woocommerce_after_' . $this->object_type . '_object_save', $this, $this->data_store );
+
+
 					unset( $this->meta_data[ $array_key ] );
 				}
 			} elseif ( empty( $meta->id ) ) {
+				/**
+				 * Trigger action before saving to the DB. Allows you to adjust order props before save.
+				 *
+				 * @param WC_Data          $this The object being saved.
+				 * @param WC_Data_Store_WP $data_store THe data store persisting the data.
+				 */
+				do_action( 'woocommerce_before_' . $this->object_type . '_object_save', $this, $this->data_store );
+
 				$meta->id = $this->data_store->add_meta( $this, $meta );
+
+				/**
+				 * Trigger action before saving to the DB. Allows you to adjust order props before save.
+				 *
+				 * @param WC_Data          $this The object being saved.
+				 * @param WC_Data_Store_WP $data_store THe data store persisting the data.
+				 */
+				do_action( 'woocommerce_after_' . $this->object_type . '_object_save', $this, $this->data_store );
+
 				$meta->apply_changes();
 			} else {
 				if ( $meta->get_changes() ) {
+					/**
+					 * Trigger action before saving to the DB. Allows you to adjust order props before save.
+					 *
+					 * @param WC_Data          $this The object being saved.
+					 * @param WC_Data_Store_WP $data_store THe data store persisting the data.
+					 */
+					do_action( 'woocommerce_before_' . $this->object_type . '_object_save', $this, $this->data_store );
+
 					$this->data_store->update_meta( $this, $meta );
+
+					/**
+					 * Trigger action before saving to the DB. Allows you to adjust order props before save.
+					 *
+					 * @param WC_Data          $this The object being saved.
+					 * @param WC_Data_Store_WP $data_store THe data store persisting the data.
+					 */
+					do_action( 'woocommerce_after_' . $this->object_type . '_object_save', $this, $this->data_store );
+
 					$meta->apply_changes();
 				}
 			}

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
@@ -684,14 +684,44 @@ abstract class WC_Data {
 			if ( is_null( $meta->value ) ) {
 				if ( ! empty( $meta->id ) ) {
 					$this->data_store->delete_meta( $this, $meta );
+					/**
+					 * Fires immediately after deleting metadata.
+					 *
+					 * @param int    $meta_id    ID of added metadata entry.
+					 * @param int    $object_id  Object ID.
+					 * @param string $meta_key   Metadata key.
+					 * @param mixed  $meta_value Metadata value.
+					 */
+					do_action( "deleted_{$this->object_type}_meta", $meta->id, $this->get_id(), $meta->key, $meta->value );
+
 					unset( $this->meta_data[ $array_key ] );
 				}
 			} elseif ( empty( $meta->id ) ) {
 				$meta->id = $this->data_store->add_meta( $this, $meta );
+				/**
+				 * Fires immediately after adding metadata.
+				 *
+				 * @param int    $meta_id    ID of added metadata entry.
+				 * @param int    $object_id  Object ID.
+				 * @param string $meta_key   Metadata key.
+				 * @param mixed  $meta_value Metadata value.
+				 */
+				do_action( "added_{$this->object_type}_meta", $meta->id, $this->get_id(), $meta->key, $meta->value );
+
 				$meta->apply_changes();
 			} else {
 				if ( $meta->get_changes() ) {
 					$this->data_store->update_meta( $this, $meta );
+					/**
+					 * Fires immediately after updating metadata.
+					 *
+					 * @param int    $meta_id    ID of added metadata entry.
+					 * @param int    $object_id  Object ID.
+					 * @param string $meta_key   Metadata key.
+					 * @param mixed  $meta_value Metadata value.
+					 */
+					do_action( "updated_{$this->object_type}_meta", $meta->id, $this->get_id(), $meta->key, $meta->value );
+
 					$meta->apply_changes();
 				}
 			}

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
@@ -687,10 +687,10 @@ abstract class WC_Data {
 					/**
 					 * Fires immediately after deleting metadata.
 					 *
-					 * @param int    $meta_id    ID of added metadata entry.
+					 * @param int    $meta_id    ID of deleted metadata entry.
 					 * @param int    $object_id  Object ID.
 					 * @param string $meta_key   Metadata key.
-					 * @param mixed  $meta_value Metadata value.
+					 * @param mixed  $meta_value Metadata value (will be empty for delete).
 					 */
 					do_action( "deleted_{$this->object_type}_meta", $meta->id, $this->get_id(), $meta->key, $meta->value );
 
@@ -715,7 +715,7 @@ abstract class WC_Data {
 					/**
 					 * Fires immediately after updating metadata.
 					 *
-					 * @param int    $meta_id    ID of added metadata entry.
+					 * @param int    $meta_id    ID of updated metadata entry.
 					 * @param int    $object_id  Object ID.
 					 * @param string $meta_key   Metadata key.
 					 * @param mixed  $meta_value Metadata value.

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-data.php
@@ -683,67 +683,15 @@ abstract class WC_Data {
 		foreach ( $this->meta_data as $array_key => $meta ) {
 			if ( is_null( $meta->value ) ) {
 				if ( ! empty( $meta->id ) ) {
-					/**
-					 * Trigger action before saving to the DB. Allows you to adjust order props before save.
-					 *
-					 * @param WC_Data          $this The object being saved.
-					 * @param WC_Data_Store_WP $data_store THe data store persisting the data.
-					 */
-					do_action( 'woocommerce_before_' . $this->object_type . '_object_save', $this, $this->data_store );
-
 					$this->data_store->delete_meta( $this, $meta );
-
-					/**
-					 * Trigger action before saving to the DB. Allows you to adjust order props before save.
-					 *
-					 * @param WC_Data          $this The object being saved.
-					 * @param WC_Data_Store_WP $data_store THe data store persisting the data.
-					 */
-					do_action( 'woocommerce_after_' . $this->object_type . '_object_save', $this, $this->data_store );
-
-
 					unset( $this->meta_data[ $array_key ] );
 				}
 			} elseif ( empty( $meta->id ) ) {
-				/**
-				 * Trigger action before saving to the DB. Allows you to adjust order props before save.
-				 *
-				 * @param WC_Data          $this The object being saved.
-				 * @param WC_Data_Store_WP $data_store THe data store persisting the data.
-				 */
-				do_action( 'woocommerce_before_' . $this->object_type . '_object_save', $this, $this->data_store );
-
 				$meta->id = $this->data_store->add_meta( $this, $meta );
-
-				/**
-				 * Trigger action before saving to the DB. Allows you to adjust order props before save.
-				 *
-				 * @param WC_Data          $this The object being saved.
-				 * @param WC_Data_Store_WP $data_store THe data store persisting the data.
-				 */
-				do_action( 'woocommerce_after_' . $this->object_type . '_object_save', $this, $this->data_store );
-
 				$meta->apply_changes();
 			} else {
 				if ( $meta->get_changes() ) {
-					/**
-					 * Trigger action before saving to the DB. Allows you to adjust order props before save.
-					 *
-					 * @param WC_Data          $this The object being saved.
-					 * @param WC_Data_Store_WP $data_store THe data store persisting the data.
-					 */
-					do_action( 'woocommerce_before_' . $this->object_type . '_object_save', $this, $this->data_store );
-
 					$this->data_store->update_meta( $this, $meta );
-
-					/**
-					 * Trigger action before saving to the DB. Allows you to adjust order props before save.
-					 *
-					 * @param WC_Data          $this The object being saved.
-					 * @param WC_Data_Store_WP $data_store THe data store persisting the data.
-					 */
-					do_action( 'woocommerce_after_' . $this->object_type . '_object_save', $this, $this->data_store );
-
 					$meta->apply_changes();
 				}
 			}

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -715,15 +715,27 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 
 		foreach ( $order->get_meta_data() as $meta_data ) {
 			if ( isset( $existing_meta_data[ $meta_data->key ] ) ) {
-				// We don't know if the meta is single or array, so we assume it to be array.
+				// We don't know if the meta is single or array, so we assume it to be an array.
 				$meta_value = is_array( $meta_data->value ) ? $meta_data->value : array( $meta_data->value );
+
 				if ( $existing_meta_data[ $meta_data->key ] === $meta_value ) {
 					unset( $existing_meta_data[ $meta_data->key ] );
 					continue;
 				}
 
+				if ( is_array( $existing_meta_data[ $meta_data->key ] ) ) {
+					$key_search = array_search( $meta_data->value, $existing_meta_data[ $meta_data->key ], true );
+					if ( false !== $key_search ) {
+						unset( $existing_meta_data[ $meta_data->key ][ $key_search ] );
+						if ( 0 === count( $existing_meta_data[ $meta_data->key ] ) ) {
+							unset( $existing_meta_data[ $meta_data->key ] );
+						}
+						continue;
+					}
+				}
+
 				unset( $existing_meta_data[ $meta_data->key ] );
-				delete_post_meta( $order->get_id(), $meta_data->key );
+				delete_post_meta( $order->get_id(), $meta_data->key, $meta_data->value );
 			}
 			add_post_meta( $order->get_id(), $meta_data->key, $meta_data->value, false );
 		}

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -748,7 +748,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 		foreach ( $keys_to_delete as $meta_key ) {
 			if ( isset( $existing_meta_data[ $meta_key ] ) ) {
 				foreach ( $existing_meta_data[ $meta_key ] as $meta_value ) {
-					delete_post_meta( $order->get_id(), $meta_key, $meta_value );
+					delete_post_meta( $order->get_id(), $meta_key, maybe_unserialize( $meta_value ) );
 				}
 			}
 		}

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -724,18 +724,15 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 				}
 
 				if ( is_array( $existing_meta_data[ $meta_data->key ] ) ) {
-					$key_search = array_search( $meta_data->value, $existing_meta_data[ $meta_data->key ], true );
-					if ( false !== $key_search ) {
-						unset( $existing_meta_data[ $meta_data->key ][ $key_search ] );
+					$value_index = array_search( $meta_data->value, $existing_meta_data[ $meta_data->key ], true );
+					if ( false !== $value_index ) {
+						unset( $existing_meta_data[ $meta_data->key ][ $value_index ] );
 						if ( 0 === count( $existing_meta_data[ $meta_data->key ] ) ) {
 							unset( $existing_meta_data[ $meta_data->key ] );
 						}
 						continue;
 					}
 				}
-
-				unset( $existing_meta_data[ $meta_data->key ] );
-				delete_post_meta( $order->get_id(), $meta_data->key, $meta_data->value );
 			}
 			add_post_meta( $order->get_id(), $meta_data->key, $meta_data->value, false );
 		}
@@ -749,7 +746,11 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 		);
 
 		foreach ( $keys_to_delete as $meta_key ) {
-			delete_post_meta( $order->get_id(), $meta_key );
+			if ( isset( $existing_meta_data[ $meta_key ] ) ) {
+				foreach ( $existing_meta_data[ $meta_key ] as $meta_value ) {
+					delete_post_meta( $order->get_id(), $meta_key, $meta_value );
+				}
+			}
 		}
 
 		$this->update_post_meta( $order );

--- a/plugins/woocommerce/src/Internal/DataStores/CustomMetaDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/CustomMetaDataStore.php
@@ -114,7 +114,7 @@ abstract class CustomMetaDataStore {
 	 * @param  stdClass $meta (containing ->key and ->value).
 	 * @param  string   $meta_type Meta type.
 	 *
-	 * @return int meta ID
+	 * @return int|false meta ID
 	 */
 	protected function add_meta_with_type( &$object, $meta, $meta_type ) {
 		global $wpdb;
@@ -159,7 +159,7 @@ abstract class CustomMetaDataStore {
 	 *
 	 * @return bool
 	 */
-	protected function update_meta_with_type( &$object, $meta, $meta_type ) {
+	protected function update_meta_with_type( &$object, $meta, $meta_type ) : bool {
 		global $wpdb;
 
 		if ( ! isset( $meta->id ) || empty( $meta->key ) ) {

--- a/plugins/woocommerce/src/Internal/DataStores/CustomMetaDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/CustomMetaDataStore.php
@@ -78,11 +78,10 @@ abstract class CustomMetaDataStore {
 	 *
 	 * @param  WC_Data  $object WC_Data object.
 	 * @param  stdClass $meta (containing at least ->id).
-	 * @param  string   $meta_type Meta type.
 	 *
 	 * @return bool
 	 */
-	protected function delete_meta_with_type( &$object, $meta, $meta_type ) : bool {
+	public function delete_meta( &$object, $meta ) : bool {
 		global $wpdb;
 
 		if ( ! isset( $meta->id ) ) {
@@ -92,19 +91,7 @@ abstract class CustomMetaDataStore {
 		$db_info = $this->get_db_info();
 		$meta_id = absint( $meta->id );
 
-		$result = (bool) $wpdb->delete( $db_info['table'], array( $db_info['meta_id_field'] => $meta_id ) );
-
-		/**
-		 * Fires immediately after deleting metadata.
-		 *
-		 * @param int    $meta_id    ID of updated metadata entry.
-		 * @param int    $object_id  Post ID.
-		 * @param string $meta_key   Metadata key.
-		 * @param mixed  $meta_value Metadata value.
-		 */
-		do_action( "deleted_{$meta_type}_meta", $meta_id, $object->get_id(), $meta->key, $meta->value );
-
-		return $result;
+		return (bool) $wpdb->delete( $db_info['table'], array( $db_info['meta_id_field'] => $meta_id ) );
 	}
 
 	/**
@@ -112,11 +99,10 @@ abstract class CustomMetaDataStore {
 	 *
 	 * @param  WC_Data  $object WC_Data object.
 	 * @param  stdClass $meta (containing ->key and ->value).
-	 * @param  string   $meta_type Meta type.
 	 *
 	 * @return int|false meta ID
 	 */
-	protected function add_meta_with_type( &$object, $meta, $meta_type ) {
+	public function add_meta( &$object, $meta ) {
 		global $wpdb;
 
 		$db_info = $this->get_db_info();
@@ -135,19 +121,8 @@ abstract class CustomMetaDataStore {
 			)
 		);
 		// phpcs:enable WordPress.DB.SlowDBQuery.slow_db_query_meta_value,WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-		$meta_id = $result ? (int) $wpdb->insert_id : false;
 
-		/**
-		 * Fires immediately after adding metadata.
-		 *
-		 * @param int    $meta_id    ID of updated metadata entry.
-		 * @param int    $object_id  Post ID.
-		 * @param string $meta_key   Metadata key.
-		 * @param mixed  $meta_value Metadata value.
-		 */
-		do_action( "added_{$meta_type}_meta", $meta_id, $object->get_id(), $meta_key, $meta_value );
-
-		return $meta_id;
+		return $result ? (int) $wpdb->insert_id : false;
 	}
 
 	/**
@@ -155,11 +130,10 @@ abstract class CustomMetaDataStore {
 	 *
 	 * @param  WC_Data  $object WC_Data object.
 	 * @param  stdClass $meta (containing ->id, ->key and ->value).
-	 * @param  string   $meta_type Meta type.
 	 *
 	 * @return bool
 	 */
-	protected function update_meta_with_type( &$object, $meta, $meta_type ) : bool {
+	public function update_meta( &$object, $meta ) : bool {
 		global $wpdb;
 
 		if ( ! isset( $meta->id ) || empty( $meta->key ) ) {
@@ -182,16 +156,6 @@ abstract class CustomMetaDataStore {
 			'%s',
 			'%d'
 		);
-
-		/**
-		 * Fires immediately after updating metadata.
-		 *
-		 * @param int    $meta_id    ID of updated metadata entry.
-		 * @param int    $object_id  Post ID.
-		 * @param string $meta_key   Metadata key.
-		 * @param mixed  $meta_value Metadata value.
-		 */
-		do_action( "updated_{$meta_type}_meta", $meta->id, $object->get_id(), $meta->key, $meta->value );
 
 		return 1 === $result;
 	}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2920,14 +2920,25 @@ CREATE TABLE $meta_table (
 	 * @param \WC_Meta_Data     $meta  Metadata object.
 	 */
 	protected function after_meta_change( &$order, $meta ) {
-		$current_date_time = new \WC_DateTime( current_time( 'mysql', 1 ), new \DateTimeZone( 'GMT' ) );
 		method_exists( $meta, 'apply_changes' ) && $meta->apply_changes();
 		$this->clear_caches( $order );
 
 		// Prevent this happening multiple time in same request.
-		if ( $order->get_date_modified() < $current_date_time && empty( $order->get_changes() ) ) {
+		if ( $this->should_save_after_meta_change( $order )  ) {
 			$order->set_date_modified( current_time( 'mysql' ) );
 			$order->save();
 		}
+	}
+
+	/**
+	 * Helper function to check whether the modified date needs to be updated after a meta save.
+	 *
+	 * @param WC_Order $order Order object.
+	 *
+	 * @return bool Whether the modified date needs to be updated.
+	 */
+	private function should_save_after_meta_change( $order ) {
+		$current_date_time = new \WC_DateTime( current_time( 'mysql', 1 ), new \DateTimeZone( 'GMT' ) );
+		return $order->get_date_modified() < $current_date_time && empty( $order->get_changes() );
 	}
 }

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2938,6 +2938,10 @@ CREATE TABLE $meta_table (
 	/**
 	 * Helper function to check whether the modified date needs to be updated after a meta save.
 	 *
+	 * This method prevents order->save() call multiple times in the same request after any meta update by checking if:
+	 * 1. Order modified date is already the current date, no updates needed in this case.
+	 * 2. If there are changes already queued for order object, then we don't need to update the modified date as it will be updated ina subsequent save() call.
+	 *
 	 * @param WC_Order $order Order object.
 	 *
 	 * @return bool Whether the modified date needs to be updated.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2850,7 +2850,7 @@ CREATE TABLE $meta_table (
 	 * @return bool
 	 */
 	public function delete_meta( &$object, $meta ) {
-		if ( $this->should_backfill_post_record() && isset( $meta->id ) && ! isset( $meta->key ) ) {
+		if ( $this->should_backfill_post_record() && isset( $meta->id ) ) {
 			// Let's get the actual meta key before its deleted for backfilling. We cannot delete just by ID because meta IDs are different in HPOS and posts tables.
 			$db_meta = $this->data_store_meta->get_metadata_by_id( $meta->id );
 			if ( $db_meta ) {
@@ -2886,7 +2886,7 @@ CREATE TABLE $meta_table (
 
 		if ( ! $changes_applied && $object instanceof WC_Abstract_Order && $this->should_backfill_post_record() ) {
 			self::$backfilling_order_ids[] = $object->get_id();
-			add_post_meta( $object->get_id(), $meta->key, $meta->value, true );
+			add_post_meta( $object->get_id(), $meta->key, $meta->value );
 			self::$backfilling_order_ids = array_diff( self::$backfilling_order_ids, array( $object->get_id() ) );
 		}
 
@@ -2927,7 +2927,7 @@ CREATE TABLE $meta_table (
 		$this->clear_caches( $order );
 
 		// Prevent this happening multiple time in same request.
-		if ( $this->should_save_after_meta_change( $order )  ) {
+		if ( $this->should_save_after_meta_change( $order ) ) {
 			$order->set_date_modified( current_time( 'mysql' ) );
 			$order->save();
 			return true;

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStoreMeta.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStoreMeta.php
@@ -29,40 +29,4 @@ class OrdersTableDataStoreMeta extends CustomMetaDataStore {
 	protected function get_object_id_field() {
 		return 'order_id';
 	}
-
-	/**
-	 * Deletes meta based on meta ID.
-	 *
-	 * @param  WC_Data  $object WC_Data object.
-	 * @param  stdClass $meta (containing at least ->id).
-	 *
-	 * @return bool
-	 */
-	public function delete_meta( &$object, $meta ) : bool {
-		return $this->delete_meta_with_type( $object, $meta, 'order' );
-	}
-
-	/**
-	 * Add new piece of meta.
-	 *
-	 * @param  WC_Data  $object WC_Data object.
-	 * @param  stdClass $meta (containing ->key and ->value).
-	 *
-	 * @return int|false meta ID
-	 */
-	public function add_meta( &$object, $meta ) {
-		return $this->add_meta_with_type( $object, $meta, 'order' );
-	}
-
-	/**
-	 * Update meta.
-	 *
-	 * @param  WC_Data  $object WC_Data object.
-	 * @param  stdClass $meta (containing ->id, ->key and ->value).
-	 *
-	 * @return bool
-	 */
-	public function update_meta( &$object, $meta ) : bool {
-		return $this->update_meta_with_type( $object, $meta, 'order' );
-	}
 }

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStoreMeta.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStoreMeta.php
@@ -29,4 +29,5 @@ class OrdersTableDataStoreMeta extends CustomMetaDataStore {
 	protected function get_object_id_field() {
 		return 'order_id';
 	}
+
 }

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStoreMeta.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStoreMeta.php
@@ -30,4 +30,39 @@ class OrdersTableDataStoreMeta extends CustomMetaDataStore {
 		return 'order_id';
 	}
 
+	/**
+	 * Deletes meta based on meta ID.
+	 *
+	 * @param  WC_Data  $object WC_Data object.
+	 * @param  stdClass $meta (containing at least ->id).
+	 *
+	 * @return bool
+	 */
+	public function delete_meta( &$object, $meta ) {
+		return $this->delete_meta_with_type( $object, $meta, 'order' );
+	}
+
+	/**
+	 * Add new piece of meta.
+	 *
+	 * @param  WC_Data  $object WC_Data object.
+	 * @param  stdClass $meta (containing ->key and ->value).
+	 *
+	 * @return int meta ID
+	 */
+	public function add_meta( &$object, $meta ) {
+		return $this->add_meta_with_type( $object, $meta, 'order' );
+	}
+
+	/**
+	 * Update meta.
+	 *
+	 * @param  WC_Data  $object WC_Data object.
+	 * @param  stdClass $meta (containing ->id, ->key and ->value).
+	 *
+	 * @return bool
+	 */
+	public function update_meta( &$object, $meta ) {
+		return $this->update_meta_with_type( $object, $meta, 'order' );
+	}
 }

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStoreMeta.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStoreMeta.php
@@ -38,7 +38,7 @@ class OrdersTableDataStoreMeta extends CustomMetaDataStore {
 	 *
 	 * @return bool
 	 */
-	public function delete_meta( &$object, $meta ) {
+	public function delete_meta( &$object, $meta ) : bool {
 		return $this->delete_meta_with_type( $object, $meta, 'order' );
 	}
 
@@ -48,7 +48,7 @@ class OrdersTableDataStoreMeta extends CustomMetaDataStore {
 	 * @param  WC_Data  $object WC_Data object.
 	 * @param  stdClass $meta (containing ->key and ->value).
 	 *
-	 * @return int meta ID
+	 * @return int|false meta ID
 	 */
 	public function add_meta( &$object, $meta ) {
 		return $this->add_meta_with_type( $object, $meta, 'order' );
@@ -62,7 +62,7 @@ class OrdersTableDataStoreMeta extends CustomMetaDataStore {
 	 *
 	 * @return bool
 	 */
-	public function update_meta( &$object, $meta ) {
+	public function update_meta( &$object, $meta ) : bool {
 		return $this->update_meta_with_type( $object, $meta, 'order' );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -2962,5 +2962,16 @@ class OrdersTableDataStoreTests extends HposTestCase {
 		 */
 		$post_meta = get_post_meta( $order->get_id(), 'test_key' );
 		$this->assertTrue( in_array( 'test_value3', $post_meta, true ) );
+
+		$order->set_date_modified( gmdate( 'Y-m-d H:i:s', strtotime( '-2 day' ) ) );
+		$order->save();
+
+		add_post_meta( $order->get_id(), 'test_key2', 'test_value5' );
+		$order->add_meta_data( 'test_key2', 'test_value4' );
+		$order->save();
+
+		$post_meta = get_post_meta( $order->get_id(), 'test_key2' );
+		$this->assertTrue( in_array( 'test_value4', $post_meta, true ) );
+		$this->assertFalse( in_array( 'test_value5', $post_meta, true ) );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -2925,7 +2925,9 @@ class OrdersTableDataStoreTests extends HposTestCase {
 
 		$order = WC_Helper_Order::create_order();
 		// Force an earlier modified date to trigger the `should_save_after_meta_change` to be true later in the test.
-		$order->set_date_modified( date( 'Y-m-d H:i:s', strtotime( '-1 hour' ) ) );
+		$order->set_date_modified( gmdate( 'Y-m-d H:i:s', strtotime( '-2 day' ) ) );
+		$current_date_time = new \WC_DateTime( current_time( 'mysql', 1 ), new \DateTimeZone( 'GMT' ) );
+		assert( $order->get_date_modified() < $current_date_time ); // Meta check, to make sure our test stay effective if we run testsuite in a different timezone.
 		$order->save();
 
 		$order->add_meta_data( 'test_key', 'test_value' );
@@ -2935,14 +2937,30 @@ class OrdersTableDataStoreTests extends HposTestCase {
 		$this->assertCount( 1, $post_meta );
 		$this->assertEquals( 'test_value', $post_meta[0] );
 
-		wp_cache_flush();
 		$order->add_meta_data( 'test_key', 'test_value' );
 		$order->save_meta_data();
 
-		wp_cache_flush();
 		$post_meta = get_post_meta( $order->get_id(), 'test_key' );
 		$this->assertCount( 2, $post_meta );
 		$this->assertEquals( 'test_value', $post_meta[0] );
 		$this->assertEquals( 'test_value', $post_meta[1] );
+
+		$order->add_meta_data( 'test_key', 'test_value2' );
+		$order->save_meta_data();
+
+		$post_meta = get_post_meta( $order->get_id(), 'test_key' );
+		$this->assertCount( 3, $post_meta );
+		$this->assertTrue( in_array( 'test_value2', $post_meta, true ) );
+
+		$order->set_date_modified( gmdate( 'Y-m-d H:i:s', strtotime( '-1 hour' ) ) );
+		$order->save();
+		$order->update_meta_data( 'test_key', 'test_value3' );
+		$order->save_meta_data();
+
+		/**
+		 * Note that WC_Data has a bug where if we update a duplicate key, it will delete rest of other keys. But since this bug has been there for 5 years as of writing this code, we will not assert whether postmeta is exactly the same as order_meta but only test that out value was saved.
+		 */
+		$post_meta = get_post_meta( $order->get_id(), 'test_key' );
+		$this->assertTrue( in_array( 'test_value3', $post_meta, true ) );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -2915,4 +2915,30 @@ class OrdersTableDataStoreTests extends HposTestCase {
 			$this->assertEquals( $value, $order_data[ $order->get_id() ]->{$key}, "Unable to match $key for {$order_data[ $order->get_id() ]->{$key}}. Expected $value" );
 		}
 	}
+
+	/**
+	 * @testDox Test that duplicate key, value pairs are also synced properly.
+	 */
+	public function test_duplicate_meta_is_synced_properly() {
+		$this->toggle_cot_authoritative( true );
+		$this->enable_cot_sync();
+
+		$order = WC_Helper_Order::create_order();
+		$order->add_meta_data( 'test_key', 'test_value' );
+		$order->save_meta_data();
+
+		$post_meta = get_post_meta( $order->get_id(), 'test_key' );
+		$this->assertCount( 1, $post_meta );
+		$this->assertEquals( 'test_value', $post_meta[0] );
+
+		wp_cache_flush();
+		$order->add_meta_data( 'test_key', 'test_value' );
+		$order->save_meta_data();
+
+		wp_cache_flush();
+		$post_meta = get_post_meta( $order->get_id(), 'test_key' );
+		$this->assertCount( 2, $post_meta );
+		$this->assertEquals( 'test_value', $post_meta[0] );
+		$this->assertEquals( 'test_value', $post_meta[1] );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -2924,6 +2924,10 @@ class OrdersTableDataStoreTests extends HposTestCase {
 		$this->enable_cot_sync();
 
 		$order = WC_Helper_Order::create_order();
+		// Force an earlier modified date to trigger the `should_save_after_meta_change` to be true later in the test.
+		$order->set_date_modified( date( 'Y-m-d H:i:s', strtotime( '-1 hour' ) ) );
+		$order->save();
+
 		$order->add_meta_data( 'test_key', 'test_value' );
 		$order->save_meta_data();
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This change adds added|updated|deleted_order_meta actions to provide compatibility with respective actions for postmeta (i.e. added|updated|deleted_post_meta actions). 

### Open questions ❓

#### Order subclasses

One thing to note is that the actions for `postmeta` were much broader, so they included also **subclasses** (i.e. orders, subscriptions, refunds, etc). Therefore, it seemed like the right choice to opt for more general actions here as well (i.e. actioned_order_meta) rather than actions for each subtype. However, it should be possible to achieve greater granularity by subclassing `\Automattic\WooCommerce\Internal\DataStores\CustomMetaDataStore` or `\Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStoreMeta` and overriding the methods add|update|delete_meta methods.

#### What's a meta data anyway?

Another potential gotcha is that in the HPOS implementation, there are **fewer pieces of data stored as meta**, so while `added_post_meta` might be called on some meta data in the CPT data store, it might not be for the HPOS data store. 

To further complicate this a bit, `_customer_ip_address`,`_recorded_sales`, `_order_total`, `_order_currency`, etc. are what we call `internal meta keys`. With CPT data store, they are stored as postmeta, but "[are not considered meta](https://github.com/woocommerce/woocommerce/blob/8.0.3/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php#L29)". With HPOS, they are mostly stored in the new orders table.

This could be potentially problematic, as it breaks the meta abstraction to a degree. 

~This shouldn't be a problem for new meta data extensions add (those will always be meta), but it _could_ be a problem if extensions would want to detect changes to fields such as `_order_total`.~

After further examination, this works fine as long as the WC_Order methods are used (`\WC_Data::add_meta_data` etc). Of course, it would break when the code uses `add_post_meta`.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Note that when testing this PR, instructions from #40129 also needs to be followed.

1. Enable HPOS with sync on.
1. To see when the actions have been called, add the following snippet to your environment. Each call will be logged to the PHP error log (location of which you can find via `phpinfo()`). You can easily monitor the file in console via calling `tail -f /path/to/file`:
```
function log_meta_filter( $filter_name, $obj_id, $args ){
	$obj = wc_get_order( $obj_id );
	if ( ! is_a( $obj, 'WC_Abstract_Order' ) ){
		return;
	}
	$datetime_now = new DateTime();
	error_log( $datetime_now->format( 'Y-m-d H:i:s' ) . ": $filter_name: " . print_r( $args, true ) . "\n" );
}

add_filter( 'added_post_meta', function( $meta_id, $object_id, $meta_key, $_meta_value ){
	log_meta_filter( 'added_post_meta', $object_id, [ $meta_id, $object_id, $meta_key, $_meta_value ] );
}, 10, 4 );

add_filter( 'updated_post_meta', function( $meta_id, $object_id, $meta_key, $_meta_value ){
	log_meta_filter( 'updated_post_meta', $object_id, [ $meta_id, $object_id, $meta_key, $_meta_value ] );
}, 10, 4 );

add_filter( 'deleted_post_meta', function( $meta_id, $object_id, $meta_key, $_meta_value ){
	log_meta_filter( 'deleted_post_meta', $object_id, [ $meta_id, $object_id, $meta_key, $_meta_value ] );
}, 10, 4 );

add_filter( 'added_order_meta', function( $meta_id, $object_id, $meta_key, $_meta_value ){
	log_meta_filter( 'added_order_meta', $object_id, [ $meta_id, $object_id, $meta_key, $_meta_value ] );
}, 10, 4 );

add_filter( 'updated_order_meta', function( $meta_id, $object_id, $meta_key, $_meta_value ){
	log_meta_filter( 'updated_order_meta', $object_id, [ $meta_id, $object_id, $meta_key, $_meta_value ] );
}, 10, 4 );

add_filter( 'deleted_order_meta', function( $meta_id, $object_id, $meta_key, $_meta_value ){
	log_meta_filter( 'deleted_order_meta', $object_id, [ $meta_id, $object_id, $meta_key, $_meta_value ] );
}, 10, 4 );



```
3. Run the following via `wp shell`:
```
// Create an order. Please note that this creates a bunch of postmeta by calling `add_post_meta`, 
// but it won't create any meta data in the new data store, 
// so it is expected that there aren't corresponding `added_order_meta` calls here
$order = wc_create_order();

// Add a true meta key & value pair. 
// After save gets called, this should generate messages for both actions 
// (added_post and added_order) with the same params.
$order->add_meta_data( 'test_key1', 'test_value1' );
$order->save();

// Add a true meta key & value pair. 
// After save_meta_data gets called, this should generate messages for both actions 
// (added_post and added_order) with the same params.
$order->add_meta_data( 'test_key2', 'test_value_2' );
$order->save_meta_data();


// Update a true meta value. 
// Again, after save gets called, this should generate messages for both actions 
// (deleted_post and added_post as an update and updated_order) with the same params.
$order->update_meta_data( 'test_key2', 'test_value_3' );
$order->save();

// Update an internal meta value. 
// After save gets called, this should generate messages for both actions 
// However, for CPT, the meta reverts back to original (correct) value afterwards. This will be fixed in a separate issue.
$order->update_meta_data( '_order_total', 42 );
$order->save();


// Delete a meta value. 
// Again, after save gets called, this should generate messages for both actions 
// (deleted_post and deleted_order) with the same params.
$order->delete_meta_data( 'test_key2', 'test_value_3' );
$order->save();

```
5. Turn off sync, run the same code in wp shell. Now, you should not see any updates for `_post_` actions in the log.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message Added `added|updated|deleted_{object-type}_meta` actions to WC_Data. When HPOS is active, these can be used as a replacement for similar actions added|updated|deleted_post_meta.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
