### PR TITLE
[Customize Your Store] Switch Theme to TT3

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/services.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/services.ts
@@ -373,6 +373,31 @@ export const assembleSite = async (
 	}
 };
 
+const installAndActivateTheme = async () => {
+	const themeSlug = 'twentytwentythree';
+
+	try {
+		await apiFetch( {
+			path: `/wc-admin/onboarding/themes/install?theme=${ themeSlug }`,
+			method: 'POST',
+		} );
+
+		await apiFetch( {
+			path: `/wc-admin/onboarding/themes/activate?theme=${ themeSlug }&theme_switch_via_cys_ai_loader=1`,
+			method: 'POST',
+		} );
+	} catch ( error ) {
+		recordEvent(
+			'customize_your_store_ai_install_and_activate_theme_error',
+			{
+				theme: themeSlug,
+				error: error instanceof Error ? error.message : 'unknown',
+			}
+		);
+		throw error;
+	}
+};
+
 const saveAiResponseToOption = ( context: designWithAiStateMachineContext ) => {
 	return dispatch( OPTIONS_STORE_NAME ).updateOptions( {
 		woocommerce_customize_store_ai_suggestions: context.aiSuggestions,
@@ -386,4 +411,5 @@ export const services = {
 	assembleSite,
 	updateStorePatterns,
 	saveAiResponseToOption,
+	installAndActivateTheme,
 };

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/state-machine.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/state-machine.tsx
@@ -287,113 +287,113 @@ export const designWithAiStateMachineDefinition = createMachine(
 						],
 						type: 'parallel',
 						states: {
-							// chooseColorPairing: {
-							// 	initial: 'pending',
-							// 	states: {
-							// 		pending: {
-							// 			invoke: {
-							// 				src: 'queryAiEndpoint',
-							// 				data: ( context ) => {
-							// 					return {
-							// 						...defaultColorPalette,
-							// 						prompt: defaultColorPalette.prompt(
-							// 							context
-							// 								.businessInfoDescription
-							// 								.descriptionText,
-							// 							context.lookAndFeel
-							// 								.choice,
-							// 							context.toneOfVoice
-							// 								.choice
-							// 						),
-							// 					};
-							// 				},
-							// 				onDone: {
-							// 					actions: [
-							// 						'assignDefaultColorPalette',
-							// 					],
-							// 					target: 'success',
-							// 				},
-							// 				// If there's an error we don't want to block the user from proceeding.
-							// 				onError: {
-							// 					target: 'success',
-							// 				},
-							// 			},
-							// 		},
-							// 		success: { type: 'final' },
-							// 	},
-							// },
-							// chooseFontPairing: {
-							// 	initial: 'pending',
-							// 	states: {
-							// 		pending: {
-							// 			invoke: {
-							// 				src: 'queryAiEndpoint',
-							// 				data: ( context ) => {
-							// 					return {
-							// 						...fontPairings,
-							// 						prompt: fontPairings.prompt(
-							// 							context
-							// 								.businessInfoDescription
-							// 								.descriptionText,
-							// 							context.lookAndFeel
-							// 								.choice,
-							// 							context.toneOfVoice
-							// 								.choice
-							// 						),
-							// 					};
-							// 				},
-							// 				onDone: {
-							// 					actions: [
-							// 						'assignFontPairing',
-							// 					],
-							// 					target: 'success',
-							// 				},
-							// 				// If there's an error we don't want to block the user from proceeding.
-							// 				onError: {
-							// 					target: 'success',
-							// 				},
-							// 			},
-							// 		},
-							// 		success: { type: 'final' },
-							// 	},
-							// },
-							// chooseHomepageTemplate: {
-							// 	initial: 'pending',
-							// 	states: {
-							// 		pending: {
-							// 			invoke: {
-							// 				src: 'queryAiEndpoint',
-							// 				data: ( context ) => {
-							// 					return {
-							// 						...defaultHomepageTemplate,
-							// 						prompt: defaultHomepageTemplate.prompt(
-							// 							context
-							// 								.businessInfoDescription
-							// 								.descriptionText,
-							// 							context.lookAndFeel
-							// 								.choice,
-							// 							context.toneOfVoice
-							// 								.choice
-							// 						),
-							// 					};
-							// 				},
-							// 				onDone: {
-							// 					actions: [
-							// 						'assignHomepageTemplate',
-							// 					],
-							// 					target: 'success',
-							// 				},
-							// 				onError: {
-							// 					actions: [
-							// 						'assignAPICallLoaderError',
-							// 					],
-							// 					target: '#toneOfVoice',
-							// 				},
-							// 			},
-							// 		},
-							// 		success: { type: 'final' },
-							// 	},
-							// },
+							chooseColorPairing: {
+								initial: 'pending',
+								states: {
+									pending: {
+										invoke: {
+											src: 'queryAiEndpoint',
+											data: ( context ) => {
+												return {
+													...defaultColorPalette,
+													prompt: defaultColorPalette.prompt(
+														context
+															.businessInfoDescription
+															.descriptionText,
+														context.lookAndFeel
+															.choice,
+														context.toneOfVoice
+															.choice
+													),
+												};
+											},
+											onDone: {
+												actions: [
+													'assignDefaultColorPalette',
+												],
+												target: 'success',
+											},
+											// If there's an error we don't want to block the user from proceeding.
+											onError: {
+												target: 'success',
+											},
+										},
+									},
+									success: { type: 'final' },
+								},
+							},
+							chooseFontPairing: {
+								initial: 'pending',
+								states: {
+									pending: {
+										invoke: {
+											src: 'queryAiEndpoint',
+											data: ( context ) => {
+												return {
+													...fontPairings,
+													prompt: fontPairings.prompt(
+														context
+															.businessInfoDescription
+															.descriptionText,
+														context.lookAndFeel
+															.choice,
+														context.toneOfVoice
+															.choice
+													),
+												};
+											},
+											onDone: {
+												actions: [
+													'assignFontPairing',
+												],
+												target: 'success',
+											},
+											// If there's an error we don't want to block the user from proceeding.
+											onError: {
+												target: 'success',
+											},
+										},
+									},
+									success: { type: 'final' },
+								},
+							},
+							chooseHomepageTemplate: {
+								initial: 'pending',
+								states: {
+									pending: {
+										invoke: {
+											src: 'queryAiEndpoint',
+											data: ( context ) => {
+												return {
+													...defaultHomepageTemplate,
+													prompt: defaultHomepageTemplate.prompt(
+														context
+															.businessInfoDescription
+															.descriptionText,
+														context.lookAndFeel
+															.choice,
+														context.toneOfVoice
+															.choice
+													),
+												};
+											},
+											onDone: {
+												actions: [
+													'assignHomepageTemplate',
+												],
+												target: 'success',
+											},
+											onError: {
+												actions: [
+													'assignAPICallLoaderError',
+												],
+												target: '#toneOfVoice',
+											},
+										},
+									},
+									success: { type: 'final' },
+								},
+							},
 							updateStorePatterns: {
 								initial: 'pending',
 								states: {

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/state-machine.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/state-machine.tsx
@@ -287,100 +287,120 @@ export const designWithAiStateMachineDefinition = createMachine(
 						],
 						type: 'parallel',
 						states: {
-							chooseColorPairing: {
+							// chooseColorPairing: {
+							// 	initial: 'pending',
+							// 	states: {
+							// 		pending: {
+							// 			invoke: {
+							// 				src: 'queryAiEndpoint',
+							// 				data: ( context ) => {
+							// 					return {
+							// 						...defaultColorPalette,
+							// 						prompt: defaultColorPalette.prompt(
+							// 							context
+							// 								.businessInfoDescription
+							// 								.descriptionText,
+							// 							context.lookAndFeel
+							// 								.choice,
+							// 							context.toneOfVoice
+							// 								.choice
+							// 						),
+							// 					};
+							// 				},
+							// 				onDone: {
+							// 					actions: [
+							// 						'assignDefaultColorPalette',
+							// 					],
+							// 					target: 'success',
+							// 				},
+							// 				// If there's an error we don't want to block the user from proceeding.
+							// 				onError: {
+							// 					target: 'success',
+							// 				},
+							// 			},
+							// 		},
+							// 		success: { type: 'final' },
+							// 	},
+							// },
+							// chooseFontPairing: {
+							// 	initial: 'pending',
+							// 	states: {
+							// 		pending: {
+							// 			invoke: {
+							// 				src: 'queryAiEndpoint',
+							// 				data: ( context ) => {
+							// 					return {
+							// 						...fontPairings,
+							// 						prompt: fontPairings.prompt(
+							// 							context
+							// 								.businessInfoDescription
+							// 								.descriptionText,
+							// 							context.lookAndFeel
+							// 								.choice,
+							// 							context.toneOfVoice
+							// 								.choice
+							// 						),
+							// 					};
+							// 				},
+							// 				onDone: {
+							// 					actions: [
+							// 						'assignFontPairing',
+							// 					],
+							// 					target: 'success',
+							// 				},
+							// 				// If there's an error we don't want to block the user from proceeding.
+							// 				onError: {
+							// 					target: 'success',
+							// 				},
+							// 			},
+							// 		},
+							// 		success: { type: 'final' },
+							// 	},
+							// },
+							// chooseHomepageTemplate: {
+							// 	initial: 'pending',
+							// 	states: {
+							// 		pending: {
+							// 			invoke: {
+							// 				src: 'queryAiEndpoint',
+							// 				data: ( context ) => {
+							// 					return {
+							// 						...defaultHomepageTemplate,
+							// 						prompt: defaultHomepageTemplate.prompt(
+							// 							context
+							// 								.businessInfoDescription
+							// 								.descriptionText,
+							// 							context.lookAndFeel
+							// 								.choice,
+							// 							context.toneOfVoice
+							// 								.choice
+							// 						),
+							// 					};
+							// 				},
+							// 				onDone: {
+							// 					actions: [
+							// 						'assignHomepageTemplate',
+							// 					],
+							// 					target: 'success',
+							// 				},
+							// 				onError: {
+							// 					actions: [
+							// 						'assignAPICallLoaderError',
+							// 					],
+							// 					target: '#toneOfVoice',
+							// 				},
+							// 			},
+							// 		},
+							// 		success: { type: 'final' },
+							// 	},
+							// },
+							updateStorePatterns: {
 								initial: 'pending',
 								states: {
 									pending: {
 										invoke: {
-											src: 'queryAiEndpoint',
-											data: ( context ) => {
-												return {
-													...defaultColorPalette,
-													prompt: defaultColorPalette.prompt(
-														context
-															.businessInfoDescription
-															.descriptionText,
-														context.lookAndFeel
-															.choice,
-														context.toneOfVoice
-															.choice
-													),
-												};
-											},
+											src: 'updateStorePatterns',
 											onDone: {
-												actions: [
-													'assignDefaultColorPalette',
-												],
-												target: 'success',
-											},
-											// If there's an error we don't want to block the user from proceeding.
-											onError: {
-												target: 'success',
-											},
-										},
-									},
-									success: { type: 'final' },
-								},
-							},
-							chooseFontPairing: {
-								initial: 'pending',
-								states: {
-									pending: {
-										invoke: {
-											src: 'queryAiEndpoint',
-											data: ( context ) => {
-												return {
-													...fontPairings,
-													prompt: fontPairings.prompt(
-														context
-															.businessInfoDescription
-															.descriptionText,
-														context.lookAndFeel
-															.choice,
-														context.toneOfVoice
-															.choice
-													),
-												};
-											},
-											onDone: {
-												actions: [
-													'assignFontPairing',
-												],
-												target: 'success',
-											},
-											// If there's an error we don't want to block the user from proceeding.
-											onError: {
-												target: 'success',
-											},
-										},
-									},
-									success: { type: 'final' },
-								},
-							},
-							chooseHomepageTemplate: {
-								initial: 'pending',
-								states: {
-									pending: {
-										invoke: {
-											src: 'queryAiEndpoint',
-											data: ( context ) => {
-												return {
-													...defaultHomepageTemplate,
-													prompt: defaultHomepageTemplate.prompt(
-														context
-															.businessInfoDescription
-															.descriptionText,
-														context.lookAndFeel
-															.choice,
-														context.toneOfVoice
-															.choice
-													),
-												};
-											},
-											onDone: {
-												actions: [
-													'assignHomepageTemplate',
-												],
 												target: 'success',
 											},
 											onError: {
@@ -394,12 +414,12 @@ export const designWithAiStateMachineDefinition = createMachine(
 									success: { type: 'final' },
 								},
 							},
-							updateStorePatterns: {
+							installAndActivateTheme: {
 								initial: 'pending',
 								states: {
 									pending: {
 										invoke: {
-											src: 'updateStorePatterns',
+											src: 'installAndActivateTheme',
 											onDone: {
 												target: 'success',
 											},

--- a/plugins/woocommerce/changelog/add-cys-swtich-theme-tt3
+++ b/plugins/woocommerce/changelog/add-cys-swtich-theme-tt3
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Switch theme to TT3 during cys loading screen

--- a/plugins/woocommerce/src/Admin/API/OnboardingThemes.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingThemes.php
@@ -159,9 +159,8 @@ class OnboardingThemes extends \WC_REST_Data_Controller {
 	 * @return WP_Error|array Theme activation status.
 	 */
 	public function activate_theme( $request ) {
-		$allowed_themes                 = Themes::get_allowed_themes();
-		$theme                          = sanitize_text_field( $request['theme'] );
-		$theme_switch_via_cys_ai_loader = 1 === absint( $request['theme_switch_via_cys_ai_loader'] );
+		$allowed_themes = Themes::get_allowed_themes();
+		$theme          = sanitize_text_field( $request['theme'] );
 
 		if ( ! in_array( $theme, $allowed_themes, true ) ) {
 			return new \WP_Error( 'woocommerce_rest_invalid_theme', __( 'Invalid theme.', 'woocommerce' ), 404 );
@@ -174,12 +173,6 @@ class OnboardingThemes extends \WC_REST_Data_Controller {
 		if ( ! in_array( $theme, array_keys( $installed_themes ), true ) ) {
 			/* translators: %s: theme slug (example: woocommerce-services) */
 			return new \WP_Error( 'woocommerce_rest_invalid_theme', sprintf( __( 'Invalid theme %s.', 'woocommerce' ), $theme ), 404 );
-		}
-
-		// Prevent the task from being marked as complete if theme is switched via the CYS ai loading screen.
-		if ( $theme_switch_via_cys_ai_loader ) {
-			$task = TaskLists::get_task( 'customize-store' );
-			remove_action( 'switch_theme', array( $task, 'mark_task_as_complete' ) );
 		}
 
 		$result = switch_theme( $theme );

--- a/plugins/woocommerce/src/Admin/API/OnboardingThemes.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingThemes.php
@@ -8,6 +8,8 @@
 namespace Automattic\WooCommerce\Admin\API;
 
 use Automattic\WooCommerce\Internal\Admin\Onboarding\OnboardingThemes as Themes;
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists;
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\CustomizeStore;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -157,8 +159,10 @@ class OnboardingThemes extends \WC_REST_Data_Controller {
 	 * @return WP_Error|array Theme activation status.
 	 */
 	public function activate_theme( $request ) {
-		$allowed_themes = Themes::get_allowed_themes();
-		$theme          = sanitize_text_field( $request['theme'] );
+		$allowed_themes                 = Themes::get_allowed_themes();
+		$theme                          = sanitize_text_field( $request['theme'] );
+		$theme_switch_via_cys_ai_loader = 1 === absint( $request['theme_switch_via_cys_ai_loader'] );
+
 		if ( ! in_array( $theme, $allowed_themes, true ) ) {
 			return new \WP_Error( 'woocommerce_rest_invalid_theme', __( 'Invalid theme.', 'woocommerce' ), 404 );
 		}
@@ -170,6 +174,12 @@ class OnboardingThemes extends \WC_REST_Data_Controller {
 		if ( ! in_array( $theme, array_keys( $installed_themes ), true ) ) {
 			/* translators: %s: theme slug (example: woocommerce-services) */
 			return new \WP_Error( 'woocommerce_rest_invalid_theme', sprintf( __( 'Invalid theme %s.', 'woocommerce' ), $theme ), 404 );
+		}
+
+		// Prevent the task from being marked as complete if theme is switched via the CYS ai loading screen.
+		if ( $theme_switch_via_cys_ai_loader ) {
+			$task = TaskLists::get_task( 'customize-store' );
+			remove_action( 'switch_theme', array( $task, 'mark_task_as_complete' ) );
 		}
 
 		$result = switch_theme( $theme );

--- a/plugins/woocommerce/src/Admin/API/OnboardingThemes.php
+++ b/plugins/woocommerce/src/Admin/API/OnboardingThemes.php
@@ -8,8 +8,6 @@
 namespace Automattic\WooCommerce\Admin\API;
 
 use Automattic\WooCommerce\Internal\Admin\Onboarding\OnboardingThemes as Themes;
-use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists;
-use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\CustomizeStore;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -161,7 +159,6 @@ class OnboardingThemes extends \WC_REST_Data_Controller {
 	public function activate_theme( $request ) {
 		$allowed_themes = Themes::get_allowed_themes();
 		$theme          = sanitize_text_field( $request['theme'] );
-
 		if ( ! in_array( $theme, $allowed_themes, true ) ) {
 			return new \WP_Error( 'woocommerce_rest_invalid_theme', __( 'Invalid theme.', 'woocommerce' ), 404 );
 		}

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/CustomizeStore.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/CustomizeStore.php
@@ -18,6 +18,7 @@ class CustomizeStore extends Task {
 		parent::__construct( $task_list );
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'possibly_add_site_editor_scripts' ) );
+		// Use "switch_theme" instead of "after_switch_theme" because the latter is fired after the next WP load and we need to remove action when switching theme to TT3 via onboarding theme API. See Automattic\WooCommerce\Admin\API\OnboardingThemes::activate_theme().
 		add_action( 'switch_theme', array( $this, 'mark_task_as_complete' ) );
 	}
 

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/CustomizeStore.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/CustomizeStore.php
@@ -18,7 +18,7 @@ class CustomizeStore extends Task {
 		parent::__construct( $task_list );
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'possibly_add_site_editor_scripts' ) );
-		add_action( 'after_switch_theme', array( $this, 'mark_task_as_complete' ) );
+		add_action( 'switch_theme', array( $this, 'mark_task_as_complete' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/CustomizeStore.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/CustomizeStore.php
@@ -18,8 +18,13 @@ class CustomizeStore extends Task {
 		parent::__construct( $task_list );
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'possibly_add_site_editor_scripts' ) );
-		// Use "switch_theme" instead of "after_switch_theme" because the latter is fired after the next WP load and we need to remove action when switching theme to TT3 via onboarding theme API. See Automattic\WooCommerce\Admin\API\OnboardingThemes::activate_theme().
-		add_action( 'switch_theme', array( $this, 'mark_task_as_complete' ) );
+
+		// Use "switch_theme" instead of "after_switch_theme" because the latter is fired after the next WP load and we don't want to trigger action when switching theme to TT3 via onboarding theme API.
+		global $_GET;
+		$theme_switch_via_cys_ai_loader = isset( $_GET['theme_switch_via_cys_ai_loader'] ) ? 1 === absint( $_GET['theme_switch_via_cys_ai_loader'] ) : false;
+		if ( ! $theme_switch_via_cys_ai_loader ) {
+				add_action( 'switch_theme', array( $this, 'mark_task_as_complete' ) );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/40462.

Switch Theme to TT3 during CYS AI Wizard loading screen and remove swtich_theme "action" so that task won't be marked complete.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

This feature is part of the larger customize your store development and behind a feature flag, hence QA review can be deferred until the call for testing before release.

Make sure you are testing this with a Jetpack connected instance of WooCommerce, as the AI text completion endpoint can only be called with a Jetpack connected account.

1. Create a new WooCommerce installation with this version.
2. Install  WooCommerce Block [Nightly](https://github.com/woocommerce/woocommerce-blocks/releases/tag/nightly)
3. Make sure to enable `customize-store` feature flag
4. Switch the theme to a block theme other than TT3
5. Delete `woocommerce_admin_customize_store_completed` option 
6. Go to `WooCommerce -> Home` and click `Customize Store` task
7. Click `Design with AI` button
8. Fill in the business description and click on 'continue'
9. Proceed with the rest of the AI wizard
10. After reaching the site assembler, go to `/wp-admin/themes.php`
11. Confirm theme is switched to `Twenty Twenty-Three`
12. Go to `WooCommerce -> Home`
13. Observe that `Customize Store` task is still active.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
