### PR TITLE
Ignore some metadata in the HPOS verify tool

### DIFF
--- a/plugins/woocommerce/changelog/tweak-ignore-some-metadata-in-hpos-verify-tool
+++ b/plugins/woocommerce/changelog/tweak-ignore-some-metadata-in-hpos-verify-tool
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Exclude some metadata from being considered in HPOS verify tool.

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -581,11 +581,19 @@ class CLIRunner {
 	 * @return array Failed IDs with meta details.
 	 */
 	private function verify_meta_data( array $order_ids, array $failed_ids ) : array {
+		$meta_keys_to_ignore = array(
+			'_paid_date', // This is set by the CPT datastore but no longer used anywhere.
+			'_edit_lock',
+		);
+
 		global $wpdb;
 		if ( ! count( $order_ids ) ) {
 			return array();
 		}
-		$excluded_columns             = $this->post_to_cot_migrator->get_migrated_meta_keys();
+		$excluded_columns             = array_merge(
+			$this->post_to_cot_migrator->get_migrated_meta_keys(),
+			$meta_keys_to_ignore
+		);
 		$excluded_columns_placeholder = implode( ', ', array_fill( 0, count( $excluded_columns ), '%s' ) );
 		$order_ids_placeholder        = implode( ', ', array_fill( 0, count( $order_ids ), '%d' ) );
 		$meta_table                   = OrdersTableDataStore::get_meta_table_name();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Currently, `wp wc cot verify_cot_data` reports as error the fact that HPOS tables are missing the `_paid_date` metadata, but this is intentional since `_paid_date` has been deprecated (even in CPT) but [it is still being set](https://github.com/woocommerce/woocommerce/blob/93b6f1b8ce5b27064ef9745cf4f49026365b114e/plugins/woocommerce/includes/data-stores/class-wc-order-data-store-cpt.php#L320-L325) despite being slated for removal a while ago (it's been replaced by `_date_paid`, which is correctly synced to HPOS).

While we could remove if from the CPT datastore, at this point, it'd be best to ignore instead of creating a migration just to remove some metadata that is no longer in use.

This PR makes sure `wp wc cot verify_cot_data` won't trigger an error for this missing bit of metadata.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure HPOS and sync are enabled in WC > Settings > Advanced > Features.
2. Go to WC > Orders.
3. Click **Add Order** and take note of the order ID.
4. Add any details you'd like and make sure to set the status to "Processing".
5. **Click Create**.
6. Run `wp wc cot verify_cot_data --start-from=<order_id>` (replacing `<order_id>` by the order ID from step 3) and make sure no errors are reported*.

* If you get some errors related to the shipping and billing address indexes, those are safe to ignore for now. They are handled by #40332.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
