### PR TITLE
Add global attribute terms filtering

### DIFF
--- a/plugins/woocommerce/changelog/add-40070_global_attribute_terms_filtering
+++ b/plugins/woocommerce/changelog/add-40070_global_attribute_terms_filtering
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add attributes filter to variations endpoint and deprecate local_attributes filter.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This deprecates the use of the `local_attributes` filter and replaces it with just an `attributes` filter.
The filter will support both local and global attributes.

Closes #40070 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to **WooCommerce > Products > Add new** (in the classic editor)
2. Create a new variable product with at-least two attributes ( one global and one local )
One of using colour and the other being size for example.
3. Now go to the Variations tab and select **Generate variations** and save the product
4. Open your console now and note the product id (displayed in the url -> `post=<PRODUCT_ID>`
5. Run this in your console:
```
wp.apiFetch({ path: wp.url.addQueryArgs( '/wc/v3/products/<PRODUCT_ID>/variations' ) });
```
6. Open your network tab and look at the last request, it should display the entire list of variations
7. Go to your console again and run:
**Note::** If you use a global attribute, you want to use the slug, global attributes that tend to start with `pa_` ex: ( for the Colour global attribute it will become: `pa_colour`.
```
wp.apiFetch({ path: wp.url.addQueryArgs( '/wc/v3/products/1151/variations',
                {
                    attributes: [
                        {
                           "attribute": "size", // slug of your local attribute
                          "term": "Small"
        } ]
   })
} );
```
8. Go back to your network tab, the variations returned should now be filtered by the attribute term selected above.
9. You could add a second attribute in, which should return a single variation for only the variation that matches those 'two' attributes.
10. You can test a couple variations of this.
11. Now run the same console but replacing the `attributes` key to `local_attributes`
12. Note this should still work, but should show a deprecation warning/error in your error.log.
13. Lastly make sure the PHP unit tests run correctly in GH actions, you can also run them locally by following [these instructions](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/tests/README.md#mysql-database) and running: `vendor/bin/phpunit --filter Product_Variations_API` (in the `plugins/woocommerce` folder.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
