### PR TITLE
Rather than adding border, add color to border of search box

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/search/search.scss
+++ b/plugins/woocommerce-admin/client/marketplace/components/search/search.scss
@@ -3,6 +3,7 @@
 .woocommerce-marketplace__search {
 	grid-area: mktpl-search;
 	background: $gutenberg-gray-100;
+	border: 1.5px solid transparent;
 	border-radius: 2px;
 	display: flex;
 	height: 40px;
@@ -15,7 +16,7 @@
 
 	&:focus-within {
 		background: #fff;
-		border: 1.5px solid var(--wp-admin-theme-color, #3858e9);
+		border-color: var(--wp-admin-theme-color, #3858e9);
 	}
 
 	@media (width <= $breakpoint-medium) {

--- a/plugins/woocommerce/changelog/fix-wccom-18179-search-box-border
+++ b/plugins/woocommerce/changelog/fix-wccom-18179-search-box-border
@@ -2,4 +2,3 @@ Significance: patch
 Type: fix
 Comment: Prevented a 1.5px cosmetic shift of contents in the Extension Search box when focussing/unfocussing.
 
-

--- a/plugins/woocommerce/changelog/fix-wccom-18179-search-box-border
+++ b/plugins/woocommerce/changelog/fix-wccom-18179-search-box-border
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Prevented a 1.5px cosmetic shift of contents in the Extension Search box when focussing/unfocussing.
+
+

--- a/plugins/woocommerce/changelog/fix-wccom-18179-search-box-border
+++ b/plugins/woocommerce/changelog/fix-wccom-18179-search-box-border
@@ -3,3 +3,4 @@ Type: fix
 Comment: Prevented a 1.5px cosmetic shift of contents in the Extension Search box when focussing/unfocussing.
 
 
+

--- a/plugins/woocommerce/changelog/fix-wccom-18179-search-box-border
+++ b/plugins/woocommerce/changelog/fix-wccom-18179-search-box-border
@@ -2,3 +2,4 @@ Significance: patch
 Type: fix
 Comment: Prevented a 1.5px cosmetic shift of contents in the Extension Search box when focussing/unfocussing.
 
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes [WCCOM#18179](https://github.com/Automattic/woocommerce.com/issues/18179).

It's hard to spot until it's pointed out to you. But once you see it, you can't unsee it. When you focus/unfocus the marketplace "search" field the border's appearance/disappearance makes the content, including the search button, "shift" by a few pixels:

https://github.com/woocommerce/woocommerce/assets/53293/bd20cf38-4cc0-4f97-b892-95f081541059

This PR fixes that by adding the border at all times, but transparent, and then merely changing the color of it on focus.

### How to test the changes in this Pull Request:

1. Checkout this branch and rebuild WooCommerce Admin assets (e.g. `cd plugins/woocommerce-admin  && pnpm run start`)
2. Go to the [In-App Marketplace Extensions page](http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fextensions&tab=extensions) and focus/unfocus the search field
3. _Don't_ see the ugliness shown in the video above!

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

Prevented a 1.5px cosmetic "shift" of contents in the Extension Search box when focussing/unfocussing.

</details>
