### PR TITLE
Fix duplicate meta handling by passing meta_value|unique in post calls

### DIFF
--- a/plugins/woocommerce/changelog/fix-duplicate-meta-handling
+++ b/plugins/woocommerce/changelog/fix-duplicate-meta-handling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+[HPOS]Fix duplicate meta handling by passing meta_value|unique in post calls

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -715,15 +715,27 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 
 		foreach ( $order->get_meta_data() as $meta_data ) {
 			if ( isset( $existing_meta_data[ $meta_data->key ] ) ) {
-				// We don't know if the meta is single or array, so we assume it to be array.
+				// We don't know if the meta is single or array, so we assume it to be an array.
 				$meta_value = is_array( $meta_data->value ) ? $meta_data->value : array( $meta_data->value );
+
 				if ( $existing_meta_data[ $meta_data->key ] === $meta_value ) {
 					unset( $existing_meta_data[ $meta_data->key ] );
 					continue;
 				}
 
+				if ( is_array( $existing_meta_data[ $meta_data->key ] ) ) {
+					$key_search = array_search( $meta_data->value, $existing_meta_data[ $meta_data->key ], true );
+					if ( false !== $key_search ) {
+						unset( $existing_meta_data[ $meta_data->key ][ $key_search ] );
+						if ( 0 === count( $existing_meta_data[ $meta_data->key ] ) ) {
+							unset( $existing_meta_data[ $meta_data->key ] );
+						}
+						continue;
+					}
+				}
+
 				unset( $existing_meta_data[ $meta_data->key ] );
-				delete_post_meta( $order->get_id(), $meta_data->key );
+				delete_post_meta( $order->get_id(), $meta_data->key, $meta_data->value );
 			}
 			add_post_meta( $order->get_id(), $meta_data->key, $meta_data->value, false );
 		}

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -748,7 +748,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 		foreach ( $keys_to_delete as $meta_key ) {
 			if ( isset( $existing_meta_data[ $meta_key ] ) ) {
 				foreach ( $existing_meta_data[ $meta_key ] as $meta_value ) {
-					delete_post_meta( $order->get_id(), $meta_key, $meta_value );
+					delete_post_meta( $order->get_id(), $meta_key, maybe_unserialize( $meta_value ) );
 				}
 			}
 		}

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -724,18 +724,15 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 				}
 
 				if ( is_array( $existing_meta_data[ $meta_data->key ] ) ) {
-					$key_search = array_search( $meta_data->value, $existing_meta_data[ $meta_data->key ], true );
-					if ( false !== $key_search ) {
-						unset( $existing_meta_data[ $meta_data->key ][ $key_search ] );
+					$value_index = array_search( $meta_data->value, $existing_meta_data[ $meta_data->key ], true );
+					if ( false !== $value_index ) {
+						unset( $existing_meta_data[ $meta_data->key ][ $value_index ] );
 						if ( 0 === count( $existing_meta_data[ $meta_data->key ] ) ) {
 							unset( $existing_meta_data[ $meta_data->key ] );
 						}
 						continue;
 					}
 				}
-
-				unset( $existing_meta_data[ $meta_data->key ] );
-				delete_post_meta( $order->get_id(), $meta_data->key, $meta_data->value );
 			}
 			add_post_meta( $order->get_id(), $meta_data->key, $meta_data->value, false );
 		}
