### PR TITLE
Correctly set 'created_via' for HPOS orders created on the admin

### DIFF
--- a/plugins/woocommerce/changelog/fix-created-via-admin-hpos
+++ b/plugins/woocommerce/changelog/fix-created-via-admin-hpos
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Correctly set 'created_via' for HPOS orders created on the admin.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php
@@ -384,6 +384,7 @@ class PageController {
 		$this->order = new $order_class_name();
 		$this->order->set_object_read( false );
 		$this->order->set_status( 'auto-draft' );
+		$this->order->set_created_via( 'admin' );
 		$this->order->save();
 		$this->handle_edit_lock();
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
CPT-based orders created on the admin have their `created_via` property set to `admin`, but this isn't happening for HPOS orders.
Even though HPOS calls the same code [to set some of the order properties](https://github.com/woocommerce/woocommerce/blob/8685fd211ed12c0f2834fde5559a8ec3892791ed/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php#L100), the part that sets the `created_via` property depends on the presence of certain fields [that are only available in the edit post screen](https://github.com/woocommerce/woocommerce/blob/8c55e53772a20a84f7071089dbf1675bc7dceb02/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php#L702-L704).

This PR makes sure HPOS mimics the CPT behavior for backwards compatibility.

Closes #40465.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure HPOS is enabled on WooCommerce > Settings > Advanced > Features.
2. Go to WC > Orders.
3. Click **Add order**.
4. Enter any details and click **Create**. Take note of the order ID.
5. Use WP-CLI to confirm that the order you just created has its `created_via` property to `admin`:
   ```wp eval 'echo wc_get_order( ORDER_ID )->get_created_via();'```

   Replace `ORDER_ID` with the order ID from step 4.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
