### PR TITLE
Escape the default "Thank you" text instead of the filtered message

### DIFF
--- a/plugins/woocommerce/changelog/trunk
+++ b/plugins/woocommerce/changelog/trunk
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Escape the default 'thank you' text instead of the filtered message.

--- a/plugins/woocommerce/templates/checkout/order-received.php
+++ b/plugins/woocommerce/templates/checkout/order-received.php
@@ -32,10 +32,10 @@ defined( 'ABSPATH' ) || exit;
 	 */
 	$message = apply_filters(
 		'woocommerce_thankyou_order_received_text',
-		__( 'Thank you. Your order has been received.', 'woocommerce' ),
+		esc_html( __( 'Thank you. Your order has been received.', 'woocommerce' ) ),
 		$order
 	);
 
-	echo esc_html( $message );
+	echo $message;
 	?>
 </p>

--- a/plugins/woocommerce/templates/checkout/order-received.php
+++ b/plugins/woocommerce/templates/checkout/order-received.php
@@ -36,6 +36,7 @@ defined( 'ABSPATH' ) || exit;
 		$order
 	);
 
+	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	echo $message;
 	?>
 </p>

--- a/plugins/woocommerce/templates/checkout/order-received.php
+++ b/plugins/woocommerce/templates/checkout/order-received.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 8.1.0
+ * @version 8.3.0
  *
  * @var WC_Order|false $order
  */


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #40329 and #40352

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Activate this code snippet in your site:

```php
add_filter('woocommerce_thankyou_order_received_text', 'wc_test_thank_you_link', 10, 2);
function wc_test_thank_you_link( $text, $order ) {
    $text .= '<p><a href="https://example.com">Click here</a></p>';
    return $text;
}
```
2. Place a new order and check the code displayed after "Thank you. Your order has been received.", which should look like this:

![image](https://github.com/woocommerce/woocommerce/assets/38109855/3c45a02a-93f5-45e9-b1cc-608f246d0aa6)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Escape the default 'thank you' text instead of the filtered message.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
