### PR TITLE
Add cys ai header/footer

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/actions.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/actions.ts
@@ -15,6 +15,7 @@ import {
 	FontPairing,
 	LookAndToneCompletionResponse,
 	Header,
+	Footer,
 } from './types';
 import { aiWizardClosedBeforeCompletionEvent } from './events';
 import {
@@ -129,6 +130,24 @@ const assignHeader = assign<
 	},
 } );
 
+const assignFooter = assign<
+	designWithAiStateMachineContext,
+	designWithAiStateMachineEvents
+>( {
+	aiSuggestions: ( context, event: unknown ) => {
+		return {
+			...context.aiSuggestions,
+			footer: (
+				event as {
+					data: {
+						response: Footer;
+					};
+				}
+			 ).data.response.slug,
+		};
+	},
+} );
+
 const logAIAPIRequestError = () => {
 	// log AI API request error
 	// eslint-disable-next-line no-console
@@ -198,6 +217,7 @@ export const actions = {
 	assignDefaultColorPalette,
 	assignFontPairing,
 	assignHeader,
+	assignFooter,
 	logAIAPIRequestError,
 	updateQueryStep,
 	recordTracksStepViewed,

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/actions.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/actions.ts
@@ -14,6 +14,7 @@ import {
 	designWithAiStateMachineEvents,
 	FontPairing,
 	LookAndToneCompletionResponse,
+	Header,
 } from './types';
 import { aiWizardClosedBeforeCompletionEvent } from './events';
 import {
@@ -110,6 +111,24 @@ const assignFontPairing = assign<
 	},
 } );
 
