### PR TITLE
[Customize your store] Make the frame not navigable for the MVP

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/auto-block-preview.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/auto-block-preview.tsx
@@ -47,6 +47,7 @@ export type ScaledBlockPreviewProps = {
 	};
 	additionalStyles: string;
 	onClickNavigationItem: ( event: MouseEvent ) => void;
+	isNavigable: boolean;
 };
 
 function ScaledBlockPreview( {
@@ -55,6 +56,7 @@ function ScaledBlockPreview( {
 	settings,
 	additionalStyles,
 	onClickNavigationItem,
+	isNavigable = false,
 }: ScaledBlockPreviewProps ) {
 	const { setLogoBlock } = useContext( LogoBlockContext );
 	const [ fontFamilies ] = useGlobalSetting(
@@ -77,139 +79,153 @@ function ScaledBlockPreview( {
 			<Iframe
 				aria-hidden
 				tabIndex={ -1 }
-				contentRef={ useRefEffect( ( bodyElement: HTMLBodyElement ) => {
-					const {
-						ownerDocument: { documentElement },
-					} = bodyElement;
+				readonly={ ! isNavigable }
+				contentRef={ useRefEffect(
+					( bodyElement: HTMLBodyElement ) => {
+						const {
+							ownerDocument: { documentElement },
+						} = bodyElement;
 
-					documentElement.classList.add(
-						'block-editor-block-preview__content-iframe'
-					);
-					documentElement.style.position = 'absolute';
-					documentElement.style.width = '100%';
+						documentElement.classList.add(
+							'block-editor-block-preview__content-iframe'
+						);
+						documentElement.style.position = 'absolute';
+						documentElement.style.width = '100%';
 
-					// Necessary for contentResizeListener to work.
-					bodyElement.style.boxSizing = 'border-box';
-					bodyElement.style.position = 'absolute';
-					bodyElement.style.width = '100%';
+						// Necessary for contentResizeListener to work.
+						bodyElement.style.boxSizing = 'border-box';
+						bodyElement.style.position = 'absolute';
+						bodyElement.style.width = '100%';
 
-					let navigationContainers: NodeListOf< HTMLDivElement >;
-					let siteTitles: NodeListOf< HTMLAnchorElement >;
-					const onClickNavigation = ( event: MouseEvent ) => {
-						event.preventDefault();
-						onClickNavigationItem( event );
-					};
+						let navigationContainers: NodeListOf< HTMLDivElement >;
+						let siteTitles: NodeListOf< HTMLAnchorElement >;
+						const onClickNavigation = ( event: MouseEvent ) => {
+							event.preventDefault();
+							onClickNavigationItem( event );
+						};
 
-					const onMouseMove = ( event: MouseEvent ) => {
-						event.stopImmediatePropagation();
-					};
+						const onMouseMove = ( event: MouseEvent ) => {
+							event.stopImmediatePropagation();
+						};
 
-					const possiblyRemoveAllListeners = () => {
-						bodyElement.removeEventListener(
+						const possiblyRemoveAllListeners = () => {
+							bodyElement.removeEventListener(
+								'mousemove',
+								onMouseMove,
+								false
+							);
+							if ( navigationContainers ) {
+								navigationContainers.forEach( ( element ) => {
+									element.removeEventListener(
+										'click',
+										onClickNavigation
+									);
+								} );
+							}
+
+							if ( siteTitles ) {
+								siteTitles.forEach( ( element ) => {
+									element.removeEventListener(
+										'click',
+										onClickNavigation
+									);
+								} );
+							}
+						};
+
+						const enableNavigation = () => {
+							// Remove contenteditable and inert attributes from editable elements so that users can click on navigation links.
+							bodyElement
+								.querySelectorAll(
+									'.block-editor-rich-text__editable[contenteditable="true"]'
+								)
+								.forEach( ( element ) => {
+									element.removeAttribute(
+										'contenteditable'
+									);
+								} );
+
+							bodyElement
+								.querySelectorAll( '*[inert="true"]' )
+								.forEach( ( element ) => {
+									element.removeAttribute( 'inert' );
+								} );
+
+							possiblyRemoveAllListeners();
+							navigationContainers = bodyElement.querySelectorAll(
+								'.wp-block-navigation__container'
+							);
+							navigationContainers.forEach( ( element ) => {
+								element.addEventListener(
+									'click',
+									onClickNavigation,
+									true
+								);
+							} );
+
+							siteTitles = bodyElement.querySelectorAll(
+								'.wp-block-site-title a'
+							);
+							siteTitles.forEach( ( element ) => {
+								element.addEventListener(
+									'click',
+									onClickNavigation,
+									true
+								);
+							} );
+						};
+
+						const onChange = () => {
+							// Get the current logo block client ID from DOM and set it in the logo block context. This is used for the logo settings. See: ./sidebar/sidebar-navigation-screen-logo.tsx
+							// Ideally, we should be able to get the logo block client ID from the block editor store but it is not available.
+							// We should update this code once the there is a selector in the block editor store that can be used to get the logo block client ID.
+							const siteLogo = bodyElement.querySelector(
+								'.wp-block-site-logo'
+							);
+
+							const blockClientId = siteLogo
+								? siteLogo.getAttribute( 'data-block' )
+								: null;
+
+							setLogoBlock( {
+								clientId: blockClientId,
+								isLoading: false,
+							} );
+
+							if ( isNavigable ) {
+								enableNavigation();
+							}
+						};
+
+						// Stop mousemove event listener to disable block tool insertion feature.
+						bodyElement.addEventListener(
 							'mousemove',
 							onMouseMove,
-							false
-						);
-						if ( navigationContainers ) {
-							navigationContainers.forEach( ( element ) => {
-								element.removeEventListener(
-									'click',
-									onClickNavigation
-								);
-							} );
-						}
-
-						if ( siteTitles ) {
-							siteTitles.forEach( ( element ) => {
-								element.removeEventListener(
-									'click',
-									onClickNavigation
-								);
-							} );
-						}
-					};
-
-					const onChange = () => {
-						// Remove contenteditable and inert attributes from editable elements so that users can click on navigation links.
-						bodyElement
-							.querySelectorAll(
-								'.block-editor-rich-text__editable[contenteditable="true"]'
-							)
-							.forEach( ( element ) => {
-								element.removeAttribute( 'contenteditable' );
-							} );
-
-						bodyElement
-							.querySelectorAll( '*[inert="true"]' )
-							.forEach( ( element ) => {
-								element.removeAttribute( 'inert' );
-							} );
-
-						possiblyRemoveAllListeners();
-						navigationContainers = bodyElement.querySelectorAll(
-							'.wp-block-navigation__container'
-						);
-						navigationContainers.forEach( ( element ) => {
-							element.addEventListener(
-								'click',
-								onClickNavigation,
-								true
-							);
-						} );
-
-						siteTitles = bodyElement.querySelectorAll(
-							'.wp-block-site-title a'
-						);
-						siteTitles.forEach( ( element ) => {
-							element.addEventListener(
-								'click',
-								onClickNavigation,
-								true
-							);
-						} );
-
-						// Get the current logo block client ID from DOM and set it in the logo block context. This is used for the logo settings. See: ./sidebar/sidebar-navigation-screen-logo.tsx
-						// Ideally, we should be able to get the logo block client ID from the block editor store but it is not available.
-						// We should update this code once the there is a selector in the block editor store that can be used to get the logo block client ID.
-						const siteLogo = bodyElement.querySelector(
-							'.wp-block-site-logo'
+							true
 						);
 
-						const blockClientId = siteLogo
-							? siteLogo.getAttribute( 'data-block' )
-							: null;
+						const observer = new window.MutationObserver(
+							onChange
+						);
 
-						setLogoBlock( {
-							clientId: blockClientId,
-							isLoading: false,
+						observer.observe( bodyElement, {
+							attributes: true,
+							characterData: false,
+							subtree: true,
+							childList: true,
 						} );
-					};
 
-					// Stop mousemove event listener to disable block tool insertion feature.
-					bodyElement.addEventListener(
-						'mousemove',
-						onMouseMove,
-						true
-					);
-
-					const observer = new window.MutationObserver( onChange );
-
-					observer.observe( bodyElement, {
-						attributes: true,
-						characterData: false,
-						subtree: true,
-						childList: true,
-					} );
-
-					return () => {
-						observer.disconnect();
-						possiblyRemoveAllListeners();
-						setLogoBlock( {
-							clientId: null,
-							isLoading: true,
-						} );
-					};
-				}, [] ) }
+						return () => {
+							observer.disconnect();
+							possiblyRemoveAllListeners();
+							setLogoBlock( {
+								clientId: null,
+								isLoading: true,
+							} );
+						};
+					},
+					[ isNavigable ]
+				) }
 			>
 				<EditorStyles styles={ settings.styles } />
 				<style>

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/block-editor.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/block-editor.tsx
@@ -123,6 +123,7 @@ export const BlockEditor = ( {} ) => {
 					blocks={ blocks }
 					settings={ settings }
 					additionalStyles={ '' }
+					isNavigable={ false }
 					onClickNavigationItem={ onClickNavigationItem }
 					// Don't use sub registry so that we can get the logo block from the main registry on the logo sidebar navigation screen component.
 					useSubRegistry={ false }

--- a/plugins/woocommerce/changelog/update-disable-cys-frame-navigation
+++ b/plugins/woocommerce/changelog/update-disable-cys-frame-navigation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+CYS: Make the frame not navigable for the MVP


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #40427.

This PR adds a prop to enable/disable the navigation feature in the preview frame and set it to `false` for MVP.

https://github.com/woocommerce/woocommerce/assets/4344253/876cd23e-c40d-4a66-883d-20edb01f7f44

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

This feature is part of the larger customize your store development and behind a feature flag, hence QA review can be deferred until the call for testing before release.

1. Create a new WooCommerce installation with this version.
2. Make sure to enable `customize-store` feature flag
2. Go to `/wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store%2Fassembler-hub`
3. Confirm the frame is not navigable and read-only 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
