### PR TITLE
Customize Your Store - Implement back to home buttons

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/index.tsx
@@ -4,7 +4,11 @@
 import { Sender, createMachine } from 'xstate';
 import { useEffect, useMemo, useState } from '@wordpress/element';
 import { useMachine, useSelector } from '@xstate/react';
-import { getQuery, updateQueryString } from '@woocommerce/navigation';
+import {
+	getNewPath,
+	getQuery,
+	updateQueryString,
+} from '@woocommerce/navigation';
 import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 import { dispatch } from '@wordpress/data';
 
@@ -59,6 +63,10 @@ const updateQueryStep = (
 	}
 };
 
+const redirectToWooHome = () => {
+	window.location.href = getNewPath( {}, '/', {} );
+};
+
 const markTaskComplete = async () => {
 	return dispatch( OPTIONS_STORE_NAME ).updateOptions( {
 		woocommerce_admin_customize_store_completed: 'yes',
@@ -78,6 +86,7 @@ const browserPopstateHandler =
 
 export const machineActions = {
 	updateQueryStep,
+	redirectToWooHome,
 };
 
 export const customizeStoreStateMachineActions = {
@@ -184,7 +193,7 @@ export const customizeStoreStateMachineDefinition = createMachine( {
 					target: 'assemblerHub',
 				},
 				CLICKED_ON_BREADCRUMB: {
-					target: 'backToHomescreen',
+					actions: 'redirectToWooHome',
 				},
 				SELECTED_NEW_THEME: {
 					target: 'appearanceTask',
@@ -263,11 +272,10 @@ export const customizeStoreStateMachineDefinition = createMachine( {
 			},
 			on: {
 				GO_BACK_TO_HOME: {
-					target: 'backToHomescreen',
+					actions: 'redirectToWooHome',
 				},
 			},
 		},
-		backToHomescreen: {},
 		appearanceTask: {},
 	},
 } );

--- a/plugins/woocommerce/changelog/update-40298-implement-back-to-home-button
+++ b/plugins/woocommerce/changelog/update-40298-implement-back-to-home-button
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Implement back to home actions for the customize your store.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #40298  .

This PR implements `Back to home` button actions.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


1. Create a new WooCommerce installation with this version.
2. Make sure to enable `customize-store` feature flag in `Tools -> WCA Test Helper -> Features`
3. Go to `WooCommerce -> Home` and click `Customize Store` task
4. Click on the back button and confirm you're redirected back to `WooCommerce -> Home`
 
![Screen Shot 2023-09-20 at 4 42 32 PM](https://github.com/woocommerce/woocommerce/assets/4723145/a76d0aa4-8885-431f-8cfe-46207bf0c5dc)

5. Navigate to http://your-site/wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store%2Fassembler-hub
6. Click on `Done` button.
7. Click on `Back to home` at the bottom of the page.
8. Confirm you're redirected to `WooCommerce -> Home`

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Implement back to home actions for the customize your store.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
