### PR TITLE
Fix the position and sizing of pagination controls in the variations table

### DIFF
--- a/packages/js/product-editor/changelog/fix-40199
+++ b/packages/js/product-editor/changelog/fix-40199
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the position and sizing of the pagination controls in variations table

--- a/packages/js/product-editor/src/components/variations-table/pagination/index.ts
+++ b/packages/js/product-editor/src/components/variations-table/pagination/index.ts
@@ -1,0 +1,2 @@
+export * from './pagination';
+export * from './types';

--- a/packages/js/product-editor/src/components/variations-table/pagination/pagination.tsx
+++ b/packages/js/product-editor/src/components/variations-table/pagination/pagination.tsx
@@ -1,0 +1,67 @@
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+import { __, sprintf } from '@wordpress/i18n';
+import {
+	PaginationPageSizePicker,
+	PaginationPageArrowsWithPicker,
+	usePagination,
+} from '@woocommerce/components';
+import { createElement } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { PaginationProps } from './types';
+import {
+	DEFAULT_VARIATION_PER_PAGE_OPTION,
+	DEFAULT_VARIATION_PER_PAGE_OPTIONS,
+} from '../../../constants';
+
+export function Pagination( {
+	className,
+	totalCount,
+	perPageOptions = DEFAULT_VARIATION_PER_PAGE_OPTIONS,
+	defaultPerPage = DEFAULT_VARIATION_PER_PAGE_OPTION,
+	onPageChange,
+	onPerPageChange,
+}: PaginationProps ) {
+	const paginationProps = usePagination( {
+		defaultPerPage,
+		totalCount,
+		onPageChange,
+		onPerPageChange,
+	} );
+
+	return (
+		<div
+			className={ classNames(
+				className,
+				'woocommerce-product-variations-pagination'
+			) }
+		>
+			<div className="woocommerce-product-variations-pagination__info">
+				{ sprintf(
+					__( 'Viewing %d-%d of %d items', 'woocommerce' ),
+					paginationProps.start,
+					paginationProps.end,
+					totalCount
+				) }
+			</div>
+
+			<div className="woocommerce-product-variations-pagination__current-page">
+				<PaginationPageArrowsWithPicker { ...paginationProps } />
+			</div>
+
+			<div className="woocommerce-product-variations-pagination__page-size">
+				<PaginationPageSizePicker
+					{ ...paginationProps }
+					total={ totalCount }
+					perPageOptions={ perPageOptions }
+					label=""
+				/>
+			</div>
+		</div>
+	);
+}

