### PR TITLE
Search for taxonomy with special characters

### DIFF
--- a/packages/js/components/changelog/fix-taxonomy-special-characters
+++ b/packages/js/components/changelog/fix-taxonomy-special-characters
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Decode html characters in SelectTree
+
+

--- a/packages/js/components/src/experimental-select-tree-control/select-tree.tsx
+++ b/packages/js/components/src/experimental-select-tree-control/select-tree.tsx
@@ -6,6 +6,7 @@ import classNames from 'classnames';
 import { createElement, useEffect, useState } from '@wordpress/element';
 import { useInstanceId } from '@wordpress/compose';
 import { BaseControl, TextControl } from '@wordpress/components';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -131,7 +132,7 @@ export const SelectTree = function SelectTree( {
 			setInputValue( event.target.value );
 		},
 		placeholder,
-		value: inputValue,
+		value: decodeEntities( inputValue ),
 	};
 
 	return (
@@ -185,7 +186,7 @@ export const SelectTree = function SelectTree( {
 					) : (
 						<TextControl
 							{ ...inputProps }
-							value={ props.createValue || '' }
+							value={ decodeEntities( props.createValue || '' ) }
 							onChange={ ( value ) => {
 								if ( onInputChange ) onInputChange( value );
 								const item = items.find(

--- a/packages/js/components/src/experimental-select-tree-control/select-tree.tsx
+++ b/packages/js/components/src/experimental-select-tree-control/select-tree.tsx
@@ -17,6 +17,7 @@ import { SelectedItems } from '../experimental-select-control/selected-items';
 import { ComboBox } from '../experimental-select-control/combo-box';
 import { SuffixIcon } from '../experimental-select-control/suffix-icon';
 import { SelectTreeMenu } from './select-tree-menu';
+import { escapeHTML } from '../utils';
 
 interface SelectTreeProps extends TreeControlProps {
 	id: string;
@@ -27,13 +28,6 @@ interface SelectTreeProps extends TreeControlProps {
 	label: string | JSX.Element;
 	onInputChange?: ( value: string | undefined ) => void;
 	initialInputValue?: string | undefined;
-}
-
-function escapeHTML( string: string ) {
-	return string
-		.replace( /&/g, '&amp;' )
-		.replace( />/g, '&gt;' )
-		.replace( /</g, '&lt;' );
 }
 
 export const SelectTree = function SelectTree( {

--- a/packages/js/components/src/experimental-select-tree-control/select-tree.tsx
+++ b/packages/js/components/src/experimental-select-tree-control/select-tree.tsx
@@ -132,7 +132,7 @@ export const SelectTree = function SelectTree( {
 			setInputValue( event.target.value );
 		},
 		placeholder,
-		value: decodeEntities( inputValue ),
+		value: inputValue,
 	};
 
 	return (

--- a/packages/js/components/src/experimental-select-tree-control/select-tree.tsx
+++ b/packages/js/components/src/experimental-select-tree-control/select-tree.tsx
@@ -29,6 +29,13 @@ interface SelectTreeProps extends TreeControlProps {
 	initialInputValue?: string | undefined;
 }
 
+function escapeHTML( string: string ) {
+	return string
+		.replace( /&/g, '&amp;' )
+		.replace( />/g, '&gt;' )
+		.replace( /</g, '&lt;' );
+}
+
 export const SelectTree = function SelectTree( {
 	items,
 	treeRef: ref,
@@ -190,7 +197,7 @@ export const SelectTree = function SelectTree( {
 							onChange={ ( value ) => {
 								if ( onInputChange ) onInputChange( value );
 								const item = items.find(
-									( i ) => i.label === value
+									( i ) => i.label === escapeHTML( value )
 								);
 								if ( props.onSelect && item ) {
 									props.onSelect( item );

--- a/packages/js/components/src/index.ts
+++ b/packages/js/components/src/index.ts
@@ -84,7 +84,7 @@ export { DynamicForm } from './dynamic-form';
 export { default as TourKit } from './tour-kit';
 export * as TourKitTypes from './tour-kit/types';
 export { CollapsibleContent } from './collapsible-content';
-export { createOrderedChildren, sortFillsByOrder } from './utils';
+export { createOrderedChildren, sortFillsByOrder, escapeHTML } from './utils';
 export { WooProductFieldItem as __experimentalWooProductFieldItem } from './woo-product-field-item';
 export { WooProductSectionItem as __experimentalWooProductSectionItem } from './woo-product-section-item';
 export { WooProductTabItem as __experimentalWooProductTabItem } from './woo-product-tab-item';

--- a/packages/js/components/src/utils.tsx
+++ b/packages/js/components/src/utils.tsx
@@ -85,3 +85,10 @@ export const sortFillsByOrder: Slot.Props[ 'children' ] = ( fills ) => {
 
 	return <Fragment>{ sortedFills }</Fragment>;
 };
+
+export const escapeHTML = ( string: string ) => {
+	return string
+		.replace( /&/g, '&amp;' )
+		.replace( />/g, '&gt;' )
+		.replace( /</g, '&lt;' );
+};

--- a/packages/js/product-editor/changelog/fix-taxonomy-special-characters
+++ b/packages/js/product-editor/changelog/fix-taxonomy-special-characters
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Escape special characters when searching for taxonomies
+
+

--- a/packages/js/product-editor/src/blocks/taxonomy/use-taxonomy-search.ts
+++ b/packages/js/product-editor/src/blocks/taxonomy/use-taxonomy-search.ts
@@ -45,6 +45,15 @@ interface UseTaxonomySearchOptions {
 	fetchParents?: boolean;
 }
 
+function htmlEscape( string: string ) {
+	return string
+		.replace( /&/g, '&amp;' )
+		.replace( /'/g, '&apos;' )
+		.replace( /"/g, '&quot;' )
+		.replace( />/g, '&gt;' )
+		.replace( /</g, '&lt;' );
+}
+
 const useTaxonomySearch = (
 	taxonomyName: string,
 	options: UseTaxonomySearchOptions = { fetchParents: true }
@@ -61,7 +70,7 @@ const useTaxonomySearch = (
 				Taxonomy[]
 			>( 'taxonomy', taxonomyName, {
 				per_page: PAGINATION_SIZE,
-				search,
+				search: htmlEscape( search ),
 			} );
 			if ( options?.fetchParents ) {
 				taxonomies = await getTaxonomiesMissingParents(

--- a/packages/js/product-editor/src/blocks/taxonomy/use-taxonomy-search.ts
+++ b/packages/js/product-editor/src/blocks/taxonomy/use-taxonomy-search.ts
@@ -45,11 +45,9 @@ interface UseTaxonomySearchOptions {
 	fetchParents?: boolean;
 }
 
-function htmlEscape( string: string ) {
+function escapeHTML( string: string ) {
 	return string
 		.replace( /&/g, '&amp;' )
-		.replace( /'/g, '&apos;' )
-		.replace( /"/g, '&quot;' )
 		.replace( />/g, '&gt;' )
 		.replace( /</g, '&lt;' );
 }
@@ -70,7 +68,7 @@ const useTaxonomySearch = (
 				Taxonomy[]
 			>( 'taxonomy', taxonomyName, {
 				per_page: PAGINATION_SIZE,
-				search: htmlEscape( search ),
+				search: escapeHTML( search ),
 			} );
 			if ( options?.fetchParents ) {
 				taxonomies = await getTaxonomiesMissingParents(

--- a/packages/js/product-editor/src/blocks/taxonomy/use-taxonomy-search.ts
+++ b/packages/js/product-editor/src/blocks/taxonomy/use-taxonomy-search.ts
@@ -3,6 +3,7 @@
  */
 import { useState } from '@wordpress/element';
 import { resolveSelect } from '@wordpress/data';
+import { escapeHTML } from '@woocommerce/components';
 /**
  * Internal dependencies
  */
@@ -43,13 +44,6 @@ const PAGINATION_SIZE = 30;
 
 interface UseTaxonomySearchOptions {
 	fetchParents?: boolean;
-}
-
-function escapeHTML( string: string ) {
-	return string
-		.replace( /&/g, '&amp;' )
-		.replace( />/g, '&gt;' )
-		.replace( /</g, '&lt;' );
 }
 
 const useTaxonomySearch = (


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Following up https://github.com/woocommerce/woocommerce/pull/40047, which turned out to be incomplete, I found more places where HTML characters were not decoded in the taxonomy field and also found that it was not possible to search for taxonomies that contain special characters.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to the new product editor
2. Go to Organization tab
3. Create a new Category with the characters &, ' (single quote), ", <, and >. (Here's a name that I used to test: `1 ! 2 @ 3 # 4 $ 5 % 6 ^ 7 & 8 * 9 ( 0 ) a ' b " d ? , . { } [ ] | \ zzz > cccc < dddd`)
4. Check if it's represented correctly in all places.
5. Check if it's possible to search for it by typing its name.
6. Create another Category (also add some special characters)  and add the previously created category as parent. Try typing the parent name manually and see if the search works and if the field is filled correctly when the focus is removed after typing the complete name.
7. Check if it's created correctly and is represented correctly in all places.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
