### PR TITLE
Improve `remove_duplicate_notices` which fixes issue 35005

### DIFF
--- a/plugins/woocommerce/changelog/fix-cart-duplicate-notices
+++ b/plugins/woocommerce/changelog/fix-cart-duplicate-notices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixes the logic responsible for removing duplicate notices from the (classic) cart page.

--- a/plugins/woocommerce/client/legacy/js/frontend/cart.js
+++ b/plugins/woocommerce/client/legacy/js/frontend/cart.js
@@ -60,23 +60,22 @@ jQuery( function( $ ) {
 	/**
 	 * Removes duplicate notices.
 	 *
-	 * @param {JQuery Object} notices
+	 * @param {JQuery Object} $notices
 	 */
-	var remove_duplicate_notices = function( notices ) {
-		var seen = [];
-		var new_notices = notices;
+	var remove_duplicate_notices = function( $notices ) {
+		var seen                 = new Set();
+		var deduplicated_notices = [];
 
-		notices.each( function( index ) {
-			var text = $( this ).text();
+		$notices.each( function() {
+			const text = $( this ).text();
 
-			if ( 'undefined' === typeof seen[ text ] ) {
-				seen[ text ] = true;
-			} else {
-				new_notices.splice( index, 1 );
+			if ( ! seen.has( text ) ) {
+				seen.add( text );
+				deduplicated_notices.push( this );
 			}
 		} );
 
-		return new_notices;
+		return $( deduplicated_notices );
 	};
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When the cart is updated, it is possible that various notices will also be returned (usually there will be at least one *"Cart updated"* notice, and plugins may add others):

<div align="center"><img width="700" alt="Cart with update notifications" src="https://github.com/woocommerce/woocommerce/assets/3594411/552c220d-c682-4d48-9162-a98dbbff0f95"></div>

In some cases, error messages may be duplicated, and it is the job of the `remove_duplicate_notices` function to filter those out. As described in the linked issue, it does not always work reliably. This PR improves the situation.

Closes #35005.

### How to test the changes in this Pull Request

> :bulb: This fix specifically applies to the classic or legacy cart, and not the new Blocks-driven cart experience.

> :bulb: Please test with the [Storefront theme](https://wordpress.org/themes/storefront/), which ensures that notices we are interested in testing are rendered on the cart page. It's possible to set this up with other themes, too, but a [different problem](https://github.com/woocommerce/woocommerce/issues/38169) makes this a little tricky when working in the (now default) block editor.

Start by making sure you can replicate the original problem. First, add this snippet to a suitable location (could be `wp-content/mu-plugins/test-pr-40170.php` ... and please remove once you complete testing):

```php
<?php

add_action( 'wp_loaded', function () {
	$request = isset( $_REQUEST ) ? (array) $_REQUEST : [];

	$cart_actions = [
		'apply_coupon',
		'remove_coupon',
		'remove_item',
		'undo_item',
		'update_cart',
		'proceed',
	];

	if ( count( array_intersect( $cart_actions, array_keys( $request ) ) ) ) {
		wc_add_notice( 'There can be only one.' );
		wc_add_notice( 'There can be only two.' );
		wc_add_notice( 'There can be only one.' );
		wc_add_notice( 'There can be only two.' );
		wc_add_notice( 'There can be only two.' );
		wc_add_notice( 'There can be only two.' );
	}
} );
```

1. Checkout `trunk`.
2. You may wish to recompile legacy assets: `pnpm run --filter='woocommerce/client/legacy' build`.
3. Visit your storefront, add an item to the cart, and proceed to the cart page.
4. Modify the cart, by adjusting the line item quantity then clicking *Update Cart.*
5. Once the cart has finished updating, you will see a range of notices including several duplicates.

<div align="center"><img width="700" alt="Duplicate notices" src="https://github.com/woocommerce/woocommerce/assets/3594411/0e4764d1-be96-456e-8043-f94588cc6667"></div>

1. Now test the fix by checking out this branch.
2. Recompile legacy assets: `pnpm run --filter='woocommerce/client/legacy' build`.
3. Visit your storefront, add an item to the cart, and proceed to the cart page.
4. Take a moment to clear your browser's cache and reload the page (so that the updated `cart.js` code is loaded).
5. Modify the cart, by adjusting the line item quantity then clicking *Update Cart.*
6. Once the cart has finished updating, you will see a range of notices but no duplicates should be present.

<div align="center"><img width="700" alt="Duplicate notices removed" src="https://github.com/woocommerce/woocommerce/assets/3594411/642775c5-0f38-4f77-b17b-aa1d75a36bde"></div>

### Notes

- This is a very specific change: it applies to notices on the (class/legacy) cart page, and not to the frontend shopping UX in general.
- As briefly discussed in the parent issue, it may not even by ideal for `cart.js` to do this (not all 'duplicates' may be the result of mistakes, and indeed the definition of duplicate in this case is based only on the element's text, and not other attributes). However, getting the expected functionality working is a reasonable first step. Further work can be driven forward in the new Block-powered cart.