### PR TITLE
In-app Marketplace: gracefully handle products with no vendorUrl

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/product-list-content/product-list-content.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/product-list-content/product-list-content.tsx
@@ -22,12 +22,16 @@ export default function ProductListContent( props: {
 						title: product.title,
 						icon: product.icon,
 						vendorName: product.vendorName,
-						vendorUrl: appendURLParams( product.vendorUrl, [
-							[ 'utm_source', 'extensionsscreen' ],
-							[ 'utm_medium', 'product' ],
-							[ 'utm_campaign', 'wcaddons' ],
-							[ 'utm_content', 'devpartner' ],
-						] ),
+						vendorUrl: (
+							product.vendorUrl ?
+							appendURLParams( product.vendorUrl, [
+								[ 'utm_source', 'extensionsscreen' ],
+								[ 'utm_medium', 'product' ],
+								[ 'utm_campaign', 'wcaddons' ],
+								[ 'utm_content', 'devpartner' ],
+							] ) :
+							''
+						),
 						price: product.price,
 						url: appendURLParams(
 							product.url,

--- a/plugins/woocommerce-admin/client/marketplace/components/product-list-content/product-list-content.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/product-list-content/product-list-content.tsx
@@ -22,16 +22,14 @@ export default function ProductListContent( props: {
 						title: product.title,
 						icon: product.icon,
 						vendorName: product.vendorName,
-						vendorUrl: (
-							product.vendorUrl ?
-							appendURLParams( product.vendorUrl, [
-								[ 'utm_source', 'extensionsscreen' ],
-								[ 'utm_medium', 'product' ],
-								[ 'utm_campaign', 'wcaddons' ],
-								[ 'utm_content', 'devpartner' ],
-							] ) :
-							''
-						),
+						vendorUrl: product.vendorUrl
+							? appendURLParams( product.vendorUrl, [
+									[ 'utm_source', 'extensionsscreen' ],
+									[ 'utm_medium', 'product' ],
+									[ 'utm_campaign', 'wcaddons' ],
+									[ 'utm_content', 'devpartner' ],
+							  ] )
+							: '',
 						price: product.price,
 						url: appendURLParams(
 							product.url,

--- a/plugins/woocommerce/changelog/fix-wccom-marketplace-products-with-no-vendorurl
+++ b/plugins/woocommerce/changelog/fix-wccom-marketplace-products-with-no-vendorurl
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: More-resilient handling of absent product vendor URLs when browsing WooCommerce > Extensions.
+
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Sometimes, a product on WooCommerce.com does not return a `vendor_url` from the API endpoint. This crashes WooCommerce > Extensions. You can see if in some countries by using Browse > Payments, because the WooPayments extension is affected in this way.

![Markup on 2023-09-19 at 11:40:35](https://github.com/woocommerce/woocommerce/assets/53293/b845097b-2f2f-4753-a485-16305506ada2)

This PR improves the resilience of the `<ProductListContent>` component by having it handle this possibility by _not_ attempting to append `utm_*` parameters onto nonexistent vendor URLs.

### How to test the changes in this Pull Request:

1. Check out this branch and recompile the assets with e.g. `cd plugins/woocommerce-admin && pnpm start`.
2.Browse to WooCommerce > Extensions > Browse > category "Payments" and see no error.
3. If sad-path testing, you might need to tweak your locale to one in which WooPayments is promoted; I'm using `GB`.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

More-resilient handling of absent product vendor URLs when browsing WooCommerce > Extensions.

</details>
