### PR TITLE
Trigger `woocommerce_update_order` even when order has no changes

### DIFF
--- a/plugins/woocommerce/changelog/fix-40511
+++ b/plugins/woocommerce/changelog/fix-40511
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Make sure 'woocommerce_update_order' is always triggered even when no changes are made to the order.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -7,6 +7,7 @@ namespace Automattic\WooCommerce\Internal\DataStores\Orders;
 
 use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Caches\OrderCache;
+use Automattic\WooCommerce\Internal\Admin\Orders\EditLock;
 use Automattic\WooCommerce\Internal\Utilities\DatabaseUtil;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
 use Automattic\WooCommerce\Utilities\ArrayUtil;
@@ -2928,7 +2929,7 @@ CREATE TABLE $meta_table (
 		method_exists( $meta, 'apply_changes' ) && $meta->apply_changes();
 
 		// Prevent this happening multiple time in same request.
-		if ( $this->should_save_after_meta_change( $order ) ) {
+		if ( $this->should_save_after_meta_change( $order, $meta ) ) {
 			$order->set_date_modified( current_time( 'mysql' ) );
 			$order->save();
 			return true;
@@ -2947,12 +2948,17 @@ CREATE TABLE $meta_table (
 	 * 1. Order modified date is already the current date, no updates needed in this case.
 	 * 2. If there are changes already queued for order object, then we don't need to update the modified date as it will be updated ina subsequent save() call.
 	 *
-	 * @param WC_Order $order Order object.
+	 * @param WC_Order           $order Order object.
+	 * @param \WC_Meta_Data|null $meta  Metadata object.
 	 *
 	 * @return bool Whether the modified date needs to be updated.
 	 */
-	private function should_save_after_meta_change( $order ) {
+	private function should_save_after_meta_change( $order, $meta = null ) {
+		$skip_for = array(
+			EditLock::META_KEY_NAME,
+		);
+
 		$current_date_time = new \WC_DateTime( current_time( 'mysql', 1 ), new \DateTimeZone( 'GMT' ) );
-		return $order->get_date_modified() < $current_date_time && empty( $order->get_changes() );
+		return $order->get_date_modified() < $current_date_time && empty( $order->get_changes() ) && ( ! is_object( $meta ) || ! in_array( $meta->key, $skip_for, true ) );
 	}
 }

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php
@@ -2482,7 +2482,7 @@ FROM $order_meta_table
 
 		// For backwards compat with CPT, trashing/untrashing and changing previously datastore-level props does not trigger the update hook.
 		if ( ( ! empty( $changes['status'] ) && in_array( 'trash', array( $changes['status'], $previous_status ), true ) )
-			|| ! array_diff_key( $changes, array_flip( $this->get_post_data_store_for_backfill()->get_internal_data_store_key_getters() ) ) ) {
+			|| ( ! empty( $changes ) && ! array_diff_key( $changes, array_flip( $this->get_post_data_store_for_backfill()->get_internal_data_store_key_getters() ) ) ) ) {
 			return;
 		}
 

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -2700,21 +2700,26 @@ class OrdersTableDataStoreTests extends HposTestCase {
 		$this->assertEquals( 1, $new_count );
 		$this->assertEquals( 0, $update_count );
 
-		// An update to the order should only trigger 'woocommerce_update_order'.
-		$order->set_billing_city( 'Los Angeles' );
+		// Saving an order again (with no changes) should still trigger 'woocommerce_update_order'.
 		$order->save();
 		$this->assertEquals( 1, $new_count );
 		$this->assertEquals( 1, $update_count );
 
+		// An update to the order should only trigger 'woocommerce_update_order'.
+		$order->set_billing_city( 'Los Angeles' );
+		$order->save();
+		$this->assertEquals( 1, $new_count );
+		$this->assertEquals( 2, $update_count );
+
 		// Updating datastore-level props should not trigger anything.
 		$order->get_data_store()->set_download_permissions_granted( $order->get_id(), true );
 		$this->assertEquals( 1, $new_count );
-		$this->assertEquals( 1, $update_count );
+		$this->assertEquals( 2, $update_count );
 
 		// Trashing should not fire an update.
 		$order->get_data_store()->delete( $order );
 		$this->assertEquals( $order->get_status(), 'trash' );
-		$this->assertEquals( 1, $update_count );
+		$this->assertEquals( 2, $update_count );
 
 		// Untrashing should not fire an update.
 		if ( $cot_is_authoritative ) {
@@ -2725,7 +2730,7 @@ class OrdersTableDataStoreTests extends HposTestCase {
 			$order = wc_get_order( $order->get_id() ); // Refresh order.
 		}
 		$this->assertNotEquals( $order->get_status(), 'trash' );
-		$this->assertEquals( 1, $update_count );
+		$this->assertEquals( 2, $update_count );
 
 		// An auto-draft order should not trigger 'woocommerce_new_order' until first saved with a valid status.
 		if ( $cot_is_authoritative ) {
@@ -2734,13 +2739,13 @@ class OrdersTableDataStoreTests extends HposTestCase {
 			$order->save();
 
 			$this->assertEquals( 1, $new_count );
-			$this->assertEquals( 1, $update_count );
+			$this->assertEquals( 2, $update_count );
 
 			$order->set_status( 'on-hold' );
 			$order->save();
 
 			$this->assertEquals( 2, $new_count );
-			$this->assertEquals( 1, $update_count );
+			$this->assertEquals( 2, $update_count );
 		}
 
 		remove_action( 'woocommerce_new_order', $callback );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
It was brought to our attention (see #40511) that in the CPT world, `woocommerce_update_order` is triggered even when no changes are made to the order, something we did change in HPOS.

Unless we want to publicly communicate this change in behavior later, for the time being, it'd be best to remain backwards compatible. This PR makes HPOS trigger said hook even when no change was made to the order. It also adds some logic to prevent full-order saves when only updating the edit lock metadata (as this metadata is irrelevant for sync purposes).

Closes #40511.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable HPOS in WC > Settings > Advanced > Features. No need to enable sync.
2. Run the following PHP snippet (for example via `wp shell` or `wp eval`) and make sure that the "woocommerce_update_order action was called" message is displayed and the script exits.
   ```php
   $order = new \WC_Order();
   $order->save();
   add_action('woocommerce_update_order', function() { die('woocommerce_update_order action was called'); });
   $order->save();
   ```
3. Disable HPOS in WC > Settings > Advanced > Features and repeat step 2.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
