### PR TITLE
Add default price support to product variations

### DIFF
--- a/packages/js/data/changelog/add-40042_default_price
+++ b/packages/js/data/changelog/add-40042_default_price
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Update totalCount in crud store to avoid unnecessary requests.

--- a/packages/js/data/changelog/add-40042_default_values_for_variations
+++ b/packages/js/data/changelog/add-40042_default_values_for_variations
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add support for default_values param in productVariations store

--- a/packages/js/data/src/crud/resolvers.ts
+++ b/packages/js/data/src/crud/resolvers.ts
@@ -57,6 +57,13 @@ export const createResolvers = ( {
 		const urlParameters = getUrlParameters( namespace, query || {} );
 		const resourceQuery = cleanQuery( query || {}, namespace );
 
+		yield controls.dispatch(
+			storeName,
+			'startResolution',
+			`get${ pluralResourceName }TotalCount`,
+			[ query ]
+		);
+
 		// Require ID when requesting specific fields to later update the resource data.
 		if (
 			resourceQuery &&
@@ -98,6 +105,16 @@ export const createResolvers = ( {
 	};
 
 	const getItemsTotalCount = function* ( query?: Partial< ItemQuery > ) {
+		const startedTotalCountUsingGetItems: boolean = yield controls.select(
+			storeName,
+			'hasStartedResolution',
+			`get${ pluralResourceName }`,
+			[ query ]
+		);
+		// Skip resolver as we get the total count from the getItems query as well with same query parameters.
+		if ( startedTotalCountUsingGetItems ) {
+			return;
+		}
 		const totalsQuery = {
 			...( query || {} ),
 			page: 1,

--- a/packages/js/data/src/product-variations/types.ts
+++ b/packages/js/data/src/product-variations/types.ts
@@ -96,6 +96,7 @@ export type ActionDispatchers = DispatchFromMap< ProductVariationActions >;
 
 export type GenerateRequest = {
 	delete?: boolean;
+	default_values?: Partial< ProductVariation >;
 };
 
 export type BatchUpdateRequest = {

--- a/packages/js/product-editor/changelog/add-40042_default_price
+++ b/packages/js/product-editor/changelog/add-40042_default_price
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add regular price as default value if available when generating new product variations.

--- a/packages/js/product-editor/src/components/variations-table/variations-table.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variations-table.tsx
@@ -116,14 +116,6 @@ export const VariationsTable = forwardRef<
 		} ),
 		[ productId, currentPage, perPage ]
 	);
-	const totalCountRequestParams = useMemo(
-		() => ( {
-			product_id: productId,
-			order: 'asc',
-			orderby: 'menu_order',
-		} ),
-		[ productId ]
-	);
 
 	const context = useContext( CurrencyContext );
 	const { formatAmount } = context;
@@ -155,9 +147,8 @@ export const VariationsTable = forwardRef<
 			);
 
 			return {
-				totalCount: getProductVariationsTotalCount< number >(
-					totalCountRequestParams
-				),
+				totalCount:
+					getProductVariationsTotalCount< number >( requestParams ),
 			};
 		},
 		[ productId ]

--- a/packages/js/product-editor/src/hooks/use-product-variations-helper.ts
+++ b/packages/js/product-editor/src/hooks/use-product-variations-helper.ts
@@ -22,11 +22,9 @@ async function getDefaultVariationValues(
 	productId: number
 ): Promise< Partial< Omit< ProductVariation, 'id' > > > {
 	try {
-		const { attributes } = ( await resolveSelect( 'core' ).getEntityRecord(
-			'postType',
-			'product',
-			productId
-		) ) as Product;
+		const { attributes } = await resolveSelect(
+			'core'
+		).getEntityRecord< Product >( 'postType', 'product', productId );
 		const alreadyHasVariableAttribute = attributes.some(
 			( attr ) => attr.variation
 		);
@@ -77,13 +75,13 @@ export function useProductVariationsHelper() {
 		) => {
 			setIsGenerating( true );
 
-			const { status: lastStatus } = ( await resolveSelect(
+			const { status: lastStatus } = await resolveSelect(
 				'core'
-			).getEditedEntityRecord(
+			).getEditedEntityRecord< Product >(
 				'postType',
 				'product',
 				productId
-			) ) as Product;
+			);
 			const hasVariableAttribute = attributes.some(
 				( attr ) => attr.variation
 			);

--- a/packages/js/product-editor/src/hooks/use-product-variations-helper.ts
+++ b/packages/js/product-editor/src/hooks/use-product-variations-helper.ts
@@ -9,12 +9,49 @@ import {
 	EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME,
 	Product,
 	ProductDefaultAttribute,
+	ProductVariation,
 } from '@woocommerce/data';
 
 /**
  * Internal dependencies
  */
 import { EnhancedProductAttribute } from './use-product-attributes';
+
+async function getDefaultVariationValues(
+	productId: number
+): Promise< Partial< Omit< ProductVariation, 'id' > > > {
+	const attributes = (
+		( await resolveSelect( 'core' ).getEntityRecord(
+			'postType',
+			'product',
+			productId
+		) ) as Product
+	 ).attributes;
+	const alreadyHasVariableAttribute = attributes.some(
+		( attr ) => attr.variation
+	);
+	if ( ! alreadyHasVariableAttribute ) {
+		return {};
+	}
+	try {
+		const productsWithPrice = await resolveSelect(
+			EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME
+		).getProductVariations< Pick< ProductVariation, 'regular_price' >[] >( {
+			product_id: productId,
+			per_page: 1,
+			has_price: true,
+			_fields: [ 'regular_price' ],
+		} );
+		if ( productsWithPrice && productsWithPrice.length > 0 ) {
+			return {
+				regular_price: productsWithPrice[ 0 ].regular_price,
+			};
+		}
+	} catch {
+		return {};
+	}
+	return {};
+}
 
 export function useProductVariationsHelper() {
 	const [ productId ] = useEntityProp< number >(
@@ -47,6 +84,10 @@ export function useProductVariationsHelper() {
 				( attr ) => attr.variation
 			);
 
+			const defaultVariationValues = await getDefaultVariationValues(
+				productId
+			);
+
 			return _generateProductVariations< {
 				count: number;
 				deleted_count: number;
@@ -61,6 +102,7 @@ export function useProductVariationsHelper() {
 				},
 				{
 					delete: true,
+					default_values: defaultVariationValues,
 				}
 			)
 				.then( () => {

--- a/packages/js/product-editor/src/hooks/use-product-variations-helper.ts
+++ b/packages/js/product-editor/src/hooks/use-product-variations-helper.ts
@@ -16,6 +16,7 @@ import {
  * Internal dependencies
  */
 import { EnhancedProductAttribute } from './use-product-attributes';
+import { DEFAULT_VARIATION_PER_PAGE_OPTION } from '../constants';
 
 async function getDefaultVariationValues(
 	productId: number
@@ -34,17 +35,22 @@ async function getDefaultVariationValues(
 		return {};
 	}
 	try {
-		const productsWithPrice = await resolveSelect(
+		const products = await resolveSelect(
 			EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME
-		).getProductVariations< Pick< ProductVariation, 'regular_price' >[] >( {
+		).getProductVariations< ProductVariation[] >( {
 			product_id: productId,
-			per_page: 1,
-			has_price: true,
-			_fields: [ 'regular_price' ],
+			page: 1,
+			per_page: DEFAULT_VARIATION_PER_PAGE_OPTION,
+			order: 'asc',
+			orderby: 'menu_order',
 		} );
-		if ( productsWithPrice && productsWithPrice.length > 0 ) {
+		if ( products && products.length > 0 && products[ 0 ].regular_price ) {
 			return {
-				regular_price: productsWithPrice[ 0 ].regular_price,
+				regular_price: products[ 0 ].regular_price,
+				stock_quantity: products[ 0 ].stock_quantity,
+				stock_status: products[ 0 ].stock_status,
+				manage_stock: products[ 0 ].manage_stock,
+				low_stock_amount: products[ 0 ].low_stock_amount,
 			};
 		}
 	} catch {

--- a/packages/js/product-editor/src/hooks/use-product-variations-helper.ts
+++ b/packages/js/product-editor/src/hooks/use-product-variations-helper.ts
@@ -21,20 +21,18 @@ import { DEFAULT_VARIATION_PER_PAGE_OPTION } from '../constants';
 async function getDefaultVariationValues(
 	productId: number
 ): Promise< Partial< Omit< ProductVariation, 'id' > > > {
-	const attributes = (
-		( await resolveSelect( 'core' ).getEntityRecord(
+	try {
+		const { attributes } = ( await resolveSelect( 'core' ).getEntityRecord(
 			'postType',
 			'product',
 			productId
-		) ) as Product
-	 ).attributes;
-	const alreadyHasVariableAttribute = attributes.some(
-		( attr ) => attr.variation
-	);
-	if ( ! alreadyHasVariableAttribute ) {
-		return {};
-	}
-	try {
+		) ) as Product;
+		const alreadyHasVariableAttribute = attributes.some(
+			( attr ) => attr.variation
+		);
+		if ( ! alreadyHasVariableAttribute ) {
+			return {};
+		}
 		const products = await resolveSelect(
 			EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME
 		).getProductVariations< ProductVariation[] >( {
@@ -53,10 +51,10 @@ async function getDefaultVariationValues(
 				low_stock_amount: products[ 0 ].low_stock_amount,
 			};
 		}
+		return {};
 	} catch {
 		return {};
 	}
-	return {};
 }
 
 export function useProductVariationsHelper() {
@@ -79,13 +77,13 @@ export function useProductVariationsHelper() {
 		) => {
 			setIsGenerating( true );
 
-			const lastStatus = (
-				( await resolveSelect( 'core' ).getEditedEntityRecord(
-					'postType',
-					'product',
-					productId
-				) ) as Product
-			 ).status;
+			const { status: lastStatus } = ( await resolveSelect(
+				'core'
+			).getEditedEntityRecord(
+				'postType',
+				'product',
+				productId
+			) ) as Product;
 			const hasVariableAttribute = attributes.some(
 				( attr ) => attr.variation
 			);

--- a/plugins/woocommerce/changelog/add-40042_default_price
+++ b/plugins/woocommerce/changelog/add-40042_default_price
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add support for default values when generating variations in data store and REST API.

--- a/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1180,9 +1180,10 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	 * @todo   Add to interface in 4.0.
 	 * @param  WC_Product $product Variable product.
 	 * @param  int        $limit Limit the number of created variations.
+	 * @param  array  	  $default_values Key value pairs to set on created variations.
 	 * @return int        Number of created variations.
 	 */
-	public function create_all_product_variations( $product, $limit = -1 ) {
+	public function create_all_product_variations( $product, $limit = -1, $default_values = array() ) {
 		$count = 0;
 
 		if ( ! $product ) {
@@ -1211,6 +1212,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 				continue;
 			}
 			$variation = wc_get_product_object( 'variation' );
+			$variation->set_props( $default_values );
 			$variation->set_parent_id( $product->get_id() );
 			$variation->set_attributes( $possible_attribute );
 			$variation_id = $variation->save();

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
@@ -48,6 +48,11 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 						'description' => __( 'Deletes unused variations.', 'woocommerce' ),
 						'type'        => 'boolean',
 					),
+					'default_values' => array(
+						'description' => __( 'Default values for generated variations.', 'woocommerce' ),
+						'type' 		 => 'object',
+						'properties' => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+					)
 				),
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
@@ -1000,8 +1005,9 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 
 		$response          = array();
 		$product           = wc_get_product( $product_id );
+		$default_values	   = isset( $request['default_values'] ) ? $request['default_values'] : array();
 		$data_store        = $product->get_data_store();
-		$response['count'] = $data_store->create_all_product_variations( $product, Constants::get_constant( 'WC_MAX_LINKED_VARIATIONS' ) );
+		$response['count'] = $data_store->create_all_product_variations( $product, Constants::get_constant( 'WC_MAX_LINKED_VARIATIONS' ), $default_values );
 
 		if ( isset( $request['delete'] ) && $request['delete'] ) {
 			$deleted_count = $this->delete_unmatched_product_variations( $product );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR add support for adding default values to generated product variations.
We make use of this in order to auto add a regular price if one was already set in existing variations.

I also optimized the crud data store `totalCount` selector, so we avoid an additional request when necessary.

Closes #40042 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the new product editor in **WooCommerce > Settings > Advanced > Features**
2. Go to **WooCommerce > Products > Add new**
3. Add a unique name and click save draft
4. Now go to the Variations tab and add a couple variation options.
5. Variations should be auto generated
6. Now add a price to either all of them or at-least the first one.
7. Add some new variation options
8. The new variations should be auto generated, **Note:** the new variations should include the regular price of the first existing variation by default.
9. Open your console and go to the network tab
10. Refresh your page
11. Go to your network tab again and filter by `variations`, there should only be **two** variation requests:
One for all the variations and one for the count of variations without a price ( `has_price: false` ).
Previously we had four requests.
12. Now turn off the new editor in **WooCommerce > Settings > Advanced > Features** and go to **WooCommerce > Products > Add new**
13. Create a new variable product with several attributes
14. Click **Generate variations** in the old editor
15. Variations should be generated successfully (**Note:** we are not using default values here ).
16. Lastly make sure the PHP unit tests run correctly in GH actions, you can also run them locally by following [these instructions](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/tests/README.md#mysql-database) and running: `vendor/bin/phpunit --filter Product_Variations_API` (in the `plugins/woocommerce` folder.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
