### PR TITLE
Fix: order metadata changes from admin not applied with HPOS active.

### DIFF
--- a/plugins/woocommerce/changelog/fix-metadata-not-updated-on-order-update
+++ b/plugins/woocommerce/changelog/fix-metadata-not-updated-on-order-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix changes in order custom fields made from admin not being applied when using the order Update button with HPOS active.

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -8,7 +8,6 @@
  * @version     2.2.0
  */
 
-use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -709,37 +709,6 @@ class WC_Meta_Box_Order_Data {
 			$props['customer_note'] = sanitize_textarea_field( wp_unslash( $_POST['customer_note'] ) );
 		}
 
-		// Metadata (only needed when HPOS table is in use).
-		if ( wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled() ) {
-			$order_meta = $order->get_meta_data();
-
-			$order_meta =
-				array_combine(
-					array_map( fn( $meta ) => $meta->id, $order_meta ),
-					array_map( fn( $meta ) => $meta, $order_meta )
-				);
-
-			// phpcs:disable WordPress.Security.ValidatedSanitizedInput
-
-			foreach ( ( $_POST['meta'] ?? array() ) as $request_meta_id => $request_meta_data ) {
-				$request_meta_id    = wp_unslash( $request_meta_id );
-				$request_meta_key   = wp_unslash( $request_meta_data['key'] );
-				$request_meta_value = wp_unslash( $request_meta_data['value'] );
-				if ( array_key_exists( $request_meta_id, $order_meta ) &&
-					( $order_meta[ $request_meta_id ]->key !== $request_meta_key || $order_meta[ $request_meta_id ]->value !== $request_meta_value ) ) {
-					$order->update_meta_data( $request_meta_key, $request_meta_value, $request_meta_id );
-				}
-			}
-
-			$request_new_key   = wp_unslash( $_POST['metakeyinput'] ?? '' );
-			$request_new_value = wp_unslash( $_POST['metavalue'] ?? '' );
-			if ( '' !== $request_new_key ) {
-				$order->add_meta_data( $request_new_key, $request_new_value );
-			}
-
-			// phpcs:enable WordPress.Security.ValidatedSanitizedInput
-		}
-
 		// Save order data.
 		$order->set_props( $props );
 		$order->set_status( wc_clean( wp_unslash( $_POST['order_status'] ) ), '', true );

