### PR TITLE
Add variable product experiment

### DIFF
--- a/plugins/woocommerce-admin/client/task-lists/fills/products/use-create-product-by-type.ts
+++ b/plugins/woocommerce-admin/client/task-lists/fills/products/use-create-product-by-type.ts
@@ -15,11 +15,28 @@ import { ProductTypeKey } from './constants';
 import { createNoticesFromResponse } from '../../../lib/notices';
 import { getAdminSetting } from '~/utils/admin-settings';
 
+const PHYSICAL = 'physical';
+const VARIABLE = 'variable';
+
 export const useCreateProductByType = () => {
 	const { createProductFromTemplate } = useDispatch( ITEMS_STORE_NAME );
 	const [ isRequesting, setIsRequesting ] = useState< boolean >( false );
+
 	const isNewExperienceEnabled =
 		window.wcAdminFeatures[ 'new-product-management-experience' ];
+
+	const getExperimentName = ( type: string ) => {
+		const baseName = 'woocommerce_product_creation_experience';
+		const version =
+			type === PHYSICAL ? '202308_v3' : 'add_variations_202310_v1';
+		return `${ baseName }_${ version }`;
+	};
+
+	const redirectToProductBlockEditor = () => {
+		const _feature_nonce = getAdminSetting( '_feature_nonce' );
+		const url = `post-new.php?post_type=product&product_block_editor=1&_feature_nonce=${ _feature_nonce }`;
+		window.location.href = getAdminLink( url );
+	};
 
 	const createProductByType = async ( type: ProductTypeKey ) => {
 		if ( type === 'subscription' ) {
@@ -31,21 +48,15 @@ export const useCreateProductByType = () => {
 
 		setIsRequesting( true );
 
-		if ( type === 'physical' ) {
+		if ( [ PHYSICAL, VARIABLE ].includes( type ) ) {
 			if ( isNewExperienceEnabled ) {
 				navigateTo( { url: getNewPath( {}, '/add-product', {} ) } );
 				return;
 			}
-
-			const assignment = await loadExperimentAssignment(
-				'woocommerce_product_creation_experience_202308_v3'
-			);
-
+			const experimentName = getExperimentName( type );
+			const assignment = await loadExperimentAssignment( experimentName );
 			if ( assignment.variationName === 'treatment' ) {
-				const _feature_nonce = getAdminSetting( '_feature_nonce' );
-				window.location.href = getAdminLink(
-					`post-new.php?post_type=product&product_block_editor=1&_feature_nonce=${ _feature_nonce }`
-				);
+				redirectToProductBlockEditor();
 				return;
 			}
 		}

--- a/plugins/woocommerce-admin/client/task-lists/fills/products/use-create-product-by-type.ts
+++ b/plugins/woocommerce-admin/client/task-lists/fills/products/use-create-product-by-type.ts
@@ -15,8 +15,8 @@ import { ProductTypeKey } from './constants';
 import { createNoticesFromResponse } from '../../../lib/notices';
 import { getAdminSetting } from '~/utils/admin-settings';
 
-const PHYSICAL = 'physical';
-const VARIABLE = 'variable';
+const EXPERIMENT_NAME =
+	'woocommerce_product_creation_experience_add_variations_202310_v1';
 
 export const useCreateProductByType = () => {
 	const { createProductFromTemplate } = useDispatch( ITEMS_STORE_NAME );
@@ -24,19 +24,6 @@ export const useCreateProductByType = () => {
 
 	const isNewExperienceEnabled =
 		window.wcAdminFeatures[ 'new-product-management-experience' ];
-
-	const getExperimentName = ( type: string ) => {
-		const baseName = 'woocommerce_product_creation_experience';
-		const version =
-			type === PHYSICAL ? '202308_v3' : 'add_variations_202310_v1';
-		return `${ baseName }_${ version }`;
-	};
-
-	const redirectToProductBlockEditor = () => {
-		const _feature_nonce = getAdminSetting( '_feature_nonce' );
-		const url = `post-new.php?post_type=product&product_block_editor=1&_feature_nonce=${ _feature_nonce }`;
-		window.location.href = getAdminLink( url );
-	};
 
 	const createProductByType = async ( type: ProductTypeKey ) => {
 		if ( type === 'subscription' ) {
@@ -48,15 +35,19 @@ export const useCreateProductByType = () => {
 
 		setIsRequesting( true );
 
-		if ( [ PHYSICAL, VARIABLE ].includes( type ) ) {
+		if ( type === 'physical' || type === 'variable' ) {
 			if ( isNewExperienceEnabled ) {
 				navigateTo( { url: getNewPath( {}, '/add-product', {} ) } );
 				return;
 			}
-			const experimentName = getExperimentName( type );
-			const assignment = await loadExperimentAssignment( experimentName );
+			const assignment = await loadExperimentAssignment(
+				EXPERIMENT_NAME
+			);
 			if ( assignment.variationName === 'treatment' ) {
-				redirectToProductBlockEditor();
+				const _feature_nonce = getAdminSetting( '_feature_nonce' );
+				window.location.href = getAdminLink(
+					`post-new.php?post_type=product&product_block_editor=1&_feature_nonce=${ _feature_nonce }`
+				);
 				return;
 			}
 		}

--- a/plugins/woocommerce-admin/client/task-lists/fills/products/use-create-product-by-type.ts
+++ b/plugins/woocommerce-admin/client/task-lists/fills/products/use-create-product-by-type.ts
@@ -21,7 +21,6 @@ const EXPERIMENT_NAME =
 export const useCreateProductByType = () => {
 	const { createProductFromTemplate } = useDispatch( ITEMS_STORE_NAME );
 	const [ isRequesting, setIsRequesting ] = useState< boolean >( false );
-
 	const isNewExperienceEnabled =
 		window.wcAdminFeatures[ 'new-product-management-experience' ];
 

--- a/plugins/woocommerce/changelog/add-40069_test_new_product_type
+++ b/plugins/woocommerce/changelog/add-40069_test_new_product_type
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add variable product experiment

--- a/plugins/woocommerce/client/admin/config/core.json
+++ b/plugins/woocommerce/client/admin/config/core.json
@@ -19,7 +19,7 @@
 		"new-product-management-experience": false,
 		"onboarding": true,
 		"onboarding-tasks": true,
-		"product-variation-management": false,
+		"product-variation-management": true,
 		"remote-inbox-notifications": true,
 		"remote-free-extensions": true,
 		"payment-gateway-suggestions": true,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This Pull Request introduces the Variable Product Experiment.

Closes #40069.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Note: Before testing this, please ensure that the features "new-product-management-experience" and "product-variation-management" are both disabled under `/wp-admin/tools.php?page=woocommerce-admin-test-helper`.

1. Go to the ExPlat experiment `woocommerce_product_creation_experience_add_variations_202310_v1 ` and choose the variation you want to test.
2. When hovering over any `Bookmarklet` link of control or treatment variation, a popover should appear with instructions to try one of the variations.
3. Be sure to save the suggested link to your browser bookmarks.
4. Go to WooCommerce > Home and go through the OBW.
5. Go to `/wp-admin/admin.php?page=wc-admin` and click on the second item to add a new product.
6. Click on the bookmark saved on step 3.
7. After clicking the saved bookmark, a modal with this title should be shown `ExPlat: Successful Assignment`
8. Close the modal
9. Then, click on either `Physical product` or `Variable product` item.
10. If you chose the "control" variation, you should see the old/legacy product form.
11. If you selected the "treatment" variation, you should see the blocks product editor.
12. Confirm that the "Variations" tab is visible.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
