### PR TITLE
Properly convert shorthand date queries in local time to UTC

### DIFF
--- a/plugins/woocommerce/changelog/fix-39927
+++ b/plugins/woocommerce/changelog/fix-39927
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Properly convert local time date queries to UTC in the HPOS datastore.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -711,20 +711,15 @@ class ListTable extends WP_List_Table {
 		global $wpdb;
 
 		$orders_table = esc_sql( OrdersTableDataStore::get_orders_table_name() );
+		$utc_offset = wc_timezone_offset();
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$order_dates = $wpdb->get_results(
 			"
-				SELECT DISTINCT YEAR( date_created_gmt ) AS year,
-								MONTH( date_created_gmt ) AS month
-
-				FROM $orders_table
-
-				WHERE status NOT IN (
-					'trash'
-				)
-
-				ORDER BY year DESC, month DESC;
+				SELECT DISTINCT YEAR( t.date_created_local ) AS year,
+								MONTH( t.date_created_local ) AS month
+				FROM ( SELECT DATE_ADD( date_created_gmt, INTERVAL $utc_offset SECOND ) AS date_created_local FROM $orders_table WHERE status != 'trash' ) t
+				ORDER BY year DESC, month DESC
 			"
 		);
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -378,7 +378,7 @@ class OrdersTableQuery {
 
 		// Convert YYYY-MM-DD to UTC timestamp. Per https://github.com/woocommerce/woocommerce/wiki/wc_get_orders-and-WC_Order_Query#date only date is relevant (time is ignored).
 		foreach ( $dates_raw as &$raw_date ) {
-			$raw_date = strtotime( get_gmt_from_date( date( 'Y-m-d', strtotime( $raw_date ) ) ) );
+			$raw_date = is_numeric( $raw_date ) ? $raw_date : strtotime( get_gmt_from_date( date( 'Y-m-d', strtotime( $raw_date ) ) ) );
 		}
 
 		$date1  = end( $dates_raw );
@@ -492,7 +492,7 @@ class OrdersTableQuery {
 			if ( $is_local ) {
 				$date_key = $local_to_gmt_date_keys[ $date_key ];
 
-				if ( ! is_numeric( $dates_raw[0] ) && ! is_numeric( $dates_raw[1] ) ) {
+				if ( ! is_numeric( $dates_raw[0] ) && ( ! isset( $dates_raw[1] ) || ! is_numeric( $dates_raw[1] ) ) ) {
 					// Only non-numeric args can be considered local time. Timestamps are assumed to be UTC per https://github.com/woocommerce/woocommerce/wiki/wc_get_orders-and-WC_Order_Query#date.
 					$date_queries[] = array_merge(
 						array(

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -346,7 +346,11 @@ class OrdersTableQuery {
 			$date      = new \WC_DateTime( "@{$date}", new \DateTimeZone( $timezone ) );
 			$precision = 'default' === $precision ? 'second' : $precision;
 		} elseif ( ! is_a( $date, 'WC_DateTime' ) ) {
-			// YYYY-MM-DD queries have 'day' precision for backwards compat.
+			// For backwards compat (see https://github.com/woocommerce/woocommerce/wiki/wc_get_orders-and-WC_Order_Query#date)
+			// only YYYY-MM-DD is considered for date values. Timestamps do support second precision.
+			$date = date( 'Y-m-d', strtotime( $date ) );
+
+			// By default, YYYY-MM-DD queries have 'day' precision for backwards compat.
 			$date      = wc_string_to_datetime( $date . ' ' . $timezone );
 			$precision = 'default' === $precision ? 'day' : $precision;
 		}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -332,10 +332,9 @@ class OrdersTableQuery {
 	 * YYYY-MM-DD queries have 'day' precision for backwards compatibility.
 	 *
 	 * @param mixed  $date The date. Can be a {@see \WC_DateTime}, a timestamp or a string.
-	 * @param string $timezone The timezone to use for the date.
 	 * @return array An array with keys 'year', 'month', 'day' and possibly 'hour', 'minute' and 'second'.
 	 */
-	private function date_to_date_query_arg( $date, $timezone = 'UTC', $precision = 'default' ): array {
+	private function date_to_date_query_arg( $date ): array {
 		$result    = array(
 			'year'  => '',
 			'month' => '',
@@ -343,16 +342,13 @@ class OrdersTableQuery {
 		);
 
 		if ( is_numeric( $date ) ) {
-			$date      = new \WC_DateTime( "@{$date}", new \DateTimeZone( $timezone ) );
-			$precision = 'default' === $precision ? 'second' : $precision;
+			$date      = new \WC_DateTime( "@{$date}", new \DateTimeZone( 'UTC' ) );
+			$precision = 'second';
 		} elseif ( ! is_a( $date, 'WC_DateTime' ) ) {
 			// For backwards compat (see https://github.com/woocommerce/woocommerce/wiki/wc_get_orders-and-WC_Order_Query#date)
 			// only YYYY-MM-DD is considered for date values. Timestamps do support second precision.
-			$date = date( 'Y-m-d', strtotime( $date ) );
-
-			// By default, YYYY-MM-DD queries have 'day' precision for backwards compat.
-			$date      = wc_string_to_datetime( $date . ' ' . $timezone );
-			$precision = 'default' === $precision ? 'day' : $precision;
+			$date      = date( 'Y-m-d', strtotime( $date ) );
+			$precision = 'day';
 		}
 
 		$result['year']  = $date->date( 'Y' );

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -347,7 +347,7 @@ class OrdersTableQuery {
 		} elseif ( ! is_a( $date, 'WC_DateTime' ) ) {
 			// For backwards compat (see https://github.com/woocommerce/woocommerce/wiki/wc_get_orders-and-WC_Order_Query#date)
 			// only YYYY-MM-DD is considered for date values. Timestamps do support second precision.
-			$date      = date( 'Y-m-d', strtotime( $date ) );
+			$date      = wc_string_to_datetime( date( 'Y-m-d', strtotime( $date ) ) );
 			$precision = 'day';
 		}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -335,20 +335,20 @@ class OrdersTableQuery {
 	 * @param string $timezone The timezone to use for the date.
 	 * @return array An array with keys 'year', 'month', 'day' and possibly 'hour', 'minute' and 'second'.
 	 */
-	private function date_to_date_query_arg( $date, $timezone ): array {
+	private function date_to_date_query_arg( $date, $timezone = 'UTC', $precision = 'default' ): array {
 		$result    = array(
 			'year'  => '',
 			'month' => '',
 			'day'   => '',
 		);
-		$precision = 'second';
 
 		if ( is_numeric( $date ) ) {
-			$date = new \WC_DateTime( "@{$date}", new \DateTimeZone( $timezone ) );
+			$date      = new \WC_DateTime( "@{$date}", new \DateTimeZone( $timezone ) );
+			$precision = 'default' === $precision ? 'second' : $precision;
 		} elseif ( ! is_a( $date, 'WC_DateTime' ) ) {
 			// YYYY-MM-DD queries have 'day' precision for backwards compat.
-			$date      = wc_string_to_datetime( $date );
-			$precision = 'day';
+			$date      = wc_string_to_datetime( $date . ' ' . $timezone );
+			$precision = 'default' === $precision ? 'day' : $precision;
 		}
 
 		$result['year']  = $date->date( 'Y' );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
According to [our own docs](https://github.com/woocommerce/woocommerce/wiki/wc_get_orders-and-WC_Order_Query#date) when a query involves properties `date_created`, `date_updated`, `date_paid` and `date_completed` the expectation is that local time will be used (except when explicitly using the `_gmt` variants of those properties).

In particular, a query such as `['date_created' => '2023-09-10']` should return all orders created on 2023-09-10 in local time, but it is currently returning all orders created on `2023-09-10` in UTC, which is not necessarily the same.

For example, for a site in UTC+2, a query for orders created on 2023-09-10 (local time) should include all those created between 2023-09-09 22:00 and 2023-09-10 22:00, but should not include any orders between 22:00 and 23:59:59 UTC on the 10th. 

This PR introduces a few changes to how we deal with these queries, but the main change is that when querying a specific date (in local time) we convert that to the appropriate UTC-based date query.

It also fixes a query in the orders list table that resulted in the dates filter showing dates in UTC time instead of local time (despite the filtering always occurring in local time).

Closes #39927.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

That unit tests (which involve date queries) continue to pass is a good sign, but you can also confirm that things are looking ok via the admin:

1. Make sure HPOS is enabled: **High-performance order storage** should be selected as **Order data storage** in WC > Settings > Advanced > Features.
2. Change your site timezone to **UTC+2** in Settings > General.
3. Go to WC > Orders and click **Add order**.
4. Enter any details you want for this order but make sure that _Date created_ is **2023-09-01 01:00**. Click **Create** to save the order.
5. Repeat steps 3-4 but this time setting _Date created_ to **2023-10-31 00:00**.
6. Go to WC > Orders.
7. Confirm that the dates filter ("All Dates" dropdown) shows both September 2023 and October 2023.
8. Confirm that selecting one of these months and clicking **Filter** results in the appropriate order(s) being shown.

**Optional:** Contrast the above with current `trunk`, which would show August 2023 and September 2023 in the dropdown, and will display the Sept order in Aug, and the Oct order in Sep.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
