### PR TITLE
Use Correct PR Numbers In Code Freeze Changelog Command

### DIFF
--- a/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
@@ -54,8 +54,8 @@ const updateReleaseChangelogs = async (
 
 	// Convert PR number to markdown link.
 	nextLog = nextLog.replace(
-		/\[#(\d+)\]/g,
-		'[$&](https://github.com/woocommerce/woocommerce/pull/$1)'
+		/\[#(\d+)\](?!\()/g,
+		'[#$1](https://github.com/woocommerce/woocommerce/pull/$1)'
 	);
 
 	readme = readme.replace(

--- a/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/changelog/lib/index.ts
@@ -81,7 +81,8 @@ export const updateReleaseBranchChangelogs = async (
 ): Promise< { deletionCommitHash: string; prNumber: number } > => {
 	const { owner, name, version } = options;
 	try {
-		await checkoutRemoteBranch( tmpRepoPath, releaseBranch );
+		// Do a full checkout so that we can find the correct PR numbers for changelog entries.
+		await checkoutRemoteBranch( tmpRepoPath, releaseBranch, false );
 	} catch ( e ) {
 		if ( e.message.includes( "couldn't find remote ref" ) ) {
 			Logger.error(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

It was pointed out that [the changelog for WooCommerce 8.1](https://github.com/woocommerce/woocommerce/blob/70a4cb10883ae07f0218675d58156128bc116bf4/plugins/woocommerce/readme.txt#L166-L253) has the same PR number associated with every entry. I discovered that this was due to `checkoutRemoteBranch`'s `isShallow` parameter defaulting to `true`. The end result was that all of the changelog entries ended up with the latest PR number rather than the one that added the file. Simply passing `false` explicitly here ensures that the correct commit is given and the PR number is added as expected.

In debugging this problem I also noticed that an additional set of brackets was being placed around the PR number. The regex used to convert the PR number to markdown was a little bit too aggressive and would even re-parse markdown and create broken markdown. I adjusted the regex slightly so that it wouldn't introduce extra brackets and wouldn't parse markdown that was already prepared.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a fork of `woocommerce/woocommerce` if you do not already have one. If you do, make sure to sync the latest `trunk`.
2. Clone this fork and run `pnpm install`.
3. Run `git checkout -b release/8.2` and `git push --set-upstream origin release/8.2`. **Note: Make sure you're doing this in your fork directory rather than in your WooCommerce directory! Please don't make a real release branch! :smile:**
4. Run `pnpm utils code-freeze changelog -o {the owner of your fork. In my case, obliviousharmony} -v 8.2`
5. Review the resulting pull requests and make sure that the one which generates the `readme.txt` changelog has the correct PR numbers rather than the same.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
