### PR TITLE
Add notice when variation prices are not set yet

### DIFF
--- a/packages/js/data/changelog/add-40042_prices_not_set_notice
+++ b/packages/js/data/changelog/add-40042_prices_not_set_notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add additional type to user preferences config.

--- a/packages/js/data/src/user/types.ts
+++ b/packages/js/data/src/user/types.ts
@@ -29,6 +29,7 @@ export type UserPreferences = {
 	variable_product_block_tour_shown?: string;
 	variations_report_columns?: string;
 	product_block_variable_options_notice_dismissed?: string;
+	variable_items_without_price_notice_dismissed?: Record< number, string >;
 };
 
 export type WoocommerceMeta = UserPreferences & {

--- a/packages/js/data/src/user/types.ts
+++ b/packages/js/data/src/user/types.ts
@@ -34,6 +34,7 @@ export type UserPreferences = {
 
 export type WoocommerceMeta = UserPreferences & {
 	task_list_tracked_started_tasks?: string;
+	variable_items_without_price_notice_dismissed?: string;
 };
 
 export type WCUser<

--- a/packages/js/product-editor/changelog/add-40042_prices_not_set_notice
+++ b/packages/js/product-editor/changelog/add-40042_prices_not_set_notice
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add notice to variations when variations do not have prices set.

--- a/packages/js/product-editor/src/blocks/variation-items/edit.tsx
+++ b/packages/js/product-editor/src/blocks/variation-items/edit.tsx
@@ -81,12 +81,20 @@ export function Edit( {
 
 	const { ref: variationTableRef } = useValidation< Product >(
 		`variations`,
-		async function regularPriceValidator( defaultValue, additionalData ) {
+		async function regularPriceValidator( defaultValue, newData ) {
+			/**
+			 * We cause a validation error if there is:
+			 * - more then one variation without a price.
+			 * - the notice hasn't been dismissed.
+			 * - The product hasn't already been published.
+			 * - We are publishing the product.
+			 */
 			if (
 				totalCountWithoutPrice > 0 &&
 				! noticeDimissed.current &&
 				productStatus !== 'publish' &&
-				additionalData?.status === 'publish'
+				// New status.
+				newData?.status === 'publish'
 			) {
 				if ( itemsWithoutPriceNoticeDismissed !== 'yes' ) {
 					updateUserPreferences( {

--- a/packages/js/product-editor/src/blocks/variation-items/edit.tsx
+++ b/packages/js/product-editor/src/blocks/variation-items/edit.tsx
@@ -1,14 +1,26 @@
 /**
  * External dependencies
  */
+import { sprintf, __ } from '@wordpress/i18n';
+import {
+	EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME,
+	Product,
+	useUserPreferences,
+} from '@woocommerce/data';
 import { useBlockProps } from '@wordpress/block-editor';
 import { BlockEditProps } from '@wordpress/blocks';
-import { createElement } from '@wordpress/element';
+import { createElement, useMemo, useRef } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore No types for this exist yet.
+// eslint-disable-next-line @woocommerce/dependency-group
+import { useEntityId, useEntityProp } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
 import { VariationsTable } from '../../components/variations-table';
+import { useValidation } from '../../contexts/validation-context';
 import { VariationOptionsBlockAttributes } from './types';
 import { VariableProductTour } from './variable-product-tour';
 
@@ -19,11 +31,123 @@ export function Edit( {
 		isInSelectedTab?: boolean;
 	};
 } ) {
+	const noticeDimissed = useRef( false );
+	const { invalidateResolution } = useDispatch(
+		EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME
+	);
+	const productId = useEntityId( 'postType', 'product' );
 	const blockProps = useBlockProps();
+	const [ productStatus ] = useEntityProp< string >(
+		'postType',
+		'product',
+		'status'
+	);
+
+	const totalCountWithoutPriceRequestParams = useMemo(
+		() => ( {
+			product_id: productId,
+			order: 'asc',
+			orderby: 'menu_order',
+			has_price: false,
+		} ),
+		[ productId ]
+	);
+
+	const { totalCountWithoutPrice } = useSelect(
+		( select ) => {
+			const { getProductVariationsTotalCount } = select(
+				EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME
+			);
+
+			return {
+				totalCountWithoutPrice:
+					getProductVariationsTotalCount< number >(
+						totalCountWithoutPriceRequestParams
+					),
+			};
+		},
+		[ productId ]
+	);
+
+	const {
+		updateUserPreferences,
+		variable_items_without_price_notice_dismissed:
+			itemsWithoutPriceNoticeDismissed,
+	} = useUserPreferences();
+
+	const { ref: variationTableRef } = useValidation< Product >(
+		`variations`,
+		async function regularPriceValidator( defaultValue, additionalData ) {
+			if (
+				totalCountWithoutPrice > 0 &&
+				! noticeDimissed.current &&
+				productStatus !== 'publish' &&
+				additionalData?.status === 'publish'
+			) {
+				if ( itemsWithoutPriceNoticeDismissed !== 'yes' ) {
+					updateUserPreferences( {
+						variable_items_without_price_notice_dismissed: {
+							...( itemsWithoutPriceNoticeDismissed || {} ),
+							[ productId ]: 'no',
+						},
+					} );
+				}
+				return __(
+					'Set variation prices before adding this product.',
+					'woocommerce'
+				);
+			}
+		},
+		[ totalCountWithoutPrice ]
+	);
+
+	const hasNotDismissedNotice =
+		! itemsWithoutPriceNoticeDismissed ||
+		itemsWithoutPriceNoticeDismissed[ productId ] !== 'yes';
+	const noticeText =
+		totalCountWithoutPrice > 0 && hasNotDismissedNotice
+			? sprintf(
+					/** Translators: Number of variations without price */
+					__(
+						'%d variations do not have prices. Variations that do not have prices will not be visible to customers.',
+						'woocommerce'
+					),
+					totalCountWithoutPrice
+			  )
+			: '';
 
 	return (
 		<div { ...blockProps }>
-			<VariationsTable />
+			<VariationsTable
+				ref={ variationTableRef as React.Ref< HTMLDivElement > }
+				noticeText={ noticeText }
+				onNoticeDismiss={ () => {
+					noticeDimissed.current = true;
+					updateUserPreferences( {
+						variable_items_without_price_notice_dismissed: {
+							...( itemsWithoutPriceNoticeDismissed || {} ),
+							[ productId ]: 'yes',
+						},
+					} );
+				} }
+				onVariationTableChange={ ( type, update ) => {
+					if (
+						type === 'delete' ||
+						( type === 'update' &&
+							update &&
+							update.find(
+								( variation ) =>
+									variation.regular_price ||
+									variation.sale_price
+							) )
+					) {
+						invalidateResolution(
+							'getProductVariationsTotalCount',
+							[ totalCountWithoutPriceRequestParams ]
+						);
+					}
+				} }
+			/>
 			{ context?.isInSelectedTab && <VariableProductTour /> }
 		</div>
 	);

--- a/packages/js/product-editor/src/components/header/hooks/use-publish/use-publish.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-publish/use-publish.tsx
@@ -26,7 +26,7 @@ export function usePublish( {
 	onPublishSuccess?( product: Product ): void;
 	onPublishError?( error: WPError ): void;
 } ): Button.ButtonProps {
-	const { isValidating, validate } = useValidations();
+	const { isValidating, validate } = useValidations< Product >();
 
 	const [ productId ] = useEntityProp< number >(
 		'postType',
@@ -61,7 +61,9 @@ export function usePublish( {
 		}
 
 		try {
-			await validate();
+			await validate( {
+				status: 'publish',
+			} );
 
 			// The publish button click not only change the status of the product
 			// but also save all the pending changes. So even if the status is
@@ -93,6 +95,12 @@ export function usePublish( {
 							? 'product_publish_error'
 							: 'product_create_error',
 					} as WPError;
+					if ( ( error as Record< string, string > ).variations ) {
+						wpError.code = 'variable_product_no_variation_prices';
+						wpError.message = (
+							error as Record< string, string >
+						 ).variations;
+					}
 				}
 				onPublishError( wpError );
 			}

--- a/packages/js/product-editor/src/components/header/hooks/use-save-draft/use-save-draft.tsx
+++ b/packages/js/product-editor/src/components/header/hooks/use-save-draft/use-save-draft.tsx
@@ -56,7 +56,7 @@ export function useSaveDraft( {
 		[ productId ]
 	);
 
-	const { isValidating, validate } = useValidations();
+	const { isValidating, validate } = useValidations< Product >();
 
 	const ariaDisabled =
 		disabled ||
@@ -76,7 +76,7 @@ export function useSaveDraft( {
 		}
 
 		try {
-			await validate();
+			await validate( { status: 'draft' } );
 
 			await editEntityRecord( 'postType', 'product', productId, {
 				status: 'draft',

--- a/packages/js/product-editor/src/components/variations-table/styles.scss
+++ b/packages/js/product-editor/src/components/variations-table/styles.scss
@@ -15,6 +15,11 @@ $table-row-height: calc($grid-unit * 9);
 		border-bottom: 1px solid $gray-200;
 	}
 
+	&__notice {
+		border-left: 0px;
+		margin: 0 0 $gap-large 0;
+	}
+
 	&__table {
 		height: $table-row-height * 5;
 		overflow: auto;

--- a/packages/js/product-editor/src/components/variations-table/styles.scss
+++ b/packages/js/product-editor/src/components/variations-table/styles.scss
@@ -18,6 +18,16 @@ $table-row-height: calc($grid-unit * 9);
 	&__notice {
 		border-left: 0px;
 		margin: 0 0 $gap-large 0;
+		&.is-error {
+			background-color: #fcf0f1;
+		}
+
+		.components-notice__actions {
+			margin-top: $gap-small;
+			.components-button:first-child {
+				margin-left: 0px;
+			}
+		}
 	}
 
 	&__table {

--- a/packages/js/product-editor/src/components/variations-table/variations-table.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variations-table.tsx
@@ -62,7 +62,10 @@ type VariationsTableProps = {
 	onNoticeDismiss?: () => void;
 	noticeActions?: {
 		label: string;
-		onClick: () => void;
+		onClick: (
+			handleUpdateAll: ( update: Partial< ProductVariation >[] ) => void,
+			handleDeleteAll: ( update: Partial< ProductVariation >[] ) => void
+		) => void;
 		className?: string;
 		variant?: string;
 	}[];
@@ -331,7 +334,12 @@ export const VariationsTable = forwardRef<
 					status={ noticeStatus }
 					className="woocommerce-product-variations__notice"
 					onRemove={ onNoticeDismiss }
-					actions={ noticeActions }
+					actions={ noticeActions.map( ( action ) => ( {
+						...action,
+						onClick: () => {
+							action?.onClick( handleUpdateAll, handleDeleteAll );
+						},
+					} ) ) }
 				>
 					{ noticeText }
 				</Notice>

--- a/packages/js/product-editor/src/components/variations-table/variations-table.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variations-table.tsx
@@ -60,6 +60,12 @@ type VariationsTableProps = {
 	noticeText?: string;
 	noticeStatus?: 'error' | 'warning' | 'success' | 'info';
 	onNoticeDismiss?: () => void;
+	noticeActions?: {
+		label: string;
+		onClick: () => void;
+		className?: string;
+		variant?: string;
+	}[];
 	onVariationTableChange?: (
 		type: 'update' | 'delete',
 		updates?: Partial< ProductVariation >[]
@@ -72,6 +78,7 @@ export const VariationsTable = forwardRef<
 >( function Table(
 	{
 		noticeText,
+		noticeActions = [],
 		noticeStatus = 'error',
 		onNoticeDismiss = () => {},
 		onVariationTableChange = () => {},
@@ -324,6 +331,7 @@ export const VariationsTable = forwardRef<
 					status={ noticeStatus }
 					className="woocommerce-product-variations__notice"
 					onRemove={ onNoticeDismiss }
+					actions={ noticeActions }
 				>
 					{ noticeText }
 				</Notice>

--- a/packages/js/product-editor/src/components/variations-table/variations-table.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variations-table.tsx
@@ -5,6 +5,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import {
 	Button,
 	CheckboxControl,
+	Notice,
 	Spinner,
 	Tooltip,
 } from '@wordpress/components';
@@ -27,6 +28,8 @@ import {
 	createElement,
 	useRef,
 	useMemo,
+	Fragment,
+	forwardRef,
 } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import classnames from 'classnames';
@@ -53,7 +56,28 @@ import HiddenWithHelpIcon from '../../icons/hidden-with-help-icon';
 
 const NOT_VISIBLE_TEXT = __( 'Not visible to customers', 'woocommerce' );
 
-export function VariationsTable() {
+type VariationsTableProps = {
+	noticeText?: string;
+	noticeStatus?: 'error' | 'warning' | 'success' | 'info';
+	onNoticeDismiss?: () => void;
+	onVariationTableChange?: (
+		type: 'update' | 'delete',
+		updates?: Partial< ProductVariation >[]
+	) => void;
+};
+
+export const VariationsTable = forwardRef<
+	HTMLDivElement,
+	VariationsTableProps
+>( function Table(
+	{
+		noticeText,
+		noticeStatus = 'error',
+		onNoticeDismiss = () => {},
+		onVariationTableChange = () => {},
+	}: VariationsTableProps,
+	ref
+) {
 	const [ currentPage, setCurrentPage ] = useState( 1 );
 	const lastVariations = useRef< ProductVariation[] | null >( null );
 	const [ perPage, setPerPage ] = useState(
@@ -90,22 +114,9 @@ export function VariationsTable() {
 		} ),
 		[ productId ]
 	);
+
 	const context = useContext( CurrencyContext );
 	const { formatAmount } = context;
-	const { totalCount } = useSelect(
-		( select ) => {
-			const { getProductVariationsTotalCount } = select(
-				EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME
-			);
-
-			return {
-				totalCount: getProductVariationsTotalCount< number >(
-					totalCountRequestParams
-				),
-			};
-		},
-		[ productId ]
-	);
 	const { isLoading, latestVariations, isGeneratingVariations } = useSelect(
 		( select ) => {
 			const {
@@ -125,6 +136,21 @@ export function VariationsTable() {
 			};
 		},
 		[ currentPage, perPage, productId ]
+	);
+
+	const { totalCount } = useSelect(
+		( select ) => {
+			const { getProductVariationsTotalCount } = select(
+				EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME
+			);
+
+			return {
+				totalCount: getProductVariationsTotalCount< number >(
+					totalCountRequestParams
+				),
+			};
+		},
+		[ productId ]
 	);
 
 	const paginationProps = usePagination( {
@@ -179,13 +205,17 @@ export function VariationsTable() {
 				recordEvent( 'product_variations_delete', {
 					source: TRACKS_SOURCE,
 				} );
+				invalidateResolution( 'getProductVariations', [
+					requestParams,
+				] );
 			} )
-			.finally( () =>
+			.finally( () => {
 				setIsUpdating( ( prevState ) => ( {
 					...prevState,
 					[ variationId ]: false,
-				} ) )
-			);
+				} ) );
+				onVariationTableChange( 'delete' );
+			} );
 	}
 
 	function handleVariationChange(
@@ -212,12 +242,13 @@ export function VariationsTable() {
 					__( 'Failed to save variation.', 'woocommerce' )
 				);
 			} )
-			.finally( () =>
+			.finally( () => {
 				setIsUpdating( ( prevState ) => ( {
 					...prevState,
 					[ variationId ]: false,
-				} ) )
-			);
+				} ) );
+				onVariationTableChange( 'update', [ variation ] );
+			} );
 	}
 
 	function handleUpdateAll( update: Partial< ProductVariation >[] ) {
@@ -238,6 +269,7 @@ export function VariationsTable() {
 						response.update.length
 					)
 				);
+				onVariationTableChange( 'update', update );
 			} )
 			.catch( () => {
 				createErrorNotice(
@@ -266,6 +298,7 @@ export function VariationsTable() {
 						response.delete.length
 					)
 				);
+				onVariationTableChange( 'delete' );
 			} )
 			.catch( () => {
 				createErrorNotice(
@@ -275,7 +308,7 @@ export function VariationsTable() {
 	}
 
 	return (
-		<div className="woocommerce-product-variations">
+		<div className="woocommerce-product-variations" ref={ ref }>
 			{ ( isLoading || isGeneratingVariations ) && (
 				<div className="woocommerce-product-variations__loading">
 					<Spinner />
@@ -285,6 +318,15 @@ export function VariationsTable() {
 						</span>
 					) }
 				</div>
+			) }
+			{ noticeText && (
+				<Notice
+					status={ noticeStatus }
+					className="woocommerce-product-variations__notice"
+					onRemove={ onNoticeDismiss }
+				>
+					{ noticeText }
+				</Notice>
 			) }
 			<div className="woocommerce-product-variations__header">
 				<div className="woocommerce-product-variations__selection">
@@ -401,18 +443,25 @@ export function VariationsTable() {
 								}
 							) }
 						>
-							<span
-								className={ classnames(
-									'woocommerce-product-variations__status-dot',
-									getProductStockStatusClass( variation )
-								) }
-							>
-								●
-							</span>
-							{ getProductStockStatus( variation ) }
+							{ variation.regular_price && (
+								<>
+									<span
+										className={ classnames(
+											'woocommerce-product-variations__status-dot',
+											getProductStockStatusClass(
+												variation
+											)
+										) }
+									>
+										●
+									</span>
+									{ getProductStockStatus( variation ) }
+								</>
+							) }
 						</div>
 						<div className="woocommerce-product-variations__actions">
-							{ variation.status === 'private' && (
+							{ ( variation.status === 'private' ||
+								! variation.regular_price ) && (
 								<Tooltip
 									// @ts-expect-error className is missing in TS, should remove this when it is included.
 									className="woocommerce-attribute-list-item__actions-tooltip"
@@ -459,4 +508,4 @@ export function VariationsTable() {
 			) }
 		</div>
 	);
-}
+} );

--- a/packages/js/product-editor/src/contexts/validation-context/types.ts
+++ b/packages/js/product-editor/src/contexts/validation-context/types.ts
@@ -1,6 +1,9 @@
 export type ValidatorResponse = Promise< ValidationError >;
 
-export type Validator< T > = ( initialValue?: T ) => ValidatorResponse;
+export type Validator< T > = (
+	initialValue?: T,
+	additionalData?: Partial< T >
+) => ValidatorResponse;
 
 export type ValidationContextProps< T > = {
 	errors: ValidationErrors;
@@ -9,7 +12,7 @@ export type ValidationContextProps< T > = {
 		validator: Validator< T >
 	): React.Ref< HTMLElement >;
 	validateField( name: string ): ValidatorResponse;
-	validateAll(): Promise< ValidationErrors >;
+	validateAll( additionalData?: Partial< T > ): Promise< ValidationErrors >;
 };
 
 export type ValidationProviderProps< T > = {
@@ -19,9 +22,9 @@ export type ValidationProviderProps< T > = {
 export type ValidationError = string | undefined;
 export type ValidationErrors = Record< string, ValidationError >;
 
-export type ValidatorRegistration = {
+export type ValidatorRegistration< T > = {
 	name: string;
 	ref: React.Ref< HTMLElement >;
 	error?: ValidationError;
-	validate(): ValidatorResponse;
+	validate( additionalData?: Partial< T > ): ValidatorResponse;
 };

--- a/packages/js/product-editor/src/contexts/validation-context/types.ts
+++ b/packages/js/product-editor/src/contexts/validation-context/types.ts
@@ -2,7 +2,7 @@ export type ValidatorResponse = Promise< ValidationError >;
 
 export type Validator< T > = (
 	initialValue?: T,
-	additionalData?: Partial< T >
+	newData?: Partial< T >
 ) => ValidatorResponse;
 
 export type ValidationContextProps< T > = {
@@ -12,7 +12,7 @@ export type ValidationContextProps< T > = {
 		validator: Validator< T >
 	): React.Ref< HTMLElement >;
 	validateField( name: string ): ValidatorResponse;
-	validateAll( additionalData?: Partial< T > ): Promise< ValidationErrors >;
+	validateAll( newData?: Partial< T > ): Promise< ValidationErrors >;
 };
 
 export type ValidationProviderProps< T > = {
@@ -26,5 +26,5 @@ export type ValidatorRegistration< T > = {
 	name: string;
 	ref: React.Ref< HTMLElement >;
 	error?: ValidationError;
-	validate( additionalData?: Partial< T > ): ValidatorResponse;
+	validate( newData?: Partial< T > ): ValidatorResponse;
 };

--- a/packages/js/product-editor/src/contexts/validation-context/use-validations.ts
+++ b/packages/js/product-editor/src/contexts/validation-context/use-validations.ts
@@ -13,17 +13,17 @@ function isInvalid( errors: ValidationErrors ) {
 	return Object.values( errors ).some( Boolean );
 }
 
-export function useValidations() {
+export function useValidations< T = unknown >() {
 	const context = useContext( ValidationContext );
 	const [ isValidating, setIsValidating ] = useState( false );
 
 	return {
 		isValidating,
-		async validate() {
+		async validate( additionalData?: Partial< T > ) {
 			setIsValidating( true );
 			return new Promise< void >( ( resolve, reject ) => {
 				context
-					.validateAll()
+					.validateAll( additionalData )
 					.then( ( errors ) => {
 						if ( isInvalid( errors ) ) {
 							reject( errors );

--- a/packages/js/product-editor/src/contexts/validation-context/use-validations.ts
+++ b/packages/js/product-editor/src/contexts/validation-context/use-validations.ts
@@ -19,11 +19,11 @@ export function useValidations< T = unknown >() {
 
 	return {
 		isValidating,
-		async validate( additionalData?: Partial< T > ) {
+		async validate( newData?: Partial< T > ) {
 			setIsValidating( true );
 			return new Promise< void >( ( resolve, reject ) => {
 				context
-					.validateAll( additionalData )
+					.validateAll( newData )
 					.then( ( errors ) => {
 						if ( isInvalid( errors ) ) {
 							reject( errors );

--- a/packages/js/product-editor/src/contexts/validation-context/validation-provider.tsx
+++ b/packages/js/product-editor/src/contexts/validation-context/validation-provider.tsx
@@ -38,11 +38,14 @@ export function ValidationProvider< T >( {
 		};
 	}
 
-	async function validateField( validatorId: string ): ValidatorResponse {
+	async function validateField(
+		validatorId: string,
+		additionalData?: Partial< T >
+	): ValidatorResponse {
 		const validators = validatorsRef.current;
 		if ( validatorId in validators ) {
 			const validator = validators[ validatorId ];
-			const result = validator( initialValue );
+			const result = validator( initialValue, additionalData );
 
 			return result.then( ( error ) => {
 				setErrors( ( currentErrors ) => ( {
@@ -56,12 +59,17 @@ export function ValidationProvider< T >( {
 		return Promise.resolve( undefined );
 	}
 
-	async function validateAll(): Promise< ValidationErrors > {
+	async function validateAll(
+		additionalData: Partial< T >
+	): Promise< ValidationErrors > {
 		const newErrors: ValidationErrors = {};
 		const validators = validatorsRef.current;
 
 		for ( const validatorId in validators ) {
-			newErrors[ validatorId ] = await validateField( validatorId );
+			newErrors[ validatorId ] = await validateField(
+				validatorId,
+				additionalData
+			);
 		}
 
 		setErrors( newErrors );

--- a/packages/js/product-editor/src/contexts/validation-context/validation-provider.tsx
+++ b/packages/js/product-editor/src/contexts/validation-context/validation-provider.tsx
@@ -40,12 +40,12 @@ export function ValidationProvider< T >( {
 
 	async function validateField(
 		validatorId: string,
-		additionalData?: Partial< T >
+		newData?: Partial< T >
 	): ValidatorResponse {
 		const validators = validatorsRef.current;
 		if ( validatorId in validators ) {
 			const validator = validators[ validatorId ];
-			const result = validator( initialValue, additionalData );
+			const result = validator( initialValue, newData );
 
 			return result.then( ( error ) => {
 				setErrors( ( currentErrors ) => ( {
@@ -60,7 +60,7 @@ export function ValidationProvider< T >( {
 	}
 
 	async function validateAll(
-		additionalData: Partial< T >
+		newData: Partial< T >
 	): Promise< ValidationErrors > {
 		const newErrors: ValidationErrors = {};
 		const validators = validatorsRef.current;
@@ -68,7 +68,7 @@ export function ValidationProvider< T >( {
 		for ( const validatorId in validators ) {
 			newErrors[ validatorId ] = await validateField(
 				validatorId,
-				additionalData
+				newData
 			);
 		}
 

--- a/packages/js/product-editor/src/utils/get-product-error-message.ts
+++ b/packages/js/product-editor/src/utils/get-product-error-message.ts
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 
 export type WPErrorCode =
+	| 'variable_product_no_variation_prices'
 	| 'product_invalid_sku'
 	| 'product_create_error'
 	| 'product_publish_error'
@@ -19,6 +20,8 @@ export type WPError = {
 
 export function getProductErrorMessage( error: WPError ) {
 	switch ( error.code ) {
+		case 'variable_product_no_variation_prices':
+			return error.message;
 		case 'product_invalid_sku':
 			return __( 'Invalid or duplicated SKU.', 'woocommerce' );
 		case 'product_create_error':

--- a/plugins/woocommerce-admin/client/layout/transient-notices/style.scss
+++ b/plugins/woocommerce-admin/client/layout/transient-notices/style.scss
@@ -1,11 +1,11 @@
-@import "../../navigation/stylesheets/variables.scss";
+@import '../../navigation/stylesheets/variables.scss';
 
 .woocommerce-transient-notices {
 	position: absolute;
 	left: $gap;
 	bottom: 100%;
 	margin-bottom: $gap-small;
-	z-index: calc(z-index(".components-snackbar-list") + 1);
+	z-index: calc(z-index('.components-snackbar-list') + 1);
 	width: auto;
 
 	.woocommerce-profile-wizard__body & {

--- a/plugins/woocommerce-admin/client/layout/transient-notices/style.scss
+++ b/plugins/woocommerce-admin/client/layout/transient-notices/style.scss
@@ -1,11 +1,11 @@
-@import '../../navigation/stylesheets/variables.scss';
+@import "../../navigation/stylesheets/variables.scss";
 
 .woocommerce-transient-notices {
 	position: absolute;
 	left: $gap;
 	bottom: 100%;
 	margin-bottom: $gap-small;
-	z-index: calc(z-index('.components-snackbar-list') + 1);
+	z-index: calc(z-index(".components-snackbar-list") + 1);
 	width: auto;
 
 	.woocommerce-profile-wizard__body & {
@@ -22,6 +22,10 @@
 .components-snackbar {
 	&.components-snackbar-explicit-dismiss {
 		cursor: default;
+	}
+
+	&__content {
+		white-space: pre-line;
 	}
 
 	.components-snackbar__content-with-icon {

--- a/plugins/woocommerce/changelog/add-40042_prices_not_set_notice
+++ b/plugins/woocommerce/changelog/add-40042_prices_not_set_notice
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add has_price param to the variations REST API query.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
@@ -866,6 +866,17 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 			$args['meta_query'] = $this->add_meta_query( $args, wc_get_min_max_price_meta_query( $request ) );  // WPCS: slow query ok.
 		}
 
+		// Price filter.
+		if ( is_bool( $request['has_price'] ) ) {
+			$args['meta_query'] = $this->add_meta_query( // WPCS: slow query ok.
+				$args,
+				array(
+					'key'     => '_price',
+					'compare' => $request['has_price'] ? 'EXISTS' : 'NOT EXISTS',
+				)
+			);
+		}
+
 		// Filter product based on stock_status.
 		if ( ! empty( $request['stock_status'] ) ) {
 			$args['meta_query'] = $this->add_meta_query( // WPCS: slow query ok.
@@ -924,6 +935,13 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 			'type'              => 'string',
 			'enum'              => array_keys( wc_get_product_stock_status_options() ),
 			'sanitize_callback' => 'sanitize_text_field',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+
+		$params['has_price'] = array(
+			'description'       => __( 'Limit result set to products with or without price.', 'woocommerce' ),
+			'type'              => 'boolean',
+			'sanitize_callback' => 'wc_string_to_bool',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -184,6 +184,7 @@ class Init {
 			array(
 				'variable_product_block_tour_shown',
 				'product_block_variable_options_notice_dismissed',
+				'variable_items_without_price_notice_dismissed'
 			)
 		);
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The main premise of this PR is to add a notice with `Set prices` to the variations tab in order to notify users that the variations are not shown when the price is not set.
This did require several other changes, like the `has_price` param in the API and some validation updates.

Closes #40042 

<img width="790" alt="Screenshot 2023-09-19 at 2 11 45 PM" src="https://github.com/woocommerce/woocommerce/assets/2240960/b099f7b3-85db-4b6e-9bef-afb7ed17e2b6">


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the new product editor under **WooCommerce > settings > advanced > features**
2. Go to **Products > Add new**
3. Add a name and click **Save draft**
4. Go to the **Variations** tab and add several variation options
5. Variations should auto create, notice how an red alert shows up with the number for variations with missing price.
6. Try to click **Add** ( you should still be able to save as draft )
7. A notice should pop up saying: **set variation prices before adding this product**
8. The variation list should show the (not visible icon) and the **In stock** should not be present.
9. Click **Set prices** and set a price
10. The notice should disappear and you should be able to publish the product now by click **Add**
11. Create a new product again, with a new name and save as draft, and some new variation options again.
12. Now dismiss the variation notice by click 'x'
13. Refresh the page, the notice should not show up again.
14. Click **Add** to publish
15. Notice how the notice shows up again with the same error notice as well.
16. Dismiss the notice and click **Add**
17. The product should now be published successfully.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
