### PR TITLE
Update WooCommerce blocks package to 11.1.1

### DIFF
--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-11.1.1
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-11.1.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Bump Woo Blocks 11.1.1

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -23,7 +23,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.6.3",
-		"woocommerce/woocommerce-blocks": "11.1.0"
+		"woocommerce/woocommerce-blocks": "11.1.1"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.3.0",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cc5c4172d1078ecf041bdf3240a8c4e1",
+    "content-hash": "e5800331e1c25cd08ad877b665da724f",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1004,16 +1004,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "11.1.0",
+            "version": "11.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "9a9749f72c16bbb9cd75e23061f6b19dec01c262"
+                "reference": "81bff865d7fdd7de40a4da8fc49539a124ac1863"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/9a9749f72c16bbb9cd75e23061f6b19dec01c262",
-                "reference": "9a9749f72c16bbb9cd75e23061f6b19dec01c262",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/81bff865d7fdd7de40a4da8fc49539a124ac1863",
+                "reference": "81bff865d7fdd7de40a4da8fc49539a124ac1863",
                 "shasum": ""
             },
             "require": {
@@ -1062,9 +1062,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v11.1.0"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v11.1.1"
             },
-            "time": "2023-09-12T13:56:36+00:00"
+            "time": "2023-09-20T10:14:34+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 11.1.1

## Blocks 11.1.1

* [Release PR](https://github.com/woocommerce/woocommerce-blocks/pull/11000)
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/1111.md)




### Changelog entry

### The following changelog entries are only those that impact existing blocks and functionality surfaced to users:

#### Bug Fixes

- Improved escaping around attributes [bb37d05](https://github.com/woocommerce/woocommerce-blocks/commit/bb37d056bccccd714fa6617c5da6f50d54837f41)





