### PR TITLE
Address conflict between HPOS & WP edit lock

### DIFF
--- a/plugins/woocommerce/changelog/fix-wp-post-lock-conflict
+++ b/plugins/woocommerce/changelog/fix-wp-post-lock-conflict
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Disable WP's post lock on HPOS order edit screen.

--- a/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
+++ b/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
@@ -725,7 +725,7 @@
 			},
 
 			send_orders_in_list: function( e, data ) {
-				data['wc-check-locked-orders'] = wc_order_lock.$list_table.find( 'tr input[name="order"]' ).map(
+				data['wc-check-locked-orders'] = wc_order_lock.$list_table.find( 'tr input[name="id[]"]' ).map(
 					function() { return this.value; }
 				).get();
 			},
@@ -735,7 +735,7 @@
 
 				wc_order_lock.$list_table.find( 'tr' ).each( function( i, tr ) {
 					var $tr      = $( tr );
-					var order_id = $tr.find( 'input[name="order"]' ).val();
+					var order_id = $tr.find( 'input[name="id[]"]' ).val();
 
 					if ( locked_orders[ order_id ] ) {
 						if ( ! $tr.hasClass( 'wp-locked' ) ) {

--- a/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
+++ b/plugins/woocommerce/client/legacy/js/admin/woocommerce_admin.js
@@ -675,6 +675,10 @@
 				// Order screen.
 				this.$lock_dialog = $( '.woocommerce_page_wc-orders #post-lock-dialog.order-lock-dialog' );
 				if ( 0 !== this.$lock_dialog.length && 'undefined' !== typeof woocommerce_admin_meta_boxes ) {
+					// We do not want WP's lock to interfere.
+					$( document ).off( 'heartbeat-send.refresh-lock' );
+					$( document ).off( 'heartbeat-tick.refresh-lock' );
+
 					$( document ).on( 'heartbeat-send', this.refresh_order_lock );
 					$( document ).on( 'heartbeat-tick', this.check_order_lock );
 				}
@@ -688,6 +692,7 @@
 			},
 
 			refresh_order_lock: function( e, data ) {
+				delete data['wp-refresh-post-lock'];
 				data['wc-refresh-order-lock'] = woocommerce_admin_meta_boxes.post_id;
 			},
 

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -209,7 +209,7 @@ class WC_AJAX {
 				function( $response, $data ) use ( $ajax_callback ) {
 					return call_user_func_array( array( __CLASS__, $ajax_callback ), func_get_args() );
 				},
-				10,
+				11,
 				2
 			);
 		}

--- a/plugins/woocommerce/src/Internal/Admin/Orders/EditLock.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/EditLock.php
@@ -99,6 +99,8 @@ class EditLock {
 			return $response;
 		}
 
+		unset( $response['wp-refresh-post-lock'] );
+
 		$order = wc_get_order( $order_id );
 		if ( ! $order || ( ! current_user_can( get_post_type_object( $order->get_type() )->cap->edit_post, $order->get_id() ) && ! current_user_can( 'manage_woocommerce' ) ) ) {
 			return $response;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
In #39321 we added a `post_ID` field to the HPOS order edit screen. This makes WP think it's a regular post and try to control the edit lock for the order (in postmeta).
Our code also tries to control the edit lock (in the HPOS meta table) which results in the strange behavior described in #40331 where trying to take over an order results in neither user being able to do so.

Interestingly, this doesn't happen when HPOS is enabled _with sync_ as the sync takes care of propagating the edit lock to the post meta table and keeping things in line.

This PR makes sure that the WP post lock mechanism isn't engaged when the HPOS one is in use. It also fixes a small issue with the list table, where the lock indicating an order is being edited wasn't being displayed.


Closes #40331.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Note:** This PR modifies JS code, so make sure to build it first with `pnpm --filter=woocommerce/client/legacy run build`.

1. Make sure HPOS is enabled in WC > Settings > Advanced > Features but sync (compatibility mode) is disabled.
1. If your site doesn't have orders already, go to WC > Orders and create a few by clicking **Add Order**.
1. Go to Users and make sure to have at least 2 admin users. Say "admin1" and "admin2".
1. Log in as "admin1" in a browser window and as "admin2" in an incognito window or a different browser. Keep both windows/browsers open.
1. (As admin1 and admin2) Go to WC > Orders.
1. (As admin1) Click on any order.
1. (As admin2) Wait for a little while (until the heartbeat event has been processed) and confirm that the order admin1 is editing shows with a lock next to it.
1. (As admin2) Click on the "locked" order and confirm that you get a dialog asking whether you want to take over the order. Click **Take over**.
1. (As admin1) Wait for a little while (again, until the heartbeat event has been processed) and confirm that you get a dialog indicating that admin2 has taken over.
1. If desired, try the above with various orders and makes sure the lock/dialogs appear as expected.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