--- a/packages/js/product-editor/src/components/variations-table/pagination/pagination.tsx
+++ b/packages/js/product-editor/src/components/variations-table/pagination/pagination.tsx
@@ -43,6 +43,8 @@ export function Pagination( {
 		>
 			<div className="woocommerce-product-variations-pagination__info">
 				{ sprintf(
+					// eslint-disable-next-line max-len
+					// translators: Viewing 1-5 of 100 items. First two %ds are a range of items that are shown on the screen. The last %d is the total amount of items that exist.
 					__( 'Viewing %d-%d of %d items', 'woocommerce' ),
 					paginationProps.start,
 					paginationProps.end,

--- a/packages/js/product-editor/src/components/variations-table/pagination/styles.scss
+++ b/packages/js/product-editor/src/components/variations-table/pagination/styles.scss
@@ -13,9 +13,28 @@
 
 	&__current-page {
 		justify-content: center;
+
+		.woocommerce-pagination__page-arrow-picker-input {
+			border-radius: 2px;
+		}
+
+		.components-button.has-icon {
+			min-width: initial;
+			width: 30px;
+			height: 30px;
+			padding: 3px;
+		}
 	}
 
 	&__page-size {
 		justify-content: flex-end;
+
+		> .woocommerce-pagination__per-page-picker
+			.components-base-control
+			.components-select-control
+			.components-input-control__container
+			.components-select-control__input {
+			min-height: 30px;
+		}
 	}
 }

--- a/packages/js/product-editor/src/components/variations-table/pagination/styles.scss
+++ b/packages/js/product-editor/src/components/variations-table/pagination/styles.scss
@@ -1,0 +1,21 @@
+.woocommerce-product-variations-pagination {
+	display: grid;
+	grid-template-columns: 1fr 1fr 1fr;
+	gap: $gap;
+	width: 100%;
+
+	&__info,
+	&__current-page,
+	&__page-size {
+		display: flex;
+		align-items: center;
+	}
+
+	&__current-page {
+		justify-content: center;
+	}
+
+	&__page-size {
+		justify-content: flex-end;
+	}
+}

--- a/packages/js/product-editor/src/components/variations-table/pagination/types.ts
+++ b/packages/js/product-editor/src/components/variations-table/pagination/types.ts
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import { usePaginationProps } from '@woocommerce/components';
 
 export type PaginationProps = usePaginationProps & {

--- a/packages/js/product-editor/src/components/variations-table/pagination/types.ts
+++ b/packages/js/product-editor/src/components/variations-table/pagination/types.ts
@@ -1,0 +1,7 @@
+import { usePaginationProps } from '@woocommerce/components';
+
+export type PaginationProps = usePaginationProps & {
+	className?: string;
+	perPageOptions?: number[];
+	defaultPerPage?: number;
+};

--- a/packages/js/product-editor/src/components/variations-table/styles.scss
+++ b/packages/js/product-editor/src/components/variations-table/styles.scss
@@ -1,4 +1,5 @@
 @import "./variations-actions-menu/styles.scss";
+@import "./pagination/styles.scss";
 
 $table-row-height: calc($grid-unit * 9);
 
@@ -166,7 +167,7 @@ $table-row-height: calc($grid-unit * 9);
 	}
 
 	&__footer {
-		padding: $gap 0;
-		justify-content: space-between;
+		border-top: 1px solid $gray-200;
+		padding-top: $grid-unit-30;
 	}
 }

--- a/packages/js/product-editor/src/components/variations-table/variations-table.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variations-table.tsx
@@ -14,14 +14,7 @@ import {
 	ProductVariation,
 } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
-import {
-	ListItem,
-	Sortable,
-	Tag,
-	PaginationPageSizePicker,
-	PaginationPageArrowsWithPicker,
-	usePagination,
-} from '@woocommerce/components';
+import { ListItem, Sortable, Tag } from '@woocommerce/components';
 import {
 	useContext,
 	useState,
@@ -53,6 +46,7 @@ import { VariationActionsMenu } from './variation-actions-menu';
 import { useSelection } from '../../hooks/use-selection';
 import { VariationsActionsMenu } from './variations-actions-menu';
 import HiddenIcon from '../../icons/hidden-icon';
+import { Pagination } from './pagination';
 
 const NOT_VISIBLE_TEXT = __( 'Not visible to customers', 'woocommerce' );
 
@@ -158,13 +152,6 @@ export const VariationsTable = forwardRef<
 		},
 		[ productId ]
 	);
-
-	const paginationProps = usePagination( {
-		totalCount,
-		defaultPerPage: DEFAULT_VARIATION_PER_PAGE_OPTION,
-		onPageChange: setCurrentPage,
-		onPerPageChange: setPerPage,
-	} );
 
 	const {
 		updateProductVariation,
@@ -524,23 +511,12 @@ export const VariationsTable = forwardRef<
 			</Sortable>
 
 			{ totalCount > 5 && (
-				<div className="woocommerce-product-variations__footer woocommerce-pagination">
-					<div>
-						{ sprintf(
-							__( 'Viewing %d-%d of %d items', 'woocommerce' ),
-							paginationProps.start,
-							paginationProps.end,
-							totalCount
-						) }
-					</div>
-					<PaginationPageArrowsWithPicker { ...paginationProps } />
-					<PaginationPageSizePicker
-						{ ...paginationProps }
-						total={ totalCount }
-						perPageOptions={ [ 5, 10, 25 ] }
-						label=""
-					/>
-				</div>
+				<Pagination
+					className="woocommerce-product-variations__footer"
+					totalCount={ totalCount }
+					onPageChange={ setCurrentPage }
+					onPerPageChange={ setPerPage }
+				/>
 			) }
 		</div>
 	);

--- a/packages/js/product-editor/src/constants.ts
+++ b/packages/js/product-editor/src/constants.ts
@@ -64,3 +64,4 @@ export const TRACKS_SOURCE = 'product-block-editor-v1';
 export const DEFAULT_PER_PAGE_OPTION = 25;
 
 export const DEFAULT_VARIATION_PER_PAGE_OPTION = 5;
+export const DEFAULT_VARIATION_PER_PAGE_OPTIONS = [ 5, 10, 25 ];


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #40199
Closes #40209

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure feature `product-variation-management` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper` (WooCommerce Beta Tester plugin) is required
3. Go to `/wp-admin/admin.php?page=wc-admin&path=/add-product&tab=variations` and add some attributes to generate more than 5 variation (important to be able to see the pagination component at the bottom of the Variations table).
4. Wait until variations get generated
5. If more than 5 variations are generated then the Pagination component should be shown at the bottom of the Variations table 
<img width="745" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/3a11c4bb-1c86-4506-9ee9-62c58f8b1a2b">

6. Moving across pages should NOT move the page arrows components as mentioned https://github.com/woocommerce/woocommerce/issues/40199, they should remains fixed at the center. 

7. Also the rows per page dropdown is the same size as the page number input field (30 px).

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>