### PR TITLE
Tweak flaky meta data save test

### DIFF
--- a/plugins/woocommerce/changelog/tweak-flaky-meta-data-save-test
+++ b/plugins/woocommerce/changelog/tweak-flaky-meta-data-save-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Tweak a flaky test for meta data saving

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2953,7 +2953,7 @@ CREATE TABLE $meta_table (
 	 *
 	 * @return bool Whether the modified date needs to be updated.
 	 */
-    private function should_save_after_meta_change( $order, $meta = null ) {
+	private function should_save_after_meta_change( $order, $meta = null ) {
 		$current_time      = $this->legacy_proxy->call_function( 'current_time', 'mysql', 1 );
 		$current_date_time = new \WC_DateTime( $current_time, new \DateTimeZone( 'GMT' ) );
 		$skip_for          = array(

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2953,12 +2953,12 @@ CREATE TABLE $meta_table (
 	 *
 	 * @return bool Whether the modified date needs to be updated.
 	 */
-	private function should_save_after_meta_change( $order, $meta = null ) {
-		$skip_for = array(
+    private function should_save_after_meta_change( $order, $meta = null ) {
+		$current_time      = $this->legacy_proxy->call_function( 'current_time', 'mysql', 1 );
+		$current_date_time = new \WC_DateTime( $current_time, new \DateTimeZone( 'GMT' ) );
+		$skip_for          = array(
 			EditLock::META_KEY_NAME,
 		);
-
-		$current_date_time = new \WC_DateTime( current_time( 'mysql', 1 ), new \DateTimeZone( 'GMT' ) );
 		return $order->get_date_modified() < $current_date_time && empty( $order->get_changes() ) && ( ! is_object( $meta ) || ! in_array( $meta->key, $skip_for, true ) );
 	}
 }

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Helpers/OrderHelper.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Helpers/OrderHelper.php
@@ -165,7 +165,7 @@ class OrderHelper {
 
 		// Confirm things are really correct.
 		$wc_data_store = WC_Data_Store::load( 'order' );
-		assert( is_a( $wc_data_store->get_current_class_name(), OrdersTableDataStore::class, true ) === $enabled, 'data store\'s classname is "' . $wc_data_store->get_current_class_name() . '", but $enabled is "' . var_export( boolval( $enabled ), true ) . '"' );
+		assert( is_a( $wc_data_store->get_current_class_name(), OrdersTableDataStore::class, true ) === $enabled, 'data store\'s classname is "' . $wc_data_store->get_current_class_name() . '", but $enabled is "' . ( $enabled ? 'true' : 'false' ) . '"' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Helpers/OrderHelper.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Helpers/OrderHelper.php
@@ -165,7 +165,7 @@ class OrderHelper {
 
 		// Confirm things are really correct.
 		$wc_data_store = WC_Data_Store::load( 'order' );
-		assert( is_a( $wc_data_store->get_current_class_name(), OrdersTableDataStore::class, true ) === $enabled );
+		assert( is_a( $wc_data_store->get_current_class_name(), OrdersTableDataStore::class, true ) === $enabled, 'data store\'s classname is "' . $wc_data_store->get_current_class_name() . '", but $enabled is "' . var_export( boolval( $enabled ), true ) . '"' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -3070,6 +3070,9 @@ class OrdersTableDataStoreTests extends HposTestCase {
 		$this->toggle_cot_authoritative( true );
 		$this->enable_cot_sync();
 
+		$orders_table_data_store = fn() => wc_get_container()->get( OrdersTableDataStore::class );
+		add_filter( 'woocommerce_order_data_store', $orders_table_data_store, 1000, 0 );
+
 		$order = wc_create_order();
 
 		assert( empty( $order->get_changes() ), 'Order was not saved properly, test cannot continue.' );
@@ -3081,7 +3084,8 @@ class OrdersTableDataStoreTests extends HposTestCase {
 		$order->save();
 
 		$this->assertTrue( $call_private->call( $this->sut, $order ) );
-
+	
+		// count the calls to the filter to ensure it's called only once.
 		$count = 0;
 		add_filter(
 			'woocommerce_before_order_object_save',
@@ -3092,14 +3096,16 @@ class OrdersTableDataStoreTests extends HposTestCase {
 
 		/**
 		 * fix for previously flaky test:
-		 * less than a second of time passes while the following saves happen.
+		 * freeze time to ensure less than a second passes while the following saves happen.
 		 */
-		$datetime = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
-		$now      = $datetime->format( 'Y-m-d H:i:s' );
-		$this->reset_legacy_proxy_mocks();
+		$current_time_called = false;
+		$datetime            = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
+		$now                 = $datetime->format( 'Y-m-d H:i:s' );
+		
 		$this->register_legacy_proxy_function_mocks(
 			array(
-				'current_time' => function( $type, $gmt ) {
+				'current_time' => function( $type, $gmt ) use ( &$current_time_called, $now ) {
+					$current_time_called = true;
 					return $now;
 				},
 			)
@@ -3117,6 +3123,9 @@ class OrdersTableDataStoreTests extends HposTestCase {
 		$order->save_meta_data();
 
 		$this->assertEquals( 1, $count );
+		$this->assertTrue( $current_time_called, 'current_time mock was not called' );
+
+		remove_filter( 'woocommerce_order_data_store', $orders_table_data_store, 1000 );
 		remove_all_actions( 'woocommerce_before_order_object_save' );
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -3090,6 +3090,7 @@ class OrdersTableDataStoreTests extends HposTestCase {
 			}
 		);
 
+		$time = time();
 		$order->add_meta_data( 'key1', 'value' );
 		$order->save_meta_data();
 		$order->add_meta_data( 'key2', 'value' );
@@ -3100,7 +3101,12 @@ class OrdersTableDataStoreTests extends HposTestCase {
 		$order->save_meta_data();
 		$order->delete_meta_data( 'key1' );
 		$order->save_meta_data();
-		$this->assertEquals( 1, $count );
+
+		$expected_saves = 1;
+		if ( $time < time() ) {
+			$expected_saves = 2;
+		}
+		$this->assertEquals( $expected_saves, $count );
 		remove_all_actions( 'woocommerce_before_order_object_save' );
 	}
 

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -3084,7 +3084,7 @@ class OrdersTableDataStoreTests extends HposTestCase {
 		$order->save();
 
 		$this->assertTrue( $call_private->call( $this->sut, $order ) );
-	
+
 		// count the calls to the filter to ensure it's called only once.
 		$count = 0;
 		add_filter(
@@ -3101,7 +3101,7 @@ class OrdersTableDataStoreTests extends HposTestCase {
 		$current_time_called = false;
 		$datetime            = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
 		$now                 = $datetime->format( 'Y-m-d H:i:s' );
-		
+
 		$this->register_legacy_proxy_function_mocks(
 			array(
 				'current_time' => function( $type, $gmt ) use ( &$current_time_called, $now ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The `test_order_save_is_not_called_frequently_on_meta_save` test was flaky a few times before, most likely caused by a timing issue (cf. [`should_save_after_meta_change`](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php#L2956)). This PR adds the possibility of `time()` having advanced during the five calls to `save_meta_data`. 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. ensure CI passes
2. ensure the updated test looks good still

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
