### PR TITLE
Template API: Expose template block id and order to client

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -3,6 +3,7 @@
 	"MD003": { "style": "atx" },
 	"MD007": { "indent": 4 },
 	"MD013": { "line_length": 9999 },
+	"MD024": { "allow_different_nesting": true },
 	"no-hard-tabs": false,
 	"whitespace": false
 }

--- a/.syncpackrc
+++ b/.syncpackrc
@@ -118,6 +118,7 @@
 				"@wordpress/edit-site"
 			],
 			"packages": [
+				"@woocommerce/block-templates",
 				"@woocommerce/product-editor",
 				"woocommerce/client/admin",
 				"@woocommerce/components"

--- a/packages/js/block-templates/.eslintrc.js
+++ b/packages/js/block-templates/.eslintrc.js
@@ -1,0 +1,12 @@
+module.exports = {
+	extends: [ 'plugin:@woocommerce/eslint-plugin/recommended' ],
+	root: true,
+	overrides: [
+		{
+			files: [ '**/*.js', '**/*.jsx', '**/*.tsx' ],
+			rules: {
+				'react/react-in-jsx-scope': 'off',
+			},
+		},
+	],
+};

--- a/packages/js/block-templates/.npmrc
+++ b/packages/js/block-templates/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/packages/js/block-templates/README.md
+++ b/packages/js/block-templates/README.md
@@ -8,7 +8,7 @@ A collection of utility functions for use with WooCommerce admin block templates
 
 Registers a WooCommerce block type.
 
-_Usage_
+#### Usage
 
 ```js
 import { registerWooBlockType } from '@woocommerce/block-templates';
@@ -25,11 +25,11 @@ registerWooBlockType( {
 } );
 ```
 
-_Parameters_
+#### Parameters
 
 - _blockMetadata_ `Object`: Block metadata.
 
-_Returns_
+#### Returns
 
 - `WPBlockType | undefined`: The block type if it was registered successfully, otherwise `undefined`.
 
@@ -39,7 +39,7 @@ This hook is used to lightly mark an element as a WooCommerce block template blo
 
 If you define a ref for the element, it is important to pass the ref to this hook, which the hook in turn will pass to the component through the props it returns. Optionally, you can also pass any other props through this hook, and they will be merged and returned.
 
-_Usage_
+#### Usage
 
 ```js
 import { useWooBlockProps } from '@woocommerce/block-templates';
@@ -60,10 +60,11 @@ export function Edit( { attributes } ) {
 }
 ```
 
-_Parameters_
+#### Parameters
+
 - _attributes_: `Object`: Block attributes.
 - _props_: `Object`: Optional. Props to pass to the element.
 
-_Returns_
+#### Returns
 
 - `Object`: Props to pass to the element to mark as a WooCommerce block.

--- a/packages/js/block-templates/README.md
+++ b/packages/js/block-templates/README.md
@@ -1,3 +1,69 @@
 # @woocommerce/block-templates
 
 A collection of utility functions for use with WooCommerce admin block templates.
+
+## API
+
+### registerWooBlockType
+
+Registers a WooCommerce block type.
+
+_Usage_
+
+```js
+import { registerWooBlockType } from '@woocommerce/block-templates';
+
+import metadata from './block.json';
+import { Edit } from './edit';
+
+registerWooBlockType( {
+  name: metadata.name,
+  metadata: metadata,
+  settings: {
+    edit: Edit,
+  }
+} );
+```
+
+_Parameters_
+
+- _blockMetadata_ `Object`: Block metadata.
+
+_Returns_
+
+- `WPBlockType | undefined`: The block type if it was registered successfully, otherwise `undefined`.
+
+### useWooBlockProps
+
+This hook is used to lightly mark an element as a WooCommerce block template block. The block's attributes must be passed to this hook and the return result passed to the outermost element of the block in order for the block to properly function in WooCommerce block template contexts.
+
+If you define a ref for the element, it is important to pass the ref to this hook, which the hook in turn will pass to the component through the props it returns. Optionally, you can also pass any other props through this hook, and they will be merged and returned.
+
+_Usage_
+
+```js
+import { useWooBlockProps } from '@woocommerce/block-templates';
+
+export function Edit( { attributes } ) {
+  const { blockProps } = useWooBlockProps( 
+    attributes,
+    {
+      className: 'my-block',
+    }
+  );
+
+  return (
+    <div { ...blockProps }>
+      Block content
+    </div>
+  );
+}
+```
+
+_Parameters_
+- _attributes_: `Object`: Block attributes.
+- _props_: `Object`: Optional. Props to pass to the element.
+
+_Returns_
+
+- `Object`: Props to pass to the element to mark as a WooCommerce block.

--- a/packages/js/block-templates/README.md
+++ b/packages/js/block-templates/README.md
@@ -1,0 +1,3 @@
+# @woocommerce/block-templates
+
+A collection of utility functions for use with WooCommerce admin block templates.

--- a/packages/js/block-templates/babel.config.js
+++ b/packages/js/block-templates/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	extends: '../internal-js-tests/babel.config.js',
+};

--- a/packages/js/block-templates/changelog.md
+++ b/packages/js/block-templates/changelog.md
@@ -1,0 +1,3 @@
+# Changelog
+
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/packages/js/block-templates/changelog/add-expose-block-id-and-order
+++ b/packages/js/block-templates/changelog/add-expose-block-id-and-order
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Initial version of @woocommerce/block-templates package. Adds registerWooBlockType and useWooBlockProps.

--- a/packages/js/block-templates/composer.json
+++ b/packages/js/block-templates/composer.json
@@ -1,0 +1,32 @@
+{
+	"name": "woocommerce/block-templates",
+	"description": "WooCommerce Admin block templates component library",
+	"type": "library",
+	"license": "GPL-3.0-or-later",
+	"minimum-stability": "dev",
+	"require-dev": {
+		"automattic/jetpack-changelogger": "3.3.0"
+	},
+	"config": {
+		"platform": {
+			"php": "7.2"
+		}
+	},
+	"extra": {
+		"changelogger": {
+			"formatter": {
+				"filename": "../../../tools/changelogger/class-package-formatter.php"
+			},
+			"types": {
+				"fix": "Fixes an existing bug",
+				"add": "Adds functionality",
+				"update": "Update existing functionality",
+				"dev": "Development related task",
+				"tweak": "A minor adjustment to the codebase",
+				"performance": "Address performance issues",
+				"enhancement": "Improve existing functionality"
+			},
+			"changelog": "CHANGELOG.md"
+		}
+	}
+}

--- a/packages/js/block-templates/composer.lock
+++ b/packages/js/block-templates/composer.lock
@@ -1,0 +1,483 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "2d316cec186ab12385e8dda54f6df0f6",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "automattic/jetpack-changelogger",
+            "version": "v3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-changelogger.git",
+                "reference": "8f63c829b8d1b0d7b1d5de93510d78523ed18959"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-changelogger/zipball/8f63c829b8d1b0d7b1d5de93510d78523ed18959",
+                "reference": "8f63c829b8d1b0d7b1d5de93510d78523ed18959",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "symfony/console": "^3.4 || ^5.2 || ^6.0",
+                "symfony/process": "^3.4 || ^5.2 || ^6.0",
+                "wikimedia/at-ease": "^1.2 || ^2.0"
+            },
+            "require-dev": {
+                "wikimedia/testing-access-wrapper": "^1.0 || ^2.0",
+                "yoast/phpunit-polyfills": "1.0.4"
+            },
+            "bin": [
+                "bin/changelogger"
+            ],
+            "type": "project",
+            "extra": {
+                "autotagger": true,
+                "branch-alias": {
+                    "dev-trunk": "3.3.x-dev"
+                },
+                "mirror-repo": "Automattic/jetpack-changelogger",
+                "version-constants": {
+                    "::VERSION": "src/Application.php"
+                },
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-changelogger/compare/${old}...${new}"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Automattic\\Jetpack\\Changelog\\": "lib",
+                    "Automattic\\Jetpack\\Changelogger\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Jetpack Changelogger tool. Allows for managing changelogs by dropping change files into a changelog directory with each PR.",
+            "support": {
+                "source": "https://github.com/Automattic/jetpack-changelogger/tree/v3.3.0"
+            },
+            "time": "2022-12-26T13:49:01+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/1.1.4"
+            },
+            "time": "2021-05-03T11:20:27+00:00"
+        },
+        {
+            "name": "symfony/console",
+            "version": "3.4.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "a10b1da6fc93080c180bba7219b5ff5b7518fe81"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/a10b1da6fc93080c180bba7219b5ff5b7518fe81",
+                "reference": "a10b1da6fc93080c180bba7219b5ff5b7518fe81",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8",
+                "symfony/debug": "~2.8|~3.0|~4.0",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<3.4",
+                "symfony/process": "<3.3"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~3.3|~4.0",
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/event-dispatcher": "~2.8|~3.0|~4.0",
+                "symfony/lock": "~3.4|~4.0",
+                "symfony/process": "~3.3|~4.0"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/lock": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Console Component",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/console/tree/3.4"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-24T10:57:07+00:00"
+        },
+        {
+            "name": "symfony/debug",
+            "version": "4.4.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/debug.git",
+                "reference": "1a692492190773c5310bc7877cb590c04c2f05be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/1a692492190773c5310bc7877cb590c04c2f05be",
+                "reference": "1a692492190773c5310bc7877cb590c04c2f05be",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.3",
+                "psr/log": "^1|^2|^3"
+            },
+            "conflict": {
+                "symfony/http-kernel": "<3.4"
+            },
+            "require-dev": {
+                "symfony/http-kernel": "^3.4|^4.0|^5.0"
+            },
+            "default-branch": true,
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Debug\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools to ease debugging PHP code",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/debug/tree/v4.4.44"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "abandoned": "symfony/error-handler",
+            "time": "2022-07-28T16:29:46+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "1.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "42292d99c55abe617799667f454222c54c60e229"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/42292d99c55abe617799667f454222c54c60e229",
+                "reference": "42292d99c55abe617799667f454222c54c60e229",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "default-branch": true,
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.28-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.28.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-07-28T09:04:16+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "3.4.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "b8648cf1d5af12a44a51d07ef9bf980921f15fca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/b8648cf1d5af12a44a51d07ef9bf980921f15fca",
+                "reference": "b8648cf1d5af12a44a51d07ef9bf980921f15fca",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Process Component",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/process/tree/3.4"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-24T10:57:07+00:00"
+        },
+        {
+            "name": "wikimedia/at-ease",
+            "version": "v2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wikimedia/at-ease.git",
+                "reference": "013ac61929797839c80a111a3f1a4710d8248e7a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wikimedia/at-ease/zipball/013ac61929797839c80a111a3f1a4710d8248e7a",
+                "reference": "013ac61929797839c80a111a3f1a4710d8248e7a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.99"
+            },
+            "require-dev": {
+                "jakub-onderka/php-console-highlighter": "0.3.2",
+                "jakub-onderka/php-parallel-lint": "1.0.0",
+                "mediawiki/mediawiki-codesniffer": "22.0.0",
+                "mediawiki/minus-x": "0.3.1",
+                "ockcyp/covers-validator": "0.5.1 || 0.6.1",
+                "phpunit/phpunit": "4.8.36 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/Wikimedia/Functions.php"
+                ],
+                "psr-4": {
+                    "Wikimedia\\AtEase\\": "src/Wikimedia/AtEase/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Tim Starling",
+                    "email": "tstarling@wikimedia.org"
+                },
+                {
+                    "name": "MediaWiki developers",
+                    "email": "wikitech-l@lists.wikimedia.org"
+                }
+            ],
+            "description": "Safe replacement to @ for suppressing warnings.",
+            "homepage": "https://www.mediawiki.org/wiki/at-ease",
+            "support": {
+                "source": "https://github.com/wikimedia/at-ease/tree/master"
+            },
+            "time": "2018-10-10T15:39:06+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "dev",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "7.2"
+    },
+    "plugin-api-version": "2.6.0"
+}

--- a/packages/js/block-templates/jest.config.json
+++ b/packages/js/block-templates/jest.config.json
@@ -1,0 +1,4 @@
+{
+	"rootDir": "./src",
+	"preset": "../node_modules/@woocommerce/internal-js-tests/jest-preset.js"
+}

--- a/packages/js/block-templates/package.json
+++ b/packages/js/block-templates/package.json
@@ -28,13 +28,14 @@
 		"access": "public"
 	},
 	"dependencies": {
-		"@wordpress/blocks": "^12.3.0",
-		"@wordpress/block-editor": "^9.8.0"
+		"@wordpress/block-editor": "^9.8.0",
+		"@wordpress/blocks": "^12.3.0"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.21.3",
 		"@babel/runtime": "^7.17.2",
 		"@testing-library/jest-dom": "^5.16.2",
+		"@testing-library/react-hooks": "^8.0.1",
 		"@types/jest": "^27.4.1",
 		"@types/testing-library__jest-dom": "^5.14.3",
 		"@types/wordpress__block-editor": "^7.0.0",

--- a/packages/js/block-templates/package.json
+++ b/packages/js/block-templates/package.json
@@ -1,0 +1,76 @@
+{
+	"name": "@woocommerce/block-templates",
+	"version": "1.0.0-beta.0",
+	"description": "Utilities for working with block templates in WooCommerce admin.",
+	"author": "Automattic",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"wordpress",
+		"woocommerce"
+	],
+	"homepage": "https://github.com/woocommerce/woocommerce/tree/trunk/packages/js/block-templates/README.md",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/woocommerce/woocommerce.git"
+	},
+	"bugs": {
+		"url": "https://github.com/woocommerce/woocommerce/issues"
+	},
+	"main": "build/index.js",
+	"module": "build-module/index.js",
+	"types": "build-types",
+	"react-native": "src/index",
+	"sideEffects": [
+		"build-style/**",
+		"src/**/*.scss"
+	],
+	"publishConfig": {
+		"access": "public"
+	},
+	"dependencies": {
+		"@wordpress/blocks": "^12.3.0",
+		"@wordpress/block-editor": "^9.8.0"
+	},
+	"devDependencies": {
+		"@babel/core": "^7.21.3",
+		"@babel/runtime": "^7.17.2",
+		"@testing-library/jest-dom": "^5.16.2",
+		"@types/jest": "^27.4.1",
+		"@types/testing-library__jest-dom": "^5.14.3",
+		"@types/wordpress__block-editor": "^7.0.0",
+		"@types/wordpress__blocks": "^11.0.7",
+		"@woocommerce/eslint-plugin": "workspace:*",
+		"@woocommerce/internal-js-tests": "workspace:*",
+		"@woocommerce/internal-style-build": "workspace:*",
+		"@wordpress/browserslist-config": "wp-6.0",
+		"copy-webpack-plugin": "^9.1.0",
+		"css-loader": "^3.6.0",
+		"eslint": "^8.32.0",
+		"jest": "^27.5.1",
+		"jest-cli": "^27.5.1",
+		"postcss": "^8.4.7",
+		"postcss-loader": "^4.3.0",
+		"rimraf": "^3.0.2",
+		"sass-loader": "^10.2.1",
+		"ts-jest": "^27.1.3",
+		"typescript": "^5.1.6",
+		"webpack": "^5.70.0",
+		"webpack-cli": "^3.3.12"
+	},
+	"scripts": {
+		"turbo:build": "pnpm run build:js && pnpm run build:css",
+		"turbo:test": "jest --config ./jest.config.json",
+		"prepare": "composer install",
+		"changelog": "composer exec -- changelogger",
+		"clean": "pnpm exec rimraf tsconfig.tsbuildinfo build build-*",
+		"build": "pnpm -w exec turbo run turbo:build --filter=$npm_package_name",
+		"test": "pnpm -w exec turbo run turbo:test --filter=$npm_package_name",
+		"lint": "eslint --output-file eslint_report.json --format json src",
+		"build:js": "tsc --project tsconfig.json && tsc --project tsconfig-cjs.json",
+		"build:css": "webpack",
+		"start": "concurrently \"tsc --project tsconfig.json --watch\" \"tsc --project tsconfig-cjs.json --watch\" \"webpack --watch\"",
+		"prepack": "pnpm run clean && pnpm run build",
+		"lint:fix": "eslint src --fix"
+	},
+	"peerDependencies": {}
+}

--- a/packages/js/block-templates/package.json
+++ b/packages/js/block-templates/package.json
@@ -71,6 +71,5 @@
 		"start": "concurrently \"tsc --project tsconfig.json --watch\" \"tsc --project tsconfig-cjs.json --watch\" \"webpack --watch\"",
 		"prepack": "pnpm run clean && pnpm run build",
 		"lint:fix": "eslint src --fix"
-	},
-	"peerDependencies": {}
+	}
 }

--- a/packages/js/block-templates/src/hooks/index.ts
+++ b/packages/js/block-templates/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './use-woo-block-props';

--- a/packages/js/block-templates/src/hooks/use-woo-block-props/index.ts
+++ b/packages/js/block-templates/src/hooks/use-woo-block-props/index.ts
@@ -1,0 +1,1 @@
+export * from './use-woo-block-props';

--- a/packages/js/block-templates/src/hooks/use-woo-block-props/test/use-woo-block-props.test.ts
+++ b/packages/js/block-templates/src/hooks/use-woo-block-props/test/use-woo-block-props.test.ts
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react-hooks';
+import { useBlockProps } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { useWooBlockProps } from '../use-woo-block-props';
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	useBlockProps: jest.fn(),
+} ) );
+
+describe( 'useWooBlockProps', () => {
+	it( 'should return the block props with the block id and block order attributes', () => {
+		renderHook( () =>
+			useWooBlockProps(
+				{
+					foo: 'bar',
+					_templateBlockId: 'test/block',
+					_templateBlockOrder: 30,
+				},
+				{
+					className: 'test',
+				}
+			)
+		);
+
+		expect( useBlockProps ).toHaveBeenCalledWith( {
+			'data-template-block-id': 'test/block',
+			'data-template-block-order': 30,
+			className: 'test',
+		} );
+	} );
+} );

--- a/packages/js/block-templates/src/hooks/use-woo-block-props/use-woo-block-props.ts
+++ b/packages/js/block-templates/src/hooks/use-woo-block-props/use-woo-block-props.ts
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+
+interface TemplateBlockAttributes {
+	_templateBlockId?: string;
+	_templateBlockOrder?: number;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	[ key: string ]: any;
+}
+
+export const useWooBlockProps = ( attributes: TemplateBlockAttributes ) => {
+	const additionalProps = {
+		'data-template-block-id': attributes._templateBlockId,
+		'data-template-block-order': attributes._templateBlockOrder,
+	};
+
+	return useBlockProps( additionalProps );
+};

--- a/packages/js/block-templates/src/hooks/use-woo-block-props/use-woo-block-props.ts
+++ b/packages/js/block-templates/src/hooks/use-woo-block-props/use-woo-block-props.ts
@@ -10,10 +10,14 @@ interface TemplateBlockAttributes {
 	[ key: string ]: any;
 }
 
