### PR TITLE
Shipping Classes: Create add/edit modal functionality

### DIFF
--- a/plugins/woocommerce/changelog/add-shipping-class-edit-modal
+++ b/plugins/woocommerce/changelog/add-shipping-class-edit-modal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add modal for adding and editing Shipping Classes

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -3887,6 +3887,48 @@ table {
 	}
 }
 
+.wc-shipping-class-modal {
+	font-family: $font-sf-pro-text;
+	font-size: 13px;
+	font-weight: 400;
+	line-height: 18px;
+
+	.edit {
+		margin: 5px 0;
+	}
+	
+	.edit > input,
+	.edit > select {
+		width: 100%;
+		max-width: 100%;
+	}
+
+	.view {
+		font-weight: 600;
+	}
+
+	.wc-shipping-class-modal-action-inactive {
+		display: none;
+	}
+
+	.wc-shipping-class-modal-input {
+		padding: 10px 0;
+	}
+
+	.wc-shipping-class-count {
+		display: none;
+	}
+
+	.wc-shipping-class-modal-help-text {
+		font-size: 12px;
+		line-height: 17px;
+	}
+}
+
+.wc-shipping-class-hide-sibling-view + .view { 
+	display: none;
+}
+
 .wc-shipping-zones-heading .page-title-action {
 	display: inline-block;
 }
@@ -4091,13 +4133,13 @@ table.wc-shipping-classes {
 		a.wc-shipping-zone-method-delete,
 		a.wc-shipping-class-delete {
 			color: #a00;
-		}
 	}
 
 	.wc-shipping-class-description,
 	.wc-shipping-class-name,
 	.wc-shipping-class-slug,
 	.wc-shipping-zone-name,
+	.wc-shipping-class-actions,
 	.wc-shipping-zone-region {
 		input,
 		select,

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -4133,6 +4133,7 @@ table.wc-shipping-classes {
 		a.wc-shipping-zone-method-delete,
 		a.wc-shipping-class-delete {
 			color: #a00;
+		}
 	}
 
 	.wc-shipping-class-description,

--- a/plugins/woocommerce/client/legacy/js/admin/backbone-modal.js
+++ b/plugins/woocommerce/client/legacy/js/admin/backbone-modal.js
@@ -56,7 +56,8 @@
 			'click #btn-ok'     : 'addButton',
 			'click #btn-next'   : 'nextButton',
 			'touchstart #btn-ok': 'addButton',
-			'keydown'           : 'keyboardActions'
+			'keydown'           : 'keyboardActions',
+			'input'             : 'handleInputValidation'
 		},
 		resizeContent: function() {
 			var $content  = $( '.wc-backbone-modal-content' ).find( 'article' );
@@ -117,10 +118,12 @@
 			}
 			$( document.body ).trigger( 'wc_backbone_modal_next_response', [ this._target, this.getFormData(), closeModal ] );
 		},
