### PR TITLE
Add track events to customize store AI wizard

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/actions.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/actions.ts
@@ -3,6 +3,7 @@
  */
 import { assign } from 'xstate';
 import { getQuery, updateQueryString } from '@woocommerce/navigation';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -11,6 +12,7 @@ import {
 	designWithAiStateMachineContext,
 	designWithAiStateMachineEvents,
 } from './types';
+import { aiWizardClosedBeforeCompletionEvent } from './events';
 import {
 	businessInfoDescriptionCompleteEvent,
 	lookAndFeelCompleteEvent,
@@ -99,6 +101,38 @@ const updateQueryStep = (
 	}
 };
 
+const recordTracksStepViewed = (
+	_context: unknown,
+	_event: unknown,
+	{ action }: { action: unknown }
+) => {
+	const { step } = action as { step: string };
+	recordEvent( 'customize_your_store_ai_wizard_step_view', {
+		step,
+	} );
+};
+
+const recordTracksStepClosed = (
+	_context: unknown,
+	event: aiWizardClosedBeforeCompletionEvent
+) => {
+	const { step } = event.payload;
+	recordEvent( `customize_your_store_ai_wizard_step_close`, {
+		step: step.replaceAll( '-', '_' ),
+	} );
+};
+
+const recordTracksStepCompleted = (
+	_context: unknown,
+	_event: unknown,
+	{ action }: { action: unknown }
+) => {
+	const { step } = action as { step: string };
+	recordEvent( 'customize_your_store_ai_wizard_step_complete', {
+		step,
+	} );
+};
+
 export const actions = {
 	assignBusinessInfoDescription,
 	assignLookAndFeel,
@@ -106,4 +140,7 @@ export const actions = {
 	assignLookAndTone,
 	logAIAPIRequestError,
 	updateQueryStep,
+	recordTracksStepViewed,
+	recordTracksStepClosed,
+	recordTracksStepCompleted,
 };

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/actions.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/actions.ts
@@ -76,6 +76,10 @@ const logAIAPIRequestError = () => {
 	// log AI API request error
 	// eslint-disable-next-line no-console
 	console.log( 'API Request error' );
+	recordEvent(
+		'customize_your_store_look_and_tone_ai_completion_response_error',
+		{ error_type: 'http_network_error' }
+	);
 };
 
 const updateQueryStep = (

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/services.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/services.ts
@@ -50,17 +50,14 @@ export const parseLookAndToneCompletionResponse = (
 		}
 	} catch {
 		recordEvent(
-			'customize_your_store_look_and_tone_ai_completion_response_error',
+			'customize_your_store_ai_wizard_completion_response_error',
 			{ error_type: 'json_parse_error', response: JSON.stringify( obj ) }
 		);
 	}
-	recordEvent(
-		'customize_your_store_look_and_tone_ai_completion_response_error',
-		{
-			error_type: 'valid_json_invalid_values',
-			response: JSON.stringify( obj ),
-		}
-	);
+	recordEvent( 'customize_your_store_ai_wizard_completion_response_error', {
+		error_type: 'valid_json_invalid_values',
+		response: JSON.stringify( obj ),
+	} );
 	throw new Error( 'Could not parse Look and Tone completion response.' );
 };
 

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/services.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/services.ts
@@ -50,14 +50,17 @@ export const parseLookAndToneCompletionResponse = (
 		}
 	} catch {
 		recordEvent(
-			'customize_your_store_ai_wizard_completion_response_error',
+			'customize_your_store_look_and_tone_ai_completion_response_error',
 			{ error_type: 'json_parse_error', response: JSON.stringify( obj ) }
 		);
 	}
