### PR TITLE
Fix field label styling in the edit attribute modal

### DIFF
--- a/packages/js/product-editor/changelog/dev-40203_edit_attribute_modal_styles
+++ b/packages/js/product-editor/changelog/dev-40203_edit_attribute_modal_styles
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Fix field label styling in the edit attribute modal #40449

--- a/packages/js/product-editor/src/components/attribute-control/edit-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/edit-attribute-modal.tsx
@@ -124,6 +124,7 @@ export const EditAttributeModal: React.FC< EditAttributeModalProps > = ( {
 									terms: val,
 								} );
 							} }
+							readOnlyWhenClosed={ false }
 						/>
 					) : (
 						<CustomAttributeTermInputField

--- a/packages/js/product-editor/src/components/attribute-term-input-field/attribute-term-input-field.tsx
+++ b/packages/js/product-editor/src/components/attribute-term-input-field/attribute-term-input-field.tsx
@@ -41,6 +41,7 @@ type AttributeTermInputFieldProps = {
 	disabled?: boolean;
 	label?: string;
 	autoCreateOnSelect?: boolean;
+	readOnlyWhenClosed?: boolean;
 };
 
 interface customError extends Error {
@@ -60,6 +61,7 @@ export const AttributeTermInputField: React.FC<
 	attributeId,
 	label = '',
 	autoCreateOnSelect = true,
+	readOnlyWhenClosed = true,
 } ) => {
 	const attributeTermInputId = useRef(
 		`woocommerce-attribute-term-field-${ ++uniqueId }`
@@ -266,6 +268,7 @@ export const AttributeTermInputField: React.FC<
 				selected={ value }
 				onSelect={ onSelect }
 				onRemove={ onRemove }
+				readOnlyWhenClosed={ readOnlyWhenClosed }
 				className={
 					'woocommerce-attribute-term-field ' +
 					attributeTermInputId.current


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR addresses the issue of field label styling in the edit attribute modal by adding the `readOnlyWhenClosed` prop.

Before

<img width="182" alt="image" src="https://github.com/woocommerce/woocommerce/assets/79307566/4ba3cb27-0d0c-44a8-b2fd-6fb53617b41e">

After

![Screenshot 2023-09-26 at 17 18 46](https://github.com/woocommerce/woocommerce/assets/1314156/ccbf4a9c-cfc3-420d-a70a-9e826823231e)

**Design**
AkVNGImLgSqCObTQ3idVn7-fi-6572_310851

**Acceptance criteria**

- [ ] Field labels in the edit attribute modal match the rest of the form.
- [ ] Changes apply to the edit attribute and edit variation option modals.

Closes #40203.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the product blocks editor under WooCommerce -> Settings -> Advanced -> Features.
2. Make sure feature `product-variation-management` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper`.
3. Navigate to the `Add Product` page.
4. Go to the `Organization` tab and press the `Add new` button under `Attributes`.
5. Create an attribute with a few Values.
6. The new attribute should be listed under the button. Press the `Edit` button next to the `X`.
7. The values should be shown as tags (not as a flat list).
8. Go to the `Variations` tab and verify that the Variation options work as expected. 

![Screen Capture on 2023-09-26 at 17-28-11](https://github.com/woocommerce/woocommerce/assets/1314156/8837c8f8-a5d7-4f87-9003-70558a454b18)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
