### PR TITLE
Fix CYS `__experimentalReapplyBlockTypeFilters` is not a function

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/index.tsx
@@ -92,8 +92,13 @@ export const AssemblerHub: CustomizeStoreComponent = ( props ) => {
 		) => fetchLinkSuggestions( search, searchOptions, settings );
 		settings.__experimentalFetchRichUrlData = fetchUrlData;
 
-		// @ts-ignore No types for this exist yet.
-		dispatch( blocksStore ).__experimentalReapplyBlockTypeFilters();
+		const reapplyBlockTypeFilters =
+			// @ts-ignore No types for this exist yet.
+			dispatch( blocksStore ).__experimentalReapplyBlockTypeFilters || // GB < 16.6
+			// @ts-ignore No types for this exist yet.
+			dispatch( blocksStore ).reapplyBlockTypeFilters; // GB >= 16.6
+		reapplyBlockTypeFilters();
+
 		const coreBlocks = __experimentalGetCoreBlocks().filter(
 			( { name }: { name: string } ) =>
 				name !== 'core/freeform' && ! getBlockType( name )

--- a/plugins/woocommerce/changelog/fix-cys-reapply-block-type-filters-error
+++ b/plugins/woocommerce/changelog/fix-cys-reapply-block-type-filters-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix CYS `__experimentalReapplyBlockTypeFilters` is not a function


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes`__experimentalReapplyBlockTypeFilters is not a function` error due to [the method change](https://github.com/WordPress/gutenberg/pull/53807/files#diff-5cc3977e318367783d0292d63e984c66441bc21f29de1832de970f6b0aec291aL204-R57) in Gutenberg 16.6.



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

This is part of the bigger customize your store feature development and does not require QA review as it is behind a feature flag.



<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Use WP 6.3 and Gutenberg [16.5](https://github.com/WordPress/gutenberg/releases/tag/v16.5.1)
2. Install the `WooCommerce Beta Tester` plugin
3. Go to /wp-admin/tools.php?page=woocommerce-admin-test-helper and enable `customize-store` feature flag
4. Go to `WooCommerce > Home`
5. Click on `Customize your store` task 
6. Confirm the intro page is shown.
7. Click on `Assembler Hub` button
8. Confirm the Assembler Hub is loaded.
9. Upgrade Gutenberg to 16.6/latest
10. Repeat 4-6 steps

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix CYS `__experimentalReapplyBlockTypeFilters` is not a function

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