@@ -749,7 +746,11 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 		);
 
 		foreach ( $keys_to_delete as $meta_key ) {
-			delete_post_meta( $order->get_id(), $meta_key );
+			if ( isset( $existing_meta_data[ $meta_key ] ) ) {
+				foreach ( $existing_meta_data[ $meta_key ] as $meta_value ) {
+					delete_post_meta( $order->get_id(), $meta_key, $meta_value );
+				}
+			}
 		}
 
 		$this->update_post_meta( $order );

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2920,14 +2920,25 @@ CREATE TABLE $meta_table (
 	 * @param \WC_Meta_Data     $meta  Metadata object.
 	 */
 	protected function after_meta_change( &$order, $meta ) {
-		$current_date_time = new \WC_DateTime( current_time( 'mysql', 1 ), new \DateTimeZone( 'GMT' ) );
 		method_exists( $meta, 'apply_changes' ) && $meta->apply_changes();
 		$this->clear_caches( $order );
 
 		// Prevent this happening multiple time in same request.
-		if ( $order->get_date_modified() < $current_date_time && empty( $order->get_changes() ) ) {
+		if ( $this->should_save_after_meta_change( $order )  ) {
 			$order->set_date_modified( current_time( 'mysql' ) );
 			$order->save();
 		}
+	}
+
+	/**
+	 * Helper function to check whether the modified date needs to be updated after a meta save.
+	 *
+	 * @param WC_Order $order Order object.
+	 *
+	 * @return bool Whether the modified date needs to be updated.
+	 */
+	private function should_save_after_meta_change( $order ) {
+		$current_date_time = new \WC_DateTime( current_time( 'mysql', 1 ), new \DateTimeZone( 'GMT' ) );
+		return $order->get_date_modified() < $current_date_time && empty( $order->get_changes() );
 	}
 }

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2938,6 +2938,10 @@ CREATE TABLE $meta_table (
 	/**
 	 * Helper function to check whether the modified date needs to be updated after a meta save.
 	 *
+	 * This method prevents order->save() call multiple times in the same request after any meta update by checking if:
+	 * 1. Order modified date is already the current date, no updates needed in this case.
+	 * 2. If there are changes already queued for order object, then we don't need to update the modified date as it will be updated ina subsequent save() call.
+	 *
 	 * @param WC_Order $order Order object.
 	 *
 	 * @return bool Whether the modified date needs to be updated.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2850,7 +2850,7 @@ CREATE TABLE $meta_table (
 	 * @return bool
 	 */
 	public function delete_meta( &$object, $meta ) {
-		if ( $this->should_backfill_post_record() && isset( $meta->id ) && ! isset( $meta->key ) ) {
+		if ( $this->should_backfill_post_record() && isset( $meta->id ) ) {
 			// Let's get the actual meta key before its deleted for backfilling. We cannot delete just by ID because meta IDs are different in HPOS and posts tables.
 			$db_meta = $this->data_store_meta->get_metadata_by_id( $meta->id );
 			if ( $db_meta ) {
@@ -2886,7 +2886,7 @@ CREATE TABLE $meta_table (
 
 		if ( ! $changes_applied && $object instanceof WC_Abstract_Order && $this->should_backfill_post_record() ) {
 			self::$backfilling_order_ids[] = $object->get_id();
-			add_post_meta( $object->get_id(), $meta->key, $meta->value, true );
+			add_post_meta( $object->get_id(), $meta->key, $meta->value );
 			self::$backfilling_order_ids = array_diff( self::$backfilling_order_ids, array( $object->get_id() ) );
 		}
 
@@ -2927,7 +2927,7 @@ CREATE TABLE $meta_table (
 		$this->clear_caches( $order );
 
 		// Prevent this happening multiple time in same request.
-		if ( $this->should_save_after_meta_change( $order )  ) {
+		if ( $this->should_save_after_meta_change( $order ) ) {
 			$order->set_date_modified( current_time( 'mysql' ) );
 			$order->save();
 			return true;

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -2962,5 +2962,16 @@ class OrdersTableDataStoreTests extends HposTestCase {
 		 */
 		$post_meta = get_post_meta( $order->get_id(), 'test_key' );
 		$this->assertTrue( in_array( 'test_value3', $post_meta, true ) );
+
+		$order->set_date_modified( gmdate( 'Y-m-d H:i:s', strtotime( '-2 day' ) ) );
+		$order->save();
+
+		add_post_meta( $order->get_id(), 'test_key2', 'test_value5' );
+		$order->add_meta_data( 'test_key2', 'test_value4' );
+		$order->save();
+
+		$post_meta = get_post_meta( $order->get_id(), 'test_key2' );
+		$this->assertTrue( in_array( 'test_value4', $post_meta, true ) );
+		$this->assertFalse( in_array( 'test_value5', $post_meta, true ) );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -2925,7 +2925,9 @@ class OrdersTableDataStoreTests extends HposTestCase {
 
 		$order = WC_Helper_Order::create_order();
 		// Force an earlier modified date to trigger the `should_save_after_meta_change` to be true later in the test.
-		$order->set_date_modified( date( 'Y-m-d H:i:s', strtotime( '-1 hour' ) ) );
+		$order->set_date_modified( gmdate( 'Y-m-d H:i:s', strtotime( '-2 day' ) ) );
+		$current_date_time = new \WC_DateTime( current_time( 'mysql', 1 ), new \DateTimeZone( 'GMT' ) );
+		assert( $order->get_date_modified() < $current_date_time ); // Meta check, to make sure our test stay effective if we run testsuite in a different timezone.
 		$order->save();
 
 		$order->add_meta_data( 'test_key', 'test_value' );
@@ -2935,14 +2937,30 @@ class OrdersTableDataStoreTests extends HposTestCase {
 		$this->assertCount( 1, $post_meta );
 		$this->assertEquals( 'test_value', $post_meta[0] );
 
-		wp_cache_flush();
 		$order->add_meta_data( 'test_key', 'test_value' );
 		$order->save_meta_data();
 
-		wp_cache_flush();
 		$post_meta = get_post_meta( $order->get_id(), 'test_key' );
 		$this->assertCount( 2, $post_meta );
 		$this->assertEquals( 'test_value', $post_meta[0] );
 		$this->assertEquals( 'test_value', $post_meta[1] );
+
+		$order->add_meta_data( 'test_key', 'test_value2' );
+		$order->save_meta_data();
+
+		$post_meta = get_post_meta( $order->get_id(), 'test_key' );
+		$this->assertCount( 3, $post_meta );
+		$this->assertTrue( in_array( 'test_value2', $post_meta, true ) );
+
+		$order->set_date_modified( gmdate( 'Y-m-d H:i:s', strtotime( '-1 hour' ) ) );
+		$order->save();
+		$order->update_meta_data( 'test_key', 'test_value3' );
+		$order->save_meta_data();
+
+		/**
+		 * Note that WC_Data has a bug where if we update a duplicate key, it will delete rest of other keys. But since this bug has been there for 5 years as of writing this code, we will not assert whether postmeta is exactly the same as order_meta but only test that out value was saved.
+		 */
+		$post_meta = get_post_meta( $order->get_id(), 'test_key' );
+		$this->assertTrue( in_array( 'test_value3', $post_meta, true ) );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -2915,4 +2915,30 @@ class OrdersTableDataStoreTests extends HposTestCase {
 			$this->assertEquals( $value, $order_data[ $order->get_id() ]->{$key}, "Unable to match $key for {$order_data[ $order->get_id() ]->{$key}}. Expected $value" );
 		}
 	}
+
+	/**
+	 * @testDox Test that duplicate key, value pairs are also synced properly.
+	 */
+	public function test_duplicate_meta_is_synced_properly() {
+		$this->toggle_cot_authoritative( true );
+		$this->enable_cot_sync();
+
+		$order = WC_Helper_Order::create_order();
+		$order->add_meta_data( 'test_key', 'test_value' );
+		$order->save_meta_data();
+
+		$post_meta = get_post_meta( $order->get_id(), 'test_key' );
+		$this->assertCount( 1, $post_meta );
+		$this->assertEquals( 'test_value', $post_meta[0] );
+
+		wp_cache_flush();
+		$order->add_meta_data( 'test_key', 'test_value' );
+		$order->save_meta_data();
+
+		wp_cache_flush();
+		$post_meta = get_post_meta( $order->get_id(), 'test_key' );
+		$this->assertCount( 2, $post_meta );
+		$this->assertEquals( 'test_value', $post_meta[0] );
+		$this->assertEquals( 'test_value', $post_meta[1] );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -2924,6 +2924,10 @@ class OrdersTableDataStoreTests extends HposTestCase {
 		$this->enable_cot_sync();
 
 		$order = WC_Helper_Order::create_order();
+		// Force an earlier modified date to trigger the `should_save_after_meta_change` to be true later in the test.
+		$order->set_date_modified( date( 'Y-m-d H:i:s', strtotime( '-1 hour' ) ) );
+		$order->save();
+
 		$order->add_meta_data( 'test_key', 'test_value' );
 		$order->save_meta_data();
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Depends on #40088.

This PR contains a couple of fixes:

1. Better handling of duplicate metadata, i.e. two meta entries with the same key and same value, we were only inserting it once in the post table since we were checking for any key value, and assuming it to be already there. Similarly, for deleting, we were deleting all duplicate entries, even if only one of the duplicates was requested to be deleted.

2. Fixes a regression from #39911, where we were doing some actions twice in certain cases. Basically, if the order was updated a while ago, and new metadata was being added to it with sync enabled, we would add the metadata twice, because of both a `save` in `after_meta_change` method + another meta entry in `add_post_meta` inside backfill section. This PR prevents duplication by checking if `after_meta_change` had already saved the order.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Since I found the bugs while reviewing #40088 , we are going to use similar testing instructions to reproduce and fix the issue.

1. Set HPOS to authoritative and sync to on.
2. Add the following code snippets, so that whenever something happens we get a log of it:
```
	$obj = wc_get_order( $obj_id );
	if ( ! is_a( $obj, 'WC_Abstract_Order' ) ){
		return;
	}
	$datetime_now = new DateTime();
	error_log( $datetime_now->format( 'Y-m-d H:i:s' ) . ": $filter_name: " . print_r( $args, true ) . "\n" );
}

add_filter( 'added_post_meta', function( $meta_id, $object_id, $meta_key, $_meta_value ){
	log_meta_filter( 'added_post_meta', $object_id, [ $meta_id, $object_id, $meta_key, $_meta_value ] );
}, 10, 4 );

add_filter( 'updated_post_meta', function( $meta_id, $object_id, $meta_key, $_meta_value ){
	log_meta_filter( 'updated_post_meta', $object_id, [ $meta_id, $object_id, $meta_key, $_meta_value ] );
}, 10, 4 );

add_filter( 'deleted_post_meta', function( $meta_id, $object_id, $meta_key, $_meta_value ){
	log_meta_filter( 'deleted_post_meta', $object_id, [ $meta_id, $object_id, $meta_key, $_meta_value ] );
}, 10, 4 );

add_filter( 'added_order_meta', function( $meta_id, $object_id, $meta_key, $_meta_value ){
	log_meta_filter( 'added_order_meta', $object_id, [ $meta_id, $object_id, $meta_key, $_meta_value ] );
}, 10, 4 );

add_filter( 'updated_order_meta', function( $meta_id, $object_id, $meta_key, $_meta_value ){
	log_meta_filter( 'updated_order_meta', $object_id, [ $meta_id, $object_id, $meta_key, $_meta_value ] );
}, 10, 4 );

add_filter( 'deleted_order_meta', function( $meta_id, $object_id, $meta_key, $_meta_value ){
	log_meta_filter( 'deleted_order_meta', $object_id, [ $meta_id, $object_id, $meta_key, $_meta_value ] );
}, 10, 4 );
```
3. Open a `wp shell` and run the following commands to test:
```php
// Create a new order, there will be a bunch of logs printed, but we can ignore them for now.
$order = wc_create_order();

// wait a couple of seconds, or run this command to trip the check that prevents the expensive operation from happening too many times (inside `after_meta_change` function).
sleep(2);

// Add a meta and see what gets fired. Test that there is exactly 1 `added_post_meta` log and exactly 1 `added_order_meta` log.
$order->add_meta_data( 'test_key', 'test_value' );
$order->save_meta_data();

// Add another duplicate of this meta, check that again there is exactly 1 `added_post_meta` log and exactly 1 `added_order_meta` log.
$order->add_meta_data( 'test_key', 'test_value' );
$order->save_meta_data();

// delete one of the meta data, check that there is exactly 1 `deleted_post_meta` and 2 `deleted_order_meta` log.
$order->delete_meta_data( 'test_key', 'test_value' );
$order->save_meta_data();
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
