### PR TITLE
Fix failing "API on WP Latest" in release tests

### DIFF
--- a/.github/actions/tests/run-api-tests/action.yml
+++ b/.github/actions/tests/run-api-tests/action.yml
@@ -16,6 +16,12 @@ outputs:
 runs:
     using: composite
     steps:
+        - name: Download and install Chromium browser.
+          if: ${{ env.API_BASE_URL && ! contains( env.API_BASE_URL, 'localhost' ) }}
+          shell: bash
+          working-directory: plugins/woocommerce
+          run: pnpm exec playwright install chromium
+
         - name: Run API tests.
           id: run-api-tests
           working-directory: plugins/woocommerce

--- a/.github/actions/tests/run-api-tests/action.yml
+++ b/.github/actions/tests/run-api-tests/action.yml
@@ -1,6 +1,5 @@
 name: Run API tests
 description: Runs the WooCommerce Core API tests and generates Allure report.
-permissions: {}
 
 inputs:
     report-name:

--- a/.github/workflows/smoke-test-release.yml
+++ b/.github/workflows/smoke-test-release.yml
@@ -165,6 +165,7 @@ jobs:
                   API_BASE_URL: ${{ secrets.RELEASE_TEST_URL }}
                   USER_KEY: ${{ secrets.RELEASE_TEST_ADMIN_USER }}
                   USER_SECRET: ${{ secrets.RELEASE_TEST_ADMIN_PASSWORD }}
+                  UPDATE_WC: ${{ needs.get-tag.outputs.tag }}
 
             - name: Upload Allure artifacts to bucket
               if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )

--- a/plugins/woocommerce/changelog/dev-ci-release-fix-api-wp-latest
+++ b/plugins/woocommerce/changelog/dev-ci-release-fix-api-wp-latest
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix "API on WP Latest" job in "Smoke test release" workflow.

--- a/plugins/woocommerce/tests/api-core-tests/global-setup.js
+++ b/plugins/woocommerce/tests/api-core-tests/global-setup.js
@@ -144,7 +144,7 @@ module.exports = async ( config ) => {
 					setupPage.locator( '#pluginzip' ).click(),
 				] );
 				await fileChooser.setFiles( woocommerceZipPath );
-				console.log( 'Uploading nightly build...' );
+				console.log( 'Uploading build...' );
 				await setupPage
 					.locator( '#install-plugin-submit' )
 					.click( { timeout: 60000 } );

--- a/plugins/woocommerce/tests/api-core-tests/global-setup.js
+++ b/plugins/woocommerce/tests/api-core-tests/global-setup.js
@@ -3,7 +3,7 @@ const { downloadZip, deleteZip } = require( './utils/plugin-utils' );
 const axios = require( 'axios' ).default;
 
 module.exports = async ( config ) => {
-	// If API_BASE_URL is configured and doesn't include localhost, running on daily host
+	// If API_BASE_URL is configured and doesn't include localhost, running on remote host
 	if (
 		process.env.API_BASE_URL &&
 		! process.env.API_BASE_URL.includes( 'localhost' )


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes the broken "API on WP Latest" job in our release tests.

Cause of the failure: Our "Smoke test release" workflow doesn't download the chromium browser, which is needed by the API tests in order to execute the recently added `plugins/woocommerce/tests/api-core-tests/global-setup.js`.

Solution: Add a step to conditionally download the chromium browser in the "Run API tests" composite action.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Verify that the check "Run API tests" in this PR passes.
2. Go to [Smoke test release](https://github.com/woocommerce/woocommerce/actions/workflows/smoke-test-release.yml).
3. In the "Run workflow" menu, select this branch ( `dev/ci-release-api-quick-fix` );
4. Enter any recent `8.2` version like `8.2.0-a.1` into the `WooCommerce Release Tag` field.
5. Click the green "Run workflow" button.
6. Wait for the workflow to finish.
7. Verify that the "API on WP Latest" job downloaded chromium successfully. The tests don't necessarily need to pass.
    

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
