### PR TITLE
Redirect to product editing page when product was still in auto draft

### DIFF
--- a/packages/js/product-editor/changelog/fix-40166_redirect_to_edit_page_when_variation_added
+++ b/packages/js/product-editor/changelog/fix-40166_redirect_to_edit_page_when_variation_added
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add redirection to product edit page if variations are added before it being saved.

--- a/packages/js/product-editor/src/components/attribute-list-item/attribute-list-item.tsx
+++ b/packages/js/product-editor/src/components/attribute-list-item/attribute-list-item.tsx
@@ -89,7 +89,9 @@ export const AttributeListItem: React.FC< AttributeListItemProps > = ( {
 						position="top center"
 						text={ NOT_VISIBLE_TEXT }
 					>
-						<HiddenWithHelpIcon />
+						<div>
+							<HiddenWithHelpIcon />
+						</div>
 					</Tooltip>
 				) }
 				{ typeof onEditClick === 'function' && (

--- a/packages/js/product-editor/src/hooks/use-confirm-unsaved-product-changes.ts
+++ b/packages/js/product-editor/src/hooks/use-confirm-unsaved-product-changes.ts
@@ -33,5 +33,8 @@ export function useConfirmUnsavedProductChanges() {
 		[ productId ]
 	);
 
-	useConfirmUnsavedChanges( hasEdits || isSaving, preventLeavingProductForm );
+	useConfirmUnsavedChanges(
+		hasEdits || isSaving,
+		preventLeavingProductForm( productId )
+	);
 }

--- a/packages/js/product-editor/src/hooks/use-product-variations-helper.ts
+++ b/packages/js/product-editor/src/hooks/use-product-variations-helper.ts
@@ -1,11 +1,13 @@
 /**
  * External dependencies
  */
-import { useDispatch } from '@wordpress/data';
+import { resolveSelect, useDispatch } from '@wordpress/data';
 import { useEntityProp } from '@wordpress/core-data';
 import { useCallback, useState } from '@wordpress/element';
+import { getNewPath, getPath, navigateTo } from '@woocommerce/navigation';
 import {
 	EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME,
+	Product,
 	ProductDefaultAttribute,
 } from '@woocommerce/data';
 
@@ -34,6 +36,13 @@ export function useProductVariationsHelper() {
 		) => {
 			setIsGenerating( true );
 
+			const lastStatus = (
+				( await resolveSelect( 'core' ).getEditedEntityRecord(
+					'postType',
+					'product',
+					productId
+				) ) as Product
+			 ).status;
 			const hasVariableAttribute = attributes.some(
 				( attr ) => attr.variation
 			);
@@ -64,6 +73,13 @@ export function useProductVariationsHelper() {
 				} )
 				.finally( () => {
 					setIsGenerating( false );
+					if (
+						lastStatus === 'auto-draft' &&
+						getPath().endsWith( 'add-product' )
+					) {
+						const url = getNewPath( {}, `/product/${ productId }` );
+						navigateTo( { url } );
+					}
 				} );
 		},
 		[]

--- a/packages/js/product-editor/src/utils/prevent-leaving-product-form.ts
+++ b/packages/js/product-editor/src/utils/prevent-leaving-product-form.ts
@@ -6,10 +6,19 @@ import { Location } from 'react-router-dom';
 /**
  * Allow switching between tabs without prompting for unsaved changes.
  */
-export const preventLeavingProductForm = ( toUrl: URL, fromUrl: Location ) => {
-	const toParams = new URLSearchParams( toUrl.search );
-	const fromParams = new URLSearchParams( fromUrl.search );
-	toParams.delete( 'tab' );
-	fromParams.delete( 'tab' );
-	return toParams.toString() !== fromParams.toString();
-};
+export const preventLeavingProductForm =
+	( productId?: number ) => ( toUrl: URL, fromUrl: Location ) => {
+		const toParams = new URLSearchParams( toUrl.search );
+		const fromParams = new URLSearchParams( fromUrl.search );
+		toParams.delete( 'tab' );
+		fromParams.delete( 'tab' );
+		// Prevent dialog from happening if moving from add new to edit page of same product.
+		if (
+			productId !== undefined &&
+			fromParams.get( 'path' ) === '/add-product' &&
+			toParams.get( 'path' ) === '/product/' + productId
+		) {
+			return false;
+		}
+		return toParams.toString() !== fromParams.toString();
+	};

--- a/packages/js/product-editor/src/utils/test/prevent-leaving-product-form.test.ts
+++ b/packages/js/product-editor/src/utils/test/prevent-leaving-product-form.test.ts
@@ -16,7 +16,7 @@ describe( 'preventLeavingProductForm', () => {
 		const fromUrl = {
 			search: 'admin.php?page=wc-admin&path=/product/123&tab=general',
 		} as Location;
-		const shouldPrevent = preventLeavingProductForm( toUrl, fromUrl );
+		const shouldPrevent = preventLeavingProductForm()( toUrl, fromUrl );
 		expect( shouldPrevent ).toBe( true );
 	} );
 
