### PR TITLE
Template API: Add after_add_block and after_remove_block actions

### DIFF
--- a/plugins/woocommerce/changelog/add-block-template-after-add-remove-hooks
+++ b/plugins/woocommerce/changelog/add-block-template-after-add-remove-hooks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add after_add_block and after_remove block hooks to the block template API.

--- a/plugins/woocommerce/src/Admin/BlockTemplates/BlockInterface.php
+++ b/plugins/woocommerce/src/Admin/BlockTemplates/BlockInterface.php
@@ -71,6 +71,11 @@ interface BlockInterface {
 	public function &get_root_template(): BlockTemplateInterface;
 
 	/**
+	 * Remove the block from its parent.
+	 */
+	public function remove();
+
+	/**
 	 * Check if the block is detached from its parent or root template.
 	 *
 	 * @return bool True if the block is detached from its parent or root template.

--- a/plugins/woocommerce/src/Admin/BlockTemplates/BlockInterface.php
+++ b/plugins/woocommerce/src/Admin/BlockTemplates/BlockInterface.php
@@ -62,22 +62,20 @@ interface BlockInterface {
 
 	/**
 	 * Get the parent container that the block belongs to.
-	 *
-	 * @throws \RuntimeException If the block does not have a parent.
 	 */
-	public function &get_parent(): ?ContainerInterface;
+	public function &get_parent(): ContainerInterface;
 
 	/**
 	 * Get the root template that the block belongs to.
-	 *
-	 * @throws \RuntimeException If the block does not have a root template.
 	 */
 	public function &get_root_template(): BlockTemplateInterface;
 
 	/**
-	 * Detach the block from its parent and root template.
+	 * Check if the block is detached from its parent or root template.
+	 *
+	 * @return bool True if the block is detached from its parent or root template.
 	 */
-	public function detach();
+	public function is_detached(): bool;
 
 	/**
 	 * Get the block configuration as a formatted template.

--- a/plugins/woocommerce/src/Admin/BlockTemplates/BlockTemplateInterface.php
+++ b/plugins/woocommerce/src/Admin/BlockTemplates/BlockTemplateInterface.php
@@ -27,13 +27,6 @@ interface BlockTemplateInterface extends ContainerInterface {
 	public function get_area(): string;
 
 	/**
-	 * Get a block by ID.
-	 *
-	 * @param string $block_id The block ID.
-	 */
-	public function get_block( string $block_id ): ?BlockInterface;
-
-	/**
 	 * Generate a block ID based on a base.
 	 *
 	 * @param string $id_base The base to use when generating an ID.

--- a/plugins/woocommerce/src/Admin/BlockTemplates/ContainerInterface.php
+++ b/plugins/woocommerce/src/Admin/BlockTemplates/ContainerInterface.php
@@ -17,6 +17,13 @@ interface ContainerInterface {
 	public function get_formatted_template(): array;
 
 	/**
+	 * Get a block by ID.
+	 *
+	 * @param string $block_id The block ID.
+	 */
+	public function get_block( string $block_id ): ?BlockInterface;
+
+	/**
 	 * Removes a block from the container.
 	 *
 	 * @param string $block_id The block ID.

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/AbstractProductFormTemplate.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/AbstractProductFormTemplate.php
@@ -10,6 +10,13 @@ use Automattic\WooCommerce\Internal\Admin\BlockTemplates\AbstractBlockTemplate;
  */
 abstract class AbstractProductFormTemplate extends AbstractBlockTemplate implements ProductFormTemplateInterface {
 	/**
+	 * Get the template area.
+	 */
+	public function get_area(): string {
+		return 'product-form';
+	}
+
+	/**
 	 * Get a group block by ID.
 	 *
 	 * @param string $group_id The group block ID.

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplates/AbstractBlock.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplates/AbstractBlock.php
@@ -189,7 +189,7 @@ class AbstractBlock implements BlockInterface {
 		$is_in_parent        = $this->parent->get_block( $this->id ) === $this;
 		$is_in_root_template = $this->get_root_template()->get_block( $this->id ) === $this;
 
-		return ! $is_in_parent || ! $is_in_root_template;
+		return ! ( $is_in_parent && $is_in_root_template );
 	}
 	/**
 	 * Get the block configuration as a formatted template.

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplates/AbstractBlock.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplates/AbstractBlock.php
@@ -174,6 +174,13 @@ class AbstractBlock implements BlockInterface {
 	}
 
 	/**
+	 * Remove the block from its parent.
+	 */
+	public function remove() {
+		$this->parent->remove_block( $this->id );
+	}
+
+	/**
 	 * Check if the block is detached from its parent block container or the template it belongs to.
 	 *
 	 * @return bool True if the block is detached from its parent block container or the template it belongs to.

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplates/AbstractBlock.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplates/AbstractBlock.php
@@ -161,38 +161,29 @@ class AbstractBlock implements BlockInterface {
 
 	/**
 	 * Get the template that this block belongs to.
-	 *
-	 * @throws \RuntimeException If the block does not have a root template.
 	 */
 	public function &get_root_template(): BlockTemplateInterface {
-		if ( is_null( $this->root_template ) ) {
-			throw new \RuntimeException( 'The block does not have a root template.' );
-		}
-
 		return $this->root_template;
 	}
 
 	/**
 	 * Get the parent block container.
-	 *
-	 * @throws \RuntimeException If the block does not have a parent.
 	 */
 	public function &get_parent(): ContainerInterface {
-		if ( is_null( $this->parent ) ) {
-			throw new \RuntimeException( 'The block does not have a parent.' );
-		}
-
 		return $this->parent;
 	}
 
 	/**
-	 * Detach the block from its parent block container and the template it belongs to.
+	 * Check if the block is detached from its parent block container or the template it belongs to.
+	 *
+	 * @return bool True if the block is detached from its parent block container or the template it belongs to.
 	 */
-	public function detach() {
-		$this->parent        = null;
-		$this->root_template = null;
-	}
+	public function is_detached(): bool {
+		$is_in_parent        = $this->parent->get_block( $this->id ) === $this;
+		$is_in_root_template = $this->get_root_template()->get_block( $this->id ) === $this;
 
+		return ! $is_in_parent || ! $is_in_root_template;
+	}
 	/**
 	 * Get the block configuration as a formatted template.
 	 *

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockContainerTrait.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockContainerTrait.php
@@ -78,6 +78,31 @@ trait BlockContainerTrait {
 	}
 
 	/**
+	 * Get a block by ID.
+	 *
+	 * @param string $block_id The block ID.
+	 */
+	public function get_block( string $block_id ): ?BlockInterface {
+		foreach ( $this->inner_blocks as $block ) {
+			if ( $block->get_id() === $block_id ) {
+				return $block;
+			}
+		}
+
+		foreach ( $this->inner_blocks as $block ) {
+			if ( $block instanceof ContainerInterface ) {
+				$block = $block->get_block( $block_id );
+
+				if ( $block ) {
+					return $block;
+				}
+			}
+		}
+
+		return null;
+	}
+
+	/**
 	 * Remove a block from the block container.
 	 *
 	 * @param string $block_id The block ID.
@@ -108,10 +133,6 @@ trait BlockContainerTrait {
 
 		$parent = $block->get_parent();
 		$parent->remove_inner_block( $block );
-
-		// Detach block from parent and root template.
-		$block->detach();
-
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockContainerTrait.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockContainerTrait.php
@@ -39,23 +39,23 @@ trait BlockContainerTrait {
 		}
 
 		$is_detached = method_exists( $this, 'is_detached' ) && $this->is_detached();
-		if ( ! $is_detached ) {
+		if ( $is_detached ) {
+			BlockTemplateLogger::get_instance()->warning(
+				'Block added to detached container. Block will not be included in the template, since the container will not be included in the template.',
+				[
+					'block'     => $block,
+					'container' => $this,
+					'template'  => $this->get_root_template(),
+				]
+			);
+		} else {
 			$this->get_root_template()->cache_block( $block );
 		}
 
 		$this->inner_blocks[] = &$block;
 
-		/**
-		 * Action called after a block is added to a block container.
-		 *
-		 * This action can be used to perform actions after a block is added to the block container,
-		 * such as adding a dependent block.
-		 *
-		 * @param BlockInterface $block The block.
-		 *
-		 * @since 8.2.0
-		 */
-		do_action( 'woocommerce_block_template_after_add_block', $block );
+		$this->do_after_add_block_action( $block );
+		$this->do_after_add_specific_block_action( $block );
 
 		return $block;
 	}
@@ -131,10 +131,6 @@ trait BlockContainerTrait {
 			$block->remove_blocks();
 		}
 
-		// Remove block from root template's cache.
-		$root_template = $this->get_root_template();
-		$root_template->uncache_block( $block->get_id() );
-
 		$parent = $block->get_parent();
 		$parent->remove_inner_block( $block );
 	}
