### PR TITLE
Remove confirmation modal for dismissing unsaved attributes or variation options

### DIFF
--- a/packages/js/product-editor/changelog/dev-40216_remove_confirmation_modal_for_dismissing_attributes_variations
+++ b/packages/js/product-editor/changelog/dev-40216_remove_confirmation_modal_for_dismissing_attributes_variations
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Remove confirmation modal for dismissing unsaved attributes or variation options #40500

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
@@ -2,12 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	useState,
-	createElement,
-	Fragment,
-	useEffect,
-} from '@wordpress/element';
+import { createElement, Fragment, useEffect } from '@wordpress/element';
 import { resolveSelect } from '@wordpress/data';
 import { trash } from '@wordpress/icons';
 import {
@@ -20,13 +15,7 @@ import {
 	ProductAttributeTerm,
 } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
-import {
-	Button,
-	Modal,
-	Notice,
-	// @ts-expect-error ConfirmDialog is not part of the typescript definition yet.
-	__experimentalConfirmDialog as ConfirmDialog,
-} from '@wordpress/components';
+import { Button, Modal, Notice } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -53,9 +42,6 @@ type NewAttributeModalProps = {
 	cancelLabel?: string;
 	addAccessibleLabel?: string;
 	addLabel?: string;
-	confirmMessage?: string;
-	confirmCancelLabel?: string;
-	confirmConfirmLabel?: string;
 	onCancel: () => void;
 	onAdd: ( newCategories: EnhancedProductAttribute[] ) => void;
 	selectedAttributeIds?: number[];
@@ -87,12 +73,6 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 	cancelLabel = __( 'Cancel', 'woocommerce' ),
 	addAccessibleLabel = __( 'Add attributes', 'woocommerce' ),
 	addLabel = __( 'Add', 'woocommerce' ),
-	confirmMessage = __(
-		'You have some attributes added to the list, are you sure you want to cancel?',
-		'woocommerce'
-	),
-	confirmCancelLabel = __( 'No thanks', 'woocommerce' ),
-	confirmConfirmLabel = __( 'Yes please!', 'woocommerce' ),
 	onCancel,
 	onAdd,
 	selectedAttributeIds = [],
@@ -113,7 +93,6 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 			attributeRow?.scrollIntoView( { behavior: 'smooth' } );
 		}, 0 );
 	};
-	const [ showConfirmClose, setShowConfirmClose ] = useState( false );
 	const addAnother = (
 		values: AttributeForm,
 		setValue: (
@@ -212,18 +191,6 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 		}, 0 );
 	};
 
-	const onClose = ( values: AttributeForm ) => {
-		const hasValuesSet = values.attributes.some(
-			( value ) =>
-				value !== null && value?.terms && value?.terms.length > 0
-		);
-		if ( hasValuesSet ) {
-			setShowConfirmClose( true );
-		} else {
-			onCancel();
-		}
-	};
-
 	useEffect( function focusFirstAttributeField() {
 		const firstAttributeFieldLabel =
 			document.querySelector< HTMLLabelElement >(
@@ -316,7 +283,7 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 									| React.FocusEvent< Element >
 							) => {
 								if ( ! event.isPropagationStopped() ) {
-									onClose( values );
+									onCancel();
 								}
 							} }
 							className="woocommerce-new-attribute-modal"
@@ -499,7 +466,7 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 								<Button
 									isSecondary
 									label={ cancelLabel }
-									onClick={ () => onClose( values ) }
+									onClick={ () => onCancel() }
 								>
 									{ cancelLabel }
 								</Button>
@@ -525,16 +492,6 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 			</Form>
 			{ /* Add slot so select control menu renders correctly within Modal */ }
 			<SelectControlMenuSlot />
-			{ showConfirmClose && (
-				<ConfirmDialog
-					cancelButtonText={ confirmCancelLabel }
-					confirmButtonText={ confirmConfirmLabel }
-					onCancel={ () => setShowConfirmClose( false ) }
-					onConfirm={ onCancel }
-				>
-					{ confirmMessage }
-				</ConfirmDialog>
-			) }
 		</>
 	);
 };


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR removes the confirmation modal for dismissing unsaved attributes/variation options

<img width="620" alt="image" src="https://github.com/woocommerce/woocommerce/assets/79307566/428b0398-b3da-4795-8cff-11512fc0197c">

Closes #40216.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the product blocks editor under WooCommerce -> Settings -> Advanced -> Features.
2. Ensure the feature `product-variation-management` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper`.
3. Navigate to the `Add Product` page.
4. Go to the `Organization` tab and press the `Add new` button under `Attributes`.
5. Create an attribute with a few Values.
6. Without saving, click outside the modal.
7. No confirmation modal should be shown.
8. Go to the `Variations` tab and do the same with the `Variation options`.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
