### PR TITLE
Add order instance argument to woocommerce_get_cancel_order_url filter hook

### DIFF
--- a/plugins/woocommerce/changelog/pr-40275
+++ b/plugins/woocommerce/changelog/pr-40275
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add order instance argument to woocommerce_get_cancel_order_url and woocommerce_get_cancel_order_url_raw filters

--- a/plugins/woocommerce/changelog/pr-40275
+++ b/plugins/woocommerce/changelog/pr-40275
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Add order instance argument to woocommerce_get_cancel_order_url and woocommerce_get_cancel_order_url_raw filters
+Add order instance and redirect URL arguments to woocommerce_get_cancel_order_url and woocommerce_get_cancel_order_url_raw filters

--- a/plugins/woocommerce/includes/class-wc-order.php
+++ b/plugins/woocommerce/includes/class-wc-order.php
@@ -1784,6 +1784,14 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string
 	 */
 	public function get_cancel_order_url( $redirect = '' ) {
+		/**
+		 * Filter the URL to cancel the order in the frontend.
+		 *
+		 * @since 2.2.0
+		 *
+		 * @param string $url
+		 * @param WC_Order $order
+		 */
 		return apply_filters(
 			'woocommerce_get_cancel_order_url',
 			wp_nonce_url(
@@ -1809,6 +1817,14 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string The unescaped cancel-order URL.
 	 */
 	public function get_cancel_order_url_raw( $redirect = '' ) {
+		/**
+		 * Filter the raw URL to cancel the order in the frontend.
+		 *
+		 * @since 2.2.0
+		 *
+		 * @param string $url
+		 * @param WC_Order $order
+		 */
 		return apply_filters(
 			'woocommerce_get_cancel_order_url_raw',
 			add_query_arg(

--- a/plugins/woocommerce/includes/class-wc-order.php
+++ b/plugins/woocommerce/includes/class-wc-order.php
@@ -1797,7 +1797,8 @@ class WC_Order extends WC_Abstract_Order {
 					$this->get_cancel_endpoint()
 				),
 				'woocommerce-cancel_order'
-			)
+			),
+			$this
 		);
 	}
 
@@ -1819,7 +1820,8 @@ class WC_Order extends WC_Abstract_Order {
 					'_wpnonce'     => wp_create_nonce( 'woocommerce-cancel_order' ),
 				),
 				$this->get_cancel_endpoint()
-			)
+			),
+			$this
 		);
 	}
 

--- a/plugins/woocommerce/includes/class-wc-order.php
+++ b/plugins/woocommerce/includes/class-wc-order.php
@@ -1790,7 +1790,8 @@ class WC_Order extends WC_Abstract_Order {
 		 * @since 2.2.0
 		 *
 		 * @param string $url
-		 * @param WC_Order $order
+		 * @param WC_Order $order Order data.
+		 * @param string $redirect Redirect URL.
 		 */
 		return apply_filters(
 			'woocommerce_get_cancel_order_url',
@@ -1806,7 +1807,8 @@ class WC_Order extends WC_Abstract_Order {
 				),
 				'woocommerce-cancel_order'
 			),
-			$this
+			$this,
+			$redirect
 		);
 	}
 
@@ -1823,7 +1825,8 @@ class WC_Order extends WC_Abstract_Order {
 		 * @since 2.2.0
 		 *
 		 * @param string $url
-		 * @param WC_Order $order
+		 * @param WC_Order $order Order data.
+		 * @param string $redirect Redirect URL.
 		 */
 		return apply_filters(
 			'woocommerce_get_cancel_order_url_raw',
@@ -1837,7 +1840,8 @@ class WC_Order extends WC_Abstract_Order {
 				),
 				$this->get_cancel_endpoint()
 			),
-			$this
+			$this,
+			$redirect
 		);
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Support access to the order instance in `woocommerce_get_cancel_order_url` and `woocommerce_get_cancel_order_url_raw` filters just like the `woocommerce_get_checkout_order_received_url` filter.

```php
add_filter('woocommerce_get_cancel_order_url', function ($cancel_url, $order, $redirect) {
    if ($order->is_created_via('store-api')) {
        // ...
    }
    
    return $cancel_url;
}, 10, 3);
```

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a test plugin with the following filter hook:

```php
<?php

add_filter('woocommerce_get_cancel_order_url', function ($cancel_url, $order, $redirect) {
    if ($order->get_payment_method() === 'bacs') {
        return home_url('/customer-service/bacs/cancel');
    }
    
    return $cancel_url;
}, 10, 3);
```

2. Navigate to the storefront.
3. Add any product to the cart and checkout with the _cash on delivery_ payment method.
4. Notice the order cancel URL remains unchanged.
5. Create a new order by adding any product to the cart and checkout with the _direct bank transfer_ payment method.
6. Notice the order cancel URL uses the custom URL from the filter hook.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message Add order instance argument to woocommerce_get_cancel_order_url and woocommerce_get_cancel_order_url_raw filters

</details>
