### PR TITLE
Add new E2E tests to cover Shopper Mini Cart

### DIFF
--- a/plugins/woocommerce/changelog/e2e-add-test-shopper-mini-cart
+++ b/plugins/woocommerce/changelog/e2e-add-test-shopper-mini-cart
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Adds tests to cover shopper and mini cart flows

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/mini-cart.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/mini-cart.spec.js
@@ -135,7 +135,7 @@ test.describe( 'Mini Cart block page', () => {
 		await page.goto( '/mini-cart' );
 		await expect(
 			page.locator( '.wc-block-mini-cart__button' )
-		).toContainText( `$${ singleProductSalePrice }(incl. tax)` );
+		).toContainText( `$${ singleProductSalePrice }` );
 		await page.locator( miniCartButton ).click();
 		await expect(
 			page.getByRole( 'heading', { name: 'Your cart (1 item)' } )
@@ -152,8 +152,11 @@ test.describe( 'Mini Cart block page', () => {
 			page.getByRole( 'heading', { name: 'Your cart (2 items)' } )
 		).toBeVisible();
 		await expect(
+			page.locator( '.wc-block-mini-cart__button' )
+		).toContainText( `$${ singleProductSalePrice * 2 }` );
+		await expect(
 			page.locator( '.wc-block-components-totals-item__value' )
-		).toContainText( `$${ singleProductPrice }` );
+		).toContainText( `$${ singleProductSalePrice * 2 }` );
 		await page
 			.getByRole( 'button' )
 			.filter( { hasText: 'Remove item' } )

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/mini-cart.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/mini-cart.spec.js
@@ -1,0 +1,185 @@
+const { test, expect, request } = require( '@playwright/test' );
+const { admin } = require( '../../test-data/data' );
+const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
+
+const pageTitle = 'Mini Cart';
+const miniCartButton = '.wc-block-mini-cart__button';
+
+const simpleProductName = 'Single Hundred Product';
+const simpleProductDesc = 'Lorem ipsum dolor sit amet.';
+const singleProductPrice = '100.00';
+const singleProductSalePrice = '50.00';
+
+let product1Id;
+
+test.describe( 'Mini Cart block page', () => {
+	test.use( { storageState: process.env.ADMINSTATE } );
+
+	test.beforeAll( async ( { baseURL } ) => {
+		const api = new wcApi( {
+			url: baseURL,
+			consumerKey: process.env.CONSUMER_KEY,
+			consumerSecret: process.env.CONSUMER_SECRET,
+			version: 'wc/v3',
+		} );
+		// add product
+		await api
+			.post( 'products', {
+				name: simpleProductName,
+				description: simpleProductDesc,
+				type: 'simple',
+				regular_price: singleProductPrice,
+				sale_price: singleProductSalePrice,
+			} )
+			.then( ( response ) => {
+				product1Id = response.data.id;
+			} );
+	} );
+
+	test.afterAll( async ( { baseURL } ) => {
+		const api = new wcApi( {
+			url: baseURL,
+			consumerKey: process.env.CONSUMER_KEY,
+			consumerSecret: process.env.CONSUMER_SECRET,
+			version: 'wc/v3',
+		} );
+		await api.post( 'products/batch', {
+			delete: [ product1Id ],
+		} );
+		const base64auth = Buffer.from(
+			`${ admin.username }:${ admin.password }`
+		).toString( 'base64' );
+		const wpApi = await request.newContext( {
+			baseURL: `${ baseURL }/wp-json/wp/v2/`,
+			extraHTTPHeaders: {
+				Authorization: `Basic ${ base64auth }`,
+			},
+		} );
+		let response = await wpApi.get( `pages` );
+		const allPages = await response.json();
+		await allPages.forEach( async ( page ) => {
+			if ( page.title.rendered === pageTitle ) {
+				response = await wpApi.delete( `pages/${ page.id }`, {
+					data: {
+						force: true,
+					},
+				} );
+			}
+		} );
+	} );
+
+	test( 'can see empty mini cart', async ( { page } ) => {
+		// create a new page with mini cart block
+		await page.goto( 'wp-admin/post-new.php?post_type=page' );
+
+		const welcomeModalVisible = await page
+			.getByRole( 'heading', {
+				name: 'Welcome to the block editor',
+			} )
+			.isVisible();
+
+		if ( welcomeModalVisible ) {
+			await page.getByRole( 'button', { name: 'Close' } ).click();
+		}
+
+		await page
+			.getByRole( 'textbox', { name: 'Add Title' } )
+			.fill( pageTitle );
+
+		await page.getByRole( 'button', { name: 'Add default block' } ).click();
+
+		await page
+			.getByRole( 'document', {
+				name: 'Empty block; start writing or type forward slash to choose a block',
+			} )
+			.fill( '/mini' );
+		await page.keyboard.press( 'Enter' );
+
+		await page
+			.getByRole( 'button', { name: 'Publish', exact: true } )
+			.click();
+
+		await page
+			.getByRole( 'region', { name: 'Editor publish' } )
+			.getByRole( 'button', { name: 'Publish', exact: true } )
+			.click();
+
+		await expect(
+			page.getByText( `${ pageTitle } is now live.` )
+		).toBeVisible();
+
+		// go to the page to test mini cart
+		await page.goto( '/mini-cart' );
+		await expect(
+			page.getByRole( 'heading', { name: pageTitle } )
+		).toBeVisible();
+		await page.locator( miniCartButton ).click();
+		await expect(
+			page.getByText( 'Your cart is currently empty!' )
+		).toBeVisible();
+		await page.getByRole( 'link', { name: 'Start shopping' } ).click();
+		await expect(
+			page.getByRole( 'heading', { name: 'Shop' } )
+		).toBeVisible();
+	} );
+
+	test( 'can proceed to mini cart, observe it and proceed to the checkout', async ( {
+		page,
+	} ) => {
+		const slug = simpleProductName.replace( / /gi, '-' ).toLowerCase();
+		// add product to cart
+		await page.goto( `product/${ slug }` );
+		await page.getByRole( 'button', { name: 'Add to cart' } ).click();
+
+		// go to page with mini cart block and test with the product added
+		await page.goto( '/mini-cart' );
+		await expect(
+			page.locator( '.wc-block-mini-cart__button' )
+		).toContainText( `$${ singleProductSalePrice }(incl. tax)` );
+		await page.locator( miniCartButton ).click();
+		await expect(
+			page.getByRole( 'heading', { name: 'Your cart (1 item)' } )
+		).toBeVisible();
+		await expect(
+			page.getByRole( 'link', { name: simpleProductName } )
+		).toBeVisible();
+		await expect(
+			page.locator( '.wc-block-components-product-badge' )
+		).toContainText( `Save $${ singleProductSalePrice }` );
+		await expect( page.getByText( simpleProductDesc ) ).toBeVisible();
+		await page.getByRole( 'button' ).filter( { hasText: '＋' } ).click();
+		await expect(
+			page.getByRole( 'heading', { name: 'Your cart (2 items)' } )
+		).toBeVisible();
+		await expect(
+			page.locator( '.wc-block-components-totals-item__value' )
+		).toContainText( `$${ singleProductPrice }` );
+		await page
+			.getByRole( 'button' )
+			.filter( { hasText: 'Remove item' } )
+			.click();
+		await expect(
+			page.getByText( 'Your cart is currently empty!' )
+		).toBeVisible();
+
+		// add product to cart and redirect from mini to regular cart
+		await page.goto( `product/${ slug }` );
+		await page.getByRole( 'button', { name: 'Add to cart' } ).click();
+		await page.goto( '/mini-cart' );
+		await page.locator( miniCartButton ).click();
+		await page.getByRole( 'link', { name: 'View my cart' } ).click();
+		await expect(
+			page.getByRole( 'heading', { name: 'Cart', exact: true } )
+		).toBeVisible();
+		await expect( page.locator( miniCartButton ) ).toBeHidden();
+
+		// go to mini cart and test redirection from mini cart to checkout
+		await page.goto( '/mini-cart' );
+		await page.locator( miniCartButton ).click();
+		await page.getByRole( 'link', { name: 'Go to checkout' } ).click();
+		await expect(
+			page.getByRole( 'heading', { name: 'Checkout', exact: true } )
+		).toBeVisible();
+		await expect( page.locator( miniCartButton ) ).toBeHidden();
+	} );
+} );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # [30](https://github.com/woocommerce/woocommerce-quality/milestone/30) in Woo Quality

Covered 6 out of 7 flows from the Mini Cart milestone. Left comment on remaining 1. The thing is that it seems impossible testing Taxes on Mini Cart because Taxes aren't present, there's a message telling customer that taxes are shown in the checkout.

Also commented 2 flows about Cannot View Mini Cart Block on Checkout Page and Cart Page, they are part of this PR but just as a simple test that mini cart's CSS is not present on pages cart and checkout.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout this branch locally
2. Execute the test: `pnpm test:e2e-pw ./tests/e2e-pw/tests/shopper/mini-cart.spec.js --headed`
3. Optionally execute the whole test suite: `pnpm test:e2e-pw`
4. Should be all green (passing)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
