### PR TITLE
Marketplace: Reset search input when tab changes

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/search/search.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/search/search.tsx
@@ -26,6 +26,8 @@ function Search(): JSX.Element {
 	useEffect( () => {
 		if ( query.term ) {
 			setSearchTerm( query.term );
+		} else {
+			setSearchTerm( '' );
 		}
 	}, [ query.term ] );
 

--- a/plugins/woocommerce/changelog/fix-wccom-18033-reset-search-when-tab-changes
+++ b/plugins/woocommerce/changelog/fix-wccom-18033-reset-search-when-tab-changes
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Reset search input when switching between tabs in the marketplace page
+
+


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When the tab is changed, the `@woocommerce/navigation` package resets the `term` query parameter. So `query.term` becomes undefined.

Adding the else block allows us to catch that case and then we can reset the search input.

### How to test the changes in this Pull Request:

1. Checkout this branch and rebuild WooCommerce Admin assets (go into `plugins/woocommerce-admin` folder and run `pnpm run start`
2. Go to the in app marketplace page and switch to the **Browse** tab
3. Perform a search. You can input any search term.
4. After you see results, switch back to the **Discover tab** and confirm the search input is now reset and doesn't have your search term in it

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment Reset search input when switching between tabs in the marketplace page

</details>