### PR TITLE
TreeSelectControl: Handle ROOT selection with individuallySelectParent

### DIFF
--- a/packages/js/components/changelog/fix-tree-select-control-individuallySelectParent-includeParent
+++ b/packages/js/components/changelog/fix-tree-select-control-individuallySelectParent-includeParent
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Fixes and earlier unreleaed change, not changelog required
+
+

--- a/packages/js/components/src/tree-select-control/index.js
+++ b/packages/js/components/src/tree-select-control/index.js
@@ -235,8 +235,8 @@ const TreeSelectControl = ( {
 				 */
 				get() {
 					if (
-						( includeParent || individuallySelectParent ) &&
-						this.value !== ROOT_VALUE
+						( includeParent && this.value !== ROOT_VALUE ) ||
+						individuallySelectParent
 					) {
 						return cache.selectedValues.includes( this.value );
 					}
@@ -434,7 +434,16 @@ const TreeSelectControl = ( {
 			: option.leaves
 					.filter( ( opt ) => opt.checked !== checked )
 					.map( ( opt ) => opt.value );
-		if ( includeParent && option.value !== ROOT_VALUE ) {
+		/**
+		 * If includeParent is true, we need to add the parent value to the array of
+		 * changed values. However, if for some reason includeParent AND individuallySelectParent
+		 * are both set to true, we want to avoid duplicating the parent value in the array.
+		 */
+		if (
+			includeParent &&
+			! individuallySelectParent &&
+			option.value !== ROOT_VALUE
+		) {
 			changedValues.push( option.value );
 		}
 		if ( checked ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Discovered in https://github.com/woocommerce/woocommerce/pull/40184, selecting the top most level option with `individuallySelectParent` set to `true` resulted in odd behaviour.

![1PrgO4.gif](https://github.com/woocommerce/woocommerce/assets/789421/b2985a07-9f8d-4031-8447-c95bc73ceed7)

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR separates a check for `ROOT_VALUE` and `includeParent` from the check for `individuallySelectParent` when trying to determine if a value is checked or not.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. `cd tools/storybook && pnpm storybook`
2. Head to `http://localhost:6007/?path=/docs/woocommerce-admin-components-treeselectcontrol--base`
3. By default `individuallySelectParent` and `includeParent` are each set to `false`. Selecting a parent, including the top level parent, will select all child elements. Confirm this is working correctly.
4. Now set  `includeParent` to `true`. In this scenario, selecting a parent will select all children and the parent value. Selecting the top-level parent, "All countries", will NOT add the parent value. This is the original behaviour and I'm hesitant to change this.
5. Set `includeParent` to `false` and `individuallySelectParent` to `true`. Now selecting a parent value, including the top-level, will select only the parent value, not the children. Ensure toggling the top level "All countries" works as expected - this is the original bug.
6. Finally set `includeParent` and `individuallySelectParent` to `true`. Setting both to `true` doesn't make sense logically, but I handled this in case. The behaviour should be the same as in step 5.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