@@ -158,15 +154,28 @@ trait BlockContainerTrait {
 	 * @param BlockInterface $block The block.
 	 */
 	public function remove_inner_block( BlockInterface $block ) {
+		// Remove block from root template's cache.
+		$root_template = $this->get_root_template();
+		$root_template->uncache_block( $block->get_id() );
+
 		$this->inner_blocks = array_filter(
 			$this->inner_blocks,
 			function ( BlockInterface $inner_block ) use ( $block ) {
 				return $inner_block !== $block;
 			}
 		);
+
+		BlockTemplateLogger::get_instance()->info(
+			'Block removed from template.',
+			[
+				'block'    => $block,
+				'template' => $root_template,
+			]
+		);
+
+		$this->do_after_remove_block_action( $block );
+		$this->do_after_remove_specific_block_action( $block );
 	}
-
-
 
 	/**
 	 * Get the inner blocks sorted by order.
@@ -205,5 +214,142 @@ trait BlockContainerTrait {
 		}
 
 		return $arr;
+	}
+
+	/**
+	 * Do the `woocommerce_block_template_after_add_block` action.
+	 * Handle exceptions thrown by the action.
+	 *
+	 * @param BlockInterface $block The block.
+	 */
+	private function do_after_add_block_action( BlockInterface $block ) {
+		try {
+			/**
+			 * Action called after a block is added to a block container.
+			 *
+			 * This action can be used to perform actions after a block is added to the block container,
+			 * such as adding a dependent block.
+			 *
+			 * @param BlockInterface $block The block.
+			 *
+			 * @since 8.2.0
+			 */
+			do_action( 'woocommerce_block_template_after_add_block', $block );
+		} catch ( \Exception $e ) {
+			$this->handle_exception_doing_action(
+				'Error after adding block to template.',
+				'woocommerce_block_template_after_add_block',
+				$block,
+				$e
+			);
+		}
+	}
+
+	/**
+	 * Do the `woocommerce_block_template_area_{template_area}_after_add_block_{block_id}` action.
+	 * Handle exceptions thrown by the action.
+	 *
+	 * @param BlockInterface $block The block.
+	 */
+	private function do_after_add_specific_block_action( BlockInterface $block ) {
+		try {
+			/**
+			 * Action called after a specific block is added to a template with a specific area.
+			 *
+			 * This action can be used to perform actions after a specific block is added to a template with a specific area,
+			 * such as adding a dependent block.
+			 *
+			 * @param BlockInterface $block The block.
+			 *
+			 * @since 8.2.0
+			 */
+			do_action( "woocommerce_block_template_area_{$this->get_root_template()->get_area()}_after_add_block_{$block->get_id()}", $block );
+		} catch ( \Exception $e ) {
+			$this->handle_exception_doing_action(
+				'Error after adding block to template.',
+				"woocommerce_block_template_area_{$this->get_root_template()->get_area()}_after_add_block_{$block->get_id()}",
+				$block,
+				$e
+			);
+		}
+	}
+
+	/**
+	 * Do the `woocommerce_block_template_after_remove_block` action.
+	 * Handle exceptions thrown by the action.
+	 *
+	 * @param BlockInterface $block The block.
+	 */
+	private function do_after_remove_block_action( BlockInterface $block ) {
+		try {
+			/**
+			 * Action called after a block is removed from a block container.
+			 *
+			 * This action can be used to perform actions after a block is removed from the block container,
+			 * such as removing a dependent block.
+			 *
+			 * @param BlockInterface $block The block.
+			 *
+			 * @since 8.2.0
+			 */
+			do_action( 'woocommerce_block_template_after_remove_block', $block );
+		} catch ( \Exception $e ) {
+			$this->handle_exception_doing_action(
+				'Error after removing block from template.',
+				'woocommerce_block_template_after_remove_block',
+				$block,
+				$e
+			);
+		}
+	}
+
+	/**
+	 * Do the `woocommerce_block_template_area_{template_area}_after_remove_block_{block_id}` action.
+	 * Handle exceptions thrown by the action.
+	 *
+	 * @param BlockInterface $block The block.
+	 */
+	private function do_after_remove_specific_block_action( BlockInterface $block ) {
+		try {
+			/**
+			 * Action called after a specific block is removed from a template with a specific area.
+			 *
+			 * This action can be used to perform actions after a specific block is removed from a template with a specific area,
+			 * such as removing a dependent block.
+			 *
+			 * @param BlockInterface $block The block.
+			 *
+			 * @since 8.2.0
+			 */
+			do_action( "woocommerce_block_template_area_{$this->get_root_template()->get_area()}_after_remove_block_{$block->get_id()}", $block );
+		} catch ( \Exception $e ) {
+			$this->handle_exception_doing_action(
+				'Error after removing block from template.',
+				"woocommerce_block_template_area_{$this->get_root_template()->get_area()}_after_remove_block_{$block->get_id()}",
+				$block,
+				$e
+			);
+		}
+	}
+
+	/**
+	 * Handle an exception thrown by an action.
+	 *
+	 * @param string         $message    The message.
+	 * @param string         $action_tag The action tag.
+	 * @param BlockInterface $block      The block.
+	 * @param \Exception     $e          The exception.
+	 */
+	private function handle_exception_doing_action( string $message, string $action_tag, BlockInterface $block, \Exception $e ) {
+		BlockTemplateLogger::get_instance()->error(
+			$message,
+			[
+				'exception' => $e,
+				'action'    => $action_tag,
+				'container' => $this,
+				'block'     => $block,
+				'template'  => $this->get_root_template(),
+			],
+		);
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockContainerTrait.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockContainerTrait.php
@@ -38,7 +38,11 @@ trait BlockContainerTrait {
 			throw new \UnexpectedValueException( 'The block container\'s root template is not the same as the block\'s root template.' );
 		}
 
-		$this->get_root_template()->cache_block( $block );
+		$is_detached = method_exists( $this, 'is_detached' ) && $this->is_detached();
+		if ( ! $is_detached ) {
+			$this->get_root_template()->cache_block( $block );
+		}
+
 		$this->inner_blocks[] = &$block;
 
 		/**

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockContainerTrait.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockContainerTrait.php
@@ -40,6 +40,19 @@ trait BlockContainerTrait {
 		$root_template = $block->get_root_template();
 		$root_template->cache_block( $block );
 		$this->inner_blocks[] = &$block;
+
+		/**
+		 * Action called after a block is added to a block container.
+		 *
+		 * This action can be used to perform actions after a block is added to the block container,
+		 * such as adding a dependent block.
+		 *
+		 * @param BlockInterface $block The block.
+		 *
+		 * @since 8.2.0
+		 */
+		do_action( 'woocommerce_block_template_after_add_block', $block );
+
 		return $block;
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockContainerTrait.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockContainerTrait.php
@@ -27,18 +27,18 @@ trait BlockContainerTrait {
 	 * @throws \ValueError If the block configuration is invalid.
 	 * @throws \ValueError If a block with the specified ID already exists in the template.
 	 * @throws \UnexpectedValueException If the block container is not the parent of the block.
+	 * @throws \UnexpectedValueException If the block container's root template is not the same as the block's root template.
 	 */
 	protected function &add_inner_block( BlockInterface $block ): BlockInterface {
-		if ( ! $block instanceof BlockInterface ) {
-			throw new \UnexpectedValueException( 'The block must return an instance of BlockInterface.' );
-		}
-
 		if ( $block->get_parent() !== $this ) {
 			throw new \UnexpectedValueException( 'The block container is not the parent of the block.' );
 		}
 
-		$root_template = $block->get_root_template();
-		$root_template->cache_block( $block );
+		if ( $block->get_root_template() !== $this->get_root_template() ) {
+			throw new \UnexpectedValueException( 'The block container\'s root template is not the same as the block\'s root template.' );
+		}
+
+		$this->get_root_template()->cache_block( $block );
 		$this->inner_blocks[] = &$block;
 
 		/**

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockTemplateLogger.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockTemplateLogger.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace Automattic\WooCommerce\Internal\Admin\BlockTemplates;
+
+use Automattic\WooCommerce\Admin\BlockTemplates\BlockContainerInterface;
+use Automattic\WooCommerce\Admin\BlockTemplates\BlockInterface;
+use Automattic\WooCommerce\Admin\BlockTemplates\BlockTemplateInterface;
+
+/**
+ * Logger for block template modifications.
+ */
+class BlockTemplateLogger {
+	/**
+	 * Singleton instance.
+	 *
+	 * @var BlockTemplateLogger
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Logger instance.
+	 *
+	 * @var \WC_Logger
+	 */
+	protected $logger = null;
+
+	/**
+	 * Get the singleton instance.
+	 */
+	public static function get_instance(): BlockTemplateLogger {
+		if ( ! self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Constructor.
+	 */
+	protected function __construct() {
+		$this->logger = wc_get_logger();
+	}
+
+	/**
+	 * Log an informational message.
+	 *
+	 * @param string $message Message to log.
+	 * @param array  $info    Additional info to log.
+	 */
+	public function info( string $message, array $info = [] ) {
+		$this->logger->info(
+			$this->format_message( $message, $info ),
+			[ 'source' => 'block_template' ]
+		);
+	}
+
+	/**
+	 * Log a warning message.
+	 *
+	 * @param string $message Message to log.
+	 * @param array  $info    Additional info to log.
+	 */
+	public function warning( string $message, array $info = [] ) {
+		$this->logger->warning(
+			$this->format_message( $message, $info ),
+			[ 'source' => 'block_template' ]
+		);
+	}
+
+	/**
+	 * Log an error message.
+	 *
+	 * @param string $message Message to log.
+	 * @param array  $info    Additional info to log.
+	 */
+	public function error( string $message, array $info = [] ) {
+		$this->logger->error(
+			$this->format_message( $message, $info ),
+			[ 'source' => 'block_template' ]
+		);
+	}
+
+	/**
+	 * Format a message for logging.
+	 *
+	 * @param string $message Message to log.
+	 * @param array  $info    Additional info to log.
+	 */
+	private function format_message( string $message, array $info = [] ): string {
+		$formatted_message = sprintf(
+			"%s\n%s",
+			$message,
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
+			print_r( $this->format_info( $info ), true ),
+		);
+
+		return $formatted_message;
+	}
+
+	/**
+	 * Format info for logging.
+	 *
+	 * @param array $info Info to log.
+	 */
+	private function format_info( array $info ): array {
+		$formatted_info = $info;
+
+		if ( isset( $info['exception'] ) && $info['exception'] instanceof \Exception ) {
+			$formatted_info['exception'] = $this->format_exception( $info['exception'] );
+		}
+
+		if ( isset( $info['container'] ) ) {
+			if ( $info['container'] instanceof BlockContainerInterface ) {
+				$formatted_info['container'] = $this->format_block( $info['container'] );
+			} elseif ( $info['container'] instanceof BlockTemplateInterface ) {
+				$formatted_info['container'] = $this->format_template( $info['container'] );
+			} elseif ( $info['container'] instanceof BlockInterface ) {
+				$formatted_info['container'] = $this->format_block( $info['container'] );
+			}
+		}
+
+		if ( isset( $info['block'] ) && $info['block'] instanceof BlockInterface ) {
+			$formatted_info['block'] = $this->format_block( $info['block'] );
+		}
+
+		if ( isset( $info['template'] ) && $info['template'] instanceof BlockTemplateInterface ) {
+			$formatted_info['template'] = $this->format_template( $info['template'] );
+		}
+
+		return $formatted_info;
+	}
+
+	/**
+	 * Format an exception for logging.
+	 *
+	 * @param \Exception $exception Exception to format.
+	 */
+	private function format_exception( \Exception $exception ): array {
+		return [
+			'message' => $exception->getMessage(),
+			'source' => "{$exception->getFile()}: {$exception->getLine()}",
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
+			'trace'  => print_r( $this->format_exception_trace( $exception->getTrace() ), true ),
+		];
+	}
+
+	/**
+	 * Format an exception trace for logging.
+	 *
+	 * @param array $trace Exception trace to format.
+	 */
+	private function format_exception_trace( array $trace ): array {
+		$formatted_trace = [];
+
+		foreach ( $trace as $source ) {
+			$formatted_trace[] = "{$source['file']}: {$source['line']}";
+		}
+
+		return $formatted_trace;
+	}
+
+	/**
+	 * Format a block template for logging.
+	 *
+	 * @param BlockTemplateInterface $template Template to format.
+	 */
+	private function format_template( BlockTemplateInterface $template ): string {
+		return "{$template->get_id()} (area: {$template->get_area()})";
+	}
+
+	/**
+	 * Format a block for logging.
+	 *
+	 * @param BlockInterface $block Block to format.
+	 */
+	private function format_block( BlockInterface $block ): string {
+		return "{$block->get_id()} (name: {$block->get_name()})";
+	}
+}

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockTemplateLogger.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockTemplateLogger.php
@@ -139,9 +139,9 @@ class BlockTemplateLogger {
 	private function format_exception( \Exception $exception ): array {
 		return [
 			'message' => $exception->getMessage(),
-			'source' => "{$exception->getFile()}: {$exception->getLine()}",
+			'source'  => "{$exception->getFile()}: {$exception->getLine()}",
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
-			'trace'  => print_r( $this->format_exception_trace( $exception->getTrace() ), true ),
+			'trace'   => print_r( $this->format_exception_trace( $exception->getTrace() ), true ),
 		];
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/BlockTemplateTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/BlockTemplateTest.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\WooCommerce\Tests\Internal\Admin\BlockTemplates;
 
+use Automattic\WooCommerce\Admin\BlockTemplates\BlockInterface;
 use Automattic\WooCommerce\Internal\Admin\BlockTemplates\BlockTemplate;
 
 use WC_Unit_Test_Case;
@@ -33,6 +34,135 @@ class BlockTemplateTest extends WC_Unit_Test_Case {
 		);
 
 		$this->assertSame( $block, $template->get_block( 'test-block-id' ) );
+	}
+
+	/**
+	 * Test the after_add_block hooks fires.
+	 */
+	public function test_after_add_block_hooks() {
+		$template = new BlockTemplate();
+
+		$hook_called = false;
+
+		$after_add_block_hook = function( BlockInterface $block ) use ( &$hook_called ) {
+			$hook_called = true;
+
+			if ( 'test-block-id' === $block->get_id() ) {
+				$hook_called = true;
+			}
+
+			$root_template = $block->get_root_template();
+
+			if ( $root_template->get_block( 'test-block-id-2' ) ) {
+				// The block was already added, so just return.
+				// This short-circuiting is needed because this hook will be called two times:
+				// 1. When the `test-block-id` block is added to the root template.
+				// 2. When the `test-block-id-2` block is added to the template in this hook.
+				return;
+			}
+
+			$root_template->add_block(
+				[
+					'id'        => 'test-block-id-2',
+					'blockName' => 'test-block-name-2',
+				]
+			);
+		};
+
+		add_action( 'woocommerce_block_template_after_add_block', $after_add_block_hook );
+
+		$specific_hook_called = false;
+
+		$specific_after_add_block_hook = function( BlockInterface $block ) use ( &$specific_hook_called ) {
+			if ( 'test-block-id' === $block->get_id() ) {
+				$specific_hook_called = true;
+			}
+		};
+
+		add_action( 'woocommerce_block_template_area_uncategorized_after_add_block_test-block-id', $specific_after_add_block_hook );
+
+		$template->add_block(
+			[
+				'id'        => 'test-block-id',
+				'blockName' => 'test-block-name',
+			]
+		);
+
+		$this->assertTrue(
+			$hook_called,
+			'Failed asserting that that the hook was called.'
+		);
+
+		$this->assertTrue(
+			$specific_hook_called,
+			'Failed asserting that that the specific hook was called.'
+		);
+
+		$this->assertNotNull(
+			$template->get_block( 'test-block-id-2' ),
+			'Failed asserting that the block was added to the template from the hook.'
+		);
+
+		remove_action( 'woocommerce_block_template_after_add_block', $after_add_block_hook );
+		remove_action( 'woocommerce_block_template_area_uncategorized_after_add_block_test-block-id', $specific_after_add_block_hook );
+	}
+
+	/**
+	 * Test the after_remove_block hooks fires.
+	 */
+	public function test_after_remove_block_hooks() {
+		$template = new BlockTemplate();
+
+		$hook_called = false;
+
+		$after_remove_block_hook = function( BlockInterface $block ) use ( &$hook_called ) {
+			$hook_called = true;
+
+			if ( 'test-block-id' === $block->get_id() ) {
+				$hook_called = true;
+			}
+
+			$root_template = $block->get_root_template();
+		};
+
+		add_action( 'woocommerce_block_template_after_remove_block', $after_remove_block_hook );
+
+		$specific_hook_called = false;
+
+		$specific_after_remove_block_hook = function( BlockInterface $block ) use ( &$specific_hook_called ) {
+			if ( 'test-block-id' === $block->get_id() ) {
+				$specific_hook_called = true;
+			}
+		};
+
+		add_action( 'woocommerce_block_template_area_uncategorized_after_remove_block_test-block-id', $specific_after_remove_block_hook );
+
+		$block = $template->add_block(
+			[
+				'id'        => 'test-block-id',
+				'blockName' => 'test-block-name',
+			]
+		);
+
+		$block->remove();
+
+		$this->assertTrue(
+			$hook_called,
+			'Failed asserting that that the hook was called.'
+		);
+
+		$this->assertTrue(
+			$specific_hook_called,
+			'Failed asserting that that the specific hook was called.'
+		);
+
+		$this->assertTrue(
+			$block->is_detached(),
+			'Failed asserting that the block was added to the template from the hook.'
+		);
+
+		remove_action( 'woocommerce_block_template_after_remove_block', $after_remove_block_hook );
+		remove_action( 'woocommerce_block_template_area_uncategorized_after_remove_block_test-block-id', $specific_after_remove_block_hook );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/BlockTemplateTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/BlockTemplateTest.php
@@ -55,9 +55,11 @@ class BlockTemplateTest extends WC_Unit_Test_Case {
 
 			if ( $root_template->get_block( 'test-block-id-2' ) ) {
 				// The block was already added, so just return.
-				// This short-circuiting is needed because this hook will be called two times:
+				// This short-circuiting done because this hook will be called two times:
 				// 1. When the `test-block-id` block is added to the root template.
 				// 2. When the `test-block-id-2` block is added to the template in this hook.
+				// Without this short-circuiting, the second time `add_block` is called in this
+				// hook would throw an exception, which is handled by the API (an error gets logged).
 				return;
 			}
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/BlockTemplateTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/BlockTemplateTest.php
@@ -71,42 +71,44 @@ class BlockTemplateTest extends WC_Unit_Test_Case {
 			);
 		};
 
-		add_action( 'woocommerce_block_template_after_add_block', $after_add_block_hook );
+		try {
+			add_action( 'woocommerce_block_template_after_add_block', $after_add_block_hook );
 
-		$specific_hook_called = false;
+			$specific_hook_called = false;
 
-		$specific_after_add_block_hook = function( BlockInterface $block ) use ( &$specific_hook_called ) {
-			if ( 'test-block-id' === $block->get_id() ) {
-				$specific_hook_called = true;
-			}
-		};
+			$specific_after_add_block_hook = function( BlockInterface $block ) use ( &$specific_hook_called ) {
+				if ( 'test-block-id' === $block->get_id() ) {
+					$specific_hook_called = true;
+				}
+			};
 
-		add_action( 'woocommerce_block_template_area_uncategorized_after_add_block_test-block-id', $specific_after_add_block_hook );
+			add_action( 'woocommerce_block_template_area_uncategorized_after_add_block_test-block-id', $specific_after_add_block_hook );
 
-		$template->add_block(
-			[
-				'id'        => 'test-block-id',
-				'blockName' => 'test-block-name',
-			]
-		);
+			$template->add_block(
+				[
+					'id'        => 'test-block-id',
+					'blockName' => 'test-block-name',
+				]
+			);
 
-		$this->assertTrue(
-			$hook_called,
-			'Failed asserting that that the hook was called.'
-		);
+			$this->assertTrue(
+				$hook_called,
+				'Failed asserting that that the hook was called.'
+			);
 
-		$this->assertTrue(
-			$specific_hook_called,
-			'Failed asserting that that the specific hook was called.'
-		);
+			$this->assertTrue(
+				$specific_hook_called,
+				'Failed asserting that that the specific hook was called.'
+			);
 
-		$this->assertNotNull(
-			$template->get_block( 'test-block-id-2' ),
-			'Failed asserting that the block was added to the template from the hook.'
-		);
-
-		remove_action( 'woocommerce_block_template_after_add_block', $after_add_block_hook );
-		remove_action( 'woocommerce_block_template_area_uncategorized_after_add_block_test-block-id', $specific_after_add_block_hook );
+			$this->assertNotNull(
+				$template->get_block( 'test-block-id-2' ),
+				'Failed asserting that the block was added to the template from the hook.'
+			);
+		} finally {
+			remove_action( 'woocommerce_block_template_after_add_block', $after_add_block_hook );
+			remove_action( 'woocommerce_block_template_area_uncategorized_after_add_block_test-block-id', $specific_after_add_block_hook );
+		}
 	}
 
 	/**
@@ -127,8 +129,6 @@ class BlockTemplateTest extends WC_Unit_Test_Case {
 			$root_template = $block->get_root_template();
 		};
 
-		add_action( 'woocommerce_block_template_after_remove_block', $after_remove_block_hook );
-
 		$specific_hook_called = false;
 
 		$specific_after_remove_block_hook = function( BlockInterface $block ) use ( &$specific_hook_called ) {
@@ -137,34 +137,37 @@ class BlockTemplateTest extends WC_Unit_Test_Case {
 			}
 		};
 
-		add_action( 'woocommerce_block_template_area_uncategorized_after_remove_block_test-block-id', $specific_after_remove_block_hook );
+		try {
+			add_action( 'woocommerce_block_template_after_remove_block', $after_remove_block_hook );
+			add_action( 'woocommerce_block_template_area_uncategorized_after_remove_block_test-block-id', $specific_after_remove_block_hook );
 
-		$block = $template->add_block(
-			[
-				'id'        => 'test-block-id',
-				'blockName' => 'test-block-name',
-			]
-		);
+			$block = $template->add_block(
+				[
+					'id'        => 'test-block-id',
+					'blockName' => 'test-block-name',
+				]
+			);
 
-		$block->remove();
+			$block->remove();
 
-		$this->assertTrue(
-			$hook_called,
-			'Failed asserting that that the hook was called.'
-		);
+			$this->assertTrue(
+				$hook_called,
+				'Failed asserting that that the hook was called.'
+			);
 
-		$this->assertTrue(
-			$specific_hook_called,
-			'Failed asserting that that the specific hook was called.'
-		);
+			$this->assertTrue(
+				$specific_hook_called,
+				'Failed asserting that that the specific hook was called.'
+			);
 
-		$this->assertTrue(
-			$block->is_detached(),
-			'Failed asserting that the block was added to the template from the hook.'
-		);
-
-		remove_action( 'woocommerce_block_template_after_remove_block', $after_remove_block_hook );
-		remove_action( 'woocommerce_block_template_area_uncategorized_after_remove_block_test-block-id', $specific_after_remove_block_hook );
+			$this->assertTrue(
+				$block->is_detached(),
+				'Failed asserting that the block was added to the template from the hook.'
+			);
+		} finally {
+			remove_action( 'woocommerce_block_template_after_remove_block', $after_remove_block_hook );
+			remove_action( 'woocommerce_block_template_area_uncategorized_after_remove_block_test-block-id', $specific_after_remove_block_hook );
+		}
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/BlockTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/BlockTest.php
@@ -106,7 +106,7 @@ class BlockTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that removing a block from a block sets the parent and root template to null
+	 * Test that removing a block from a block detaches it
 	 * and that the block is removed from the root template.
 	 */
 	public function test_remove_block() {
@@ -145,7 +145,7 @@ class BlockTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that removing a block from a block sets the parent and root template to null
+	 * Test that removing a block from a block detaches it
 	 * and that the block is removed from the root template, as well as any descendants.
 	 */
 	public function test_remove_nested_block() {
@@ -184,7 +184,7 @@ class BlockTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that removing a block from a block sets the parent and root template to null
+	 * Test that removing a block from a block detaches it
 	 * and that the block is removed from the root template, as well as any descendants.
 	 */
 	public function test_remove_block_and_descendants() {

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/BlockTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/BlockTest.php
@@ -233,6 +233,27 @@ class BlockTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that removing a block by calling remove on it detaches it.
+	 */
+	public function test_remove_block_self() {
+		$template = new BlockTemplate();
+
+		$block = $template->add_block(
+			[
+				'id'        => 'test-block-id',
+				'blockName' => 'test-block-name',
+			]
+		);
+
+		$block->remove();
+
+		$this->assertTrue(
+			$block->is_detached(),
+			'Failed asserting that the block is detached from its parent and root template.'
+		);
+	}
+
+	/**
 	 * Test that adding nested blocks sets the parent and root template correctly.
 	 */
 	public function test_nested_add_block() {

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/BlockTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/BlockTest.php
@@ -290,6 +290,49 @@ class BlockTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that a block added to a detached block is detached.
+	 */
+	public function test_block_added_to_detached_block_is_detached() {
+		$template = new BlockTemplate();
+
+		$block = $template->add_block(
+			[
+				'id'        => 'test-block-id',
+				'blockName' => 'test-block-name',
+			]
+		);
+
+		$template->remove_block( 'test-block-id' );
+
+		$child_block = $block->add_block(
+			[
+				'id'        => 'test-block-id-2',
+				'blockName' => 'test-block-name-2',
+			]
+		);
+
+		$this->assertNull(
+			$template->get_block( 'test-block-id' ),
+			'Failed asserting that the block was removed from the root template.'
+		);
+
+		$this->assertNull(
+			$template->get_block( 'test-block-id-2' ),
+			'Failed asserting that the nested block is not in the root template.'
+		);
+
+		$this->assertNotNull(
+			$block->get_block( 'test-block-id-2' ),
+			'Failed asserting that the nested block is in the parent.'
+		);
+
+		$this->assertTrue(
+			$child_block->is_detached(),
+			'Failed asserting that the nested descendent block is detached from its parent and root template.'
+		);
+	}
+
+	/**
 	 * Test that getting the block as a formatted template is structured correctly.
 	 */
 	public function test_get_formatted_template() {

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/BlockTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/BlockTest.php
@@ -133,9 +133,15 @@ class BlockTest extends WC_Unit_Test_Case {
 			'Failed asserting that the child block was removed from the root template.'
 		);
 
-		$this->expectException( \RuntimeException::class );
+		$this->assertNull(
+			$block->get_block( 'test-block-id-2' ),
+			'Failed asserting that the child block was removed from the parent.'
+		);
 
-		$child_block->get_parent();
+		$this->assertTrue(
+			$child_block->is_detached(),
+			'Failed asserting that the child block is detached from its parent and root template.'
+		);
 	}
 
 	/**
@@ -166,9 +172,15 @@ class BlockTest extends WC_Unit_Test_Case {
 			'Failed asserting that the nested descendent block was removed from the root template.'
 		);
 
-		$this->expectException( \RuntimeException::class );
+		$this->assertNull(
+			$block->get_block( 'test-block-id-2' ),
+			'Failed asserting that the nested descendent block was removed from the parent.'
+		);
 
-		$child_block->get_parent();
+		$this->assertTrue(
+			$child_block->is_detached(),
+			'Failed asserting that the nested descendent block is detached from its parent and root template.'
+		);
 	}
 
 	/**
@@ -204,9 +216,20 @@ class BlockTest extends WC_Unit_Test_Case {
 			'Failed asserting that the nested descendent block was removed from the root template.'
 		);
 
-		$this->expectException( \RuntimeException::class );
+		$this->assertNull(
+			$block->get_block( 'test-block-id-2' ),
+			'Failed asserting that the child block was removed from the parent.'
+		);
 
-		$child_block->get_parent();
+		$this->assertTrue(
+			$block->is_detached(),
+			'Failed asserting that the block is detached from its parent and root template.'
+		);
+
+		$this->assertTrue(
+			$child_block->is_detached(),
+			'Failed asserting that the child block is detached from its parent and root template.'
+		);
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/CustomBlockTemplate.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/CustomBlockTemplate.php
@@ -42,7 +42,7 @@ class CustomBlockTemplate extends AbstractBlockTemplate {
 	 *
 	 * @param array $block_config The block data.
 	 */
-	public function add_custom_block( array $block_config ): BlockInterface {
+	public function add_custom_block( array $block_config ): CustomBlockInterface {
 		$block = new CustomBlock( $block_config, $this->get_root_template(), $this );
 		return $this->add_inner_block( $block );
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/CustomBlockTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/CustomBlockTest.php
@@ -7,7 +7,7 @@ use Automattic\WooCommerce\Admin\BlockTemplates\BlockTemplateInterface;
 
 use Automattic\WooCommerce\Internal\Admin\BlockTemplates\Block;
 use Automattic\WooCommerce\Internal\Admin\BlockTemplates\BlockTemplate;
-
+use Customers;
 use WC_Unit_Test_Case;
 
 /**
@@ -18,13 +18,8 @@ class CustomBlockTest extends WC_Unit_Test_Case {
 	 * Test that the add_block method does not exist by default on blocks.
 	 */
 	public function test_add_block_does_not_exist() {
-		$template = new BlockTemplate();
-		$block    = new CustomBlock(
-			[
-				'blockName' => 'test-block-name',
-			],
-			$template
-		);
+		$template = new CustomBlockTemplate();
+		$block    = $template->add_custom_block( [ 'blockName' => 'test-block-name' ] );
 
 		$this->assertFalse( method_exists( $block, 'add_block' ) );
 	}
@@ -33,13 +28,8 @@ class CustomBlockTest extends WC_Unit_Test_Case {
 	 * Test that a custom block inserter method inserts as expected.
 	 */
 	public function test_add_custom_inner_block() {
-		$template = new BlockTemplate();
-		$block    = new CustomBlock(
-			[
-				'blockName' => 'test-block-name',
-			],
-			$template
-		);
+		$template = new CustomBlockTemplate();
+		$block    = $template->add_custom_block( [ 'blockName' => 'test-block-name' ] );
 
 		$block->add_custom_inner_block( 'a' );
 		$block->add_custom_inner_block( 'b' );
@@ -72,14 +62,8 @@ class CustomBlockTest extends WC_Unit_Test_Case {
 	 * Test that a custom block is removed as expected.
 	 */
 	public function test_remove_custom_inner_block() {
-		$template = new BlockTemplate();
-		$block    = new CustomBlock(
-			[
-				'blockName' => 'test-block-name',
-			],
-			$template
-		);
-
+		$template = new CustomBlockTemplate();
+		$block    = $template->add_custom_block( [ 'blockName' => 'test-block-name' ] );
 		$block->add_custom_inner_block( 'a' );
 		$block->add_custom_inner_block( 'b' );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR closes #40149 and makes the following changes to the template API:

- Adds the following actions:
    - `woocommerce_block_template_after_add_block` called after any block is added to any template, with the block that was added in passed as a parameter
    - `woocommerce_block_template_area_{template_area}_after_add_block_{block_id}` called after a block with {block_id} is added to a template with area {template_area}, with the block that was added in passed as a parameter
    - `woocommerce_block_template_after_remove_block` called after any block is removed from any template, with the block that was removed passed as a parameter
    - `woocommerce_block_template_area_{template_area}_after_add_block_{block_id}` called after a block with {block_id} is removed from a template with area {template_area}, with the block that was added in passed as a parameter
- Removes `BlockInterface::detach()` method in favor of automatically determining if a block is detached based on it's relationship with its parent and template and providing a `BlockInterface::is_detached()` method
    - When blocks are removed, they keep their `parent` and `root_template` property values, which allow for more flexible/robust extensibility code (especially in the case where a block is removed right after it has been added)
- Adds a convenience method `BlockInterface::remove()` to allow for easier to write (and less likely to mess up) extensibility code
- Sets the `area` of the product form templates to `product-form`
- Adds a `BlockTemplateLogger` class for that is used to:
    - Log exceptions thrown by action hooks
    - Log info message when blocks are removed
    - Log warning message when blocks are added to detached blocks 
    - (Log files found at WooCommerce > Status > Logs > `block_template_`)
- Adds unit tests for the actions, and a few more tests surrounding removal/detachment
- Cleans up code docs

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Automated testing:

1. Run the unit tests:

```
pnpm --filter=woocommerce env:test
pnpm test:unit:env --filter 'Automattic\\WooCommerce\\Tests\\Internal\\Admin\\BlockTemplates'
```

Manual testing:

1. Verify the unmodified product form template works as expected (no regression).
2. Using the API (the new actions), make modifications to the product form template.
2. Verify they work as expected.
3. Verify the `block_template` log (WooCommerce > Status > Logs) is updated appropriately.

As an example... 

<details>

<summary>
Here is what the product form looks like without the modifications...
</summary>

<img width="1097" alt="Screenshot 2023-09-13 at 11 41 14" src="https://github.com/woocommerce/woocommerce/assets/2098816/c6da242d-71c0-47dc-ac5e-38ef4c7aa555">

</details>

<details>

<summary>
Here is the code I've used during development...
</summary>

```php
use Automattic\WooCommerce\Admin\BlockTemplates\BlockInterface;

if ( ! function_exists( 'example_hook_up_block_template_modifications' ) ) {
	/**
	 * Hook up the block template after hooks.
	 */
	function example_hook_up_block_template_modifications() {
		add_action(
			'woocommerce_block_template_area_product-form_after_add_block_product-description-section',
			'example_add_section'
		);

		add_action(
			'woocommerce_block_template_area_product-form_after_add_block_product-summary',
			'example_add_show_summary_toggle'
		);
		add_action(
			'woocommerce_block_template_area_product-form_after_remove_block_product-summary',
			'example_remove_show_summary_toggle'
		);

		add_action(
			'woocommerce_block_template_area_product-form_after_add_block_product-summary',
			'example_remove_summary_field'
		);

		add_action(
			'woocommerce_block_template_area_product-form_after_add_block_product-sale-price',
			'example_replace_sale_price_field'
		);

		add_action(
			'woocommerce_block_template_area_product-form_after_add_block_product-images-section',
			'example_remove_images_section'
		);

		add_action(
			'woocommerce_block_template_after_add_block',
			'example_after_add_block'
		);
		add_action(
			'woocommerce_block_template_after_remove_block',
			'example_after_remove_block'
		);

		add_action(
			'woocommerce_block_template_area_product-form_after_add_block_product-description-section',
			'example_after_add_description_section'
		);
	}
}

add_action( 'init', 'example_hook_up_block_template_modifications', 0 );

if ( ! function_exists( 'example_add_section' ) ) {
	/**
	 * Add a new section to the template.
	 *
	 * @param BlockInterface $product_description_section The block.
	 */
	function example_add_section( BlockInterface $product_description_section ) {
		$parent = $product_description_section->get_parent();

		$section = $parent->add_section(
			[
				'id'         => 'example-custom-section',
				// Note: this order is relative to the section, not the template.
				// We could have just hard-coded the order here, but this is more flexible.
				'order'      => $product_description_section->get_order() + 5,
				'attributes' => [
					'title' => __( 'My custom section', 'woocommerce' ),
				],
			]
		);

		$section->add_block(
			[
				'id'         => 'example-custom-toggle',
				'order'      => 10,
				'blockName'  => 'woocommerce/product-toggle-field',
				'attributes' => [
					// Note: this property needs to be configured in the REST API.
					'property' => 'example_custom_toggle',
					'label'    => __( 'Enable extra awesomeness', 'woocommerce' ),
				],
			]
		);
	}
}

if ( ! function_exists( 'example_remove_summary_field' ) ) {
	/**
	 * Remove the summary field.
	 *
	 * @param BlockInterface $product_summary_field The block.
	 */
	function example_remove_summary_field( BlockInterface $product_summary_field ) {
		$product_summary_field->remove();
	}
}

if ( ! function_exists( 'example_add_show_summary_toggle' ) ) {
	/**
	 * Add a show summary toggle after the summary field.
	 *
	 * @param BlockInterface $product_summary_field The block.
	 */
	function example_add_show_summary_toggle( BlockInterface $product_summary_field ) {
		$product_summary_field->get_parent()->add_block(
			[
				'id'         => 'example-show-summary-toggle',
				'blockName'  => 'woocommerce/product-toggle-field',
				'order'      => $product_summary_field->get_order() + 5,
				'attributes' => [
					// Note: this property needs to be configured in the REST API.
					'property' => 'example_show_summary',
					'label'    => __( 'Show summary', 'woocommerce' ),
				],
			]
		);
	}
}

if ( ! function_exists( 'example_remove_show_summary_toggle' ) ) {
	/**
	 * Remove the summary toggle after the summary field.
	 *
	 * @param BlockInterface $product_summary_field The block.
	 */
	function example_remove_show_summary_toggle( BlockInterface $product_summary_field ) {
		$product_summary_field->get_root_template()->remove_block( 'example-show-summary-toggle' );
	}
}

if ( ! function_exists( 'example_remove_images_section' ) ) {
	/**
	 * Remove the images section.
	 *
	 * @param BlockInterface $images_section The block.
	 */
	function example_remove_images_section( BlockInterface $images_section ) {
		// This will trigger warnings to be logged, since SimpleProductTemplate will try to add
		// blocks to the images section after it is detached.
		$images_section->remove();
	}
}

if ( ! function_exists( 'example_replace_sale_price_field' ) ) {
	/**
	 * Replace the sale price field.
	 *
	 * @param BlockInterface $sale_price_field The block.
	 */
	function example_replace_sale_price_field( BlockInterface $sale_price_field ) {
		$sale_price_field->remove();

		$sale_price_field->get_parent()->add_block(
			[
				'id'         => 'matt-sherman-random-sale-price-checkbox',
				'blockName'  => 'woocommerce/product-checkbox-field',
				// Use the same order as the sale price field so that it appears in the same place.
				'order'      => $sale_price_field->get_order(),
				'attributes' => [
					// Note: this property needs to be configured in the REST API.
					'property' => 'matt_sherman_random_sale_price_checkbox',
					'label'    => __( 'Random sale', 'woocommerce' ),
				],
			]
		);
	}
}

if ( ! function_exists( 'example_after_add_block' ) ) {
	/**
	 * Do something after any block is added.
	 *
	 * @param BlockInterface $block The block.
	 */
	function example_after_add_block( BlockInterface $block ) {
		// Calling these will not throw exceptions if the block is detached.
		$template = $block->get_root_template();
		$parent   = $block->get_parent();
	}
}

if ( ! function_exists( 'example_after_remove_block' ) ) {
	/**
	 * Do something after any block is removed.
	 *
	 * @param BlockInterface $block The block.
	 */
	function example_after_remove_block( BlockInterface $block ) {
		// Calling these will not throw exceptions if the block is detached.
		$template = $block->get_root_template();
		$parent   = $block->get_parent();
	}
}

if ( ! function_exists( 'example_after_add_description_section' ) ) {
	/**
	 * Be careless and throw an exception.
	 *
	 * @param BlockInterface $description_section The block.
	 *
	 * @throws \Exception An exception.
	 */
	function example_after_add_description_section( BlockInterface $description_section ) {
		// This exception will be caught and logged.
		throw new \Exception( 'Something went wrong!' );
	}
}
```

</details>

<details>

<summary>
Here is what the product form looks like with the modifications...
</summary>

<img width="1097" alt="Screenshot 2023-09-13 at 11 42 00" src="https://github.com/woocommerce/woocommerce/assets/2098816/2b44dbc5-719e-4e88-8338-eb3c4581473a">

</details>

<details>

<summary>
Here is what is logged...
</summary>

```
2023-09-13T15:42:15+00:00 INFO Block removed from template.
Array
(
    [block] => product-summary (name: woocommerce/product-summary-field)
    [template] => simple-product (area: product-form)
)

2023-09-13T15:42:15+00:00 INFO Block removed from template.
Array
(
    [block] => example-show-summary-toggle (name: woocommerce/product-toggle-field)
    [template] => simple-product (area: product-form)
)

2023-09-13T15:42:15+00:00 INFO Block removed from template.
Array
(
    [block] => product-sale-price (name: woocommerce/product-sale-price-field)
    [template] => simple-product (area: product-form)
)

2023-09-13T15:42:15+00:00 ERROR Error after adding block to template.
Array
(
    [exception] => Array
        (
            [message] => Something went wrong!
            [source] => /var/www/html/wp-content/mu-plugins/matt-sherman-template-mods.php: 217
            [trace] => Array
(
    [0] => /var/www/html/wp-includes/class-wp-hook.php: 310
    [1] => /var/www/html/wp-includes/class-wp-hook.php: 334
    [2] => /var/www/html/wp-includes/plugin.php: 517
    [3] => /var/www/html/wp-content/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockContainerTrait.php: 266
    [4] => /var/www/html/wp-content/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockContainerTrait.php: 58
    [5] => /var/www/html/wp-content/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/Group.php: 47
    [6] => /var/www/html/wp-content/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php: 208
    [7] => /var/www/html/wp-content/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php: 31
    [8] => /var/www/html/wp-content/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php: 52
    [9] => /var/www/html/wp-content/plugins/woocommerce/src/Admin/Features/Features.php: 138
    [10] => /var/www/html/wp-includes/class-wp-hook.php: 310
    [11] => /var/www/html/wp-includes/class-wp-hook.php: 334
    [12] => /var/www/html/wp-includes/plugin.php: 517
    [13] => /var/www/html/wp-settings.php: 632
    [14] => /var/www/html/wp-config.php: 261
    [15] => /var/www/html/wp-load.php: 50
    [16] => /var/www/html/wp-admin/admin.php: 34
)

        )

    [action] => woocommerce_block_template_area_product-form_after_add_block_product-description-section
    [container] => general (name: woocommerce/product-tab)
    [block] => product-description-section (name: woocommerce/product-section)
    [template] => simple-product (area: product-form)
)

2023-09-13T15:42:15+00:00 INFO Block removed from template.
Array
(
    [block] => product-images-section (name: woocommerce/product-section)
    [template] => simple-product (area: product-form)
)

2023-09-13T15:42:15+00:00 WARNING Block added to detached container. Block will not be included in the template, since the container will not be included in the template.
Array
(
    [block] => product-images (name: woocommerce/product-images-field)
    [container] => product-images-section (name: woocommerce/product-section)
    [template] => simple-product (area: product-form)
)
```

</details>

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
