### PR TITLE
Fix: HPOS keeping disabled when the database tables were created via enabling the setting

### DIFF
--- a/plugins/woocommerce/changelog/pr-40466
+++ b/plugins/woocommerce/changelog/pr-40466
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Fix: HPOS keeping disabled when the database tables were created via enabling the setting

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -253,23 +253,6 @@ class CustomOrdersTableController {
 	}
 
 	/**
-	 * Create the custom orders tables in response to the user pressing the tool button.
-	 *
-	 * @param bool $verify_nonce True to perform the nonce verification, false to skip it.
-	 *
-	 * @throws \Exception Can't create the tables.
-	 */
-	private function create_custom_orders_tables( bool $verify_nonce = true ) {
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput
-		if ( $verify_nonce && ( ! isset( $_REQUEST['_wpnonce'] ) || wp_verify_nonce( $_REQUEST['_wpnonce'], 'debug_action' ) === false ) ) {
-			throw new \Exception( 'Invalid nonce' );
-		}
-
-		$this->data_synchronizer->create_database_tables();
-		update_option( self::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, 'no' );
-	}
-
-	/**
 	 * Delete the custom orders tables and any related options and data in response to the user pressing the tool button.
 	 *
 	 * @throws \Exception Can't delete the tables.
@@ -371,7 +354,10 @@ class CustomOrdersTableController {
 		}
 
 		if ( ! $this->data_synchronizer->check_orders_table_exists() ) {
-			$this->create_custom_orders_tables( false );
+			$success = $this->data_synchronizer->create_database_tables();
+			if ( ! $success ) {
+				update_option( self::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, 'no' );
+			}
 		}
 	}
 
@@ -467,7 +453,7 @@ class CustomOrdersTableController {
 			'disabled'    => $disabled_option,
 			'desc'        => $plugin_incompat_warning,
 			'desc_at_end' => true,
-			'row_class' => self::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION,
+			'row_class'   => self::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION,
 		);
 	}
 
@@ -501,10 +487,12 @@ class CustomOrdersTableController {
 				wc_get_container()->get( FeaturesController::class )->get_features_page_url()
 			);
 
-			$sync_message[] = wp_kses_data( __(
-				'You can switch order data storage <strong>only when the posts and orders tables are in sync</strong>.',
-				'woocommerce'
-			) );
+			$sync_message[] = wp_kses_data(
+				__(
+					'You can switch order data storage <strong>only when the posts and orders tables are in sync</strong>.',
+					'woocommerce'
+				)
+			);
 
 			$sync_message[] = sprintf(
 				'<a href="%1$s" class="button button-link">%2$s</a>',

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -175,11 +175,19 @@ class DataSynchronizer implements BatchProcessorInterface {
 	}
 
 	/**
-	 * Create the custom orders database tables.
+	 * Create the custom orders database tables and log an error if that's not possible.
+	 *
+	 * @return bool True if all the tables were successfully created, false otherwise.
 	 */
 	public function create_database_tables() {
 		$this->database_util->dbdelta( $this->data_store->get_database_schema() );
-		$this->check_orders_table_exists();
+		$success = $this->check_orders_table_exists();
+		if ( ! $success ) {
+			$missing_tables = $this->database_util->get_missing_tables( $this->data_store->get_database_schema() );
+			$missing_tables = implode( ', ', $missing_tables );
+			$this->error_logger->error( "HPOS tables are missing in the database and couldn't be created. The missing tables are: $missing_tables" );
+		}
+		return $success;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Utilities/DatabaseUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/DatabaseUtil.php
@@ -52,7 +52,7 @@ class DatabaseUtil {
 
 		foreach ( $dbdelta_output as $table_name => $result ) {
 			if ( "Created table $table_name" === $result ) {
-				$created_tables[] = $table_name;
+				$created_tables[] = str_replace( '(', '', $table_name );
 			}
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When the HPOS tables don't exist and are created on the fly by setting the new tables as authoritative (via the dedicated UI tool, or by setting the new tables as authoritative in setting), the setting wasn't changing and the posts table were still authoritative after the tables creation was completed. With the fix, this will be the case only when the creation of the tables fails.

Additionally:

* An error is logged if the tables can't be created, including the names of the affected tables.
* A minor bug in `DatabaseUtil::parse_dbdelta_output` is fixed (the returned table names had a `(` appended at the end).

### How to test the changes in this Pull Request:

### Happy path

1. Make sure that the posts table is authoritative (via UI, in WooCommerce - Settings - Advanced - Features; or via command line, `wp wc cot disable`).
2. Go to WooCommerce - Status - Tools and run the "Delete the custom order tables" tool. Verify that the tables have been deleted (e.g. `wp_wc_orders`).
3. Change to the new tables as authoritative (via UI or via command line, `wp wc cot enable`).
4. Verify that the new tables have been recreated and that thet are indeed authoritative by reloading the settings page in UI (without the fix, the posts table will still be authoritative).

### Error path

To test the error case you'll need to do some temporary changes to the code (there's no need to delete the tables this time, just apply these changes while the new tables are authoritative):

1. Remove/comment the first table of `DataSyncrhonizer::create_database_tables` (the one that invokes `dbdelta`).
2. Add the following at the end of the string returned by `OrdersTableDataStore::get_database_schema`:

```
CREATE TABLE wp_wc_foobar (id int);
CREATE TABLE wp_wc_fizzbuzz (id int);
```

Now try to set the new tables as authoritative with `wp wc cot enable`. You'll get a " [Failed] Orders table could not be created" error, the posts table will be authoritative now, and if you check the logs you'll see the following entry: _ERROR HPOS tables are missing in the database and couldn't be created. The missing tables are: wp_wc_foobar, wp_wc_fizzbuzz_.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Fix: HPOS keeping disabled when the database tables were created via enabling the setting

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
