### PR TITLE
add: save cys ai input and response to options

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/actions.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/actions.ts
@@ -156,7 +156,11 @@ const updateWooAiStoreDescriptionOption = ( descriptionText: string ) => {
 	} );
 };
 
-const spawnSaveDescriptionToOption = assign( {
+const spawnSaveDescriptionToOption = assign<
+	designWithAiStateMachineContext,
+	designWithAiStateMachineEvents,
+	designWithAiStateMachineEvents
+>( {
 	spawnSaveDescriptionToOptionRef: (
 		context: designWithAiStateMachineContext
 	) =>

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/actions.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/actions.ts
@@ -1,9 +1,11 @@
 /**
  * External dependencies
  */
-import { assign } from 'xstate';
+import { assign, spawn } from 'xstate';
 import { getQuery, updateQueryString } from '@woocommerce/navigation';
 import { recordEvent } from '@woocommerce/tracks';
+import { dispatch } from '@wordpress/data';
+import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -148,6 +150,25 @@ const assignFooter = assign<
 	},
 } );
 
+const updateWooAiStoreDescriptionOption = ( descriptionText: string ) => {
+	return dispatch( OPTIONS_STORE_NAME ).updateOptions( {
+		woo_ai_describe_store_description: descriptionText,
+	} );
+};
+
+const spawnSaveDescriptionToOption = assign( {
+	spawnSaveDescriptionToOptionRef: (
+		context: designWithAiStateMachineContext
+	) =>
+		spawn(
+			() =>
+				updateWooAiStoreDescriptionOption(
+					context.businessInfoDescription.descriptionText
+				),
+			'update-woo-ai-business-description-option'
+		),
+} );
+
 const logAIAPIRequestError = () => {
 	// log AI API request error
 	// eslint-disable-next-line no-console
@@ -223,4 +244,5 @@ export const actions = {
 	recordTracksStepViewed,
 	recordTracksStepClosed,
 	recordTracksStepCompleted,
+	spawnSaveDescriptionToOption,
 };

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/services.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/services.ts
@@ -383,10 +383,17 @@ export const assembleSite = async (
 	invalidateResolutionForStoreSelector( '__experimentalGetTemplateForLink' );
 };
 
+const saveAiResponseToOption = ( context: designWithAiStateMachineContext ) => {
+	return dispatch( OPTIONS_STORE_NAME ).updateOptions( {
+		woocommerce_customize_store_ai_suggestions: context.aiSuggestions,
+	} );
+};
+
 export const services = {
 	getLookAndTone,
 	browserPopstateHandler,
 	queryAiEndpoint,
 	assembleSite,
 	updateStorePatterns,
+	saveAiResponseToOption,
 };

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/types.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/types.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { z } from 'zod';
+import { spawn } from 'xstate';
 /**
  * Internal dependencies
  */
@@ -31,6 +32,7 @@ export type designWithAiStateMachineContext = {
 	};
 	// If we require more data from options, previously provided core profiler details,
 	// we can retrieve them in preBusinessInfoDescription and then assign them here
+	spawnSaveDescriptionToOptionRef?: ReturnType< typeof spawn >;
 };
 export type designWithAiStateMachineEvents =
 	| { type: 'AI_WIZARD_CLOSED_BEFORE_COMPLETION'; payload: { step: string } }

--- a/plugins/woocommerce-admin/client/customize-store/style.scss
+++ b/plugins/woocommerce-admin/client/customize-store/style.scss
@@ -24,6 +24,10 @@ body.woocommerce-customize-store.js.is-fullscreen-mode {
 	& > div.tour-kit.woocommerce-tour-kit > div > div.tour-kit-spotlight.is-visible {
 		outline: 99999px solid rgba(0, 0, 0, 0.15);
 	}
+
+	#screen-meta-links {
+		display: none;
+	}
 }
 
 .woocommerce-cys-layout {

--- a/plugins/woocommerce/changelog/add-cys-ai-save-options
+++ b/plugins/woocommerce/changelog/add-cys-ai-save-options
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Save CYS AI wizard response to options


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

1. and 7. on
https://github.com/woocommerce/woocommerce/issues/40162

Also fixes a layout artifact caused by the 'screen options' overlay

![image](https://github.com/woocommerce/woocommerce/assets/27843274/519f2103-2416-4f4b-b37b-2783bb9fa96e)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

This feature is part of the larger customize your store development and behind a feature flag, hence QA review can be deferred until the call for testing before release.

Make sure you are testing this with a Jetpack connected instance of WooCommerce, as the AI text completion endpoint can only be called with a Jetpack connected account.

Some ways to inspect options could be either using WC Test helper plugin or WP-CLI.
For WP-CLI, the commands `wp option get woocommerce_customize_store_ai_suggestions` and `wp option get woo_ai_describe_store_description` will be useful

1. Create a new WooCommerce installation with this version.
2. Make sure to enable `customize-store` feature flag
3. Go to `WooCommerce -> Home` and click `Customize Store` task
4. Click `Design with AI` button
5. Observe that the 'Screen Options' overlay is no longer present (I think it only manifests in WooX live environments, I didn't notice this issue on JN and local dev)
6. Fill in the business description and click on 'continue'
7. Should be able to see that the option `woo_ai_describe_store_description` has been filled with the input
8. Proceed with the rest of the AI wizard
9. After reaching the site assembler / editor, observe that the same values have been saved into the `woocommerce_customize_store_ai_suggestions` option.

e.g:

![image](https://github.com/woocommerce/woocommerce/assets/27843274/07a9db1f-d866-43dd-8e73-f2e4d396744b)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>