### PR TITLE
Shipping Settings: Add React base Region Picker

### DIFF
--- a/plugins/woocommerce-admin/client/wp-admin-scripts/shipping-settings-region-picker/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/shipping-settings-region-picker/index.js
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import { render, createRoot } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { RegionPicker } from './region-picker';
+
+const shippingZoneRegionPickerRoot = document.getElementById(
+	'wc-shipping-zone-region-picker-root'
+);
+
+const options = JSON.parse( shippingZoneRegionPickerRoot.dataset.options );
+const initialValues = JSON.parse( shippingZoneRegionPickerRoot.dataset.values );
+
+if ( shippingZoneRegionPickerRoot ) {
+	if ( createRoot ) {
+		createRoot( shippingZoneRegionPickerRoot ).render(
+			<RegionPicker options={ options } initialValues={ initialValues } />
+		);
+	} else {
+		render(
+			<RegionPicker
+				options={ options }
+				initialValues={ initialValues }
+			/>,
+			shippingZoneRegionPickerRoot
+		);
+	}
+}

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/shipping-settings-region-picker/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/shipping-settings-region-picker/index.js
@@ -13,7 +13,7 @@ const shippingZoneRegionPickerRoot = document.getElementById(
 );
 
 const options = window.shippingZoneMethodsLocalizeScript?.region_options ?? [];
