### PR TITLE
add: use ai suggestions to populate color schemes in assembler hub

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/color-palette-variations/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/color-palette-variations/index.tsx
@@ -1,11 +1,14 @@
 // Reference: https://github.com/WordPress/gutenberg/blob/d5ab7238e53d0947d4bb0853464b1c58325b6130/packages/edit-site/src/components/global-styles/style-variations-container.js
-/* eslint-disable @woocommerce/dependency-group */
-/* eslint-disable @typescript-eslint/ban-ts-comment */
+// @ts-expect-error -- No types for this exist yet.
+// eslint-disable-next-line @woocommerce/dependency-group
+import { __experimentalGrid as Grid } from '@wordpress/components';
+
 /**
  * External dependencies
  */
-// @ts-ignore No types for this exist yet.
-import { __experimentalGrid as Grid } from '@wordpress/components';
+import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { useSelect } from '@wordpress/data';
+import { useState, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -13,20 +16,63 @@ import { __experimentalGrid as Grid } from '@wordpress/components';
 import { COLOR_PALETTES } from './constants';
 import { VariationContainer } from '../variation-container';
 import { ColorPaletteVariationPreview } from './preview';
+import { ColorPaletteResponse } from '~/customize-store/design-with-ai/types';
 
 export const ColorPalette = () => {
+	const { aiSuggestions, isLoading } = useSelect( ( select ) => {
+		const { getOption, hasFinishedResolution } =
+			select( OPTIONS_STORE_NAME );
+		return {
+			aiSuggestions: getOption(
+				'woocommerce_customize_store_ai_suggestions'
+			) as { defaultColorPalette: ColorPaletteResponse },
+			isLoading: ! hasFinishedResolution( 'getOption', [
+				'woocommerce_customize_store_ai_suggestions',
+			] ),
+		};
+	} );
+
+	const [ colorPalettes, setColorPalettes ] = useState(
+		[] as typeof COLOR_PALETTES
+	);
+
+	useEffect( () => {
+		if ( ! isLoading ) {
+			if (
+				aiSuggestions?.defaultColorPalette?.bestColors?.length > 0 &&
+				aiSuggestions?.defaultColorPalette?.default
+			) {
+				setColorPalettes(
+					COLOR_PALETTES.filter(
+						( palette ) =>
+							aiSuggestions.defaultColorPalette?.bestColors.includes(
+								palette.title
+							) ||
+							aiSuggestions.defaultColorPalette.default ===
+								palette.title
+					)
+				);
+			} else {
+				// seems that aiSuggestions weren't correctly populated, we'll just use the first 9
+				setColorPalettes( COLOR_PALETTES.slice( 0, 9 ) );
+			}
+		}
+	}, [ isLoading, aiSuggestions?.defaultColorPalette ] );
+
 	return (
 		<Grid
 			columns={ 3 }
 			gap={ 4 }
 			className="woocommerce-customize-store_color-palette-container"
 		>
-			{ /* TODO: Show 9 colors based on the AI recommendation */ }
-			{ COLOR_PALETTES.slice( 0, 9 ).map( ( variation, index ) => (
-				<VariationContainer key={ index } variation={ variation }>
-					<ColorPaletteVariationPreview title={ variation?.title } />
-				</VariationContainer>
-			) ) }
+			{ ! isLoading &&
+				colorPalettes?.map( ( variation, index ) => (
+					<VariationContainer key={ index } variation={ variation }>
+						<ColorPaletteVariationPreview
+							title={ variation?.title }
+						/>
+					</VariationContainer>
+				) ) }
 		</Grid>
 	);
 };

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/prompts/colorChoices.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/prompts/colorChoices.ts
@@ -231,16 +231,17 @@ export const defaultColorPalette = {
 	queryId: 'default_color_palette',
 
 	// make sure version is updated every time the prompt is changed
-	version: '2023-09-18',
+	version: '2023-09-22',
 	prompt: ( businessDescription: string, look: string, tone: string ) => {
 		return `
-            You are a WordPress theme expert. Analyse the following store description, merchant's chosen look and tone, and determine the most appropriate color scheme, along with 8 best alternatives.
-            Respond in the form: "{ default: "palette name", bestColors: [ "palette name 1", "palette name 2", "palette name 3", "palette name 4", "palette name 5", "palette name 6", "palette name 7", "palette name 8" ] }"
-
+            You are a WordPress theme expert designing a WooCommerce site. Analyse the following store description, merchant's chosen look and tone, and determine the most appropriate color scheme, along with 8 best alternatives.
+			Do not use any palette names that are not part of the color choices provided below.
+			Respond in the form: "{ default: "palette name", bestColors: [ "palette name 1", "palette name 2", "palette name 3", "palette name 4", "palette name 5", "palette name 6", "palette name 7", "palette name 8" ] }"
+			
             Chosen look and tone: ${ look } look, ${ tone } tone.
             Business description: ${ businessDescription }
 
-            Colors to choose from: 
+            Colors schemes to choose from: 
             ${ JSON.stringify( colorChoices ) }
         `;
 	},

--- a/plugins/woocommerce/changelog/add-cys-ai-select-color-palettes
+++ b/plugins/woocommerce/changelog/add-cys-ai-select-color-palettes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Use CYS AI suggestions to populate the color schemes in assembler hub color palette selection


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

- Uses the AI suggestions that are previously saved to populate the color schemes in the site assembler
- Tweak the color palette prompt a bit as it was returning invalid results due to unclear instructions

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

This feature is part of the larger customize your store development and behind a feature flag, hence QA review can be deferred until the call for testing before release.

Make sure you are testing this with a Jetpack connected instance of WooCommerce, as the AI text completion endpoint can only be called with a Jetpack connected account.

1. Use a WooExpress site pdibGW-2pG-p2
2. Create a new WooCommerce installation with this version.
3. Make sure to enable `customize-store` feature flag
4. Go to `/wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store%2Fassembler-hub`
5. Click on `Change the color palette`
6. Observe that the displayed color palettes reflect the ones saved in the option `woocommerce_customize_store_ai_suggestions`
7. Modify the option `woocommerce_customize_store_ai_suggestions` so that it does not have the `defaultColorPalette` key
8. Reload the site assembler and note that there are still color schemes shown

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
