### PR TITLE
Fix cached refund not deleted when refund is deleted with HPOS active

### DIFF
--- a/plugins/woocommerce/changelog/fix-bad-uncaching-of-order-refunds
+++ b/plugins/woocommerce/changelog/fix-bad-uncaching-of-order-refunds
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix cached refund not deleted when the refund is deleted with HPOS active

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableRefundDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableRefundDataStore.php
@@ -6,7 +6,8 @@
 
 namespace Automattic\WooCommerce\Internal\DataStores\Orders;
 
-use WC_Meta_Data;
+use \WC_Cache_Helper;
+use \WC_Meta_Data;
 
 /**
  * Class OrdersTableRefundDataStore.
@@ -76,6 +77,9 @@ class OrdersTableRefundDataStore extends OrdersTableDataStore {
 		if ( ! $refund_id ) {
 			return;
 		}
+
+		$refund_cache_key = WC_Cache_Helper::get_cache_prefix( 'orders' ) . 'refunds' . $refund->get_parent_id();
+		wp_cache_delete( $refund_cache_key, 'orders' );
 
 		$this->delete_order_data_from_custom_order_tables( $refund_id );
 		$refund->set_id( 0 );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Modify `OrdersTableRefundDataStore::delete` so that it removes the refund from the cache, in the same was as `WC_Order_Refund_Data_Store_CPT::delete` does.

Closes #38688.

### How to test the changes in this Pull Request:

To test the changes in this pull request you need a WordPress instance with an external object cache active (you can test if this is the case in WooCommerce - Status - "WordPress environment" section, "External object cache" key). An easy way to add such a cache is installing [the Docket Cache](https://wordpress.org/plugins/docket-cache/) plugin.

1. Set the new orders table as authoritative in WooCommerce - Settings - Advanced - Features - "Data storage for orders". Turn also sync on to ease testing, although in principle it shouldn't be necessary.
2. Go to Orders and create a new order.
3. Add a fee of any value to the order ("Refund" button) and save the order ("Update" button).
4. Add a refund for any amount that is less than the value of the refund ("Refund" button, enter the amount, click "Refund X manually" button), verify that the refund is created correctly and that the "Refunded" and "Net payment" amounts are correct.
5. Delete the refund clicking the X icon next to it, verify that the refund isn't listed anymore and that the "Refunded" and "Net payment" amounts are still correct.
7. Repeat, this time setting the posts table as authoritative in step 1.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Fix cached refund not deleted when the refund is deleted with HPOS active

#### Comment

</details>
