### PR TITLE
Fix recently failing "API on WP Latest" job in release testing workflow

### DIFF
--- a/.github/actions/tests/run-api-tests/action.yml
+++ b/.github/actions/tests/run-api-tests/action.yml
@@ -1,6 +1,5 @@
 name: Run API tests
 description: Runs the WooCommerce Core API tests and generates Allure report.
-permissions: {}
 
 inputs:
     report-name:
@@ -8,6 +7,9 @@ inputs:
         required: true
     tests:
         description: Specific tests to run, separated by single whitespace. See https://playwright.dev/docs/test-cli
+    playwright-config:
+        description: Playwright config file to be used
+        default: playwright.config.js
 
 outputs:
     result:
@@ -23,7 +25,7 @@ runs:
           shell: bash
           run: |
               pnpm exec playwright test \
-              --config=tests/api-core-tests/playwright.config.js \
+              --config=tests/api-core-tests/${{ inputs.playwright-config }} \
               ${{ inputs.tests }}
 
         - name: Generate Test report.

--- a/.github/workflows/smoke-test-release.yml
+++ b/.github/workflows/smoke-test-release.yml
@@ -706,43 +706,42 @@ jobs:
                   env-slug: ${{ matrix.env_description }}
                   release-version: ${{ needs.get-tag.outputs.tag }}
 
-    # mytodo: re-enable
-    # post-slack-summary:
-    #     name: Post Slack summary
-    #     runs-on: ubuntu-20.04
-    #     permissions:
-    #         contents: read
-    #     if: |
-    #         success() || (
-    #           failure() && contains( needs.*.result, 'failure' )
-    #         )
-    #     needs:
-    #         - e2e-wp-latest
-    #         - get-tag
-    #         - test-php-versions
-    #         - test-plugins
-    #         - test-wp-latest-1
-    #     steps:
-    #         - uses: actions/checkout@v3
+    post-slack-summary:
+        name: Post Slack summary
+        runs-on: ubuntu-20.04
+        permissions:
+            contents: read
+        if: |
+            success() || (
+              failure() && contains( needs.*.result, 'failure' )
+            )
+        needs:
+            - e2e-wp-latest
+            - get-tag
+            - test-php-versions
+            - test-plugins
+            - test-wp-latest-1
+        steps:
+            - uses: actions/checkout@v3
 
-    #         - name: Download all slack blocks
-    #           id: download-slack-blocks
-    #           uses: actions/download-artifact@v3
-    #           with:
-    #               name: ${{ env.SLACK_BLOCKS_ARTIFACT }}
-    #               path: /tmp/slack-payload
+            - name: Download all slack blocks
+              id: download-slack-blocks
+              uses: actions/download-artifact@v3
+              with:
+                  name: ${{ env.SLACK_BLOCKS_ARTIFACT }}
+                  path: /tmp/slack-payload
 
-    #         - name: Construct payload from all blocks
-    #           id: run-payload-action
-    #           uses: ./.github/actions/tests/slack-summary-on-release/slack-payload
-    #           with:
-    #               release-version: ${{ needs.get-tag.outputs.tag }}
-    #               blocks-dir: ${{ steps.download-slack-blocks.outputs.download-path }}
+            - name: Construct payload from all blocks
+              id: run-payload-action
+              uses: ./.github/actions/tests/slack-summary-on-release/slack-payload
+              with:
+                  release-version: ${{ needs.get-tag.outputs.tag }}
+                  blocks-dir: ${{ steps.download-slack-blocks.outputs.download-path }}
 
-    #         - name: Send Slack message
-    #           uses: slackapi/slack-github-action@v1.23.0
-    #           with:
-    #               channel-id: ${{ secrets.RELEASE_TEST_SLACK_CHANNEL }}
-    #               payload: ${{ steps.run-payload-action.outputs.payload }}
-    #           env:
-    #               SLACK_BOT_TOKEN: ${{ secrets.E2E_SLACK_TOKEN }}
+            - name: Send Slack message
+              uses: slackapi/slack-github-action@v1.23.0
+              with:
+                  channel-id: ${{ secrets.RELEASE_TEST_SLACK_CHANNEL }}
+                  payload: ${{ steps.run-payload-action.outputs.payload }}
+              env:
+                  SLACK_BOT_TOKEN: ${{ secrets.E2E_SLACK_TOKEN }}

--- a/.github/workflows/smoke-test-release.yml
+++ b/.github/workflows/smoke-test-release.yml
@@ -155,6 +155,10 @@ jobs:
                   install-filters: woocommerce
                   build: false
 
+            - name: Download and install Chromium browser.
+              working-directory: plugins/woocommerce
+              run: pnpm exec playwright install chromium
+
             - name: Run API tests
               id: run-api-composite-action
               uses: ./.github/actions/tests/run-api-tests