--- a/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
@@ -208,7 +208,6 @@ class Edit {
 	 * @return void
 	 */
 	public function handle_order_update() {
-		global $theorder;
 		if ( ! isset( $this->order ) ) {
 			return;
 		}
@@ -232,6 +231,10 @@ class Edit {
 		 * @since 2.1.0
 		 */
 		do_action( 'woocommerce_process_shop_order_meta', $this->order->get_id(), $this->order );
+
+		if ( wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled() ) {
+			$this->custom_meta_box->handle_metadata_changes($this->order);
+		}
 
 		// Order updated message.
 		$this->message = 1;

--- a/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
@@ -232,9 +232,7 @@ class Edit {
 		 */
 		do_action( 'woocommerce_process_shop_order_meta', $this->order->get_id(), $this->order );
 
-		if ( wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled() ) {
-			$this->custom_meta_box->handle_metadata_changes($this->order);
-		}
+		$this->custom_meta_box->handle_metadata_changes($this->order);
 
 		// Order updated message.
 		$this->message = 1;

--- a/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomMetaBox.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/MetaBoxes/CustomMetaBox.php
@@ -242,7 +242,7 @@ class CustomMetaBox {
 	 * @return void
 	 */
 	private function handle_add_meta( WC_Order $order, string $meta_key, string $meta_value ) {
-		$count            = 0;
+		$count = 0;
 		if ( is_protected_meta( $meta_key ) ) {
 			wp_send_json_error( 'protected_meta' );
 			wp_die();
@@ -408,5 +408,53 @@ class CustomMetaBox {
 			wp_die( 1 );
 		}
 		wp_die( 0 );
+	}
+
+	/**
+	 * Handle the possible changes in order metadata coming from an order edit page in admin
+	 * (labeled "custom fields" in the UI).
+	 *
+	 * This method expects the $_POST array to contain a 'meta' key that is an associative
+	 * array of [meta item id => [ 'key' => meta item name, 'value' => meta item value ];
+	 * and also to contain (possibly empty) 'metakeyinput' and 'metavalue' keys.
+	 *
+	 * @param WC_Order $order The order to handle.
+	 */
+	public function handle_metadata_changes( $order ) {
+		$has_meta_changes = false;
+
+		$order_meta = $order->get_meta_data();
+
+		$order_meta =
+			array_combine(
+				array_map( fn( $meta ) => $meta->id, $order_meta ),
+				$order_meta
+			);
+
+		// phpcs:disable WordPress.Security.ValidatedSanitizedInput, WordPress.Security.NonceVerification.Missing
+
+		foreach ( ( $_POST['meta'] ?? array() ) as $request_meta_id => $request_meta_data ) {
+			$request_meta_id    = wp_unslash( $request_meta_id );
+			$request_meta_key   = wp_unslash( $request_meta_data['key'] );
+			$request_meta_value = wp_unslash( $request_meta_data['value'] );
+			if ( array_key_exists( $request_meta_id, $order_meta ) &&
+				( $order_meta[ $request_meta_id ]->key !== $request_meta_key || $order_meta[ $request_meta_id ]->value !== $request_meta_value ) ) {
+				$order->update_meta_data( $request_meta_key, $request_meta_value, $request_meta_id );
+				$has_meta_changes = true;
+			}
+		}
+
+		$request_new_key   = wp_unslash( $_POST['metakeyinput'] ?? '' );
+		$request_new_value = wp_unslash( $_POST['metavalue'] ?? '' );
+		if ( '' !== $request_new_key ) {
+			$order->add_meta_data( $request_new_key, $request_new_value );
+			$has_meta_changes = true;
+		}
+
+		// phpcs:enable WordPress.Security.ValidatedSanitizedInput, WordPress.Security.NonceVerification.Missing
+
+		if ( $has_meta_changes ) {
+			$order->save();
+		}
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When an order is open in the admin area and changes are made to custom field keys or values, or a new custom field is added in the "Add New Custom Field" section, but the order "Update" button is clicked directly (without having clicked the "Update" button in the modified fields or the "Add Custom Field" button), the changes in the custom fields should be applied to the order anyway. That was happening when the posts table is authoritative but not when the orders table is authoritative. This pull request fixes that.

Closes #40161.

### How to test the changes in this Pull Request:

1. Make sure that HPOS is enabled (WooCommerce - Settings - Advanced - Features - Order data storage, or from command line: `wp wc cot enable`).
2. Create an order or open an existing order in the admin area. If it has custom fields already, delete all of them and reload the page.
3. Create four custom fields, with names `name1` to `name4` and values `value1` to `value4` respectively (click "Add custom field" for each). Reload the page.
4. Now do the following:
   * Delete the `name1` field (using the "Delete" button below the field name).
   * Change the _name_ of the `name2` field to `name2!`. **Don't** click "Update".
   * Change the _value_ of the `name3` field to `value3!`. **Don't** click "Update".
   * In the "Add New Custom Field" section write `name4` as the name and `value4!` as the value. **Don't** click "Add Custom Field".
5. Scroll up and click the "Update" button in the "Order actions" section.
6. Wait for the page to reload and verify that the changes have been applied as expected, including having now two fields named `name4` (this is consistent with the behavior when the posts table is authoritative):

![image](https://github.com/woocommerce/woocommerce/assets/937723/60460f9f-a1c2-4074-af21-de430ce7ff39)

7. Finally, verify that you can add a new custom field with an empty value (as before: write the name but directly click "Update" in "Order actions").

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Fix changes in order custom fields made from admin not being applied when using the order "Update" button with HPOS active.

#### Comment

</details>