-	recordEvent( 'customize_your_store_ai_wizard_completion_response_error', {
-		error_type: 'valid_json_invalid_values',
-		response: JSON.stringify( obj ),
-	} );
+	recordEvent(
+		'customize_your_store_look_and_tone_ai_completion_response_error',
+		{
+			error_type: 'valid_json_invalid_values',
+			response: JSON.stringify( obj ),
+		}
+	);
 	throw new Error( 'Could not parse Look and Tone completion response.' );
 };
 

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/state-machine.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/state-machine.tsx
@@ -50,7 +50,10 @@ export const designWithAiStateMachineDefinition = createMachine(
 				target: 'navigate',
 			},
 			AI_WIZARD_CLOSED_BEFORE_COMPLETION: {
-				actions: sendParent( ( _context, event ) => event ),
+				actions: [
+					sendParent( ( _context, event ) => event ),
+					'recordTracksStepClosed',
+				],
 			},
 		},
 		context: {
@@ -116,6 +119,12 @@ export const designWithAiStateMachineDefinition = createMachine(
 						meta: {
 							component: BusinessInfoDescription,
 						},
+						entry: [
+							{
+								type: 'recordTracksStepViewed',
+								step: 'business_info_description',
+							},
+						],
 						on: {
 							BUSINESS_INFO_DESCRIPTION_COMPLETE: {
 								actions: [ 'assignBusinessInfoDescription' ],
@@ -127,11 +136,23 @@ export const designWithAiStateMachineDefinition = createMachine(
 						invoke: {
 							src: 'getLookAndTone',
 							onError: {
-								actions: [ 'logAIAPIRequestError' ],
+								actions: [
+									{
+										type: 'recordTracksStepCompleted',
+										step: 'business_info_description',
+									},
+									'logAIAPIRequestError',
+								],
 								target: '#lookAndFeel',
 							},
 							onDone: {
-								actions: [ 'assignLookAndTone' ],
+								actions: [
+									{
+										type: 'recordTracksStepCompleted',
+										step: 'business_info_description',
+									},
+									'assignLookAndTone',
+								],
 								target: '#lookAndFeel',
 							},
 						},
@@ -156,10 +177,20 @@ export const designWithAiStateMachineDefinition = createMachine(
 								type: 'updateQueryStep',
 								step: 'look-and-feel',
 							},
+							{
+								type: 'recordTracksStepViewed',
+								step: 'look_and_feel',
+							},
 						],
 						on: {
 							LOOK_AND_FEEL_COMPLETE: {
-								actions: [ 'assignLookAndFeel' ],
+								actions: [
+									{
+										type: 'recordTracksStepCompleted',
+										step: 'look_and_feel',
+									},
+									'assignLookAndFeel',
+								],
 								target: 'postLookAndFeel',
 							},
 						},
@@ -189,10 +220,20 @@ export const designWithAiStateMachineDefinition = createMachine(
 								type: 'updateQueryStep',
 								step: 'tone-of-voice',
 							},
+							{
+								type: 'recordTracksStepViewed',
+								step: 'tone_of_voice',
+							},
 						],
 						on: {
 							TONE_OF_VOICE_COMPLETE: {
-								actions: [ 'assignToneOfVoice' ],
+								actions: [
+									'assignToneOfVoice',
+									{
+										type: 'recordTracksStepCompleted',
+										step: 'tone_of_voice',
+									},
+								],
 								target: 'postToneOfVoice',
 							},
 						},

--- a/plugins/woocommerce/changelog/add-cys-ai-wizard-tracks
+++ b/plugins/woocommerce/changelog/add-cys-ai-wizard-tracks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add track events to customize store AI wizard


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #40127.

Add tracks to monitor Drop Off rate and rename the AI error response event name.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


1. Use WP 6.3 
2. Install the `WooCommerce Beta Tester` plugin
3. Go to /wp-admin/tools.php?page=woocommerce-admin-test-helper and enable `customize-store` feature flag
4. Open your browser developer console and run `localStorage.setItem( 'debug', 'wc-admin:*' );` to set debug for tracks
5. Go to `/wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store%2Fdesign-with-ai`
6. Observe that `wcadmin_customize_your_store_ai_wizard_step_view` event is recorded with step name `business_info_description`
7. Fill the business description and click on `Continue` button
8. Observe that `wcadmin_customize_your_store_ai_wizard_step_complete` event is recorded with step name `business_info_description`
9. Observe that `wcadmin_customize_your_store_ai_wizard_step_view` event is recorded with step name `look_and_feel`
10. Click on `Continue` button
11. Observe that `wcadmin_customize_your_store_ai_wizard_step_complete` event is recorded with step name `look_and_feel`
12. Observe that `wcadmin_customize_your_store_ai_wizard_step_view` event is recorded with step name `tone_of_voice`
13. Click on `Continue` button
14. Observe that `wcadmin_customize_your_store_ai_wizard_step_complete` event is recorded with step name `tone_of_voice`


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add track events to customize store AI wizard

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
