### PR TITLE
Disable forms after creating variations

### DIFF
--- a/packages/js/product-editor/changelog/dev-40167_disable_forms_after_creating_variations
+++ b/packages/js/product-editor/changelog/dev-40167_disable_forms_after_creating_variations
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Disable forms after creating variations #40342

--- a/packages/js/product-editor/src/blocks/section/block.json
+++ b/packages/js/product-editor/src/blocks/section/block.json
@@ -30,5 +30,6 @@
 		"lock": false,
 		"__experimentalToolbar": false
 	},
+	"usesContext": [ "selectedTab" ],
 	"editorStyle": "file:./editor.css"
 }

--- a/packages/js/product-editor/src/blocks/section/edit.tsx
+++ b/packages/js/product-editor/src/blocks/section/edit.tsx
@@ -2,8 +2,10 @@
  * External dependencies
  */
 import classNames from 'classnames';
-import { createElement } from '@wordpress/element';
+import { Product } from '@woocommerce/data';
+import { createElement, useEffect } from '@wordpress/element';
 import type { BlockEditProps } from '@wordpress/blocks';
+import { useEntityProp } from '@wordpress/core-data';
 import {
 	useBlockProps,
 	// @ts-expect-error no exported member.
@@ -15,17 +17,35 @@ import {
  */
 import { sanitizeHTML } from '../../utils/sanitize-html';
 import { SectionBlockAttributes } from './types';
+import { hasAttributesUsedForVariations } from '../../utils';
 
 export function Edit( {
 	attributes,
-}: BlockEditProps< SectionBlockAttributes > ) {
+	context,
+}: BlockEditProps< SectionBlockAttributes > & {
+	context?: {
+		selectedTab?: string | null;
+	};
+} ) {
 	const { description, title, blockGap } = attributes;
+	const tab = context?.selectedTab || '';
 	const blockProps = useBlockProps();
+	const [ productAttributes ] = useEntityProp< Product[ 'attributes' ] >(
+		'postType',
+		'product',
+		'attributes'
+	);
+	const isDisabledSection =
+		hasAttributesUsedForVariations( productAttributes ) &&
+		[ 'inventory', 'pricing', 'shipping' ].includes( tab );
 	const innerBlockProps = useInnerBlocksProps(
 		{
 			className: classNames(
 				'wp-block-woocommerce-product-section__content',
-				`wp-block-woocommerce-product-section__content--block-gap-${ blockGap }`
+				`wp-block-woocommerce-product-section__content--block-gap-${ blockGap }`,
+				{
+					'is-disabled-section': isDisabledSection,
+				}
 			),
 		},
 		{ templateLock: 'all' }
@@ -33,10 +53,55 @@ export function Edit( {
 	const SectionTagName = title ? 'fieldset' : 'div';
 	const HeadingTagName = SectionTagName === 'fieldset' ? 'legend' : 'div';
 
+	useEffect( () => {
+		const elementsToReEnable: (
+			| HTMLInputElement
+			| HTMLButtonElement
+			| HTMLSelectElement
+			| HTMLTextAreaElement
+		 )[] = [];
+
+		if ( isDisabledSection ) {
+			const disabledSections = document.querySelectorAll(
+				'.is-disabled-section'
+			);
+
+			disabledSections.forEach( ( section ) => {
+				const controls = section.querySelectorAll(
+					'input, button, select, textarea'
+				);
+
+				controls.forEach( ( control ) => {
+					if (
+						control instanceof HTMLInputElement ||
+						control instanceof HTMLButtonElement ||
+						control instanceof HTMLSelectElement ||
+						control instanceof HTMLTextAreaElement
+					) {
+						if ( ! control.disabled ) {
+							elementsToReEnable.push( control );
+							control.disabled = true;
+						}
+					}
+				} );
+			} );
+		}
+		return () => {
+			elementsToReEnable.forEach( ( control ) => {
+				control.disabled = false;
+			} );
+		};
+	}, [ isDisabledSection ] );
+
 	return (
 		<SectionTagName { ...blockProps }>
 			{ title && (
-				<HeadingTagName className="wp-block-woocommerce-product-section__heading">
+				<HeadingTagName
+					className={ classNames(
+						'wp-block-woocommerce-product-section__heading',
+						{ 'is-disabled-section': isDisabledSection }
+					) }
+				>
 					<h2 className="wp-block-woocommerce-product-section__heading-title">
 						{ title }
 					</h2>

--- a/packages/js/product-editor/src/blocks/section/editor.scss
+++ b/packages/js/product-editor/src/blocks/section/editor.scss
@@ -58,4 +58,10 @@
 			border-bottom: none;
 		}
 	}
+	.is-disabled-section {
+		opacity: 0.4;
+		a, button, input, label, select, textarea {
+			pointer-events: none;
+		}
+	}
 }

--- a/plugins/woocommerce/changelog/dev-40167_disable_forms_after_creating_variations
+++ b/plugins/woocommerce/changelog/dev-40167_disable_forms_after_creating_variations
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Disable forms after creating variations #40342

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -362,7 +362,7 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 				'blockName'  => 'woocommerce/product-has-variations-notice',
 				'order'      => 10,
 				'attributes' => [
-					'content'    => __( 'This product has options, such as size or color. You can now manage each variation\'s price and other details individually.', 'woocommerce' ),
+					'content'    => __( 'This product has variation options, such as size or color. You can now manage each variation\'s price and other details individually.', 'woocommerce' ),
 					'buttonText' => __( 'Go to Variations', 'woocommerce' ),
 					'type'       => 'info',
 				],
@@ -521,7 +521,7 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 				'blockName'  => 'woocommerce/product-has-variations-notice',
 				'order'      => 10,
 				'attributes' => [
-					'content'    => __( 'This product has options, such as size or color. You can now manage each variation\'s price and other details individually.', 'woocommerce' ),
+					'content'    => __( 'This product has variation options, such as size or color. You can now manage each variation\'s stock and other details individually.', 'woocommerce' ),
 					'buttonText' => __( 'Go to Variations', 'woocommerce' ),
 					'type'       => 'info',
 				],
@@ -735,7 +735,7 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 				'blockName'  => 'woocommerce/product-has-variations-notice',
 				'order'      => 10,
 				'attributes' => [
-					'content'    => __( 'This product has options, such as size or color. You can now manage each variation\'s price and other details individually.', 'woocommerce' ),
+					'content'    => __( 'This product has variation options, such as size or color. You can now manage each variation\'s shipping dimensions and other details individually.', 'woocommerce' ),
 					'buttonText' => __( 'Go to Variations', 'woocommerce' ),
 					'type'       => 'info',
 				],


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

When the user creates at least one variation, the form items under `Pricing`, `Inventory` and `Shipping` are disabled.

https://github.com/woocommerce/woocommerce/assets/79307566/d0dac310-3c61-4266-82b6-bcbb1e43338d

Design: AkVNGImLgSqCObTQ3idVn7-fi-2780_278432

**Acceptance criteria**
- [ ] When variations are enabled, we show notices in the Pricing, Inventory, and Shipping tabs. The notices have different copy.
   - [ ] Pricing: `This product has variation options, such as size or color. You can now manage each variation's price and other details individually.`
   - [ ] Inventory: `This product has variation options, such as size or color. You can now manage each variation's stock and other details individually.`
   - [ ] Shipping: `This product has variation options, such as size or color. You can now manage each variation's shipping dimensions and other details individually.`
- [ ] Fields in each tab are disabled and faded (40% opacity).
- [ ] When the user deletes all variations, fields become active again.

Closes #40167.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the product blocks editor under WooCommerce -> Settings -> Advanced -> Features.
2. Make sure feature `product-variation-management` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper`.
3. Navigate to the Add Product page.
4. Go to `Variations` and add a variation.
5. Go to `Pricing`, `Inventory` and `Shipping`, and verify that the form items are disabled.
6. Go to `General`, `Organization` and `Variations` and verify that everything is working well.
7. Delete the variations you created and verify that the form items are enabled again.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
