### PR TITLE
Remove "soberano" from the VES currency name (Venezuelan bolívar)

### DIFF
--- a/plugins/woocommerce/changelog/pr-40424
+++ b/plugins/woocommerce/changelog/pr-40424
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Rename the Venezuelan currency from Bolivar soberano to just Bolivar

--- a/plugins/woocommerce/i18n/locale-info.php
+++ b/plugins/woocommerce/i18n/locale-info.php
@@ -3781,7 +3781,7 @@ return array(
 		'dimension_unit' => 'cm',
 		'direction'      => 'ltr',
 		'default_locale' => 'es_VE',
-		'name'           => 'Bolívar soberano',
+		'name'           => 'Bolívar',
 		'singular'       => 'Venezuelan bolívar',
 		'plural'         => 'Venezuelan bolívars',
 		'short_symbol'   => null,

--- a/plugins/woocommerce/tests/api-core-tests/tests/data/data-crud.test.js
+++ b/plugins/woocommerce/tests/api-core-tests/tests/data/data-crud.test.js
@@ -3307,7 +3307,7 @@ test.describe( 'Data API tests', () => {
 						},
 						{
 							code: 'VE',
-							name: 'Bolívar soberano',
+							name: 'Bolívar',
 							currency_code: 'VES',
 							currency_pos: 'left',
 							decimal_sep: ',',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

As explained extensively [here](https://github.com/woocommerce/woocommerce/pull/29380), "soberano" is an epithet no longer valid since February 14, 2019. This PR removes the last traces of it.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Remove "soberano" from the VES currency name (Venezuelan bolívar)

</details>
