### PR TITLE
Font sizes differ between chips used in the variations options table and variations list

### DIFF
--- a/packages/js/product-editor/changelog/fix-40202
+++ b/packages/js/product-editor/changelog/fix-40202
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix font sizes difference between chips used in the variations options table and variations list

--- a/packages/js/product-editor/src/components/attribute-control/test/attribute-field.spec.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/test/attribute-field.spec.tsx
@@ -79,6 +79,7 @@ jest.mock( '@woocommerce/components', () => ( {
 	__esModule: true,
 	__experimentalSelectControlMenuSlot: () => <div></div>,
 	ListItem: ( { children }: { children: JSX.Element } ) => children,
+	Tag: ( { label }: { label: string } ) => <span>{ label }</span>,
 	Sortable: ( {
 		onOrderChange,
 		children,

--- a/packages/js/product-editor/src/components/attribute-list-item/attribute-list-item.scss
+++ b/packages/js/product-editor/src/components/attribute-list-item/attribute-list-item.scss
@@ -16,20 +16,6 @@
 		margin-bottom: -1px;
 	}
 
-	&__options {
-		display: flex;
-		flex-direction: row;
-		gap: $gap-smallest;
-	}
-
-	&__option-chip {
-		padding: $gap-smallest $gap-smaller;
-		gap: 2px;
-
-		background: $gray-100;
-		border-radius: 2px;
-	}
-
 	&__actions {
 		display: flex;
 		flex-direction: row;

--- a/packages/js/product-editor/src/components/attribute-list-item/attribute-list-item.tsx
+++ b/packages/js/product-editor/src/components/attribute-list-item/attribute-list-item.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { DragEventHandler } from 'react';
-import { ListItem } from '@woocommerce/components';
+import { ListItem, Tag } from '@woocommerce/components';
 import { ProductAttribute } from '@woocommerce/data';
 import { sprintf, __ } from '@wordpress/i18n';
 import { Button, Tooltip } from '@wordpress/components';
@@ -47,24 +47,19 @@ export const AttributeListItem: React.FC< AttributeListItemProps > = ( {
 			onDragEnd={ onDragEnd }
 		>
 			<div>{ attribute.name }</div>
-			<div className="woocommerce-attribute-list-item__options">
+			<div>
 				{ attribute.options
 					.slice( 0, attribute.options.length > 3 ? 2 : 3 )
-					.map( ( option, index ) => (
-						<div
-							className="woocommerce-attribute-list-item__option-chip"
-							key={ index }
-						>
-							{ option }
-						</div>
+					.map( ( option ) => (
+						<Tag key={ option } label={ option } />
 					) ) }
 				{ attribute.options.length > 3 && (
-					<div className="woocommerce-attribute-list-item__option-chip">
-						{ sprintf(
+					<Tag
+						label={ sprintf(
 							__( '+ %i more', 'woocommerce' ),
 							attribute.options.length - 2
 						) }
-					</div>
+					/>
 				) }
 			</div>
 			<div className="woocommerce-attribute-list-item__actions">


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #40202

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure feature `product-variation-management` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper` (WooCommerce Beta Tester plugin) is required
3. Go to `/wp-admin/admin.php?page=wc-admin&path=/add-product&tab=variations` and add some attributes
4. Wait until variations get generated
5. The chips font size from the `Variation options` table and the `Variations` table should be `12px`

<img width="738" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/59846d86-3656-4713-8253-88b42fc97ec1">
<img width="723" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/5cde0207-bfaa-471d-b2d2-520af890dc0d">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