--- a/.github/workflows/smoke-test-release.yml
+++ b/.github/workflows/smoke-test-release.yml
@@ -165,10 +165,12 @@ jobs:
               with:
                   report-name: ${{ env.API_WP_LATEST_ARTIFACT }}
                   tests: hello
+                  playwright-config: ci-release.playwright.config.js
               env:
                   API_BASE_URL: ${{ secrets.RELEASE_TEST_URL }}
                   USER_KEY: ${{ secrets.RELEASE_TEST_ADMIN_USER }}
                   USER_SECRET: ${{ secrets.RELEASE_TEST_ADMIN_PASSWORD }}
+                  UPDATE_WC: ${{ needs.get-tag.outputs.tag }}
 
             - name: Upload Allure artifacts to bucket
               if: success() || ( failure() && steps.run-api-composite-action.conclusion == 'failure' )

--- a/.github/workflows/smoke-test-release.yml
+++ b/.github/workflows/smoke-test-release.yml
@@ -337,7 +337,7 @@ jobs:
                   script: |
                       const { getVersionWPLatestMinusOne } = require( './plugins/woocommerce/tests/e2e-pw/utils/wordpress' );
                       await getVersionWPLatestMinusOne( { core, github } );
-                      
+
             - name: Setup WooCommerce Monorepo
               uses: ./.github/actions/setup-woocommerce-monorepo
               with:
@@ -347,7 +347,7 @@ jobs:
               working-directory: plugins/woocommerce
               run: pnpm run env:test
               env:
-                WP_ENV_CORE: WordPress/WordPress#${{ steps.get-wp-latest-1.outputs.version }}
+                  WP_ENV_CORE: WordPress/WordPress#${{ steps.get-wp-latest-1.outputs.version }}
 
             - name: Download release zip
               env:

--- a/.github/workflows/smoke-test-release.yml
+++ b/.github/workflows/smoke-test-release.yml
@@ -706,42 +706,43 @@ jobs:
                   env-slug: ${{ matrix.env_description }}
                   release-version: ${{ needs.get-tag.outputs.tag }}
 
-    post-slack-summary:
-        name: Post Slack summary
-        runs-on: ubuntu-20.04
-        permissions:
-            contents: read
-        if: |
-            success() || (
-              failure() && contains( needs.*.result, 'failure' )
-            )
-        needs:
-            - e2e-wp-latest
-            - get-tag
-            - test-php-versions
-            - test-plugins
-            - test-wp-latest-1
-        steps:
-            - uses: actions/checkout@v3
+    # mytodo: re-enable
+    # post-slack-summary:
+    #     name: Post Slack summary
+    #     runs-on: ubuntu-20.04
+    #     permissions:
+    #         contents: read
+    #     if: |
+    #         success() || (
+    #           failure() && contains( needs.*.result, 'failure' )
+    #         )
+    #     needs:
+    #         - e2e-wp-latest
+    #         - get-tag
+    #         - test-php-versions
+    #         - test-plugins
+    #         - test-wp-latest-1
+    #     steps:
+    #         - uses: actions/checkout@v3
 
-            - name: Download all slack blocks
-              id: download-slack-blocks
-              uses: actions/download-artifact@v3
-              with:
-                  name: ${{ env.SLACK_BLOCKS_ARTIFACT }}
-                  path: /tmp/slack-payload
+    #         - name: Download all slack blocks
+    #           id: download-slack-blocks
+    #           uses: actions/download-artifact@v3
+    #           with:
+    #               name: ${{ env.SLACK_BLOCKS_ARTIFACT }}
+    #               path: /tmp/slack-payload
 
-            - name: Construct payload from all blocks
-              id: run-payload-action
-              uses: ./.github/actions/tests/slack-summary-on-release/slack-payload
-              with:
-                  release-version: ${{ needs.get-tag.outputs.tag }}
-                  blocks-dir: ${{ steps.download-slack-blocks.outputs.download-path }}
+    #         - name: Construct payload from all blocks
+    #           id: run-payload-action
+    #           uses: ./.github/actions/tests/slack-summary-on-release/slack-payload
+    #           with:
+    #               release-version: ${{ needs.get-tag.outputs.tag }}
+    #               blocks-dir: ${{ steps.download-slack-blocks.outputs.download-path }}
 
-            - name: Send Slack message
-              uses: slackapi/slack-github-action@v1.23.0
-              with:
-                  channel-id: ${{ secrets.RELEASE_TEST_SLACK_CHANNEL }}
-                  payload: ${{ steps.run-payload-action.outputs.payload }}
-              env:
-                  SLACK_BOT_TOKEN: ${{ secrets.E2E_SLACK_TOKEN }}
+    #         - name: Send Slack message
+    #           uses: slackapi/slack-github-action@v1.23.0
+    #           with:
+    #               channel-id: ${{ secrets.RELEASE_TEST_SLACK_CHANNEL }}
+    #               payload: ${{ steps.run-payload-action.outputs.payload }}
+    #           env:
+    #               SLACK_BOT_TOKEN: ${{ secrets.E2E_SLACK_TOKEN }}

