### PR TITLE
Components: TreeSelectControl - Make sure individuallySelectParent value is preserved

### DIFF
--- a/packages/js/components/changelog/fix-tree-select-control-individuallySelectParent
+++ b/packages/js/components/changelog/fix-tree-select-control-individuallySelectParent
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+TreeSelectControl Component - Make sure individuallySelectParent prop is respected

--- a/packages/js/components/src/tree-select-control/index.js
+++ b/packages/js/components/src/tree-select-control/index.js
@@ -234,7 +234,10 @@ const TreeSelectControl = ( {
 				 * @return {boolean} True if checked, false otherwise.
 				 */
 				get() {
-					if ( includeParent && this.value !== ROOT_VALUE ) {
+					if (
+						( includeParent || individuallySelectParent ) &&
+						this.value !== ROOT_VALUE
+					) {
 						return cache.selectedValues.includes( this.value );
 					}
 					if ( this.hasChildren ) {
@@ -427,7 +430,7 @@ const TreeSelectControl = ( {
 	const handleParentChange = ( checked, option ) => {
 		let newValue;
 		const changedValues = individuallySelectParent
-			? []
+			? [ option.value ]
 			: option.leaves
 					.filter( ( opt ) => opt.checked !== checked )
 					.map( ( opt ) => opt.value );

--- a/packages/js/components/src/tree-select-control/stories/index.js
+++ b/packages/js/components/src/tree-select-control/stories/index.js
@@ -96,6 +96,7 @@ Base.args = {
 	selectAllLabel: 'All countries',
 	includeParent: false,
 	alwaysShowPlaceholder: false,
+	individuallySelectParent: false,
 };
 
 Base.argTypes = {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The `TreeSelectControl` component wasn't allowing selection of parent options on an individual basis. This PR makes sure a user can select just a parent option when the `individuallySelectParent` is set to true. Behaviour is unchanged otherwise.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. `cd tools/storybook && pnpm storybook`
2. Visit Storybook url TreeSelectControl page `http://localhost:6007/?path=/story/woocommerce-admin-components-treeselectcontrol--base`
3. Select the `Docs` tab
4. Set the `individuallySelectParent` prop to `true`
5. Visit the Canvas tab and select any parent option
6. Ensure only the parent option is selected, not the children
7. Make sure the tag is displayed correctly and the option is checked
8. Uncheck and make sure its working as expected

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
TreeSelectControl Component - Make sure individuallySelectParent prop is respected 

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
