### PR TITLE
Remove unnecessary APIs calls when the setup tasklist is shown

### DIFF
--- a/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
+++ b/plugins/woocommerce-admin/client/activity-panel/activity-panel.js
@@ -164,9 +164,9 @@ export const ActivityPanel = ( { isEmbedded, query } ) => {
 			ONBOARDING_STORE_NAME
 		);
 
-		const setupList = getTaskList( activeSetupList );
+		const setupList = activeSetupList && getTaskList( activeSetupList );
 
-		const isSetupTaskListHidden = setupList?.isHidden ?? true;
+		const isSetupTaskListHidden = setupList?.isHidden ?? false;
 		const setupVisibleTasks = getVisibleTasks( setupList?.tasks || [] );
 		const extendedTaskList = getTaskList( 'extended' );
 

--- a/plugins/woocommerce-admin/client/homescreen/layout.js
+++ b/plugins/woocommerce-admin/client/homescreen/layout.js
@@ -112,7 +112,7 @@ export const Layout = ( {
 						/>
 					) }
 					{ shouldShowWCPayFeature && <WooHomescreenWCPayFeature /> }
-					{ <ActivityPanel /> }
+					{ isTaskListHidden && <ActivityPanel /> }
 					{ hasTaskList && renderTaskList() }
 					<InboxPanel />
 				</Column>

--- a/plugins/woocommerce/changelog/fix-setup-tasklist-is-considered-as-hidden
+++ b/plugins/woocommerce/changelog/fix-setup-tasklist-is-considered-as-hidden
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove unnecessary APIs calls when the setup tasklist is shown


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #40292 .

This PR fixes a bug where ActivtiyPanel calls orders, reviews, and stock APIs even when the setup tasklist is shown. The APIs should only be called when the tasklist is hidden.

- Sets default value to false to prevent [checkIfHasAbbreviatedNotifications](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce-admin/client/activity-panel/activity-panel.js#L177) from calling the APIs when the tasklist is being resolved.
- Consider setup tasklist is hidden when `activeSetupList` is null



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new JN site with this branch.
2. Complete the core profiler and navigate to `WooCommerce -> Home`
3. Make sure the setup tasklist is shown.
4. Open your browser console and click `Network` tab.
5. Make sure the following API endpoints are not called.

APIs
- /wp-json/wc-analytics/products/low-in-stock
- /wp-json/wc-analytics/products/reviews
- /wp-json/wc-analytics/orders

6. Hide the setup tasklist

![Screen Shot 2023-09-19 at 5 19 14 PM](https://github.com/woocommerce/woocommerce/assets/4723145/8d5c3d82-9f6d-4906-8c4a-6f36f1da6b44)

7. Refresh the page.
8. Confirm the APIs are requested.
9. Navigate to other WC pages such as products, analytics, and confirm the same behavior.



<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Remove unnecessary APIs calls when the setup tasklist is shown

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
