### PR TITLE
Add missing order type handling in HPOS sync

### DIFF
--- a/plugins/woocommerce/changelog/fix-hpos-pending-sync-count-order-types
+++ b/plugins/woocommerce/changelog/fix-hpos-pending-sync-count-order-types
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Address missing order type handling in HPOS compatibility mode sync.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
When HPOS is authoritative, the sync process (and associated "pending sync count") might attempt to include orders that are in the orders table but with a type that is not known to WooCommerce (for example, order types added by plugins no longer active).
Such orders will be skipped by the process but still counted as pending, resulting in an endless sync.

This PR makes sure order types are taking into account when syncing from HPOS to posts. In particular, unknown order types shouldn't be counted nor synced.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. I your site already has orders, make sure they've been synced. You can do this on the command line with `wp wc cot sync`.
1. Now, make sure HPOS is enabled in WC > Settings > Advanced > Features. **Compatibility mode (sync) should be disabled.**
1. Go to WC > Orders.
1. Click "Add Order", enter any details and save the order. Take note of the order ID.
1. Go to WC > Settings > Advanced > Features and make sure that you're notified that 1 order is pending to be synchronized. You can also use `wp wc cot count_unmigrated`, which should also report the one order.
1. Run the following command to change the order type for the order you created in step 4 to something WC doesn't know about:
   ```
   wp db query "UPDATE $(wp db prefix)wc_orders SET type='shop_unknown' WHERE id=<id>" 
   ```
   Replace `<id>` with the order ID.
1. Go back to WC > Settings > Advanced > Features and confirm that there's no longer an indication that orders need to be synced.
1. Confirm the above by running `wp wc cot count_unmigrated` on the command line.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
