### PR TITLE
Fix dropdown and list behavior in attributes variation modals

### DIFF
--- a/packages/js/product-editor/changelog/fix-40210_dropdown_and_list_behavior_in_attributes_variation_modals
+++ b/packages/js/product-editor/changelog/fix-40210_dropdown_and_list_behavior_in_attributes_variation_modals
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix dropdown and list behavior in attributes variation modals #40496

--- a/packages/js/product-editor/src/components/attribute-control/edit-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/edit-attribute-modal.tsx
@@ -184,7 +184,11 @@ export const EditAttributeModal: React.FC< EditAttributeModalProps > = ( {
 					{ attribute.terms ? (
 						<AttributeTermInputField
 							label={ termsLabel }
-							placeholder={ termsPlaceholder }
+							placeholder={
+								editableAttribute?.terms.length > 0
+									? ''
+									: termsPlaceholder
+							}
 							value={ editableAttribute?.terms }
 							attributeId={ editableAttribute?.id }
 							onChange={ ( val ) => {
@@ -197,7 +201,11 @@ export const EditAttributeModal: React.FC< EditAttributeModalProps > = ( {
 					) : (
 						<CustomAttributeTermInputField
 							label={ termsLabel }
-							placeholder={ termsPlaceholder }
+							placeholder={
+								editableAttribute?.options.length > 0
+									? ''
+									: termsPlaceholder
+							}
 							disabled={ ! attribute?.name }
 							value={ editableAttribute?.options }
 							onChange={ ( val ) => {

--- a/packages/js/product-editor/src/components/attribute-control/edit-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/edit-attribute-modal.tsx
@@ -185,6 +185,7 @@ export const EditAttributeModal: React.FC< EditAttributeModalProps > = ( {
 						<AttributeTermInputField
 							label={ termsLabel }
 							placeholder={
+								editableAttribute?.terms &&
 								editableAttribute?.terms.length > 0
 									? ''
 									: termsPlaceholder
@@ -202,6 +203,7 @@ export const EditAttributeModal: React.FC< EditAttributeModalProps > = ( {
 						<CustomAttributeTermInputField
 							label={ termsLabel }
 							placeholder={
+								editableAttribute?.options &&
 								editableAttribute?.options.length > 0
 									? ''
 									: termsPlaceholder

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.scss
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.scss
@@ -54,7 +54,6 @@
 		display: grid;
 		grid-template-columns: 40% 55% 5%;
 		border-bottom: 1px solid $gray-300;
-		align-items: center;
 	}
 	&__table-row {
 		padding: $gap-large 0;
@@ -83,13 +82,13 @@
 	&__table-attribute-trash-column {
 		display: flex;
 		justify-content: center;
+		align-items: center;
 
 		@include breakpoint( '<782px' ) {
 			position: absolute;
 			top: 0;
 			right: 0;
 			bottom: 0;
-			align-items: center;
 		}
 
 		.components-button.has-icon {

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
@@ -356,10 +356,11 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 														attribute.id !== 0 ? (
 															<AttributeTermInputField
 																placeholder={
+																	attribute?.terms &&
 																	attribute
 																		?.terms
 																		.length >
-																	0
+																		0
 																		? ''
 																		: termPlaceholder
 																}
@@ -398,10 +399,11 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 														) : (
 															<CustomAttributeTermInputField
 																placeholder={
+																	attribute?.options &&
 																	attribute
 																		?.options
 																		.length >
-																	0
+																		0
 																		? ''
 																		: termPlaceholder
 																}

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
@@ -356,7 +356,12 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 														attribute.id !== 0 ? (
 															<AttributeTermInputField
 																placeholder={
-																	termPlaceholder
+																	attribute
+																		?.terms
+																		.length >
+																	0
+																		? ''
+																		: termPlaceholder
 																}
 																disabled={
 																	attribute
@@ -393,7 +398,12 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 														) : (
 															<CustomAttributeTermInputField
 																placeholder={
-																	termPlaceholder
+																	attribute
+																		?.options
+																		.length >
+																	0
+																		? ''
+																		: termPlaceholder
 																}
 																disabled={
 																	! attribute.name

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { createElement, Fragment, useEffect } from '@wordpress/element';
 import { resolveSelect } from '@wordpress/data';
-import { trash } from '@wordpress/icons';
+import { closeSmall } from '@wordpress/icons';
 import {
 	Form,
 	__experimentalSelectControlMenuSlot as SelectControlMenuSlot,
@@ -419,7 +419,7 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 													</td>
 													<td className="woocommerce-new-attribute-modal__table-attribute-trash-column">
 														<Button
-															icon={ trash }
+															icon={ closeSmall }
 															disabled={
 																values
 																	.attributes


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

**Acceptance criteria**

- [ ] Item rows in the add attributes and add variation options modals are aligned to the top.
- [ ] Field placeholder text is hidden when at least 1 value is added.
- [ ] Replace the trash icon with the X icon (color: Gutenberg-700).

Closes #40210.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the product blocks editor under WooCommerce -> Settings -> Advanced -> Features.
2. Ensure the feature `product-variation-management` is enabled under the `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper`.
3. Navigate to WooCommerce > Add New.
4. Go to the `Organization` tab and press the `Add new` button under `Attributes`. Add an `Attribute` and create a few Values (to have at least two lines).
5.  Verify that the Attribute and Values selectors are aligned to the top, the delete button is an X (instead of a trash can) and the `Values` placeholder is empty.

![Screenshot 2023-10-02 at 12 11 57](https://github.com/woocommerce/woocommerce/assets/1314156/42e4cf11-2107-407d-ba02-a2a40a2a15b4)

6. Create the attribute and then press the `Edit` button next to the attribute you just added. Verify the placeholder content disappears after selecting at leat one value.

![Screen Capture on 2023-10-02 at 12-05-12](https://github.com/woocommerce/woocommerce/assets/1314156/e558661b-022d-4b2f-b22a-4028a95d2f86)

7. Go to the `Variations` tab and press `Add variation options`.
8. Repeat steps 4 to 6. 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
