### PR TITLE
add: best colours AI suggestions

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/actions.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/actions.ts
@@ -9,7 +9,7 @@ import { recordEvent } from '@woocommerce/tracks';
  * Internal dependencies
  */
 import {
-	ColorPalette,
+	ColorPaletteResponse,
 	designWithAiStateMachineContext,
 	designWithAiStateMachineEvents,
 	FontPairing,
@@ -84,7 +84,7 @@ const assignDefaultColorPalette = assign<
 			defaultColorPalette: (
 				event as {
 					data: {
-						response: ColorPalette;
+						response: ColorPaletteResponse;
 					};
 				}
 			 ).data.response,

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/prompts/test/colorChoices.test.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/prompts/test/colorChoices.test.ts
@@ -1,9 +1,9 @@
 /**
  * Internal dependencies
  */
-import { defaultColorPalette } from '..';
+import { colorPaletteValidator, defaultColorPalette } from '..';
 
-describe( 'colorPairing.responseValidation', () => {
+describe( 'colorPaletteValidator', () => {
 	it( 'should validate a correct color palette', () => {
 		const validPalette = {
 			name: 'Ancient Bronze',
@@ -13,8 +13,7 @@ describe( 'colorPairing.responseValidation', () => {
 			background: '#ffffff',
 		};
 
-		const parsedResult =
-			defaultColorPalette.responseValidation( validPalette );
+		const parsedResult = colorPaletteValidator.parse( validPalette );
 		expect( parsedResult ).toEqual( validPalette );
 	} );
 
@@ -26,7 +25,7 @@ describe( 'colorPairing.responseValidation', () => {
 			foreground: '#11163d',
 			background: '#ffffff',
 		};
-		expect( () => defaultColorPalette.responseValidation( invalidPalette ) )
+		expect( () => colorPaletteValidator.parse( invalidPalette ) )
 			.toThrowErrorMatchingInlineSnapshot( `
 		"[
 		  {
@@ -48,7 +47,7 @@ describe( 'colorPairing.responseValidation', () => {
 			foreground: '#11163d',
 			background: '#ffffff',
 		};
-		expect( () => defaultColorPalette.responseValidation( invalidPalette ) )
+		expect( () => colorPaletteValidator.parse( invalidPalette ) )
 			.toThrowErrorMatchingInlineSnapshot( `
 		"[
 		  {
@@ -71,7 +70,7 @@ describe( 'colorPairing.responseValidation', () => {
 			foreground: '#11163d',
 			background: '#ffffff',
 		};
-		expect( () => defaultColorPalette.responseValidation( invalidPalette ) )
+		expect( () => colorPaletteValidator.parse( invalidPalette ) )
 			.toThrowErrorMatchingInlineSnapshot( `
 		"[
 		  {
@@ -94,7 +93,7 @@ describe( 'colorPairing.responseValidation', () => {
 			foreground: '#invalid_color',
 			background: '#ffffff',
 		};
-		expect( () => defaultColorPalette.responseValidation( invalidPalette ) )
+		expect( () => colorPaletteValidator.parse( invalidPalette ) )
 			.toThrowErrorMatchingInlineSnapshot( `
 		"[
 		  {
@@ -125,7 +124,7 @@ describe( 'colorPairing.responseValidation', () => {
 			foreground: '#11163d',
 			background: '#fffff',
 		};
-		expect( () => defaultColorPalette.responseValidation( invalidPalette ) )
+		expect( () => colorPaletteValidator.parse( invalidPalette ) )
 			.toThrowErrorMatchingInlineSnapshot( `
 		"[
 		  {
@@ -134,6 +133,103 @@ describe( 'colorPairing.responseValidation', () => {
 		    \\"message\\": \\"Invalid background color\\",
 		    \\"path\\": [
 		      \\"background\\"
+		    ]
+		  }
+		]"
+	` );
+	} );
+} );
+
+describe( 'colorPaletteResponseValidator', () => {
+	it( 'should validate a correct color palette response', () => {
+		const validPalette = {
+			default: 'Ancient Bronze',
+			bestColors: Array( 8 ).fill( 'Ancient Bronze' ),
+		};
+
+		const parsedResult =
+			defaultColorPalette.responseValidation( validPalette );
+		expect( parsedResult ).toEqual( validPalette );
+	} );
+
+	it( 'should fail if array contains invalid color', () => {
+		const invalidPalette = {
+			default: 'Ancient Bronze',
+			bestColors: Array( 7 )
+				.fill( 'Ancient Bronze' )
+				.concat( [ 'Invalid Color' ] ),
+		};
+		expect( () => defaultColorPalette.responseValidation( invalidPalette ) )
+			.toThrowErrorMatchingInlineSnapshot( `
+		"[
+		  {
+		    \\"code\\": \\"custom\\",
+		    \\"message\\": \\"Color palette not part of allowed list\\",
+		    \\"path\\": [
+		      \\"bestColors\\",
+		      7
+		    ]
+		  }
+		]"
+	` );
+	} );
+
+	it( 'should fail if bestColors property is missing', () => {
+		const invalidPalette = {
+			default: 'Ancient Bronze',
+		};
+		expect( () => defaultColorPalette.responseValidation( invalidPalette ) )
+			.toThrowErrorMatchingInlineSnapshot( `
+		"[
+		  {
+		    \\"code\\": \\"invalid_type\\",
+		    \\"expected\\": \\"array\\",
+		    \\"received\\": \\"undefined\\",
+		    \\"path\\": [
+		      \\"bestColors\\"
+		    ],
+		    \\"message\\": \\"Required\\"
+		  }
+		]"
+	` );
+	} );
+	it( 'should fail if default property is missing', () => {
+		const invalidPalette = {
+			bestColors: Array( 8 ).fill( 'Ancient Bronze' ),
+		};
+		expect( () => defaultColorPalette.responseValidation( invalidPalette ) )
+			.toThrowErrorMatchingInlineSnapshot( `
+		"[
+		  {
+		    \\"code\\": \\"invalid_type\\",
+		    \\"expected\\": \\"string\\",
+		    \\"received\\": \\"undefined\\",
+		    \\"path\\": [
+		      \\"default\\"
+		    ],
+		    \\"message\\": \\"Required\\"
+		  }
+		]"
+	` );
+	} );
+
+	it( 'should fail if bestColors array is not of length 8', () => {
+		const invalidPalette = {
+			default: 'Ancient Bronze',
+			bestColors: Array( 7 ).fill( 'Ancient Bronze' ),
+		};
+		expect( () => defaultColorPalette.responseValidation( invalidPalette ) )
+			.toThrowErrorMatchingInlineSnapshot( `
+		"[
+		  {
+		    \\"code\\": \\"too_small\\",
+		    \\"minimum\\": 8,
+		    \\"type\\": \\"array\\",
+		    \\"inclusive\\": true,
+		    \\"exact\\": true,
+		    \\"message\\": \\"Array must contain exactly 8 element(s)\\",
+		    \\"path\\": [
+		      \\"bestColors\\"
 		    ]
 		  }
 		]"

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/state-machine.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/state-machine.tsx
@@ -10,8 +10,8 @@ import { getQuery } from '@woocommerce/navigation';
 import {
 	designWithAiStateMachineContext,
 	designWithAiStateMachineEvents,
-	ColorPalette,
 	FontPairing,
+	ColorPaletteResponse,
 } from './types';
 import {
 	BusinessInfoDescription,
@@ -70,7 +70,7 @@ export const designWithAiStateMachineDefinition = createMachine(
 				choice: '',
 			},
 			aiSuggestions: {
-				defaultColorPalette: {} as ColorPalette,
+				defaultColorPalette: {} as ColorPaletteResponse,
 				fontPairing: '' as FontPairing[ 'pair_name' ],
 			},
 		},

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/types.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/types.ts
@@ -5,7 +5,11 @@ import { z } from 'zod';
 /**
  * Internal dependencies
  */
-import { colorPaletteValidator, fontChoiceValidator } from './prompts';
+import {
+	colorPaletteValidator,
+	colorPaletteResponseValidator,
+	fontChoiceValidator,
+} from './prompts';
 
 export type designWithAiStateMachineContext = {
 	businessInfoDescription: {
@@ -18,7 +22,7 @@ export type designWithAiStateMachineContext = {
 		choice: Tone | '';
 	};
 	aiSuggestions: {
-		defaultColorPalette: ColorPalette;
+		defaultColorPalette: ColorPaletteResponse;
 		fontPairing: FontPairing[ 'pair_name' ];
 	};
 	// If we require more data from options, previously provided core profiler details,
@@ -51,5 +55,8 @@ export interface LookAndToneCompletionResponse {
 }
 
 export type ColorPalette = z.infer< typeof colorPaletteValidator >;
+export type ColorPaletteResponse = z.infer<
+	typeof colorPaletteResponseValidator
+>;
 
 export type FontPairing = z.infer< typeof fontChoiceValidator >;

--- a/plugins/woocommerce/changelog/add-customize-store-best-colours
+++ b/plugins/woocommerce/changelog/add-customize-store-best-colours
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add customize store AI wizard call for best colour palette suggestions.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

- add: cys ai best colour palettes suggestion

Part of https://github.com/woocommerce/woocommerce/issues/40162

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

This feature is part of the larger customize your store development and behind a feature flag, hence QA review can be deferred until the call for testing before release.

Make sure you are testing this with a Jetpack connected instance of WooCommerce, as the AI text completion endpoint can only be called with a Jetpack connected account.


#### Default Font Pairing

This text completion is called during the loading screen after all the steps of Design With AI are complete. It takes into account the business description text given by the user, as well as the choices they made for Look and Tone.

For now, the response is only persisted into the state machine context.

1. Create a new WooCommerce installation with this version.
2. Make sure to enable `customize-store` feature flag
3. Go to `WooCommerce -> Home` and click `Customize Store` task
4. Click `Design with AI` button
5. Follow through the flow all the way till the loader shows up
6. The loader is not expected to terminate
7. Examine that the returned colour palettes has been saved into the machine context

This can be inspected using the XState inspector:

<img width="701" alt="image" src="https://github.com/woocommerce/woocommerce/assets/27843274/9205d328-516d-42fa-a909-dbc74592b478">

Do also test around the error states and tracks.

<!-- End testing instructions -->



<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
