### PR TITLE
Do not send user meta data back in `woocommerce_get_customer_details`

### DIFF
--- a/plugins/woocommerce/changelog/fix-meta-data-customer-details
+++ b/plugins/woocommerce/changelog/fix-meta-data-customer-details
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Do not send user meta data back in .

--- a/plugins/woocommerce/changelog/fix-meta-data-customer-details
+++ b/plugins/woocommerce/changelog/fix-meta-data-customer-details
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Do not send user meta data back in .
+Do not send user meta data back in `woocommerce_get_customer_details` response.

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -971,6 +971,8 @@ class WC_AJAX {
 		$data['date_created']  = $data['date_created'] ? $data['date_created']->getTimestamp() : null;
 		$data['date_modified'] = $data['date_modified'] ? $data['date_modified']->getTimestamp() : null;
 
+		unset( $data['meta_data'] );
+
 		$customer_data = apply_filters( 'woocommerce_ajax_get_customer_details', $data, $customer, $user_id );
 		wp_send_json( $customer_data );
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

The ajax handler for `woocommerce_get_customer_details` is primarily used (within WC core) for grabbing a customer's stored addresses. However, up until now, the response has also included all of the user's meta data, which we identified as being unnecessary and risky.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create an order or edit an existing order.
1. Select a new customer. You can pick any user you like, it can be an admin user instead of a customer.
1. Then, edit the billing address and click Load Billing Address.
1. Via your browser console or similar, inspect the ajax response: with this change in place it should not include an array of user meta data.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Do not send user meta data back in `woocommerce_get_customer_details`.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
