### PR TITLE
save hpos order data before clearing the order from cache

### DIFF
--- a/plugins/woocommerce/changelog/fix-hpos-save-before-cache
+++ b/plugins/woocommerce/changelog/fix-hpos-save-before-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+save hpos order data before clearing the order from cache

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2924,15 +2924,17 @@ CREATE TABLE $meta_table (
 	 */
 	protected function after_meta_change( &$order, $meta ) {
 		method_exists( $meta, 'apply_changes' ) && $meta->apply_changes();
-		$this->clear_caches( $order );
+		$order_saved = false;
 
 		// Prevent this happening multiple time in same request.
 		if ( $this->should_save_after_meta_change( $order ) ) {
 			$order->set_date_modified( current_time( 'mysql' ) );
 			$order->save();
-			return true;
+			$order_saved = true;
 		}
-		return false;
+
+		$this->clear_caches( $order );
+		return $order_saved;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2523,9 +2523,9 @@ FROM $order_meta_table
 		$order->save_meta_data();
 
 		if ( $backfill ) {
-			$this->clear_caches( $order );
 			self::$backfilling_order_ids[] = $order->get_id();
-			$r_order                       = wc_get_order( $order->get_id() ); // Refresh order to account for DB changes from post hooks.
+			$this->clear_caches( $order );
+			$r_order = wc_get_order( $order->get_id() ); // Refresh order to account for DB changes from post hooks.
 			$this->maybe_backfill_post_record( $r_order );
 			self::$backfilling_order_ids = array_diff( self::$backfilling_order_ids, array( $order->get_id() ) );
 		}

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2924,17 +2924,18 @@ CREATE TABLE $meta_table (
 	 */
 	protected function after_meta_change( &$order, $meta ) {
 		method_exists( $meta, 'apply_changes' ) && $meta->apply_changes();
-		$order_saved = false;
 
 		// Prevent this happening multiple time in same request.
 		if ( $this->should_save_after_meta_change( $order ) ) {
 			$order->set_date_modified( current_time( 'mysql' ) );
 			$order->save();
-			$order_saved = true;
+			return true;
+		} else {
+			$order_cache = wc_get_container()->get( OrderCache::class );
+			$order_cache->remove( $order->get_id() );
 		}
 
-		$this->clear_caches( $order );
-		return $order_saved;
+		return false;
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -3017,12 +3017,20 @@ class OrdersTableDataStoreTests extends HposTestCase {
 			wc_get_order( $order_id );
 		} );
 		$order = OrderHelper::create_order();
-		remove_all_actions( 'woocommerce_delete_shop_order_transients' );
 
 		$this->assertEquals( 1, $order->get_customer_id() );
 
 		$r_order = wc_get_order( $order->get_id() );
 		$this->assertEquals( 1, $r_order->get_customer_id() );
+
+		$this->reset_order_data_store_state( wc_get_container()->get( OrdersTableDataStore::class ) );
+		$order->set_customer_id( 2 );
+		$order->save();
+
+		$r_order = wc_get_order( $order->get_id() );
+		$this->assertEquals( 2, $r_order->get_customer_id() );
+
+		remove_all_actions( 'woocommerce_delete_shop_order_transients' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -3006,4 +3006,41 @@ class OrdersTableDataStoreTests extends HposTestCase {
 		$this->assertEquals( 0, count( $query->orders ) );
 	}
 
+	/**
+	 * @testDox Hooking into woocommerce_delete_shop_order_transients does not cause data loss.
+	 */
+	public function test_data_retained_when_hooked_in_cache_filter() {
+		$this->toggle_cot_authoritative( true );
+		$this->enable_cot_sync();
+
+		add_action( 'woocommerce_delete_shop_order_transients', function ( $order_id ) {
+			wc_get_order( $order_id );
+		} );
+		$order = OrderHelper::create_order();
+		remove_all_actions( 'woocommerce_delete_shop_order_transients' );
+
+		$this->assertEquals( 1, $order->get_customer_id() );
+
+		$r_order = wc_get_order( $order->get_id() );
+		$this->assertEquals( 1, $r_order->get_customer_id() );
+	}
+
+	/**
+	 * @testDox Cache is cleared when order meta is saved.
+	 */
+	public function test_order_cache_is_cleared_on_meta_save() {
+		$this->toggle_cot_authoritative( true );
+		$this->enable_cot_sync();
+
+		$order = OrderHelper::create_order();
+
+		// set the cache
+		wc_get_order( $order->get_id() );
+
+		$order->add_meta_data( 'test_key', 'test_value' );
+		$order->save_meta_data();
+
+		$r_order = wc_get_order( $order->get_id() );
+		$this->assertEquals( 'test_value', $r_order->get_meta( 'test_key' ) );
+	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes a regression in #39911 where the order cache is cleared before the order is saved. This causes an issue with extensions that hook into the order save hooks and rely on the order cache.

Closes #40236 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Set HPOS as authoritative and sync to on. Create a new order and note it's ID (or use an existing order with ID XXX).
2.  Open a new `wp shell` and test following:
```php
// Let's fetch the order 
$order = wc_get_order( XXX );

// Note it's current modified date
$order->get_date_modified();

// Add a new meta.
$order->add_meta_data( 'test1', 'new_value');
$order->save_meta_data();

// Note the current modified date, it should be updated.
$order->get_date_modified();

// Update the metadata.
$order->update_meta_data( 'test1', 'updated_value');
$order->save_meta_data();

// Note the current modified again, it should be updated
$order->get_date_modified();

// Delete the metadata
$order->delete_meta_data( 'test1' );
$order->save_meta_data();

// Note the current modified again, it should be updated
$order->get_date_modified();
```


#### Testing with automate woo snippet:

1. With HPOS enabled and sync to on add the following snippet:
```php
add_action( 'woocommerce_delete_shop_order_transients', function ( $order_id ) {
			wc_get_order( $order_id );
} );
```
2. Create a new order as a logged in user via checkout.
3. Go to admin view of that order, make sure that customer is set to the logged in user as expected.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
