### PR TITLE
Update WooCommerce Blocks to version to 11.2.0

### DIFF
--- a/plugins/woocommerce/bin/composer/wp/composer.lock
+++ b/plugins/woocommerce/bin/composer/wp/composer.lock
@@ -373,16 +373,16 @@
         },
         {
             "name": "wp-cli/i18n-command",
-            "version": "v2.4.3",
+            "version": "v2.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/i18n-command.git",
-                "reference": "203b020318fe2596a218bf52db25adc6b187f42d"
+                "reference": "7d82e675f271359b1af614e6325d8eeaeb7d7474"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/i18n-command/zipball/203b020318fe2596a218bf52db25adc6b187f42d",
-                "reference": "203b020318fe2596a218bf52db25adc6b187f42d",
+                "url": "https://api.github.com/repos/wp-cli/i18n-command/zipball/7d82e675f271359b1af614e6325d8eeaeb7d7474",
+                "reference": "7d82e675f271359b1af614e6325d8eeaeb7d7474",
                 "shasum": ""
             },
             "require": {
@@ -393,7 +393,7 @@
             },
             "require-dev": {
                 "wp-cli/scaffold-command": "^1.2 || ^2",
-                "wp-cli/wp-cli-tests": "^3.1"
+                "wp-cli/wp-cli-tests": "^4"
             },
             "suggest": {
                 "ext-json": "Used for reading and generating JSON translation files",
@@ -435,9 +435,9 @@
             "homepage": "https://github.com/wp-cli/i18n-command",
             "support": {
                 "issues": "https://github.com/wp-cli/i18n-command/issues",
-                "source": "https://github.com/wp-cli/i18n-command/tree/v2.4.3"
+                "source": "https://github.com/wp-cli/i18n-command/tree/v2.4.4"
             },
-            "time": "2023-03-24T18:15:59+00:00"
+            "time": "2023-08-30T18:00:10+00:00"
         },
         {
             "name": "wp-cli/mustangostang-spyc",
@@ -492,16 +492,16 @@
         },
         {
             "name": "wp-cli/php-cli-tools",
-            "version": "v0.11.19",
+            "version": "v0.11.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/php-cli-tools.git",
-                "reference": "2d27f0db5c36f5aa0064abecddd6d05f28c4d001"
+                "reference": "d788a2c79e02f2f735fbb2b9a53db94d0e1bca4f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/php-cli-tools/zipball/2d27f0db5c36f5aa0064abecddd6d05f28c4d001",
-                "reference": "2d27f0db5c36f5aa0064abecddd6d05f28c4d001",
+                "url": "https://api.github.com/repos/wp-cli/php-cli-tools/zipball/d788a2c79e02f2f735fbb2b9a53db94d0e1bca4f",
+                "reference": "d788a2c79e02f2f735fbb2b9a53db94d0e1bca4f",
                 "shasum": ""
             },
             "require": {
@@ -509,7 +509,7 @@
             },
             "require-dev": {
                 "roave/security-advisories": "dev-latest",
-                "wp-cli/wp-cli-tests": "^3.1.6"
+                "wp-cli/wp-cli-tests": "^4"
             },
             "type": "library",
             "extra": {
@@ -549,9 +549,9 @@
             ],
             "support": {
                 "issues": "https://github.com/wp-cli/php-cli-tools/issues",
-                "source": "https://github.com/wp-cli/php-cli-tools/tree/v0.11.19"
+                "source": "https://github.com/wp-cli/php-cli-tools/tree/v0.11.20"
             },
-            "time": "2023-07-21T11:37:15+00:00"
+            "time": "2023-09-01T12:21:35+00:00"
         },
         {
             "name": "wp-cli/wp-cli",

--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-11.2.0
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-11.2.0
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update WooCommerce Blocks to 11.2.0

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -17,13 +17,13 @@
 		"php": ">=7.4",
 		"automattic/jetpack-autoloader": "2.11.18",
 		"automattic/jetpack-config": "1.15.2",
-		"automattic/jetpack-connection": "1.51.7",
+		"automattic/jetpack-connection": "^1.57",
 		"automattic/jetpack-constants": "^1.6.22",
 		"composer/installers": "^1.9",
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.6.3",
-		"woocommerce/woocommerce-blocks": "11.1.1"
+		"woocommerce/woocommerce-blocks": "11.2.0"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.3.0",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e5800331e1c25cd08ad877b665da724f",
+    "content-hash": "6dbaa76c3a13dc3d312b2ad734d0bc91",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -206,28 +206,28 @@
         },
         {
             "name": "automattic/jetpack-connection",
-            "version": "v1.51.7",
+            "version": "v1.57.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-connection.git",
-                "reference": "4c4bae836858957d9aaf6854cf4e24c3261242c4"
+                "reference": "d6c83b19aef56cc08a8314e84ab79e66cfbf3e03"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-connection/zipball/4c4bae836858957d9aaf6854cf4e24c3261242c4",
-                "reference": "4c4bae836858957d9aaf6854cf4e24c3261242c4",
+                "url": "https://api.github.com/repos/Automattic/jetpack-connection/zipball/d6c83b19aef56cc08a8314e84ab79e66cfbf3e03",
+                "reference": "d6c83b19aef56cc08a8314e84ab79e66cfbf3e03",
                 "shasum": ""
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "^1.4.20",
-                "automattic/jetpack-admin-ui": "^0.2.19",
+                "automattic/jetpack-admin-ui": "^0.2.20",
                 "automattic/jetpack-constants": "^1.6.22",
                 "automattic/jetpack-redirect": "^1.7.25",
                 "automattic/jetpack-roles": "^1.4.23",
-                "automattic/jetpack-status": "^1.16.4"
+                "automattic/jetpack-status": "^1.18.0"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^3.3.2",
+                "automattic/jetpack-changelogger": "^3.3.7",
                 "automattic/wordbless": "@dev",
                 "brain/monkey": "2.6.1",
                 "yoast/phpunit-polyfills": "1.0.4"
@@ -247,7 +247,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "1.51.x-dev"
+                    "dev-trunk": "1.57.x-dev"
                 }
             },
             "autoload": {
@@ -263,9 +263,9 @@
             ],
             "description": "Everything needed to connect to the Jetpack infrastructure",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-connection/tree/v1.51.7"
