### PR TITLE
[Customize Your Store] Fix AI selected verticals not display 

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/actions.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/actions.ts
@@ -2,7 +2,11 @@
  * External dependencies
  */
 import { assign, spawn } from 'xstate';
-import { getQuery, updateQueryString } from '@woocommerce/navigation';
+import {
+	getQuery,
+	updateQueryString,
+	getNewPath,
+} from '@woocommerce/navigation';
 import { recordEvent } from '@woocommerce/tracks';
 import { dispatch } from '@wordpress/data';
 import { OPTIONS_STORE_NAME } from '@woocommerce/data';
@@ -234,6 +238,14 @@ const recordTracksStepCompleted = (
 	} );
 };
 
+const redirectToAssemblerHub = () => {
+	window.location.href = getNewPath(
+		{},
+		'/customize-store/assembler-hub',
+		{}
+	);
+};
+
 export const actions = {
 	assignBusinessInfoDescription,
 	assignLookAndFeel,
@@ -249,4 +261,5 @@ export const actions = {
 	recordTracksStepClosed,
 	recordTracksStepCompleted,
 	spawnSaveDescriptionToOption,
+	redirectToAssemblerHub,
 };

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/state-machine.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/state-machine.tsx
@@ -475,9 +475,8 @@ export const designWithAiStateMachineDefinition = createMachine(
 						},
 						onDone: {
 							actions: [
-								sendParent( () => ( {
-									type: 'THEME_SUGGESTED',
-								} ) ),
+								// Full redirect to the Assembler Hub to ensure the user see the new generated content.
+								'redirectToAssemblerHub',
 							],
 						},
 					},

--- a/plugins/woocommerce/changelog/fix-ai-generate-images-not-display
+++ b/plugins/woocommerce/changelog/fix-ai-generate-images-not-display
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+CYS: Fix AI selected verticals not display


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/team-ghidorah/issues/266.

This PR fixes the issue that fails to display AI-selected vertical images after completing the AI ​​wizard. It might be because 1) the API failed to respond successfully or 2) the state was not reset and old patterns are used.

To fix the issue, this PR checks the [API response](https://github.com/woocommerce/woocommerce-blocks/blob/dc567dc6b33bf3d280bc3122ecf860ec3f343dd7/src/StoreApi/Routes/V1/Patterns.php#L107-L121) properly and fully redirects users to the next step to ensure the latest data is used.

If you use WooExpress site for testing, you need to disable “WooCommerce Product Add-ons” and “WooCommerce Product Bundles” plugins. (The API endpoint seems to conflict with them p1695632461108599/1695384277.179509-slack-C01SFMVEYAK)


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

This feature is part of the larger customize your store development and behind a feature flag, hence QA review can be deferred until the call for testing before release.

Make sure you are testing this with a Jetpack connected instance of WooCommerce, as the AI text completion endpoint can only be called with a Jetpack connected account.

1. Create a new WooCommerce installation with this version.
2. Install the [nightly build of WooCommerce Blocks](https://github.com/woocommerce/woocommerce-blocks/releases/download/nightly/woocommerce-blocks-trunk-nightly.zip)
3. Make sure to enable `customize-store` feature flag
4. Go to `WooCommerce -> Home` and click `Customize Store` task
5. Click `Design with AI` button
6. Fill `A store that sells books` for `Tell us a bit more about your business` answer
7. Follow through the flow all the way till the loader shows up
8. Should be redirected to the assembler hub screen
9. Make sure the images on the pattern match the business description you provided
10. Click the back arrow button to go back to AI wizard
11. Please test the flow with a different  business description (e.g. books, clothes, sports gear etc.) 
12 Make sure the images on the pattern match the business description you provided

Note: You may see unexpected images due to the insufficient number of verticals.

Books: 
![Screenshot 2023-09-22 at 19 39 25](https://github.com/woocommerce/woocommerce/assets/4344253/3c2b6c36-d51f-4479-85eb-1d6cfa042e73)

Clothes:
![Screenshot 2023-09-22 at 19 39 15](https://github.com/woocommerce/woocommerce/assets/4344253/d679749f-9a64-434f-a883-dca48340f65a)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

CYS: Fix AI selected verticals not display 

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>