@@ -27,7 +27,7 @@ describe( 'preventLeavingProductForm', () => {
 		const fromUrl = {
 			search: 'admin.php?page=wc-admin&path=/product/123&tab=general',
 		} as Location;
-		const shouldPrevent = preventLeavingProductForm( toUrl, fromUrl );
+		const shouldPrevent = preventLeavingProductForm()( toUrl, fromUrl );
 		expect( shouldPrevent ).toBe( true );
 	} );
 
@@ -38,7 +38,35 @@ describe( 'preventLeavingProductForm', () => {
 		const fromUrl = {
 			search: 'admin.php?page=wc-admin&path=/product/123&tab=shipping',
 		} as Location;
-		const shouldPrevent = preventLeavingProductForm( toUrl, fromUrl );
+		const shouldPrevent = preventLeavingProductForm()( toUrl, fromUrl );
+		expect( shouldPrevent ).toBe( true );
+	} );
+
+	it( 'should allow leaving when moving from the add-product to the edit page with same product id', () => {
+		const toUrl = new URL(
+			'http://mysite.com/admin.php?page=wc-admin&path=/product/123&tab=general'
+		);
+		const fromUrl = {
+			search: 'admin.php?page=wc-admin&path=/add-product',
+		} as Location;
+		const shouldPrevent = preventLeavingProductForm( 123 )(
+			toUrl,
+			fromUrl
+		);
+		expect( shouldPrevent ).toBe( false );
+	} );
+
+	it( 'should not allow leaving when moving from the add-product to the edit page with different product id', () => {
+		const toUrl = new URL(
+			'http://mysite.com/admin.php?page=wc-admin&path=/product/123&tab=general'
+		);
+		const fromUrl = {
+			search: 'admin.php?page=wc-admin&path=/add-product',
+		} as Location;
+		const shouldPrevent = preventLeavingProductForm( 333 )(
+			toUrl,
+			fromUrl
+		);
 		expect( shouldPrevent ).toBe( true );
 	} );
 
@@ -49,7 +77,7 @@ describe( 'preventLeavingProductForm', () => {
 		const fromUrl = {
 			search: 'admin.php?page=wc-admin&path=/product/123&tab=shipping&other_param=b',
 		} as Location;
-		const shouldPrevent = preventLeavingProductForm( toUrl, fromUrl );
+		const shouldPrevent = preventLeavingProductForm()( toUrl, fromUrl );
 		expect( shouldPrevent ).toBe( true );
 	} );
 } );

--- a/plugins/woocommerce-admin/client/products/product-form-actions.tsx
+++ b/plugins/woocommerce-admin/client/products/product-form-actions.tsx
@@ -49,7 +49,7 @@ export const ProductFormActions: React.FC = () => {
 	const { isDirty, isValidForm, values, resetForm } =
 		useFormContext< Product >();
 
-	useConfirmUnsavedChanges( isDirty, preventLeavingProductForm );
+	useConfirmUnsavedChanges( isDirty, preventLeavingProductForm() );
 
 	useCustomerEffortScoreExitPageTracker(
 		! values.id ? 'new_product' : 'editing_new_product',

--- a/plugins/woocommerce-admin/client/products/product-variation-form-actions.tsx
+++ b/plugins/woocommerce-admin/client/products/product-variation-form-actions.tsx
@@ -31,7 +31,7 @@ export const ProductVariationFormActions: React.FC = () => {
 	const { createNotice } = useDispatch( 'core/notices' );
 	const [ isSaving, setIsSaving ] = useState( false );
 
-	useConfirmUnsavedChanges( isDirty, preventLeavingProductForm );
+	useConfirmUnsavedChanges( isDirty, preventLeavingProductForm() );
 
 	const onSave = async () => {
 		setIsSaving( true );

--- a/plugins/woocommerce-admin/client/products/test/product-form-actions.spec.tsx
+++ b/plugins/woocommerce-admin/client/products/test/product-form-actions.spec.tsx
@@ -44,6 +44,7 @@ jest.mock( '@woocommerce/product-editor', () => {
 		__experimentalUseFeedbackBar: () => ( {
 			maybeShowFeedbackBar: jest.fn().mockResolvedValue( {} ),
 		} ),
+		preventLeavingProductForm: () => () => false,
 	};
 } );
 jest.mock( '@woocommerce/navigation', () => ( {

--- a/plugins/woocommerce/changelog/fix-40166_redirect_to_edit_page_when_variation_added
+++ b/plugins/woocommerce/changelog/fix-40166_redirect_to_edit_page_when_variation_added
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update use of preventLeavingProductForm with new function changes.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds a redirection after variations have been added and the product hadn't been saved before (aka `auto-draft`).
I did add an extra check to see if it was also on the `add-product` page, just incase we fire this logic in other UI's

Closes #40166 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

**Requires feature flag: `product-variation-management`**

1. Enable the new product editor under **WooCommerce > Settings > Advanced > Features**
2. Install the WooCommerce Beta tester plugin and enable the `product-variation-management` feature under **Tools > WCA Test Helper > Features**
3. Go to **Products > Add new** and go to the **Variations** tab
4. Add a couple variation options ( before adding notice how the url still say's `add-product`
5. Variations should be auto generated
6. The URL should now be updated and include the product id.
7. Refresh the page, the variations should still be present up on refresh
8. Try adding/removing more variations now, things should still work as expected.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