-const initialValues = JSON.parse( shippingZoneRegionPickerRoot.dataset.values );
+const initialValues = window.shippingZoneMethodsLocalizeScript?.locations ?? [];
 
 if ( shippingZoneRegionPickerRoot ) {
 	if ( createRoot ) {

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/shipping-settings-region-picker/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/shipping-settings-region-picker/index.js
@@ -12,7 +12,7 @@ const shippingZoneRegionPickerRoot = document.getElementById(
 	'wc-shipping-zone-region-picker-root'
 );
 
-const options = JSON.parse( shippingZoneRegionPickerRoot.dataset.options );
+const options = window.shippingZoneMethodsLocalizeScript?.region_options ?? [];
 const initialValues = JSON.parse( shippingZoneRegionPickerRoot.dataset.values );
 
 if ( shippingZoneRegionPickerRoot ) {

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/shipping-settings-region-picker/region-picker.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/shipping-settings-region-picker/region-picker.js
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import { useState } from '@wordpress/element';
+import { TreeSelectControl } from '@woocommerce/components';
+
+export const RegionPicker = ( { options, initialValues } ) => {
+	const [ selected, setSelected ] = useState( initialValues );
+	const onChange = ( value ) => {
+		document.body.dispatchEvent(
+			new CustomEvent( 'wc_region_picker_update', { detail: value } )
+		);
+		setSelected( value );
+	};
+
+	return (
+		<TreeSelectControl
+			value={ selected }
+			onChange={ onChange }
+			options={ options }
+			placeholder="Start typing to filter zones"
+			selectAllLabel="Select all countries"
+			includeParent
+			individuallySelectParent
+		/>
+	);
+};

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/shipping-settings-region-picker/region-picker.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/shipping-settings-region-picker/region-picker.js
@@ -8,6 +8,7 @@ export const RegionPicker = ( { options, initialValues } ) => {
 	const [ selected, setSelected ] = useState( initialValues );
 	const onChange = ( value ) => {
 		document.body.dispatchEvent(
+			/* global CustomEvent */
 			new CustomEvent( 'wc_region_picker_update', { detail: value } )
 		);
 		setSelected( value );

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/shipping-settings-region-picker/region-picker.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/shipping-settings-region-picker/region-picker.js
@@ -20,7 +20,6 @@ export const RegionPicker = ( { options, initialValues } ) => {
 			options={ options }
 			placeholder="Start typing to filter zones"
 			selectAllLabel="Select all countries"
-			includeParent
 			individuallySelectParent
 		/>
 	);

--- a/plugins/woocommerce-admin/webpack.config.js
+++ b/plugins/woocommerce-admin/webpack.config.js
@@ -67,6 +67,7 @@ const wpAdminScripts = [
 	'product-import-tracking',
 	'variable-product-tour',
 	'product-category-metabox',
+	'shipping-settings-region-picker',
 ];
 const getEntryPoints = () => {
 	const entryPoints = {

--- a/plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js
@@ -101,8 +101,18 @@
 					$( document.body ).on( 'click', '.wc-shipping-zone-add-method', { view: this }, this.onAddShippingMethod );
 					$( document.body ).on( 'wc_backbone_modal_response', this.onConfigureShippingMethodSubmitted );
 					$( document.body ).on( 'wc_backbone_modal_response', this.onAddShippingMethodSubmitted );
+					$( document.body ).on( 'wc_region_picker_update', this.onUpdateZoneRegionPicker );
 					$( document.body ).on( 'change', '.wc-shipping-zone-method-selector select', this.onChangeShippingMethodSelector );
 					$( document.body ).on( 'click', '.wc-shipping-zone-postcodes-toggle', this.onTogglePostcodes );
+				},
+				onUpdateZoneRegionPicker: function( event ) {
+					var value = event.detail,
+						attribute = 'zone_locations',
+						changes   = {};
+
+						changes[ attribute ] = value;
+						shippingMethodView.model.set( attribute, value );
+						shippingMethodView.model.logChanges( changes );
 				},
 				onUpdateZone: function( event ) {
 					var view      = event.data.view,

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-shipping.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-shipping.php
@@ -255,7 +255,7 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 	 * @param int $shipping_continents Zone ID.
 	 */
 	protected function get_region_options( $allowed_countries, $shipping_continents ) {
-		WCAdminAssets::register_script( 'wp-admin-scripts', 'shipping-settings-region-picker', true );
+		WCAdminAssets::register_script( 'wp-admin-scripts', 'shipping-settings-region-picker', true, array( 'wc-shipping-zone-methods' ) );
 
 		$options = array();
 		foreach ( $shipping_continents as $continent_code => $continent ) {
@@ -327,26 +327,32 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 			}
 		}
 
+		$localized_object = array(
+			'methods'                 => $zone->get_shipping_methods( false, 'json' ),
+			'zone_name'               => $zone->get_zone_name(),
+			'zone_id'                 => $zone->get_id(),
+			'wc_shipping_zones_nonce' => wp_create_nonce( 'wc_shipping_zones_nonce' ),
+			'strings'                 => array(
+				'unload_confirmation_msg'             => __( 'Your changed data will be lost if you leave this page without saving.', 'woocommerce' ),
+				'save_changes_prompt'                 => __( 'Do you wish to save your changes first? Your changed data will be discarded if you choose to cancel.', 'woocommerce' ),
+				'save_failed'                         => __( 'Your changes were not saved. Please retry.', 'woocommerce' ),
+				'add_method_failed'                   => __( 'Shipping method could not be added. Please retry.', 'woocommerce' ),
+				'remove_method_failed'                => __( 'Shipping method could not be removed. Please retry.', 'woocommerce' ),
+				'yes'                                 => __( 'Yes', 'woocommerce' ),
+				'no'                                  => __( 'No', 'woocommerce' ),
+				'default_zone_name'                   => __( 'Zone', 'woocommerce' ),
+				'delete_shipping_method_confirmation' => __( 'Are you sure you want to delete this shipping method?', 'woocommerce' ),
+			),
+		);
+
+		if ( 0 !== $zone->get_id() ) {
+			$localized_object['region_options'] = $this->get_region_options( $allowed_countries, $shipping_continents );
+		}
+
 		wp_localize_script(
 			'wc-shipping-zone-methods',
 			'shippingZoneMethodsLocalizeScript',
-			array(
-				'methods'                 => $zone->get_shipping_methods( false, 'json' ),
-				'zone_name'               => $zone->get_zone_name(),
-				'zone_id'                 => $zone->get_id(),
-				'wc_shipping_zones_nonce' => wp_create_nonce( 'wc_shipping_zones_nonce' ),
-				'strings'                 => array(
-					'unload_confirmation_msg'             => __( 'Your changed data will be lost if you leave this page without saving.', 'woocommerce' ),
-					'save_changes_prompt'                 => __( 'Do you wish to save your changes first? Your changed data will be discarded if you choose to cancel.', 'woocommerce' ),
-					'save_failed'                         => __( 'Your changes were not saved. Please retry.', 'woocommerce' ),
-					'add_method_failed'                   => __( 'Shipping method could not be added. Please retry.', 'woocommerce' ),
-					'remove_method_failed'                => __( 'Shipping method could not be removed. Please retry.', 'woocommerce' ),
-					'yes'                                 => __( 'Yes', 'woocommerce' ),
-					'no'                                  => __( 'No', 'woocommerce' ),
-					'default_zone_name'                   => __( 'Zone', 'woocommerce' ),
-					'delete_shipping_method_confirmation' => __( 'Are you sure you want to delete this shipping method?', 'woocommerce' ),
-				),
-			)
+			$localized_object,
 		);
 		wp_enqueue_script( 'wc-shipping-zone-methods' );
 

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-shipping.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-shipping.php
@@ -255,8 +255,6 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 	 * @param int $shipping_continents Zone ID.
 	 */
 	protected function get_region_options( $allowed_countries, $shipping_continents ) {
-		WCAdminAssets::register_script( 'wp-admin-scripts', 'shipping-settings-region-picker', true, array( 'wc-shipping-zone-methods' ) );
-
 		$options = array();
 		foreach ( $shipping_continents as $continent_code => $continent ) {
 			$continent_data = array(
@@ -311,10 +309,6 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 		$allowed_countries   = WC()->countries->get_shipping_countries();
 		$shipping_continents = WC()->countries->get_shipping_continents();
 
-		if ( 0 !== $zone->get_id() ) {
-			$region_options = $this->get_region_options( $allowed_countries, $shipping_continents );
-		}
-
 		// Prepare locations.
 		$locations = array();
 		$postcodes = array();
@@ -347,6 +341,7 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 		);
 
 		if ( 0 !== $zone->get_id() ) {
+			WCAdminAssets::register_script( 'wp-admin-scripts', 'shipping-settings-region-picker', true, array( 'wc-shipping-zone-methods' ) );
 			$localized_object['region_options'] = $this->get_region_options( $allowed_countries, $shipping_continents );
 		}
 

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-shipping.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-shipping.php
@@ -331,6 +331,7 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 			'methods'                 => $zone->get_shipping_methods( false, 'json' ),
 			'zone_name'               => $zone->get_zone_name(),
 			'zone_id'                 => $zone->get_id(),
+			'locations'               => $locations,
 			'wc_shipping_zones_nonce' => wp_create_nonce( 'wc_shipping_zones_nonce' ),
 			'strings'                 => array(
 				'unload_confirmation_msg'             => __( 'Your changed data will be lost if you leave this page without saving.', 'woocommerce' ),

--- a/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
+++ b/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
@@ -8,6 +8,45 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
+
+use Automattic\WooCommerce\Internal\Admin\WCAdminAssets;
+
+if ( 0 !== $zone->get_id() ) {
+	WCAdminAssets::register_script( 'wp-admin-scripts', 'shipping-settings-region-picker', true );
+
+	$options = array();
+	foreach ( $shipping_continents as $continent_code => $continent ) {
+		$continent_data = array(
+			'value'    => 'continent:' . esc_attr( $continent_code ),
+			'label'    => esc_html( $continent['name'] ),
+			'children' => array(),
+		);
+
+		$countries = array_intersect( array_keys( $allowed_countries ), $continent['countries'] );
+
+		foreach ( $countries as $country_code ) {
+			$country_data = array(
+				'value'    => 'country:' . esc_attr( $country_code ),
+				'label'    => esc_html( $allowed_countries[ $country_code ] ),
+				'children' => array(),
+			);
+
+			$states = WC()->countries->get_states( $country_code );
+
+			if ( $states ) {
+				foreach ( $states as $state_code => $state_name ) {
+					$country_data['children'][] = array(
+						'value' => 'state:' . esc_attr( $country_code . ':' . $state_code ),
+						'label' => esc_html( $state_name . ', ' . $allowed_countries[ $country_code ] ),
+					);
+				}
+			}
+			$continent_data['children'][] = $country_data;
+		}
+		$options[] = $continent_data;
+	}
+}
+
 ?>
 
 <h2>
@@ -37,6 +76,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 						<?php esc_html_e( 'Zone regions', 'woocommerce' ); ?>
 						<?php echo wc_help_tip( __( 'These are regions inside this zone. Customers will be matched against these regions.', 'woocommerce' ) ); // @codingStandardsIgnoreLine ?>
 					</label>
+				</th>
+				<td id="wc-shipping-zone-region-picker-root" data-options='<?php echo wp_json_encode( $options ); ?>' data-values='<?php echo wp_json_encode( $locations ); ?>'/>
+		</tr>
+			<tr valign="top" class="">
+				<th scope="row" class="titledesc">
+					<label for="zone_locations">
+						<?php esc_html_e( 'Zone regions', 'woocommerce' ); ?>
+					</label>
+					<p class="wc-shipping-zone-help-text">
+						<?php esc_html_e( 'These are regions inside this zone. Customers will be matched against these regions.', 'woocommerce' ); ?>
+					</p>
 				</th>
 				<td class="forminp">
 					<select multiple="multiple" data-attribute="zone_locations" id="zone_locations" name="zone_locations" data-placeholder="<?php esc_attr_e( 'Select regions within this zone', 'woocommerce' ); ?>" class="wc-shipping-zone-region-select chosen_select">

--- a/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
+++ b/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
@@ -41,7 +41,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				</th>
 				<td>
 					<div>
-						<div id="wc-shipping-zone-region-picker-root" data-values='<?php echo wp_json_encode( $locations ); ?>'/>
+						<div id="wc-shipping-zone-region-picker-root"/>
 					</div>
 					<?php if ( empty( $postcodes ) ) : ?>
 						<a class="wc-shipping-zone-postcodes-toggle" href="#"><?php esc_html_e( 'Limit to specific ZIP/postcodes', 'woocommerce' ); ?></a>

--- a/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
+++ b/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
@@ -9,44 +9,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use Automattic\WooCommerce\Internal\Admin\WCAdminAssets;
-
-if ( 0 !== $zone->get_id() ) {
-	WCAdminAssets::register_script( 'wp-admin-scripts', 'shipping-settings-region-picker', true );
-
-	$options = array();
-	foreach ( $shipping_continents as $continent_code => $continent ) {
-		$continent_data = array(
-			'value'    => 'continent:' . esc_attr( $continent_code ),
-			'label'    => esc_html( $continent['name'] ),
-			'children' => array(),
-		);
-
-		$countries = array_intersect( array_keys( $allowed_countries ), $continent['countries'] );
-
-		foreach ( $countries as $country_code ) {
-			$country_data = array(
-				'value'    => 'country:' . esc_attr( $country_code ),
-				'label'    => esc_html( $allowed_countries[ $country_code ] ),
-				'children' => array(),
-			);
-
-			$states = WC()->countries->get_states( $country_code );
-
-			if ( $states ) {
-				foreach ( $states as $state_code => $state_name ) {
-					$country_data['children'][] = array(
-						'value' => 'state:' . esc_attr( $country_code . ':' . $state_code ),
-						'label' => esc_html( $state_name . ', ' . $allowed_countries[ $country_code ] ),
-					);
-				}
-			}
-			$continent_data['children'][] = $country_data;
-		}
-		$options[] = $continent_data;
-	}
-}
-
 ?>
 
 <h2>
@@ -79,7 +41,7 @@ if ( 0 !== $zone->get_id() ) {
 				</th>
 				<td>
 					<div>
-						<div id="wc-shipping-zone-region-picker-root" data-options='<?php echo wp_json_encode( $options ); ?>' data-values='<?php echo wp_json_encode( $locations ); ?>'/>
+						<div id="wc-shipping-zone-region-picker-root" data-options='<?php echo wp_json_encode( $region_options ); ?>' data-values='<?php echo wp_json_encode( $locations ); ?>'/>
 					</div>
 					<?php if ( empty( $postcodes ) ) : ?>
 						<a class="wc-shipping-zone-postcodes-toggle" href="#"><?php esc_html_e( 'Limit to specific ZIP/postcodes', 'woocommerce' ); ?></a>

--- a/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
+++ b/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
@@ -8,7 +8,6 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
-
 ?>
 
 <h2>

--- a/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
+++ b/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
@@ -77,39 +77,10 @@ if ( 0 !== $zone->get_id() ) {
 						<?php echo wc_help_tip( __( 'These are regions inside this zone. Customers will be matched against these regions.', 'woocommerce' ) ); // @codingStandardsIgnoreLine ?>
 					</label>
 				</th>
-				<td id="wc-shipping-zone-region-picker-root" data-options='<?php echo wp_json_encode( $options ); ?>' data-values='<?php echo wp_json_encode( $locations ); ?>'/>
-		</tr>
-			<tr valign="top" class="">
-				<th scope="row" class="titledesc">
-					<label for="zone_locations">
-						<?php esc_html_e( 'Zone regions', 'woocommerce' ); ?>
-					</label>
-					<p class="wc-shipping-zone-help-text">
-						<?php esc_html_e( 'These are regions inside this zone. Customers will be matched against these regions.', 'woocommerce' ); ?>
-					</p>
-				</th>
-				<td class="forminp">
-					<select multiple="multiple" data-attribute="zone_locations" id="zone_locations" name="zone_locations" data-placeholder="<?php esc_attr_e( 'Select regions within this zone', 'woocommerce' ); ?>" class="wc-shipping-zone-region-select chosen_select">
-						<?php
-						foreach ( $shipping_continents as $continent_code => $continent ) {
-							echo '<option value="continent:' . esc_attr( $continent_code ) . '"' . wc_selected( "continent:$continent_code", $locations ) . '>' . esc_html( $continent['name'] ) . '</option>';
-
-							$countries = array_intersect( array_keys( $allowed_countries ), $continent['countries'] );
-
-							foreach ( $countries as $country_code ) {
-								echo '<option value="country:' . esc_attr( $country_code ) . '"' . wc_selected( "country:$country_code", $locations ) . '>' . esc_html( '&nbsp;&nbsp; ' . $allowed_countries[ $country_code ] ) . '</option>';
-
-								$states = WC()->countries->get_states( $country_code );
-
-								if ( $states ) {
-									foreach ( $states as $state_code => $state_name ) {
-										echo '<option value="state:' . esc_attr( $country_code . ':' . $state_code ) . '"' . wc_selected( "state:$country_code:$state_code", $locations ) . '>' . esc_html( '&nbsp;&nbsp;&nbsp;&nbsp; ' . $state_name . ', ' . $allowed_countries[ $country_code ] ) . '</option>';
-									}
-								}
-							}
-						}
-						?>
-					</select>
+				<td>
+					<div>
+						<div id="wc-shipping-zone-region-picker-root" data-options='<?php echo wp_json_encode( $options ); ?>' data-values='<?php echo wp_json_encode( $locations ); ?>'/>
+					</div>
 					<?php if ( empty( $postcodes ) ) : ?>
 						<a class="wc-shipping-zone-postcodes-toggle" href="#"><?php esc_html_e( 'Limit to specific ZIP/postcodes', 'woocommerce' ); ?></a>
 					<?php endif; ?>
@@ -119,8 +90,8 @@ if ( 0 !== $zone->get_id() ) {
 						<span class="description"><?php printf( __( 'Postcodes containing wildcards (e.g. CB23*) or fully numeric ranges (e.g. <code>90210...99000</code>) are also supported. Please see the shipping zones <a href="%s" target="_blank">documentation</a> for more information.', 'woocommerce' ), 'https://docs.woocommerce.com/document/setting-up-shipping-zones/#section-3' ); ?></span><?php // @codingStandardsIgnoreLine. ?>
 					</div>
 				</td>
-			<?php endif; ?>
-		</tr>
+			</tr>
+		<?php endif; ?>
 		<tr valign="top" class="">
 			<th scope="row" class="titledesc">
 				<label>

--- a/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
+++ b/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
@@ -41,7 +41,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				</th>
 				<td>
 					<div>
-						<div id="wc-shipping-zone-region-picker-root" data-options='<?php echo wp_json_encode( $region_options ); ?>' data-values='<?php echo wp_json_encode( $locations ); ?>'/>
+						<div id="wc-shipping-zone-region-picker-root" data-values='<?php echo wp_json_encode( $locations ); ?>'/>
 					</div>
 					<?php if ( empty( $postcodes ) ) : ?>
 						<a class="wc-shipping-zone-postcodes-toggle" href="#"><?php esc_html_e( 'Limit to specific ZIP/postcodes', 'woocommerce' ); ?></a>

--- a/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php
@@ -422,15 +422,16 @@ class WCAdminAssets {
 	 * @param string $script_path_name The script path name.
 	 * @param string $script_name Filename of the script to load.
 	 * @param bool   $need_translation Whether the script need translations.
+	 * @param array  $dependencies Array of any extra dependencies. Note wc-admin and any application JS dependencies are automatically added by Dependency Extraction Webpack Plugin. Use this parameter to designate any extra dependencies.
 	 */
-	public static function register_script( $script_path_name, $script_name, $need_translation = false ) {
+	public static function register_script( $script_path_name, $script_name, $need_translation = false, $dependencies = array() ) {
 		$script_assets_filename = self::get_script_asset_filename( $script_path_name, $script_name );
 		$script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . $script_path_name . '/' . $script_assets_filename;
 
 		wp_enqueue_script(
 			'wc-admin-' . $script_name,
 			self::get_url( $script_path_name . '/' . $script_name, 'js' ),
-			array_merge( array( WC_ADMIN_APP ), $script_assets ['dependencies'] ),
+			array_merge( array( WC_ADMIN_APP ), $script_assets ['dependencies'], $dependencies ),
 			self::get_file_version( 'js' ),
 			true
 		);

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-shipping-zones.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-shipping-zones.spec.js
@@ -84,9 +84,7 @@ test.describe( 'WooCommerce Shipping Settings - Add new shipping zone', () => {
 			await page.getByRole( 'button', { name: 'Add shipping method' } ).click();
 			await page.locator('select[name="add_method_id"]')
 				.selectOption( { label: 'Local pickup' } );
-			// await page
-			// 	.getByRole( 'combobox' )
-			// 	.selectOption( { label: 'Local pickup' } );
+			
 			await page.getByRole('button', { name: 'Add shipping method' } ).last().click();
 			await page.waitForLoadState( 'networkidle' );
 			await expect(
@@ -146,9 +144,7 @@ test.describe( 'WooCommerce Shipping Settings - Add new shipping zone', () => {
 
 			await page.locator('select[name="add_method_id"]')
 				.selectOption( { label: 'Free shipping' } );
-			// await page
-			// 	.getByRole( 'combobox' )
-			// 	.selectOption( { label: 'Free shipping' } );
+			
 			await page.getByRole('button', { name: 'Add shipping method' } ).last().click();
 			await page.waitForLoadState( 'networkidle' );
 			await expect(
@@ -194,8 +190,6 @@ test.describe( 'WooCommerce Shipping Settings - Add new shipping zone', () => {
 			input.click();
 			input.type( 'Canada' );
 
-			// await page.getByPlaceholder( 'Start typing to filter zones' ).click();
-			// await page.getByPlaceholder( 'Start typing to filter zones' ).type( 'Canada' );
 			await page
 				.getByText('Canada').last()
 				.click();
@@ -206,9 +200,7 @@ test.describe( 'WooCommerce Shipping Settings - Add new shipping zone', () => {
 			await page.getByRole( 'button', { name: 'Add shipping method' } ).click();
 			await page.locator('select[name="add_method_id"]')
 				.selectOption( { label: 'Flat rate' } );
-			// await page
-			// 	.getByRole( 'combobox' )
-			// 	.selectOption( { label: 'Flat rate' } );
+
 			await page.getByRole('button', { name: 'Add shipping method' } ).last().click();
 			await page.waitForLoadState( 'networkidle' );
 			await expect(
@@ -258,24 +250,12 @@ test.describe( 'WooCommerce Shipping Settings - Add new shipping zone', () => {
 			input.click();
 			input.type( 'United States' );
 
-			// await page.getByPlaceholder( 'Start typing to filter zones' ).click();
-			// await page.getByPlaceholder( 'Start typing to filter zones' ).type( 'Canada' );
 			await page
 				.getByText( 'United States' ).last()
 				.click();
 			
 				// Close dropdown
 			await page.keyboard.press('Escape');
-
-			// await page.locator( '.select2-search__field' ).click();
-			// await page
-			// 	.locator( '.select2-search__field' )
-			// 	.type( 'United States' );
-			// await page
-			// 	.locator(
-			// 		'.select2-results__option.select2-results__option--highlighted'
-			// 	)
-			// 	.click();
 
 			await page.locator( '#submit' ).click();
 			await page.waitForFunction( () => {
@@ -298,7 +278,7 @@ test.describe( 'WooCommerce Shipping Settings - Add new shipping zone', () => {
 		await page.locator( 'a:has-text("USA Zone") >> nth=0' ).click();
 
 		//delete
-		await page.locator( 'text=×' ).click();
+		await page.getByRole( 'button', { name: 'Remove' } ).click();
 		//save changes
 		await page.locator( '#submit' ).click();
 		await page.waitForFunction( () => {
@@ -332,22 +312,12 @@ test.describe( 'WooCommerce Shipping Settings - Add new shipping zone', () => {
 			input.click();
 			input.type( 'Canada' );
 
-			// await page.getByPlaceholder( 'Start typing to filter zones' ).click();
-			// await page.getByPlaceholder( 'Start typing to filter zones' ).type( 'Canada' );
 			await page
 				.getByText( 'Canada' ).last()
 				.click();
 			
 				// Close dropdown
 			await page.keyboard.press('Escape');
-
-			// await page.locator( '.select2-search__field' ).click();
-			// await page.locator( '.select2-search__field' ).type( 'Canada' );
-			// await page
-			// 	.locator(
-			// 		'.select2-results__option.select2-results__option--highlighted'
-			// 	)
-			// 	.click();
 
 			await page.locator( 'text=Add shipping method' ).click();
 
@@ -362,12 +332,12 @@ test.describe( 'WooCommerce Shipping Settings - Add new shipping zone', () => {
 					.filter( { hasText: 'Flat rate' } )
 			).toBeVisible();
 
-			await page.locator( 'a.wc-shipping-zone-method-settings' ).click();
+			await page.getByRole( 'link', { name: 'Flat rate' } ).click();
 			await page.locator( '#woocommerce_flat_rate_cost' ).fill( '10' );
 			await page.locator( '#btn-ok' ).click();
 			await page.waitForLoadState( 'networkidle' );
 
-			await page.locator( '.wc-shipping-zone-method-settings' ).hover();
+			await page.getByRole( 'link', { name: 'Flat rate' } ).hover();
 			await page.locator( 'text=Delete' ).waitFor();
 
 			page.on( 'dialog', ( dialog ) => dialog.accept() );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-shipping-zones.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-shipping-zones.spec.js
@@ -67,22 +67,26 @@ test.describe( 'WooCommerce Shipping Settings - Add new shipping zone', () => {
 				.getByPlaceholder( 'Zone name' )
 				.fill( shippingZoneNameLocalPickup );
 
-			await page.getByPlaceholder( 'Select regions within this zone' ).click();
-			await page
-				.getByPlaceholder( 'Select regions within this zone' )
-				.type( 'British Columbia, Canada' );
+			const input = await page.getByPlaceholder( 'Start typing to filter zones' );
+			input.click();
+			input.type( 'British Columbia, Canada' );
+			
 			await page
 				.getByText( 'British Columbia, Canada' ).last()
 				.click();
-
+			
+			// Close dropdown
+			await page.keyboard.press('Escape');
+			
 			await page.getByRole( 'link', { name: 'Limit to specific ZIP/postcodes' } ).click();
 			await page.getByPlaceholder( 'List 1 postcode per line' ).fill( maynePostal );
 
 			await page.getByRole( 'button', { name: 'Add shipping method' } ).click();
-
-			await page
-				.getByRole( 'combobox' )
+			await page.locator('select[name="add_method_id"]')
 				.selectOption( { label: 'Local pickup' } );
+			// await page
+			// 	.getByRole( 'combobox' )
+			// 	.selectOption( { label: 'Local pickup' } );
 			await page.getByRole('button', { name: 'Add shipping method' } ).last().click();
 			await page.waitForLoadState( 'networkidle' );
 			await expect(
@@ -127,19 +131,24 @@ test.describe( 'WooCommerce Shipping Settings - Add new shipping zone', () => {
 			);
 			await page.getByPlaceholder( 'Zone name' ).fill( shippingZoneNameFreeShip );
 
-			await page.getByPlaceholder( 'Select regions within this zone' ).click();
-			await page
-				.getByPlaceholder( 'Select regions within this zone' )
-				.type( 'British Columbia, Canada' );
+			const input = await page.getByPlaceholder( 'Start typing to filter zones' );
+			input.click();
+			input.type( 'British Columbia, Canada' );
+			
 			await page
 				.getByText( 'British Columbia, Canada' ).last()
 				.click();
-
+			
+			// Close dropdown
+			await page.keyboard.press('Escape');
+			
 			await page.getByRole( 'button', { name: 'Add shipping method' } ).click();
 
-			await page
-				.getByRole( 'combobox' )
+			await page.locator('select[name="add_method_id"]')
 				.selectOption( { label: 'Free shipping' } );
+			// await page
+			// 	.getByRole( 'combobox' )
+			// 	.selectOption( { label: 'Free shipping' } );
 			await page.getByRole('button', { name: 'Add shipping method' } ).last().click();
 			await page.waitForLoadState( 'networkidle' );
 			await expect(
@@ -181,17 +190,25 @@ test.describe( 'WooCommerce Shipping Settings - Add new shipping zone', () => {
 			);
 			await page.getByPlaceholder( 'Zone name' ).fill( shippingZoneNameFlatRate );
 
-			await page.getByPlaceholder( 'Select regions within this zone' ).click();
-			await page.getByPlaceholder( 'Select regions within this zone' ).type( 'Canada' );
+			const input = await page.getByPlaceholder( 'Start typing to filter zones' );
+			input.click();
+			input.type( 'Canada' );
+
+			// await page.getByPlaceholder( 'Start typing to filter zones' ).click();
+			// await page.getByPlaceholder( 'Start typing to filter zones' ).type( 'Canada' );
 			await page
 				.getByText('Canada').last()
 				.click();
+			
+				// Close dropdown
+			await page.keyboard.press('Escape');
 
 			await page.getByRole( 'button', { name: 'Add shipping method' } ).click();
-
-			await page
-				.getByRole( 'combobox' )
+			await page.locator('select[name="add_method_id"]')
 				.selectOption( { label: 'Flat rate' } );
+			// await page
+			// 	.getByRole( 'combobox' )
+			// 	.selectOption( { label: 'Flat rate' } );
 			await page.getByRole('button', { name: 'Add shipping method' } ).last().click();
 			await page.waitForLoadState( 'networkidle' );
 			await expect(
@@ -237,15 +254,28 @@ test.describe( 'WooCommerce Shipping Settings - Add new shipping zone', () => {
 			);
 			await page.locator( '#zone_name' ).fill( shippingZoneNameUSRegion );
 
-			await page.locator( '.select2-search__field' ).click();
+			const input = await page.getByPlaceholder( 'Start typing to filter zones' );
+			input.click();
+			input.type( 'United States' );
+
+			// await page.getByPlaceholder( 'Start typing to filter zones' ).click();
+			// await page.getByPlaceholder( 'Start typing to filter zones' ).type( 'Canada' );
 			await page
-				.locator( '.select2-search__field' )
-				.type( 'United States' );
-			await page
-				.locator(
-					'.select2-results__option.select2-results__option--highlighted'
-				)
+				.getByText( 'United States' ).last()
 				.click();
+			
+				// Close dropdown
+			await page.keyboard.press('Escape');
+
+			// await page.locator( '.select2-search__field' ).click();
+			// await page
+			// 	.locator( '.select2-search__field' )
+			// 	.type( 'United States' );
+			// await page
+			// 	.locator(
+			// 		'.select2-results__option.select2-results__option--highlighted'
+			// 	)
+			// 	.click();
 
 			await page.locator( '#submit' ).click();
 			await page.waitForFunction( () => {
@@ -298,13 +328,26 @@ test.describe( 'WooCommerce Shipping Settings - Add new shipping zone', () => {
 			);
 			await page.locator( '#zone_name' ).fill( shippingZoneNameFlatRate );
 
-			await page.locator( '.select2-search__field' ).click();
-			await page.locator( '.select2-search__field' ).type( 'Canada' );
+			const input = await page.getByPlaceholder( 'Start typing to filter zones' );
+			input.click();
+			input.type( 'Canada' );
+
+			// await page.getByPlaceholder( 'Start typing to filter zones' ).click();
+			// await page.getByPlaceholder( 'Start typing to filter zones' ).type( 'Canada' );
 			await page
-				.locator(
-					'.select2-results__option.select2-results__option--highlighted'
-				)
+				.getByText( 'Canada' ).last()
 				.click();
+			
+				// Close dropdown
+			await page.keyboard.press('Escape');
+
+			// await page.locator( '.select2-search__field' ).click();
+			// await page.locator( '.select2-search__field' ).type( 'Canada' );
+			// await page
+			// 	.locator(
+			// 		'.select2-results__option.select2-results__option--highlighted'
+			// 	)
+			// 	.click();
 
 			await page.locator( 'text=Add shipping method' ).click();
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/40185

This PR creates a `wc-admin-script` to inject a React based Region Picker for Shipping Zone Methods.

<img width="908" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1922453/d5dd50c5-95e4-4024-8cb9-793e04857552">

It makes use of the [TreeSelectControl](https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/components/src/tree-select-control) component to render the UI.

### Known Issues

* Selecting parents doesn't work as intended. A fix in progress can be found in https://github.com/woocommerce/woocommerce/pull/40301
* When typing to filter options, once an option is selected, the filtering text goes away and the view of options changes. This can be annoying if you'd like to select, say, several Mexican states and use the "Mexico" string to filter. You'd have to re-enter the filter string every time. Possibly, I can change the component such that the view of options doesn't change. I'm open to suggestions on this one.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Fire up a Jurassic Ninja from this PR
2. Head to `/wp-admin/admin.php?page=wc-settings&tab=shipping&zone_id=new`
3. Use the Region Picker and make sure the experience is working as expected. Be sure to read the "known issues" section above.
<img width="887" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1922453/b4f4c2a4-cf03-4c0a-9775-2243bd068f43">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
