### PR TITLE
Updates the marketing knowledgebase posts endpoint

### DIFF
--- a/plugins/woocommerce/changelog/update-marketing-kb-endpoints
+++ b/plugins/woocommerce/changelog/update-marketing-kb-endpoints
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Updates the marketing knowledgebase API endpoint

--- a/plugins/woocommerce/src/Internal/Admin/Marketing/MarketingSpecs.php
+++ b/plugins/woocommerce/src/Internal/Admin/Marketing/MarketingSpecs.php
@@ -158,7 +158,7 @@ class MarketingSpecs {
 					'per_page' => 8,
 					'_embed'   => 1,
 				),
-				'https://woocommerce.com/wccom/marketing-knowledgebase/v1/posts/' . $topic
+				'https://woocommerce.com/wp-json/wccom/marketing-knowledgebase/v1/posts/' . $topic
 			);
 
 			$request = wp_remote_get(

--- a/plugins/woocommerce/src/Internal/Admin/Marketing/MarketingSpecs.php
+++ b/plugins/woocommerce/src/Internal/Admin/Marketing/MarketingSpecs.php
@@ -140,10 +140,8 @@ class MarketingSpecs {
 	 * @return array
 	 */
 	public function get_knowledge_base_posts( ?string $topic ): array {
-		$available_topics = array( 'marketing', 'coupons' );
-
 		// Default to the marketing topic (if no topic is set on the kb component).
-		if ( empty( $topic ) || ! in_array( $topic, $available_topics, true ) ) {
+		if ( empty( $topic ) ) {
 			$topic = 'marketing';
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/Marketing/MarketingSpecs.php
+++ b/plugins/woocommerce/src/Internal/Admin/Marketing/MarketingSpecs.php
@@ -136,43 +136,29 @@ class MarketingSpecs {
 	/**
 	 * Load knowledge base posts from WooCommerce.com
 	 *
-	 * @param string|null $term Term of posts to retrieve.
+	 * @param string|null $topic The topic of marketing knowledgebase to retrieve.
 	 * @return array
 	 */
-	public function get_knowledge_base_posts( ?string $term ): array {
-		$terms = array(
-			'marketing' => array(
-				'taxonomy' => 'category',
-				'term_id'  => 1744,
-				'argument' => 'categories',
-			),
-			'coupons'   => array(
-				'taxonomy' => 'post_tag',
-				'term_id'  => 1377,
-				'argument' => 'tags',
-			),
-		);
+	public function get_knowledge_base_posts( ?string $topic ): array {
+		$available_topics = array( 'marketing', 'coupons' );
 
-		// Default to the marketing category (if no term is set on the kb component).
-		if ( empty( $term ) || ! array_key_exists( $term, $terms ) ) {
-			$term = 'marketing';
+		// Default to the marketing topic (if no topic is set on the kb component).
+		if ( empty( $topic ) || ! in_array( $topic, $available_topics, true ) ) {
+			$topic = 'marketing';
 		}
 
-		$term_id      = $terms[ $term ]['term_id'];
-		$argument     = $terms[ $term ]['argument'];
-		$kb_transient = self::KNOWLEDGE_BASE_TRANSIENT . '_' . strtolower( $term );
+		$kb_transient = self::KNOWLEDGE_BASE_TRANSIENT . '_' . strtolower( $topic );
 
 		$posts = get_transient( $kb_transient );
 
 		if ( false === $posts ) {
 			$request_url = add_query_arg(
 				array(
-					$argument  => $term_id,
 					'page'     => 1,
 					'per_page' => 8,
 					'_embed'   => 1,
 				),
-				'https://woocommerce.com/wp-json/wp/v2/posts?utm_medium=product'
+				'https://woocommerce.com/wccom/marketing-knowledgebase/v1/posts/' . $topic
 			);
 
 			$request = wp_remote_get(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We added a new endpoint for the WooCommerce.com marketing knowledgebase API here:  https://github.com/Automattic/woocommerce.com/pull/18111. This allows the WooCommerce core to replace hardcoded IDs. In this PR, we'll replace the hardcode IDs in favour of the endpoints.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### Preconditions

1. Ensure WooCommerce is installed and activated. 
2. Navigate to `Marketing > Overview`.  
3. Scroll down to the `Learn about marketing a store` section. 
4. Note down the posts in the carousel.
5. Navigate to `Marketing > Coupons`.
6. Scroll down to the `WooCommerce knowledge base` section.
7. Note down the posts in the carousel.
8. Navigate to `WooCommerce > Status > Tools` and clear the transients.

#### Tests

9. Checkout this PR. Ensure WooCommerce is installed and activated.
10. Navigate to `Marketing > Overview`.  
11. Scroll down to the `Learn about marketing a store` section. 
12. Verify the posts in the carousel are the same as those noted in Step 5. 
13. Navigate to `Marketing > Coupons`.
14. Scroll down to the `WooCommerce knowledge base` section.
15. Verify the posts in the carousel are the same as those noted in Step 7. 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Updates the marketing knowledgebase API endpoint

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>