### PR TITLE
WooCommerce > Extensions > My subscriptions skeleton

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
@@ -9,12 +9,15 @@ import { useContext } from '@wordpress/element';
 import './content.scss';
 import Discover from '../discover/discover';
 import Extensions from '../extensions/extensions';
+import MySubscriptions from '../my-subscriptions/my-subscriptions';
 import { MarketplaceContext } from '../../contexts/marketplace-context';
 
 const renderContent = ( selectedTab?: string ): JSX.Element => {
 	switch ( selectedTab ) {
 		case 'extensions':
 			return <Extensions />;
+		case 'my-subscriptions':
+			return <MySubscriptions />;
 		default:
 			return <Discover />;
 	}

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.scss
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.scss
@@ -1,0 +1,29 @@
+/* Tooltip doesn't look exactly like a standard <Tooltip> */
+.woocommerce-marketplace__my-subscriptions {
+	.components-tooltip .components-popover__content {
+		background: var(--wc-content-bg);
+		border: 1px solid var(--wp-admin-theme-color);
+		border-radius: 4px;
+		color: var(--wc-secondary-text);
+		text-align: left;
+
+		& > * {
+			margin: 8px 0;
+		}
+
+		h3 {
+			font-size: 1.1em;
+		}
+
+		.woocommerce-marketplace__my-subscriptions__tooltip-external-link:after {
+			background: url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2024%2024%22%20width%3D%2224%22%20height%3D%2224%22%20aria-hidden%3D%22true%22%20focusable%3D%22false%22%3E%3Cpath%20d%3D%22M19.5%204.5h-7V6h4.44l-5.97%205.97%201.06%201.06L18%207.06v4.44h1.5v-7Zm-13%201a2%202%200%200%200-2%202v10a2%202%200%200%200%202%202h10a2%202%200%200%200%202-2v-3H17v3a.5.5%200%200%201-.5.5h-10a.5.5%200%200%201-.5-.5v-10a.5.5%200%200%201%20.5-.5h3V5.5h-3Z%22%20fill%3D%22%230073aa%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E');
+			background-position: 0 3px;
+			background-repeat: no-repeat;
+			background-size: contain;
+			content: '';
+			display: inline-block;
+			height: 15px;
+			width: 15px;
+		}
+	}
+}

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.scss
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.scss
@@ -15,8 +15,8 @@
 			font-size: 1.1em;
 		}
 
