### PR TITLE
Regression test for `woocommerce_get_customer_details` ajax endpoint.

### DIFF
--- a/plugins/woocommerce/changelog/add-regression-test-user-meta
+++ b/plugins/woocommerce/changelog/add-regression-test-user-meta
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Adds regression test for https://github.com/woocommerce/woocommerce/pull/40221.
+
+

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-edit.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-edit.spec.js
@@ -124,10 +124,6 @@ test.describe( 'Edit order', () => {
 
 		// Open our test order and select the customer we just created.
 		await page.goto( `wp-admin/post.php?post=${orderId}&action=edit` );
-		await page.evaluate(
-			( customerId ) => document.getElementById( 'customer_user' ).innerHTML = `<option value=${customerId} selected></option>`,
-			customerId
-		);
 
 		// Simulate the ajax `woocommerce_get_customer_details` call normally done inside meta-boxes-order.js.
 		const response = await page.evaluate(

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-edit.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-edit.spec.js
@@ -97,7 +97,6 @@ test.describe( 'Edit order', () => {
 			version: 'wc/v3',
 		} );
 
-		// Debug note: this request will fail with HTTP status 400 if the test is re-run without first resetting state.
 		await api
 			.post( 'customers', {
 				email: 'archie123@email.addr',
@@ -152,6 +151,9 @@ test.describe( 'Edit order', () => {
 		expect( 'billing' in response ).toBeTruthy();
 		expect( response.billing.first_name ).toContain( 'Archibald' );
 		expect( response.meta_data ).toBeUndefined();
+
+		// Clean-up.
+		await api.delete( `customers/${ customerId }`, { force: true } );
 	} );
 } );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

- Adds regression test for https://github.com/woocommerce/woocommerce/pull/40221.
- Decided to use an E2E test to try and replicate as faithfully as possible.
- Open to rewriting as a PhpUnit test, but that would almost certainly require refactoring of code inside the [`WC_AJAX`](https://github.com/woocommerce/woocommerce/blob/8.1.1/plugins/woocommerce/includes/class-wc-ajax.php#L956) class (which we can do, but I preferred not to).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Manual testing is not needed, since we are adding an E2E test and the functional change was already added and tested via https://github.com/woocommerce/woocommerce/pull/40221.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