+                "source": "https://github.com/Automattic/jetpack-connection/tree/v1.57.0"
             },
-            "time": "2023-04-10T11:44:13+00:00"
+            "time": "2023-08-21T17:33:13+00:00"
         },
         {
             "name": "automattic/jetpack-constants",
@@ -1004,20 +1004,22 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "11.1.1",
+            "version": "11.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "81bff865d7fdd7de40a4da8fc49539a124ac1863"
+                "reference": "86e93ddd06606100e199fdae049baaa5754c2a17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/81bff865d7fdd7de40a4da8fc49539a124ac1863",
-                "reference": "81bff865d7fdd7de40a4da8fc49539a124ac1863",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/86e93ddd06606100e199fdae049baaa5754c2a17",
+                "reference": "86e93ddd06606100e199fdae049baaa5754c2a17",
                 "shasum": ""
             },
             "require": {
-                "automattic/jetpack-autoloader": "^2.9.1",
+                "automattic/jetpack-autoloader": "^2.11",
+                "automattic/jetpack-config": "^1.15",
+                "automattic/jetpack-connection": "^1.57",
                 "composer/installers": "^1.7.0",
                 "ext-hash": "*",
                 "ext-json": "*"
@@ -1062,9 +1064,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v11.1.1"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v11.2.0"
             },
-            "time": "2023-09-20T10:14:34+00:00"
+            "time": "2023-09-27T17:36:02+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This pull updates the WooCommerce Blocks plugin to 11.2.0. It includes changes from WooCommerce Blocks 11.2.0 and is intended to target WooCommerce 8.3 for release.

Details from all the different releases included in this pull:

## Blocks 11.2.0
* [Release PR](https://github.com/woocommerce/woocommerce-blocks/pull/11052)
* [Testing Instructions](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/1120.md)
* [Release Post](https://developer.woocommerce.com/2023/09/29/woocommerce-blocks-11-2-0-release-notes/)

### Changelog entry

### The following changelog entries are only those that impact existing blocks and functionality surfaced to users:

#### Enhancements

- Remove order and checkout order endpoints experimental flag. ([11022](https://github.com/woocommerce/woocommerce-blocks/pull/11022))
- Ensure the content of the patterns is also AI-generated. ([10997](https://github.com/woocommerce/woocommerce-blocks/pull/10997))
- Product Collection: Transfer layout options from Toolbar to Inspector controls. ([10922](https://github.com/woocommerce/woocommerce-blocks/pull/10922))
- Add pattern chooser in Product Collection. ([10876](https://github.com/woocommerce/woocommerce-blocks/pull/10876))
- Product Gallery: Lock the Sale Badge and the Next/Prev Buttons. ([10869](https://github.com/woocommerce/woocommerce-blocks/pull/10869))
- Refactor Cart and Checkout Page Templates. ([10773](https://github.com/woocommerce/woocommerce-blocks/pull/10773))
-  Blockified Order Confirmation. ([10056](https://github.com/woocommerce/woocommerce-blocks/pull/10056))

#### Bug Fixes

- Product Gallery: Fix the Product Gallery Thumbnails on click. ([11032](https://github.com/woocommerce/woocommerce-blocks/pull/11032))
- WooExpress: Fix Checkout and Cart Blocks Editor Crash. ([11024](https://github.com/woocommerce/woocommerce-blocks/pull/11024))
- Product Gallery: Fix zoom animation on large Image. ([11023](https://github.com/woocommerce/woocommerce-blocks/pull/11023))
- Fix: Password Protection not respected on single product template. ([10999](https://github.com/woocommerce/woocommerce-blocks/pull/10999))
- Product Gallery Pager: Remove the Pager markup if there's only one image. ([10998](https://github.com/woocommerce/woocommerce-blocks/pull/10998))
- Related Products: Hide the block outside of Single Product Template and Single Product block. ([10978](https://github.com/woocommerce/woocommerce-blocks/pull/10978))
- Single Product: Fix the Align setting. ([10977](https://github.com/woocommerce/woocommerce-blocks/pull/10977))
- Hide unexpected bullet point in Product Collection on Storefront. ([10945](https://github.com/woocommerce/woocommerce-blocks/pull/10945))
- Add custom regex for validating Nicaraguan postal codes. ([10928](https://github.com/woocommerce/woocommerce-blocks/pull/10928))
- Update `postcode-validator` to 3.8.15 to validate "new" Taiwanese postcodes. ([10924](https://github.com/woocommerce/woocommerce-blocks/pull/10924))
- BlockTemplatesController: Check that $attributes['theme'] value isset before operating on it. ([10879](https://github.com/woocommerce/woocommerce-blocks/pull/10879))
- Product Gallery: CSS styling tightening up. ([10867](https://github.com/woocommerce/woocommerce-blocks/pull/10867))
- Checkout Block: Prevent changes in the selected shipping method when new rates are added or removed. ([10457](https://github.com/woocommerce/woocommerce-blocks/pull/10457))


### Changelog entry
> Dev - Update WooCommerce Blocks version to 11.2.0