### PR TITLE
Marketplace: hide search input when viewing my subscriptions page on a smaller viewport

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/header/header.scss
+++ b/plugins/woocommerce-admin/client/marketplace/components/header/header.scss
@@ -31,6 +31,14 @@
 	}
 }
 
+.woocommerce-marketplace--my-subscriptions {
+	@media (width <= $breakpoint-medium) {
+		.woocommerce-marketplace__search {
+			display: none;
+		}
+	}
+}
+
 .woocommerce-marketplace__header-title {
 	align-items: center;
 	align-self: stretch;

--- a/plugins/woocommerce-admin/client/marketplace/components/likert-scale/likert-scale.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/likert-scale/likert-scale.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import classnames from 'classnames';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -52,7 +52,7 @@ export default function LikertScale( props: LikertScaleProps ): JSX.Element {
 		},
 	];
 
-	const classes = classnames( 'woocommerce-marketplace__likert-scale', {
+	const classes = classNames( 'woocommerce-marketplace__likert-scale', {
 		'validation-failed': validationFailed,
 	} );
 

--- a/plugins/woocommerce-admin/client/marketplace/index.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/index.tsx
@@ -1,22 +1,42 @@
 /**
+ * External dependencies
+ */
+import { useContext } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import './marketplace.scss';
-import { MarketplaceContextProvider } from './contexts/marketplace-context';
+import {
+	MarketplaceContextProvider,
+	MarketplaceContext,
+} from './contexts/marketplace-context';
 import Header from './components/header/header';
 import Content from './components/content/content';
 import Footer from './components/footer/footer';
 import FeedbackModal from './components/feedback-modal/feedback-modal';
 
+function MarketplaceComponents() {
+	const { selectedTab } = useContext( MarketplaceContext );
+
+	const classNames =
+		'woocommerce-marketplace' +
+		( selectedTab ? ' woocommerce-marketplace--' + selectedTab : '' );
+
+	return (
+		<div className={ classNames }>
+			<Header />
+			<Content />
+			<FeedbackModal />
+			<Footer />
+		</div>
+	);
+}
+
 export default function Marketplace() {
 	return (
 		<MarketplaceContextProvider>
-			<div className="woocommerce-marketplace">
-				<Header />
-				<Content />
-				<FeedbackModal />
-				<Footer />
-			</div>
+			<MarketplaceComponents />
 		</MarketplaceContextProvider>
 	);
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.


### Changes proposed in this Pull Request:

Hides search input on smaller displays when we view my subscriptions page. 

Closes https://github.com/Automattic/woocommerce.com/issues/18233.

### How to test the changes in this Pull Request:

1. Checkout this branch and get a fresh build
2. Visit all three pages on a larger viewport (> 769px) and confirm search input shows up on all of them. 
3. When on [the My Subscriptions page](http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fextensions&tab=my-subscriptions), narrow down the viewport below 769 pixels. See search input disappears. 
4. Visit other WooCommerce pages (orders, products, Analytics) and WordPress pages (posts list page, block editor) and confirm we didn't break anything there with these changes.
5. Please test around this issue

![image](https://github.com/woocommerce/woocommerce/assets/10389957/07bd765a-6294-4d36-b115-9639bee97ae9)
