### PR TITLE
Add the woocommerce_order_list_table_items filter

### DIFF
--- a/plugins/woocommerce/changelog/add-woocommerce_order_list_table_items-filter
+++ b/plugins/woocommerce/changelog/add-woocommerce_order_list_table_items-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add the woocommerce_order_list_table_items filter.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -412,7 +412,19 @@ class ListTable extends WP_List_Table {
 		// We must ensure the 'paginate' argument is set.
 		$order_query_args['paginate'] = true;
 
-		$orders      = wc_get_orders( $order_query_args );
+		$orders = wc_get_orders( $order_query_args );
+
+		/**
+		 * Filters the actual orders that will be displayed in the orders list table (HPOS only).
+		 *
+		 * @param array $orders An array with the WC_Order objects that are intended to be displayed.
+		 * @param array $query_args The arguments that were used for the order query.
+		 * @returns array An array with the WC_Order objects that will actually be displayed.
+		 *
+		 * @since 8.3.0
+		 */
+		$orders->orders = apply_filters( 'woocommerce_order_list_table_items', $orders->orders, $order_query_args );
+
 		$this->items = $orders->orders;
 
 		$max_num_pages = $orders->max_num_pages;
@@ -723,7 +735,7 @@ class ListTable extends WP_List_Table {
 		global $wpdb;
 
 		$orders_table = esc_sql( OrdersTableDataStore::get_orders_table_name() );
-		$utc_offset = wc_timezone_offset();
+		$utc_offset   = wc_timezone_offset();
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$order_dates = $wpdb->get_results(
@@ -1347,7 +1359,7 @@ class ListTable extends WP_List_Table {
 	 * @return int Number of orders that were trashed.
 	 */
 	private function do_delete( array $ids, bool $force_delete = false ): int {
-		$changed      = 0;
+		$changed = 0;
 
 		foreach ( $ids as $id ) {
 			$order = wc_get_order( $id );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Add the `woocommerce_order_list_table_items` filter in the list table rendeding code for HPOS. It allows filtering the actual order objects that are rendered in the orders list, but only with HPOS active. This new filter is complementary to the `woocommerce_order_list_table_prepare_items_query_args` filter used to alter the query used to retrieve the orders from the database.

Closes #39519.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure that HPOS is enabled (WooCommerce - Settings - Advanced - Features - Order data storage, or from command line: `wp wc cot enable`).
2. Go to WooCommerce - Orders. Verify that the orders list is rendered as expected.
3. Add the following code snippet:

```php
add_filter( 'woocommerce_order_list_table_items', function($orders, $query_args) {
	return [current($orders)];
}, 10, 2);
```

4. Reload the orders page and you should see that now only the first of the orders appears in the list.

Note that if the posts table is authoritative for orders this filter has no effect (same as for the existing `woocommerce_order_list_table_prepare_items_query_args` filter).


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Add the woocommerce_order_list_table_items filter.

#### Comment

</details>