--- a/plugins/woocommerce/changelog/dev-ci-release-fix-api-wp-latest
+++ b/plugins/woocommerce/changelog/dev-ci-release-fix-api-wp-latest
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix "API on WP Latest" job in "Smoke test release" workflow.

--- a/plugins/woocommerce/tests/api-core-tests/ci-release.global-setup.js
+++ b/plugins/woocommerce/tests/api-core-tests/ci-release.global-setup.js
@@ -61,11 +61,10 @@ test( `Setup remote test site`, async ( { page, request } ) => {
 		await page.goto( '/wp-admin/plugin-install.php' );
 		await page.getByRole( 'button', { name: Upload_Plugin } ).click();
 		await page.getByLabel( Plugin_zip_file ).setInputFiles( zipPath );
-		const responsePromise = page.waitForResponse(
-			'**/wp-admin/update.php?action=upload-plugin'
-		);
 		await page.getByRole( 'button', { name: Install_Now } ).click();
-		const uploadResponse = await responsePromise;
+		const uploadResponse = await page.waitForResponse(
+			'**/wp-admin/update.php?action=upload-plugin'
+		);;
 		expect( uploadResponse.ok() ).toBeTruthy();
 		await expect(
 			page.getByRole( 'link', { name: Activate_Plugin } )

--- a/plugins/woocommerce/tests/api-core-tests/ci-release.global-setup.js
+++ b/plugins/woocommerce/tests/api-core-tests/ci-release.global-setup.js
@@ -97,8 +97,7 @@ test( `Setup remote test site`, async ( { page, request } ) => {
 		const response = await request.get( '/wp-json/wc/v3/system_status' );
 		const { database } = await response.json();
 		const { wc_database_version } = database;
-		const major = UPDATE_WC.split( '.' ).at( 0 );
-		const minor = UPDATE_WC.split( '.' ).at( 1 );
+		const [major, minor] = UPDATE_WC.split( '.' );
 		const pattern = new RegExp( `^${ major }\.${ minor }` );
 		expect( wc_database_version ).toMatch( pattern );
 	} );

--- a/plugins/woocommerce/tests/api-core-tests/ci-release.global-setup.js
+++ b/plugins/woocommerce/tests/api-core-tests/ci-release.global-setup.js
@@ -1,0 +1,109 @@
+const { UPDATE_WC, USER_KEY, USER_SECRET } = process.env;
+const { test, expect } = require( '@playwright/test' );
+const path = require( 'path' );
+const fs = require( 'fs' );
+
+const zipPath = path.resolve( 'tmp', 'woocommerce.zip' );
+const downloadURL = `https://github.com/woocommerce/woocommerce/releases/download/${ UPDATE_WC }/woocommerce.zip`;
+
+test( `Setup remote test site`, async ( { page, request } ) => {
+	await test.step( `Download WooCommerce build zip`, async () => {
+		const response = await request.get( downloadURL );
+		expect( response.ok() ).toBeTruthy();
+		const body = await response.body();
+		fs.mkdirSync( 'tmp', { recursive: true } );
+		fs.writeFileSync( zipPath, body );
+	} );
+
+	await test.step( 'Login to wp-admin', async () => {
+		const Username = 'Username or Email Address';
+		const Password = 'Password';
+		const Log_In = 'Log In';
+		const Dashboard = 'Dashboard';
+
+		// Need to wait until network idle. Otherwise, Password field gets auto-cleared after typing password in.
+		await page.goto( '/wp-admin', { waitUntil: 'networkidle' } );
+		await page.getByLabel( Username ).fill( USER_KEY );
+		await page.getByLabel( Password, { exact: true } ).fill( USER_SECRET );
+		await page.getByRole( 'button', { name: Log_In } ).click();
+		await expect(
+			page
+				.locator( '#menu-dashboard' )
+				.getByRole( 'link', { name: Dashboard } )
+		).toBeVisible();
+	} );
+
+	await test.step( `Deactivate currently installed WooCommerce version`, async () => {
+		const response = await request.put(
+			'/wp-json/wp/v2/plugins/woocommerce/woocommerce',
+			{
+				data: {
+					status: 'inactive',
+				},
+			}
+		);
+		expect( response.ok() ).toBeTruthy();
+	} );
+
+	await test.step( `Delete currently installed WooCommerce version`, async () => {
+		const response = await request.delete(
+			'/wp-json/wp/v2/plugins/woocommerce/woocommerce'
+		);
+		expect( response.ok() ).toBeTruthy();
+	} );
+
+	await test.step( `Install WooCommerce ${ UPDATE_WC }`, async () => {
+		const Upload_Plugin = 'Upload Plugin';
+		const Plugin_zip_file = 'Plugin zip file';
+		const Install_Now = 'Install Now';
+		const Activate_Plugin = 'Activate Plugin';
+
+		await page.goto( '/wp-admin/plugin-install.php' );
+		await page.getByRole( 'button', { name: Upload_Plugin } ).click();
+		await page.getByLabel( Plugin_zip_file ).setInputFiles( zipPath );
+		const responsePromise = page.waitForResponse(
+			'**/wp-admin/update.php?action=upload-plugin'
+		);
+		await page.getByRole( 'button', { name: Install_Now } ).click();
+		const uploadResponse = await responsePromise;
+		expect( uploadResponse.ok() ).toBeTruthy();
+		await expect(
+			page.getByRole( 'link', { name: Activate_Plugin } )
+		).toBeVisible();
+	} );
+
+	await test.step( `Activate WooCommerce`, async () => {
+		const response = await request.put(
+			'/wp-json/wp/v2/plugins/woocommerce/woocommerce',
+			{
+				data: {
+					status: 'active',
+				},
+			}
+		);
+		expect( response.ok() ).toBeTruthy();
+	} );
+
+	await test.step( `Verify WooCommerce version was installed`, async () => {
+		const response = await request.get(
+			'/wp-json/wp/v2/plugins/woocommerce/woocommerce'
+		);
+		const { status, version } = await response.json();
+		expect( status ).toEqual( 'active' );
+		expect( version ).toEqual( UPDATE_WC );
+	} );
+
+	await test.step( `Verify WooCommerce database version`, async () => {
+		const response = await request.get( '/wp-json/wc/v3/system_status' );
+		const { database } = await response.json();
+		const { wc_database_version } = database;
+		const major = UPDATE_WC.split( '.' ).at( 0 );
+		const minor = UPDATE_WC.split( '.' ).at( 1 );
+		const pattern = new RegExp( `^${ major }\.${ minor }` );
+		expect( wc_database_version ).toMatch( pattern );
+	} );
+
+	await test.step( `Delete zip`, async () => {
+		fs.unlinkSync( zipPath );
+	} );
+} );

--- a/plugins/woocommerce/tests/api-core-tests/ci-release.playwright.config.js
+++ b/plugins/woocommerce/tests/api-core-tests/ci-release.playwright.config.js
@@ -1,0 +1,24 @@
+const defaultConfig = require( './playwright.config' );
+
+// Global setup will be done through the 'Setup' project, not through the `globalSetup` property
+delete defaultConfig[ 'globalSetup' ];
+
+/**
+ * @type {import('@playwright/test').PlaywrightTestConfig}
+ */
+const config = {
+	...defaultConfig,
+	projects: [
+		{
+			name: 'Setup',
+			testDir: './',
+			testMatch: 'ci-release.global-setup.js',
+		},
+		{
+			name: 'API tests',
+			dependencies: [ 'Setup' ],
+		},
+	],
+};
+
+module.exports = config;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes the broken "API on WP Latest" job in our release tests.

Cause of the failure: Our "Smoke test release" workflow doesn't download the chromium browser, which is needed by the API tests in order to execute the recently added `plugins/woocommerce/tests/api-core-tests/global-setup.js`. So I added a step to download it. But a new problem came after: The global setup consistently fails when logging in to wp-admin. It was difficult to debug because `global-setup.js` doesn't provide traces, screenshots, and videos for debugging.

Final solution I went with: I created two files to be used by the "Smoke test release" workflow:
1. A dedicated playwright config named `ci-release.playwright.config.js`, and
2. A "Setup" Playwright project that's similar to what `global-setup.js` does, but creates traces, screenshots, and videos for debugging. This project uses the `ci-release.global-setup.js` file.
    - This global setup file uses Playwright's `request` object to simplify downloading of the required WooCommerce buid zip without using the `utils` folder from the E2E tests.

I didn't touch the `global-setup.js` file because it's being used in the daily tests and might mess things up there, and also to keep the focus of this PR on fixing the API tests on the release testing workflow. It would be good to have a single `global-setup.js` and Playwright config exclusively for CI runs. I'm planning to submit a PR to do just that after this.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Verify that the check "Run API tests" in this PR passes.
4. Go to [Smoke test release](https://github.com/woocommerce/woocommerce/actions/workflows/smoke-test-release.yml).
5. In the "Run workflow" menu, select this branch.
6. Enter any recent `8.2` release tag like `8.2.0-a.1` into the `WooCommerce Release Tag` field.
7. Click the green "Run workflow" button.
8. Wait for the workflow to finish.
9. Verify that the "API on WP Latest" job passes.
    

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
