### PR TITLE
Fix 40075/avoid count query unless after first page

### DIFF
--- a/plugins/woocommerce/changelog/fix-40075-avoid-count-query-unless-after-first-page
+++ b/plugins/woocommerce/changelog/fix-40075-avoid-count-query-unless-after-first-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Prevent second query used to determine real post count from running if paging isn't being used.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-crud-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-crud-controller.php
@@ -354,7 +354,7 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 		$result = $query->query( $query_args );
 
 		$total_posts = $query->found_posts;
-		if ( $total_posts < 1 ) {
+		if ( $total_posts < 1 && isset( $query_args['paged'] ) && absint( $query_args['paged'] ) > 1 ) {
 			// Out-of-bounds, run the query again without LIMIT for total count.
 			unset( $query_args['paged'] );
 			$count_query = new WP_Query();

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-posts-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-posts-controller.php
@@ -367,7 +367,7 @@ abstract class WC_REST_Posts_Controller extends WC_REST_Controller {
 		$page = (int) $query_args['paged'];
 		$total_posts = $posts_query->found_posts;
 
-		if ( $total_posts < 1 ) {
+		if ( $total_posts < 1 && $page > 1 ) {
 			// Out-of-bounds, run the query again without LIMIT for total count.
 			unset( $query_args['paged'] );
 			$count_query = new WP_Query();

--- a/plugins/woocommerce/src/Admin/API/Reports/Stock/Controller.php
+++ b/plugins/woocommerce/src/Admin/API/Reports/Stock/Controller.php
@@ -93,7 +93,7 @@ class Controller extends GenericController implements ExportableInterface {
 		$result = $query->query( $query_args );
 
 		$total_posts = $query->found_posts;
-		if ( $total_posts < 1 ) {
+		if ( $total_posts < 1 && isset( $query_args['paged'] ) && absint( $query_args['paged'] ) > 1 ) {
 			// Out-of-bounds, run the query again without LIMIT for total count.
 			unset( $query_args['paged'] );
 			$count_query = new \WP_Query();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Avoid re-running the WP_Query used in controllers if pagination isn't being used.  

We currently re-run the WP_Query in some of the controllers if the total_posts result is 0.  This appears to have been done to fix issues where pagination exceeds the total posts causing the total_post count to be 0 even when there are posts.

However, some of these queries can be extremely slow due to meta clauses and running the query a second time is essentially doubling the request time for responses with no results.

Closes #40075 .

### How to test the changes in this Pull Request:

This is covered by the orders and products tests in `api-core-tests`.
