### PR TITLE
Bump PHP version to 7.4 in the woocommerce/lib directory

### DIFF
--- a/plugins/woocommerce/changelog/bug-php-7.4-lib
+++ b/plugins/woocommerce/changelog/bug-php-7.4-lib
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Bump PHP version where it was missed in #39820.
+
+

--- a/plugins/woocommerce/lib/composer.json
+++ b/plugins/woocommerce/lib/composer.json
@@ -4,7 +4,7 @@
 	"prefer-stable": true,
 	"minimum-stability": "dev",
 	"require": {
-		"php": ">=7.2"
+		"php": ">=7.4"
 	},
 	"require-dev": {
 		"league/container": "3.3.5",
@@ -12,7 +12,7 @@
 	},
 	"config": {
 		"platform": {
-			"php": "7.2"
+			"php": "7.4"
 		}
 	},
 	"scripts": {

--- a/plugins/woocommerce/lib/composer.lock
+++ b/plugins/woocommerce/lib/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ee5352d3dc7eff84b896ab4900209e53",
+    "content-hash": "08afc0d13426146cf441a311818703f5",
     "packages": [],
     "packages-dev": [
         {
@@ -88,20 +88,20 @@
         },
         {
             "name": "psr/container",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
-                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.0"
+                "php": ">=7.4.0"
             },
             "type": "library",
             "autoload": {
@@ -130,9 +130,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.1"
+                "source": "https://github.com/php-fig/container/tree/1.1.2"
             },
-            "time": "2021-03-05T17:36:06+00:00"
+            "time": "2021-11-05T16:50:12+00:00"
         }
     ],
     "aliases": [],
@@ -141,11 +141,11 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.2"
+        "php": ">=7.4"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.2"
+        "php": "7.4"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/plugins/woocommerce/lib/packages/Psr/Container/ContainerExceptionInterface.php
+++ b/plugins/woocommerce/lib/packages/Psr/Container/ContainerExceptionInterface.php
@@ -2,9 +2,11 @@
 
 namespace Automattic\WooCommerce\Vendor\Psr\Container;
 
+use Throwable;
+
 /**
  * Base interface representing a generic exception in a container.
  */
-interface ContainerExceptionInterface
+interface ContainerExceptionInterface extends Throwable
 {
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

PR #39820 updated the minimum PHP version to 7.4, however the `lib/composer.php` file was missed. This updates the PHP version in that file.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

Bump PHP version where it was missed in #39820.

</details>
