### PR TITLE
[Customize Your Store] Call wc store patterns API

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/state-machine.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/state-machine.tsx
@@ -401,6 +401,24 @@ export const designWithAiStateMachineDefinition = createMachine(
 									success: { type: 'final' },
 								},
 							},
+							updateStorePatterns: {
+								initial: 'pending',
+								states: {
+									pending: {
+										invoke: {
+											src: 'updateStorePatterns',
+											onDone: {
+												target: 'success',
+											},
+											onError: {
+												// TODO: handle error
+												target: 'success',
+											},
+										},
+									},
+									success: { type: 'final' },
+								},
+							},
 						},
 						onDone: 'postApiCallLoader',
 					},

--- a/plugins/woocommerce/changelog/add-call-wc-store-patterns-api
+++ b/plugins/woocommerce/changelog/add-call-wc-store-patterns-api
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Call wc store patterns API to update patterns for CYS


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Part of https://github.com/woocommerce/woocommerce/issues/40162

Call `/wc/store/v1/patterns endpoint` to populate pattern images (only images for now)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

This feature is part of the larger customize your store development and behind a feature flag, hence QA review can be deferred until the call for testing before release.

Make sure you are testing this with a Jetpack connected instance of WooCommerce, as the AI text completion endpoint can only be called with a Jetpack connected account.

1. Create a new WooCommerce installation with this version.
2. Install and activate WooCommerce Blocks from this zip file: [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-blocks/files/12611550/woocommerce-gutenberg-products-block.zip)
3. Make sure to enable `customize-store` feature flag
4. Go to `WooCommerce -> Home` and click `Customize Store` task
5. Click `Design with AI` button
6. Fill `A store that sells books` for `Tell us a bit more about your business` answer
7. Follow through the flow all the way till the loader shows up
8. Should be redirected to the assembler hub screen
9. Make sure the images on the pattern match the business description you provided
10. Please test the flow with a different  business description (e.g. books, clothes, sports gear etc.) 


https://github.com/woocommerce/woocommerce/assets/4344253/36e12e73-5fee-4d56-84dd-1d7e3fe87d11



<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Call wc store patterns API to update patterns for CYS

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
