### PR TITLE
Add E2E test to check if all blocks render correctly in product editor

### DIFF
--- a/plugins/woocommerce/changelog/add-product-editor-block-render-e2e-test
+++ b/plugins/woocommerce/changelog/add-product-editor-block-render-e2e-test
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add new E2E test for the product editor to check if all blocks render correctly.

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
@@ -23,6 +23,41 @@ const productData = {
 test.describe.configure( { mode: 'serial' } );
 
 test.describe( 'General tab', () => {
+	test.describe( 'Simple product form', () => {
+		test.use( { storageState: process.env.ADMINSTATE } );
+
+		test.beforeEach( async ( { browser } ) => {
+			const context = await browser.newContext();
+			const page = await context.newPage();
+			isNewProductEditorEnabled = await isBlockProductEditorEnabled(
+				page
+			);
+			if ( ! isNewProductEditorEnabled ) {
+				await toggleBlockProductEditor( 'enable', page );
+			}
+		} );
+
+		test.afterEach( async ( { browser } ) => {
+			const context = await browser.newContext();
+			const page = await context.newPage();
+			isNewProductEditorEnabled = await isBlockProductEditorEnabled(
+				page
+			);
+			if ( isNewProductEditorEnabled ) {
+				await toggleBlockProductEditor( 'disable', page );
+			}
+		} );
+
+		test( 'renders each block without error', async ( { page } ) => {
+			await page.goto( NEW_EDITOR_ADD_PRODUCT_URL );
+			await clickOnTab( 'General', page );
+			await page.getByPlaceholder( 'e.g. 12 oz Coffee Mug' ).isVisible();
+
+			const blockWarnings = await page.locator( '.block-editor-warning' );
+			expect( blockWarnings ).toBeEmpty();
+		} );
+	} );
+
 	test.describe( 'Create product', () => {
 		let productId;
 		test.use( { storageState: process.env.ADMINSTATE } );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/products/block-editor/create-simple-product-block-editor.spec.js
@@ -53,8 +53,7 @@ test.describe( 'General tab', () => {
 			await clickOnTab( 'General', page );
 			await page.getByPlaceholder( 'e.g. 12 oz Coffee Mug' ).isVisible();
 
-			const blockWarnings = await page.locator( '.block-editor-warning' );
-			expect( blockWarnings ).toBeEmpty();
+			expect( page.locator( '.block-editor-warning' ) ).toHaveCount( 0 );
 		} );
 	} );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This adds a simple E2E test that checks the form if there are no blocks with errors on initial render.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Execute the standard commands to launch the local E2E environment for setup follow these instructions: https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/tests/e2e-pw/README.md#introduction (will also list them here)
2. `npx playwright install`
3. `pnpm --filter=woocommerce run env:start` if it fails when running tests you may have to run: `pnpm --filter=woocommerce run env:restart` and try again.
4. Run command:
    ```bash
    pnpm --filter=woocommerce run test:e2e-pw ./tests/e2e-pw/tests/merchant/products/ --retries=0 --workers=2 --repeat-each=2
    ```
5. Tests should pass, especially the `renders each block without error`
6. To see if it fails correctly you can comment out this line: https://github.com/woocommerce/woocommerce/blob/bdbd590819d2e059e4e2b63560197d95fbb40b37/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php#L103 ( `wp_enqueue_media();` )
7. Run the `env:restart` and the tests again. The `renders each block without error` should fail.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