-		.woocommerce-marketplace__my-subscriptions__tooltip-external-link:after {
-			background: url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2024%2024%22%20width%3D%2224%22%20height%3D%2224%22%20aria-hidden%3D%22true%22%20focusable%3D%22false%22%3E%3Cpath%20d%3D%22M19.5%204.5h-7V6h4.44l-5.97%205.97%201.06%201.06L18%207.06v4.44h1.5v-7Zm-13%201a2%202%200%200%200-2%202v10a2%202%200%200%200%202%202h10a2%202%200%200%200%202-2v-3H17v3a.5.5%200%200%201-.5.5h-10a.5.5%200%200%201-.5-.5v-10a.5.5%200%200%201%20.5-.5h3V5.5h-3Z%22%20fill%3D%22%230073aa%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E');
+		.woocommerce-marketplace__my-subscriptions__tooltip-external-link::after {
+			background: url(data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2024%2024%22%20width%3D%2224%22%20height%3D%2224%22%20aria-hidden%3D%22true%22%20focusable%3D%22false%22%3E%3Cpath%20d%3D%22M19.5%204.5h-7V6h4.44l-5.97%205.97%201.06%201.06L18%207.06v4.44h1.5v-7Zm-13%201a2%202%200%200%200-2%202v10a2%202%200%200%200%202%202h10a2%202%200%200%200%202-2v-3H17v3a.5.5%200%200%201-.5.5h-10a.5.5%200%200%201-.5-.5v-10a.5.5%200%200%201%20.5-.5h3V5.5h-3Z%22%20fill%3D%22%230073aa%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E);
 			background-position: 0 3px;
 			background-repeat: no-repeat;
 			background-size: contain;

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.tsx
@@ -15,8 +15,23 @@ import { Subscription } from './types';
 import './my-subscriptions.scss';
 
 export default function MySubscriptions(): JSX.Element {
-	const updateConnectionUrl = getNewPath( { page: 'wc-addons', section: 'helper', filter: 'all', 'wc-helper-refresh': 1, 'wc-helper-nonce': getAdminSetting( 'wc_helper_nonces' ).refresh }, '' );
-	const updateConnectionHTML = sprintf( __( "If you don't see your subscription, try <a href=\"%s\">updating</a> your connection.", 'woocommerce' ), updateConnectionUrl );
+	const updateConnectionUrl = getNewPath(
+		{
+			page: 'wc-addons',
+			section: 'helper',
+			filter: 'all',
+			'wc-helper-refresh': 1,
+			'wc-helper-nonce': getAdminSetting( 'wc_helper_nonces' ).refresh,
+		},
+		''
+	);
+	const updateConnectionHTML = sprintf(
+		__(
+			'If you don\'t see your subscription, try <a href="%s">updating</a> your connection.',
+			'woocommerce'
+		),
+		updateConnectionUrl
+	);
 
 	const tableHeadersInstalled = [
 		{
@@ -49,7 +64,7 @@ export default function MySubscriptions(): JSX.Element {
 			label: __( 'Actions', 'woocommerce' ),
 		},
 	];
-	const subscriptionsInstalled:Array<Subscription> = [];
+	const subscriptionsInstalled: Array< Subscription > = [];
 
 	const tableHeadersAvailable = [
 		{
@@ -82,25 +97,35 @@ export default function MySubscriptions(): JSX.Element {
 			label: __( 'Actions', 'woocommerce' ),
 		},
 	];
-	const subscriptionsAvailable:Array<Subscription> = [];
+	const subscriptionsAvailable: Array< Subscription > = [];
 
 	return (
 		<div className="woocommerce-marketplace__my-subscriptions">
 			<section>
-				<h2>
-					{ __( 'Installed on this store', 'woocommerce' ) }
-				</h2>
+				<h2>{ __( 'Installed on this store', 'woocommerce' ) }</h2>
 				<p>
-					<span dangerouslySetInnerHTML={{ __html: updateConnectionHTML }} />
+					<span
+						dangerouslySetInnerHTML={ {
+							__html: updateConnectionHTML,
+						} }
+					/>
 					<Tooltip
 						text={
 							<>
 								<h3>Still don't see your subscriptions?</h3>
-								<p>To see all your subscriptions go to your account on WooCommerce.com.</p>
+								<p>
+									To see all your subscriptions go to your
+									account on WooCommerce.com.
+								</p>
 							</>
 						}
 					>
-						<Button	icon={help}	iconSize={20}	isSmall={true} label={ __( 'Help', 'woocommerce' )} />
+						<Button
+							icon={ help }
+							iconSize={ 20 }
+							isSmall={ true }
+							label={ __( 'Help', 'woocommerce' ) }
+						/>
 					</Tooltip>
 				</p>
 				<Table
@@ -120,14 +145,15 @@ export default function MySubscriptions(): JSX.Element {
 			</section>
 
 			<section>
-				<h2>
-					{ __( 'Available', 'woocommerce' ) }
-				</h2>
+				<h2>{ __( 'Available', 'woocommerce' ) }</h2>
 				<p>
-					{ __( 'Your unused and free WooCommerce.com subscriptions.', 'woocommerce' ) }
+					{ __(
+						'Your unused and free WooCommerce.com subscriptions.',
+						'woocommerce'
+					) }
 				</p>
 				<Table
-					headers={ tableHeadersInstalled }
+					headers={ tableHeadersAvailable }
 					rows={ subscriptionsAvailable.map( ( item ) => {
 						return [
 							{ display: item.name },

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.tsx
@@ -112,11 +112,20 @@ export default function MySubscriptions(): JSX.Element {
 					<Tooltip
 						text={
 							<>
-								<h3>Still don&apos;t see your subscriptions?</h3>
-								<p>
-									To see all your subscriptions go to your
-									account on WooCommerce.com.
-								</p>
+								<h3>
+									{ __(
+										"Still don't see your subscription?",
+										'woocommerce'
+									) }
+								</h3>
+								<p
+									dangerouslySetInnerHTML={ {
+										__html: __(
+											'To see all your subscriptions go to <a href="https://woocommerce.com/my-account/" target="_blank" class="woocommerce-marketplace__my-subscriptions__tooltip-external-link">your account</a> on WooCommerce.com.',
+											'woocommerce'
+										),
+									} }
+								/>
 							</>
 						}
 					>

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.tsx
@@ -112,7 +112,7 @@ export default function MySubscriptions(): JSX.Element {
 					<Tooltip
 						text={
 							<>
-								<h3>Still don't see your subscriptions?</h3>
+								<h3>Still don&apos;t see your subscriptions?</h3>
 								<p>
 									To see all your subscriptions go to your
 									account on WooCommerce.com.

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.tsx
@@ -1,0 +1,146 @@
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { Button, Tooltip } from '@wordpress/components';
+import { getNewPath } from '@woocommerce/navigation';
+import { help } from '@wordpress/icons';
+import { Table } from '@woocommerce/components';
+
+/**
+ * Internal dependencies
+ */
+import { getAdminSetting } from '~/utils/admin-settings';
+import { Subscription } from './types';
+import './my-subscriptions.scss';
+
+export default function MySubscriptions(): JSX.Element {
+	const updateConnectionUrl = getNewPath( { page: 'wc-addons', section: 'helper', filter: 'all', 'wc-helper-refresh': 1, 'wc-helper-nonce': getAdminSetting( 'wc_helper_nonces' ).refresh }, '' );
+	const updateConnectionHTML = sprintf( __( "If you don't see your subscription, try <a href=\"%s\">updating</a> your connection.", 'woocommerce' ), updateConnectionUrl );
+
+	const tableHeadersInstalled = [
+		{
+			key: 'name',
+			label: __( 'Name', 'woocommerce' ),
+		},
+		{
+			key: 'status',
+			label: __( 'Status', 'woocommerce' ),
+		},
+		{
+			key: 'expiry',
+			label: __( 'Expiry/Renewal date', 'woocommerce' ),
+		},
+		{
+			key: 'autoRenew',
+			label: __( 'Auto-renew', 'woocommerce' ),
+		},
+		{
+			key: 'version',
+			label: __( 'Version', 'woocommerce' ),
+			isNumeric: true,
+		},
+		{
+			key: 'activated',
+			label: __( 'Activated', 'woocommerce' ),
+		},
+		{
+			key: 'actions',
+			label: __( 'Actions', 'woocommerce' ),
+		},
+	];
+	const subscriptionsInstalled:Array<Subscription> = [];
+
+	const tableHeadersAvailable = [
+		{
+			key: 'name',
+			label: __( 'Name', 'woocommerce' ),
+		},
+		{
+			key: 'status',
+			label: __( 'Status', 'woocommerce' ),
+		},
+		{
+			key: 'expiry',
+			label: __( 'Expiry/Renewal date', 'woocommerce' ),
+		},
+		{
+			key: 'autoRenew',
+			label: __( 'Auto-renew', 'woocommerce' ),
+		},
+		{
+			key: 'version',
+			label: __( 'Version', 'woocommerce' ),
+			isNumeric: true,
+		},
+		{
+			key: 'install',
+			label: __( 'Install', 'woocommerce' ),
+		},
+		{
+			key: 'actions',
+			label: __( 'Actions', 'woocommerce' ),
+		},
+	];
+	const subscriptionsAvailable:Array<Subscription> = [];
+
+	return (
+		<div className="woocommerce-marketplace__my-subscriptions">
+			<section>
+				<h2>
+					{ __( 'Installed on this store', 'woocommerce' ) }
+				</h2>
+				<p>
+					<span dangerouslySetInnerHTML={{ __html: updateConnectionHTML }} />
+					<Tooltip
+						text={
+							<>
+								<h3>Still don't see your subscriptions?</h3>
+								<p>To see all your subscriptions go to your account on WooCommerce.com.</p>
+							</>
+						}
+					>
+						<Button	icon={help}	iconSize={20}	isSmall={true} label={ __( 'Help', 'woocommerce' )} />
+					</Tooltip>
+				</p>
+				<Table
+					headers={ tableHeadersInstalled }
+					rows={ subscriptionsInstalled.map( ( item ) => {
+						return [
+							{ display: item.name },
+							{ display: item.status },
+							{ display: item.expiry },
+							{ display: item.autoRenew ? 'true' : 'false' },
+							{ display: item.version },
+							{ display: item.activated ? 'true' : 'false' },
+							{ display: '...' },
+						];
+					} ) }
+				/>
+			</section>
+
+			<section>
+				<h2>
+					{ __( 'Available', 'woocommerce' ) }
+				</h2>
+				<p>
+					{ __( 'Your unused and free WooCommerce.com subscriptions.', 'woocommerce' ) }
+				</p>
+				<Table
+					headers={ tableHeadersInstalled }
+					rows={ subscriptionsAvailable.map( ( item ) => {
+						return [
+							{ display: item.name },
+							{ display: item.status },
+							{ display: item.expiry },
+							{ display: item.autoRenew ? 'true' : 'false' },
+							{ display: item.version },
+							{ display: '...' },
+							{ display: '...' },
+						];
+					} ) }
+				/>
+			</section>
+		</div>
+	);
+}

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/types.ts
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/types.ts
@@ -1,0 +1,8 @@
+export type Subscription = {
+	name: string;
+	status: string;
+	expiry: string;
+	autoRenew: boolean;
+	version: string;
+	activated: boolean;
+};

--- a/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx
@@ -40,14 +40,7 @@ const tabs: Tabs = {
 	},
 	'my-subscriptions': {
 		name: 'my-subscriptions',
-		title: __( 'My Subscriptions', 'woocommerce' ),
-		href: getNewPath(
-			{
-				page: 'wc-addons',
-				section: 'helper',
-			},
-			''
-		),
+		title: __( 'My subscriptions', 'woocommerce' ),
 	},
 };
 

--- a/plugins/woocommerce/changelog/feature-marketplace-subscriptions-skeleton
+++ b/plugins/woocommerce/changelog/feature-marketplace-subscriptions-skeleton
@@ -1,0 +1,5 @@
+Significance: patch
+Type: add
+Comment: Add WooCommerce > Extensions > My subscriptions page skeleton to the feature branch.
+
+

--- a/plugins/woocommerce/src/Internal/Admin/Settings.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings.php
@@ -234,6 +234,9 @@ class Settings {
 		$settings['allowMarketplaceSuggestions']      = WC_Marketplace_Suggestions::allow_suggestions();
 		$settings['connectNonce']                     = wp_create_nonce( 'connect' );
 		$settings['wcpay_welcome_page_connect_nonce'] = wp_create_nonce( 'wcpay-connect' );
+		$settings['wc_helper_nonces']                 = array(
+			'refresh' => wp_create_nonce( 'refresh' ),
+		);
 
 		$settings['features'] = $this->get_features();
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR creates a skeletal "My subscriptions" page within the marketplace. Closes [WCCOM#18036](https://github.com/Automattic/woocommerce.com/issues/18036). For review by @woocommerce/alpha-fire for merging into a feature branch.

### How to test the changes in this Pull Request:

1. Check out this code and recompile the assets e.g. with `cd plugins/woocommerce-admin && pnpm start`
2. Visit the [WooCommerce > Extensions > My subscriptions tab](http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fextensions&tab=my-subscriptions) in your test environment.
3. Check that it loads and has basic content (limitations: no subscriptions yet; the tooltip doesn't stay open when told so the link in it is useless; the "updating" link does a full reload and takes you to the old subscriptions page).

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

Add WooCommerce > Extensions > My subscriptions page skeleton to the feature branch.

</details>
