### PR TITLE
fix fatal string to array conversion error in get_full_size_image_dim…

### DIFF
--- a/plugins/woocommerce/changelog/40395-bugfix-class-wc-regenerate-images-array-check
+++ b/plugins/woocommerce/changelog/40395-bugfix-class-wc-regenerate-images-array-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix fatal string to array conversion error in get_full_size_image_dimensions

--- a/plugins/woocommerce/changelog/bugfix-class-wc-regenerate-images-array-check
+++ b/plugins/woocommerce/changelog/bugfix-class-wc-regenerate-images-array-check
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-fix fatal string to array conversion error in get_full_size_image_dimensions

--- a/plugins/woocommerce/changelog/bugfix-class-wc-regenerate-images-array-check
+++ b/plugins/woocommerce/changelog/bugfix-class-wc-regenerate-images-array-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix fatal string to array conversion error in get_full_size_image_dimensions

--- a/plugins/woocommerce/includes/class-wc-regenerate-images.php
+++ b/plugins/woocommerce/includes/class-wc-regenerate-images.php
@@ -263,7 +263,7 @@ class WC_Regenerate_Images {
 	private static function get_full_size_image_dimensions( $attachment_id ) {
 		$imagedata = wp_get_attachment_metadata( $attachment_id );
 
-		if ( ! is_array($imagedata) ) {
+		if ( ! is_array( $imagedata ) ) {
 			return array();
 		}
 

--- a/plugins/woocommerce/includes/class-wc-regenerate-images.php
+++ b/plugins/woocommerce/includes/class-wc-regenerate-images.php
@@ -263,7 +263,7 @@ class WC_Regenerate_Images {
 	private static function get_full_size_image_dimensions( $attachment_id ) {
 		$imagedata = wp_get_attachment_metadata( $attachment_id );
 
-		if ( ! $imagedata ) {
+		if ( ! is_array($imagedata) ) {
 			return array();
 		}
 


### PR DESCRIPTION
…ensions

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Closes #40393 .

### How to test the changes in this Pull Request:

1. Upload an image via the media library
2. Delete this image in the uploads folder
3. Open the frontend website 


### Changelog entry


-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance


-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message 

fix fatal string to array conversion error in get_full_size_image_dimensions

#### Comment

</details>
