### PR TITLE
[Customize Your Store] Hide color panel and fix nav links on WooExpress site

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/global-styles-variation-iframe/style.scss
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/global-styles-variation-iframe/style.scss
@@ -76,6 +76,14 @@
 }
 
 // Hide "theme" and "default" sections
-.block-editor-color-gradient-control__panel > .components-flex > .components-h-stack.components-v-stack {
-	display: none;
+.block-editor-color-gradient-control__panel {
+	// Text or Background tab
+	> .components-flex > .components-h-stack.components-v-stack {
+		display: none;
+	}
+
+	// Gradient tab
+	> .components-spacer > .components-flex > .components-h-stack.components-v-stack:not(.components-custom-gradient-picker) {
+		display: none;
+	}
 }

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/global-styles-variation-iframe/style.scss
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/global-styles-variation-iframe/style.scss
@@ -73,10 +73,9 @@
 			}
 		}
 	}
+}
 
-	.block-editor-color-gradient-control__panel {
-		> .components-flex > .components-h-stack.components-v-stack {
-			display: none;
-		}
-	}
+// Hide "theme" and "default" sections
+.block-editor-color-gradient-control__panel > .components-flex > .components-h-stack.components-v-stack {
+	display: none;
 }

--- a/plugins/woocommerce/changelog/fix-color-panel-and-nav-links
+++ b/plugins/woocommerce/changelog/fix-color-panel-and-nav-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+CYS: Hide color panel and fix nav links on WooExpress site


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes the color panel picker UI and nav links for WooExpress site

1. <img src="https://github.com/woocommerce/woocommerce/assets/4344253/e8a83cd4-21a1-43bc-9b06-152106827e70" width="450px" />

2. Nav items like My Account are not clickable


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


This feature is part of the larger customize your store development and behind a feature flag, hence QA review can be deferred until the call for testing before release.

Make sure you are testing this with a Jetpack connected instance of WooCommerce, as the AI text completion endpoint can only be called with a Jetpack connected account.

1. Use a WooExpress site pdibGW-2pG-p2
2. Create a new WooCommerce installation with this version.
3. Make sure to enable `customize-store` feature flag
4. Go to `/wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store%2Fassembler-hub`
5. Click on `Change the color palette`
6. Click on `OR CREATE YOUR OWN`
7. Click on background color picker
8. Confirm there is no "theme" and "default" sections

<img src="https://github.com/woocommerce/woocommerce/assets/4344253/d31ea270-456d-437c-a757-91481e36c991" width="450px" />


9. Click on "My account" or "Contact" item on preview frame
10. Confirm it renders the corresponding  page


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

CYS: Hide color panel and fix nav links on WooExpress site

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>