### PR TITLE
Remove Incentive dismiss survey modal custom button styling and defer to core styling

### DIFF
--- a/plugins/woocommerce-admin/client/payments-welcome/style.scss
+++ b/plugins/woocommerce-admin/client/payments-welcome/style.scss
@@ -189,14 +189,6 @@
 			button {
 				margin-left: 0.5em;
 			}
-
-			button.is-destructive {
-				background-color: #cc1818;
-				color: #fff;
-				&:hover {
-					color: #fff !important;
-				}
-			}
 		}
 	}
 }

--- a/plugins/woocommerce/changelog/fix-39936-incentives-exit-survey-just-dismiss-styling
+++ b/plugins/woocommerce/changelog/fix-39936-incentives-exit-survey-just-dismiss-styling
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: This is a tiny fix of the Incentives exit survey dismiss button hover behavior.
+
+


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Removes the custom styling for the WooPayments dismissal exit survey "Just dismiss" button and lets the core styling do its thing.

**Before - Non-hover:**
![image](https://github.com/woocommerce/woocommerce/assets/45979455/cb096e30-495b-474e-9f06-990958dc14ad)

**Before - Hover:**
![image](https://github.com/woocommerce/woocommerce/assets/45979455/0f070351-f5ab-4d0e-bacf-323146873066)

**After - Non-Hover**
![Screenshot 2023-09-21 at 16 00 11](https://github.com/woocommerce/woocommerce/assets/8830539/68dd2af9-0696-453a-a1bf-83294af5988c)

**After - Hover**
![Screenshot 2023-09-21 at 16 00 18](https://github.com/woocommerce/woocommerce/assets/8830539/cb061ed5-c7a0-4f26-87c0-b5a13084cb92)

Closes #39936 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

#### Setup
- To see the welcome incentive page, you need to meet (or comment [their code](https://github.com/woocommerce/woocommerce/blob/242ee8e921554185d32e4976518edd719f1a2bad/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php#L54)) the following requirements:
  - Have **WooCommerce → Settings → Advanced → WooCommerce.com → Display suggestions withing WooCommerced** enabled.
  - Do not have WCPay installed or an existing account cached.
  - Do not have it dismissed by `wcpay_welcome_page_incentives_dismissed` option.

#### Testing
1. Checkout the PR branch on your local installation
2. Make sure your store is eligible for an Incentive (the **Payments (1)** main menu item appears)
3. Click on the **Payments (1)** menu item to see the Incentive page and click on the "No thanks" link
4. In the modal that appears, the "Just dismiss WooPayments" button should look and behave like in the "After" screenshots above.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