-		getFormData: function() {
+		getFormData: function( updating = true ) {
 			var data = {};
 
-			$( document.body ).trigger( 'wc_backbone_modal_before_update', this._target );
+			if ( updating ) {
+				$( document.body ).trigger( 'wc_backbone_modal_before_update', this._target );
+			}
 
 			$.each( $( 'form', this.$el ).serializeArray(), function( index, item ) {
 				if ( item.name.indexOf( '[]' ) !== -1 ) {
@@ -133,6 +136,9 @@
 			});
 
 			return data;
+		},
+		handleInputValidation: function() {
+			$( document.body ).trigger( 'wc_backbone_modal_validation', [ this._target, this.getFormData( false ) ] );
 		},
 		keyboardActions: function( e ) {
 			var button = e.keyCode || e.which;

--- a/plugins/woocommerce/client/legacy/js/admin/wc-shipping-classes.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-shipping-classes.js
@@ -8,44 +8,16 @@
 
 			// Backbone model
 			ShippingClass       = Backbone.Model.extend({
-				changes: {},
-				logChanges: function( changedRows ) {
-					var changes = this.changes || {};
-
-					_.each( changedRows, function( row, id ) {
-						changes[ id ] = _.extend( changes[ id ] || { term_id : id }, row );
-					} );
-
-					this.changes = changes;
-					this.trigger( 'change:classes' );
-				},
-				save: function() {
-					if ( _.size( this.changes ) ) {
-						$.post( ajaxurl + ( ajaxurl.indexOf( '?' ) > 0 ? '&' : '?' ) + 'action=woocommerce_shipping_classes_save_changes', {
-							wc_shipping_classes_nonce : data.wc_shipping_classes_nonce,
-							changes                 : this.changes
-						}, this.onSaveResponse, 'json' );
-					} else {
-						shippingClass.trigger( 'saved:classes' );
-					}
-				},
-				discardChanges: function( id ) {
-					var changes      = this.changes || {};
-
-					// Delete all changes
-					delete changes[ id ];
-
-					// No changes? Disable save button.
-					if ( 0 === _.size( this.changes ) ) {
-						shippingClassView.clearUnloadConfirmation();
-					}
+				save: function( changes ) {
+					$.post( ajaxurl + ( ajaxurl.indexOf( '?' ) > 0 ? '&' : '?' ) + 'action=woocommerce_shipping_classes_save_changes', {
+						wc_shipping_classes_nonce : data.wc_shipping_classes_nonce,
+						changes,
+					}, this.onSaveResponse, 'json' );
 				},
 				onSaveResponse: function( response, textStatus ) {
 					if ( 'success' === textStatus ) {
 						if ( response.success ) {
 							shippingClass.set( 'classes', response.data.shipping_classes );
-							shippingClass.trigger( 'change:classes' );
-							shippingClass.changes = {};
 							shippingClass.trigger( 'saved:classes' );
 						} else if ( response.data ) {
 							window.alert( response.data );
@@ -61,14 +33,11 @@
 			ShippingClassView = Backbone.View.extend({
 				rowTemplate: $row_template,
 				initialize: function() {
-					this.listenTo( this.model, 'change:classes', this.setUnloadConfirmation );
-					this.listenTo( this.model, 'saved:classes', this.clearUnloadConfirmation );
 					this.listenTo( this.model, 'saved:classes', this.render );
-					$tbody.on( 'change', { view: this }, this.updateModelOnChange );
-					$( window ).on( 'beforeunload', { view: this }, this.unloadConfirmation );
-					$save_button.on( 'click', { view: this }, this.onSubmit );
-					$( document.body ).on( 'click', '.wc-shipping-class-add', { view: this }, this.onAddNewRow );
-					$( document.body ).on( 'click', '.wc-shipping-class-save-changes', { view: this }, this.onSubmit );
+					$( document.body ).on( 'click', '.wc-shipping-class-add-new', { view: this }, this.configureNewShippingClass );
+					$( document.body ).on( 'wc_backbone_modal_response', { view: this }, this.onConfigureShippingClassSubmitted );
+					$( document.body ).on( 'wc_backbone_modal_loaded', { view: this }, this.onLoadBackboneModal );
+					$( document.body ).on( 'wc_backbone_modal_validation', this.validateFormArguments );
 				},
 				block: function() {
 					$( this.el ).block({
@@ -83,8 +52,8 @@
 					$( this.el ).unblock();
 				},
 				render: function() {
-					var classes       = _.indexBy( this.model.get( 'classes' ), 'term_id' ),
-						view        = this;
+					var classes = _.indexBy( this.model.get( 'classes' ), 'term_id' ),
+						view    = this;
 
 					this.$el.empty();
 					this.unblock();
@@ -123,114 +92,112 @@
 					$tr.find( '.edit' ).hide();
 					$tr.find( '.wc-shipping-class-edit' ).on( 'click', { view: this }, this.onEditRow );
 					$tr.find( '.wc-shipping-class-delete' ).on( 'click', { view: this }, this.onDeleteRow );
-					$tr.find( '.editing .wc-shipping-class-edit' ).trigger('click');
-					$tr.find( '.wc-shipping-class-cancel-edit' ).on( 'click', { view: this }, this.onCancelEditRow );
+					// $tr.find( '.wc-shipping-class-cancel-edit' ).on( 'click', { view: this }, this.onCancelEditRow );
+				},
+				configureNewShippingClass: function( event ) {
+					event.preventDefault();
+					const term_id = 'new-1-' + Date.now();
 
-					// Editing?
-					if ( true === rowData.editing ) {
-						$tr.addClass( 'editing' );
-						$tr.find( '.wc-shipping-class-edit' ).trigger( 'click' );
+					$( this ).WCBackboneModal({
+						template : 'wc-shipping-class-configure',
+						variable : {
+							term_id,
+							action: 'create',
+						},
+						data : {
+							term_id,
+							action: 'create',
+						}
+					});
+				},
+				onConfigureShippingClassSubmitted: function( event, target, posted_data ) {
+					if ( target === 'wc-shipping-class-configure' ) {
+						const view = event.data.view;
+						const model = view.model;
+						const isNewRow = posted_data.term_id.includes( 'new-1-' );
+						const rowData = {
+							...posted_data,
+						};
+
+						if ( isNewRow ) {
+							rowData.newRow = true;
+						}
+						
+						view.block();
+
+						model.save( {
+							[ posted_data.term_id ]: rowData
+						} );
 					}
 				},
-				onSubmit: function( event ) {
-					event.data.view.block();
-					event.data.view.model.save();
-					event.preventDefault();
-				},
-				onAddNewRow: function( event ) {
-					event.preventDefault();
-
-					var view    = event.data.view,
-						model   = view.model,
-						classes   = _.indexBy( model.get( 'classes' ), 'term_id' ),
-						changes = {},
-						size    = _.size( classes ),
-						newRow  = _.extend( {}, data.default_shipping_class, {
-							term_id: 'new-' + size + '-' + Date.now(),
-							editing: true,
-							newRow : true
-						} );
-
-					changes[ newRow.term_id ] = newRow;
-
-					model.logChanges( changes );
-					view.renderRow( newRow );
-					$( '.wc-shipping-classes-blank-state' ).remove();
+				validateFormArguments: function( element, target, data ) {
+					const requiredFields = [ 'name', 'description' ];
+					const formIsComplete = Object.keys( data ).every( key => {
+						if ( ! requiredFields.includes( key ) ) {
+							return true;
+						}
+						if ( Array.isArray( data[ key ] ) ) {
+							return data[ key ].length && !!data[ key ][ 0 ];
+						}
+						return !!data[ key ];
+					} );
+					const createButton = document.getElementById( 'btn-ok' );
+					createButton.disabled = ! formIsComplete;
+					createButton.classList.toggle( 'disabled', ! formIsComplete );
 				},
 				onEditRow: function( event ) {
+					const term_id = $( this ).closest('tr').data('id');
+					const model =  event.data.view.model;
+					const classes = _.indexBy( model.get( 'classes' ), 'term_id' );
+					const rowData = classes[ term_id ];
+					
 					event.preventDefault();
-					$( this ).closest('tr').addClass('editing');
-					$( this ).closest('tr').find('.view').hide();
-					$( this ).closest('tr').find('.edit').show();
-					event.data.view.model.trigger( 'change:classes' );
+					$( this ).WCBackboneModal({
+						template : 'wc-shipping-class-configure',
+						variable : {
+							action: 'edit',
+							...rowData
+						},
+						data : {
+							action: 'edit',
+							...rowData
+						}
+					});
+				},
+				onLoadBackboneModal: function( event, target ) {
+					if ( 'wc-shipping-class-configure' === target ) {
+						const modalContent = $('.wc-backbone-modal-content');
+						const term_id = modalContent.data('id');
+						const model =  event.data.view.model;
+						const classes = _.indexBy( model.get( 'classes' ), 'term_id' );
+						const rowData = classes[ term_id ];
+
+						if ( rowData ) {
+							// Support select boxes
+							$('.wc-backbone-modal-content').find( 'select' ).each( function() {
+								var attribute = $( this ).data( 'attribute' );
+								$( this ).find( 'option[value="' + rowData[ attribute ] + '"]' ).prop( 'selected', true );
+							} );
+						}
+					}
+					
 				},
 				onDeleteRow: function( event ) {
 					var view    = event.data.view,
 						model   = view.model,
-						classes = _.indexBy( model.get( 'classes' ), 'term_id' ),
-						changes = {},
 						term_id = $( this ).closest('tr').data('id');
 
 					event.preventDefault();
 
-					if ( classes[ term_id ] ) {
-						delete classes[ term_id ];
-						changes[ term_id ] = _.extend( changes[ term_id ] || {}, { deleted : 'deleted' } );
-						model.set( 'classes', classes );
-						model.logChanges( changes );
-					}
+					view.block();
 
-					view.render();
+					model.save( {
+						[ term_id ]: {
+							term_id,
+							deleted: 'deleted',
+						}
+					} );
 				},
-				onCancelEditRow: function( event ) {
-					var view    = event.data.view,
-						model   = view.model,
-						row     = $( this ).closest('tr'),
-						term_id = $( this ).closest('tr').data('id'),
-						classes = _.indexBy( model.get( 'classes' ), 'term_id' );
-
-					event.preventDefault();
-					model.discardChanges( term_id );
-
-					if ( classes[ term_id ] ) {
-						classes[ term_id ].editing = false;
-						row.after( view.rowTemplate( classes[ term_id ] ) );
-						view.initRow( classes[ term_id ] );
-					}
-
-					row.remove();
-				},
-				setUnloadConfirmation: function() {
-					this.needsUnloadConfirm = true;
-					$save_button.prop( 'disabled', false );
-				},
-				clearUnloadConfirmation: function() {
-					this.needsUnloadConfirm = false;
-					$save_button.attr( 'disabled', 'disabled' );
-				},
-				unloadConfirmation: function( event ) {
-					if ( event.data.view.needsUnloadConfirm ) {
-						event.returnValue = data.strings.unload_confirmation_msg;
-						window.event.returnValue = data.strings.unload_confirmation_msg;
-						return data.strings.unload_confirmation_msg;
-					}
-				},
-				updateModelOnChange: function( event ) {
-					var model     = event.data.view.model,
-						$target   = $( event.target ),
-						term_id   = $target.closest( 'tr' ).data( 'id' ),
-						attribute = $target.data( 'attribute' ),
-						value     = $target.val(),
-						classes   = _.indexBy( model.get( 'classes' ), 'term_id' ),
-						changes = {};
-
-					if ( ! classes[ term_id ] || classes[ term_id ][ attribute ] !== value ) {
-						changes[ term_id ] = {};
-						changes[ term_id ][ attribute ] = value;
-					}
-
-					model.logChanges( changes );
-				}
 			} ),
 			shippingClass = new ShippingClass({
 				classes: data.classes

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -146,7 +146,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 			wp_register_script( 'wc-backbone-modal', WC()->plugin_url() . '/assets/js/admin/backbone-modal' . $suffix . '.js', array( 'underscore', 'backbone', 'wp-util' ), $version );
 			wp_register_script( 'wc-shipping-zones', WC()->plugin_url() . '/assets/js/admin/wc-shipping-zones' . $suffix . '.js', array( 'jquery', 'wp-util', 'underscore', 'backbone', 'jquery-ui-sortable', 'wc-enhanced-select', 'wc-backbone-modal' ), $version );
 			wp_register_script( 'wc-shipping-zone-methods', WC()->plugin_url() . '/assets/js/admin/wc-shipping-zone-methods' . $suffix . '.js', array( 'jquery', 'wp-util', 'underscore', 'backbone', 'jquery-ui-sortable', 'wc-backbone-modal' ), $version );
-			wp_register_script( 'wc-shipping-classes', WC()->plugin_url() . '/assets/js/admin/wc-shipping-classes' . $suffix . '.js', array( 'jquery', 'wp-util', 'underscore', 'backbone', 'wc-backbone-modal' ), $version );
+			wp_register_script( 'wc-shipping-classes', WC()->plugin_url() . '/assets/js/admin/wc-shipping-classes' . $suffix . '.js', array( 'jquery', 'wp-util', 'underscore', 'backbone', 'wc-backbone-modal' ), $version, array( 'in_footer' => false ) );
 			wp_register_script( 'wc-clipboard', WC()->plugin_url() . '/assets/js/admin/wc-clipboard' . $suffix . '.js', array( 'jquery' ), $version );
 			wp_register_script( 'select2', WC()->plugin_url() . '/assets/js/select2/select2.full' . $suffix . '.js', array( 'jquery' ), '4.0.3' );
 			wp_register_script( 'selectWoo', WC()->plugin_url() . '/assets/js/selectWoo/selectWoo.full' . $suffix . '.js', array( 'jquery' ), '1.0.6' );

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -146,7 +146,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 			wp_register_script( 'wc-backbone-modal', WC()->plugin_url() . '/assets/js/admin/backbone-modal' . $suffix . '.js', array( 'underscore', 'backbone', 'wp-util' ), $version );
 			wp_register_script( 'wc-shipping-zones', WC()->plugin_url() . '/assets/js/admin/wc-shipping-zones' . $suffix . '.js', array( 'jquery', 'wp-util', 'underscore', 'backbone', 'jquery-ui-sortable', 'wc-enhanced-select', 'wc-backbone-modal' ), $version );
 			wp_register_script( 'wc-shipping-zone-methods', WC()->plugin_url() . '/assets/js/admin/wc-shipping-zone-methods' . $suffix . '.js', array( 'jquery', 'wp-util', 'underscore', 'backbone', 'jquery-ui-sortable', 'wc-backbone-modal' ), $version );
-			wp_register_script( 'wc-shipping-classes', WC()->plugin_url() . '/assets/js/admin/wc-shipping-classes' . $suffix . '.js', array( 'jquery', 'wp-util', 'underscore', 'backbone' ), $version );
+			wp_register_script( 'wc-shipping-classes', WC()->plugin_url() . '/assets/js/admin/wc-shipping-classes' . $suffix . '.js', array( 'jquery', 'wp-util', 'underscore', 'backbone', 'wc-backbone-modal' ), $version );
 			wp_register_script( 'wc-clipboard', WC()->plugin_url() . '/assets/js/admin/wc-clipboard' . $suffix . '.js', array( 'jquery' ), $version );
 			wp_register_script( 'select2', WC()->plugin_url() . '/assets/js/select2/select2.full' . $suffix . '.js', array( 'jquery' ), '4.0.3' );
 			wp_register_script( 'selectWoo', WC()->plugin_url() . '/assets/js/selectWoo/selectWoo.full' . $suffix . '.js', array( 'jquery' ), '1.0.6' );

--- a/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-classes.php
+++ b/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-classes.php
@@ -8,10 +8,12 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
+
 ?>
 
 <h2>
 	<?php esc_html_e( 'Shipping classes', 'woocommerce' ); ?>
+	<a class="button button-primary wc-shipping-class-add-new" href="#"><?php esc_html_e( 'Add shipping class', 'woocommerce' ); ?></a>
 </h2>
 
 <p class="wc-shipping-zone-help-text">
@@ -24,24 +26,99 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<?php foreach ( $shipping_class_columns as $class => $heading ) : ?>
 				<th class="<?php echo esc_attr( $class ); ?>"><?php echo esc_html( $heading ); ?></th>
 			<?php endforeach; ?>
-			<th></th>
+			<th />
 		</tr>
 	</thead>
-	<tfoot>
-		<tr>
-			<td colspan="<?php echo absint( count( $shipping_class_columns ) + 1 ); ?>">
-				<button type="submit" name="save" class="button button-primary wc-shipping-class-save" value="<?php esc_attr_e( 'Save shipping classes', 'woocommerce' ); ?>" disabled><?php esc_html_e( 'Save shipping classes', 'woocommerce' ); ?></button>
-				<a class="button button-secondary wc-shipping-class-add" href="#"><?php esc_html_e( 'Add shipping class', 'woocommerce' ); ?></a>
-			</td>
-		</tr>
-	</tfoot>
 	<tbody class="wc-shipping-class-rows"></tbody>
 </table>
 
 <script type="text/html" id="tmpl-wc-shipping-class-row-blank">
 	<tr>
-		<td class="wc-shipping-classes-blank-state" colspan="<?php echo absint( count( $shipping_class_columns ) ); ?>"><p><?php esc_html_e( 'No shipping classes have been created.', 'woocommerce' ); ?></p></td>
+		<td class="wc-shipping-classes-blank-state" colspan="<?php echo absint( count( $shipping_class_columns ) + 1 ); ?>"><p><?php esc_html_e( 'No shipping classes have been created.', 'woocommerce' ); ?></p></td>
 	</tr>
+</script>
+
+<!-- 1. Placeholder becomes the "label" in view class div -->
+<!-- 1. Add labelFor or some kind of attribute for semantic HTML-->
+
+<script type="text/html" id="tmpl-wc-shipping-class-configure">
+<div class="wc-backbone-modal">
+		<div class="wc-backbone-modal-content wc-shipping-class-modal" data-id="{{ data.term_id }}">
+			<section class="wc-backbone-modal-main" role="main">
+				<header class="wc-backbone-modal-header">
+					<h1><?php esc_html_e( 'Add shipping class', 'woocommerce' ); ?></h1>
+					<button class="modal-close modal-close-link dashicons dashicons-no-alt">
+						<span class="screen-reader-text"><?php esc_html_e( 'Close modal panel', 'woocommerce' ); ?></span>
+					</button>
+				</header>
+				<article>
+				<form action="" method="post">
+					<input type="hidden" name="term_id" value="{{{ data.term_id }}}" />
+					<?php
+					foreach ( $shipping_class_columns as $class => $heading ) {
+						echo '<div class="wc-shipping-class-modal-input ' . esc_attr( $class ) . '">';
+						switch ( $class ) {
+							case 'wc-shipping-class-name':
+								?>
+								<div class="view">
+									<?php echo esc_html( wc_strtoupper( $heading ) ); ?> *
+								</div>
+								<div class="edit">
+									<input type="text" name="name" data-attribute="name" value="{{ data.name }}" placeholder="<?php esc_attr_e( 'e.g. Heavy', 'woocommerce' ); ?>" />
+								</div>
+								<div class="wc-shipping-class-modal-help-text"><?php esc_html_e( 'Assign a distinctive shipping class name for easy identification', 'woocommerce' ); ?></div>
+								<?php
+								break;
+							case 'wc-shipping-class-slug':
+								?>
+								<div class="view">
+									<?php echo esc_html( wc_strtoupper( $heading ) ); ?>
+								</div>
+								<div class="edit">
+									<input type="text" name="slug" data-attribute="slug" value="{{ data.slug }}" placeholder="<?php esc_attr_e( 'e.g. heavy-packages', 'woocommerce' ); ?>" />
+								</div>
+								<div class="wc-shipping-class-modal-help-text"><?php esc_html_e( 'Slug (unique identifier) can be left blank and auto-generated, or you can enter one', 'woocommerce' ); ?></div>
+								<?php
+								break;
+							case 'wc-shipping-class-description':
+								?>
+								<div class="view">
+									<?php echo esc_html( wc_strtoupper( $heading ) ); ?> *
+								</div>
+								<div class="edit">
+									<input type="text" name="description" data-attribute="description" value="{{ data.description }}" placeholder="<?php esc_attr_e( 'e.g. For heavy items requiring higher postage', 'woocommerce' ); ?>" />
+								</div>
+								<?php
+								break;
+							case 'wc-shipping-class-count':
+								break;
+							default:
+								?>
+								<div class="view wc-shipping-class-hide-sibling-view">
+									<?php echo esc_html( wc_strtoupper( $heading ) ); ?>
+								</div>
+								<?php
+								// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+								do_action( 'woocommerce_shipping_classes_column_' . $class );
+								break;
+						}
+						echo '</div>';
+					}
+					?>
+				</form>
+				</article>
+				<footer>
+					<div class="inner">
+						<button id="btn-ok" disabled class="button button-primary button-large disabled">
+							<div class="wc-shipping-class-modal-action-{{ data.action === 'create' ? 'active' : 'inactive' }}"><?php esc_html_e( 'Create', 'woocommerce' ); ?></div>
+							<div class="wc-shipping-class-modal-action-{{ data.action === 'edit' ? 'active' : 'inactive' }}"><?php esc_html_e( 'Save', 'woocommerce' ); ?></div>
+						</button>
+					</div>
+				</footer>
+			</section>
+		</div>
+	</div>
+	<div class="wc-backbone-modal-backdrop modal-close"></div>
 </script>
 
 <script type="text/html" id="tmpl-wc-shipping-class-row">
@@ -55,24 +132,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 					<div class="view">
 						{{ data.name }}
 					</div>
-					<div class="edit">
-						<input type="text" name="name[{{ data.term_id }}]" data-attribute="name" value="{{ data.name }}" placeholder="<?php esc_attr_e( 'Shipping class name', 'woocommerce' ); ?>" />
-						<div class="row-actions">
-							<a class="wc-shipping-class-cancel-edit" href="#"><?php esc_html_e( 'Cancel changes', 'woocommerce' ); ?></a>
-						</div>
-					</div>
 					<?php
 					break;
 				case 'wc-shipping-class-slug':
 					?>
 					<div class="view">{{ data.slug }}</div>
-					<div class="edit"><input type="text" name="slug[{{ data.term_id }}]" data-attribute="slug" value="{{ data.slug }}" placeholder="<?php esc_attr_e( 'Slug', 'woocommerce' ); ?>" /></div>
 					<?php
 					break;
 				case 'wc-shipping-class-description':
 					?>
 					<div class="view">{{ data.description }}</div>
-					<div class="edit"><input type="text" name="description[{{ data.term_id }}]" data-attribute="description" value="{{ data.description }}" placeholder="<?php esc_attr_e( 'Description for your reference', 'woocommerce' ); ?>" /></div>
 					<?php
 					break;
 				case 'wc-shipping-class-count':
@@ -81,6 +150,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					<?php
 					break;
 				default:
+					// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 					do_action( 'woocommerce_shipping_classes_column_' . $class );
 					break;
 			}
@@ -89,7 +159,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		?>
 		<td class="shipping-zone-actions">
 			<div>
-				<a class="wc-shipping-class-edit" href="#"><?php esc_html_e( 'Edit', 'woocommerce' ); ?></a> | <a href="#" class="wc-shipping-class-delete"><?php esc_html_e( 'Remove', 'woocommerce' ); ?></a>
+				<a class="wc-shipping-class-edit" href="#"><?php esc_html_e( 'Edit', 'woocommerce' ); ?></a> | <a href="#" class="wc-shipping-class-delete"><?php esc_html_e( 'Delete', 'woocommerce' ); ?></a>
 			</div>
 		</td>
 	</tr>

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-shipping-classes.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-shipping-classes.spec.js
@@ -12,10 +12,6 @@ test.describe( 'Merchant can add shipping classes', () => {
 		await page
 			.locator( '.wc-shipping-class-delete >> nth=0' )
 			.dispatchEvent( 'click' );
-		await page
-			.locator( '.wc-shipping-class-delete >> nth=0' )
-			.dispatchEvent( 'click' );
-		await page.locator( 'text=Save shipping classes' ).click();
 	} );
 
 	test( 'can add shipping classes', async ( { page } ) => {
@@ -31,24 +27,27 @@ test.describe( 'Merchant can add shipping classes', () => {
 		const shippingClassNoSlug = {
 			name: 'Poster Pack',
 			slug: '',
-			description: '',
+			description: 'Posters, stickers, and other flat items.',
 		};
 		const shippingClasses = [ shippingClassSlug, shippingClassNoSlug ];
 
 		// Add shipping classes
 		for ( const { name, slug, description } of shippingClasses ) {
-			await page.locator( 'text=Add shipping class' ).click();
+			await page.getByRole('link', { name: 'Add shipping class' }).click();
 			await page
-				.locator( '.editing:last-child [data-attribute="name"]' )
+				.getByPlaceholder( 'e.g. Heavy', { exact: true } )
 				.fill( name );
 			await page
-				.locator( '.editing:last-child [data-attribute="slug"]' )
+				.getByPlaceholder( 'e.g. heavy-packages', { exact: true } )
 				.fill( slug );
 			await page
-				.locator( '.editing:last-child [data-attribute="description"]' )
+				.getByPlaceholder( 'e.g. For heavy items requiring higher postage', { exact: true } )
 				.fill( description );
+
+			await page.getByRole( 'button', { name: 'Create' } ).click();
+
+			await page.waitForLoadState( 'networkidle' );
 		}
-		await page.locator( 'text=Save shipping classes' ).click();
 
 		// Set the expected auto-generated slug
 		shippingClassNoSlug.slug = 'poster-pack';
@@ -56,15 +55,12 @@ test.describe( 'Merchant can add shipping classes', () => {
 		// Verify that the specified shipping classes were saved
 		for ( const { name, slug, description } of shippingClasses ) {
 			await expect(
-				page.getByText(`${ name }`, { exact: true })
+				page.getByText( name, { exact: true } )
 			).toBeVisible();
 			await expect( page.locator( `text=${ slug }` ) ).toBeVisible();
-			// account for blank description
-			if ( description !== '' ) {
-				await expect(
-					page.locator( `text=${ description }` )
-				).toBeVisible();
-			}
+			await expect(
+				page.getByText( description, { exact: true } )
+			).toBeVisible();
 		}
 	} );
 } );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/40190

This PR creates a modal to add and edit Shipping Classes while removing the previous in-line editing. Note the modal and table styles will be updated separately because the Shipping Zone Method modals and tables will also receive the same treatment, see https://github.com/woocommerce/woocommerce/issues/40472 and https://github.com/woocommerce/woocommerce/issues/40189.

<img width="525" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1922453/74398cb5-a1fe-478e-8d44-be4399a46d5a">

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Note that we are testing only functionality in this PR, styles will be updated in a follow up.

1. Create a Jurassic Ninja site from this PR
2. Skip the setup but be sure to use a US address and USD (for test the Fedex extension in step 5)
3. Head to Shipping Classes, `/wp-admin/admin.php?page=wc-settings&tab=shipping&section=classes`
4. Add and edit a Shipping Class. Test functionality by having a play with it to make sure data is correctly updated, persists on refresh, and deletes appropriately.
5. This PR reconfigures HTML derived from actions used by plugins to insert HTML into the shipping classes table. Test this by adding and activating such a plugin. For example, https://github.com/woocommerce/woocommerce-shipping-fedex
6. If you're testing with Fedex extension, go to `/wp-admin/admin.php?page=wc-settings&tab=shipping&section=fedex` and click `Enable freight` then save.
7. Repeat step 4 testing, but this time note the extra column in the table and additional field in the modal.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add modal for adding and editing Shipping Classes

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
