### PR TITLE
Marketplace: make tabs horizontally scrollable

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/category-selector/category-selector.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/category-selector/category-selector.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useState, useEffect } from '@wordpress/element';
+import { useState, useEffect, useContext } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Spinner } from '@wordpress/components';
 import { useQuery } from '@woocommerce/navigation';
@@ -14,6 +14,7 @@ import CategoryLink from './category-link';
 import CategoryDropdown from './category-dropdown';
 import { Category, CategoryAPIItem } from './types';
 import { fetchCategories } from '../../utils/functions';
+import { MarketplaceContext } from '../../contexts/marketplace-context';
 import './category-selector.scss';
 
 const ALL_CATEGORIES_SLUG = '_all';
@@ -23,6 +24,8 @@ export default function CategorySelector(): JSX.Element {
 	const [ dropdownItems, setDropdownItems ] = useState< Category[] >( [] );
 	const [ selected, setSelected ] = useState< Category >();
 	const [ isLoading, setIsLoading ] = useState( false );
+	const marketplaceContextValue = useContext( MarketplaceContext );
+	const { selectedTab } = marketplaceContextValue;
 
 	const query = useQuery();
 
@@ -48,7 +51,7 @@ export default function CategorySelector(): JSX.Element {
 	useEffect( () => {
 		setIsLoading( true );
 
-		fetchCategories()
+		fetchCategories( selectedTab )
 			.then( ( categoriesFromAPI: CategoryAPIItem[] ) => {
 				const categories: Category[] = categoriesFromAPI
 					.map( ( categoryAPIItem: CategoryAPIItem ): Category => {

--- a/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
@@ -9,12 +9,15 @@ import { useContext } from '@wordpress/element';
 import './content.scss';
 import Discover from '../discover/discover';
 import Extensions from '../extensions/extensions';
+import Themes from '../themes/themes';
 import { MarketplaceContext } from '../../contexts/marketplace-context';
 
 const renderContent = ( selectedTab?: string ): JSX.Element => {
 	switch ( selectedTab ) {
 		case 'extensions':
 			return <Extensions />;
+		case 'themes':
+			return <Themes />;
 		default:
 			return <Discover />;
 	}

--- a/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.scss
+++ b/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.scss
@@ -5,6 +5,7 @@
 		box-sizing: content-box;
 		display: flex;
 		gap: 24px;
+		overflow-y: auto;
 	}
 
 	&__tab-button {
@@ -17,6 +18,7 @@
 		height: 48px;
 		line-height: 16px;
 		padding: 0;
+		white-space: nowrap;
 
 		&:focus:not(:disabled) {
 			box-shadow: none;

--- a/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx
@@ -38,6 +38,10 @@ const tabs: Tabs = {
 		name: 'extensions',
 		title: __( 'Browse', 'woocommerce' ),
 	},
+	themes: {
+		name: 'themes',
+		title: __( 'Themes', 'woocommerce' ),
+	},
 	'my-subscriptions': {
 		name: 'my-subscriptions',
 		title: __( 'My Subscriptions', 'woocommerce' ),

--- a/plugins/woocommerce-admin/client/marketplace/components/themes/themes.scss
+++ b/plugins/woocommerce-admin/client/marketplace/components/themes/themes.scss
@@ -1,0 +1,6 @@
+.woocommerce-marketplace {
+	&__themes {
+		display: flex;
+		flex-direction: column;
+	}
+}

--- a/plugins/woocommerce-admin/client/marketplace/components/themes/themes.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/themes/themes.tsx
@@ -1,0 +1,127 @@
+/**
+ * External dependencies
+ */
+import { useContext, useEffect, useState } from '@wordpress/element';
+import { useQuery } from '@woocommerce/navigation';
+import { __, _n, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import './themes.scss';
+import CategorySelector from '../category-selector/category-selector';
+import { MarketplaceContext } from '../../contexts/marketplace-context';
+import ProductListContent from '../product-list-content/product-list-content';
+import ProductLoader from '../product-loader/product-loader';
+import NoResults from '../product-list-content/no-results';
+import { Product, SearchAPIProductType } from '../product-list/types';
+import { MARKETPLACE_SEARCH_API_PATH, MARKETPLACE_HOST } from '../constants';
+import { getAdminSetting } from '../../../utils/admin-settings';
+
+export default function Themes(): JSX.Element {
+	const [ productList, setProductList ] = useState< Product[] >( [] );
+	const marketplaceContextValue = useContext( MarketplaceContext );
+	const { isLoading, setIsLoading } = marketplaceContextValue;
+
+	const query = useQuery();
+
+	// Get the content for this screen
+	useEffect( () => {
+		setIsLoading( true );
+
+		const params = new URLSearchParams();
+
+		if ( query.term ) {
+			params.append( 'term', query.term );
+		}
+
+		if ( query.category ) {
+			params.append( 'category', query.category );
+		}
+
+		const wccomSettings = getAdminSetting( 'wccomHelper', false );
+		if ( wccomSettings.storeCountry ) {
+			params.append( 'country', wccomSettings.storeCountry );
+		}
+
+		const wccomSearchEndpoint =
+			MARKETPLACE_HOST +
+			MARKETPLACE_SEARCH_API_PATH +
+			'?' +
+			params.toString();
+
+		// Fetch data from WCCOM API
+		fetch( wccomSearchEndpoint )
+			.then( ( response ) => response.json() )
+			.then( ( response ) => {
+				/**
+				 * Product card component expects a Product type.
+				 * So we build that object from the API response.
+				 */
+				const products = response.products.map(
+					( product: SearchAPIProductType ): Product => {
+						return {
+							id: product.id,
+							title: product.title,
+							description: product.excerpt,
+							vendorName: product.vendor_name,
+							vendorUrl: product.vendor_url,
+							icon: product.icon,
+							url: product.link,
+							// Due to backwards compatibility, raw_price is from search API, price is from featured API
+							price: product.raw_price ?? product.price,
+							averageRating: product.rating ?? 0,
+							reviewsCount: product.reviews_count ?? 0,
+						};
+					}
+				);
+
+				setProductList( products );
+			} )
+			.catch( () => {
+				setProductList( [] );
+			} )
+			.finally( () => {
+				setIsLoading( false );
+			} );
+	}, [ query ] );
+
+	const products = productList.slice( 0, 60 );
+
+	let title = __( '0 extensions found', 'woocommerce' );
+
+	if ( products.length > 0 ) {
+		title = sprintf(
+			// translators: %s: number of extensions
+			_n(
+				'%s extension',
+				'%s extensions',
+				products.length,
+				'woocommerce'
+			),
+			products.length
+		);
+	}
+
+	function content() {
+		if ( isLoading ) {
+			return <ProductLoader />;
+		}
+
+		if ( products.length === 0 ) {
+			return <NoResults />;
+		}
+
+		return <ProductListContent products={ products } />;
+	}
+
+	return (
+		<div className="woocommerce-marketplace__themes">
+			<h2 className="woocommerce-marketplace__product-list-title  woocommerce-marketplace__product-list-title--themes">
+				{ title }
+			</h2>
+			<CategorySelector />
+			{ content() }
+		</div>
+	);
+}

--- a/plugins/woocommerce-admin/client/marketplace/utils/functions.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/utils/functions.tsx
@@ -70,6 +70,10 @@ const appendURLParams = (
 	url: string,
 	utmParams: Array< [ string, string ] >
 ): string => {
+	if ( ! url ) {
+		return url;
+	}
+
 	const urlObject = new URL( url );
 	if ( ! urlObject ) {
 		return url;

--- a/plugins/woocommerce-admin/client/marketplace/utils/functions.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/utils/functions.tsx
@@ -36,11 +36,17 @@ async function fetchDiscoverPageData(): Promise< ProductGroup[] > {
 	}
 }
 
-function fetchCategories(): Promise< CategoryAPIItem[] > {
-	let url = MARKETPLACE_HOST + MARKETPLACE_CATEGORY_API_PATH;
+function fetchCategories( selectedTab: string ): Promise< CategoryAPIItem[] > {
+	const url = new URL( MARKETPLACE_HOST + MARKETPLACE_CATEGORY_API_PATH );
 
 	if ( LOCALE.userLocale ) {
-		url = `${ url }?locale=${ LOCALE.userLocale }`;
+		url.searchParams.set( 'locale', LOCALE.userLocale );
+	}
+
+	// We don't define parent for extensions since that is provided by default
+	// This is to ensure the old marketplace continues to work when this isn't defined
+	if ( selectedTab === 'themes' ) {
+		url.searchParams.set( 'parent', selectedTab );
 	}
 
 	return fetch( url.toString() )


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

As we add more items to the tabs, we need to make navigation easier. We opted for allowing horizontal scroll in the tabs component. When items overflow, users will have to scroll to the right to see the rest of the tabs. 

It's important that we give a visual cue (scroll indicator) to the user. We thought having the last item cut-off would help us achieve that. 

There is no smart code that archives this last item cut-off. I checked different viewports and it seems the last item (my subscriptions) is cut off when we add the **Search results** and **Themes** tabs. When there are no **Search results** tab, no item is left out of the viewport. The item is perfectly cut out between 351 and 330-pixel wide screens.

### How to test the changes in this Pull Request:

1. Checkout this branch and build WooCommerce Admin assets `cd plugins/woocommerce-admin && pnpm run start`
2. Load [the new marketplace page](http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fextensions) and switch to a smaller viewport.
3. Confirm the tabs look normal. No items are cut off (screenshot).
4. Add this [to the `tabs` object in `tabs.tsx`](https://github.com/woocommerce/woocommerce/blob/f77754d9aa26e30e2c60289c6fa60f8216a0caa3/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx#L32):
```jsx
const tabs: Tabs = {
	'search-results': {
		name: 'search-results',
		title: __( 'Search Results', 'woocommerce' ),
	},
        // rest of the items
}
```
5. Reload the marketplace page and view it in a smaller viewport. See **My Subscriptions** menu is cut off and you can horizontally scroll the tabs. 
6. Please test around this issue

### Screenshots
**Tab bar with 4 items viewed in iPhone SE**
![image](https://github.com/woocommerce/woocommerce/assets/10389957/d213526b-b028-4947-9430-e0caa96efa1e)

**Tab bar with 5 items viewed in iPhone SE**
![image](https://github.com/woocommerce/woocommerce/assets/10389957/14b0d88a-dfa7-4e01-bd15-a9b25125fc91)
