### PR TITLE
Fix error displaying block after removing variation

### DIFF
--- a/packages/js/product-editor/changelog/fix-40165_error_displaying_block_when_removing_variation
+++ b/packages/js/product-editor/changelog/fix-40165_error_displaying_block_when_removing_variation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix error displaying block after removing variation #40255

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
@@ -403,7 +403,9 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 																}
 																value={
 																	attribute ===
-																	null
+																		null ||
+																	attribute ===
+																		undefined
 																		? []
 																		: attribute.terms
 																}

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
@@ -508,7 +508,9 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 									label={ addAccessibleLabel }
 									disabled={
 										values.attributes.length === 1 &&
-										values.attributes[ 0 ] === null
+										( values.attributes[ 0 ] === null ||
+											values.attributes[ 0 ] ===
+												undefined )
 									}
 									onClick={ () =>
 										onAddingAttributes( values )


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

There was an error after deleting an Attribute, in the `Add variation options` modal.

`This block has encountered an error and cannot be previewed.` showed up after attempting to delete a variation.

![RyML9K.gif](https://github.com/woocommerce/woocommerce/assets/2240960/587b1f84-6df8-44db-94aa-9f24b2cdcd7e)

This PR fixes that error.

Closes #40165.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the new product editor under **WooCommerce > Settings > Advanced > Features**
2. Install the WooCommerce Beta tester plugin and enable the `product-variation-management` feature under **Tools > WCA Test Helper > Features**
3. Go to **Products > Add new** and go to the **Variations** tab
4. Add a variation option and a few terms.
5. Now click the `Attribute` selector and delete the variation you just added.
6. Click outside the selector. That should disable the `Add` button.
7. It shouldn't show any errors.

![Screen Capture on 2023-09-18 at 17-11-12](https://github.com/woocommerce/woocommerce/assets/1314156/127e2b4f-3ade-408c-a272-629d94c7e915)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
