### PR TITLE
Hide list controls when no items are selected

### DIFF
--- a/packages/js/product-editor/changelog/add-40194
+++ b/packages/js/product-editor/changelog/add-40194
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+The Select all and Clear selection buttons are only displayed when at least 1 item is selected

--- a/packages/js/product-editor/src/components/variations-table/variations-table.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variations-table.tsx
@@ -349,20 +349,24 @@ export const VariationsTable = forwardRef<
 					/>
 				</div>
 				<div className="woocommerce-product-variations__filters">
-					<Button
-						variant="tertiary"
-						disabled={ areAllSelected( variationIds ) }
-						onClick={ () => onSelectAll( variationIds )( true ) }
-					>
-						{ __( 'Select all', 'woocommerce' ) }
-					</Button>
-					<Button
-						variant="tertiary"
-						disabled={ ! hasSelection( variationIds ) }
-						onClick={ () => onClearSelection() }
-					>
-						{ __( 'Clear selection', 'woocommerce' ) }
-					</Button>
+					{ hasSelection( variationIds ) && (
+						<>
+							<Button
+								variant="tertiary"
+								onClick={ () =>
+									onSelectAll( variationIds )( true )
+								}
+							>
+								{ __( 'Select all', 'woocommerce' ) }
+							</Button>
+							<Button
+								variant="tertiary"
+								onClick={ onClearSelection }
+							>
+								{ __( 'Clear selection', 'woocommerce' ) }
+							</Button>
+						</>
+					) }
 				</div>
 				<div>
 					<VariationsActionsMenu


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #40194

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure feature `product-variation-management` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper` (WooCommerce Beta Tester plugin) is required
3. Go to `/wp-admin/admin.php?page=wc-admin&path=/add-product&tab=variations` and add some attributes.
4. Wait until the product variations get generated.
5. Under `Variations` table header you should see `Select all` and `Clear selection` buttons only if at least one variation is selected.
<img width="726" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/9bb130c3-4072-459e-ac83-a0cd82bf160a">
<img width="742" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/544b7a43-af44-4b88-9b36-bb569af75b7e">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