-export const useWooBlockProps = ( attributes: TemplateBlockAttributes ) => {
+export const useWooBlockProps = (
+	attributes: TemplateBlockAttributes,
+	props: Record< string, unknown > = {}
+) => {
 	const additionalProps = {
 		'data-template-block-id': attributes._templateBlockId,
 		'data-template-block-order': attributes._templateBlockOrder,
+		...props,
 	};
 
 	return useBlockProps( additionalProps );

--- a/packages/js/block-templates/src/index.ts
+++ b/packages/js/block-templates/src/index.ts
@@ -1,0 +1,2 @@
+export * from './hooks';
+export * from './utils';

--- a/packages/js/block-templates/src/utils/index.ts
+++ b/packages/js/block-templates/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './register-woo-block-type';

--- a/packages/js/block-templates/src/utils/register-woo-block-type.ts
+++ b/packages/js/block-templates/src/utils/register-woo-block-type.ts
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import {
+	Block,
+	BlockConfiguration,
+	registerBlockType,
+} from '@wordpress/blocks';
+
+interface BlockRepresentation< T extends Record< string, object > > {
+	name?: string;
+	metadata: BlockConfiguration< T >;
+	settings: Partial< BlockConfiguration< T > >;
+}
+
+/**
+ * Function to register an individual block.
+ *
+ * @param block The block to be registered.
+ * @return The block, if it has been successfully registered; otherwise `undefined`.
+ */
+export function registerWooBlockType<
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	T extends Record< string, any > = Record< string, any >
+>( block: BlockRepresentation< T > ): Block< T > | undefined {
+	if ( ! block ) {
+		return;
+	}
+	const { metadata, settings, name } = block;
+
+	const templateBlockAttributes = {
+		_templateBlockId: {
+			type: 'string',
+			__experimentalRole: 'content',
+		},
+		_templateBlockOrder: {
+			type: 'integer',
+			__experimentalRole: 'content',
+		},
+	};
+
+	const augmentedMetadata = {
+		...metadata,
+		attributes: {
+			...metadata.attributes,
+			...templateBlockAttributes,
+		},
+	};
+
+	return registerBlockType< T >( { name, ...augmentedMetadata }, settings );
+}

--- a/packages/js/block-templates/src/utils/test/register-woo-block-type.test.ts
+++ b/packages/js/block-templates/src/utils/test/register-woo-block-type.test.ts
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { registerWooBlockType } from '../register-woo-block-type';
+
+jest.mock( '@wordpress/blocks', () => ( {
+	registerBlockType: jest.fn(),
+} ) );
+
+describe( 'registerWooBlockType', () => {
+	it( 'should register a block type with the block id and block order attributes', () => {
+		const block = {
+			name: 'test/block',
+			metadata: {
+				attributes: {
+					foo: {
+						type: 'boolean',
+						default: false,
+					},
+				},
+			},
+			settings: {
+				foo: 'bar',
+			},
+		};
+
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore ts2345 Complaining about the type of the foo attribute; it's fine.
+		registerWooBlockType( block );
+
+		expect( registerBlockType ).toHaveBeenCalledWith(
+			{
+				name: 'test/block',
+				attributes: {
+					foo: {
+						type: 'boolean',
+						default: false,
+					},
+					_templateBlockId: {
+						type: 'string',
+						__experimentalRole: 'content',
+					},
+					_templateBlockOrder: {
+						type: 'integer',
+						__experimentalRole: 'content',
+					},
+				},
+			},
+			{
+				foo: 'bar',
+			}
+		);
+	} );
+} );

--- a/packages/js/block-templates/tsconfig-cjs.json
+++ b/packages/js/block-templates/tsconfig-cjs.json
@@ -1,0 +1,16 @@
+{
+	"extends": "../tsconfig-cjs",
+	"include": [
+		"**/*.d.ts",
+		"src/**/*",
+		"src/**/*.json"
+	],
+	"compilerOptions": {
+		"outDir": "build",
+		"resolveJsonModule": true,
+		"typeRoots": [
+			"./typings",
+			"./node_modules/@types"
+		]
+	}
+}

--- a/packages/js/block-templates/tsconfig.json
+++ b/packages/js/block-templates/tsconfig.json
@@ -1,0 +1,20 @@
+{
+	"extends": "../tsconfig",
+	"compilerOptions": {
+		"rootDir": "src",
+		"outDir": "build-module",
+		"declaration": true,
+		"declarationMap": true,
+		"declarationDir": "./build-types",
+		"resolveJsonModule": true,
+		"typeRoots": [
+			"./typings",
+			"./node_modules/@types"
+		]
+	},
+	"include": [
+		"**/*.d.ts",
+		"src/**/*",
+		"src/**/*.json"
+	]
+}

--- a/packages/js/block-templates/webpack.config.js
+++ b/packages/js/block-templates/webpack.config.js
@@ -1,0 +1,19 @@
+/**
+ * Internal dependencies
+ */
+const { webpackConfig } = require( '@woocommerce/internal-style-build' );
+
+module.exports = {
+	mode: process.env.NODE_ENV || 'development',
+	entry: {
+		'build-style': __dirname + '/src/style.scss',
+	},
+	output: {
+		path: __dirname,
+	},
+	module: {
+		parser: webpackConfig.parser,
+		rules: webpackConfig.rules,
+	},
+	plugins: webpackConfig.plugins,
+};

--- a/packages/js/dependency-extraction-webpack-plugin/assets/packages.js
+++ b/packages/js/dependency-extraction-webpack-plugin/assets/packages.js
@@ -1,6 +1,7 @@
 module.exports = [
 	// wc-admin packages
 	'@woocommerce/admin-layout',
+	'@woocommerce/block-templates',
 	'@woocommerce/components',
 	'@woocommerce/csv-export',
 	'@woocommerce/currency',

--- a/packages/js/dependency-extraction-webpack-plugin/changelog/add-expose-block-id-and-order
+++ b/packages/js/dependency-extraction-webpack-plugin/changelog/add-expose-block-id-and-order
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Add @woocommerce/block-templates.

--- a/packages/js/product-editor/changelog/add-expose-block-id-and-order
+++ b/packages/js/product-editor/changelog/add-expose-block-id-and-order
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update blocks to use registerWooBlockType and useWooBlockProps from @woocommerce/block-templates. Deprecates initBlock.

--- a/packages/js/product-editor/package.json
+++ b/packages/js/product-editor/package.json
@@ -32,6 +32,7 @@
 		"@types/prop-types": "^15.7.4",
 		"@types/wordpress__blocks": "^11.0.7",
 		"@woocommerce/admin-layout": "workspace:*",
+		"@woocommerce/block-templates": "workspace:*",
 		"@woocommerce/components": "workspace:*",
 		"@woocommerce/currency": "workspace:*",
 		"@woocommerce/customer-effort-score": "workspace:*",

--- a/packages/js/product-editor/package.json
+++ b/packages/js/product-editor/package.json
@@ -50,6 +50,7 @@
 		"@wordpress/core-data": "wp-6.0",
 		"@wordpress/data": "wp-6.0",
 		"@wordpress/date": "wp-6.0",
+		"@wordpress/deprecated": "wp-6.0",
 		"@wordpress/editor": "wp-6.0",
 		"@wordpress/element": "wp-6.0",
 		"@wordpress/html-entities": "wp-6.0",

--- a/packages/js/product-editor/src/blocks/attributes/edit.tsx
+++ b/packages/js/product-editor/src/blocks/attributes/edit.tsx
@@ -1,9 +1,10 @@
 /**
  * External dependencies
  */
+import { BlockEditProps, BlockAttributes } from '@wordpress/blocks';
 import { createElement } from '@wordpress/element';
+import { useWooBlockProps } from '@woocommerce/block-templates';
 import { ProductAttribute } from '@woocommerce/data';
-import { useBlockProps } from '@wordpress/block-editor';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore No types for this exist yet.
 // eslint-disable-next-line @woocommerce/dependency-group
@@ -14,14 +15,14 @@ import { useEntityProp, useEntityId } from '@wordpress/core-data';
  */
 import { Attributes as AttributesContainer } from '../../components/attributes/attributes';
 
-export function Edit() {
+export function Edit( { attributes }: BlockEditProps< BlockAttributes > ) {
 	const [ entityAttributes, setEntityAttributes ] = useEntityProp<
 		ProductAttribute[]
 	>( 'postType', 'product', 'attributes' );
 
 	const productId = useEntityId( 'postType', 'product' );
 
-	const blockProps = useBlockProps();
+	const blockProps = useWooBlockProps( attributes );
 
 	return (
 		<div { ...blockProps }>

--- a/packages/js/product-editor/src/blocks/attributes/index.ts
+++ b/packages/js/product-editor/src/blocks/attributes/index.ts
@@ -1,7 +1,11 @@
 /**
+ * External dependencies
+ */
+import { registerWooBlockType } from '@woocommerce/block-templates';
+
+/**
  * Internal dependencies
  */
-import { initBlock } from '../../utils';
 import metadata from './block.json';
 import { Edit } from './edit';
 
@@ -15,7 +19,7 @@ export const settings = {
 };
 
 export const init = () =>
-	initBlock( {
+	registerWooBlockType( {
 		name,
 		metadata: metadata as never,
 		settings,

--- a/packages/js/product-editor/src/blocks/catalog-visibility/edit.tsx
+++ b/packages/js/product-editor/src/blocks/catalog-visibility/edit.tsx
@@ -1,10 +1,10 @@
 /**
  * External dependencies
  */
-import { useBlockProps } from '@wordpress/block-editor';
 import { CheckboxControl } from '@wordpress/components';
 import { useEntityProp } from '@wordpress/core-data';
 import { createElement } from '@wordpress/element';
+import { useWooBlockProps } from '@woocommerce/block-templates';
 import { Product } from '@woocommerce/data';
 
 /**
@@ -19,7 +19,7 @@ export function Edit( {
 } ) {
 	const { label, visibility } = attributes;
 
-	const blockProps = useBlockProps();
+	const blockProps = useWooBlockProps( attributes );
 
 	const [ catalogVisibility, setCatalogVisibility ] = useEntityProp<
 		Product[ 'catalog_visibility' ]

--- a/packages/js/product-editor/src/blocks/catalog-visibility/index.ts
+++ b/packages/js/product-editor/src/blocks/catalog-visibility/index.ts
@@ -2,11 +2,11 @@
  * External dependencies
  */
 import { BlockConfiguration } from '@wordpress/blocks';
+import { registerWooBlockType } from '@woocommerce/block-templates';
 
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils/init-block';
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
 import { CatalogVisibilityBlockAttributes } from './types';
@@ -24,5 +24,5 @@ export const settings: Partial<
 };
 
 export function init() {
-	return initBlock( { name, metadata, settings } );
+	return registerWooBlockType( { name, metadata, settings } );
 }

--- a/packages/js/product-editor/src/blocks/checkbox/edit.tsx
+++ b/packages/js/product-editor/src/blocks/checkbox/edit.tsx
@@ -4,17 +4,18 @@
 import { createElement } from '@wordpress/element';
 import type { BlockAttributes } from '@wordpress/blocks';
 import { CheckboxControl, Tooltip } from '@wordpress/components';
-import { useBlockProps } from '@wordpress/block-editor';
 import { useEntityProp } from '@wordpress/core-data';
 import { Icon, help } from '@wordpress/icons';
+import { useWooBlockProps } from '@woocommerce/block-templates';
 
 /**
  * Internal dependencies
  */
 
 export function Edit( { attributes }: { attributes: BlockAttributes } ) {
-	const blockProps = useBlockProps( {
+	const blockProps = useWooBlockProps( {
 		className: 'woocommerce-product-form__checkbox',
+		...attributes,
 	} );
 	const { property, title, label, tooltip } = attributes;
 	const [ value, setValue ] = useEntityProp< boolean >(

--- a/packages/js/product-editor/src/blocks/checkbox/index.ts
+++ b/packages/js/product-editor/src/blocks/checkbox/index.ts
@@ -2,11 +2,11 @@
  * External dependencies
  */
 import { BlockConfiguration } from '@wordpress/blocks';
+import { registerWooBlockType } from '@woocommerce/block-templates';
 
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils/init-block';
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
 
@@ -19,4 +19,4 @@ export const settings = {
 	edit: Edit,
 };
 
-export const init = () => initBlock( { name, metadata, settings } );
+export const init = () => registerWooBlockType( { name, metadata, settings } );

--- a/packages/js/product-editor/src/blocks/collapsible/edit.tsx
+++ b/packages/js/product-editor/src/blocks/collapsible/edit.tsx
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
+import { useWooBlockProps } from '@woocommerce/block-templates';
 import { CollapsibleContent } from '@woocommerce/components';
 import type { BlockAttributes } from '@wordpress/blocks';
 import { createElement } from '@wordpress/element';
-import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+import { InnerBlocks } from '@wordpress/block-editor';
 
 export function Edit( { attributes }: { attributes: BlockAttributes } ) {
-	const blockProps = useBlockProps();
+	const blockProps = useWooBlockProps( attributes );
 	const { toggleText, initialCollapsed, persistRender = true } = attributes;
 
 	return (

--- a/packages/js/product-editor/src/blocks/collapsible/index.ts
+++ b/packages/js/product-editor/src/blocks/collapsible/index.ts
@@ -1,7 +1,11 @@
 /**
+ * External dependencies
+ */
+import { registerWooBlockType } from '@woocommerce/block-templates';
+
+/**
  * Internal dependencies
  */
-import { initBlock } from '../../utils';
 import metadata from './block.json';
 import { Edit } from './edit';
 
@@ -15,4 +19,4 @@ export const settings = {
 };
 
 export const init = () =>
-	initBlock( { name, metadata: metadata as never, settings } );
+	registerWooBlockType( { name, metadata: metadata as never, settings } );

--- a/packages/js/product-editor/src/blocks/conditional/edit.tsx
+++ b/packages/js/product-editor/src/blocks/conditional/edit.tsx
@@ -3,8 +3,9 @@
  */
 import type { BlockAttributes } from '@wordpress/blocks';
 import { createElement, useMemo } from '@wordpress/element';
-import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+import { InnerBlocks } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
+import { useWooBlockProps } from '@woocommerce/block-templates';
 import { DisplayState } from '@woocommerce/components';
 import { Product } from '@woocommerce/data';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -19,7 +20,7 @@ export function Edit( {
 		mustMatch: Record< string, Array< string > >;
 	};
 } ) {
-	const blockProps = useBlockProps();
+	const blockProps = useWooBlockProps( attributes );
 	const { mustMatch } = attributes;
 
 	const productId = useEntityId( 'postType', 'product' );

--- a/packages/js/product-editor/src/blocks/conditional/index.ts
+++ b/packages/js/product-editor/src/blocks/conditional/index.ts
@@ -1,7 +1,11 @@
 /**
+ * External dependencies
+ */
+import { registerWooBlockType } from '@woocommerce/block-templates';
+
+/**
  * Internal dependencies
  */
-import { initBlock } from '../../utils';
 import metadata from './block.json';
 import { Edit } from './edit';
 
@@ -15,4 +19,4 @@ export const settings = {
 };
 
 export const init = () =>
-	initBlock( { name, metadata: metadata as never, settings } );
+	registerWooBlockType( { name, metadata: metadata as never, settings } );

--- a/packages/js/product-editor/src/blocks/description/edit.tsx
+++ b/packages/js/product-editor/src/blocks/description/edit.tsx
@@ -3,10 +3,16 @@
  */
 import { __ } from '@wordpress/i18n';
 import { createElement, useState } from '@wordpress/element';
-import { BlockInstance, parse, serialize } from '@wordpress/blocks';
+import {
+	BlockEditProps,
+	BlockAttributes,
+	BlockInstance,
+	parse,
+	serialize,
+} from '@wordpress/blocks';
 import { Button } from '@wordpress/components';
+import { useWooBlockProps } from '@woocommerce/block-templates';
 import { recordEvent } from '@woocommerce/tracks';
-import { useBlockProps } from '@wordpress/block-editor';
 import { useEntityProp } from '@wordpress/core-data';
 
 /**
@@ -21,7 +27,7 @@ import { ModalEditor } from '../../components/modal-editor';
 
 /**
  * By default the blocks variable always contains one paragraph
- * block with empty content, that causes the desciption to never
+ * block with empty content, that causes the description to never
  * be empty. This function removes the default block to keep
  * the description empty.
  *
@@ -39,8 +45,8 @@ function clearDescriptionIfEmpty( blocks: BlockInstance[] ) {
 	return blocks;
 }
 
-export function Edit() {
-	const blockProps = useBlockProps();
+export function Edit( { attributes }: BlockEditProps< BlockAttributes > ) {
+	const blockProps = useWooBlockProps( attributes );
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const [ description, setDescription ] = useEntityProp< string >(
 		'postType',

--- a/packages/js/product-editor/src/blocks/description/index.ts
+++ b/packages/js/product-editor/src/blocks/description/index.ts
@@ -2,11 +2,11 @@
  * External dependencies
  */
 import { BlockConfiguration } from '@wordpress/blocks';
+import { registerWooBlockType } from '@woocommerce/block-templates';
 
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils/init-block';
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
 
@@ -19,4 +19,4 @@ export const settings = {
 	edit: Edit,
 };
 
-export const init = () => initBlock( { name, metadata, settings } );
+export const init = () => registerWooBlockType( { name, metadata, settings } );

--- a/packages/js/product-editor/src/blocks/images/edit.tsx
+++ b/packages/js/product-editor/src/blocks/images/edit.tsx
@@ -2,18 +2,19 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { BlockEditProps, BlockAttributes } from '@wordpress/blocks';
 import { DropZone } from '@wordpress/components';
 import classnames from 'classnames';
 import { createElement, useState } from '@wordpress/element';
 import { Icon, trash } from '@wordpress/icons';
 import { MediaItem } from '@wordpress/media-utils';
+import { useWooBlockProps } from '@woocommerce/block-templates';
 import {
 	MediaUploader,
 	ImageGallery,
 	ImageGalleryItem,
 } from '@woocommerce/components';
 import { recordEvent } from '@woocommerce/tracks';
-import { useBlockProps } from '@wordpress/block-editor';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore No types for this exist yet.
 // eslint-disable-next-line @woocommerce/dependency-group
@@ -23,7 +24,7 @@ type Image = MediaItem & {
 	src: string;
 };
 
-export function Edit() {
+export function Edit( { attributes }: BlockEditProps< BlockAttributes > ) {
 	const [ images, setImages ] = useEntityProp< MediaItem[] >(
 		'postType',
 		'product',
@@ -36,7 +37,7 @@ export function Edit() {
 		null
 	);
 
-	const blockProps = useBlockProps( {
+	const blockProps = useWooBlockProps( attributes, {
 		className: classnames( {
 			'has-images': images.length > 0,
 		} ),

--- a/packages/js/product-editor/src/blocks/images/index.ts
+++ b/packages/js/product-editor/src/blocks/images/index.ts
@@ -1,7 +1,11 @@
 /**
+ * External dependencies
+ */
+import { registerWooBlockType } from '@woocommerce/block-templates';
+
+/**
  * Internal dependencies
  */
-import { initBlock } from '../../utils';
 import metadata from './block.json';
 import { Edit } from './edit';
 
@@ -15,7 +19,7 @@ export const settings = {
 };
 
 export const init = () =>
-	initBlock( {
+	registerWooBlockType( {
 		name,
 		metadata: metadata as never,
 		settings,

--- a/packages/js/product-editor/src/blocks/inventory-email/edit.tsx
+++ b/packages/js/product-editor/src/blocks/inventory-email/edit.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
+import { useWooBlockProps } from '@woocommerce/block-templates';
 import { Link } from '@woocommerce/components';
 import { Product } from '@woocommerce/data';
 import {
@@ -11,7 +12,6 @@ import {
 } from '@wordpress/element';
 import { getSetting } from '@woocommerce/settings';
 import { BlockEditProps } from '@wordpress/blocks';
-import { useBlockProps } from '@wordpress/block-editor';
 import { useInstanceId } from '@wordpress/compose';
 import {
 	BaseControl,
@@ -30,9 +30,10 @@ import { useValidation } from '../../contexts/validation-context';
 import { InventoryEmailBlockAttributes } from './types';
 
 export function Edit( {
+	attributes,
 	clientId,
 }: BlockEditProps< InventoryEmailBlockAttributes > ) {
-	const blockProps = useBlockProps();
+	const blockProps = useWooBlockProps( attributes );
 	const notifyLowStockAmount = getSetting( 'notifyLowStockAmount', 2 );
 
 	const [ lowStockAmount, setLowStockAmount ] = useEntityProp< number >(

--- a/packages/js/product-editor/src/blocks/inventory-email/index.ts
+++ b/packages/js/product-editor/src/blocks/inventory-email/index.ts
@@ -1,13 +1,12 @@
 /**
  * External dependencies
  */
-import { createElement } from '@wordpress/element';
 import { BlockConfiguration } from '@wordpress/blocks';
+import { registerWooBlockType } from '@woocommerce/block-templates';
 
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils/init-block';
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
 import { InventoryEmailBlockAttributes } from './types';
@@ -25,5 +24,5 @@ export const settings: Partial<
 };
 
 export function init() {
-	return initBlock( { name, metadata, settings } );
+	return registerWooBlockType( { name, metadata, settings } );
 }

--- a/packages/js/product-editor/src/blocks/inventory-quantity/edit.tsx
+++ b/packages/js/product-editor/src/blocks/inventory-quantity/edit.tsx
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
+import { useWooBlockProps } from '@woocommerce/block-templates';
 import { Product } from '@woocommerce/data';
 import { BlockEditProps } from '@wordpress/blocks';
-import { useBlockProps } from '@wordpress/block-editor';
 import { useInstanceId } from '@wordpress/compose';
 import { useEntityProp } from '@wordpress/core-data';
 import { createElement, useEffect } from '@wordpress/element';
@@ -21,9 +21,10 @@ import { TrackInventoryBlockAttributes } from './types';
 import { useValidation } from '../../contexts/validation-context';
 
 export function Edit( {
+	attributes,
 	clientId,
 }: BlockEditProps< TrackInventoryBlockAttributes > ) {
-	const blockProps = useBlockProps();
+	const blockProps = useWooBlockProps( attributes );
 
 	const [ manageStock ] = useEntityProp< boolean >(
 		'postType',

--- a/packages/js/product-editor/src/blocks/inventory-quantity/index.ts
+++ b/packages/js/product-editor/src/blocks/inventory-quantity/index.ts
@@ -1,13 +1,12 @@
 /**
  * External dependencies
  */
-import { createElement } from '@wordpress/element';
 import { BlockConfiguration } from '@wordpress/blocks';
+import { registerWooBlockType } from '@woocommerce/block-templates';
 
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils/init-block';
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
 import { TrackInventoryBlockAttributes } from './types';
@@ -25,5 +24,5 @@ export const settings: Partial<
 };
 
 export function init() {
-	return initBlock( { name, metadata, settings } );
+	return registerWooBlockType( { name, metadata, settings } );
 }

--- a/packages/js/product-editor/src/blocks/inventory-sku/edit.tsx
+++ b/packages/js/product-editor/src/blocks/inventory-sku/edit.tsx
@@ -2,8 +2,9 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { BlockEditProps, BlockAttributes } from '@wordpress/blocks';
 import { createElement, createInterpolateElement } from '@wordpress/element';
-import { useBlockProps } from '@wordpress/block-editor';
+import { useWooBlockProps } from '@woocommerce/block-templates';
 
 import {
 	BaseControl,
@@ -19,8 +20,8 @@ import { useEntityProp } from '@wordpress/core-data';
  * Internal dependencies
  */
 
-export function Edit() {
-	const blockProps = useBlockProps();
+export function Edit( { attributes }: BlockEditProps< BlockAttributes > ) {
+	const blockProps = useWooBlockProps( attributes );
 
 	const [ sku, setSku ] = useEntityProp( 'postType', 'product', 'sku' );
 

--- a/packages/js/product-editor/src/blocks/inventory-sku/index.ts
+++ b/packages/js/product-editor/src/blocks/inventory-sku/index.ts
@@ -2,11 +2,11 @@
  * External dependencies
  */
 import { BlockConfiguration } from '@wordpress/blocks';
+import { registerWooBlockType } from '@woocommerce/block-templates';
 
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils/init-block';
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
 
@@ -19,4 +19,4 @@ export const settings = {
 	edit: Edit,
 };
 
-export const init = () => initBlock( { name, metadata, settings } );
+export const init = () => registerWooBlockType( { name, metadata, settings } );

--- a/packages/js/product-editor/src/blocks/name/edit.tsx
+++ b/packages/js/product-editor/src/blocks/name/edit.tsx
@@ -9,11 +9,11 @@ import {
 	useState,
 } from '@wordpress/element';
 
-import { useBlockProps } from '@wordpress/block-editor';
 import { BlockEditProps } from '@wordpress/blocks';
 import { useInstanceId } from '@wordpress/compose';
 import { cleanForSlug } from '@wordpress/url';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { useWooBlockProps } from '@woocommerce/block-templates';
 import {
 	PRODUCTS_STORE_NAME,
 	WCDataSelector,
@@ -41,7 +41,7 @@ import { NameBlockAttributes } from './types';
 import { useProductEdits } from '../../hooks/use-product-edits';
 
 export function Edit( { attributes }: BlockEditProps< NameBlockAttributes > ) {
-	const blockProps = useBlockProps();
+	const blockProps = useWooBlockProps( attributes );
 
 	const { editEntityRecord, saveEntityRecord } = useDispatch( 'core' );
 

--- a/packages/js/product-editor/src/blocks/name/index.ts
+++ b/packages/js/product-editor/src/blocks/name/index.ts
@@ -1,7 +1,11 @@
 /**
+ * External dependencies
+ */
+import { registerWooBlockType } from '@woocommerce/block-templates';
+
+/**
  * Internal dependencies
  */
-import { initBlock } from '../../utils';
 import metadata from './block.json';
 import { Edit } from './edit';
 
@@ -15,7 +19,7 @@ export const settings = {
 };
 
 export const init = () =>
-	initBlock( {
+	registerWooBlockType( {
 		name,
 		metadata: metadata as never,
 		settings,

--- a/packages/js/product-editor/src/blocks/notice/edit.tsx
+++ b/packages/js/product-editor/src/blocks/notice/edit.tsx
@@ -1,10 +1,10 @@
 /**
  * External dependencies
  */
-import { useBlockProps } from '@wordpress/block-editor';
 import { createElement } from '@wordpress/element';
 import type { BlockAttributes, BlockEditProps } from '@wordpress/blocks';
 import { Button } from '@wordpress/components';
+import { useWooBlockProps } from '@woocommerce/block-templates';
 import { getNewPath, navigateTo } from '@woocommerce/navigation';
 import { Product } from '@woocommerce/data';
 import { useEntityProp } from '@wordpress/core-data';
@@ -25,7 +25,7 @@ export interface NoticeBlockAttributes extends BlockAttributes {
 export function Edit( {
 	attributes,
 }: BlockEditProps< NoticeBlockAttributes > ) {
-	const blockProps = useBlockProps();
+	const blockProps = useWooBlockProps( attributes );
 	const { buttonText, content, title, type = 'info' } = attributes;
 
 	const [ productAttributes ] = useEntityProp< Product[ 'attributes' ] >(

--- a/packages/js/product-editor/src/blocks/notice/index.ts
+++ b/packages/js/product-editor/src/blocks/notice/index.ts
@@ -2,11 +2,11 @@
  * External dependencies
  */
 import { BlockConfiguration } from '@wordpress/blocks';
+import { registerWooBlockType } from '@woocommerce/block-templates';
 
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils/init-block';
 import blockConfiguration from './block.json';
 import { Edit, NoticeBlockAttributes } from './edit';
 
@@ -22,5 +22,5 @@ export const settings: Partial< BlockConfiguration< NoticeBlockAttributes > > =
 	};
 
 export function init() {
-	initBlock( { name, metadata, settings } );
+	registerWooBlockType( { name, metadata, settings } );
 }

--- a/packages/js/product-editor/src/blocks/password/edit.tsx
+++ b/packages/js/product-editor/src/blocks/password/edit.tsx
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-import { useBlockProps } from '@wordpress/block-editor';
 import { BlockEditProps } from '@wordpress/blocks';
 import { useInstanceId } from '@wordpress/compose';
 import { useEntityProp } from '@wordpress/core-data';
 import { createElement, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { useWooBlockProps } from '@woocommerce/block-templates';
 import {
 	BaseControl,
 	CheckboxControl,
@@ -23,7 +23,7 @@ import { RequirePasswordBlockAttributes } from './types';
 export function Edit( {
 	attributes,
 }: BlockEditProps< RequirePasswordBlockAttributes > ) {
-	const blockProps = useBlockProps();
+	const blockProps = useWooBlockProps( attributes );
 	const { label } = attributes;
 
 	const [ postPassword, setPostPassword ] = useEntityProp< string >(

--- a/packages/js/product-editor/src/blocks/password/index.ts
+++ b/packages/js/product-editor/src/blocks/password/index.ts
@@ -2,11 +2,11 @@
  * External dependencies
  */
 import { BlockConfiguration } from '@wordpress/blocks';
+import { registerWooBlockType } from '@woocommerce/block-templates';
 
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils/init-block';
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
 import { RequirePasswordBlockAttributes } from './types';
@@ -23,5 +23,5 @@ export const settings: Partial<
 };
 
 export function init() {
-	return initBlock( { name, metadata, settings } );
+	return registerWooBlockType( { name, metadata, settings } );
 }

--- a/packages/js/product-editor/src/blocks/pricing/edit.tsx
+++ b/packages/js/product-editor/src/blocks/pricing/edit.tsx
@@ -1,10 +1,10 @@
 /**
  * External dependencies
  */
+import { useWooBlockProps } from '@woocommerce/block-templates';
 import { Link } from '@woocommerce/components';
 import { getNewPath } from '@woocommerce/navigation';
 import { recordEvent } from '@woocommerce/tracks';
-import { useBlockProps } from '@wordpress/block-editor';
 import { BlockEditProps } from '@wordpress/blocks';
 import { useInstanceId } from '@wordpress/compose';
 import { useEntityProp } from '@wordpress/core-data';
@@ -25,7 +25,7 @@ import { PricingBlockAttributes } from './types';
 export function Edit( {
 	attributes,
 }: BlockEditProps< PricingBlockAttributes > ) {
-	const blockProps = useBlockProps();
+	const blockProps = useWooBlockProps( attributes );
 	const { name, label, help } = attributes;
 	const [ price, setPrice ] = useEntityProp< string >(
 		'postType',

--- a/packages/js/product-editor/src/blocks/pricing/index.ts
+++ b/packages/js/product-editor/src/blocks/pricing/index.ts
@@ -2,11 +2,11 @@
  * External dependencies
  */
 import { BlockConfiguration } from '@wordpress/blocks';
+import { registerWooBlockType } from '@woocommerce/block-templates';
 
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils/init-block';
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
 import { PricingBlockAttributes } from './types';
@@ -23,5 +23,5 @@ export const settings: Partial< BlockConfiguration< PricingBlockAttributes > > =
 	};
 
 export function init() {
-	return initBlock( { name, metadata, settings } );
+	return registerWooBlockType( { name, metadata, settings } );
 }

--- a/packages/js/product-editor/src/blocks/radio/edit.tsx
+++ b/packages/js/product-editor/src/blocks/radio/edit.tsx
@@ -3,8 +3,8 @@
  */
 import { createElement } from '@wordpress/element';
 import { BlockEditProps } from '@wordpress/blocks';
-import { useBlockProps } from '@wordpress/block-editor';
 import { useEntityProp } from '@wordpress/core-data';
+import { useWooBlockProps } from '@woocommerce/block-templates';
 
 /**
  * Internal dependencies
@@ -13,7 +13,7 @@ import { RadioField } from '../../components/radio-field';
 import { RadioBlockAttributes } from './types';
 
 export function Edit( { attributes }: BlockEditProps< RadioBlockAttributes > ) {
-	const blockProps = useBlockProps();
+	const blockProps = useWooBlockProps( attributes );
 	const { description, options, property, title } = attributes;
 	const [ value, setValue ] = useEntityProp< string >(
 		'postType',

--- a/packages/js/product-editor/src/blocks/radio/index.ts
+++ b/packages/js/product-editor/src/blocks/radio/index.ts
@@ -2,11 +2,11 @@
  * External dependencies
  */
 import { BlockConfiguration } from '@wordpress/blocks';
+import { registerWooBlockType } from '@woocommerce/block-templates';
 
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils/init-block';
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
 import { RadioBlockAttributes } from './types';
@@ -22,5 +22,5 @@ export const settings: Partial< BlockConfiguration< RadioBlockAttributes > > = {
 };
 
 export function init() {
-	return initBlock( { name, metadata, settings } );
+	return registerWooBlockType( { name, metadata, settings } );
 }

--- a/packages/js/product-editor/src/blocks/regular-price/edit.tsx
+++ b/packages/js/product-editor/src/blocks/regular-price/edit.tsx
@@ -2,11 +2,11 @@
  * External dependencies
  */
 import classNames from 'classnames';
+import { useWooBlockProps } from '@woocommerce/block-templates';
 import { Link } from '@woocommerce/components';
 import { Product } from '@woocommerce/data';
 import { getNewPath } from '@woocommerce/navigation';
 import { recordEvent } from '@woocommerce/tracks';
-import { useBlockProps } from '@wordpress/block-editor';
 import { BlockEditProps } from '@wordpress/blocks';
 import { useInstanceId } from '@wordpress/compose';
 import { useEntityProp } from '@wordpress/core-data';
@@ -29,7 +29,7 @@ export function Edit( {
 	attributes,
 	clientId,
 }: BlockEditProps< SalePriceBlockAttributes > ) {
-	const blockProps = useBlockProps();
+	const blockProps = useWooBlockProps( attributes );
 	const { label, help } = attributes;
 	const [ regularPrice, setRegularPrice ] = useEntityProp< string >(
 		'postType',

--- a/packages/js/product-editor/src/blocks/regular-price/index.ts
+++ b/packages/js/product-editor/src/blocks/regular-price/index.ts
@@ -2,11 +2,11 @@
  * External dependencies
  */
 import { BlockConfiguration } from '@wordpress/blocks';
+import { registerWooBlockType } from '@woocommerce/block-templates';
 
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils/init-block';
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
 import { SalePriceBlockAttributes } from './types';
@@ -24,5 +24,5 @@ export const settings: Partial<
 };
 
 export function init() {
-	return initBlock( { name, metadata, settings } );
+	return registerWooBlockType( { name, metadata, settings } );
 }

--- a/packages/js/product-editor/src/blocks/sale-price/edit.tsx
+++ b/packages/js/product-editor/src/blocks/sale-price/edit.tsx
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import classNames from 'classnames';
+import { useWooBlockProps } from '@woocommerce/block-templates';
 import { Product } from '@woocommerce/data';
-import { useBlockProps } from '@wordpress/block-editor';
 import { BlockEditProps } from '@wordpress/blocks';
 import { useInstanceId } from '@wordpress/compose';
 import { useEntityProp } from '@wordpress/core-data';
@@ -26,7 +26,7 @@ export function Edit( {
 	attributes,
 	clientId,
 }: BlockEditProps< SalePriceBlockAttributes > ) {
-	const blockProps = useBlockProps();
+	const blockProps = useWooBlockProps( attributes );
 	const { label, help } = attributes;
 	const [ regularPrice ] = useEntityProp< string >(
 		'postType',

--- a/packages/js/product-editor/src/blocks/sale-price/index.ts
+++ b/packages/js/product-editor/src/blocks/sale-price/index.ts
@@ -2,11 +2,11 @@
  * External dependencies
  */
 import { BlockConfiguration } from '@wordpress/blocks';
+import { registerWooBlockType } from '@woocommerce/block-templates';
 
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils/init-block';
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
 import { SalePriceBlockAttributes } from './types';
@@ -24,5 +24,5 @@ export const settings: Partial<
 };
 
 export function init() {
-	return initBlock( { name, metadata, settings } );
+	return registerWooBlockType( { name, metadata, settings } );
 }

--- a/packages/js/product-editor/src/blocks/schedule-sale/edit.tsx
+++ b/packages/js/product-editor/src/blocks/schedule-sale/edit.tsx
@@ -1,10 +1,10 @@
 /**
  * External dependencies
  */
+import { useWooBlockProps } from '@woocommerce/block-templates';
 import { DateTimePickerControl } from '@woocommerce/components';
 import { Product } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
-import { useBlockProps } from '@wordpress/block-editor';
 import { BlockEditProps } from '@wordpress/blocks';
 import { ToggleControl } from '@wordpress/components';
 import { useEntityProp } from '@wordpress/core-data';
@@ -24,9 +24,10 @@ import { useProductEdits } from '../../hooks/use-product-edits';
 import { useValidation } from '../../contexts/validation-context';
 
 export function Edit( {
+	attributes,
 	clientId,
 }: BlockEditProps< ScheduleSalePricingBlockAttributes > ) {
-	const blockProps = useBlockProps();
+	const blockProps = useWooBlockProps( attributes );
 	const { hasEdit } = useProductEdits();
 
 	const dateTimeFormat = getSettings().formats.datetime;

--- a/packages/js/product-editor/src/blocks/schedule-sale/index.ts
+++ b/packages/js/product-editor/src/blocks/schedule-sale/index.ts
@@ -1,13 +1,12 @@
 /**
  * External dependencies
  */
-import { createElement } from '@wordpress/element';
 import { BlockConfiguration } from '@wordpress/blocks';
+import { registerWooBlockType } from '@woocommerce/block-templates';
 
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils/init-block';
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
 import { ScheduleSalePricingBlockAttributes } from './types';
@@ -25,5 +24,5 @@ export const settings: Partial<
 };
 
 export function init() {
-	return initBlock( { name, metadata, settings } );
+	return registerWooBlockType( { name, metadata, settings } );
 }

--- a/packages/js/product-editor/src/blocks/section/edit.tsx
+++ b/packages/js/product-editor/src/blocks/section/edit.tsx
@@ -4,8 +4,8 @@
 import classNames from 'classnames';
 import { createElement } from '@wordpress/element';
 import type { BlockEditProps } from '@wordpress/blocks';
+import { useWooBlockProps } from '@woocommerce/block-templates';
 import {
-	useBlockProps,
 	// @ts-expect-error no exported member.
 	useInnerBlocksProps,
 } from '@wordpress/block-editor';
@@ -20,7 +20,7 @@ export function Edit( {
 	attributes,
 }: BlockEditProps< SectionBlockAttributes > ) {
 	const { description, title, blockGap } = attributes;
-	const blockProps = useBlockProps();
+	const blockProps = useWooBlockProps( attributes );
 	const innerBlockProps = useInnerBlocksProps(
 		{
 			className: classNames(

--- a/packages/js/product-editor/src/blocks/section/index.ts
+++ b/packages/js/product-editor/src/blocks/section/index.ts
@@ -1,13 +1,12 @@
 /**
  * External dependencies
  */
-import { createElement } from '@wordpress/element';
 import { BlockConfiguration } from '@wordpress/blocks';
+import { registerWooBlockType } from '@woocommerce/block-templates';
 
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils/init-block';
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
 import { SectionBlockAttributes } from './types';
@@ -24,5 +23,5 @@ export const settings: Partial< BlockConfiguration< SectionBlockAttributes > > =
 	};
 
 export function init() {
-	return initBlock( { name, metadata, settings } );
+	return registerWooBlockType( { name, metadata, settings } );
 }

--- a/packages/js/product-editor/src/blocks/shipping-class/edit.tsx
+++ b/packages/js/product-editor/src/blocks/shipping-class/edit.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { BlockEditProps } from '@wordpress/blocks';
+import { useWooBlockProps } from '@woocommerce/block-templates';
 import { Link } from '@woocommerce/components';
 import {
 	EXPERIMENTAL_PRODUCT_SHIPPING_CLASSES_STORE_NAME,
@@ -10,7 +11,6 @@ import {
 } from '@woocommerce/data';
 import { getNewPath } from '@woocommerce/navigation';
 import { recordEvent } from '@woocommerce/tracks';
-import { useBlockProps } from '@wordpress/block-editor';
 import { BaseControl, SelectControl } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -69,11 +69,13 @@ function extractDefaultShippingClassFromProduct(
 	}
 }
 
-export function Edit( {}: BlockEditProps< ShippingClassBlockAttributes > ) {
+export function Edit( {
+	attributes,
+}: BlockEditProps< ShippingClassBlockAttributes > ) {
 	const [ showShippingClassModal, setShowShippingClassModal ] =
 		useState( false );
 
-	const blockProps = useBlockProps();
+	const blockProps = useWooBlockProps( attributes );
 
 	const { createProductShippingClass, invalidateResolution } = useDispatch(
 		EXPERIMENTAL_PRODUCT_SHIPPING_CLASSES_STORE_NAME

--- a/packages/js/product-editor/src/blocks/shipping-class/index.ts
+++ b/packages/js/product-editor/src/blocks/shipping-class/index.ts
@@ -1,13 +1,12 @@
 /**
  * External dependencies
  */
-import { createElement } from '@wordpress/element';
 import { BlockConfiguration } from '@wordpress/blocks';
+import { registerWooBlockType } from '@woocommerce/block-templates';
 
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils/init-block';
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
 import { ShippingClassBlockAttributes } from './types';
@@ -25,5 +24,5 @@ export const settings: Partial<
 };
 
 export function init() {
-	return initBlock( { name, metadata, settings } );
+	return registerWooBlockType( { name, metadata, settings } );
 }

--- a/packages/js/product-editor/src/blocks/shipping-dimensions/edit.tsx
+++ b/packages/js/product-editor/src/blocks/shipping-dimensions/edit.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useBlockProps } from '@wordpress/block-editor';
+import { useWooBlockProps } from '@woocommerce/block-templates';
 import { BlockEditProps } from '@wordpress/blocks';
 import {
 	OPTIONS_STORE_NAME,
@@ -36,9 +36,10 @@ import {
 import { useValidation } from '../../contexts/validation-context';
 
 export function Edit( {
+	attributes,
 	clientId,
 }: BlockEditProps< ShippingDimensionsBlockAttributes > ) {
-	const blockProps = useBlockProps();
+	const blockProps = useWooBlockProps( attributes );
 
 	const [ dimensions, setDimensions ] =
 		useEntityProp< Partial< ProductDimensions > | null >(

--- a/packages/js/product-editor/src/blocks/shipping-dimensions/index.ts
+++ b/packages/js/product-editor/src/blocks/shipping-dimensions/index.ts
@@ -1,13 +1,12 @@
 /**
  * External dependencies
  */
-import { createElement } from '@wordpress/element';
 import { BlockConfiguration } from '@wordpress/blocks';
+import { registerWooBlockType } from '@woocommerce/block-templates';
 
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils/init-block';
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
 import { ShippingDimensionsBlockAttributes } from './types';
@@ -25,5 +24,5 @@ export const settings: Partial<
 };
 
 export function init() {
-	return initBlock( { name, metadata, settings } );
+	return registerWooBlockType( { name, metadata, settings } );
 }

--- a/packages/js/product-editor/src/blocks/summary/edit.tsx
+++ b/packages/js/product-editor/src/blocks/summary/edit.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { useWooBlockProps } from '@woocommerce/block-templates';
 import { createElement } from '@wordpress/element';
 import { BlockEditProps } from '@wordpress/blocks';
 import { BaseControl } from '@wordpress/components';
@@ -16,7 +17,6 @@ import {
 	BlockControls,
 	RichText,
 	store as blockEditorStore,
-	useBlockProps,
 } from '@wordpress/block-editor';
 
 /**
@@ -31,7 +31,7 @@ export function Edit( {
 	setAttributes,
 }: BlockEditProps< SummaryAttributes > ) {
 	const { align, allowedFormats, direction, label } = attributes;
-	const blockProps = useBlockProps( {
+	const blockProps = useWooBlockProps( attributes, {
 		style: { direction },
 	} );
 	const contentId = useInstanceId(

--- a/packages/js/product-editor/src/blocks/summary/index.ts
+++ b/packages/js/product-editor/src/blocks/summary/index.ts
@@ -2,11 +2,11 @@
  * External dependencies
  */
 import { BlockConfiguration } from '@wordpress/blocks';
+import { registerWooBlockType } from '@woocommerce/block-templates';
 
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils';
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
 import { SummaryAttributes } from './types';
@@ -22,7 +22,7 @@ export const settings = {
 };
 
 export function init() {
-	return initBlock< SummaryAttributes >( {
+	return registerWooBlockType< SummaryAttributes >( {
 		name,
 		metadata,
 		settings,

--- a/packages/js/product-editor/src/blocks/tab/edit.tsx
+++ b/packages/js/product-editor/src/blocks/tab/edit.tsx
@@ -1,10 +1,11 @@
 /**
  * External dependencies
  */
-import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+import { InnerBlocks } from '@wordpress/block-editor';
 import classnames from 'classnames';
 import { createElement } from '@wordpress/element';
 import type { BlockAttributes, BlockEditProps } from '@wordpress/blocks';
+import { useWooBlockProps } from '@woocommerce/block-templates';
 
 /**
  * Internal dependencies
@@ -27,7 +28,7 @@ export function Edit( {
 		selectedTab?: string | null;
 	};
 } ) {
-	const blockProps = useBlockProps();
+	const blockProps = useWooBlockProps( attributes );
 	const { id, title, order, isSelected: contextIsSelected } = attributes;
 	const isSelected = context?.selectedTab === id;
 	if ( isSelected !== contextIsSelected ) {

--- a/packages/js/product-editor/src/blocks/tab/index.ts
+++ b/packages/js/product-editor/src/blocks/tab/index.ts
@@ -7,7 +7,6 @@ import { registerWooBlockType } from '@woocommerce/block-templates';
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils/init-block';
 import blockConfiguration from './block.json';
 import { Edit, TabBlockAttributes } from './edit';
 

--- a/packages/js/product-editor/src/blocks/tab/index.ts
+++ b/packages/js/product-editor/src/blocks/tab/index.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { BlockConfiguration } from '@wordpress/blocks';
+import { registerWooBlockType } from '@woocommerce/block-templates';
 
 /**
  * Internal dependencies
@@ -21,5 +22,5 @@ export const settings: Partial< BlockConfiguration< TabBlockAttributes > > = {
 };
 
 export function init() {
-	initBlock( { name, metadata, settings } );
+	registerWooBlockType( { name, metadata, settings } );
 }

--- a/packages/js/product-editor/src/blocks/tag/edit.tsx
+++ b/packages/js/product-editor/src/blocks/tag/edit.tsx
@@ -2,9 +2,9 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { useWooBlockProps } from '@woocommerce/block-templates';
 import { createElement } from '@wordpress/element';
 import { BlockAttributes } from '@wordpress/blocks';
-import { useBlockProps } from '@wordpress/block-editor';
 import { BaseControl } from '@wordpress/components';
 import { ProductTag } from '@woocommerce/data';
 import { useInstanceId } from '@wordpress/compose';
@@ -25,7 +25,7 @@ export function Edit( {
 	attributes: BlockAttributes;
 	context?: { postType?: string };
 } ) {
-	const blockProps = useBlockProps();
+	const blockProps = useWooBlockProps( attributes );
 	const { name, label, placeholder } = attributes;
 	const [ tags, setTags ] = useEntityProp<
 		Pick< ProductTag, 'id' | 'name' >[]

--- a/packages/js/product-editor/src/blocks/tag/index.ts
+++ b/packages/js/product-editor/src/blocks/tag/index.ts
@@ -1,7 +1,11 @@
 /**
+ * External dependencies
+ */
+import { registerWooBlockType } from '@woocommerce/block-templates';
+
+/**
  * Internal dependencies
  */
-import { initBlock } from '../../utils';
 import metadata from './block.json';
 import { Edit } from './edit';
 
@@ -15,4 +19,4 @@ export const settings = {
 };
 
 export const init = () =>
-	initBlock( { name, metadata: metadata as never, settings } );
+	registerWooBlockType( { name, metadata: metadata as never, settings } );

--- a/packages/js/product-editor/src/blocks/taxonomy/edit.tsx
+++ b/packages/js/product-editor/src/blocks/taxonomy/edit.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import type { BlockAttributes } from '@wordpress/blocks';
-import { useBlockProps } from '@wordpress/block-editor';
 import {
 	createElement,
 	useState,
@@ -11,6 +10,7 @@ import {
 	useEffect,
 } from '@wordpress/element';
 import '@woocommerce/settings';
+import { useWooBlockProps } from '@woocommerce/block-templates';
 import { __experimentalSelectTreeControl as SelectTreeControl } from '@woocommerce/components';
 import { useEntityProp } from '@wordpress/core-data';
 import { useDebounce, useInstanceId } from '@wordpress/compose';
@@ -37,7 +37,7 @@ export function Edit( {
 }: {
 	attributes: TaxonomyBlockAttributes;
 } ) {
-	const blockProps = useBlockProps();
+	const blockProps = useWooBlockProps( attributes );
 	const { hierarchical }: TaxonomyMetadata = useSelect(
 		( select ) =>
 			select( 'core' ).getTaxonomy( attributes.slug ) || {

--- a/packages/js/product-editor/src/blocks/taxonomy/index.ts
+++ b/packages/js/product-editor/src/blocks/taxonomy/index.ts
@@ -1,7 +1,11 @@
 /**
+ * External dependencies
+ */
+import { registerWooBlockType } from '@woocommerce/block-templates';
+
+/**
  * Internal dependencies
  */
-import { initBlock } from '../../utils';
 import metadata from './block.json';
 import { Edit } from './edit';
 
@@ -15,7 +19,7 @@ export const settings = {
 };
 
 export const init = () =>
-	initBlock( {
+	registerWooBlockType( {
 		name,
 		metadata: metadata as never,
 		settings,

--- a/packages/js/product-editor/src/blocks/toggle/edit.tsx
+++ b/packages/js/product-editor/src/blocks/toggle/edit.tsx
@@ -3,9 +3,9 @@
  */
 import { createElement } from '@wordpress/element';
 import { BlockEditProps } from '@wordpress/blocks';
-import { useBlockProps } from '@wordpress/block-editor';
 import { useEntityProp } from '@wordpress/core-data';
 import { ToggleControl } from '@wordpress/components';
+import { useWooBlockProps } from '@woocommerce/block-templates';
 
 /**
  * Internal dependencies
@@ -16,7 +16,7 @@ import { sanitizeHTML } from '../../utils/sanitize-html';
 export function Edit( {
 	attributes,
 }: BlockEditProps< ToggleBlockAttributes > ) {
-	const blockProps = useBlockProps();
+	const blockProps = useWooBlockProps( attributes );
 	const { label, property, disabled, disabledCopy } = attributes;
 	const [ value, setValue ] = useEntityProp< boolean >(
 		'postType',

--- a/packages/js/product-editor/src/blocks/toggle/index.ts
+++ b/packages/js/product-editor/src/blocks/toggle/index.ts
@@ -2,11 +2,11 @@
  * External dependencies
  */
 import { BlockConfiguration } from '@wordpress/blocks';
+import { registerWooBlockType } from '@woocommerce/block-templates';
 
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils/init-block';
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
 import { ToggleBlockAttributes } from './types';
@@ -23,5 +23,5 @@ export const settings: Partial< BlockConfiguration< ToggleBlockAttributes > > =
 	};
 
 export function init() {
-	return initBlock( { name, metadata, settings } );
+	return registerWooBlockType( { name, metadata, settings } );
 }

--- a/packages/js/product-editor/src/blocks/variation-items/edit.tsx
+++ b/packages/js/product-editor/src/blocks/variation-items/edit.tsx
@@ -8,7 +8,7 @@ import {
 	ProductVariation,
 	useUserPreferences,
 } from '@woocommerce/data';
-import { useBlockProps } from '@wordpress/block-editor';
+import { useWooBlockProps } from '@woocommerce/block-templates';
 import { recordEvent } from '@woocommerce/tracks';
 import { BlockEditProps } from '@wordpress/blocks';
 import { createElement, useMemo, useRef } from '@wordpress/element';
@@ -29,6 +29,7 @@ import { TRACKS_SOURCE } from '../../constants';
 import { handlePrompt } from '../../utils/handle-prompt';
 
 export function Edit( {
+	attributes,
 	context,
 }: BlockEditProps< VariationOptionsBlockAttributes > & {
 	context?: {
@@ -40,7 +41,7 @@ export function Edit( {
 		EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME
 	);
 	const productId = useEntityId( 'postType', 'product' );
-	const blockProps = useBlockProps();
+	const blockProps = useWooBlockProps( attributes );
 	const [ productStatus ] = useEntityProp< string >(
 		'postType',
 		'product',

--- a/packages/js/product-editor/src/blocks/variation-items/index.ts
+++ b/packages/js/product-editor/src/blocks/variation-items/index.ts
@@ -2,11 +2,11 @@
  * External dependencies
  */
 import { BlockConfiguration } from '@wordpress/blocks';
+import { registerWooBlockType } from '@woocommerce/block-templates';
 
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils/init-block';
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
 import { VariationOptionsBlockAttributes } from './types';
@@ -24,5 +24,5 @@ export const settings: Partial<
 };
 
 export function init() {
-	return initBlock( { name, metadata, settings } );
+	return registerWooBlockType( { name, metadata, settings } );
 }

--- a/packages/js/product-editor/src/blocks/variation-options/edit.tsx
+++ b/packages/js/product-editor/src/blocks/variation-options/edit.tsx
@@ -2,12 +2,13 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useBlockProps } from '@wordpress/block-editor';
+import { BlockEditProps, BlockAttributes } from '@wordpress/blocks';
 import {
 	createElement,
 	createInterpolateElement,
 	useMemo,
 } from '@wordpress/element';
+import { useWooBlockProps } from '@woocommerce/block-templates';
 import {
 	Product,
 	ProductAttribute,
@@ -26,8 +27,10 @@ import { useProductAttributes } from '../../hooks/use-product-attributes';
 import { AttributeControl } from '../../components/attribute-control';
 import { useProductVariationsHelper } from '../../hooks/use-product-variations-helper';
 
-export function Edit() {
-	const blockProps = useBlockProps();
+export function Edit( {
+	attributes: blockAttributes,
+}: BlockEditProps< BlockAttributes > ) {
+	const blockProps = useWooBlockProps( blockAttributes );
 	const { generateProductVariations } = useProductVariationsHelper();
 	const {
 		updateUserPreferences,

--- a/packages/js/product-editor/src/blocks/variation-options/index.ts
+++ b/packages/js/product-editor/src/blocks/variation-options/index.ts
@@ -1,13 +1,12 @@
 /**
  * External dependencies
  */
-import { createElement } from '@wordpress/element';
 import { BlockConfiguration } from '@wordpress/blocks';
+import { registerWooBlockType } from '@woocommerce/block-templates';
 
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils/init-block';
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
 import { VariationOptionsBlockAttributes } from './types';
@@ -25,5 +24,5 @@ export const settings: Partial<
 };
 
 export function init() {
-	return initBlock( { name, metadata, settings } );
+	return registerWooBlockType( { name, metadata, settings } );
 }

--- a/packages/js/product-editor/src/blocks/variations/edit.tsx
+++ b/packages/js/product-editor/src/blocks/variations/edit.tsx
@@ -4,12 +4,12 @@
 import classNames from 'classnames';
 import type { BlockEditProps } from '@wordpress/blocks';
 import { Button } from '@wordpress/components';
+import { useWooBlockProps } from '@woocommerce/block-templates';
 import { Product, ProductAttribute } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { createElement, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import {
-	useBlockProps,
 	// @ts-expect-error no exported member.
 	useInnerBlocksProps,
 } from '@wordpress/block-editor';
@@ -63,7 +63,7 @@ export function Edit( {
 
 	const hasAttributes = hasAttributesUsedForVariations( productAttributes );
 
-	const blockProps = useBlockProps( {
+	const blockProps = useWooBlockProps( attributes, {
 		className: classNames( {
 			'wp-block-woocommerce-product-variations-fields--has-attributes':
 				hasAttributes,

--- a/packages/js/product-editor/src/blocks/variations/index.ts
+++ b/packages/js/product-editor/src/blocks/variations/index.ts
@@ -1,13 +1,12 @@
 /**
  * External dependencies
  */
-import { createElement } from '@wordpress/element';
 import { BlockConfiguration } from '@wordpress/blocks';
+import { registerWooBlockType } from '@woocommerce/block-templates';
 
 /**
  * Internal dependencies
  */
-import { initBlock } from '../../utils/init-block';
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
 import { VariationsBlockAttributes } from './types';
@@ -25,5 +24,5 @@ export const settings: Partial<
 };
 
 export function init() {
-	return initBlock( { name, metadata, settings } );
+	return registerWooBlockType( { name, metadata, settings } );
 }

--- a/packages/js/product-editor/src/components/tabs/test/tabs.spec.tsx
+++ b/packages/js/product-editor/src/components/tabs/test/tabs.spec.tsx
@@ -13,9 +13,9 @@ import { useState } from '@wordpress/element';
 import { Tabs } from '../';
 import { Edit as Tab } from '../../../blocks/tab/edit';
 
-jest.mock( '@wordpress/block-editor', () => ( {
-	...jest.requireActual( '@wordpress/block-editor' ),
-	useBlockProps: jest.fn(),
+jest.mock( '@woocommerce/block-templates', () => ( {
+	...jest.requireActual( '@woocommerce/block-templates' ),
+	useWooBlockProps: jest.fn(),
 } ) );
 
 jest.mock( '@woocommerce/navigation', () => ( {

--- a/packages/js/product-editor/src/utils/init-block.ts
+++ b/packages/js/product-editor/src/utils/init-block.ts
@@ -1,11 +1,9 @@
 /**
  * External dependencies
  */
-import {
-	Block,
-	BlockConfiguration,
-	registerBlockType,
-} from '@wordpress/blocks';
+import { Block, BlockConfiguration } from '@wordpress/blocks';
+import deprecated from '@wordpress/deprecated';
+import { registerWooBlockType } from '@woocommerce/block-templates';
 
 interface BlockRepresentation< T extends Record< string, object > > {
 	name?: string;
@@ -23,9 +21,13 @@ export function initBlock<
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	T extends Record< string, any > = Record< string, any >
 >( block: BlockRepresentation< T > ): Block< T > | undefined {
+	deprecated( 'initBlock()', {
+		alternative: 'registerWooBlockType() from @woocommerce/block-templates',
+	} );
+
 	if ( ! block ) {
 		return;
 	}
-	const { metadata, settings, name } = block;
-	return registerBlockType< T >( { name, ...metadata }, settings );
+
+	return registerWooBlockType( block );
 }

--- a/plugins/woocommerce-admin/webpack.config.js
+++ b/plugins/woocommerce-admin/webpack.config.js
@@ -40,6 +40,7 @@ const wcAdminPackages = [
 	'data',
 	'tracks',
 	'onboarding',
+	'block-templates',
 	'product-editor',
 ];
 // wpAdminScripts are loaded on wp-admin pages outside the context of WooCommerce Admin

--- a/plugins/woocommerce-beta-tester/changelog/add-expose-block-id-and-order
+++ b/plugins/woocommerce-beta-tester/changelog/add-expose-block-id-and-order
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Code formatting only.
+
+

--- a/plugins/woocommerce-beta-tester/package.json
+++ b/plugins/woocommerce-beta-tester/package.json
@@ -50,9 +50,9 @@
 			"js": "assets/js/*.js"
 		}
 	},
-  "config": {
-    "build_step": "pnpm run build:zip"
-  },
+	"config": {
+		"build_step": "pnpm run build:zip"
+	},
 	"scripts": {
 		"postinstall": "composer install",
 		"changelog": "composer exec -- changelogger",

--- a/plugins/woocommerce/changelog/add-expose-block-id-and-order
+++ b/plugins/woocommerce/changelog/add-expose-block-id-and-order
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Include template block ID and block order in formatted block template so they are available to the client.

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplates/AbstractBlock.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplates/AbstractBlock.php
@@ -10,6 +10,8 @@ use Automattic\WooCommerce\Admin\BlockTemplates\ContainerInterface;
  * Block configuration used to specify blocks in BlockTemplate.
  */
 class AbstractBlock implements BlockInterface {
+	use BlockFormattedTemplateTrait;
+
 	/**
 	 * The block name.
 	 *
@@ -190,18 +192,5 @@ class AbstractBlock implements BlockInterface {
 		$is_in_root_template = $this->get_root_template()->get_block( $this->id ) === $this;
 
 		return ! ( $is_in_parent && $is_in_root_template );
-	}
-	/**
-	 * Get the block configuration as a formatted template.
-	 *
-	 * @return array The block configuration as a formatted template.
-	 */
-	public function get_formatted_template(): array {
-		$arr = [
-			$this->get_name(),
-			$this->get_attributes(),
-		];
-
-		return $arr;
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockContainerTrait.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockContainerTrait.php
@@ -9,6 +9,10 @@ use Automattic\WooCommerce\Admin\BlockTemplates\ContainerInterface;
  * Trait for block containers.
  */
 trait BlockContainerTrait {
+	use BlockFormattedTemplateTrait {
+		get_formatted_template as get_block_formatted_template;
+	}
+
 	/**
 	 * The inner blocks.
 	 *
@@ -197,10 +201,7 @@ trait BlockContainerTrait {
 	 * Get the inner blocks as a formatted template.
 	 */
 	public function get_formatted_template(): array {
-		$arr = [
-			$this->get_name(),
-			$this->get_attributes(),
-		];
+		$arr = $this->get_block_formatted_template();
 
 		$inner_blocks = $this->get_inner_blocks_sorted_by_order();
 

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockFormattedTemplateTrait.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockFormattedTemplateTrait.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Automattic\WooCommerce\Internal\Admin\BlockTemplates;
+
+/**
+ * Trait for block formatted template.
+ */
+trait BlockFormattedTemplateTrait {
+	/**
+	 * Get the block configuration as a formatted template.
+	 *
+	 * @return array The block configuration as a formatted template.
+	 */
+	public function get_formatted_template(): array {
+		$arr = [
+			$this->get_name(),
+			array_merge(
+				$this->get_attributes(),
+				[
+					'_templateBlockId'    => $this->get_id(),
+					'_templateBlockOrder' => $this->get_order(),
+				]
+			),
+		];
+
+		return $arr;
+	}
+}

--- a/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php
@@ -272,6 +272,7 @@ class WCAdminAssets {
 			'wc-store-data',
 			'wc-currency',
 			'wc-navigation',
+			'wc-block-templates',
 			'wc-product-editor',
 		);
 
@@ -336,6 +337,14 @@ class WCAdminAssets {
 			$css_file_version
 		);
 		wp_style_add_data( 'wc-components', 'rtl', 'replace' );
+
+		wp_register_style(
+			'wc-block-templates',
+			self::get_url( 'block-templates/style', 'css' ),
+			array(),
+			$css_file_version
+		);
+		wp_style_add_data( 'wc-block-templates', 'rtl', 'replace' );
 
 		wp_register_style(
 			'wc-product-editor',
@@ -405,6 +414,7 @@ class WCAdminAssets {
 				'wc-date',
 				'wc-components',
 				'wc-tracks',
+				'wc-block-templates',
 				'wc-product-editor',
 			];
 			foreach ( $handles_for_injection as $handle ) {

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/BlockTemplateTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/BlockTemplateTest.php
@@ -310,42 +310,55 @@ class BlockTemplateTest extends WC_Unit_Test_Case {
 				[
 					'test-block-name-a',
 					[
-						'attr-1' => 'value-1',
-						'attr-2' => 'value-2',
+						'attr-1'              => 'value-1',
+						'attr-2'              => 'value-2',
+						'_templateBlockId'    => 'test-block-name-a-1',
+						'_templateBlockOrder' => 10,
 					],
 				],
 				[
 					'test-block-name-b',
 					[
-						'attr-1' => 'value-1',
-						'attr-2' => 'value-2',
+						'attr-1'              => 'value-1',
+						'attr-2'              => 'value-2',
+						'_templateBlockId'    => 'test-block-name-b-1',
+						'_templateBlockOrder' => 50,
 					],
 					[
 						[
 							'test-block-name-1',
 							[
-								'attr-3' => 'value-3',
-								'attr-4' => 'value-4',
+								'attr-3'              => 'value-3',
+								'attr-4'              => 'value-4',
+								'_templateBlockId'    => 'test-block-name-1-1',
+								'_templateBlockOrder' => 10,
 							],
 						],
 						[
 							'test-block-name-2',
 							[
-								'attr-1' => 'value-1',
-								'attr-2' => 'value-2',
+								'attr-1'              => 'value-1',
+								'attr-2'              => 'value-2',
+								'_templateBlockId'    => 'test-block-name-2-1',
+								'_templateBlockOrder' => 20,
 							],
 						],
 						[
 							'test-block-name-3',
-							[],
+							[
+								'_templateBlockId'    => 'test-block-name-3-1',
+								'_templateBlockOrder' => 30,
+							],
 						],
 					],
 				],
 				[
 					'test-block-name-c',
 					[
-						'attr-c1' => 'value-c1',
-						'attr-c2' => 'value-c2',
+						'attr-c1'             => 'value-c1',
+						'attr-c2'             => 'value-c2',
+						'_templateBlockId'    => 'test-block-name-c-1',
+						'_templateBlockOrder' => 100,
 					],
 				],
 			],
@@ -446,52 +459,71 @@ class BlockTemplateTest extends WC_Unit_Test_Case {
 				[
 					'test-block-name-a',
 					[
-						'attr-1' => 'value-1',
-						'attr-2' => 'value-2',
+						'attr-1'              => 'value-1',
+						'attr-2'              => 'value-2',
+						'_templateBlockId'    => 'a',
+						'_templateBlockOrder' => 10,
 					],
 					[
 						[
 							'inserted-block',
-							[],
+							[
+								'_templateBlockId'    => 'inserted-block-1',
+								'_templateBlockOrder' => 10,
+							],
 						],
 					],
 				],
 				[
 					'test-block-name-b',
 					[
-						'attr-1' => 'value-1',
-						'attr-2' => 'value-2',
+						'attr-1'              => 'value-1',
+						'attr-2'              => 'value-2',
+						'_templateBlockId'    => 'b',
+						'_templateBlockOrder' => 50,
 					],
 					[
 						[
 							'test-block-name-1',
 							[
-								'attr-3' => 'value-3',
-								'attr-4' => 'value-4',
+								'attr-3'              => 'value-3',
+								'attr-4'              => 'value-4',
+								'_templateBlockId'    => 'test-block-name-1-1',
+								'_templateBlockOrder' => 10,
 							],
 						],
 						[
 							'another-inserted-block',
-							[],
+							[
+								'_templateBlockId'    => 'another-inserted-block-1',
+								'_templateBlockOrder' => 15,
+							],
 						],
 						[
 							'test-block-name-2',
 							[
-								'attr-1' => 'value-1',
-								'attr-2' => 'value-2',
+								'attr-1'              => 'value-1',
+								'attr-2'              => 'value-2',
+								'_templateBlockId'    => 'test-block-name-2-1',
+								'_templateBlockOrder' => 20,
 							],
 						],
 						[
 							'test-block-name-3',
-							[],
+							[
+								'_templateBlockId'    => 'test-block-name-3-1',
+								'_templateBlockOrder' => 30,
+							],
 						],
 					],
 				],
 				[
 					'test-block-name-c',
 					[
-						'attr-c1' => 'value-c1',
-						'attr-c2' => 'value-c2',
+						'attr-c1'             => 'value-c1',
+						'attr-c2'             => 'value-c2',
+						'_templateBlockId'    => 'test-block-name-c-1',
+						'_templateBlockOrder' => 100,
 					],
 				],
 			],
@@ -585,21 +617,28 @@ class BlockTemplateTest extends WC_Unit_Test_Case {
 				[
 					'test-block-name-a',
 					[
-						'attr-1' => 'value-1',
-						'attr-2' => 'value-2',
+						'attr-1'              => 'value-1',
+						'attr-2'              => 'value-2',
+						'_templateBlockId'    => 'a',
+						'_templateBlockOrder' => 10,
 					],
 					[
 						[
 							'inserted-block',
-							[],
+							[
+								'_templateBlockId'    => 'inserted-block-1',
+								'_templateBlockOrder' => 10,
+							],
 						],
 					],
 				],
 				[
 					'test-block-name-c',
 					[
-						'attr-c1' => 'value-c1',
-						'attr-c2' => 'value-c2',
+						'attr-c1'             => 'value-c1',
+						'attr-c2'             => 'value-c2',
+						'_templateBlockId'    => 'test-block-name-c-1',
+						'_templateBlockOrder' => 100,
 					],
 				],
 			],

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/BlockTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/BlockTest.php
@@ -394,20 +394,27 @@ class BlockTest extends WC_Unit_Test_Case {
 			[
 				'test-block-name',
 				[
-					'attr-1' => 'value-1',
-					'attr-2' => 'value-2',
+					'attr-1'              => 'value-1',
+					'attr-2'              => 'value-2',
+					'_templateBlockId'    => 'test-block-id',
+					'_templateBlockOrder' => 10,
 				],
 				[
 					[
 						'test-block-name-2',
 						[
-							'attr-3' => 'value-3',
-							'attr-4' => 'value-4',
+							'attr-3'              => 'value-3',
+							'attr-4'              => 'value-4',
+							'_templateBlockId'    => 'test-block-id-2',
+							'_templateBlockOrder' => 10,
 						],
 					],
 					[
 						'test-block-name-3',
-						[],
+						[
+							'_templateBlockId'    => 'test-block-id-3',
+							'_templateBlockOrder' => 10,
+						],
 					],
 				],
 			],
@@ -466,27 +473,45 @@ class BlockTest extends WC_Unit_Test_Case {
 		$this->assertSame(
 			[
 				'test-block-name',
-				[],
+				[
+					'_templateBlockId'    => 'test-block-name-1',
+					'_templateBlockOrder' => 10,
+				],
 				[
 					[
 						'one',
-						[],
+						[
+							'_templateBlockId'    => 'one-1',
+							'_templateBlockOrder' => 1,
+						],
 					],
 					[
 						'two',
-						[],
+						[
+							'_templateBlockId'    => 'two-1',
+							'_templateBlockOrder' => 2,
+						],
 					],
 					[
 						'three',
-						[],
+						[
+							'_templateBlockId'    => 'three-1',
+							'_templateBlockOrder' => 3,
+						],
 					],
 					[
 						'four',
-						[],
+						[
+							'_templateBlockId'    => 'four-1',
+							'_templateBlockOrder' => 4,
+						],
 					],
 					[
 						'five',
-						[],
+						[
+							'_templateBlockId'    => 'five-1',
+							'_templateBlockOrder' => 5,
+						],
 					],
 				],
 			],

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/CustomBlockTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/CustomBlockTest.php
@@ -37,18 +37,25 @@ class CustomBlockTest extends WC_Unit_Test_Case {
 		$this->assertSame(
 			[
 				'test-block-name',
-				[],
+				[
+					'_templateBlockId'    => 'test-block-name-1',
+					'_templateBlockOrder' => 10,
+				],
 				[
 					[
 						'custom-inner-block',
 						[
-							'title' => 'a',
+							'title'               => 'a',
+							'_templateBlockId'    => 'custom-inner-block-1',
+							'_templateBlockOrder' => 10,
 						],
 					],
 					[
 						'custom-inner-block',
 						[
-							'title' => 'b',
+							'title'               => 'b',
+							'_templateBlockId'    => 'custom-inner-block-2',
+							'_templateBlockOrder' => 10,
 						],
 					],
 				],
@@ -72,12 +79,17 @@ class CustomBlockTest extends WC_Unit_Test_Case {
 		$this->assertSame(
 			[
 				'test-block-name',
-				[],
+				[
+					'_templateBlockId'    => 'test-block-name-1',
+					'_templateBlockOrder' => 10,
+				],
 				[
 					[
 						'custom-inner-block',
 						[
-							'title' => 'b',
+							'title'               => 'b',
+							'_templateBlockId'    => 'custom-inner-block-2',
+							'_templateBlockOrder' => 10,
 						],
 					],
 				],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,7 +117,7 @@ importers:
         version: 1.1.2(webpack@5.76.3)
       webpack:
         specifier: ^5.76.2
-        version: 5.76.3(webpack-cli@3.3.12)
+        version: 5.76.3(webpack-cli@4.9.2)
 
   packages/js/admin-e2e-tests:
     dependencies:
@@ -459,6 +459,91 @@ importers:
       eslint:
         specifier: ^8.32.0
         version: 8.32.0
+
+  packages/js/block-templates:
+    dependencies:
+      '@wordpress/block-editor':
+        specifier: ^9.8.0
+        version: 9.8.0(@babel/core@7.21.3)(react@17.0.2)
+      '@wordpress/blocks':
+        specifier: ^12.3.0
+        version: 12.5.0(react@17.0.2)
+    devDependencies:
+      '@babel/core':
+        specifier: ^7.21.3
+        version: 7.21.3
+      '@babel/runtime':
+        specifier: ^7.17.2
+        version: 7.21.0
+      '@testing-library/jest-dom':
+        specifier: ^5.16.2
+        version: 5.16.2
+      '@testing-library/react-hooks':
+        specifier: ^8.0.1
+        version: 8.0.1(@types/react@17.0.50)(react-dom@17.0.2)(react@17.0.2)
+      '@types/jest':
+        specifier: ^27.4.1
+        version: 27.4.1
+      '@types/testing-library__jest-dom':
+        specifier: ^5.14.3
+        version: 5.14.3
+      '@types/wordpress__block-editor':
+        specifier: ^7.0.0
+        version: 7.0.0(react@17.0.2)
+      '@types/wordpress__blocks':
+        specifier: ^11.0.7
+        version: 11.0.7(react@17.0.2)
+      '@woocommerce/eslint-plugin':
+        specifier: workspace:*
+        version: link:../eslint-plugin
+      '@woocommerce/internal-js-tests':
+        specifier: workspace:*
+        version: link:../internal-js-tests
+      '@woocommerce/internal-style-build':
+        specifier: workspace:*
+        version: link:../internal-style-build
+      '@wordpress/browserslist-config':
+        specifier: wp-6.0
+        version: 4.1.3
+      copy-webpack-plugin:
+        specifier: ^9.1.0
+        version: 9.1.0(webpack@5.76.3)
+      css-loader:
+        specifier: ^3.6.0
+        version: 3.6.0(webpack@5.76.3)
+      eslint:
+        specifier: ^8.32.0
+        version: 8.32.0
+      jest:
+        specifier: ^27.5.1
+        version: 27.5.1
+      jest-cli:
+        specifier: ^27.5.1
+        version: 27.5.1
+      postcss:
+        specifier: ^8.4.7
+        version: 8.4.12
+      postcss-loader:
+        specifier: ^4.3.0
+        version: 4.3.0(postcss@8.4.12)(webpack@5.76.3)
+      rimraf:
+        specifier: ^3.0.2
+        version: 3.0.2
+      sass-loader:
+        specifier: ^10.2.1
+        version: 10.4.1(sass@1.60.0)(webpack@5.76.3)
+      ts-jest:
+        specifier: ^27.1.3
+        version: 27.1.3(@babel/core@7.21.3)(@types/jest@27.4.1)(jest@27.5.1)(typescript@5.1.6)
+      typescript:
+        specifier: ^5.1.6
+        version: 5.1.6
+      webpack:
+        specifier: ^5.70.0
+        version: 5.76.3(webpack-cli@3.3.12)
+      webpack-cli:
+        specifier: ^3.3.12
+        version: 3.3.12(webpack@5.76.3)
 
   packages/js/components:
     dependencies:
@@ -2191,6 +2276,9 @@ importers:
       '@woocommerce/admin-layout':
         specifier: workspace:*
         version: link:../admin-layout
+      '@woocommerce/block-templates':
+        specifier: workspace:*
+        version: link:../block-templates
       '@woocommerce/components':
         specifier: workspace:*
         version: link:../components
@@ -2242,6 +2330,9 @@ importers:
       '@wordpress/date':
         specifier: wp-6.0
         version: 4.6.1
+      '@wordpress/deprecated':
+        specifier: wp-6.0
+        version: 3.6.1
       '@wordpress/editor':
         specifier: wp-6.0
         version: 12.5.10(@babel/core@7.21.3)(@types/react@17.0.50)(react-dom@17.0.2)(react-with-direction@1.4.0)(react@17.0.2)
@@ -3932,7 +4023,7 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       '@jridgewell/gen-mapping': 0.1.1
-      '@jridgewell/trace-mapping': 0.3.17
+      '@jridgewell/trace-mapping': 0.3.19
 
   /@ariakit/core@0.2.9:
     resolution: {integrity: sha512-BIEfY3AHImIc8R5j5DaBrEBKLlki5f0vqZbs56I0xQb12ssjn5VqpLr8Jl4v7DBm5S4ktTgeHjLloTppKFdABg==}
@@ -4176,7 +4267,7 @@ packages:
       '@wordpress/primitives': 3.38.0
       '@wordpress/react-i18n': 3.8.0
       classnames: 2.3.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       react-popper: 2.2.5(@popperjs/core@2.11.4)(react@17.0.2)
@@ -4215,7 +4306,7 @@ packages:
       '@wordpress/primitives': 3.38.0
       '@wordpress/react-i18n': 3.8.0
       classnames: 2.3.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       react-popper: 2.2.5(@popperjs/core@2.11.4)(react@17.0.2)
@@ -4316,7 +4407,7 @@ packages:
   /@babel/code-frame@7.12.11:
     resolution: {integrity: sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==}
     dependencies:
-      '@babel/highlight': 7.18.6
+      '@babel/highlight': 7.22.13
     dev: true
 
   /@babel/code-frame@7.16.7:
@@ -4341,7 +4432,6 @@ packages:
   /@babel/compat-data@7.16.4:
     resolution: {integrity: sha512-1o/jo7D+kC9ZjHX5v+EHrdjl3PhxMrLSOTGsOdHJ+KL8HCaEK6ehrVL2RS6oHDZp+L7xLirLrPmQtEng769J/Q==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
   /@babel/compat-data@7.17.7:
     resolution: {integrity: sha512-p8pdE6j0a29TNGebNm7NzYZWB3xVZJBZ7XGs42uAKzQo8VQ3F0By/cQCtUEABwIqw5zo6WA4NbmxsfzADzMKnQ==}
@@ -4365,7 +4455,7 @@ packages:
       '@babel/traverse': 7.17.3
       '@babel/types': 7.17.0
       convert-source-map: 1.8.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       gensync: 1.0.0-beta.2
       json5: 2.2.0
       lodash: 4.17.21
@@ -4390,7 +4480,7 @@ packages:
       '@babel/traverse': 7.19.3
       '@babel/types': 7.19.3
       convert-source-map: 1.8.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       gensync: 1.0.0-beta.2
       json5: 2.2.0
       semver: 6.3.0
@@ -4412,7 +4502,7 @@ packages:
       '@babel/traverse': 7.21.3
       '@babel/types': 7.22.15
       convert-source-map: 1.8.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -4430,7 +4520,7 @@ packages:
       eslint: 8.32.0
       eslint-scope: 5.1.1
       eslint-visitor-keys: 2.1.0
-      semver: 6.3.0
+      semver: 6.3.1
     dev: true
 
   /@babel/eslint-parser@7.17.0(@babel/core@7.17.8)(eslint@8.32.0):
@@ -4487,7 +4577,7 @@ packages:
     resolution: {integrity: sha512-fqVZnmp1ncvZU757UzDheKZpfPgatqY59XtW2/j/18H7u76akb8xqvjw82f+i2UKd/ksYsSick/BCLQUUtJ/qQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.15
       '@jridgewell/gen-mapping': 0.3.2
       jsesc: 2.5.2
 
@@ -4495,9 +4585,9 @@ packages:
     resolution: {integrity: sha512-QS3iR1GYC/YGUnW7IdggFeN5c1poPUurnGttOV/bZgPGV+izC/D8HnD6DLwod0fsatNyVn1G3EVWMYIF0nHbeA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.15
       '@jridgewell/gen-mapping': 0.3.2
-      '@jridgewell/trace-mapping': 0.3.17
+      '@jridgewell/trace-mapping': 0.3.19
       jsesc: 2.5.2
 
   /@babel/helper-annotate-as-pure@7.16.0:
@@ -4511,14 +4601,14 @@ packages:
     resolution: {integrity: sha512-s6t2w/IPQVTAET1HitoowRGXooX8mCgtuP5195wD/QJPV6wYjpujCGF7JuMODVX2ZAJOf1GT6DT9MHEZvLOFSw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.15
     dev: true
 
   /@babel/helper-annotate-as-pure@7.18.6:
     resolution: {integrity: sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.15
 
   /@babel/helper-annotate-as-pure@7.22.5:
     resolution: {integrity: sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==}
@@ -4531,7 +4621,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-explode-assignable-expression': 7.18.6
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.15
 
   /@babel/helper-compilation-targets@7.16.3(@babel/core@7.12.9):
     resolution: {integrity: sha512-vKsoSQAyBmxS35JUOOt+07cLc6Nk/2ljLIHwmq2/NM6hdioUaqEXq/S+nXvbvXbZkNDlWOymPanJGOc4CBjSJA==}
@@ -4544,33 +4634,6 @@ packages:
       '@babel/helper-validator-option': 7.18.6
       browserslist: 4.19.3
       semver: 6.3.0
-    dev: true
-
-  /@babel/helper-compilation-targets@7.17.7(@babel/core@7.12.9):
-    resolution: {integrity: sha512-UFzlz2jjd8kroj0hmCFV5zr+tQPi1dpC2cRsDV/3IEW8bJfCPrPpmcSN6ZS8RqIq4LXcmpipCQFPddyFA5Yc7w==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/compat-data': 7.21.0
-      '@babel/core': 7.12.9
-      '@babel/helper-validator-option': 7.21.0
-      browserslist: 4.19.3
-      semver: 6.3.0
-    dev: true
-
-  /@babel/helper-compilation-targets@7.17.7(@babel/core@7.17.8):
-    resolution: {integrity: sha512-UFzlz2jjd8kroj0hmCFV5zr+tQPi1dpC2cRsDV/3IEW8bJfCPrPpmcSN6ZS8RqIq4LXcmpipCQFPddyFA5Yc7w==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/compat-data': 7.21.0
-      '@babel/core': 7.17.8
-      '@babel/helper-validator-option': 7.21.0
-      browserslist: 4.19.3
-      semver: 6.3.0
-    dev: true
 
   /@babel/helper-compilation-targets@7.17.7(@babel/core@7.21.3):
     resolution: {integrity: sha512-UFzlz2jjd8kroj0hmCFV5zr+tQPi1dpC2cRsDV/3IEW8bJfCPrPpmcSN6ZS8RqIq4LXcmpipCQFPddyFA5Yc7w==}
@@ -4595,7 +4658,7 @@ packages:
       '@babel/core': 7.17.8
       '@babel/helper-validator-option': 7.21.0
       browserslist: 4.21.4
-      semver: 6.3.0
+      semver: 6.3.1
 
   /@babel/helper-compilation-targets@7.20.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==}
@@ -4605,11 +4668,10 @@ packages:
     dependencies:
       '@babel/compat-data': 7.21.0
       '@babel/core': 7.12.9
-      '@babel/helper-validator-option': 7.21.0
+      '@babel/helper-validator-option': 7.22.15
       browserslist: 4.21.4
       lru-cache: 5.1.1
-      semver: 6.3.0
-    dev: true
+      semver: 6.3.1
 
   /@babel/helper-compilation-targets@7.20.7(@babel/core@7.17.8):
     resolution: {integrity: sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==}
@@ -4623,6 +4685,7 @@ packages:
       browserslist: 4.21.4
       lru-cache: 5.1.1
       semver: 6.3.1
+    dev: true
 
   /@babel/helper-compilation-targets@7.20.7(@babel/core@7.21.3):
     resolution: {integrity: sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==}
@@ -4644,15 +4707,13 @@ packages:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.21.0
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-function-name': 7.22.5
       '@babel/helper-member-expression-to-functions': 7.21.0
-      '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/helper-replace-supers': 7.20.7
-      '@babel/helper-split-export-declaration': 7.18.6
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-optimise-call-expression': 7.22.5
+      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.12.9)
+      '@babel/helper-split-export-declaration': 7.22.6
     dev: true
 
   /@babel/helper-create-class-features-plugin@7.17.6(@babel/core@7.17.8):
@@ -4680,15 +4741,13 @@ packages:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.21.0
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-function-name': 7.22.5
       '@babel/helper-member-expression-to-functions': 7.21.0
-      '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/helper-replace-supers': 7.20.7
-      '@babel/helper-split-export-declaration': 7.18.6
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-optimise-call-expression': 7.22.5
+      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.21.3)
+      '@babel/helper-split-export-declaration': 7.22.6
 
   /@babel/helper-create-class-features-plugin@7.19.0(@babel/core@7.12.9):
     resolution: {integrity: sha512-NRz8DwF4jT3UfrmUoZjd0Uph9HQnP30t7Ash+weACcyNkiYTywpIjDBgReJMKgr+n86sn2nPVVmJ28Dm053Kqw==}
@@ -4697,16 +4756,13 @@ packages:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.21.0
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-function-name': 7.22.5
       '@babel/helper-member-expression-to-functions': 7.21.0
-      '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/helper-replace-supers': 7.20.7
-      '@babel/helper-split-export-declaration': 7.18.6
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
+      '@babel/helper-optimise-call-expression': 7.22.5
+      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.12.9)
+      '@babel/helper-split-export-declaration': 7.22.6
 
   /@babel/helper-create-class-features-plugin@7.19.0(@babel/core@7.17.8):
     resolution: {integrity: sha512-NRz8DwF4jT3UfrmUoZjd0Uph9HQnP30t7Ash+weACcyNkiYTywpIjDBgReJMKgr+n86sn2nPVVmJ28Dm053Kqw==}
@@ -4715,15 +4771,14 @@ packages:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.17.8
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.21.0
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-function-name': 7.22.5
       '@babel/helper-member-expression-to-functions': 7.21.0
-      '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/helper-replace-supers': 7.20.7
-      '@babel/helper-split-export-declaration': 7.18.6
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-optimise-call-expression': 7.22.5
+      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.17.8)
+      '@babel/helper-split-export-declaration': 7.22.6
+    dev: true
 
   /@babel/helper-create-class-features-plugin@7.19.0(@babel/core@7.21.3):
     resolution: {integrity: sha512-NRz8DwF4jT3UfrmUoZjd0Uph9HQnP30t7Ash+weACcyNkiYTywpIjDBgReJMKgr+n86sn2nPVVmJ28Dm053Kqw==}
@@ -4742,6 +4797,23 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@babel/helper-create-class-features-plugin@7.22.15(@babel/core@7.12.9):
+    resolution: {integrity: sha512-jKkwA59IXcvSaiK2UN45kKwSC9o+KuoXsBDvHvU/7BecYIp8GQ2UwrVvFgJASUT+hBnwJx6MhvMCuMzwZZ7jlg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.12.9
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-function-name': 7.22.5
+      '@babel/helper-member-expression-to-functions': 7.22.15
+      '@babel/helper-optimise-call-expression': 7.22.5
+      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.12.9)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      semver: 6.3.1
+
   /@babel/helper-create-class-features-plugin@7.22.15(@babel/core@7.17.8):
     resolution: {integrity: sha512-jKkwA59IXcvSaiK2UN45kKwSC9o+KuoXsBDvHvU/7BecYIp8GQ2UwrVvFgJASUT+hBnwJx6MhvMCuMzwZZ7jlg==}
     engines: {node: '>=6.9.0'}
@@ -4758,6 +4830,7 @@ packages:
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
       semver: 6.3.1
+    dev: true
 
   /@babel/helper-create-class-features-plugin@7.22.15(@babel/core@7.21.3):
     resolution: {integrity: sha512-jKkwA59IXcvSaiK2UN45kKwSC9o+KuoXsBDvHvU/7BecYIp8GQ2UwrVvFgJASUT+hBnwJx6MhvMCuMzwZZ7jlg==}
@@ -4785,7 +4858,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-annotate-as-pure': 7.18.6
       regexpu-core: 5.2.1
-    dev: true
 
   /@babel/helper-create-regexp-features-plugin@7.19.0(@babel/core@7.17.8):
     resolution: {integrity: sha512-htnV+mHX32DF81amCDrwIDr8nrp1PTm+3wfBN9/v8QJOLEioOCOG7qNyq0nHeFiWbT3Eb7gsPwEmV64UCQ1jzw==}
@@ -4796,6 +4868,7 @@ packages:
       '@babel/core': 7.17.8
       '@babel/helper-annotate-as-pure': 7.18.6
       regexpu-core: 5.2.1
+    dev: true
 
   /@babel/helper-create-regexp-features-plugin@7.19.0(@babel/core@7.21.3):
     resolution: {integrity: sha512-htnV+mHX32DF81amCDrwIDr8nrp1PTm+3wfBN9/v8QJOLEioOCOG7qNyq0nHeFiWbT3Eb7gsPwEmV64UCQ1jzw==}
@@ -4814,10 +4887,10 @@ packages:
     dependencies:
       '@babel/core': 7.21.3
       '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.21.3)
-      '@babel/helper-module-imports': 7.21.4
+      '@babel/helper-module-imports': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/traverse': 7.21.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       lodash.debounce: 4.0.8
       resolve: 1.22.1
       semver: 6.3.1
@@ -4833,13 +4906,12 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.12.9)
       '@babel/helper-plugin-utils': 7.21.5
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       lodash.debounce: 4.0.8
       resolve: 1.22.1
-      semver: 6.3.0
+      semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/helper-define-polyfill-provider@0.3.3(@babel/core@7.17.8):
     resolution: {integrity: sha512-z5aQKU4IzbqCC1XH0nAqfsFLMVSo22SBKUc0BxGrLkolTdPTructy0ToNnlO2zA4j9Q/7pjMZf0DSY+DSTYzww==}
@@ -4848,13 +4920,14 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.17.8)
-      '@babel/helper-plugin-utils': 7.21.5
-      debug: 4.3.4(supports-color@8.1.1)
+      '@babel/helper-plugin-utils': 7.22.5
+      debug: 4.3.4(supports-color@9.2.2)
       lodash.debounce: 4.0.8
       resolve: 1.22.1
-      semver: 6.3.0
+      semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/helper-define-polyfill-provider@0.3.3(@babel/core@7.21.3):
     resolution: {integrity: sha512-z5aQKU4IzbqCC1XH0nAqfsFLMVSo22SBKUc0BxGrLkolTdPTructy0ToNnlO2zA4j9Q/7pjMZf0DSY+DSTYzww==}
@@ -4863,11 +4936,11 @@ packages:
     dependencies:
       '@babel/core': 7.21.3
       '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.21.3)
-      '@babel/helper-plugin-utils': 7.21.5
-      debug: 4.3.4(supports-color@8.1.1)
+      '@babel/helper-plugin-utils': 7.22.5
+      debug: 4.3.4(supports-color@9.2.2)
       lodash.debounce: 4.0.8
       resolve: 1.22.1
-      semver: 6.3.0
+      semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
@@ -4883,21 +4956,21 @@ packages:
     resolution: {integrity: sha512-eyAYAsQmB80jNfg4baAtLeWAQHfHFiR483rzFK+BhETlGZaQC9bsfrugfXDCbRHLQbIA7U5NxhhOxN7p/dWIcg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.15
 
   /@babel/helper-function-name@7.19.0:
     resolution: {integrity: sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/template': 7.20.7
-      '@babel/types': 7.22.4
+      '@babel/template': 7.22.15
+      '@babel/types': 7.22.15
 
   /@babel/helper-function-name@7.21.0:
     resolution: {integrity: sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/template': 7.20.7
-      '@babel/types': 7.22.4
+      '@babel/template': 7.22.15
+      '@babel/types': 7.22.15
 
   /@babel/helper-function-name@7.22.5:
     resolution: {integrity: sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==}
@@ -4910,13 +4983,13 @@ packages:
     resolution: {integrity: sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.15
 
   /@babel/helper-member-expression-to-functions@7.21.0:
     resolution: {integrity: sha512-Muu8cdZwNN6mRRNG6lAYErJ5X3bRevgYR2O8wN0yn7jJSnGDu6eG59RfT29JHxGUovyfrh6Pj0XzmR7drNVL3Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.15
 
   /@babel/helper-member-expression-to-functions@7.22.15:
     resolution: {integrity: sha512-qLNsZbgrNh0fDQBCPocSL8guki1hcPvltGDv/NxvUoABwFq7GkKSu1nRXeJkVZc+wJvne2E0RKQz+2SQrz6eAA==}
@@ -4929,26 +5002,25 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.22.4
-    dev: true
 
   /@babel/helper-module-imports@7.16.7:
     resolution: {integrity: sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.15
     dev: true
 
   /@babel/helper-module-imports@7.18.6:
     resolution: {integrity: sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.15
 
   /@babel/helper-module-imports@7.21.4:
     resolution: {integrity: sha512-orajc5T2PsRYUN3ZryCEFeMDYwyw09c/pZeaQEZPH0MpKzSvn3e0uXsDBu3k03VI+9DBiRo+l22BfKTpKwa/Wg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.15
 
   /@babel/helper-module-imports@7.22.15:
     resolution: {integrity: sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==}
@@ -4980,9 +5052,9 @@ packages:
       '@babel/helper-simple-access': 7.20.2
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/helper-validator-identifier': 7.19.1
-      '@babel/template': 7.20.7
+      '@babel/template': 7.22.15
       '@babel/traverse': 7.21.3
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.15
     transitivePeerDependencies:
       - supports-color
 
@@ -4995,11 +5067,24 @@ packages:
       '@babel/helper-simple-access': 7.20.2
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/helper-validator-identifier': 7.19.1
-      '@babel/template': 7.20.7
+      '@babel/template': 7.22.15
       '@babel/traverse': 7.21.3
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.15
     transitivePeerDependencies:
       - supports-color
+
+  /@babel/helper-module-transforms@7.22.15(@babel/core@7.12.9):
+    resolution: {integrity: sha512-l1UiX4UyHSFsYt17iQ3Se5pQQZZHa22zyIXURmvkmLCD4t/aU+dvNWHatKac/D9Vm9UES7nvIqHs4jZqKviUmQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.12.9
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-module-imports': 7.22.15
+      '@babel/helper-simple-access': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/helper-validator-identifier': 7.22.15
 
   /@babel/helper-module-transforms@7.22.15(@babel/core@7.17.8):
     resolution: {integrity: sha512-l1UiX4UyHSFsYt17iQ3Se5pQQZZHa22zyIXURmvkmLCD4t/aU+dvNWHatKac/D9Vm9UES7nvIqHs4jZqKviUmQ==}
@@ -5013,6 +5098,7 @@ packages:
       '@babel/helper-simple-access': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/helper-validator-identifier': 7.22.15
+    dev: true
 
   /@babel/helper-module-transforms@7.22.15(@babel/core@7.21.3):
     resolution: {integrity: sha512-l1UiX4UyHSFsYt17iQ3Se5pQQZZHa22zyIXURmvkmLCD4t/aU+dvNWHatKac/D9Vm9UES7nvIqHs4jZqKviUmQ==}
@@ -5031,7 +5117,7 @@ packages:
     resolution: {integrity: sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.15
 
   /@babel/helper-optimise-call-expression@7.22.5:
     resolution: {integrity: sha512-HBwaojN0xFRx4yIvpwGqxiV2tUfl7401jlok564NgB9EHS1y6QT17FmKWm4ztqjeVdXLuC4fSvHc5ePpQjoTbw==}
@@ -5046,11 +5132,11 @@ packages:
   /@babel/helper-plugin-utils@7.14.5:
     resolution: {integrity: sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
   /@babel/helper-plugin-utils@7.18.9:
     resolution: {integrity: sha512-aBXPT3bmtLryXaoJLyYPXPlSD4p1ld9aYeR+sJNOZjJJGiOpb+fKfh3NkcCu7J54nUJwCERPBExCCpyCOHnu/w==}
     engines: {node: '>=6.9.0'}
+    dev: true
 
   /@babel/helper-plugin-utils@7.20.2:
     resolution: {integrity: sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==}
@@ -5073,7 +5159,6 @@ packages:
       '@babel/types': 7.22.4
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/helper-remap-async-to-generator@7.16.8:
     resolution: {integrity: sha512-fm0gH7Flb8H51LqJHy3HJ3wnE1+qtYR2A99K06ahwrawLdOFsCEWjZOrYricXJHoPSudNKxrMBUPEIPxiIIvBw==}
@@ -5081,7 +5166,7 @@ packages:
     dependencies:
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-wrap-function': 7.19.0
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.15
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5096,10 +5181,9 @@ packages:
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-wrap-function': 7.19.0
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.15
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/helper-remap-async-to-generator@7.18.9(@babel/core@7.17.8):
     resolution: {integrity: sha512-dI7q50YKd8BAv3VEfgg7PS7yD3Rtbi2J1XMXaalXO0W0164hYLnh8zpjRS0mte9MfVp/tltvr/cfdXPvJr1opA==}
@@ -5111,9 +5195,10 @@ packages:
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-wrap-function': 7.19.0
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.15
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/helper-remap-async-to-generator@7.18.9(@babel/core@7.21.3):
     resolution: {integrity: sha512-dI7q50YKd8BAv3VEfgg7PS7yD3Rtbi2J1XMXaalXO0W0164hYLnh8zpjRS0mte9MfVp/tltvr/cfdXPvJr1opA==}
@@ -5125,7 +5210,7 @@ packages:
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-wrap-function': 7.19.0
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.15
     transitivePeerDependencies:
       - supports-color
 
@@ -5137,23 +5222,33 @@ packages:
       '@babel/helper-member-expression-to-functions': 7.21.0
       '@babel/helper-optimise-call-expression': 7.18.6
       '@babel/traverse': 7.21.3
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.15
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/helper-replace-supers@7.20.7:
     resolution: {integrity: sha512-vujDMtB6LVfNW13jhlCrp48QNslK6JXi7lQG736HVbHz/mbf4Dc7tIRh1Xf5C0rF7BP8iiSxGMCmY6Ci1ven3A==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-environment-visitor': 7.22.5
       '@babel/helper-member-expression-to-functions': 7.21.0
-      '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/template': 7.20.7
+      '@babel/helper-optimise-call-expression': 7.22.5
+      '@babel/template': 7.22.15
       '@babel/traverse': 7.21.3
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.15
     transitivePeerDependencies:
       - supports-color
+
+  /@babel/helper-replace-supers@7.22.9(@babel/core@7.12.9):
+    resolution: {integrity: sha512-LJIKvvpgPOPUThdYqcX6IXRuIcTkcAub0IaDRGCZH0p5GPUp7PhRU9QVgFcDDd51BaPkk77ZjqFwh6DZTAEmGg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.12.9
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-member-expression-to-functions': 7.22.15
+      '@babel/helper-optimise-call-expression': 7.22.5
 
   /@babel/helper-replace-supers@7.22.9(@babel/core@7.17.8):
     resolution: {integrity: sha512-LJIKvvpgPOPUThdYqcX6IXRuIcTkcAub0IaDRGCZH0p5GPUp7PhRU9QVgFcDDd51BaPkk77ZjqFwh6DZTAEmGg==}
@@ -5165,6 +5260,7 @@ packages:
       '@babel/helper-environment-visitor': 7.22.5
       '@babel/helper-member-expression-to-functions': 7.22.15
       '@babel/helper-optimise-call-expression': 7.22.5
+    dev: true
 
   /@babel/helper-replace-supers@7.22.9(@babel/core@7.21.3):
     resolution: {integrity: sha512-LJIKvvpgPOPUThdYqcX6IXRuIcTkcAub0IaDRGCZH0p5GPUp7PhRU9QVgFcDDd51BaPkk77ZjqFwh6DZTAEmGg==}
@@ -5181,13 +5277,13 @@ packages:
     resolution: {integrity: sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.15
 
   /@babel/helper-simple-access@7.20.2:
     resolution: {integrity: sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.15
 
   /@babel/helper-simple-access@7.22.5:
     resolution: {integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==}
@@ -5199,7 +5295,7 @@ packages:
     resolution: {integrity: sha512-imytd2gHi3cJPsybLRbmFrF7u5BIEuI2cNheyKi3/iOBC63kNn3q8Crn2xVuESli0aM4KYsyEqKyS7lFL8YVtw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.15
 
   /@babel/helper-skip-transparent-expression-wrappers@7.22.5:
     resolution: {integrity: sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==}
@@ -5211,7 +5307,7 @@ packages:
     resolution: {integrity: sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.15
 
   /@babel/helper-split-export-declaration@7.22.6:
     resolution: {integrity: sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==}
@@ -5242,7 +5338,6 @@ packages:
   /@babel/helper-validator-option@7.14.5:
     resolution: {integrity: sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
   /@babel/helper-validator-option@7.16.7:
     resolution: {integrity: sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==}
@@ -5266,9 +5361,9 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-function-name': 7.21.0
-      '@babel/template': 7.20.7
+      '@babel/template': 7.22.15
       '@babel/traverse': 7.21.3
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.15
     transitivePeerDependencies:
       - supports-color
 
@@ -5286,9 +5381,9 @@ packages:
     resolution: {integrity: sha512-XXve0CBtOW0pd7MRzzmoyuSj0e3SEzj8pgyFxnTT1NJZL38BD1MK7yYrm8yefRPIDvNNe14xR4FdbHwpInD4rA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/template': 7.20.7
+      '@babel/template': 7.22.15
       '@babel/traverse': 7.21.3
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.15
     transitivePeerDependencies:
       - supports-color
 
@@ -5320,14 +5415,14 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.15
 
   /@babel/parser@7.21.3:
     resolution: {integrity: sha512-lobG0d7aOfQRXh8AyklEAgZGvA4FShxo6xQbUrrT/cNBPUdIDojlokwJsQyCC/eKia7ifqM0yP+2DRZ4WKw2RQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.15
 
   /@babel/parser@7.22.15:
     resolution: {integrity: sha512-RWmQ/sklUN9BvGGpCDgSubhHWfAx24XDTDObup4ffvxaYsptOg2P3KG0j+1eWKLxpkX0j0uHxmpq2Z1SP/VhxA==}
@@ -5402,7 +5497,7 @@ packages:
       '@babel/core': ^7.13.0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.18.9
       '@babel/plugin-proposal-optional-chaining': 7.18.9(@babel/core@7.12.9)
     dev: true
@@ -5414,7 +5509,7 @@ packages:
       '@babel/core': ^7.13.0
     dependencies:
       '@babel/core': 7.17.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.18.9
       '@babel/plugin-proposal-optional-chaining': 7.18.9(@babel/core@7.17.8)
     dev: true
@@ -5450,8 +5545,8 @@ packages:
       '@babel/core': ^7.13.0
     dependencies:
       '@babel/core': 7.17.8
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/helper-skip-transparent-expression-wrappers': 7.18.9
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/plugin-proposal-optional-chaining': 7.18.9(@babel/core@7.17.8)
     dev: true
 
@@ -5462,8 +5557,8 @@ packages:
       '@babel/core': ^7.13.0
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/helper-skip-transparent-expression-wrappers': 7.18.9
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/plugin-proposal-optional-chaining': 7.18.9(@babel/core@7.21.3)
 
   /@babel/plugin-proposal-async-generator-functions@7.16.4(@babel/core@7.12.9):
@@ -5478,7 +5573,6 @@ packages:
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.12.9)
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/plugin-proposal-async-generator-functions@7.16.8(@babel/core@7.12.9):
     resolution: {integrity: sha512-71YHIvMuiuqWJQkebWJtdhQTfd4Q4mF76q2IX37uZPkG9+olBxsX+rH1vkhFto4UeJZ9dPY2s+mDvhDm1u2BGQ==}
@@ -5487,7 +5581,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.12.9)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.12.9)
     transitivePeerDependencies:
@@ -5501,7 +5595,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.17.8)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.17.8)
     transitivePeerDependencies:
@@ -5535,7 +5629,6 @@ packages:
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.12.9)
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/plugin-proposal-async-generator-functions@7.20.7(@babel/core@7.17.8):
     resolution: {integrity: sha512-xMbiLsn/8RK7Wq7VeVytytS2L6qE69bXPB10YCmMdDZbKF4okCqY74pI/jJQ/8U0b/F6NrT2+14b8/P9/3AMGA==}
@@ -5550,6 +5643,7 @@ packages:
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.17.8)
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/plugin-proposal-async-generator-functions@7.20.7(@babel/core@7.21.3):
     resolution: {integrity: sha512-xMbiLsn/8RK7Wq7VeVytytS2L6qE69bXPB10YCmMdDZbKF4okCqY74pI/jJQ/8U0b/F6NrT2+14b8/P9/3AMGA==}
@@ -5574,9 +5668,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-create-class-features-plugin': 7.19.0(@babel/core@7.12.9)
       '@babel/helper-plugin-utils': 7.20.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /@babel/plugin-proposal-class-properties@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-IobU0Xme31ewjYOShSIqd/ZGM/r/cuOz2z0MDbNrhF5FW+ZVgi0f2lyeoj9KFPDOAqsYxmLWZte1WOwlvY9aww==}
@@ -5586,9 +5677,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-create-class-features-plugin': 7.17.6(@babel/core@7.12.9)
-      '@babel/helper-plugin-utils': 7.18.9
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
   /@babel/plugin-proposal-class-properties@7.16.7(@babel/core@7.17.8):
@@ -5612,9 +5701,7 @@ packages:
     dependencies:
       '@babel/core': 7.21.3
       '@babel/helper-create-class-features-plugin': 7.17.6(@babel/core@7.21.3)
-      '@babel/helper-plugin-utils': 7.18.9
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.12.9):
     resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
@@ -5624,10 +5711,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-create-class-features-plugin': 7.19.0(@babel/core@7.12.9)
-      '@babel/helper-plugin-utils': 7.20.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.17.8):
     resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
@@ -5637,9 +5721,8 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-create-class-features-plugin': 7.19.0(@babel/core@7.17.8)
-      '@babel/helper-plugin-utils': 7.20.2
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.21.3):
     resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
@@ -5663,8 +5746,6 @@ packages:
       '@babel/helper-create-class-features-plugin': 7.19.0(@babel/core@7.12.9)
       '@babel/helper-plugin-utils': 7.21.5
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.12.9)
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@babel/plugin-proposal-class-static-block@7.17.6(@babel/core@7.17.8):
@@ -5677,8 +5758,6 @@ packages:
       '@babel/helper-create-class-features-plugin': 7.19.0(@babel/core@7.17.8)
       '@babel/helper-plugin-utils': 7.21.5
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.17.8)
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@babel/plugin-proposal-class-static-block@7.17.6(@babel/core@7.21.3):
@@ -5705,8 +5784,6 @@ packages:
       '@babel/helper-create-class-features-plugin': 7.19.0(@babel/core@7.12.9)
       '@babel/helper-plugin-utils': 7.21.5
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.12.9)
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@babel/plugin-proposal-class-static-block@7.18.6(@babel/core@7.17.8):
@@ -5719,8 +5796,6 @@ packages:
       '@babel/helper-create-class-features-plugin': 7.19.0(@babel/core@7.17.8)
       '@babel/helper-plugin-utils': 7.21.5
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.17.8)
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@babel/plugin-proposal-class-static-block@7.18.6(@babel/core@7.21.3):
@@ -5733,8 +5808,6 @@ packages:
       '@babel/helper-create-class-features-plugin': 7.19.0(@babel/core@7.21.3)
       '@babel/helper-plugin-utils': 7.21.5
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.21.3)
-    transitivePeerDependencies:
-      - supports-color
 
   /@babel/plugin-proposal-decorators@7.16.4(@babel/core@7.21.3):
     resolution: {integrity: sha512-RESBNX16eNqnBeEVR5sCJpnW0mHiNLNNvGA8PrRuK/4ZJ4TO+6bHleRUuGQYDERVySOKtOhSya/C4MIhwAMAgg==}
@@ -5744,10 +5817,8 @@ packages:
     dependencies:
       '@babel/core': 7.21.3
       '@babel/helper-create-class-features-plugin': 7.19.0(@babel/core@7.21.3)
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-decorators': 7.16.0(@babel/core@7.21.3)
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@babel/plugin-proposal-dynamic-import@7.16.0(@babel/core@7.12.9):
@@ -5759,7 +5830,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.12.9)
-    dev: true
 
   /@babel/plugin-proposal-dynamic-import@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-I8SW9Ho3/8DRSdmDdH3gORdyUuYnk1m4cMxUAdu5oy4n3OfN8flDEH+d60iG7dUfi0KkYwSvoalHzzdRzpWHTg==}
@@ -5826,15 +5896,15 @@ packages:
       '@babel/helper-plugin-utils': 7.21.5
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.21.3)
 
-  /@babel/plugin-proposal-export-default-from@7.16.7(@babel/core@7.17.8):
+  /@babel/plugin-proposal-export-default-from@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-+cENpW1rgIjExn+o5c8Jw/4BuH4eGKKYvkMB8/0ZxFQ9mC0t4z09VsPIwNg6waF69QYC81zxGeAsREGuqQoKeg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.17.8
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/plugin-syntax-export-default-from': 7.16.7(@babel/core@7.17.8)
+      '@babel/core': 7.12.9
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-export-default-from': 7.16.7(@babel/core@7.12.9)
 
   /@babel/plugin-proposal-export-default-from@7.16.7(@babel/core@7.21.3):
     resolution: {integrity: sha512-+cENpW1rgIjExn+o5c8Jw/4BuH4eGKKYvkMB8/0ZxFQ9mC0t4z09VsPIwNg6waF69QYC81zxGeAsREGuqQoKeg==}
@@ -5843,7 +5913,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-export-default-from': 7.16.7(@babel/core@7.21.3)
 
   /@babel/plugin-proposal-export-namespace-from@7.16.0(@babel/core@7.12.9):
@@ -5855,7 +5925,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.12.9)
-    dev: true
 
   /@babel/plugin-proposal-export-namespace-from@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-ZxdtqDXLRGBL64ocZcs7ovt71L3jhC1RGSyR996svrCi3PYqHNkb3SwPJCs8RIzD86s+WPpt2S73+EHCGO+NUA==}
@@ -5931,7 +6000,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.12.9)
-    dev: true
 
   /@babel/plugin-proposal-json-strings@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-lNZ3EEggsGY78JavgbHsK9u5P3pQaW7k4axlgFLYkMd7UBsiNahCITShLjNQschPyjtO6dADrL24757IdhBrsQ==}
@@ -6007,7 +6075,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.12.9)
-    dev: true
 
   /@babel/plugin-proposal-logical-assignment-operators@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-K3XzyZJGQCr00+EtYtrDjmwX7o7PLK6U9bi1nCwkQioRFVUv6dJoxbQjtWVtP+bCPy82bONBKG8NPyQ4+i6yjg==}
@@ -6083,7 +6150,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.12.9)
-    dev: true
 
   /@babel/plugin-proposal-nullish-coalescing-operator@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-aUOrYU3EVtjf62jQrCj63pYZ7k6vns2h/DQvHPWGmsJRYzWXZ6/AsfgpiRy6XiuIDADhJzP2Q9MwSMKauBQ+UQ==}
@@ -6126,7 +6192,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.21.5
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.12.9)
-    dev: true
 
   /@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.17.8):
     resolution: {integrity: sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==}
@@ -6135,8 +6200,9 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.17.8)
+    dev: true
 
   /@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.21.3):
     resolution: {integrity: sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==}
@@ -6145,7 +6211,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.21.3)
 
   /@babel/plugin-proposal-numeric-separator@7.16.0(@babel/core@7.12.9):
@@ -6157,7 +6223,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.12.9)
-    dev: true
 
   /@babel/plugin-proposal-numeric-separator@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-vQgPMknOIgiuVqbokToyXbkY/OmmjAzr/0lhSIbG/KmnzXPGwW/AdhdKpi+O4X/VkWiWjnkKOBiqJrTaC98VKw==}
@@ -6248,7 +6313,6 @@ packages:
       '@babel/helper-plugin-utils': 7.14.5
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.12.9)
       '@babel/plugin-transform-parameters': 7.16.3(@babel/core@7.12.9)
-    dev: true
 
   /@babel/plugin-proposal-object-rest-spread@7.17.3(@babel/core@7.12.9):
     resolution: {integrity: sha512-yuL5iQA/TbZn+RGAfxQXfi7CNLmKi1f8zInn4IgobuCWcAb7i+zj4TYzQ9l8cEzVyJ89PDGuqxK1xZpUDISesw==}
@@ -6304,7 +6368,6 @@ packages:
       '@babel/helper-plugin-utils': 7.21.5
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.12.9)
       '@babel/plugin-transform-parameters': 7.21.3(@babel/core@7.12.9)
-    dev: true
 
   /@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.17.8):
     resolution: {integrity: sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==}
@@ -6315,9 +6378,10 @@ packages:
       '@babel/compat-data': 7.21.0
       '@babel/core': 7.17.8
       '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.17.8)
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.17.8)
       '@babel/plugin-transform-parameters': 7.21.3(@babel/core@7.17.8)
+    dev: true
 
   /@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.21.3):
     resolution: {integrity: sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==}
@@ -6328,7 +6392,7 @@ packages:
       '@babel/compat-data': 7.21.0
       '@babel/core': 7.21.3
       '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.21.3)
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.21.3)
       '@babel/plugin-transform-parameters': 7.21.3(@babel/core@7.21.3)
 
@@ -6341,7 +6405,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.12.9)
-    dev: true
 
   /@babel/plugin-proposal-optional-catch-binding@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-eMOH/L4OvWSZAE1VkHbr1vckLG1WUcHGJSLqqQwl2GaUqG6QjddvrOaTUMNYiv77H5IKPMZ9U9P7EaHwvAShfA==}
@@ -6385,7 +6448,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.21.5
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.12.9)
-    dev: true
 
   /@babel/plugin-proposal-optional-catch-binding@7.18.6(@babel/core@7.17.8):
     resolution: {integrity: sha512-Q40HEhs9DJQyaZfUjjn6vE8Cv4GmMHCYuMGIWUnlxH6400VGxOuwWsPt4FxXxJkC/5eOzgn0z21M9gMT4MOhbw==}
@@ -6396,6 +6458,7 @@ packages:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.21.5
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.17.8)
+    dev: true
 
   /@babel/plugin-proposal-optional-catch-binding@7.18.6(@babel/core@7.21.3):
     resolution: {integrity: sha512-Q40HEhs9DJQyaZfUjjn6vE8Cv4GmMHCYuMGIWUnlxH6400VGxOuwWsPt4FxXxJkC/5eOzgn0z21M9gMT4MOhbw==}
@@ -6417,7 +6480,6 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-skip-transparent-expression-wrappers': 7.18.9
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.12.9)
-    dev: true
 
   /@babel/plugin-proposal-optional-chaining@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-eC3xy+ZrUcBtP7x+sq62Q/HYd674pPTb/77XZMb5wbDPGWIdUbSr4Agr052+zaUPSb+gGRnjxXfKFvx5iMJ+DA==}
@@ -6426,7 +6488,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.18.9
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.12.9)
     dev: true
@@ -6438,7 +6500,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.18.9
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.17.8)
     dev: true
@@ -6461,10 +6523,9 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.18.9
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.12.9)
-    dev: true
 
   /@babel/plugin-proposal-optional-chaining@7.18.9(@babel/core@7.17.8):
     resolution: {integrity: sha512-v5nwt4IqBXihxGsW2QmCWMDS3B3bzGIk/EQVZz2ei7f3NJl8NzAJVvUmpDW5q1CRNY+Beb/k58UAH1Km1N411w==}
@@ -6473,9 +6534,10 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.18.9
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.17.8)
+    dev: true
 
   /@babel/plugin-proposal-optional-chaining@7.18.9(@babel/core@7.21.3):
     resolution: {integrity: sha512-v5nwt4IqBXihxGsW2QmCWMDS3B3bzGIk/EQVZz2ei7f3NJl8NzAJVvUmpDW5q1CRNY+Beb/k58UAH1Km1N411w==}
@@ -6484,7 +6546,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.18.9
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.21.3)
 
@@ -6497,9 +6559,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-create-class-features-plugin': 7.19.0(@babel/core@7.12.9)
       '@babel/helper-plugin-utils': 7.20.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /@babel/plugin-proposal-private-methods@7.16.11(@babel/core@7.12.9):
     resolution: {integrity: sha512-F/2uAkPlXDr8+BHpZvo19w3hLFKge+k75XUprE6jaqKxjGkSYcK+4c+bup5PdW/7W/Rpjwql7FTVEDW+fRAQsw==}
@@ -6510,8 +6569,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-create-class-features-plugin': 7.17.6(@babel/core@7.12.9)
       '@babel/helper-plugin-utils': 7.18.9
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@babel/plugin-proposal-private-methods@7.16.11(@babel/core@7.17.8):
@@ -6536,8 +6593,6 @@ packages:
       '@babel/core': 7.21.3
       '@babel/helper-create-class-features-plugin': 7.17.6(@babel/core@7.21.3)
       '@babel/helper-plugin-utils': 7.18.9
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.12.9):
@@ -6549,8 +6604,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-create-class-features-plugin': 7.19.0(@babel/core@7.12.9)
       '@babel/helper-plugin-utils': 7.21.5
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.17.8):
@@ -6561,9 +6614,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-create-class-features-plugin': 7.19.0(@babel/core@7.17.8)
-      '@babel/helper-plugin-utils': 7.21.5
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
   /@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.21.3):
@@ -6574,9 +6625,7 @@ packages:
     dependencies:
       '@babel/core': 7.21.3
       '@babel/helper-create-class-features-plugin': 7.19.0(@babel/core@7.21.3)
-      '@babel/helper-plugin-utils': 7.21.5
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-proposal-private-property-in-object@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-rMQkjcOFbm+ufe3bTZLyOfsOUOxyvLXZJCTARhJr+8UMSoZmqTe1K1BgkFcrW37rAchWg57yI69ORxiWvUINuQ==}
@@ -6587,10 +6636,8 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-annotate-as-pure': 7.16.7
       '@babel/helper-create-class-features-plugin': 7.17.6(@babel/core@7.12.9)
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.12.9)
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@babel/plugin-proposal-private-property-in-object@7.16.7(@babel/core@7.17.8):
@@ -6617,10 +6664,8 @@ packages:
       '@babel/core': 7.21.3
       '@babel/helper-annotate-as-pure': 7.16.7
       '@babel/helper-create-class-features-plugin': 7.17.6(@babel/core@7.21.3)
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.21.3)
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@babel/plugin-proposal-private-property-in-object@7.18.6(@babel/core@7.12.9):
@@ -6634,8 +6679,6 @@ packages:
       '@babel/helper-create-class-features-plugin': 7.19.0(@babel/core@7.12.9)
       '@babel/helper-plugin-utils': 7.21.5
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.12.9)
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@babel/plugin-proposal-private-property-in-object@7.18.6(@babel/core@7.17.8):
@@ -6645,12 +6688,10 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.8
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-create-class-features-plugin': 7.19.0(@babel/core@7.17.8)
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.17.8)
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.17.8)
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@babel/plugin-proposal-private-property-in-object@7.18.6(@babel/core@7.21.3):
@@ -6660,12 +6701,10 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-create-class-features-plugin': 7.19.0(@babel/core@7.21.3)
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.21.3)
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.21.3)
-    transitivePeerDependencies:
-      - supports-color
 
   /@babel/plugin-proposal-unicode-property-regex@7.16.0(@babel/core@7.12.9):
     resolution: {integrity: sha512-ti7IdM54NXv29cA4+bNNKEMS4jLMCbJgl+Drv+FgYy0erJLAxNAIXcNjNjrRZEcWq0xJHsNVwQezskMFpF8N9g==}
@@ -6676,7 +6715,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-create-regexp-features-plugin': 7.19.0(@babel/core@7.12.9)
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-proposal-unicode-property-regex@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-QRK0YI/40VLhNVGIjRNAAQkEHws0cswSdFFjpFyt943YmJIU1da9uW63Iu6NFV6CxTZW5eTDCrwZUstBWgp/Rg==}
@@ -6720,7 +6758,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-create-regexp-features-plugin': 7.19.0(@babel/core@7.12.9)
       '@babel/helper-plugin-utils': 7.21.5
-    dev: true
 
   /@babel/plugin-proposal-unicode-property-regex@7.18.6(@babel/core@7.17.8):
     resolution: {integrity: sha512-2BShG/d5yoZyXZfVePH91urL5wTG6ASZU9M4o03lKK8u8UW1y08OMttBSOADTcJrnPMpvDXRG3G8fyLh4ovs8w==}
@@ -6758,6 +6795,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.21.5
+    dev: true
 
   /@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.21.3):
     resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
@@ -6808,6 +6846,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.20.2
+    dev: true
 
   /@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.21.3):
     resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
@@ -6862,8 +6901,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.21.5
-    dev: true
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.17.8):
     resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
@@ -6871,7 +6909,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.21.3):
     resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
@@ -6879,15 +6918,15 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-syntax-export-default-from@7.16.7(@babel/core@7.17.8):
+  /@babel/plugin-syntax-export-default-from@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-4C3E4NsrLOgftKaTYTULhHsuQrGv3FHrBzOMDiS7UYKIpgGBkAdawg4h+EI8zPeK9M0fiIIh72hIwsI24K7MbA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.17.8
+      '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-export-default-from@7.16.7(@babel/core@7.21.3):
@@ -6906,7 +6945,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.21.5
-    dev: true
 
   /@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.17.8):
     resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==}
@@ -6925,6 +6963,15 @@ packages:
       '@babel/core': 7.21.3
       '@babel/helper-plugin-utils': 7.21.5
 
+  /@babel/plugin-syntax-flow@7.16.7(@babel/core@7.12.9):
+    resolution: {integrity: sha512-UDo3YGQO0jH6ytzVwgSLv9i/CzMcUjbKenL67dTrAZPPv6GFAtDhe6jqnvmoKzC/7htNTohhos+onPtDMqJwaQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.12.9
+      '@babel/helper-plugin-utils': 7.22.5
+
   /@babel/plugin-syntax-flow@7.16.7(@babel/core@7.17.8):
     resolution: {integrity: sha512-UDo3YGQO0jH6ytzVwgSLv9i/CzMcUjbKenL67dTrAZPPv6GFAtDhe6jqnvmoKzC/7htNTohhos+onPtDMqJwaQ==}
     engines: {node: '>=6.9.0'}
@@ -6933,6 +6980,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-flow@7.16.7(@babel/core@7.21.3):
     resolution: {integrity: sha512-UDo3YGQO0jH6ytzVwgSLv9i/CzMcUjbKenL67dTrAZPPv6GFAtDhe6jqnvmoKzC/7htNTohhos+onPtDMqJwaQ==}
@@ -7062,6 +7110,15 @@ packages:
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
+  /@babel/plugin-syntax-jsx@7.21.4(@babel/core@7.12.9):
+    resolution: {integrity: sha512-5hewiLct5OKyh6PLKEYaFclcqtIgCb6bmELouxjF6up5q3Sov7rOayW4RwhbaBL0dit8rA80GNfY+UuDp2mBbQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.12.9
+      '@babel/helper-plugin-utils': 7.22.5
+
   /@babel/plugin-syntax-jsx@7.21.4(@babel/core@7.17.8):
     resolution: {integrity: sha512-5hewiLct5OKyh6PLKEYaFclcqtIgCb6bmELouxjF6up5q3Sov7rOayW4RwhbaBL0dit8rA80GNfY+UuDp2mBbQ==}
     engines: {node: '>=6.9.0'}
@@ -7069,7 +7126,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-jsx@7.21.4(@babel/core@7.21.3):
     resolution: {integrity: sha512-5hewiLct5OKyh6PLKEYaFclcqtIgCb6bmELouxjF6up5q3Sov7rOayW4RwhbaBL0dit8rA80GNfY+UuDp2mBbQ==}
@@ -7079,6 +7137,15 @@ packages:
     dependencies:
       '@babel/core': 7.21.3
       '@babel/helper-plugin-utils': 7.21.5
+
+  /@babel/plugin-syntax-jsx@7.22.5(@babel/core@7.12.9):
+    resolution: {integrity: sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.12.9
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-jsx@7.22.5(@babel/core@7.17.8):
     resolution: {integrity: sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==}
@@ -7138,6 +7205,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.21.5
+    dev: true
 
   /@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.21.3):
     resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
@@ -7187,6 +7255,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.21.5
+    dev: true
 
   /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.21.3):
     resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
@@ -7211,6 +7280,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.21.5
+    dev: true
 
   /@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.21.3):
     resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
@@ -7235,6 +7305,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.21.5
+    dev: true
 
   /@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.21.3):
     resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
@@ -7329,13 +7400,13 @@ packages:
       '@babel/core': 7.21.3
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-syntax-typescript@7.22.5(@babel/core@7.17.8):
+  /@babel/plugin-syntax-typescript@7.22.5(@babel/core@7.12.9):
     resolution: {integrity: sha512-1mS2o03i7t1c6VzH6fdQ3OA8tcEIxwG18zIPRp+UY1Ihv6W+XZzBCVxExF9upussPXJ0xE9XRHwMoNs1ep/nRQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.17.8
+      '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-typescript@7.22.5(@babel/core@7.21.3):
@@ -7355,7 +7426,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-arrow-functions@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-9ffkFFMbvzTvv+7dTp/66xvZAWASuPD5Tl9LK3Z9vhOmANo6j94rik+5YMBt4CwHVMWLWpMsriIc2zsa3WW3xQ==}
@@ -7395,7 +7465,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.21.5
-    dev: true
 
   /@babel/plugin-transform-arrow-functions@7.18.6(@babel/core@7.17.8):
     resolution: {integrity: sha512-9S9X9RUefzrsHZmKMbDXxweEH+YlE8JJEuat9FdvW9Qh1cw7W64jELCtWNkPBPX5En45uy28KGvA/AySqUh8CQ==}
@@ -7404,7 +7473,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-transform-arrow-functions@7.18.6(@babel/core@7.21.3):
     resolution: {integrity: sha512-9S9X9RUefzrsHZmKMbDXxweEH+YlE8JJEuat9FdvW9Qh1cw7W64jELCtWNkPBPX5En45uy28KGvA/AySqUh8CQ==}
@@ -7413,7 +7483,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-async-to-generator@7.16.0(@babel/core@7.12.9):
     resolution: {integrity: sha512-PbIr7G9kR8tdH6g8Wouir5uVjklETk91GMVSUq+VaOgiinbCkBP6Q7NN/suM/QutZkMJMvcyAriogcYAdhg8Gw==}
@@ -7427,7 +7497,6 @@ packages:
       '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.12.9)
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/plugin-transform-async-to-generator@7.16.8(@babel/core@7.12.9):
     resolution: {integrity: sha512-MtmUmTJQHCnyJVrScNzNlofQJ3dLFuobYn3mwOTKHnSCMtbNsqvF71GQmJfFjdrXSsAA7iysFmYWw4bXZ20hOg==}
@@ -7436,8 +7505,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-module-imports': 7.16.7
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-module-imports': 7.22.15
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-remap-async-to-generator': 7.16.8
     transitivePeerDependencies:
       - supports-color
@@ -7464,8 +7533,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-module-imports': 7.16.7
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-module-imports': 7.22.15
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-remap-async-to-generator': 7.16.8
     transitivePeerDependencies:
       - supports-color
@@ -7483,7 +7552,6 @@ packages:
       '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.12.9)
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/plugin-transform-async-to-generator@7.18.6(@babel/core@7.17.8):
     resolution: {integrity: sha512-ARE5wZLKnTgPW7/1ftQmSi1CmkqqHo2DNmtztFhvgtOWSDfq0Cq9/9L+KnZNYSNrydBekhW3rwShduf59RoXag==}
@@ -7497,6 +7565,7 @@ packages:
       '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.17.8)
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/plugin-transform-async-to-generator@7.18.6(@babel/core@7.21.3):
     resolution: {integrity: sha512-ARE5wZLKnTgPW7/1ftQmSi1CmkqqHo2DNmtztFhvgtOWSDfq0Cq9/9L+KnZNYSNrydBekhW3rwShduf59RoXag==}
@@ -7519,7 +7588,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-block-scoped-functions@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-JUuzlzmF40Z9cXyytcbZEZKckgrQzChbQJw/5PuEHYeqzCsvebDx0K0jWnIIVcmmDOAVctCgnYs0pMcrYj2zJg==}
@@ -7559,7 +7627,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.21.5
-    dev: true
 
   /@babel/plugin-transform-block-scoped-functions@7.18.6(@babel/core@7.17.8):
     resolution: {integrity: sha512-ExUcOqpPWnliRcPqves5HJcJOvHvIIWfuS4sroBUenPuMdmW+SMHDakmtS7qOo13sVppmUijqeTv7qqGsvURpQ==}
@@ -7569,6 +7636,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.21.5
+    dev: true
 
   /@babel/plugin-transform-block-scoped-functions@7.18.6(@babel/core@7.21.3):
     resolution: {integrity: sha512-ExUcOqpPWnliRcPqves5HJcJOvHvIIWfuS4sroBUenPuMdmW+SMHDakmtS7qOo13sVppmUijqeTv7qqGsvURpQ==}
@@ -7587,7 +7655,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-block-scoping@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-ObZev2nxVAYA4bhyusELdo9hb3H+A56bxH3FZMbEImZFiEDYVHXQSJ1hQKFlDnlt8G9bBrCZ5ZpURZUrV4G5qQ==}
@@ -7627,7 +7694,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.21.5
-    dev: true
 
   /@babel/plugin-transform-block-scoping@7.21.0(@babel/core@7.17.8):
     resolution: {integrity: sha512-Mdrbunoh9SxwFZapeHVrwFmri16+oYotcZysSzhNIVDwIAb1UV+kvnxULSYq9J3/q5MDG+4X6w8QVgD1zhBXNQ==}
@@ -7636,7 +7702,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-transform-block-scoping@7.21.0(@babel/core@7.21.3):
     resolution: {integrity: sha512-Mdrbunoh9SxwFZapeHVrwFmri16+oYotcZysSzhNIVDwIAb1UV+kvnxULSYq9J3/q5MDG+4X6w8QVgD1zhBXNQ==}
@@ -7645,7 +7712,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-classes@7.16.0(@babel/core@7.12.9):
     resolution: {integrity: sha512-HUxMvy6GtAdd+GKBNYDWCIA776byUQH8zjnfjxwT1P1ARv/wFu8eBDpmXQcLS/IwRtrxIReGiplOwMeyO7nsDQ==}
@@ -7663,7 +7730,6 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/plugin-transform-classes@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-WY7og38SFAGYRe64BrjKf8OrE6ulEHtr5jEYaZMwox9KebgqPi67Zqz8K53EKk1fFEJgm96r32rkKZ3qA2nCWQ==}
@@ -7673,12 +7739,12 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.21.0
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-function-name': 7.22.5
       '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-replace-supers': 7.19.1
-      '@babel/helper-split-export-declaration': 7.18.6
+      '@babel/helper-split-export-declaration': 7.22.6
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -7692,12 +7758,12 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.21.0
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-function-name': 7.22.5
       '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-replace-supers': 7.19.1
-      '@babel/helper-split-export-declaration': 7.18.6
+      '@babel/helper-split-export-declaration': 7.22.6
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -7740,7 +7806,6 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/plugin-transform-classes@7.21.0(@babel/core@7.17.8):
     resolution: {integrity: sha512-RZhbYTCEUAe6ntPehC4hlslPWosNHDox+vAs4On/mCLRLfoDVHf6hVEd7kuxr1RnHwJmxFfUM3cZiZRmPxJPXQ==}
@@ -7749,17 +7814,16 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.8
-      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.17.8)
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.21.0
-      '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/helper-replace-supers': 7.20.7
-      '@babel/helper-split-export-declaration': 7.18.6
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-function-name': 7.22.5
+      '@babel/helper-optimise-call-expression': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.17.8)
+      '@babel/helper-split-export-declaration': 7.22.6
       globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
+    dev: true
 
   /@babel/plugin-transform-classes@7.21.0(@babel/core@7.21.3):
     resolution: {integrity: sha512-RZhbYTCEUAe6ntPehC4hlslPWosNHDox+vAs4On/mCLRLfoDVHf6hVEd7kuxr1RnHwJmxFfUM3cZiZRmPxJPXQ==}
@@ -7768,17 +7832,15 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.21.3)
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.21.0
-      '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/helper-replace-supers': 7.20.7
-      '@babel/helper-split-export-declaration': 7.18.6
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-function-name': 7.22.5
+      '@babel/helper-optimise-call-expression': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.21.3)
+      '@babel/helper-split-export-declaration': 7.22.6
       globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
 
   /@babel/plugin-transform-computed-properties@7.16.0(@babel/core@7.12.9):
     resolution: {integrity: sha512-63l1dRXday6S8V3WFY5mXJwcRAnPYxvFfTlt67bwV1rTyVTM5zrp0DBBb13Kl7+ehkCVwIZPumPpFP/4u70+Tw==}
@@ -7788,7 +7850,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-computed-properties@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-gN72G9bcmenVILj//sv1zLNaPyYcOzUho2lIJBMh/iakJ9ygCo/hEF9cpGb61SCMEDxbbyBoVQxrt+bWKu5KGw==}
@@ -7828,7 +7889,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.21.5
-    dev: true
 
   /@babel/plugin-transform-computed-properties@7.18.9(@babel/core@7.17.8):
     resolution: {integrity: sha512-+i0ZU1bCDymKakLxn5srGHrsAPRELC2WIbzwjLhHW9SIE1cPYkLCL0NlnXMZaM1vhfgA2+M7hySk42VBvrkBRw==}
@@ -7838,6 +7898,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.21.5
+    dev: true
 
   /@babel/plugin-transform-computed-properties@7.18.9(@babel/core@7.21.3):
     resolution: {integrity: sha512-+i0ZU1bCDymKakLxn5srGHrsAPRELC2WIbzwjLhHW9SIE1cPYkLCL0NlnXMZaM1vhfgA2+M7hySk42VBvrkBRw==}
@@ -7856,7 +7917,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-destructuring@7.17.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-XVh0r5yq9sLR4vZ6eVZe8FKfIcSgaTBxVBRSYokRj2qksf6QerYnTxz9/GTuKTH/n/HwLP7t6gtlybHetJ/6hQ==}
@@ -7896,7 +7956,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.21.5
-    dev: true
 
   /@babel/plugin-transform-destructuring@7.21.3(@babel/core@7.17.8):
     resolution: {integrity: sha512-bp6hwMFzuiE4HqYEyoGJ/V2LeIWn+hLVKc4pnj++E5XQptwhtcGmSayM029d/j2X1bPKGTlsyPwAubuU22KhMA==}
@@ -7905,7 +7964,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-transform-destructuring@7.21.3(@babel/core@7.21.3):
     resolution: {integrity: sha512-bp6hwMFzuiE4HqYEyoGJ/V2LeIWn+hLVKc4pnj++E5XQptwhtcGmSayM029d/j2X1bPKGTlsyPwAubuU22KhMA==}
@@ -7914,7 +7974,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-dotall-regex@7.16.0(@babel/core@7.12.9):
     resolution: {integrity: sha512-FXlDZfQeLILfJlC6I1qyEwcHK5UpRCFkaoVyA1nk9A1L1Yu583YO4un2KsLBsu3IJb4CUbctZks8tD9xPQubLw==}
@@ -7925,7 +7985,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-create-regexp-features-plugin': 7.19.0(@babel/core@7.12.9)
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-dotall-regex@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-Lyttaao2SjZF6Pf4vk1dVKv8YypMpomAbygW+mU5cYP3S5cWTfCJjG8xV6CFdzGFlfWK81IjL9viiTvpb6G7gQ==}
@@ -7935,7 +7994,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-create-regexp-features-plugin': 7.19.0(@babel/core@7.12.9)
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
   /@babel/plugin-transform-dotall-regex@7.16.7(@babel/core@7.17.8):
@@ -7946,7 +8005,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-create-regexp-features-plugin': 7.19.0(@babel/core@7.17.8)
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
   /@babel/plugin-transform-dotall-regex@7.16.7(@babel/core@7.21.3):
@@ -7969,7 +8028,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-create-regexp-features-plugin': 7.19.0(@babel/core@7.12.9)
       '@babel/helper-plugin-utils': 7.21.5
-    dev: true
 
   /@babel/plugin-transform-dotall-regex@7.18.6(@babel/core@7.17.8):
     resolution: {integrity: sha512-6S3jpun1eEbAxq7TdjLotAsl4WpQI9DxfkycRcKrjhQYzU87qpXdknpBg/e+TdcMehqGnLFi7tnFUBR02Vq6wg==}
@@ -8000,7 +8058,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-duplicate-keys@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-03DvpbRfvWIXyK0/6QiR1KMTWeT6OcQ7tbhjrXyFS02kjuX/mu5Bvnh5SDSWHxyawit2g5aWhKwI86EE7GUnTw==}
@@ -8070,7 +8127,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.18.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-exponentiation-operator@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-8UYLSlyLgRixQvlYH3J2ekXFHDFLQutdy7FfFAMm3CPZ6q9wHCwnUyiXpQCe3gVVnQlHc5nsuiEVziteRNTXEA==}
@@ -8114,7 +8170,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.18.9
       '@babel/helper-plugin-utils': 7.21.5
-    dev: true
 
   /@babel/plugin-transform-exponentiation-operator@7.18.6(@babel/core@7.17.8):
     resolution: {integrity: sha512-wzEtc0+2c88FVR34aQmiz56dxEkxr2g8DQb/KfaFa1JYXOFVsbhvAonFN6PwVWj++fKmku8NP80plJ5Et4wqHw==}
@@ -8125,6 +8180,7 @@ packages:
       '@babel/core': 7.17.8
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.18.9
       '@babel/helper-plugin-utils': 7.21.5
+    dev: true
 
   /@babel/plugin-transform-exponentiation-operator@7.18.6(@babel/core@7.21.3):
     resolution: {integrity: sha512-wzEtc0+2c88FVR34aQmiz56dxEkxr2g8DQb/KfaFa1JYXOFVsbhvAonFN6PwVWj++fKmku8NP80plJ5Et4wqHw==}
@@ -8136,6 +8192,16 @@ packages:
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.18.9
       '@babel/helper-plugin-utils': 7.21.5
 
+  /@babel/plugin-transform-flow-strip-types@7.16.7(@babel/core@7.12.9):
+    resolution: {integrity: sha512-mzmCq3cNsDpZZu9FADYYyfZJIOrSONmHcop2XEKPdBNMa4PDC4eEvcOvzZaCNcjKu72v0XQlA5y1g58aLRXdYg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.12.9
+      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/plugin-syntax-flow': 7.16.7(@babel/core@7.12.9)
+
   /@babel/plugin-transform-flow-strip-types@7.16.7(@babel/core@7.17.8):
     resolution: {integrity: sha512-mzmCq3cNsDpZZu9FADYYyfZJIOrSONmHcop2XEKPdBNMa4PDC4eEvcOvzZaCNcjKu72v0XQlA5y1g58aLRXdYg==}
     engines: {node: '>=6.9.0'}
@@ -8145,6 +8211,7 @@ packages:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.21.5
       '@babel/plugin-syntax-flow': 7.16.7(@babel/core@7.17.8)
+    dev: true
 
   /@babel/plugin-transform-flow-strip-types@7.16.7(@babel/core@7.21.3):
     resolution: {integrity: sha512-mzmCq3cNsDpZZu9FADYYyfZJIOrSONmHcop2XEKPdBNMa4PDC4eEvcOvzZaCNcjKu72v0XQlA5y1g58aLRXdYg==}
@@ -8164,7 +8231,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-for-of@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-/QZm9W92Ptpw7sjI9Nx1mbcsWz33+l8kuMIQnDwgQBG5s3fAfQvkRjQ7NqXhtNcKOnPkdICmUHyCaWW06HCsqg==}
@@ -8204,7 +8270,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.21.5
-    dev: true
 
   /@babel/plugin-transform-for-of@7.18.8(@babel/core@7.17.8):
     resolution: {integrity: sha512-yEfTRnjuskWYo0k1mHUqrVWaZwrdq8AYbfrpqULOJOaucGSp4mNMVps+YtA8byoevxS/urwU75vyhQIxcCgiBQ==}
@@ -8213,7 +8278,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-transform-for-of@7.18.8(@babel/core@7.21.3):
     resolution: {integrity: sha512-yEfTRnjuskWYo0k1mHUqrVWaZwrdq8AYbfrpqULOJOaucGSp4mNMVps+YtA8byoevxS/urwU75vyhQIxcCgiBQ==}
@@ -8222,7 +8288,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-function-name@7.16.0(@babel/core@7.12.9):
     resolution: {integrity: sha512-lBzMle9jcOXtSOXUpc7tvvTpENu/NuekNJVova5lCCWCV9/U1ho2HH2y0p6mBg8fPm/syEAbfaaemYGOHCY3mg==}
@@ -8233,7 +8299,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-function-name': 7.19.0
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-function-name@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-SU/C68YVwTRxqWj5kgsbKINakGag0KTgq9f2iZEXdStoAbOzLHEBRYzImmA6yFo8YZhJVflvXmIHUO7GWHmxxA==}
@@ -8243,8 +8308,8 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.12.9)
-      '@babel/helper-function-name': 7.21.0
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-function-name': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
   /@babel/plugin-transform-function-name@7.16.7(@babel/core@7.17.8):
@@ -8255,8 +8320,8 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.17.8)
-      '@babel/helper-function-name': 7.21.0
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-function-name': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
   /@babel/plugin-transform-function-name@7.16.7(@babel/core@7.21.3):
@@ -8281,7 +8346,6 @@ packages:
       '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.12.9)
       '@babel/helper-function-name': 7.21.0
       '@babel/helper-plugin-utils': 7.21.5
-    dev: true
 
   /@babel/plugin-transform-function-name@7.18.9(@babel/core@7.17.8):
     resolution: {integrity: sha512-WvIBoRPaJQ5yVHzcnJFor7oS5Ls0PYixlTYE63lCj2RtdQEl15M68FXQlxnG6wdraJIXRdR7KI+hQ7q/9QjrCQ==}
@@ -8291,8 +8355,9 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.17.8)
-      '@babel/helper-function-name': 7.21.0
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-function-name': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-transform-function-name@7.18.9(@babel/core@7.21.3):
     resolution: {integrity: sha512-WvIBoRPaJQ5yVHzcnJFor7oS5Ls0PYixlTYE63lCj2RtdQEl15M68FXQlxnG6wdraJIXRdR7KI+hQ7q/9QjrCQ==}
@@ -8302,8 +8367,8 @@ packages:
     dependencies:
       '@babel/core': 7.21.3
       '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.21.3)
-      '@babel/helper-function-name': 7.21.0
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-function-name': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-literals@7.16.0(@babel/core@7.12.9):
     resolution: {integrity: sha512-gQDlsSF1iv9RU04clgXqRjrPyyoJMTclFt3K1cjLmTKikc0s/6vE3hlDeEVC71wLTRu72Fq7650kABrdTc2wMQ==}
@@ -8313,7 +8378,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-literals@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-6tH8RTpTWI0s2sV6uq3e/C9wPo4PTqqZps4uF0kzQ9/xPLFQtipynvmT1g/dOfEJ+0EQsHhkQ/zyRId8J2b8zQ==}
@@ -8353,7 +8417,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.21.5
-    dev: true
 
   /@babel/plugin-transform-literals@7.18.9(@babel/core@7.17.8):
     resolution: {integrity: sha512-IFQDSRoTPnrAIrI5zoZv73IFeZu2dhu6irxQjY9rNjTT53VmKg9fenjvoiOWOkJ6mm4jKVPtdMzBY98Fp4Z4cg==}
@@ -8363,6 +8426,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.21.5
+    dev: true
 
   /@babel/plugin-transform-literals@7.18.9(@babel/core@7.21.3):
     resolution: {integrity: sha512-IFQDSRoTPnrAIrI5zoZv73IFeZu2dhu6irxQjY9rNjTT53VmKg9fenjvoiOWOkJ6mm4jKVPtdMzBY98Fp4Z4cg==}
@@ -8381,7 +8445,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-member-expression-literals@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-mBruRMbktKQwbxaJof32LT9KLy2f3gH+27a5XSuXo6h7R3vqltl0PgZ80C8ZMKw98Bf8bqt6BEVi3svOh2PzMw==}
@@ -8421,7 +8484,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.21.5
-    dev: true
 
   /@babel/plugin-transform-member-expression-literals@7.18.6(@babel/core@7.17.8):
     resolution: {integrity: sha512-qSF1ihLGO3q+/g48k85tUjD033C29TNTVB2paCwZPVmOsjn9pClvYYrM2VeJpBY2bcNkuny0YUyTNRyRxJ54KA==}
@@ -8431,6 +8493,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.21.5
+    dev: true
 
   /@babel/plugin-transform-member-expression-literals@7.18.6(@babel/core@7.21.3):
     resolution: {integrity: sha512-qSF1ihLGO3q+/g48k85tUjD033C29TNTVB2paCwZPVmOsjn9pClvYYrM2VeJpBY2bcNkuny0YUyTNRyRxJ54KA==}
@@ -8453,7 +8516,6 @@ packages:
       babel-plugin-dynamic-import-node: 2.3.3
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/plugin-transform-modules-amd@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-KaaEtgBL7FKYwjJ/teH63oAmE3lP34N3kshz8mm4VMAw7U3PxjVwwUmxEFksbgsNUaO3wId9R2AVQYSEGRa2+g==}
@@ -8462,11 +8524,9 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-module-transforms': 7.21.2
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-module-transforms': 7.22.15(@babel/core@7.12.9)
+      '@babel/helper-plugin-utils': 7.22.5
       babel-plugin-dynamic-import-node: 2.3.3
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@babel/plugin-transform-modules-amd@7.16.7(@babel/core@7.17.8):
@@ -8476,11 +8536,9 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.8
-      '@babel/helper-module-transforms': 7.21.2
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-module-transforms': 7.22.15(@babel/core@7.17.8)
+      '@babel/helper-plugin-utils': 7.22.5
       babel-plugin-dynamic-import-node: 2.3.3
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@babel/plugin-transform-modules-amd@7.16.7(@babel/core@7.21.3):
@@ -8504,10 +8562,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-module-transforms': 7.21.2
+      '@babel/helper-module-transforms': 7.22.15(@babel/core@7.12.9)
       '@babel/helper-plugin-utils': 7.21.5
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@babel/plugin-transform-modules-amd@7.20.11(@babel/core@7.17.8):
@@ -8517,10 +8573,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.8
-      '@babel/helper-module-transforms': 7.21.2
+      '@babel/helper-module-transforms': 7.22.15(@babel/core@7.17.8)
       '@babel/helper-plugin-utils': 7.21.5
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@babel/plugin-transform-modules-amd@7.20.11(@babel/core@7.21.3):
@@ -8530,10 +8584,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-module-transforms': 7.21.2
+      '@babel/helper-module-transforms': 7.22.15(@babel/core@7.21.3)
       '@babel/helper-plugin-utils': 7.21.5
-    transitivePeerDependencies:
-      - supports-color
 
   /@babel/plugin-transform-modules-commonjs@7.16.0(@babel/core@7.12.9):
     resolution: {integrity: sha512-Dzi+NWqyEotgzk/sb7kgQPJQf7AJkQBWsVp1N6JWc1lBVo0vkElUnGdr1PzUBmfsCCN5OOFya3RtpeHk15oLKQ==}
@@ -8548,7 +8600,6 @@ packages:
       babel-plugin-dynamic-import-node: 2.3.3
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/plugin-transform-modules-commonjs@7.17.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-ITPmR2V7MqioMJyrxUo2onHNC3e+MvfFiFIR0RP21d3PtlVb6sfzoxNKiphSZUOM9hEIdzCcZe83ieX3yoqjUA==}
@@ -8601,11 +8652,9 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-module-transforms': 7.21.2
+      '@babel/helper-module-transforms': 7.22.15(@babel/core@7.12.9)
       '@babel/helper-plugin-utils': 7.21.5
       '@babel/helper-simple-access': 7.20.2
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@babel/plugin-transform-modules-commonjs@7.21.2(@babel/core@7.17.8):
@@ -8615,11 +8664,9 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.8
-      '@babel/helper-module-transforms': 7.21.2
+      '@babel/helper-module-transforms': 7.22.15(@babel/core@7.17.8)
       '@babel/helper-plugin-utils': 7.21.5
       '@babel/helper-simple-access': 7.20.2
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@babel/plugin-transform-modules-commonjs@7.21.2(@babel/core@7.21.3):
@@ -8629,20 +8676,18 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-module-transforms': 7.21.2
+      '@babel/helper-module-transforms': 7.22.15(@babel/core@7.21.3)
       '@babel/helper-plugin-utils': 7.21.5
       '@babel/helper-simple-access': 7.20.2
-    transitivePeerDependencies:
-      - supports-color
 
-  /@babel/plugin-transform-modules-commonjs@7.22.15(@babel/core@7.17.8):
+  /@babel/plugin-transform-modules-commonjs@7.22.15(@babel/core@7.12.9):
     resolution: {integrity: sha512-jWL4eh90w0HQOTKP2MoXXUpVxilxsB2Vl4ji69rSjS3EcZ/v4sBmn+A3NpepuJzBhOaEBbR7udonlHHn5DWidg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.17.8
-      '@babel/helper-module-transforms': 7.22.15(@babel/core@7.17.8)
+      '@babel/core': 7.12.9
+      '@babel/helper-module-transforms': 7.22.15(@babel/core@7.12.9)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-simple-access': 7.22.5
 
@@ -8671,7 +8716,6 @@ packages:
       babel-plugin-dynamic-import-node: 2.3.3
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/plugin-transform-modules-systemjs@7.17.8(@babel/core@7.12.9):
     resolution: {integrity: sha512-39reIkMTUVagzgA5x88zDYXPCMT6lcaRKs1+S9K6NKBPErbgO/w/kP8GlNQTC87b412ZTlmNgr3k2JrWgHH+Bw==}
@@ -8681,12 +8725,10 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-hoist-variables': 7.18.6
-      '@babel/helper-module-transforms': 7.21.2
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/helper-validator-identifier': 7.19.1
+      '@babel/helper-module-transforms': 7.22.15(@babel/core@7.12.9)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-validator-identifier': 7.22.15
       babel-plugin-dynamic-import-node: 2.3.3
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@babel/plugin-transform-modules-systemjs@7.17.8(@babel/core@7.17.8):
@@ -8697,12 +8739,10 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-hoist-variables': 7.18.6
-      '@babel/helper-module-transforms': 7.21.2
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/helper-validator-identifier': 7.19.1
+      '@babel/helper-module-transforms': 7.22.15(@babel/core@7.17.8)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-validator-identifier': 7.22.15
       babel-plugin-dynamic-import-node: 2.3.3
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@babel/plugin-transform-modules-systemjs@7.17.8(@babel/core@7.21.3):
@@ -8729,11 +8769,9 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-hoist-variables': 7.18.6
-      '@babel/helper-module-transforms': 7.21.2
+      '@babel/helper-module-transforms': 7.22.15(@babel/core@7.12.9)
       '@babel/helper-plugin-utils': 7.21.5
       '@babel/helper-validator-identifier': 7.19.1
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@babel/plugin-transform-modules-systemjs@7.20.11(@babel/core@7.17.8):
@@ -8744,11 +8782,9 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-hoist-variables': 7.18.6
-      '@babel/helper-module-transforms': 7.21.2
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/helper-validator-identifier': 7.19.1
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-module-transforms': 7.22.15(@babel/core@7.17.8)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-validator-identifier': 7.22.15
     dev: true
 
   /@babel/plugin-transform-modules-systemjs@7.20.11(@babel/core@7.21.3):
@@ -8759,11 +8795,9 @@ packages:
     dependencies:
       '@babel/core': 7.21.3
       '@babel/helper-hoist-variables': 7.18.6
-      '@babel/helper-module-transforms': 7.21.2
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/helper-validator-identifier': 7.19.1
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-module-transforms': 7.22.15(@babel/core@7.21.3)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-validator-identifier': 7.22.15
 
   /@babel/plugin-transform-modules-umd@7.16.0(@babel/core@7.12.9):
     resolution: {integrity: sha512-nx4f6no57himWiHhxDM5pjwhae5vLpTK2zCnDH8+wNLJy0TVER/LJRHl2bkt6w9Aad2sPD5iNNoUpY3X9sTGDg==}
@@ -8776,7 +8810,6 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/plugin-transform-modules-umd@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-EMh7uolsC8O4xhudF2F6wedbSHm1HHZ0C6aJ7K67zcDNidMzVcxWdGr+htW9n21klm+bOn+Rx4CBsAntZd3rEQ==}
@@ -8785,10 +8818,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-module-transforms': 7.21.2
-      '@babel/helper-plugin-utils': 7.21.5
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-module-transforms': 7.22.15(@babel/core@7.12.9)
+      '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
   /@babel/plugin-transform-modules-umd@7.16.7(@babel/core@7.17.8):
@@ -8798,10 +8829,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.8
-      '@babel/helper-module-transforms': 7.21.2
-      '@babel/helper-plugin-utils': 7.21.5
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-module-transforms': 7.22.15(@babel/core@7.17.8)
+      '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
   /@babel/plugin-transform-modules-umd@7.16.7(@babel/core@7.21.3):
@@ -8824,10 +8853,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-module-transforms': 7.21.2
+      '@babel/helper-module-transforms': 7.22.15(@babel/core@7.12.9)
       '@babel/helper-plugin-utils': 7.21.5
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@babel/plugin-transform-modules-umd@7.18.6(@babel/core@7.17.8):
@@ -8837,10 +8864,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.8
-      '@babel/helper-module-transforms': 7.21.2
-      '@babel/helper-plugin-utils': 7.21.5
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-module-transforms': 7.22.15(@babel/core@7.17.8)
+      '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
   /@babel/plugin-transform-modules-umd@7.18.6(@babel/core@7.21.3):
@@ -8850,10 +8875,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-module-transforms': 7.21.2
-      '@babel/helper-plugin-utils': 7.21.5
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-module-transforms': 7.22.15(@babel/core@7.21.3)
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-named-capturing-groups-regex@7.16.0(@babel/core@7.12.9):
     resolution: {integrity: sha512-LogN88uO+7EhxWc8WZuQ8vxdSyVGxhkh8WTC3tzlT8LccMuQdA81e9SGV6zY7kY2LjDhhDOFdQVxdGwPyBCnvg==}
@@ -8863,7 +8886,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-create-regexp-features-plugin': 7.19.0(@babel/core@7.12.9)
-    dev: true
 
   /@babel/plugin-transform-named-capturing-groups-regex@7.16.8(@babel/core@7.12.9):
     resolution: {integrity: sha512-j3Jw+n5PvpmhRR+mrgIh04puSANCk/T/UA3m3P1MjJkhlK906+ApHhDIqBQDdOgL/r1UYpz4GNclTXxyZrYGSw==}
@@ -8904,7 +8926,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-create-regexp-features-plugin': 7.19.0(@babel/core@7.12.9)
       '@babel/helper-plugin-utils': 7.21.5
-    dev: true
 
   /@babel/plugin-transform-named-capturing-groups-regex@7.19.1(@babel/core@7.17.8):
     resolution: {integrity: sha512-oWk9l9WItWBQYS4FgXD4Uyy5kq898lvkXpXQxoJEY1RnvPk4R/Dvu2ebXU9q8lP+rlMwUQTFf2Ok6d78ODa0kw==}
@@ -8915,6 +8936,7 @@ packages:
       '@babel/core': 7.17.8
       '@babel/helper-create-regexp-features-plugin': 7.19.0(@babel/core@7.17.8)
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-transform-named-capturing-groups-regex@7.19.1(@babel/core@7.21.3):
     resolution: {integrity: sha512-oWk9l9WItWBQYS4FgXD4Uyy5kq898lvkXpXQxoJEY1RnvPk4R/Dvu2ebXU9q8lP+rlMwUQTFf2Ok6d78ODa0kw==}
@@ -8934,7 +8956,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-new-target@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-xiLDzWNMfKoGOpc6t3U+etCE2yRnn3SM09BXqWPIZOBpL2gvVrBWUKnsJx0K/ADi5F5YC5f8APFfWrz25TdlGg==}
@@ -9006,7 +9027,6 @@ packages:
       '@babel/helper-replace-supers': 7.19.1
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/plugin-transform-object-super@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-14J1feiQVWaGvRxj2WjyMuXS2jsBkgB3MdSN5HuC2G5nRspa5RK9COcs82Pwy5BuGcjb+fYaUj94mYcOj7rCvw==}
@@ -9015,7 +9035,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-replace-supers': 7.19.1
     transitivePeerDependencies:
       - supports-color
@@ -9028,7 +9048,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-replace-supers': 7.19.1
     transitivePeerDependencies:
       - supports-color
@@ -9058,7 +9078,6 @@ packages:
       '@babel/helper-replace-supers': 7.20.7
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/plugin-transform-object-super@7.18.6(@babel/core@7.17.8):
     resolution: {integrity: sha512-uvGz6zk+pZoS1aTZrOvrbj6Pp/kK2mp45t2B+bTDre2UgsZZ8EZLSJtUg7m/no0zOJUWgFONpB7Zv9W2tSaFlA==}
@@ -9071,6 +9090,7 @@ packages:
       '@babel/helper-replace-supers': 7.20.7
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/plugin-transform-object-super@7.18.6(@babel/core@7.21.3):
     resolution: {integrity: sha512-uvGz6zk+pZoS1aTZrOvrbj6Pp/kK2mp45t2B+bTDre2UgsZZ8EZLSJtUg7m/no0zOJUWgFONpB7Zv9W2tSaFlA==}
@@ -9092,7 +9112,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-parameters@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-AT3MufQ7zZEhU2hwOA11axBnExW0Lszu4RL/tAlUJBuNoRak+wehQW8h6KcXOcgjY42fHtDxswuMhMjFEuv/aw==}
@@ -9131,8 +9150,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.21.5
-    dev: true
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-parameters@7.21.3(@babel/core@7.17.8):
     resolution: {integrity: sha512-Wxc+TvppQG9xWFYatvCGPvZ6+SIUxQ2ZdiBP+PHYMIjnPXD+uThCshaz4NZOnODAtBjjcVQQ/3OKs9LW28purQ==}
@@ -9141,7 +9159,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-transform-parameters@7.21.3(@babel/core@7.21.3):
     resolution: {integrity: sha512-Wxc+TvppQG9xWFYatvCGPvZ6+SIUxQ2ZdiBP+PHYMIjnPXD+uThCshaz4NZOnODAtBjjcVQQ/3OKs9LW28purQ==}
@@ -9150,7 +9169,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-property-literals@7.16.0(@babel/core@7.12.9):
     resolution: {integrity: sha512-XLldD4V8+pOqX2hwfWhgwXzGdnDOThxaNTgqagOcpBgIxbUvpgU2FMvo5E1RyHbk756WYgdbS0T8y0Cj9FKkWQ==}
@@ -9160,7 +9179,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-property-literals@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-z4FGr9NMGdoIl1RqavCqGG+ZuYjfZ/hkCIeuH6Do7tXmSm0ls11nYVSJqFEUOSJbDab5wC6lRE/w6YjVcr6Hqw==}
@@ -9200,7 +9218,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.21.5
-    dev: true
 
   /@babel/plugin-transform-property-literals@7.18.6(@babel/core@7.17.8):
     resolution: {integrity: sha512-cYcs6qlgafTud3PAzrrRNbQtfpQ8+y/+M5tKmksS9+M1ckbH6kzY8MrexEM9mcA6JDsukE19iIRvAyYl463sMg==}
@@ -9210,6 +9227,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.21.5
+    dev: true
 
   /@babel/plugin-transform-property-literals@7.18.6(@babel/core@7.21.3):
     resolution: {integrity: sha512-cYcs6qlgafTud3PAzrrRNbQtfpQ8+y/+M5tKmksS9+M1ckbH6kzY8MrexEM9mcA6JDsukE19iIRvAyYl463sMg==}
@@ -9230,6 +9248,15 @@ packages:
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
+  /@babel/plugin-transform-react-display-name@7.18.6(@babel/core@7.12.9):
+    resolution: {integrity: sha512-TV4sQ+T013n61uMoygyMRm+xf04Bd5oqFpv2jAEQwSZ8NwQA7zeRPg1LMVg2PWi3zWBz+CLKD+v5bcpZ/BS0aA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.12.9
+      '@babel/helper-plugin-utils': 7.21.5
+
   /@babel/plugin-transform-react-display-name@7.18.6(@babel/core@7.17.8):
     resolution: {integrity: sha512-TV4sQ+T013n61uMoygyMRm+xf04Bd5oqFpv2jAEQwSZ8NwQA7zeRPg1LMVg2PWi3zWBz+CLKD+v5bcpZ/BS0aA==}
     engines: {node: '>=6.9.0'}
@@ -9238,6 +9265,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.21.5
+    dev: true
 
   /@babel/plugin-transform-react-display-name@7.18.6(@babel/core@7.21.3):
     resolution: {integrity: sha512-TV4sQ+T013n61uMoygyMRm+xf04Bd5oqFpv2jAEQwSZ8NwQA7zeRPg1LMVg2PWi3zWBz+CLKD+v5bcpZ/BS0aA==}
@@ -9268,13 +9296,13 @@ packages:
       '@babel/plugin-transform-react-jsx': 7.22.3(@babel/core@7.21.3)
     dev: true
 
-  /@babel/plugin-transform-react-jsx-self@7.18.6(@babel/core@7.17.8):
+  /@babel/plugin-transform-react-jsx-self@7.18.6(@babel/core@7.12.9):
     resolution: {integrity: sha512-A0LQGx4+4Jv7u/tWzoJF7alZwnBDQd6cGLh9P+Ttk4dpiL+J5p7NSNv/9tlEFFJDq3kjxOavWmbm6t0Gk+A3Ig==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.17.8
+      '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-react-jsx-self@7.18.6(@babel/core@7.21.3):
@@ -9286,13 +9314,13 @@ packages:
       '@babel/core': 7.21.3
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-react-jsx-source@7.18.6(@babel/core@7.17.8):
+  /@babel/plugin-transform-react-jsx-source@7.18.6(@babel/core@7.12.9):
     resolution: {integrity: sha512-utZmlASneDfdaMh0m/WausbjUjEdGrQJz0vFK93d7wD3xf5wBtX219+q6IlCNZeguIcxS2f/CvLZrlLSvSHQXw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.17.8
+      '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-react-jsx-source@7.18.6(@babel/core@7.21.3):
@@ -9357,7 +9385,20 @@ packages:
       '@babel/helper-module-imports': 7.21.4
       '@babel/helper-plugin-utils': 7.21.5
       '@babel/plugin-syntax-jsx': 7.21.4(@babel/core@7.21.3)
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.15
+
+  /@babel/plugin-transform-react-jsx@7.22.3(@babel/core@7.12.9):
+    resolution: {integrity: sha512-JEulRWG2f04a7L8VWaOngWiK6p+JOSpB+DAtwfJgOaej1qdbNxqtK7MwTBHjUA10NeFcszlFNqCdbRcirzh2uQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.12.9
+      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-module-imports': 7.22.15
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-jsx': 7.21.4(@babel/core@7.12.9)
+      '@babel/types': 7.22.15
 
   /@babel/plugin-transform-react-jsx@7.22.3(@babel/core@7.17.8):
     resolution: {integrity: sha512-JEulRWG2f04a7L8VWaOngWiK6p+JOSpB+DAtwfJgOaej1qdbNxqtK7MwTBHjUA10NeFcszlFNqCdbRcirzh2uQ==}
@@ -9367,10 +9408,11 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-module-imports': 7.21.4
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-module-imports': 7.22.15
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-jsx': 7.21.4(@babel/core@7.17.8)
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.15
+    dev: true
 
   /@babel/plugin-transform-react-jsx@7.22.3(@babel/core@7.21.3):
     resolution: {integrity: sha512-JEulRWG2f04a7L8VWaOngWiK6p+JOSpB+DAtwfJgOaej1qdbNxqtK7MwTBHjUA10NeFcszlFNqCdbRcirzh2uQ==}
@@ -9392,8 +9434,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.8
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
   /@babel/plugin-transform-react-pure-annotations@7.18.6(@babel/core@7.21.3):
@@ -9415,7 +9457,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       regenerator-transform: 0.14.5
-    dev: true
 
   /@babel/plugin-transform-regenerator@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-mF7jOgGYCkSJagJ6XCujSQg+6xC1M77/03K2oBmVJWoFGNUtnVJO4WHKJk3dnPC8HCcj4xBQP1Egm8DWh3Pb3Q==}
@@ -9465,7 +9506,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       regenerator-transform: 0.15.0
     dev: true
 
@@ -9476,7 +9517,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       regenerator-transform: 0.15.0
 
   /@babel/plugin-transform-reserved-words@7.16.0(@babel/core@7.12.9):
@@ -9487,7 +9528,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-reserved-words@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-KQzzDnZ9hWQBjwi5lpY5v9shmm6IVG0U9pB18zvMu2i4H90xpT4gmqwPYsn8rObiadYe2M0gmgsiOIF5A/2rtg==}
@@ -9582,18 +9622,18 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-runtime@7.19.1(@babel/core@7.17.8):
+  /@babel/plugin-transform-runtime@7.19.1(@babel/core@7.12.9):
     resolution: {integrity: sha512-2nJjTUFIzBMP/f/miLxEK9vxwW/KUXsdvN4sR//TmuDhe6yU2h57WmIOE12Gng3MDP/xpjUV/ToZRdcf8Yj4fA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.17.8
-      '@babel/helper-module-imports': 7.21.4
+      '@babel/core': 7.12.9
+      '@babel/helper-module-imports': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
-      babel-plugin-polyfill-corejs2: 0.3.3(@babel/core@7.17.8)
-      babel-plugin-polyfill-corejs3: 0.6.0(@babel/core@7.17.8)
-      babel-plugin-polyfill-regenerator: 0.4.1(@babel/core@7.17.8)
+      babel-plugin-polyfill-corejs2: 0.3.3(@babel/core@7.12.9)
+      babel-plugin-polyfill-corejs3: 0.6.0(@babel/core@7.12.9)
+      babel-plugin-polyfill-regenerator: 0.4.1(@babel/core@7.12.9)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -9605,7 +9645,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-module-imports': 7.21.4
+      '@babel/helper-module-imports': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
       babel-plugin-polyfill-corejs2: 0.3.3(@babel/core@7.21.3)
       babel-plugin-polyfill-corejs3: 0.6.0(@babel/core@7.21.3)
@@ -9622,7 +9662,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-shorthand-properties@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-hah2+FEnoRoATdIb05IOXf+4GzXYTq75TVhIn1PewihbpyrNWUt2JbudKQOETWw6QpLe+AIUpJ5MVLYTQbeeUg==}
@@ -9662,7 +9701,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.21.5
-    dev: true
 
   /@babel/plugin-transform-shorthand-properties@7.18.6(@babel/core@7.17.8):
     resolution: {integrity: sha512-eCLXXJqv8okzg86ywZJbRn19YJHU4XUa55oz2wbHhaQVn/MM+XhukiT7SYqp/7o00dg52Rj51Ny+Ecw4oyoygw==}
@@ -9671,7 +9709,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-transform-shorthand-properties@7.18.6(@babel/core@7.21.3):
     resolution: {integrity: sha512-eCLXXJqv8okzg86ywZJbRn19YJHU4XUa55oz2wbHhaQVn/MM+XhukiT7SYqp/7o00dg52Rj51Ny+Ecw4oyoygw==}
@@ -9680,7 +9719,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-spread@7.16.0(@babel/core@7.12.9):
     resolution: {integrity: sha512-Ao4MSYRaLAQczZVp9/7E7QHsCuK92yHRrmVNRe/SlEJjhzivq0BSn8mEraimL8wizHZ3fuaHxKH0iwzI13GyGg==}
@@ -9691,7 +9730,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-skip-transparent-expression-wrappers': 7.18.9
-    dev: true
 
   /@babel/plugin-transform-spread@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-+pjJpgAngb53L0iaA5gU/1MLXJIfXcYepLgXB3esVRf4fqmj8f2cxM3/FKaHsZms08hFQJkFccEWuIpm429TXg==}
@@ -9700,7 +9738,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.18.9
     dev: true
 
@@ -9711,7 +9749,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.18.9
     dev: true
 
@@ -9735,7 +9773,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.21.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.18.9
-    dev: true
 
   /@babel/plugin-transform-spread@7.19.0(@babel/core@7.17.8):
     resolution: {integrity: sha512-RsuMk7j6n+r752EtzyScnWkQyuJdli6LdO5Klv8Yx0OfPVTcQkIUfS8clx5e9yHXzlnhOZF3CbQ8C2uP5j074w==}
@@ -9744,8 +9781,9 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.8
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.18.9
+    dev: true
 
   /@babel/plugin-transform-spread@7.19.0(@babel/core@7.21.3):
     resolution: {integrity: sha512-RsuMk7j6n+r752EtzyScnWkQyuJdli6LdO5Klv8Yx0OfPVTcQkIUfS8clx5e9yHXzlnhOZF3CbQ8C2uP5j074w==}
@@ -9754,7 +9792,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.18.9
 
   /@babel/plugin-transform-sticky-regex@7.16.0(@babel/core@7.12.9):
@@ -9765,7 +9803,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-sticky-regex@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-NJa0Bd/87QV5NZZzTuZG5BPJjLYadeSZ9fO6oOUoL4iQx+9EEuw/eEM92SrsT19Yc2jgB1u1hsjqDtH02c3Drw==}
@@ -9805,7 +9842,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.21.5
-    dev: true
 
   /@babel/plugin-transform-sticky-regex@7.18.6(@babel/core@7.17.8):
     resolution: {integrity: sha512-kfiDrDQ+PBsQDO85yj1icueWMfGfJFKN1KCkndygtu/C9+XUfydLC8Iv5UYJqRwy4zk8EcplRxEOeLyjq1gm6Q==}
@@ -9815,6 +9851,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.21.5
+    dev: true
 
   /@babel/plugin-transform-sticky-regex@7.18.6(@babel/core@7.21.3):
     resolution: {integrity: sha512-kfiDrDQ+PBsQDO85yj1icueWMfGfJFKN1KCkndygtu/C9+XUfydLC8Iv5UYJqRwy4zk8EcplRxEOeLyjq1gm6Q==}
@@ -9833,7 +9870,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-template-literals@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-VwbkDDUeenlIjmfNeDX/V0aWrQH2QiVyJtwymVQSzItFDTpxfyJh3EVaQiS0rIN/CqbLGr0VcGmuwyTdZtdIsA==}
@@ -9873,7 +9909,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.21.5
-    dev: true
 
   /@babel/plugin-transform-template-literals@7.18.9(@babel/core@7.17.8):
     resolution: {integrity: sha512-S8cOWfT82gTezpYOiVaGHrCbhlHgKhQt8XH5ES46P2XWmX92yisoZywf5km75wv5sYcXDUCLMmMxOLCtthDgMA==}
@@ -9883,6 +9918,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-plugin-utils': 7.21.5
+    dev: true
 
   /@babel/plugin-transform-template-literals@7.18.9(@babel/core@7.21.3):
     resolution: {integrity: sha512-S8cOWfT82gTezpYOiVaGHrCbhlHgKhQt8XH5ES46P2XWmX92yisoZywf5km75wv5sYcXDUCLMmMxOLCtthDgMA==}
@@ -9901,7 +9937,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-typeof-symbol@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-p2rOixCKRJzpg9JB4gjnG4gjWkWa89ZoYUnl9snJ1cWIcTH/hvxZqfO+WjG6T8DRBpctEol5jw1O5rA8gkCokQ==}
@@ -9972,8 +10007,6 @@ packages:
       '@babel/helper-create-class-features-plugin': 7.19.0(@babel/core@7.17.8)
       '@babel/helper-plugin-utils': 7.21.5
       '@babel/plugin-syntax-typescript': 7.16.7(@babel/core@7.17.8)
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@babel/plugin-transform-typescript@7.16.8(@babel/core@7.21.3):
@@ -9996,23 +10029,21 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-create-class-features-plugin': 7.19.0(@babel/core@7.21.3)
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/plugin-syntax-typescript': 7.18.6(@babel/core@7.21.3)
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.21.3)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-typescript': 7.22.5(@babel/core@7.21.3)
 
-  /@babel/plugin-transform-typescript@7.22.15(@babel/core@7.17.8):
+  /@babel/plugin-transform-typescript@7.22.15(@babel/core@7.12.9):
     resolution: {integrity: sha512-1uirS0TnijxvQLnlv5wQBwOX3E1wCFX7ITv+9pBV2wKEk4K+M5tqDaoNXnTH8tjEIYHLO98MwiTWO04Ggz4XuA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.17.8
+      '@babel/core': 7.12.9
       '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.17.8)
+      '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.12.9)
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-typescript': 7.22.5(@babel/core@7.17.8)
+      '@babel/plugin-syntax-typescript': 7.22.5(@babel/core@7.12.9)
 
   /@babel/plugin-transform-typescript@7.22.15(@babel/core@7.21.3):
     resolution: {integrity: sha512-1uirS0TnijxvQLnlv5wQBwOX3E1wCFX7ITv+9pBV2wKEk4K+M5tqDaoNXnTH8tjEIYHLO98MwiTWO04Ggz4XuA==}
@@ -10034,7 +10065,6 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-unicode-escapes@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-TAV5IGahIz3yZ9/Hfv35TV2xEm+kaBDaZQCn2S/hG9/CZ0DktxJv9eKfPc7yYCvOYR4JGx1h8C+jcSOvgaaI/Q==}
@@ -10104,7 +10134,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-create-regexp-features-plugin': 7.19.0(@babel/core@7.12.9)
       '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-transform-unicode-regex@7.16.7(@babel/core@7.12.9):
     resolution: {integrity: sha512-oC5tYYKw56HO75KZVLQ+R/Nl3Hro9kf8iG0hXoaHP7tjAyCpvqBiSNe6vGrZni1Z6MggmUOC6A7VP7AVmw225Q==}
@@ -10114,7 +10143,7 @@ packages:
     dependencies:
       '@babel/core': 7.12.9
       '@babel/helper-create-regexp-features-plugin': 7.19.0(@babel/core@7.12.9)
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
   /@babel/plugin-transform-unicode-regex@7.16.7(@babel/core@7.17.8):
@@ -10125,7 +10154,7 @@ packages:
     dependencies:
       '@babel/core': 7.17.8
       '@babel/helper-create-regexp-features-plugin': 7.19.0(@babel/core@7.17.8)
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
   /@babel/plugin-transform-unicode-regex@7.16.7(@babel/core@7.21.3):
@@ -10148,7 +10177,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-create-regexp-features-plugin': 7.19.0(@babel/core@7.12.9)
       '@babel/helper-plugin-utils': 7.21.5
-    dev: true
 
   /@babel/plugin-transform-unicode-regex@7.18.6(@babel/core@7.17.8):
     resolution: {integrity: sha512-gE7A6Lt7YLnNOL3Pb9BNeZvi+d8l7tcRrG4+pwJjK9hD2xX4mEvjlQW60G9EEmfXVYRPv9VRQcyegIVHCql/AA==}
@@ -10159,6 +10187,7 @@ packages:
       '@babel/core': 7.17.8
       '@babel/helper-create-regexp-features-plugin': 7.19.0(@babel/core@7.17.8)
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-transform-unicode-regex@7.18.6(@babel/core@7.21.3):
     resolution: {integrity: sha512-gE7A6Lt7YLnNOL3Pb9BNeZvi+d8l7tcRrG4+pwJjK9hD2xX4mEvjlQW60G9EEmfXVYRPv9VRQcyegIVHCql/AA==}
@@ -10252,7 +10281,6 @@ packages:
       semver: 5.7.1
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/preset-env@7.16.11(@babel/core@7.12.9):
     resolution: {integrity: sha512-qcmWG8R7ZW6WBRPZK//y+E3Cli151B20W1Rv7ln27vuPaXU/8TKms6jFdiJtF7UDTxcrb7mZd88tAeK9LjdT8g==}
@@ -10262,7 +10290,7 @@ packages:
     dependencies:
       '@babel/compat-data': 7.17.7
       '@babel/core': 7.12.9
-      '@babel/helper-compilation-targets': 7.17.7(@babel/core@7.12.9)
+      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.12.9)
       '@babel/helper-plugin-utils': 7.18.9
       '@babel/helper-validator-option': 7.16.7
       '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.16.7(@babel/core@7.12.9)
@@ -10329,12 +10357,12 @@ packages:
       '@babel/plugin-transform-unicode-escapes': 7.16.7(@babel/core@7.12.9)
       '@babel/plugin-transform-unicode-regex': 7.16.7(@babel/core@7.12.9)
       '@babel/preset-modules': 0.1.5(@babel/core@7.12.9)
-      '@babel/types': 7.17.0
+      '@babel/types': 7.22.15
       babel-plugin-polyfill-corejs2: 0.3.0(@babel/core@7.12.9)
       babel-plugin-polyfill-corejs3: 0.5.2(@babel/core@7.12.9)
       babel-plugin-polyfill-regenerator: 0.3.0(@babel/core@7.12.9)
       core-js-compat: 3.21.1
-      semver: 6.3.0
+      semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10347,7 +10375,7 @@ packages:
     dependencies:
       '@babel/compat-data': 7.17.7
       '@babel/core': 7.17.8
-      '@babel/helper-compilation-targets': 7.17.7(@babel/core@7.17.8)
+      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.17.8)
       '@babel/helper-plugin-utils': 7.18.9
       '@babel/helper-validator-option': 7.16.7
       '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.16.7(@babel/core@7.17.8)
@@ -10414,12 +10442,12 @@ packages:
       '@babel/plugin-transform-unicode-escapes': 7.16.7(@babel/core@7.17.8)
       '@babel/plugin-transform-unicode-regex': 7.16.7(@babel/core@7.17.8)
       '@babel/preset-modules': 0.1.5(@babel/core@7.17.8)
-      '@babel/types': 7.17.0
+      '@babel/types': 7.22.15
       babel-plugin-polyfill-corejs2: 0.3.0(@babel/core@7.17.8)
       babel-plugin-polyfill-corejs3: 0.5.2(@babel/core@7.17.8)
       babel-plugin-polyfill-regenerator: 0.3.0(@babel/core@7.17.8)
       core-js-compat: 3.21.1
-      semver: 6.3.0
+      semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10800,7 +10828,6 @@ packages:
       '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.12.9)
       '@babel/types': 7.22.4
       esutils: 2.0.3
-    dev: true
 
   /@babel/preset-modules@0.1.5(@babel/core@7.17.8):
     resolution: {integrity: sha512-A57th6YRG7oR3cq/yt/Y84MvGgE0eJG2F1JLhKuyG+jFxEgrd/HAMJatiFtmOiZurz+0DkrvbheCLaV5f2JfjA==}
@@ -10834,8 +10861,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.8
-      '@babel/helper-plugin-utils': 7.21.5
-      '@babel/helper-validator-option': 7.21.0
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-validator-option': 7.22.15
       '@babel/plugin-transform-react-display-name': 7.18.6(@babel/core@7.17.8)
       '@babel/plugin-transform-react-jsx': 7.22.3(@babel/core@7.17.8)
       '@babel/plugin-transform-react-jsx-development': 7.18.6(@babel/core@7.17.8)
@@ -10867,8 +10894,6 @@ packages:
       '@babel/helper-plugin-utils': 7.21.5
       '@babel/helper-validator-option': 7.21.0
       '@babel/plugin-transform-typescript': 7.16.8(@babel/core@7.17.8)
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@babel/preset-typescript@7.16.7(@babel/core@7.21.3):
@@ -10894,8 +10919,6 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-validator-option': 7.22.15
       '@babel/plugin-transform-typescript': 7.19.3(@babel/core@7.21.3)
-    transitivePeerDependencies:
-      - supports-color
 
   /@babel/preset-typescript@7.22.15(@babel/core@7.21.3):
     resolution: {integrity: sha512-HblhNmh6yM+cU4VwbBRpxFhxsTdfS1zsvH9W+gEjD0ARV9+8B4sNfpI6GuhePti84nuvhiwKS539jKPFHskA9A==}
@@ -10995,17 +11018,17 @@ packages:
     resolution: {integrity: sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.18.6
-      '@babel/parser': 7.21.3
-      '@babel/types': 7.22.4
+      '@babel/code-frame': 7.22.13
+      '@babel/parser': 7.22.15
+      '@babel/types': 7.22.15
 
   /@babel/template@7.20.7:
     resolution: {integrity: sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.18.6
-      '@babel/parser': 7.21.3
-      '@babel/types': 7.22.4
+      '@babel/code-frame': 7.22.13
+      '@babel/parser': 7.22.15
+      '@babel/types': 7.22.15
 
   /@babel/template@7.22.15:
     resolution: {integrity: sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==}
@@ -11027,30 +11050,13 @@ packages:
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/parser': 7.21.3
       '@babel/types': 7.21.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
 
   /@babel/traverse@7.19.3:
     resolution: {integrity: sha512-qh5yf6149zhq2sgIXmwjnsvmnNQC2iw70UFjp4olxucKrWd/dvlUsBI88VSLUsnMNF7/vnOiA+nk1+yLoCqROQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.21.3
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.21.0
-      '@babel/helper-hoist-variables': 7.18.6
-      '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.21.3
-      '@babel/types': 7.22.4
-      debug: 4.3.4(supports-color@8.1.1)
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-
-  /@babel/traverse@7.21.3:
-    resolution: {integrity: sha512-XLyopNeaTancVitYZe2MlUEvgKb6YVVPXzofHgqHijCImG33b/uTurMS488ht/Hbsb2XK3U2BnSTxKVNGV3nGQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.22.13
@@ -11061,7 +11067,24 @@ packages:
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/parser': 7.22.15
       '@babel/types': 7.22.15
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+
+  /@babel/traverse@7.21.3:
+    resolution: {integrity: sha512-XLyopNeaTancVitYZe2MlUEvgKb6YVVPXzofHgqHijCImG33b/uTurMS488ht/Hbsb2XK3U2BnSTxKVNGV3nGQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.22.13
+      '@babel/generator': 7.21.3
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-function-name': 7.22.5
+      '@babel/helper-hoist-variables': 7.18.6
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/parser': 7.22.15
+      '@babel/types': 7.22.15
+      debug: 4.3.4(supports-color@9.2.2)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -11072,7 +11095,6 @@ packages:
     dependencies:
       '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
-    dev: true
 
   /@babel/types@7.17.0:
     resolution: {integrity: sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==}
@@ -11543,7 +11565,7 @@ packages:
     engines: {node: ^10.12.0 || >=12.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       espree: 7.3.1
       globals: 13.19.0
       ignore: 4.0.6
@@ -11560,7 +11582,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       espree: 9.4.1
       globals: 13.19.0
       ignore: 5.2.0
@@ -11589,6 +11611,7 @@ packages:
 
   /@floating-ui/core@1.0.1:
     resolution: {integrity: sha512-bO37brCPfteXQfFY0DyNDGB3+IMe4j150KFQcgJ5aBP295p9nBGeHEs/p0czrRbtlHq4Px/yoPXO/+dOCcF4uA==}
+    dev: true
 
   /@floating-ui/core@1.4.1:
     resolution: {integrity: sha512-jk3WqquEJRlcyu7997NtR5PibI+y5bi+LS3hPmguVClypenMsCY3CBa3LAQnozRCtCrYWSEtAdiskpamuJRFOQ==}
@@ -11611,6 +11634,7 @@ packages:
     resolution: {integrity: sha512-5X9WSvZ8/fjy3gDu8yx9HAA4KG1lazUN2P4/VnaXLxTO9Dz53HI1oYoh1OlhqFNlHgGDiwFX5WhFCc2ljbW3yA==}
     dependencies:
       '@floating-ui/core': 1.0.1
+    dev: true
 
   /@floating-ui/dom@1.5.1:
     resolution: {integrity: sha512-KwvVcPSXg6mQygvA1TjbN/gh///36kKtllIF8SUm0qpFj8+rvYrpvlYdL1JoA71SHpDqgSSdGOSoQ0Mp3uY5aw==}
@@ -11652,7 +11676,7 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
     dependencies:
-      '@floating-ui/dom': 1.0.2
+      '@floating-ui/dom': 1.5.1
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
@@ -11719,7 +11743,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -11729,7 +11753,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -12943,7 +12967,7 @@ packages:
   /@kwsites/file-exists@1.1.1:
     resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -13302,7 +13326,7 @@ packages:
       '@oclif/color': 1.0.1
       '@oclif/core': 1.16.1
       chalk: 4.1.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       fs-extra: 9.1.0
       http-call: 5.3.0
       load-json-file: 5.3.0
@@ -13320,7 +13344,7 @@ packages:
     dependencies:
       '@oclif/core': 1.16.1
       chalk: 4.1.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       fs-extra: 9.1.0
       http-call: 5.3.0
       lodash: 4.17.21
@@ -13857,7 +13881,7 @@ packages:
       react-refresh: 0.11.0
       schema-utils: 3.1.1
       source-map: 0.7.3
-      webpack: 5.76.3(webpack-cli@3.3.12)
+      webpack: 5.76.3(webpack-cli@4.9.2)
     dev: true
 
   /@pmmmwh/react-refresh-webpack-plugin@0.5.10(react-refresh@0.14.0)(webpack-dev-server@4.12.0)(webpack@5.70.0):
@@ -14966,7 +14990,7 @@ packages:
     transitivePeerDependencies:
       - encoding
 
-  /@react-native-community/cli-plugin-metro@9.1.1(@babel/core@7.17.8):
+  /@react-native-community/cli-plugin-metro@9.1.1(@babel/core@7.12.9):
     resolution: {integrity: sha512-8CBwEZrbYIeQw69Exg/oW20pV9C6mbYlDz0pxZJ0AYmC20Q+wFFs6sUh5zm28ZUh1L0LxNGmhle/YvMPqA+fMQ==}
     dependencies:
       '@react-native-community/cli-server-api': 9.1.0
@@ -14975,7 +14999,7 @@ packages:
       metro: 0.72.2
       metro-config: 0.72.2
       metro-core: 0.72.2
-      metro-react-native-babel-transformer: 0.72.1(@babel/core@7.17.8)
+      metro-react-native-babel-transformer: 0.72.1(@babel/core@7.12.9)
       metro-resolver: 0.72.2
       metro-runtime: 0.72.2
       readline: 1.3.0
@@ -15024,7 +15048,7 @@ packages:
     dependencies:
       joi: 17.6.0
 
-  /@react-native-community/cli@9.1.1(@babel/core@7.17.8):
+  /@react-native-community/cli@9.1.1(@babel/core@7.12.9):
     resolution: {integrity: sha512-LjXcYahjFzM7TlsGzQLH9bCx3yvBsHEj/5Ytdnk0stdDET329JdXWEh6JiSRjVWPVAoDAV5pRAFmEOEGDNIiAw==}
     engines: {node: '>=14'}
     hasBin: true
@@ -15034,7 +15058,7 @@ packages:
       '@react-native-community/cli-debugger-ui': 9.0.0
       '@react-native-community/cli-doctor': 9.1.1
       '@react-native-community/cli-hermes': 9.1.0
-      '@react-native-community/cli-plugin-metro': 9.1.1(@babel/core@7.17.8)
+      '@react-native-community/cli-plugin-metro': 9.1.1(@babel/core@7.12.9)
       '@react-native-community/cli-server-api': 9.1.0
       '@react-native-community/cli-tools': 9.1.0
       '@react-native-community/cli-types': 9.1.0
@@ -15873,7 +15897,7 @@ packages:
       ts-dedent: 2.2.0
       typescript: 5.1.6
       util-deprecate: 1.0.2
-      webpack: 5.76.3(webpack-cli@3.3.12)
+      webpack: 5.76.3(webpack-cli@4.9.2)
       webpack-dev-middleware: 4.3.0(webpack@5.76.3)
       webpack-hot-middleware: 2.25.1
       webpack-virtual-modules: 0.4.3
@@ -16086,7 +16110,7 @@ packages:
       typescript: 5.1.6
       unfetch: 4.2.0
       util-deprecate: 1.0.2
-      webpack: 5.76.3(webpack-cli@3.3.12)
+      webpack: 5.76.3(webpack-cli@4.9.2)
     dev: true
 
   /@storybook/core-common@6.5.17-alpha.0(eslint@8.32.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6)(webpack-cli@3.3.12):
@@ -16352,7 +16376,7 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       typescript: 5.1.6
-      webpack: 5.76.3(webpack-cli@3.3.12)
+      webpack: 5.76.3(webpack-cli@4.9.2)
     transitivePeerDependencies:
       - '@storybook/mdx2-csf'
       - acorn
@@ -16599,7 +16623,7 @@ packages:
       ts-dedent: 2.2.0
       typescript: 5.1.6
       util-deprecate: 1.0.2
-      webpack: 5.76.3(webpack-cli@3.3.12)
+      webpack: 5.76.3(webpack-cli@4.9.2)
       webpack-dev-middleware: 4.3.0(webpack@5.76.3)
       webpack-virtual-modules: 0.4.3
     transitivePeerDependencies:
@@ -16720,7 +16744,7 @@ packages:
       typescript: '>= 4.x'
       webpack: '>= 4'
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       endent: 2.1.0
       find-cache-dir: 3.3.2
       flat-cache: 3.0.4
@@ -16728,7 +16752,7 @@ packages:
       react-docgen-typescript: 2.2.2(typescript@5.1.6)
       tslib: 2.5.0
       typescript: 5.1.6
-      webpack: 5.76.3(webpack-cli@3.3.12)
+      webpack: 5.76.3(webpack-cli@4.9.2)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -16892,7 +16916,7 @@ packages:
       ts-dedent: 2.2.0
       typescript: 5.1.6
       util-deprecate: 1.0.2
-      webpack: 5.76.3(webpack-cli@3.3.12)
+      webpack: 5.76.3(webpack-cli@4.9.2)
     transitivePeerDependencies:
       - '@storybook/mdx2-csf'
       - '@swc/core'
@@ -17383,7 +17407,7 @@ packages:
     resolution: {integrity: sha512-EbDKwO9GpfWP4jN9sGdYwPBU0kdomaPIL2Eu4YwmgP+sJeXT+L7bMwJUBnhzfH8Q2qMBqZ4fJwpCyYsAN3mt2Q==}
     engines: {node: '>=14'}
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.15
       entities: 4.5.0
     dev: true
 
@@ -17434,7 +17458,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       cosmiconfig: 7.0.1
-      deepmerge: 4.3.0
+      deepmerge: 4.3.1
       svgo: 1.3.2
     dev: true
 
@@ -17446,7 +17470,7 @@ packages:
     dependencies:
       '@svgr/core': 6.5.1
       cosmiconfig: 7.0.1
-      deepmerge: 4.3.0
+      deepmerge: 4.3.1
       svgo: 2.8.0
     dev: true
 
@@ -17685,8 +17709,8 @@ packages:
   /@types/babel__core@7.1.16:
     resolution: {integrity: sha512-EAEHtisTMM+KaKwfWdC3oyllIqswlznXCIVCt7/oRNrh+DhgT4UEBNC/jlADNjvw7UnfbcdkGQcPVZ1xYiLcrQ==}
     dependencies:
-      '@babel/parser': 7.21.3
-      '@babel/types': 7.22.4
+      '@babel/parser': 7.22.15
+      '@babel/types': 7.22.15
       '@types/babel__generator': 7.6.3
       '@types/babel__template': 7.4.1
       '@types/babel__traverse': 7.14.2
@@ -17694,13 +17718,13 @@ packages:
   /@types/babel__generator@7.6.3:
     resolution: {integrity: sha512-/GWCmzJWqV7diQW54smJZzWbSFf4QYtF71WCKhcx6Ru/tFyQIY2eiiITcCAeuPbNSvT9YCGkVMqqvSk2Z0mXiA==}
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.15
 
   /@types/babel__template@7.4.1:
     resolution: {integrity: sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==}
     dependencies:
-      '@babel/parser': 7.21.3
-      '@babel/types': 7.22.4
+      '@babel/parser': 7.22.15
+      '@babel/types': 7.22.15
 
   /@types/babel__traverse@7.14.2:
     resolution: {integrity: sha512-K2waXdXBi2302XUdcHcR1jCeU0LL4TD9HRs/gk0N2Xvrht+G/BfJa4QObBQZfhMdxiCpV3COl5Nfq4uKTeTnJA==}
@@ -18260,6 +18284,21 @@ packages:
       - react
       - react-dom
 
+  /@types/wordpress__block-editor@7.0.0(react@17.0.2):
+    resolution: {integrity: sha512-JERpxKAQ7J07C2wtKxr+5ZE9NETIcpu0EiXuXka6Qmrq74oOypdy9jYdhMIYBDMOx4ptR3ne7edaFb2+1SBcqA==}
+    dependencies:
+      '@types/react': 17.0.50
+      '@types/wordpress__blocks': 11.0.7(react@17.0.2)
+      '@types/wordpress__components': 19.10.5(react-dom@16.14.0)(react@17.0.2)
+      '@types/wordpress__data': 6.0.2
+      '@types/wordpress__keycodes': 2.3.1
+      '@wordpress/element': 4.4.1
+      react-autosize-textarea: 7.1.0(react-dom@17.0.2)(react@17.0.2)
+    transitivePeerDependencies:
+      - react
+      - react-dom
+    dev: true
+
   /@types/wordpress__block-library@2.6.1:
     resolution: {integrity: sha512-x+V2iqNZiCbNHwMLxszv0qHZ0ooYXZYisKxUIGTOhlrQDrYIiSIZG2+6UgS65UFnwGQve3EGP/RlMYIpQT6TyQ==}
 
@@ -18272,6 +18311,17 @@ packages:
     transitivePeerDependencies:
       - react
       - react-dom
+
+  /@types/wordpress__blocks@11.0.7(react@17.0.2):
+    resolution: {integrity: sha512-8BcT3CUxHt73CepaLtQHAhA7uBhDOK9x5HJOAxzV+Bl37W04u4jSNulXxwX/6tI7t7Knux5lnN9bvKf/1sg+Rw==}
+    dependencies:
+      '@types/react': 17.0.50
+      '@types/wordpress__components': 19.10.5(react-dom@16.14.0)(react@17.0.2)
+      '@wordpress/element': 4.4.1
+    transitivePeerDependencies:
+      - react
+      - react-dom
+    dev: true
 
   /@types/wordpress__components@19.10.5(react-dom@16.14.0)(react@17.0.2):
     resolution: {integrity: sha512-0BfLFVB9IxrYH1llVM3LltalJiHn7jyS3k6FEC0wQMoIzs+kXI9w5rSI06faodBcwp9YQDjhK+Bkr49dqx+3dQ==}
@@ -18455,7 +18505,7 @@ packages:
       '@typescript-eslint/experimental-utils': 4.33.0(eslint@7.32.0)(typescript@5.1.6)
       '@typescript-eslint/parser': 4.33.0(eslint@8.32.0)(typescript@5.1.6)
       '@typescript-eslint/scope-manager': 4.33.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       eslint: 7.32.0
       functional-red-black-tree: 1.0.1
       ignore: 5.2.0
@@ -18482,7 +18532,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.54.0
       '@typescript-eslint/type-utils': 5.54.0(eslint@8.32.0)(typescript@5.1.6)
       '@typescript-eslint/utils': 5.54.0(eslint@8.32.0)(typescript@5.1.6)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       eslint: 8.32.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.0
@@ -18570,7 +18620,7 @@ packages:
       '@typescript-eslint/scope-manager': 4.33.0
       '@typescript-eslint/types': 4.33.0
       '@typescript-eslint/typescript-estree': 4.33.0(typescript@5.1.6)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       eslint: 8.32.0
       typescript: 5.1.6
     transitivePeerDependencies:
@@ -18590,7 +18640,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.54.0
       '@typescript-eslint/types': 5.54.0
       '@typescript-eslint/typescript-estree': 5.54.0(typescript@5.1.6)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       eslint: 8.32.0
       typescript: 5.1.6
     transitivePeerDependencies:
@@ -18623,7 +18673,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.54.0(typescript@5.1.6)
       '@typescript-eslint/utils': 5.54.0(eslint@8.32.0)(typescript@5.1.6)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       eslint: 8.32.0
       tsutils: 3.21.0(typescript@5.1.6)
       typescript: 5.1.6
@@ -18648,7 +18698,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       eslint-visitor-keys: 1.3.0
       glob: 7.2.3
       is-glob: 4.0.3
@@ -18671,7 +18721,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 4.33.0
       '@typescript-eslint/visitor-keys': 4.33.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.3
@@ -18692,7 +18742,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.54.0
       '@typescript-eslint/visitor-keys': 5.54.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.0
@@ -18715,7 +18765,7 @@ packages:
       eslint: 8.32.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0(eslint@8.32.0)
-      semver: 7.5.0
+      semver: 7.5.3
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -19171,13 +19221,6 @@ packages:
       '@babel/runtime': 7.21.0
     dev: false
 
-  /@wordpress/autop@3.28.0:
-    resolution: {integrity: sha512-plCKPzTBiZ+R69PsIXUk1wmn4+/JxmmsXL6SklwH/o5cKyY4dcuq6v6wPbfLv5Rb+S19wguNP8DdWFwjSsIOZQ==}
-    engines: {node: '>=12'}
-    dependencies:
-      '@babel/runtime': 7.21.0
-    dev: false
-
   /@wordpress/autop@3.40.0:
     resolution: {integrity: sha512-AuuZpPLnonNNlekiE+gDmQEz+juHvCZJml1aGllip4txXCKZDvJUU6WVmnQYp+m1V/Wj4/Szb8w1muUslsjb7Q==}
     engines: {node: '>=12'}
@@ -19375,8 +19418,8 @@ packages:
       '@wordpress/notices': 3.28.0(react@17.0.2)
       '@wordpress/rich-text': 5.17.0(react@17.0.2)
       '@wordpress/shortcode': 3.40.0
-      '@wordpress/style-engine': 1.2.0
-      '@wordpress/token-list': 2.28.0
+      '@wordpress/style-engine': 1.23.0
+      '@wordpress/token-list': 2.40.0
       '@wordpress/url': 3.41.0
       '@wordpress/warning': 2.40.0
       '@wordpress/wordcount': 3.40.0
@@ -19604,17 +19647,17 @@ packages:
       '@wordpress/html-entities': 3.40.0
       '@wordpress/i18n': 4.40.0
       '@wordpress/icons': 9.31.0
-      '@wordpress/is-shallow-equal': 4.28.0
+      '@wordpress/is-shallow-equal': 4.40.0
       '@wordpress/keyboard-shortcuts': 3.17.0(react@17.0.2)
       '@wordpress/keycodes': 3.40.0
       '@wordpress/notices': 3.28.0(react@17.0.2)
       '@wordpress/rich-text': 5.17.0(react@17.0.2)
-      '@wordpress/shortcode': 3.28.0
+      '@wordpress/shortcode': 3.40.0
       '@wordpress/style-engine': 0.15.0
-      '@wordpress/token-list': 2.28.0
+      '@wordpress/token-list': 2.40.0
       '@wordpress/url': 3.41.0
       '@wordpress/warning': 2.40.0
-      '@wordpress/wordcount': 3.28.0
+      '@wordpress/wordcount': 3.40.0
       change-case: 4.1.2
       classnames: 2.3.1
       colord: 2.9.2
@@ -19626,7 +19669,7 @@ packages:
       react-autosize-textarea: 7.1.0(react-dom@17.0.2)(react@17.0.2)
       react-dom: 17.0.2(react@17.0.2)
       react-easy-crop: 3.5.3(react-dom@17.0.2)(react@17.0.2)
-      rememo: 4.0.0
+      rememo: 4.0.2
       remove-accents: 0.4.2
       traverse: 0.6.6
     transitivePeerDependencies:
@@ -19657,17 +19700,17 @@ packages:
       '@wordpress/html-entities': 3.40.0
       '@wordpress/i18n': 4.40.0
       '@wordpress/icons': 9.31.0
-      '@wordpress/is-shallow-equal': 4.28.0
+      '@wordpress/is-shallow-equal': 4.40.0
       '@wordpress/keyboard-shortcuts': 3.17.0(react@17.0.2)
       '@wordpress/keycodes': 3.40.0
       '@wordpress/notices': 3.28.0(react@17.0.2)
       '@wordpress/rich-text': 5.17.0(react@17.0.2)
-      '@wordpress/shortcode': 3.28.0
+      '@wordpress/shortcode': 3.40.0
       '@wordpress/style-engine': 0.15.0
-      '@wordpress/token-list': 2.28.0
+      '@wordpress/token-list': 2.40.0
       '@wordpress/url': 3.41.0
       '@wordpress/warning': 2.40.0
-      '@wordpress/wordcount': 3.28.0
+      '@wordpress/wordcount': 3.40.0
       change-case: 4.1.2
       classnames: 2.3.1
       colord: 2.9.2
@@ -19679,7 +19722,60 @@ packages:
       react-autosize-textarea: 7.1.0(react-dom@17.0.2)(react@17.0.2)
       react-dom: 17.0.2(react@17.0.2)
       react-easy-crop: 3.5.3(react-dom@17.0.2)(react@17.0.2)
-      rememo: 4.0.0
+      rememo: 4.0.2
+      remove-accents: 0.4.2
+      traverse: 0.6.6
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@types/react'
+    dev: false
+
+  /@wordpress/block-editor@9.8.0(@babel/core@7.21.3)(react@17.0.2):
+    resolution: {integrity: sha512-zIPqEysaLFJMnVKU/yCoCEBT3Co9xsa4Ow91T/LI94ll3LeWG/pyiX4PSSQNTx74AqbcNO2p79LVON4FLdu+mQ==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: ^17.0.0
+      react-dom: ^17.0.0
+    dependencies:
+      '@babel/runtime': 7.21.0
+      '@react-spring/web': 9.5.5(react-dom@17.0.2)(react@17.0.2)
+      '@wordpress/a11y': 3.40.0
+      '@wordpress/api-fetch': 6.37.0
+      '@wordpress/blob': 3.40.0
+      '@wordpress/blocks': 11.18.0(react@17.0.2)
+      '@wordpress/components': 20.0.0(@babel/core@7.21.3)(react@17.0.2)
+      '@wordpress/compose': 5.17.0(react@17.0.2)
+      '@wordpress/data': 7.3.0(react@17.0.2)
+      '@wordpress/date': 4.40.0
+      '@wordpress/deprecated': 3.40.0
+      '@wordpress/dom': 3.40.0
+      '@wordpress/element': 4.20.0
+      '@wordpress/hooks': 3.40.0
+      '@wordpress/html-entities': 3.40.0
+      '@wordpress/i18n': 4.40.0
+      '@wordpress/icons': 9.31.0
+      '@wordpress/is-shallow-equal': 4.40.0
+      '@wordpress/keyboard-shortcuts': 3.17.0(react@17.0.2)
+      '@wordpress/keycodes': 3.40.0
+      '@wordpress/notices': 3.28.0(react@17.0.2)
+      '@wordpress/rich-text': 5.17.0(react@17.0.2)
+      '@wordpress/shortcode': 3.40.0
+      '@wordpress/style-engine': 0.15.0
+      '@wordpress/token-list': 2.40.0
+      '@wordpress/url': 3.41.0
+      '@wordpress/warning': 2.40.0
+      '@wordpress/wordcount': 3.40.0
+      change-case: 4.1.2
+      classnames: 2.3.1
+      colord: 2.9.2
+      diff: 4.0.2
+      dom-scroll-into-view: 1.2.1
+      inherits: 2.0.4
+      lodash: 4.17.21
+      react: 17.0.2
+      react-autosize-textarea: 7.1.0(react-dom@17.0.2)(react@17.0.2)
+      react-easy-crop: 3.5.3(react-dom@17.0.2)(react@17.0.2)
+      rememo: 4.0.2
       remove-accents: 0.4.2
       traverse: 0.6.6
     transitivePeerDependencies:
@@ -19806,13 +19902,6 @@ packages:
       - vite
     dev: false
 
-  /@wordpress/block-serialization-default-parser@4.28.0:
-    resolution: {integrity: sha512-ZtrcHI3PbWgWQO1AmL7IXGTItV8y/dfz+OhmgANpDil/OWUhACOgBIgiPn3ymwspjgsw6r2MB6s3rRMEzjzhxg==}
-    engines: {node: '>=12'}
-    dependencies:
-      '@babel/runtime': 7.21.0
-    dev: false
-
   /@wordpress/block-serialization-default-parser@4.40.0:
     resolution: {integrity: sha512-MFQ82tIf/finWY4TPDYP1ZYQfg2MLCC7j60idEwfd4y2jWW+LiksaUOEFBnSryAgZ5nhr2PQd7aciZpg8JM3dA==}
     engines: {node: '>=12'}
@@ -19895,9 +19984,9 @@ packages:
       react: ^18.0.0
     dependencies:
       '@babel/runtime': 7.21.0
-      '@wordpress/autop': 3.28.0
+      '@wordpress/autop': 3.40.0
       '@wordpress/blob': 3.40.0
-      '@wordpress/block-serialization-default-parser': 4.28.0
+      '@wordpress/block-serialization-default-parser': 4.40.0
       '@wordpress/compose': 6.17.0(react@17.0.2)
       '@wordpress/data': 8.5.0(react@17.0.2)
       '@wordpress/deprecated': 3.40.0
@@ -19906,9 +19995,9 @@ packages:
       '@wordpress/hooks': 3.40.0
       '@wordpress/html-entities': 3.40.0
       '@wordpress/i18n': 4.40.0
-      '@wordpress/is-shallow-equal': 4.28.0
+      '@wordpress/is-shallow-equal': 4.40.0
       '@wordpress/private-apis': 0.10.0
-      '@wordpress/shortcode': 3.28.0
+      '@wordpress/shortcode': 3.40.0
       change-case: 4.1.2
       colord: 2.9.2
       fast-deep-equal: 3.1.3
@@ -19917,7 +20006,7 @@ packages:
       lodash: 4.17.21
       memize: 1.1.0
       react: 17.0.2
-      rememo: 4.0.0
+      rememo: 4.0.2
       remove-accents: 0.4.2
       showdown: 1.9.1
       simple-html-tokenizer: 0.5.11
@@ -20420,6 +20509,60 @@ packages:
       react-colorful: 5.6.1(react-dom@17.0.2)(react@17.0.2)
       react-dom: 17.0.2(react@17.0.2)
       reakit: 1.3.11(react-dom@17.0.2)(react@17.0.2)
+      remove-accents: 0.4.2
+      use-lilius: 2.0.3(react-dom@17.0.2)(react@17.0.2)
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@types/react'
+    dev: false
+
+  /@wordpress/components@20.0.0(@babel/core@7.21.3)(react@17.0.2):
+    resolution: {integrity: sha512-RBPjtGLSoiV5YKhrBYh+/X8LbzbA99BJaB4Q+P0e1rVOwGzeBF3M7YEjmg1PrrzWaItqJZTvDoyZo+ql7c0KfA==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: ^17.0.0
+      react-dom: ^17.0.0
+    dependencies:
+      '@babel/runtime': 7.21.0
+      '@emotion/cache': 11.10.5
+      '@emotion/css': 11.7.1(@babel/core@7.21.3)
+      '@emotion/react': 11.10.5(@babel/core@7.21.3)(@types/react@17.0.50)(react@17.0.2)
+      '@emotion/serialize': 1.1.1
+      '@emotion/styled': 11.8.1(@babel/core@7.21.3)(@emotion/react@11.10.5)(@types/react@17.0.50)(react@17.0.2)
+      '@emotion/utils': 1.2.0
+      '@floating-ui/react-dom': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@use-gesture/react': 10.2.27(react@17.0.2)
+      '@wordpress/a11y': 3.40.0
+      '@wordpress/compose': 5.17.0(react@17.0.2)
+      '@wordpress/date': 4.40.0
+      '@wordpress/deprecated': 3.40.0
+      '@wordpress/dom': 3.40.0
+      '@wordpress/element': 4.20.0
+      '@wordpress/escape-html': 2.40.0
+      '@wordpress/hooks': 3.40.0
+      '@wordpress/i18n': 4.40.0
+      '@wordpress/icons': 9.31.0
+      '@wordpress/is-shallow-equal': 4.40.0
+      '@wordpress/keycodes': 3.40.0
+      '@wordpress/primitives': 3.38.0
+      '@wordpress/rich-text': 5.17.0(react@17.0.2)
+      '@wordpress/warning': 2.40.0
+      change-case: 4.1.2
+      classnames: 2.3.1
+      colord: 2.9.2
+      date-fns: 2.29.3
+      dom-scroll-into-view: 1.2.1
+      downshift: 6.1.12(react@17.0.2)
+      framer-motion: 6.2.8(react-dom@16.14.0)(react@17.0.2)
+      gradient-parser: 0.1.5
+      highlight-words-core: 1.2.2
+      lodash: 4.17.21
+      memize: 1.1.0
+      re-resizable: 6.9.5(react-dom@16.14.0)(react@17.0.2)
+      react: 17.0.2
+      react-colorful: 5.6.1(react-dom@16.14.0)(react@17.0.2)
+      reakit: 1.3.11(react-dom@16.14.0)(react@17.0.2)
       remove-accents: 0.4.2
       use-lilius: 2.0.3(react-dom@17.0.2)(react@17.0.2)
       uuid: 8.3.2
@@ -21873,12 +22016,6 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.0
 
-  /@wordpress/is-shallow-equal@4.28.0:
-    resolution: {integrity: sha512-RN6ME/m+HJ3BwwpSJBG7kl7SSJgCkaJ7MR7v27vRRvzt9iAiGbv7s5wq2P1WiwX7xqCViRYDC3HVGbwqB7miAA==}
-    engines: {node: '>=12'}
-    dependencies:
-      '@babel/runtime': 7.21.0
-
   /@wordpress/is-shallow-equal@4.4.1:
     resolution: {integrity: sha512-NlcqqrukKe4zT5fCs3O5FVYwqmHhtqM//KqWs7xfIaoz9B07oKZQNZqOrU72mgz7mgRliQumTQHzFM76RO0hZQ==}
     engines: {node: '>=12'}
@@ -21947,7 +22084,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.0
       jest: 29.5.0(@types/node@16.18.21)(ts-node@10.9.1)
-      jest-matcher-utils: 29.5.0
+      jest-matcher-utils: 29.6.2
     dev: true
 
   /@wordpress/jest-preset-default@11.5.0(@babel/core@7.21.3)(jest@29.5.0):
@@ -22973,13 +23110,6 @@ packages:
       - vite
     dev: false
 
-  /@wordpress/shortcode@3.28.0:
-    resolution: {integrity: sha512-Il9NMftqN2WCMqrTxHFyKPnyQc1T80mCU34cTRvR5ZbZMrWNDDdYKMIYwmFc4ehcdWvddkMSPB8JA0ZNbw8NbA==}
-    engines: {node: '>=12'}
-    dependencies:
-      '@babel/runtime': 7.21.0
-      memize: 1.1.0
-
   /@wordpress/shortcode@3.40.0:
     resolution: {integrity: sha512-H3jd1GgsNHtRuXVvItsjtf/OQOGI0vEZ+o964Ie4xqODwqOceYKASj4Bu2x9FKl94xa7tNfsn9ZSs6ADKWHh3g==}
     engines: {node: '>=12'}
@@ -22996,14 +23126,6 @@ packages:
 
   /@wordpress/style-engine@0.6.0:
     resolution: {integrity: sha512-HIHIhlR1ZulA9j7Z5519/bRAo5v9HSJJFx8CBz+b02XhTUWSgYkUerkHL+UhCTWJpnyBNcPeNDrc0xR1xj7HMA==}
-    engines: {node: '>=12'}
-    dependencies:
-      '@babel/runtime': 7.21.0
-      lodash: 4.17.21
-    dev: false
-
-  /@wordpress/style-engine@1.2.0:
-    resolution: {integrity: sha512-RoyTFpxDS7uOJuNG31J/153JLKCNftU1/wMMkf0qXDpP+1k4h9em1+iIPPAGPRW5pSq/ky95fAaQAnl+FgI6Wg==}
     engines: {node: '>=12'}
     dependencies:
       '@babel/runtime': 7.21.0
@@ -23082,18 +23204,11 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@wordpress/token-list@2.28.0:
-    resolution: {integrity: sha512-MLe7/Ma5BcFzz62ObRwvNFQakdBHCqNkOHLS/PBmWpDSi4Y9+qvICdEn8Od3d0RkPdjupBdtF1ZBeYoaL04K2Q==}
-    engines: {node: '>=12'}
-    dependencies:
-      '@babel/runtime': 7.21.0
-
   /@wordpress/token-list@2.40.0:
     resolution: {integrity: sha512-cVEgf0PRpN9I1csIi24dElhH3zghH2yC2afgjlZwNPWy8jmUNbgLEBwtgt+iA9WpmhanvS1XhwVoP4EY3WESEg==}
     engines: {node: '>=12'}
     dependencies:
       '@babel/runtime': 7.21.0
-    dev: false
 
   /@wordpress/url@2.22.2(react-native@0.70.0):
     resolution: {integrity: sha512-aqpYKQXzyzkCOm+GzZRYlLb+wh58g0cwR1PaKAl0UXaBS4mdS+X6biMriylb4P8CVC/RR7CSw5XI20JC24KDwQ==}
@@ -23216,18 +23331,11 @@ packages:
       - vite
     dev: false
 
-  /@wordpress/wordcount@3.28.0:
-    resolution: {integrity: sha512-SMgmLGeazocSxNpagXav8/6sRMuldH/EgCPmdXK6SKr4tJb8JbKINW74U208c7IBpRG0GjR+1JNyq6jikT/K4g==}
-    engines: {node: '>=12'}
-    dependencies:
-      '@babel/runtime': 7.21.0
-
   /@wordpress/wordcount@3.40.0:
     resolution: {integrity: sha512-emZQt/WwrIYk5iOO6LjrGBZ7FB6rUms4CaFoj2Zfs5JZAkXxjnT5cO355rA1woJOmYD+4L2X4qgz5X3rePSIRA==}
     engines: {node: '>=12'}
     dependencies:
       '@babel/runtime': 7.21.0
-    dev: false
 
   /@xstate/graph@1.4.2(xstate@4.37.1):
     resolution: {integrity: sha512-XIh6opCf9ukXRj4dXe2fv2kwFFUl15B5Ob8ELNOOqDXB2BPyNwp6TaLe5KJn/na3gzC9B7LyOo+2d0dPkC8PWQ==}
@@ -23425,7 +23533,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -23433,7 +23541,7 @@ packages:
     resolution: {integrity: sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==}
     engines: {node: '>= 8.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       depd: 1.1.2
       humanize-ms: 1.2.1
     transitivePeerDependencies:
@@ -24183,10 +24291,10 @@ packages:
     peerDependencies:
       eslint: '>= 4.12.1'
     dependencies:
-      '@babel/code-frame': 7.16.7
-      '@babel/parser': 7.17.8
-      '@babel/traverse': 7.17.3
-      '@babel/types': 7.17.0
+      '@babel/code-frame': 7.22.13
+      '@babel/parser': 7.22.15
+      '@babel/traverse': 7.21.3
+      '@babel/types': 7.22.15
       eslint: 7.32.0
       eslint-visitor-keys: 1.3.0
       resolve: 1.20.0
@@ -24437,7 +24545,7 @@ packages:
       loader-utils: 2.0.4
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.76.3(webpack-cli@3.3.12)
+      webpack: 5.76.3(webpack-cli@4.9.2)
     dev: true
 
   /babel-loader@8.3.0(@babel/core@7.17.8)(webpack@4.46.0):
@@ -24543,7 +24651,7 @@ packages:
   /babel-plugin-emotion@10.2.2:
     resolution: {integrity: sha512-SMSkGoqTbTyUTDeuVuPIWifPdUGkTk1Kf9BWRiXIOIcuyMfsdp2EjeiiFvOzX8NOBvEh/ypKYvUh2rkgAJMCLA==}
     dependencies:
-      '@babel/helper-module-imports': 7.21.4
+      '@babel/helper-module-imports': 7.22.15
       '@emotion/hash': 0.8.0
       '@emotion/memoize': 0.7.4
       '@emotion/serialize': 0.11.16
@@ -24577,7 +24685,7 @@ packages:
     resolution: {integrity: sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/helper-plugin-utils': 7.22.5
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-instrument: 5.1.0
@@ -24596,7 +24704,7 @@ packages:
     resolution: {integrity: sha512-u+/W+WAjMlvoocYGTwthAiQSxDcJAyHpQ6oWlHdFZaaN+Rlk8Q7iiwDPg2lN/FyJtAYnKjFxbn7xus4HCFkg5g==}
     engines: {node: '>= 8.3'}
     dependencies:
-      '@babel/template': 7.20.7
+      '@babel/template': 7.22.15
       '@babel/types': 7.22.15
       '@types/babel__traverse': 7.14.2
     dev: true
@@ -24605,7 +24713,7 @@ packages:
     resolution: {integrity: sha512-PO9t0697lNTmcEHH69mdtYiOIkkOlj9fySqfO3K1eCcdISevLAE0xY59VLLUj0SoiPiTX/JU2CYFpILydUa5Lw==}
     engines: {node: '>= 10.14.2'}
     dependencies:
-      '@babel/template': 7.20.7
+      '@babel/template': 7.22.15
       '@babel/types': 7.22.15
       '@types/babel__core': 7.1.16
       '@types/babel__traverse': 7.14.2
@@ -24614,8 +24722,8 @@ packages:
     resolution: {integrity: sha512-50wCwD5EMNW4aRpOwtqzyZHIewTYNxLA4nhB+09d8BIssfNfzBRhkBIHiaPv1Si226TQSvp8gxAJm2iY2qs2hQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@babel/template': 7.20.7
-      '@babel/types': 7.22.4
+      '@babel/template': 7.22.15
+      '@babel/types': 7.22.15
       '@types/babel__core': 7.1.16
       '@types/babel__traverse': 7.14.2
 
@@ -24669,7 +24777,7 @@ packages:
       '@babel/compat-data': 7.21.0
       '@babel/core': 7.17.8
       '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.17.8)
-      semver: 6.3.0
+      semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -24682,7 +24790,7 @@ packages:
       '@babel/compat-data': 7.21.0
       '@babel/core': 7.21.3
       '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.21.3)
-      semver: 6.3.0
+      semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -24695,10 +24803,9 @@ packages:
       '@babel/compat-data': 7.21.0
       '@babel/core': 7.12.9
       '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.12.9)
-      semver: 6.3.0
+      semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /babel-plugin-polyfill-corejs2@0.3.3(@babel/core@7.17.8):
     resolution: {integrity: sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==}
@@ -24708,9 +24815,10 @@ packages:
       '@babel/compat-data': 7.21.0
       '@babel/core': 7.17.8
       '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.17.8)
-      semver: 6.3.0
+      semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /babel-plugin-polyfill-corejs2@0.3.3(@babel/core@7.21.3):
     resolution: {integrity: sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==}
@@ -24720,7 +24828,7 @@ packages:
       '@babel/compat-data': 7.21.0
       '@babel/core': 7.21.3
       '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.21.3)
-      semver: 6.3.0
+      semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
@@ -24806,7 +24914,6 @@ packages:
       core-js-compat: 3.25.5
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /babel-plugin-polyfill-corejs3@0.6.0(@babel/core@7.17.8):
     resolution: {integrity: sha512-+eHqR6OPcBhJOGgsIar7xoAB1GcSwVUA3XjAd7HJNzOXT4wv6/H7KIdA/Nc60cvUlDbKApmqNvD1B1bzOt4nyA==}
@@ -24818,6 +24925,7 @@ packages:
       core-js-compat: 3.25.5
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /babel-plugin-polyfill-corejs3@0.6.0(@babel/core@7.21.3):
     resolution: {integrity: sha512-+eHqR6OPcBhJOGgsIar7xoAB1GcSwVUA3XjAd7HJNzOXT4wv6/H7KIdA/Nc60cvUlDbKApmqNvD1B1bzOt4nyA==}
@@ -24872,7 +24980,6 @@ packages:
       '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.12.9)
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /babel-plugin-polyfill-regenerator@0.4.1(@babel/core@7.17.8):
     resolution: {integrity: sha512-NtQGmyQDXjQqQ+IzRkBVwEOz9lQ4zxAQZgoAYEtU9dJjnl1Oc98qnN7jcp+bE7O7aYzVpavXE3/VKXNzUbh7aw==}
@@ -24883,6 +24990,7 @@ packages:
       '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.17.8)
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /babel-plugin-polyfill-regenerator@0.4.1(@babel/core@7.21.3):
     resolution: {integrity: sha512-NtQGmyQDXjQqQ+IzRkBVwEOz9lQ4zxAQZgoAYEtU9dJjnl1Oc98qnN7jcp+bE7O7aYzVpavXE3/VKXNzUbh7aw==}
@@ -25029,38 +25137,38 @@ packages:
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.21.3)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.21.3)
 
-  /babel-preset-fbjs@3.4.0(@babel/core@7.17.8):
+  /babel-preset-fbjs@3.4.0(@babel/core@7.12.9):
     resolution: {integrity: sha512-9ywCsCvo1ojrw0b+XYk7aFvTH6D9064t0RIL1rtMf3nsa02Xw41MS7sZw216Im35xj/UY0PDBQsa1brUDDF1Ow==}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.17.8
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.17.8)
-      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.17.8)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.17.8)
-      '@babel/plugin-syntax-flow': 7.16.7(@babel/core@7.17.8)
-      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.17.8)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.17.8)
-      '@babel/plugin-transform-arrow-functions': 7.18.6(@babel/core@7.17.8)
-      '@babel/plugin-transform-block-scoped-functions': 7.18.6(@babel/core@7.17.8)
-      '@babel/plugin-transform-block-scoping': 7.21.0(@babel/core@7.17.8)
-      '@babel/plugin-transform-classes': 7.21.0(@babel/core@7.17.8)
-      '@babel/plugin-transform-computed-properties': 7.18.9(@babel/core@7.17.8)
-      '@babel/plugin-transform-destructuring': 7.21.3(@babel/core@7.17.8)
-      '@babel/plugin-transform-flow-strip-types': 7.16.7(@babel/core@7.17.8)
-      '@babel/plugin-transform-for-of': 7.18.8(@babel/core@7.17.8)
-      '@babel/plugin-transform-function-name': 7.18.9(@babel/core@7.17.8)
-      '@babel/plugin-transform-literals': 7.18.9(@babel/core@7.17.8)
-      '@babel/plugin-transform-member-expression-literals': 7.18.6(@babel/core@7.17.8)
-      '@babel/plugin-transform-modules-commonjs': 7.22.15(@babel/core@7.17.8)
-      '@babel/plugin-transform-object-super': 7.18.6(@babel/core@7.17.8)
-      '@babel/plugin-transform-parameters': 7.21.3(@babel/core@7.17.8)
-      '@babel/plugin-transform-property-literals': 7.18.6(@babel/core@7.17.8)
-      '@babel/plugin-transform-react-display-name': 7.18.6(@babel/core@7.17.8)
-      '@babel/plugin-transform-react-jsx': 7.22.3(@babel/core@7.17.8)
-      '@babel/plugin-transform-shorthand-properties': 7.18.6(@babel/core@7.17.8)
-      '@babel/plugin-transform-spread': 7.19.0(@babel/core@7.17.8)
-      '@babel/plugin-transform-template-literals': 7.18.9(@babel/core@7.17.8)
+      '@babel/core': 7.12.9
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.12.9)
+      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.12.9)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.12.9)
+      '@babel/plugin-syntax-flow': 7.16.7(@babel/core@7.12.9)
+      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.12.9)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.12.9)
+      '@babel/plugin-transform-arrow-functions': 7.18.6(@babel/core@7.12.9)
+      '@babel/plugin-transform-block-scoped-functions': 7.18.6(@babel/core@7.12.9)
+      '@babel/plugin-transform-block-scoping': 7.21.0(@babel/core@7.12.9)
+      '@babel/plugin-transform-classes': 7.21.0(@babel/core@7.12.9)
+      '@babel/plugin-transform-computed-properties': 7.18.9(@babel/core@7.12.9)
+      '@babel/plugin-transform-destructuring': 7.21.3(@babel/core@7.12.9)
+      '@babel/plugin-transform-flow-strip-types': 7.16.7(@babel/core@7.12.9)
+      '@babel/plugin-transform-for-of': 7.18.8(@babel/core@7.12.9)
+      '@babel/plugin-transform-function-name': 7.18.9(@babel/core@7.12.9)
+      '@babel/plugin-transform-literals': 7.18.9(@babel/core@7.12.9)
+      '@babel/plugin-transform-member-expression-literals': 7.18.6(@babel/core@7.12.9)
+      '@babel/plugin-transform-modules-commonjs': 7.22.15(@babel/core@7.12.9)
+      '@babel/plugin-transform-object-super': 7.18.6(@babel/core@7.12.9)
+      '@babel/plugin-transform-parameters': 7.21.3(@babel/core@7.12.9)
+      '@babel/plugin-transform-property-literals': 7.18.6(@babel/core@7.12.9)
+      '@babel/plugin-transform-react-display-name': 7.18.6(@babel/core@7.12.9)
+      '@babel/plugin-transform-react-jsx': 7.22.3(@babel/core@7.12.9)
+      '@babel/plugin-transform-shorthand-properties': 7.18.6(@babel/core@7.12.9)
+      '@babel/plugin-transform-spread': 7.19.0(@babel/core@7.12.9)
+      '@babel/plugin-transform-template-literals': 7.18.9(@babel/core@7.12.9)
       babel-plugin-syntax-trailing-function-commas: 7.0.0-beta.0
     transitivePeerDependencies:
       - supports-color
@@ -26007,7 +26115,7 @@ packages:
     resolution: {integrity: sha512-FwZ/wxjqe+5RgzF2SRsPSWsVB9+McAVRWW0tRkmbh7fBjrf3HFZZbcr8vr61p1K+NBaAPv57DRjxgIyfbHmd7g==}
     engines: {node: '>=7.6.0'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       puppeteer-core: 1.12.2
     transitivePeerDependencies:
       - bufferutil
@@ -26171,7 +26279,7 @@ packages:
       minimist: 1.2.8
       object-filter: 1.0.2
       run-parallel: 1.2.0
-      semver: 6.3.0
+      semver: 6.3.1
     dev: true
 
   /check-types@8.0.3:
@@ -27045,7 +27153,7 @@ packages:
       normalize-path: 3.0.0
       schema-utils: 4.0.0
       serialize-javascript: 6.0.0
-      webpack: 5.76.3(webpack-cli@3.3.12)
+      webpack: 5.76.3(webpack-cli@4.9.2)
     dev: true
 
   /copy-webpack-plugin@9.1.0(webpack@5.70.0):
@@ -27083,7 +27191,6 @@ packages:
     dependencies:
       browserslist: 4.19.3
       semver: 7.0.0
-    dev: true
 
   /core-js-compat@3.21.1:
     resolution: {integrity: sha512-gbgX5AUvMb8gwxC7FLVWYT7Kkgu/y7+h/h1X43yJkNqhlK2fuYyQimqvKGNZFAY6CKii/GFKJ2cp/1/42TN36g==}
@@ -27383,7 +27490,7 @@ packages:
       postcss-modules-values: 3.0.0
       postcss-value-parser: 4.2.0
       schema-utils: 2.7.1
-      semver: 6.3.0
+      semver: 6.3.1
       webpack: 5.70.0(webpack-cli@3.3.12)
 
   /css-loader@3.6.0(webpack@5.76.3):
@@ -27424,7 +27531,7 @@ packages:
       postcss-value-parser: 4.2.0
       schema-utils: 3.1.1
       semver: 7.5.3
-      webpack: 5.76.3(webpack-cli@3.3.12)
+      webpack: 5.76.3(webpack-cli@4.9.2)
     dev: true
 
   /css-loader@6.7.1(webpack@5.70.0):
@@ -27458,7 +27565,7 @@ packages:
       postcss-modules-values: 4.0.0(postcss@8.4.21)
       postcss-value-parser: 4.2.0
       semver: 7.3.8
-      webpack: 5.76.3(webpack-cli@3.3.12)
+      webpack: 5.76.3(webpack-cli@4.9.2)
     dev: true
 
   /css-select-base-adapter@0.1.1:
@@ -27952,7 +28059,6 @@ packages:
     dependencies:
       ms: 2.1.2
       supports-color: 9.2.2
-    dev: true
 
   /debuglog@1.0.1:
     resolution: {integrity: sha512-syBZ+rnAK3EgMsH2aYEOLUW7mZSY9Gb+0wUMCFsZvcmiz+HigA0LOcq/HoQqVuGG+EKykunc7QG2bzrponfaSw==}
@@ -29062,7 +29168,7 @@ packages:
       eslint: '*'
       eslint-plugin-import: '*'
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       eslint: 8.32.0
       eslint-plugin-import: 2.25.4(@typescript-eslint/parser@5.54.0)(eslint-import-resolver-typescript@2.5.0)(eslint-import-resolver-webpack@0.13.2)(eslint@8.32.0)
       glob: 7.2.3
@@ -29333,7 +29439,7 @@ packages:
       eslint: ^5.0.0 || ^6.0.0
     dependencies:
       comment-parser: 0.7.6
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       eslint: 8.32.0
       jsdoctypeparser: 6.1.0
       lodash: 4.17.21
@@ -29352,7 +29458,7 @@ packages:
       eslint: ^6.0.0 || ^7.0.0
     dependencies:
       comment-parser: 0.7.6
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       eslint: 7.32.0
       jsdoctypeparser: 9.0.0
       lodash: 4.17.21
@@ -29371,7 +29477,7 @@ packages:
     dependencies:
       '@es-joy/jsdoccomment': 0.10.8
       comment-parser: 1.2.4
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       eslint: 7.32.0
       esquery: 1.4.0
       jsdoc-type-pratt-parser: 1.2.0
@@ -29391,11 +29497,11 @@ packages:
     dependencies:
       '@es-joy/jsdoccomment': 0.36.1
       comment-parser: 1.3.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       escape-string-regexp: 4.0.0
       eslint: 8.32.0
       esquery: 1.4.0
-      semver: 7.5.0
+      semver: 7.5.3
       spdx-expression-parse: 3.0.1
     transitivePeerDependencies:
       - supports-color
@@ -29557,7 +29663,7 @@ packages:
       object.values: 1.1.5
       prop-types: 15.8.1
       resolve: 2.0.0-next.3
-      semver: 6.3.0
+      semver: 6.3.1
       string.prototype.matchall: 4.0.6
     dev: true
 
@@ -29693,7 +29799,7 @@ packages:
       ajv: 6.12.6
       chalk: 2.4.2
       cross-spawn: 6.0.5
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       doctrine: 3.0.0
       eslint-scope: 4.0.3
       eslint-utils: 1.4.3
@@ -29738,7 +29844,7 @@ packages:
       ajv: 6.12.6
       chalk: 2.4.2
       cross-spawn: 6.0.5
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       doctrine: 3.0.0
       eslint-scope: 5.1.1
       eslint-utils: 1.4.3
@@ -29786,7 +29892,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       doctrine: 3.0.0
       enquirer: 2.3.6
       escape-string-regexp: 4.0.0
@@ -29836,7 +29942,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.1.1
@@ -30282,7 +30388,7 @@ packages:
     engines: {node: '>= 10.17.0'}
     hasBin: true
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -30631,7 +30737,7 @@ packages:
     dependencies:
       chalk: 4.1.2
       commander: 5.1.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -30905,12 +31011,12 @@ packages:
       vue-template-compiler:
         optional: true
     dependencies:
-      '@babel/code-frame': 7.18.6
+      '@babel/code-frame': 7.22.13
       '@types/json-schema': 7.0.9
       chalk: 4.1.2
       chokidar: 3.5.3
       cosmiconfig: 6.0.0
-      deepmerge: 4.3.0
+      deepmerge: 4.3.1
       eslint: 8.32.0
       fs-extra: 9.1.0
       glob: 7.2.3
@@ -30952,7 +31058,7 @@ packages:
       semver: 7.5.3
       tapable: 1.1.3
       typescript: 5.1.6
-      webpack: 5.76.3(webpack-cli@3.3.12)
+      webpack: 5.76.3(webpack-cli@4.9.2)
     dev: true
 
   /fork-ts-checker-webpack-plugin@8.0.0(typescript@5.1.6)(webpack@5.70.0):
@@ -32504,7 +32610,7 @@ packages:
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.76.3(webpack-cli@3.3.12)
+      webpack: 5.76.3(webpack-cli@4.9.2)
     transitivePeerDependencies:
       - acorn
     dev: true
@@ -32536,7 +32642,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       content-type: 1.0.4
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       is-retry-allowed: 1.2.0
       is-stream: 2.0.1
       parse-json: 4.0.0
@@ -32575,7 +32681,7 @@ packages:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -32585,7 +32691,7 @@ packages:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -32656,7 +32762,7 @@ packages:
     engines: {node: '>= 6.0.0'}
     dependencies:
       agent-base: 5.1.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -32665,7 +32771,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -32675,7 +32781,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -32709,7 +32815,7 @@ packages:
     dependencies:
       '@tannin/sprintf': 1.2.0
       '@wordpress/compose': 3.25.3(react@17.0.2)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       events: 3.3.0
       hash.js: 1.1.7
       interpolate-components: 1.1.1
@@ -32730,7 +32836,7 @@ packages:
       '@babel/runtime': 7.21.0
       '@tannin/sprintf': 1.2.0
       '@wordpress/compose': 3.25.3(react@17.0.2)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       events: 3.3.0
       hash.js: 1.1.7
       interpolate-components: 1.1.1
@@ -32752,7 +32858,7 @@ packages:
       '@babel/runtime': 7.21.0
       '@tannin/sprintf': 1.2.0
       '@wordpress/compose': 5.4.1(react@17.0.2)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       events: 3.3.0
       hash.js: 1.1.7
       lodash: 4.17.21
@@ -33772,7 +33878,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/parser': 7.21.3
+      '@babel/parser': 7.22.15
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
       semver: 6.3.1
@@ -33821,7 +33927,7 @@ packages:
     resolution: {integrity: sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==}
     engines: {node: '>=6'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       istanbul-lib-coverage: 2.0.5
       make-dir: 2.1.0
       rimraf: 2.7.1
@@ -33834,7 +33940,7 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       istanbul-lib-coverage: 3.2.0
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -34271,7 +34377,7 @@ packages:
       '@jest/types': 25.5.0
       babel-jest: 25.5.1(@babel/core@7.21.3)
       chalk: 3.0.0
-      deepmerge: 4.3.0
+      deepmerge: 4.3.1
       glob: 7.2.3
       graceful-fs: 4.2.9
       jest-environment-jsdom: 25.5.0
@@ -34306,7 +34412,7 @@ packages:
       '@jest/types': 26.6.2
       babel-jest: 26.6.3(@babel/core@7.21.3)
       chalk: 4.1.2
-      deepmerge: 4.3.0
+      deepmerge: 4.3.1
       glob: 7.2.3
       graceful-fs: 4.2.9
       jest-environment-jsdom: 26.6.2
@@ -34701,11 +34807,11 @@ packages:
     dependencies:
       '@jest/environment': 29.5.0
       '@jest/fake-timers': 29.5.0
-      '@jest/types': 29.5.0
+      '@jest/types': 29.6.1
       '@types/jsdom': 20.0.1
       '@types/node': 16.18.21
       jest-mock: 29.5.0
-      jest-util: 29.5.0
+      jest-util: 29.6.2
       jsdom: 20.0.3
     transitivePeerDependencies:
       - bufferutil
@@ -34767,10 +34873,10 @@ packages:
     dependencies:
       '@jest/environment': 29.5.0
       '@jest/fake-timers': 29.5.0
-      '@jest/types': 29.5.0
+      '@jest/types': 29.6.1
       '@types/node': 16.18.21
       jest-mock: 29.5.0
-      jest-util: 29.5.0
+      jest-util: 29.6.2
     dev: true
 
   /jest-environment-node@29.6.2:
@@ -35141,16 +35247,6 @@ packages:
       jest-get-type: 27.5.1
       pretty-format: 27.5.1
 
-  /jest-matcher-utils@29.5.0:
-    resolution: {integrity: sha512-lecRtgm/rjIK0CQ7LPQwzCs2VwW6WAahA55YBuI+xqmhm7LAaxokSB8C97yJeYyT+HvQkH741StzpU41wohhWw==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      chalk: 4.1.2
-      jest-diff: 29.6.2
-      jest-get-type: 29.4.3
-      pretty-format: 29.6.2
-    dev: true
-
   /jest-matcher-utils@29.6.2:
     resolution: {integrity: sha512-4LiAk3hSSobtomeIAzFTe+N8kL6z0JtF3n6I4fg29iIW7tt99R7ZcIFW34QkX+DuVrf+CUe6wuVOpm7ZKFJzZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -35194,7 +35290,7 @@ packages:
     resolution: {integrity: sha512-rGiLePzQ3AzwUshu2+Rn+UMFk0pHN58sOG+IaJbk5Jxuqo3NYO1U2/MIR4S1sKgsoYSXSzdtSa0TgrmtUwEbmA==}
     engines: {node: '>= 10.14.2'}
     dependencies:
-      '@babel/code-frame': 7.18.6
+      '@babel/code-frame': 7.22.13
       '@jest/types': 26.6.2
       '@types/stack-utils': 2.0.1
       chalk: 4.1.2
@@ -35209,7 +35305,7 @@ packages:
     resolution: {integrity: sha512-rMyFe1+jnyAAf+NHwTclDz0eAaLkVDdKVHHBFWsBWHnnh5YeJMNWWsv7AbFYXfK3oTqvL7VTWkhNLu1jX24D+g==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@babel/code-frame': 7.18.6
+      '@babel/code-frame': 7.22.13
       '@jest/types': 27.5.1
       '@types/stack-utils': 2.0.1
       chalk: 4.1.2
@@ -35223,7 +35319,7 @@ packages:
     resolution: {integrity: sha512-Kijeg9Dag6CKtIDA7O21zNTACqD5MD/8HfIV8pdD94vFyFuer52SigdC3IQMhab3vACxXMiFk+yMHNdbqtyTGA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@babel/code-frame': 7.18.6
+      '@babel/code-frame': 7.22.13
       '@jest/types': 29.6.1
       '@types/stack-utils': 2.0.1
       chalk: 4.1.2
@@ -35238,7 +35334,7 @@ packages:
     resolution: {integrity: sha512-vnIGYEjoPSuRqV8W9t+Wow95SDp6KPX2Uf7EoeG9G99J2OVh7OSwpS4B6J0NfpEIpfkBNHlBZpA2rblEuEFhZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@babel/code-frame': 7.18.6
+      '@babel/code-frame': 7.22.13
       '@jest/types': 29.6.1
       '@types/stack-utils': 2.0.1
       chalk: 4.1.2
@@ -36028,7 +36124,7 @@ packages:
     resolution: {integrity: sha512-OLhxz05EzUtsAmOMzuupt1lHYXCNib0ECyuZ/PZOx9TrZcC8vL0x+DUG3TL+GLX3yHG45e6YGjIm0XwDc3q3og==}
     engines: {node: '>= 10.14.2'}
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.15
       '@jest/types': 26.6.2
       '@types/babel__traverse': 7.14.2
       '@types/prettier': 2.4.2
@@ -36056,7 +36152,7 @@ packages:
       '@babel/generator': 7.21.3
       '@babel/plugin-syntax-typescript': 7.18.6(@babel/core@7.21.3)
       '@babel/traverse': 7.21.3
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.15
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
       '@types/babel__traverse': 7.14.2
@@ -36086,7 +36182,7 @@ packages:
       '@babel/plugin-syntax-jsx': 7.21.4(@babel/core@7.21.3)
       '@babel/plugin-syntax-typescript': 7.18.6(@babel/core@7.21.3)
       '@babel/traverse': 7.21.3
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.15
       '@jest/expect-utils': 29.5.0
       '@jest/transform': 29.6.2
       '@jest/types': 29.6.1
@@ -36116,7 +36212,7 @@ packages:
       '@babel/generator': 7.21.3
       '@babel/plugin-syntax-jsx': 7.21.4(@babel/core@7.21.3)
       '@babel/plugin-syntax-typescript': 7.18.6(@babel/core@7.21.3)
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.15
       '@jest/expect-utils': 29.6.2
       '@jest/transform': 29.6.2
       '@jest/types': 29.6.1
@@ -36581,6 +36677,35 @@ packages:
   /jsc-android@250230.2.1:
     resolution: {integrity: sha512-KmxeBlRjwoqCnBBKGsihFtvsBHyUFlBxJPK4FzeYcIuBfdjv6jFys44JITAgSTbQD+vIdwMEfyZklsuQX0yI1Q==}
 
+  /jscodeshift@0.13.1(@babel/preset-env@7.12.7):
+    resolution: {integrity: sha512-lGyiEbGOvmMRKgWk4vf+lUrCWO/8YR8sUR3FKF1Cq5fovjZDlIcw3Hu5ppLHAnEXshVffvaM0eyuY/AbOeYpnQ==}
+    hasBin: true
+    peerDependencies:
+      '@babel/preset-env': ^7.1.6
+    dependencies:
+      '@babel/core': 7.21.3
+      '@babel/parser': 7.17.8
+      '@babel/plugin-proposal-class-properties': 7.16.7(@babel/core@7.21.3)
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.16.7(@babel/core@7.21.3)
+      '@babel/plugin-proposal-optional-chaining': 7.16.7(@babel/core@7.21.3)
+      '@babel/plugin-transform-modules-commonjs': 7.17.7(@babel/core@7.21.3)
+      '@babel/preset-env': 7.12.7(@babel/core@7.12.9)
+      '@babel/preset-flow': 7.16.7(@babel/core@7.21.3)
+      '@babel/preset-typescript': 7.16.7(@babel/core@7.21.3)
+      '@babel/register': 7.18.9(@babel/core@7.21.3)
+      babel-core: 7.0.0-bridge.0(@babel/core@7.21.3)
+      chalk: 4.1.2
+      flow-parser: 0.121.0
+      graceful-fs: 4.2.9
+      micromatch: 3.1.10(supports-color@6.1.0)
+      neo-async: 2.6.2
+      node-dir: 0.1.17
+      recast: 0.20.5
+      temp: 0.8.4
+      write-file-atomic: 2.4.1
+    transitivePeerDependencies:
+      - supports-color
+
   /jscodeshift@0.13.1(@babel/preset-env@7.20.2):
     resolution: {integrity: sha512-lGyiEbGOvmMRKgWk4vf+lUrCWO/8YR8sUR3FKF1Cq5fovjZDlIcw3Hu5ppLHAnEXshVffvaM0eyuY/AbOeYpnQ==}
     hasBin: true
@@ -36609,6 +36734,7 @@ packages:
       write-file-atomic: 2.4.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /jsdoc-type-pratt-parser@1.1.1:
     resolution: {integrity: sha512-uelRmpghNwPBuZScwgBG/OzodaFk5RbO5xaivBdsAY70icWfShwZ7PCMO0x1zSkOa8T1FzHThmrdoyg/0AwV5g==}
@@ -37574,7 +37700,7 @@ packages:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
     engines: {node: '>=8'}
     dependencies:
-      semver: 6.3.0
+      semver: 6.3.1
 
   /make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
@@ -38202,48 +38328,48 @@ packages:
     dependencies:
       uglify-es: 3.3.9
 
-  /metro-react-native-babel-preset@0.72.1(@babel/core@7.17.8):
+  /metro-react-native-babel-preset@0.72.1(@babel/core@7.12.9):
     resolution: {integrity: sha512-DlvMw2tFrCqD9OXBoN11fPM09kHC22FZpnkTmG4Pr4kecV+aDmEGxwakjUcjELrX1JCXz2MLPvqeJkbiP1f5CA==}
     peerDependencies:
       '@babel/core': '*'
     dependencies:
-      '@babel/core': 7.17.8
-      '@babel/plugin-proposal-async-generator-functions': 7.20.7(@babel/core@7.17.8)
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.17.8)
-      '@babel/plugin-proposal-export-default-from': 7.16.7(@babel/core@7.17.8)
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.17.8)
-      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.17.8)
-      '@babel/plugin-proposal-optional-catch-binding': 7.18.6(@babel/core@7.17.8)
-      '@babel/plugin-proposal-optional-chaining': 7.18.9(@babel/core@7.17.8)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.17.8)
-      '@babel/plugin-syntax-export-default-from': 7.16.7(@babel/core@7.17.8)
-      '@babel/plugin-syntax-flow': 7.16.7(@babel/core@7.17.8)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.17.8)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.17.8)
-      '@babel/plugin-transform-arrow-functions': 7.18.6(@babel/core@7.17.8)
-      '@babel/plugin-transform-async-to-generator': 7.18.6(@babel/core@7.17.8)
-      '@babel/plugin-transform-block-scoping': 7.21.0(@babel/core@7.17.8)
-      '@babel/plugin-transform-classes': 7.21.0(@babel/core@7.17.8)
-      '@babel/plugin-transform-computed-properties': 7.18.9(@babel/core@7.17.8)
-      '@babel/plugin-transform-destructuring': 7.21.3(@babel/core@7.17.8)
-      '@babel/plugin-transform-exponentiation-operator': 7.18.6(@babel/core@7.17.8)
-      '@babel/plugin-transform-flow-strip-types': 7.16.7(@babel/core@7.17.8)
-      '@babel/plugin-transform-function-name': 7.18.9(@babel/core@7.17.8)
-      '@babel/plugin-transform-literals': 7.18.9(@babel/core@7.17.8)
-      '@babel/plugin-transform-modules-commonjs': 7.22.15(@babel/core@7.17.8)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.19.1(@babel/core@7.17.8)
-      '@babel/plugin-transform-parameters': 7.21.3(@babel/core@7.17.8)
-      '@babel/plugin-transform-react-display-name': 7.18.6(@babel/core@7.17.8)
-      '@babel/plugin-transform-react-jsx': 7.22.3(@babel/core@7.17.8)
-      '@babel/plugin-transform-react-jsx-self': 7.18.6(@babel/core@7.17.8)
-      '@babel/plugin-transform-react-jsx-source': 7.18.6(@babel/core@7.17.8)
-      '@babel/plugin-transform-runtime': 7.19.1(@babel/core@7.17.8)
-      '@babel/plugin-transform-shorthand-properties': 7.18.6(@babel/core@7.17.8)
-      '@babel/plugin-transform-spread': 7.19.0(@babel/core@7.17.8)
-      '@babel/plugin-transform-sticky-regex': 7.18.6(@babel/core@7.17.8)
-      '@babel/plugin-transform-template-literals': 7.18.9(@babel/core@7.17.8)
-      '@babel/plugin-transform-typescript': 7.22.15(@babel/core@7.17.8)
-      '@babel/plugin-transform-unicode-regex': 7.18.6(@babel/core@7.17.8)
+      '@babel/core': 7.12.9
+      '@babel/plugin-proposal-async-generator-functions': 7.20.7(@babel/core@7.12.9)
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.12.9)
+      '@babel/plugin-proposal-export-default-from': 7.16.7(@babel/core@7.12.9)
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.12.9)
+      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.12.9)
+      '@babel/plugin-proposal-optional-catch-binding': 7.18.6(@babel/core@7.12.9)
+      '@babel/plugin-proposal-optional-chaining': 7.18.9(@babel/core@7.12.9)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.12.9)
+      '@babel/plugin-syntax-export-default-from': 7.16.7(@babel/core@7.12.9)
+      '@babel/plugin-syntax-flow': 7.16.7(@babel/core@7.12.9)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.12.9)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.12.9)
+      '@babel/plugin-transform-arrow-functions': 7.18.6(@babel/core@7.12.9)
+      '@babel/plugin-transform-async-to-generator': 7.18.6(@babel/core@7.12.9)
+      '@babel/plugin-transform-block-scoping': 7.21.0(@babel/core@7.12.9)
+      '@babel/plugin-transform-classes': 7.21.0(@babel/core@7.12.9)
+      '@babel/plugin-transform-computed-properties': 7.18.9(@babel/core@7.12.9)
+      '@babel/plugin-transform-destructuring': 7.21.3(@babel/core@7.12.9)
+      '@babel/plugin-transform-exponentiation-operator': 7.18.6(@babel/core@7.12.9)
+      '@babel/plugin-transform-flow-strip-types': 7.16.7(@babel/core@7.12.9)
+      '@babel/plugin-transform-function-name': 7.18.9(@babel/core@7.12.9)
+      '@babel/plugin-transform-literals': 7.18.9(@babel/core@7.12.9)
+      '@babel/plugin-transform-modules-commonjs': 7.22.15(@babel/core@7.12.9)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.19.1(@babel/core@7.12.9)
+      '@babel/plugin-transform-parameters': 7.21.3(@babel/core@7.12.9)
+      '@babel/plugin-transform-react-display-name': 7.18.6(@babel/core@7.12.9)
+      '@babel/plugin-transform-react-jsx': 7.22.3(@babel/core@7.12.9)
+      '@babel/plugin-transform-react-jsx-self': 7.18.6(@babel/core@7.12.9)
+      '@babel/plugin-transform-react-jsx-source': 7.18.6(@babel/core@7.12.9)
+      '@babel/plugin-transform-runtime': 7.19.1(@babel/core@7.12.9)
+      '@babel/plugin-transform-shorthand-properties': 7.18.6(@babel/core@7.12.9)
+      '@babel/plugin-transform-spread': 7.19.0(@babel/core@7.12.9)
+      '@babel/plugin-transform-sticky-regex': 7.18.6(@babel/core@7.12.9)
+      '@babel/plugin-transform-template-literals': 7.18.9(@babel/core@7.12.9)
+      '@babel/plugin-transform-typescript': 7.22.15(@babel/core@7.12.9)
+      '@babel/plugin-transform-unicode-regex': 7.18.6(@babel/core@7.12.9)
       '@babel/template': 7.22.15
       react-refresh: 0.4.3
     transitivePeerDependencies:
@@ -38296,16 +38422,16 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /metro-react-native-babel-transformer@0.72.1(@babel/core@7.17.8):
+  /metro-react-native-babel-transformer@0.72.1(@babel/core@7.12.9):
     resolution: {integrity: sha512-hMnN0MOgVloAk94YuXN7sLeDaZ51Y6xIcJXxIU1s/KaygAGXk6o7VAdwf2MY/IV1SIct5lkW4Gn71u/9/EvfXA==}
     peerDependencies:
       '@babel/core': '*'
     dependencies:
-      '@babel/core': 7.17.8
-      babel-preset-fbjs: 3.4.0(@babel/core@7.17.8)
+      '@babel/core': 7.12.9
+      babel-preset-fbjs: 3.4.0(@babel/core@7.12.9)
       hermes-parser: 0.8.0
       metro-babel-transformer: 0.72.1
-      metro-react-native-babel-preset: 0.72.1(@babel/core@7.17.8)
+      metro-react-native-babel-preset: 0.72.1(@babel/core@7.12.9)
       metro-source-map: 0.72.1
       nullthrows: 1.1.1
     transitivePeerDependencies:
@@ -38484,7 +38610,7 @@ packages:
   /micromark@2.11.4:
     resolution: {integrity: sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       parse-entities: 2.0.0
     transitivePeerDependencies:
       - supports-color
@@ -39012,7 +39138,7 @@ packages:
     dependencies:
       carlo: 0.9.46
       chokidar: 3.5.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       isbinaryfile: 3.0.3
       mime: 2.5.2
       opn: 5.5.0
@@ -39366,7 +39492,7 @@ packages:
       ajv-errors: 1.0.1(ajv@6.12.6)
       chalk: 4.1.2
       cosmiconfig: 7.0.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       globby: 11.1.0
       ignore: 5.2.0
       is-plain-obj: 3.0.0
@@ -39647,7 +39773,7 @@ packages:
       '@oclif/plugin-warn-if-update-available': 2.0.4
       aws-sdk: 2.1215.0
       concurrently: 7.0.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       find-yarn-workspace-root: 2.0.0
       fs-extra: 8.1.0
       github-slugger: 1.4.0
@@ -39977,7 +40103,7 @@ packages:
     resolution: {integrity: sha512-UJKdSzgd3KOnXXAtqN5+/eeHcvTn1hBkesEmElVgvO/NAYcxAvmjzIGmnNd3Tb/gRAvMBdNRFD4qAWdHxY6QXg==}
     engines: {node: '>=12.10.0'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       p-queue: 6.6.2
     transitivePeerDependencies:
       - supports-color
@@ -40136,7 +40262,7 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/code-frame': 7.18.6
+      '@babel/code-frame': 7.22.13
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.1.6
@@ -40346,7 +40472,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.0
       crc32: 0.2.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       seed-random: 2.2.0
     transitivePeerDependencies:
       - supports-color
@@ -40742,8 +40868,8 @@ packages:
       loader-utils: 2.0.4
       postcss: 8.4.21
       schema-utils: 3.1.1
-      semver: 7.5.0
-      webpack: 5.76.3(webpack-cli@3.3.12)
+      semver: 7.5.3
+      webpack: 5.76.3(webpack-cli@4.9.2)
     dev: true
 
   /postcss-loader@6.2.1(postcss@8.4.21)(webpack@5.76.3):
@@ -41738,7 +41864,7 @@ packages:
     engines: {node: '>=6.4.0'}
     requiresBuild: true
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       extract-zip: 1.7.0
       https-proxy-agent: 2.2.4
       mime: 2.6.0
@@ -41779,7 +41905,7 @@ packages:
     engines: {node: '>=10.18.1'}
     dependencies:
       cross-fetch: 3.1.5
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       devtools-protocol: 0.0.981744
       extract-zip: 2.0.1
       https-proxy-agent: 5.0.1
@@ -41808,7 +41934,7 @@ packages:
     dependencies:
       chromium-bidi: 0.4.4(devtools-protocol@0.0.1094867)
       cross-fetch: 3.1.5
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       devtools-protocol: 0.0.1094867
       extract-zip: 2.0.1
       https-proxy-agent: 5.0.1
@@ -41829,7 +41955,7 @@ packages:
     engines: {node: '>=10.18.1'}
     dependencies:
       '@types/mime-types': 2.1.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       extract-zip: 2.0.1
       https-proxy-agent: 4.0.0
       mime: 2.6.0
@@ -41853,7 +41979,7 @@ packages:
     requiresBuild: true
     dependencies:
       '@types/mime-types': 2.1.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       extract-zip: 1.7.0
       https-proxy-agent: 4.0.0
       mime: 2.6.0
@@ -41879,7 +42005,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       chalk: 2.4.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       execa: 0.10.0
       fs-extra: 6.0.1
       get-stream: 5.2.0
@@ -42416,12 +42542,12 @@ packages:
       moment: 2.29.4
     dev: false
 
-  /react-native-codegen@0.70.4(@babel/preset-env@7.20.2):
+  /react-native-codegen@0.70.4(@babel/preset-env@7.12.7):
     resolution: {integrity: sha512-bPyd5jm840omfx24VRyMP+KPzAefpRDwE18w5ywMWHCWZBSqLn1qI9WgBPnavlIrjTEuzxznWQNcaA26lw8AMQ==}
     dependencies:
       '@babel/parser': 7.22.15
       flow-parser: 0.121.0
-      jscodeshift: 0.13.1(@babel/preset-env@7.20.2)
+      jscodeshift: 0.13.1(@babel/preset-env@7.12.7)
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - '@babel/preset-env'
@@ -42435,10 +42561,10 @@ packages:
     peerDependencies:
       react-native: '*'
     dependencies:
-      react-native: 0.70.0(@babel/core@7.17.8)(@babel/preset-env@7.20.2)(react@17.0.2)
+      react-native: 0.70.0(@babel/core@7.12.9)(@babel/preset-env@7.12.7)(react@18.1.0)
       whatwg-url-without-unicode: 8.0.0-3
 
-  /react-native@0.70.0(@babel/core@7.17.8)(@babel/preset-env@7.20.2)(react@17.0.2):
+  /react-native@0.70.0(@babel/core@7.12.9)(@babel/preset-env@7.12.7)(react@18.1.0):
     resolution: {integrity: sha512-QjXLbrK9f+/B2eCzn6kAvglLV/8nwPuFGaFv7ggPpAzFRyx5bVN1dwQLHL3MrP7iXR/M7Jc6Nnid7tmRSic6vA==}
     engines: {node: '>=14'}
     hasBin: true
@@ -42446,7 +42572,7 @@ packages:
       react: 18.1.0
     dependencies:
       '@jest/create-cache-key-function': 27.5.1
-      '@react-native-community/cli': 9.1.1(@babel/core@7.17.8)
+      '@react-native-community/cli': 9.1.1(@babel/core@7.12.9)
       '@react-native-community/cli-platform-android': 9.1.0
       '@react-native-community/cli-platform-ios': 9.1.0
       '@react-native/assets': 1.0.0
@@ -42459,23 +42585,23 @@ packages:
       invariant: 2.2.4
       jsc-android: 250230.2.1
       memoize-one: 5.2.1
-      metro-react-native-babel-transformer: 0.72.1(@babel/core@7.17.8)
+      metro-react-native-babel-transformer: 0.72.1(@babel/core@7.12.9)
       metro-runtime: 0.72.1
       metro-source-map: 0.72.1
       mkdirp: 0.5.5
       nullthrows: 1.1.1
       pretty-format: 26.6.2
       promise: 8.2.0
-      react: 17.0.2
+      react: 18.1.0
       react-devtools-core: 4.24.0
-      react-native-codegen: 0.70.4(@babel/preset-env@7.20.2)
+      react-native-codegen: 0.70.4(@babel/preset-env@7.12.7)
       react-native-gradle-plugin: 0.70.2
       react-refresh: 0.4.3
-      react-shallow-renderer: 16.15.0(react@17.0.2)
+      react-shallow-renderer: 16.15.0(react@18.1.0)
       regenerator-runtime: 0.13.11
       scheduler: 0.22.0
       stacktrace-parser: 0.1.10
-      use-sync-external-store: 1.2.0(react@17.0.2)
+      use-sync-external-store: 1.2.0(react@18.1.0)
       whatwg-fetch: 3.6.2
       ws: 6.2.2
     transitivePeerDependencies:
@@ -42729,13 +42855,13 @@ packages:
       react: 17.0.2
       react-is: 17.0.2
 
-  /react-shallow-renderer@16.15.0(react@17.0.2):
+  /react-shallow-renderer@16.15.0(react@18.1.0):
     resolution: {integrity: sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==}
     peerDependencies:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0
     dependencies:
       object-assign: 4.1.1
-      react: 17.0.2
+      react: 18.1.0
       react-is: 18.2.0
 
   /react-sizeme@3.0.2:
@@ -42940,6 +43066,12 @@ packages:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
+
+  /react@18.1.0:
+    resolution: {integrity: sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      loose-envify: 1.4.0
 
   /read-cmd-shim@3.0.1:
     resolution: {integrity: sha512-kEmDUoYf/CDy8yZbLTmhB1X9kkjf9Q80PCNsDMb7ufrGd6zZSQA1+UyjrO+pZm5K/S4OXCWJeiIt1JA8kAsa6g==}
@@ -43276,7 +43408,6 @@ packages:
     resolution: {integrity: sha512-eOf6vka5IO151Jfsw2NO9WpGX58W6wWmefK3I1zEGr0lOD0u8rwPaNqQL1aRxUaxLeKO3ArNh3VYg1KbaD+FFw==}
     dependencies:
       '@babel/runtime': 7.21.0
-    dev: true
 
   /regenerator-transform@0.15.0:
     resolution: {integrity: sha512-LsrGtPmbYg19bcPHwdtmXwbW+TqNvtY4riE3P83foeHRroMbH6/2ddFBfab3t7kbzc7v7p4wbkIecHImqt0QNg==}
@@ -43469,6 +43600,7 @@ packages:
 
   /rememo@4.0.0:
     resolution: {integrity: sha512-6BAfg1Dqg6UteZBEH9k6EHHersM86/EcBOMtJV+h+xEn1GC3H+gAgJWpexWYAamAxD0qXNmIt50iS/zuZKnQag==}
+    dev: false
 
   /rememo@4.0.2:
     resolution: {integrity: sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ==}
@@ -44016,7 +44148,7 @@ packages:
       sass: 1.60.0
       schema-utils: 3.1.1
       semver: 7.5.0
-      webpack: 5.76.3(webpack-cli@3.3.12)
+      webpack: 5.76.3(webpack-cli@4.9.2)
     dev: true
 
   /sass-loader@12.6.0(sass@1.60.0)(webpack@5.76.3):
@@ -44065,7 +44197,7 @@ packages:
       neo-async: 2.6.2
       sass: 1.60.0
       schema-utils: 2.7.1
-      semver: 6.3.0
+      semver: 6.3.1
       webpack: 4.46.0(webpack-cli@3.3.12)
     dev: true
 
@@ -44230,7 +44362,6 @@ packages:
   /semver@7.0.0:
     resolution: {integrity: sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==}
     hasBin: true
-    dev: true
 
   /semver@7.3.5:
     resolution: {integrity: sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==}
@@ -44483,7 +44614,7 @@ packages:
     dependencies:
       '@kwsites/file-exists': 1.1.1
       '@kwsites/promise-deferred': 1.1.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -44494,7 +44625,7 @@ packages:
     resolution: {integrity: sha512-D1SaWpOW8afq1CZGWB8xTfrT3FekjQmPValrqncJMX7QFl8YwhrPTZvMCANLtgBwwdS+7zURyqxDDEmY558tTw==}
     dependencies:
       buffer: 6.0.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       err-code: 3.0.1
       get-browser-rtc: 1.1.0
       queue-microtask: 1.2.3
@@ -44668,7 +44799,7 @@ packages:
     engines: {node: '>= 10'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       socks: 2.7.0
     transitivePeerDependencies:
       - supports-color
@@ -44679,7 +44810,7 @@ packages:
     engines: {node: '>= 10'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       socks: 2.7.0
     transitivePeerDependencies:
       - supports-color
@@ -44839,7 +44970,7 @@ packages:
   /spdy-transport@3.0.0:
     resolution: {integrity: sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -44852,7 +44983,7 @@ packages:
     resolution: {integrity: sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==}
     engines: {node: '>=6.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
@@ -45283,7 +45414,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.1.1
-      webpack: 5.76.3(webpack-cli@3.3.12)
+      webpack: 5.76.3(webpack-cli@4.9.2)
     dev: true
 
   /style-search@0.1.0:
@@ -45474,7 +45605,7 @@ packages:
       balanced-match: 2.0.0
       chalk: 4.1.2
       cosmiconfig: 7.0.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       execall: 2.0.0
       fast-glob: 3.2.7
       fastest-levenshtein: 1.0.12
@@ -45533,7 +45664,7 @@ packages:
       balanced-match: 1.0.2
       chalk: 4.1.2
       cosmiconfig: 7.0.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       execall: 2.0.0
       fast-glob: 3.2.11
       fastest-levenshtein: 1.0.12
@@ -45590,7 +45721,7 @@ packages:
       colord: 2.9.2
       cosmiconfig: 7.0.1
       css-functions-list: 3.0.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       execall: 2.0.0
       fast-glob: 3.2.11
       fastest-levenshtein: 1.0.12
@@ -45653,7 +45784,7 @@ packages:
     dependencies:
       component-emitter: 1.3.0
       cookiejar: 2.1.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       fast-safe-stringify: 2.1.1
       form-data: 4.0.0
       formidable: 2.0.1
@@ -45720,7 +45851,6 @@ packages:
   /supports-color@9.2.2:
     resolution: {integrity: sha512-XC6g/Kgux+rJXmwokjm9ECpD6k/smUoS5LKlUCcsYr4IY3rW0XyAympon2RmxGrlnZURMpg5T18gWDP9CsHXFA==}
     engines: {node: '>=12'}
-    dev: true
 
   /supports-hyperlinks@2.2.0:
     resolution: {integrity: sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==}
@@ -46118,7 +46248,7 @@ packages:
       serialize-javascript: 6.0.0
       source-map: 0.6.1
       terser: 5.10.0(acorn@8.8.1)
-      webpack: 5.76.3(webpack-cli@3.3.12)
+      webpack: 5.76.3(webpack-cli@4.9.2)
     transitivePeerDependencies:
       - acorn
     dev: true
@@ -47327,7 +47457,7 @@ packages:
       loader-utils: 1.4.0
       mime: 2.6.0
       schema-utils: 1.0.0
-      webpack: 5.76.3(webpack-cli@3.3.12)
+      webpack: 5.76.3(webpack-cli@4.9.2)
     dev: true
 
   /url-loader@3.0.0(webpack@4.46.0):
@@ -47509,6 +47639,14 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
       react: 17.0.2
+    dev: false
+
+  /use-sync-external-store@1.2.0(react@18.1.0):
+    resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.1.0
 
   /use@3.1.1:
     resolution: {integrity: sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==}
@@ -47876,7 +48014,7 @@ packages:
     dependencies:
       chalk: 2.4.2
       commander: 3.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -48167,7 +48305,7 @@ packages:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 3.1.1
-      webpack: 5.76.3(webpack-cli@3.3.12)
+      webpack: 5.76.3(webpack-cli@4.9.2)
     dev: true
 
   /webpack-dev-middleware@5.3.3(webpack@5.70.0):
@@ -48877,7 +49015,7 @@ packages:
     resolution: {integrity: sha512-NMp0YsBM40CuI5vWtHpjWOuf96rPfbpGkamlJpVwYvgenIh1ynRzqVnGfsnjofgz13T2qcKkdwJY0Y2X7z+W+w==}
     dependencies:
       '@babel/runtime': 7.21.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       progress-event: 1.0.0
       uuid: 7.0.3
       wp-error: 1.3.0
@@ -49360,7 +49498,7 @@ packages:
       cli-table: 0.3.11
       commander: 7.1.0
       dateformat: 4.6.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       diff: 5.1.0
       error: 10.4.0
       escape-string-regexp: 4.0.0
@@ -49404,7 +49542,7 @@ packages:
     dependencies:
       chalk: 4.1.2
       dargs: 7.0.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.2)
       execa: 5.1.1
       github-username: 6.0.0
       lodash: 4.17.21


### PR DESCRIPTION
**Please don't run away... I saw you look at the file change count and the number of lines changed! 🙀 I assure you, the actual changes in this PR are pretty small and confined to the new product editor. 😇 These changes are easy to test and verify.**

The changes in this PR break down as follows:

- **source changes, core: 217 lines**
- source changes, replacing `initBlock` and `useBlockProps` in `@woocommerce/product-editor` for all blocks: 313 lines
- test changes (mostly test data changes): 203 lines
- documentation: 70 lines
- changelogs: 21 lines
- config files (mostly boilerplate; because of new `@woocommerce/block-templates` project): 195 lines
- **lock files (because of new project): 2,799 lines**


### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR exposes the template block ID and block order to the client (JS) code, to enable easier development and debugging (since these values are needed when using the template API).

This PR implements the acceptance criteria of #40228:

- PHP: `AbstractBlock::get_formatted_template()` and `BlockContainerTrait::get_formatted_template()` includes the following attributes in its output:
    - `_templateBlockId`
    - `_templateBlockOrder`
- JS: A `registerWooBlockType` method that registers a block and auto-adds the following attributes to it's metadata:
    - `_templateBlockId`
    - `_templateBlockOrder`
- JS: A `useWooBlockProps` hook that takes the block's attributes as a param and returns the props from the core `useBlockProps` plus the following props:
    - `data-template-block-id`
    - `data-template-block-order`
- JS: All blocks in `@woocommerce/product-editor` updated to use `useWooBlockProps` and `registerWooBlockType`, which results in the following attributes on their DOM elements when rendered:
    - `data-template-block-id`
    - `data-template-block-order`

Closes #40228.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Automated unit tests (run locally or just verify they pass in GH on this PR):

1. PHP unit tests:

```
pnpm --filter=woocommerce env:test
pnpm test:unit:env --filter 'Automattic\\WooCommerce\\Tests\\Internal\\Admin\\BlockTemplates'
```

2. JS unit tests:

```
pnpm run test --filter=@woocommerce/block-templates
```

Manual testing:

1. Enable the **Product Block Editor** under **WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**.
2. Go to **Products** > **Add New**
3. Verify each block has the `data-template-block-id` and `data-template-block-id` attributes. You can do this one of two ways:
    - The hard way: view the Elements tab of the browser developer tools and look for these DOM attributes
    - The easy way: Install the [WooCommerce Block Template Inspector plugin](https://github.com/woocommerce/woocommerce-block-template-inspector) and focus (click) on each field.
 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
