### PR TITLE
fix: cys site assembler color palette persistence bug

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/variation-container.jsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/variation-container.jsx
@@ -29,12 +29,23 @@ export const VariationContainer = ( { variation, children } ) => {
 
 	const selectVariation = () => {
 		// Remove the hasCreatedOwnColors flag if the user is switching to a color palette
+		// hasCreatedOwnColors flag is used for visually deselecting preset color palettes if user has created their own
 		if (
 			variation.settings.color &&
 			user.settings.color &&
-			user.settings.color.hasCreatedOwnColors
+			user.settings.color.palette.hasCreatedOwnColors
 		) {
 			delete user.settings.color.palette.hasCreatedOwnColors;
+			// some color palettes don't define all the possible color options, e.g headings and captions
+			// if the user selects a pre-defined color palette with some own colors defined for these,
+			// we need to delete these user customizations as the below merge will persist them since
+			// the incoming variation won't have these properties defined
+			delete user.styles.color;
+			for ( const elementKey in user.styles.elements ) {
+				if ( user.styles.elements[ elementKey ].color ) {
+					delete user.styles.elements[ elementKey ].color;
+				}
+			}
 		}
 
 		setUserConfig( () => {

--- a/plugins/woocommerce/changelog/fix-cys-assembler-color-palette-persistence
+++ b/plugins/woocommerce/changelog/fix-cys-assembler-color-palette-persistence
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+CYS: Fix the bug where sometimes switching from user defined color palettes to a pre-defined color palette won't set some colors.


### PR DESCRIPTION
Fix the bug where sometimes switching from user defined color palettes to a pre-defined color palette won't set some colors.

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fix the bug where sometimes switching from user defined color palettes to a pre-defined color palette won't set some colors.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

This feature is part of the larger customize your store development and behind a feature flag, hence QA review can be deferred until the call for testing before release.

Make sure you are testing this with a Jetpack connected instance of WooCommerce, as the AI text completion endpoint can only be called with a Jetpack connected account.

1. Create a new WooCommerce installation with this version.
1. Make sure to enable `customize-store` feature flag
1. Go to `WooCommerce -> Home` and click `Customize Store` task
1. Click `Design with AI` button
1. Proceed all steps until the end
1. Play around with the custom color palette settings and toggle back and forth between pre-defined and custom
1. Observe that selecting a pre-defined should never keep any customisations now

https://github.com/woocommerce/woocommerce/assets/27843274/7e9df535-397c-4ed0-97fc-374f54e478cc

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
