### PR TITLE
Implement customize your store task completion logic

### DIFF
--- a/plugins/woocommerce/changelog/update-cys-completion-logic
+++ b/plugins/woocommerce/changelog/update-cys-completion-logic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Implement customize your store task completion logic

--- a/plugins/woocommerce/src/Admin/API/Options.php
+++ b/plugins/woocommerce/src/Admin/API/Options.php
@@ -214,6 +214,7 @@ class Options extends \WC_REST_Data_Controller {
 			'wcpay_welcome_page_viewed_timestamp',
 			'wcpay_welcome_page_exit_survey_more_info_needed_timestamp',
 			'woocommerce_customize_store_onboarding_tour_hidden',
+			'woocommerce_admin_customize_store_completed',
 			// WC Test helper options.
 			'wc-admin-test-helper-rest-api-filters',
 			'wc_admin_helper_feature_values',

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/CustomizeStore.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/CustomizeStore.php
@@ -15,7 +15,9 @@ class CustomizeStore extends Task {
 	 */
 	public function __construct( $task_list ) {
 		parent::__construct( $task_list );
+
 		add_action( 'admin_enqueue_scripts', array( $this, 'possibly_add_site_editor_scripts' ) );
+		add_action( 'after_switch_theme', array( $this, 'mark_task_as_complete' ) );
 	}
 
 	/**
@@ -182,5 +184,12 @@ class CustomizeStore extends Task {
 		 * @since 8.0.3
 		*/
 		do_action( 'enqueue_block_editor_assets' );
+	}
+
+	/**
+	 * Mark task as complete.
+	 */
+	public function mark_task_as_complete() {
+		update_option( 'woocommerce_admin_customize_store_completed', 'yes' );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #40126.

This PR Implement Customize store task completion logic

1. When the user Clicks on “Done” on the Assembler Hub screen. Then, mark the Customize store task as complete.
2. When the user changes and activates their theme, then mark the Customize Store task as complete.

We'll need to update the WPCOM backend for the case where the users decide to continue with their active theme.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Use WP 6.3 
2. Install the `WooCommerce Beta Tester` plugin
3. Go to /wp-admin/tools.php?page=woocommerce-admin-test-helper and enable `customize-store` feature flag
4. Go to `WooCommerce > Home`
5. Click on `Customize your store` task 
6. Click on `Assembler Hub` button
7. Click on `Done` button
8. Go to `WooCommerce > Home`
9. Observe that Customize your store task is marked as complete.
10. Delete option `woocommerce_admin_customize_store_completed`
11. Go to the theme page and switch to a theme
12. Go to `WooCommerce > Home`
13. Observe that Customize your store task is marked as complete.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Implement customize your store task completion logic

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
