### PR TITLE
Add track events to customize store transitional page

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/index.tsx
@@ -137,6 +137,13 @@ export const customizeStoreStateMachineDefinition = createMachine( {
 					},
 				},
 				{
+					target: 'transitionalScreen',
+					cond: {
+						type: 'hasStepInUrl',
+						step: 'transitional',
+					},
+				},
+				{
 					target: 'intro',
 				},
 			],
@@ -233,6 +240,7 @@ export const customizeStoreStateMachineDefinition = createMachine( {
 			},
 		},
 		transitionalScreen: {
+			entry: [ { type: 'updateQueryStep', step: 'transitional' } ],
 			meta: {
 				component: Transitional,
 			},

--- a/plugins/woocommerce-admin/client/customize-store/transitional/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/transitional/index.tsx
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { getSetting } from '@woocommerce/settings';
+import { recordEvent } from '@woocommerce/tracks';
 import {
 	Button,
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -59,8 +60,12 @@ export const Transitional = ( {
 				<Button
 					className="woocommerce-customize-store__transitional-preview-button"
 					variant="primary"
-					href={ homeUrl }
-					target="_blank"
+					onClick={ () => {
+						recordEvent(
+							'customize_your_transitional_preview_store_click'
+						);
+						window.open( homeUrl, '_blank' );
+					} }
 				>
 					{ __( 'Preview store', 'woocommerce' ) }
 				</Button>
@@ -89,7 +94,12 @@ export const Transitional = ( {
 						</p>
 						<Button
 							variant="tertiary"
-							href={ `${ ADMIN_URL }site-editor.php` }
+							onClick={ () => {
+								recordEvent(
+									'customize_your_transitional_editor_click'
+								);
+								window.location.href = `${ ADMIN_URL }site-editor.php`;
+							} }
 						>
 							{ __( 'Go to the Editor', 'woocommerce' ) }
 						</Button>
@@ -110,11 +120,14 @@ export const Transitional = ( {
 						</p>
 						<Button
 							variant="tertiary"
-							onClick={ () =>
+							onClick={ () => {
+								recordEvent(
+									'customize_your_transitional_home_click'
+								);
 								sendEvent( {
 									type: 'GO_BACK_TO_HOME',
-								} )
-							}
+								} );
+							} }
 						>
 							{ __( 'Back to Home', 'woocommerce' ) }
 						</Button>

--- a/plugins/woocommerce-admin/client/customize-store/transitional/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/transitional/index.tsx
@@ -62,7 +62,7 @@ export const Transitional = ( {
 					variant="primary"
 					onClick={ () => {
 						recordEvent(
-							'customize_your_transitional_preview_store_click'
+							'customize_your_store_transitional_preview_store_click'
 						);
 						window.open( homeUrl, '_blank' );
 					} }

--- a/plugins/woocommerce-admin/client/customize-store/transitional/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/transitional/index.tsx
@@ -96,7 +96,7 @@ export const Transitional = ( {
 							variant="tertiary"
 							onClick={ () => {
 								recordEvent(
-									'customize_your_transitional_editor_click'
+									'customize_your_store_transitional_editor_click'
 								);
 								window.location.href = `${ ADMIN_URL }site-editor.php`;
 							} }

--- a/plugins/woocommerce-admin/client/customize-store/transitional/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/transitional/index.tsx
@@ -122,7 +122,7 @@ export const Transitional = ( {
 							variant="tertiary"
 							onClick={ () => {
 								recordEvent(
-									'customize_your_transitional_home_click'
+									'customize_your_store_transitional_home_click'
 								);
 								sendEvent( {
 									type: 'GO_BACK_TO_HOME',

--- a/plugins/woocommerce-admin/client/customize-store/transitional/test/index.test.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/transitional/test/index.test.tsx
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import { render, screen } from '@testing-library/react';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -22,6 +23,8 @@ jest.mock( '../../assembler-hub/site-hub', () => ( {
 		return <div />;
 	},
 } ) );
+
+jest.mock( '@woocommerce/tracks', () => ( { recordEvent: jest.fn() } ) );
 
 describe( 'Transitional', () => {
 	let props: {
@@ -45,13 +48,13 @@ describe( 'Transitional', () => {
 		expect( screen.getByRole( 'img' ) ).toBeInTheDocument();
 
 		expect(
-			screen.getByRole( 'link', {
+			screen.getByRole( 'button', {
 				name: /Preview store/i,
 			} )
 		).toBeInTheDocument();
 
 		expect(
-			screen.getByRole( 'link', {
+			screen.getByRole( 'button', {
 				name: /Go to the Editor/i,
 			} )
 		).toBeInTheDocument();
@@ -61,6 +64,44 @@ describe( 'Transitional', () => {
 				name: /Back to Home/i,
 			} )
 		).toBeInTheDocument();
+	} );
+
+	it( 'should record an event when clicking on "Preview store" button', () => {
+		window.open = jest.fn();
+		// @ts-ignore
+		render( <Transitional { ...props } /> );
+
+		screen
+			.getByRole( 'button', {
+				name: /Preview store/i,
+			} )
+			.click();
+
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'customize_your_transitional_preview_store_click'
+		);
+	} );
+
+	it( 'should record an event when clicking on "Go to the Editor" button', () => {
+		// @ts-ignore Mocking window location
+		delete window.location;
+		window.location = {
+			// @ts-ignore Mocking window location href
+			href: jest.fn(),
+		};
+
+		// @ts-ignore
+		render( <Transitional { ...props } /> );
+
+		screen
+			.getByRole( 'button', {
+				name: /Go to the Editor/i,
+			} )
+			.click();
+
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'customize_your_transitional_editor_click'
+		);
 	} );
 
 	it( 'should send GO_BACK_TO_HOME event when clicking on "Back to Home" button', () => {
@@ -76,5 +117,8 @@ describe( 'Transitional', () => {
 		expect( props.sendEvent ).toHaveBeenCalledWith( {
 			type: 'GO_BACK_TO_HOME',
 		} );
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'customize_your_transitional_home_click'
+		);
 	} );
 } );

--- a/plugins/woocommerce-admin/client/customize-store/transitional/test/index.test.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/transitional/test/index.test.tsx
@@ -78,7 +78,7 @@ describe( 'Transitional', () => {
 			.click();
 
 		expect( recordEvent ).toHaveBeenCalledWith(
-			'customize_your_transitional_preview_store_click'
+			'customize_your_store_transitional_preview_store_click'
 		);
 	} );
 
@@ -100,7 +100,7 @@ describe( 'Transitional', () => {
 			.click();
 
 		expect( recordEvent ).toHaveBeenCalledWith(
-			'customize_your_transitional_editor_click'
+			'customize_your_store_transitional_editor_click'
 		);
 	} );
 
@@ -118,7 +118,7 @@ describe( 'Transitional', () => {
 			type: 'GO_BACK_TO_HOME',
 		} );
 		expect( recordEvent ).toHaveBeenCalledWith(
-			'customize_your_transitional_home_click'
+			'customize_your_store_transitional_home_click'
 		);
 	} );
 } );

--- a/plugins/woocommerce/changelog/add-cys-transitional-tracks
+++ b/plugins/woocommerce/changelog/add-cys-transitional-tracks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add track events to customize store transitional page


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #40128.

Adds tracks to monitor:

- % of users that click on “Preview store”.
- % of users that click on “Go to the Editor”.
- % of users that click on “Back to Home”.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Use WP 6.3 
2. Install the `WooCommerce Beta Tester` plugin
3. Go to /wp-admin/tools.php?page=woocommerce-admin-test-helper and enable `customize-store` feature flag
4. Open your browser developer console and run `localStorage.setItem( 'debug', 'wc-admin:*' );` to set debug for tracks
5. Go to `WooCommerce > Home`
6. Click on `Customize your store` task 
7. Click on `Assembler Hub` button
8. Click on `Done` button
9. A transitional page is shown
10. Open the dev console and turn on the "Preserve log" option
11. Click on "Preview store"
12. Observe that `wcadmin_customize_your_store_transitional_preview_store_click` event is recorded.
13. Click on “Go to the Editor”
14.  Observe that `wcadmin_customize_your_store_transitional_editor_click` event is recorded
15. Click on "Back to Home"
16. Observe that `wcadmin_customize_your_store_transitional_home_click` event is recorded

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add track events to customize store transitional page

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
