### PR TITLE
[Customize Your Store] Add track events to intro page

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/index.tsx
@@ -186,19 +186,23 @@ export const customizeStoreStateMachineDefinition = createMachine( {
 				},
 			},
 			on: {
-				DESIGN_WITH_AI: {
-					target: 'designWithAi',
-				},
-				SELECTED_ACTIVE_THEME: {
-					target: 'assemblerHub',
-				},
 				CLICKED_ON_BREADCRUMB: {
 					actions: 'redirectToWooHome',
 				},
+				DESIGN_WITH_AI: {
+					actions: [ 'recordTracksDesignWithAIClicked' ],
+					target: 'designWithAi',
+				},
 				SELECTED_NEW_THEME: {
+					actions: [ 'recordTracksThemeSelected' ],
+					target: 'appearanceTask',
+				},
+				SELECTED_ACTIVE_THEME: {
+					actions: [ 'recordTracksThemeSelected' ],
 					target: 'appearanceTask',
 				},
 				SELECTED_BROWSE_ALL_THEMES: {
+					actions: [ 'recordTracksBrowseAllThemesClicked' ],
 					target: 'appearanceTask',
 				},
 			},

--- a/plugins/woocommerce-admin/client/customize-store/intro/actions.ts
+++ b/plugins/woocommerce-admin/client/customize-store/intro/actions.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { assign, DoneInvokeEvent } from 'xstate';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -13,6 +14,7 @@ import { customizeStoreStateMachineEvents } from '..';
  */
 import { customizeStoreStateMachineContext } from '../types';
 import { ThemeCard } from './theme-cards';
+import { events } from './';
 
 export const assignThemeCards = assign<
 	customizeStoreStateMachineContext,
@@ -23,3 +25,24 @@ export const assignThemeCards = assign<
 		return { ...context.intro, themeCards };
 	},
 } );
+
+export const recordTracksDesignWithAIClicked = () => {
+	recordEvent( 'customize_your_store_intro_design_with_ai_click' );
+};
+
+export const recordTracksThemeSelected = (
+	_context: customizeStoreStateMachineContext,
+	event: Extract<
+		events,
+		{ type: 'SELECTED_ACTIVE_THEME' | 'SELECTED_NEW_THEME' }
+	>
+) => {
+	recordEvent( 'wcadmin_customize_your_store_intro_theme_select', {
+		theme: event.payload.theme,
+		is_active: event.type === 'SELECTED_ACTIVE_THEME' ? 'yes' : 'no',
+	} );
+};
+
+export const recordTracksBrowseAllThemesClicked = () => {
+	recordEvent( 'customize_your_store_intro_browse_all_themes_click' );
+};

--- a/plugins/woocommerce-admin/client/customize-store/intro/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/intro/index.tsx
@@ -4,6 +4,7 @@
 
 import { __ } from '@wordpress/i18n';
 import { chevronLeft } from '@wordpress/icons';
+import { Button } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -16,7 +17,7 @@ export type events =
 	| { type: 'DESIGN_WITH_AI' }
 	| { type: 'CLICKED_ON_BREADCRUMB' }
 	| { type: 'SELECTED_BROWSE_ALL_THEMES' }
-	| { type: 'SELECTED_ACTIVE_THEME' }
+	| { type: 'SELECTED_ACTIVE_THEME'; payload: { theme: string } }
 	| { type: 'SELECTED_NEW_THEME'; payload: { theme: string } };
 
 export * as actions from './actions';
@@ -89,7 +90,24 @@ export const Intro: CustomizeStoreComponent = ( { sendEvent, context } ) => {
 
 					<div className="woocommerce-customize-store-theme-cards">
 						{ themeCards?.map( ( themeCard ) => (
-							<div className="theme-card" key={ themeCard.slug }>
+							<Button
+								variant="link"
+								className="theme-card"
+								key={ themeCard.slug }
+								onClick={ () => {
+									if ( themeCard.isActive ) {
+										sendEvent( {
+											type: 'SELECTED_ACTIVE_THEME',
+											payload: { theme: themeCard.slug },
+										} );
+									} else {
+										sendEvent( {
+											type: 'SELECTED_NEW_THEME',
+											payload: { theme: themeCard.slug },
+										} );
+									}
+								} }
+							>
 								<div>
 									<img
 										src={ themeCard.image }
@@ -99,7 +117,7 @@ export const Intro: CustomizeStoreComponent = ( { sendEvent, context } ) => {
 								<h2 className="theme-card__title">
 									{ themeCard.name }
 								</h2>
-							</div>
+							</Button>
 						) ) }
 					</div>
 
@@ -114,14 +132,6 @@ export const Intro: CustomizeStoreComponent = ( { sendEvent, context } ) => {
 							{ __( 'Browse all themes', 'woocommerce' ) }
 						</button>
 					</div>
-
-					<button
-						onClick={ () =>
-							sendEvent( { type: 'SELECTED_ACTIVE_THEME' } )
-						}
-					>
-						Assembler Hub
-					</button>
 				</div>
 			</div>
 		</>

--- a/plugins/woocommerce-admin/client/customize-store/intro/intro.scss
+++ b/plugins/woocommerce-admin/client/customize-store/intro/intro.scss
@@ -124,6 +124,8 @@
 
 	.theme-card {
 		flex-basis: 45%;
+		display: block;
+		text-decoration: none;
 
 		img {
 			border-radius: 4px;

--- a/plugins/woocommerce-admin/client/customize-store/intro/services.ts
+++ b/plugins/woocommerce-admin/client/customize-store/intro/services.ts
@@ -8,6 +8,7 @@ export const fetchThemeCards = async () => {
 			description: 'The default theme for WordPress.',
 			image: 'https://i0.wp.com/s2.wp.com/wp-content/themes/pub/twentytwentyone/screenshot.png',
 			styleVariations: [],
+			isActive: true,
 		},
 		{
 			slug: 'twentytwenty',

--- a/plugins/woocommerce/changelog/add-cys-intro-tracks
+++ b/plugins/woocommerce/changelog/add-cys-intro-tracks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add tracks to cys intro page


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #40125.

Add tracks:

- % of users that click on “Design with AI”
- % of users that proceed with a theme
- % of users that click on “Browse all themes”.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Use WP 6.3 
2. Install the `WooCommerce Beta Tester` plugin
3. Go to /wp-admin/tools.php?page=woocommerce-admin-test-helper and enable `customize-store` feature flag
4. Open your browser developer console and run `localStorage.setItem( 'debug', 'wc-admin:*' );` to set debug for tracks
5. Go to `/wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store`
6. Click on `Design with AI`
7. Observe that `wcadmin_customize_your_store_intro_design_with_ai_click` event is recorded
8. Go back to intro page
9. Click on TT1 theme
10. Observe that `wcadmin_wcadmin_customize_your_store_intro_theme_select ` event event is recorded with theme = `twentytwentyone` and is_active = `yes`
11. Reload the page
12. Click on other theme
13. Observe that `wcadmin_wcadmin_customize_your_store_intro_theme_select ` event event is recorded with theme = `[theme you selected]` and is_active = `no`
14. Reload the page
15. Click on `Browse all themes` button
16. Observe that `wcadmin_customize_your_store_intro_browse_all_themes_click` event is recorded 


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