+const assignHeader = assign<
+	designWithAiStateMachineContext,
+	designWithAiStateMachineEvents
+>( {
+	aiSuggestions: ( context, event: unknown ) => {
+		return {
+			...context.aiSuggestions,
+			header: (
+				event as {
+					data: {
+						response: Header;
+					};
+				}
+			 ).data.response.slug,
+		};
+	},
+} );
+
 const logAIAPIRequestError = () => {
 	// log AI API request error
 	// eslint-disable-next-line no-console
@@ -178,6 +197,7 @@ export const actions = {
 	assignLookAndTone,
 	assignDefaultColorPalette,
 	assignFontPairing,
+	assignHeader,
 	logAIAPIRequestError,
 	updateQueryStep,
 	recordTracksStepViewed,

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/prompts/footer.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/prompts/footer.ts
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import { z } from 'zod';
+
+const footerChoices = [
+	{
+		slug: 'woocommerce-blocks/footer-simple-menu-and-cart',
+		label: 'Footer with Simple Menu and Cart',
+	},
+	{
+		slug: 'woocommerce-blocks/footer-with-3-menus',
+		label: 'Footer with 3 Menus',
+	},
+	{
+		slug: 'woocommerce-blocks/footer-large',
+		label: 'Large Footer',
+	},
+];
+
+const allowedFooter: string[] = footerChoices.map( ( footer ) => footer.slug );
+
+export const footerValidator = z.object( {
+	slug: z.string().refine( ( slug ) => allowedFooter.includes( slug ), {
+		message: 'Footer not part of allowed list',
+	} ),
+} );
+
+export const defaultFooter = {
+	queryId: 'default_footer',
+
+	// make sure version is updated every time the prompt is changed
+	version: '2023-09-19',
+	prompt: ( businessDescription: string, look: string, tone: string ) => {
+		return `
+            You are a WordPress theme expert. Analyse the following store description, merchant's chosen look and tone, and determine the most appropriate footer.
+            Respond only with one footer and only its JSON.
+
+            Chosen look and tone: ${ look } look, ${ tone } tone.
+            Business description: ${ businessDescription }
+
+            Footer to choose from: 
+            ${ JSON.stringify( footerChoices ) }
+        `;
+	},
+	responseValidation: footerValidator.parse,
+};

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/prompts/header.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/prompts/header.ts
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import { z } from 'zod';
+
+const headerChoices = [
+	{
+		slug: 'woocommerce-blocks/header-essential',
+		label: 'Essential Header',
+	},
+	{
+		slug: 'woocommerce-blocks/header-centered-menu-with-search',
+		label: 'Centered Menu with search Header',
+	},
+	{
+		slug: 'woocommerce-blocks/header-minimal',
+		label: 'Minimal Header',
+	},
+	{
+		slug: 'woocommerce-blocks/header-large',
+		label: 'Large Header',
+	},
+];
+
+const allowedHeaders: string[] = headerChoices.map( ( header ) => header.slug );
+
+export const headerValidator = z.object( {
+	slug: z.string().refine( ( slug ) => allowedHeaders.includes( slug ), {
+		message: 'Header not part of allowed list',
+	} ),
+} );
+
+export const defaultHeader = {
+	queryId: 'default_header',
+
+	// make sure version is updated every time the prompt is changed
+	version: '2023-09-19',
+	prompt: ( businessDescription: string, look: string, tone: string ) => {
+		return `
+            You are a WordPress theme expert. Analyse the following store description, merchant's chosen look and tone, and determine the most appropriate header.
+            Respond only with one header and only its JSON.
+
+            Chosen look and tone: ${ look } look, ${ tone } tone.
+            Business description: ${ businessDescription }
+
+            Headers to choose from: 
+            ${ JSON.stringify( headerChoices ) }
+        `;
+	},
+	responseValidation: headerValidator.parse,
+};

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/prompts/index.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/prompts/index.ts
@@ -2,3 +2,4 @@ export * from './colorChoices';
 export * from './lookAndTone';
 export * from './fontPairings';
 export * from './header';
+export * from './footer';

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/prompts/index.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/prompts/index.ts
@@ -1,3 +1,4 @@
 export * from './colorChoices';
 export * from './lookAndTone';
 export * from './fontPairings';
+export * from './header';

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/prompts/test/footer.test.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/prompts/test/footer.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Internal dependencies
+ */
+import { footerValidator } from '..';
+
+describe( 'footerValidator', () => {
+	it( 'should validate when footer is part of the allowed list', () => {
+		const validFooter = { slug: 'woocommerce-blocks/footer-large' };
+		expect( () => footerValidator.parse( validFooter ) ).not.toThrow();
+	} );
+
+	it( 'should not validate when footer is not part of the allowed list', () => {
+		const invalidFooter = {
+			slug: 'woocommerce-blocks/footer-large-invalid',
+		};
+		expect( () => footerValidator.parse( invalidFooter ) )
+			.toThrowErrorMatchingInlineSnapshot( `
+		"[
+		  {
+		    \\"code\\": \\"custom\\",
+		    \\"message\\": \\"Footer not part of allowed list\\",
+		    \\"path\\": [
+		      \\"slug\\"
+		    ]
+		  }
+		]"
+	` );
+	} );
+
+	it( 'should not validate when slug is not a string', () => {
+		const invalidType = { slug: 123 };
+		expect( () => footerValidator.parse( invalidType ) )
+			.toThrowErrorMatchingInlineSnapshot( `
+		"[
+		  {
+		    \\"code\\": \\"invalid_type\\",
+		    \\"expected\\": \\"string\\",
+		    \\"received\\": \\"number\\",
+		    \\"path\\": [
+		      \\"slug\\"
+		    ],
+		    \\"message\\": \\"Expected string, received number\\"
+		  }
+		]"
+	` );
+	} );
+} );

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/prompts/test/header.test.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/prompts/test/header.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Internal dependencies
+ */
+import { headerValidator } from '..';
+
+describe( 'headerValidator', () => {
+	it( 'should validate when header is part of the allowed list', () => {
+		const validHeader = { slug: 'woocommerce-blocks/header-large' };
+		expect( () => headerValidator.parse( validHeader ) ).not.toThrow();
+	} );
+
+	it( 'should not validate when header is not part of the allowed list', () => {
+		const invalidHeader = {
+			slug: 'woocommerce-blocks/header-large-invalid',
+		};
+		expect( () => headerValidator.parse( invalidHeader ) )
+			.toThrowErrorMatchingInlineSnapshot( `
+		"[
+		  {
+		    \\"code\\": \\"custom\\",
+		    \\"message\\": \\"Header not part of allowed list\\",
+		    \\"path\\": [
+		      \\"slug\\"
+		    ]
+		  }
+		]"
+	` );
+	} );
+
+	it( 'should not validate when slug is not a string', () => {
+		const invalidType = { slug: 123 };
+		expect( () => headerValidator.parse( invalidType ) )
+			.toThrowErrorMatchingInlineSnapshot( `
+		"[
+		  {
+		    \\"code\\": \\"invalid_type\\",
+		    \\"expected\\": \\"string\\",
+		    \\"received\\": \\"number\\",
+		    \\"path\\": [
+		      \\"slug\\"
+		    ],
+		    \\"message\\": \\"Expected string, received number\\"
+		  }
+		]"
+	` );
+	} );
+} );

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/state-machine.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/state-machine.tsx
@@ -13,6 +13,7 @@ import {
 	ColorPalette,
 	FontPairing,
 	Header,
+	Footer,
 } from './types';
 import {
 	BusinessInfoDescription,
@@ -22,7 +23,12 @@ import {
 } from './pages';
 import { actions } from './actions';
 import { services } from './services';
-import { defaultColorPalette, fontPairings, defaultHeader } from './prompts';
+import {
+	defaultColorPalette,
+	fontPairings,
+	defaultHeader,
+	defaultFooter,
+} from './prompts';
 
 export const hasStepInUrl = (
 	_ctx: unknown,
@@ -74,6 +80,7 @@ export const designWithAiStateMachineDefinition = createMachine(
 				defaultColorPalette: {} as ColorPalette,
 				fontPairing: '' as FontPairing[ 'pair_name' ],
 				header: '' as Header[ 'slug' ],
+				footer: '' as Footer[ 'slug' ],
 			},
 		},
 		initial: 'navigate',
@@ -330,6 +337,25 @@ export const designWithAiStateMachineDefinition = createMachine(
 									},
 									onDone: {
 										actions: [ 'assignHeader' ],
+									},
+								},
+							},
+							chooseFooter: {
+								invoke: {
+									src: 'queryAiEndpoint',
+									data: ( context ) => {
+										return {
+											...defaultFooter,
+											prompt: defaultFooter.prompt(
+												context.businessInfoDescription
+													.descriptionText,
+												context.lookAndFeel.choice,
+												context.toneOfVoice.choice
+											),
+										};
+									},
+									onDone: {
+										actions: [ 'assignFooter' ],
 									},
 								},
 							},

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/state-machine.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/state-machine.tsx
@@ -12,6 +12,7 @@ import {
 	designWithAiStateMachineEvents,
 	ColorPalette,
 	FontPairing,
+	Header,
 } from './types';
 import {
 	BusinessInfoDescription,
@@ -21,7 +22,7 @@ import {
 } from './pages';
 import { actions } from './actions';
 import { services } from './services';
-import { defaultColorPalette, fontPairings } from './prompts';
+import { defaultColorPalette, fontPairings, defaultHeader } from './prompts';
 
 export const hasStepInUrl = (
 	_ctx: unknown,
@@ -72,6 +73,7 @@ export const designWithAiStateMachineDefinition = createMachine(
 			aiSuggestions: {
 				defaultColorPalette: {} as ColorPalette,
 				fontPairing: '' as FontPairing[ 'pair_name' ],
+				header: '' as Header[ 'slug' ],
 			},
 		},
 		initial: 'navigate',
@@ -309,6 +311,25 @@ export const designWithAiStateMachineDefinition = createMachine(
 									},
 									onDone: {
 										actions: [ 'assignFontPairing' ],
+									},
+								},
+							},
+							chooseHeader: {
+								invoke: {
+									src: 'queryAiEndpoint',
+									data: ( context ) => {
+										return {
+											...defaultHeader,
+											prompt: defaultHeader.prompt(
+												context.businessInfoDescription
+													.descriptionText,
+												context.lookAndFeel.choice,
+												context.toneOfVoice.choice
+											),
+										};
+									},
+									onDone: {
+										actions: [ 'assignHeader' ],
 									},
 								},
 							},

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/types.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/types.ts
@@ -11,7 +11,6 @@ import {
 	headerValidator,
 	footerValidator,
 	colorPaletteResponseValidator,
-	fontChoiceValidator,
 } from './prompts';
 
 export type designWithAiStateMachineContext = {

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/types.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/types.ts
@@ -5,7 +5,11 @@ import { z } from 'zod';
 /**
  * Internal dependencies
  */
-import { colorPaletteValidator, fontChoiceValidator } from './prompts';
+import {
+	colorPaletteValidator,
+	fontChoiceValidator,
+	headerValidator,
+} from './prompts';
 
 export type designWithAiStateMachineContext = {
 	businessInfoDescription: {
@@ -20,6 +24,7 @@ export type designWithAiStateMachineContext = {
 	aiSuggestions: {
 		defaultColorPalette: ColorPalette;
 		fontPairing: FontPairing[ 'pair_name' ];
+		header: Header[ 'slug' ];
 	};
 	// If we require more data from options, previously provided core profiler details,
 	// we can retrieve them in preBusinessInfoDescription and then assign them here
@@ -53,3 +58,5 @@ export interface LookAndToneCompletionResponse {
 export type ColorPalette = z.infer< typeof colorPaletteValidator >;
 
 export type FontPairing = z.infer< typeof fontChoiceValidator >;
+
+export type Header = z.infer< typeof headerValidator >;

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/types.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/types.ts
@@ -9,6 +9,7 @@ import {
 	colorPaletteValidator,
 	fontChoiceValidator,
 	headerValidator,
+	footerValidator,
 } from './prompts';
 
 export type designWithAiStateMachineContext = {
@@ -25,6 +26,7 @@ export type designWithAiStateMachineContext = {
 		defaultColorPalette: ColorPalette;
 		fontPairing: FontPairing[ 'pair_name' ];
 		header: Header[ 'slug' ];
+		footer: Footer[ 'slug' ];
 	};
 	// If we require more data from options, previously provided core profiler details,
 	// we can retrieve them in preBusinessInfoDescription and then assign them here
@@ -60,3 +62,5 @@ export type ColorPalette = z.infer< typeof colorPaletteValidator >;
 export type FontPairing = z.infer< typeof fontChoiceValidator >;
 
 export type Header = z.infer< typeof headerValidator >;
+
+export type Footer = z.infer< typeof footerValidator >;

--- a/plugins/woocommerce-admin/client/xstate.js
+++ b/plugins/woocommerce-admin/client/xstate.js
@@ -23,7 +23,7 @@ async function enableXStateInspect() {
 }
 
 if (
-	process.env.NODE_ENV === 'development' &&
+	// process.env.NODE_ENV === 'development' &&
 	window.localStorage.getItem( 'xstate_inspect' ) === 'true'
 ) {
 	enableXStateInspect();

--- a/plugins/woocommerce-admin/client/xstate.js
+++ b/plugins/woocommerce-admin/client/xstate.js
@@ -23,7 +23,7 @@ async function enableXStateInspect() {
 }
 
 if (
-	// process.env.NODE_ENV === 'development' &&
+	process.env.NODE_ENV === 'development' &&
 	window.localStorage.getItem( 'xstate_inspect' ) === 'true'
 ) {
 	enableXStateInspect();

--- a/plugins/woocommerce/changelog/add-cys-ai-header-footer
+++ b/plugins/woocommerce/changelog/add-cys-ai-header-footer
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add cys ai header/footer


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

- add: cys ai header and footer suggestions

Part of https://github.com/woocommerce/woocommerce/issues/40162

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

This feature is part of the larger customize your store development and behind a feature flag, hence QA review can be deferred until the call for testing before release.

Make sure you are testing this with a Jetpack connected instance of WooCommerce, as the AI text completion endpoint can only be called with a Jetpack connected account.


#### Default header / footer

This text completion is called during the loading screen after all the steps of Design With AI are complete. It takes into account the business description text given by the user, as well as the choices they made for Look and Tone.

For now, the response is only persisted into the state machine context.

1. Create a new WooCommerce installation with this version.
2. Make sure to enable `customize-store` feature flag
3. Go to `WooCommerce -> Home` and click `Customize Store` task
4. Click `Design with AI` button
5. Follow through the flow all the way till the loader shows up
6. The loader is not expected to terminate
7. Examine that the returned header and footer have been saved into the machine context

This can be inspected using the XState inspector:

![Screenshot 2023-09-19 at 19 48 28](https://github.com/woocommerce/woocommerce/assets/4344253/54fc132a-0609-4917-a7da-baf49be859de)


Do also test around the error states and tracks.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add cys ai header/footer

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
