### PR TITLE
Add missing Tracks events to attribute modals

### DIFF
--- a/packages/js/product-editor/changelog/fix-40502_record_events_for_variation_options_modal
+++ b/packages/js/product-editor/changelog/fix-40502_record_events_for_variation_options_modal
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Add missing Tracks events to attribute modals #40517

--- a/packages/js/product-editor/src/blocks/variation-options/edit.tsx
+++ b/packages/js/product-editor/src/blocks/variation-options/edit.tsx
@@ -135,6 +135,11 @@ export function Edit( {
 				onNewModalOpen={ () => {
 					recordEvent( 'product_options_add_option' );
 				} }
+				onRemoveItem={ () => {
+					recordEvent(
+						'product_add_options_modal_remove_option_button_click'
+					);
+				} }
 				onRemove={ () =>
 					recordEvent(
 						'product_remove_option_confirmation_confirm_click'

--- a/packages/js/product-editor/src/blocks/variation-options/edit.tsx
+++ b/packages/js/product-editor/src/blocks/variation-options/edit.tsx
@@ -14,6 +14,7 @@ import {
 	ProductAttribute,
 	useUserPreferences,
 } from '@woocommerce/data';
+import { recordEvent } from '@woocommerce/tracks';
 import { Link } from '@woocommerce/components';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore No types for this exist yet.
@@ -112,6 +113,9 @@ export function Edit( {
 					attributes,
 					entityDefaultAttributes,
 				] ) }
+				onAdd={ () => {
+					recordEvent( 'product_options_modal_add_button_click' );
+				} }
 				onChange={ handleChange }
 				createNewAttributesAsGlobal={ true }
 				useRemoveConfirmationModal={ true }
@@ -119,6 +123,27 @@ export function Edit( {
 					updateUserPreferences( {
 						product_block_variable_options_notice_dismissed: 'yes',
 					} )
+				}
+				onAddAnother={ () => {
+					recordEvent(
+						'product_add_options_modal_add_another_option_button_click'
+					);
+				} }
+				onNewModalCancel={ () => {
+					recordEvent( 'product_options_modal_cancel_button_click' );
+				} }
+				onNewModalOpen={ () => {
+					recordEvent( 'product_options_add_option' );
+				} }
+				onRemove={ () =>
+					recordEvent(
+						'product_remove_option_confirmation_confirm_click'
+					)
+				}
+				onRemoveCancel={ () =>
+					recordEvent(
+						'product_remove_option_confirmation_cancel_click'
+					)
 				}
 				disabledAttributeIds={ entityAttributes
 					.filter( ( attr ) => ! attr.variation )

--- a/packages/js/product-editor/src/blocks/variations/edit.tsx
+++ b/packages/js/product-editor/src/blocks/variations/edit.tsx
@@ -79,6 +79,7 @@ export function Edit( {
 
 	const openNewModal = () => {
 		setIsNewModalVisible( true );
+		recordEvent( 'product_options_add_first_option' );
 	};
 
 	const closeNewModal = () => {

--- a/packages/js/product-editor/src/blocks/variations/edit.tsx
+++ b/packages/js/product-editor/src/blocks/variations/edit.tsx
@@ -134,9 +134,22 @@ export function Edit( {
 					createNewAttributesAsGlobal={ true }
 					notice={ '' }
 					onCancel={ () => {
+						recordEvent(
+							'product_options_modal_cancel_button_click'
+						);
 						closeNewModal();
 					} }
 					onAdd={ handleAdd }
+					onAddAnother={ () => {
+						recordEvent(
+							'product_add_options_modal_add_another_option_button_click'
+						);
+					} }
+					onRemoveItem={ () => {
+						recordEvent(
+							'product_add_options_modal_remove_option_button_click'
+						);
+					} }
 					selectedAttributeIds={ variationOptions.map(
 						( attr ) => attr.id
 					) }

--- a/packages/js/product-editor/src/components/attribute-control/attribute-control.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/attribute-control.tsx
@@ -36,6 +36,7 @@ import { TRACKS_SOURCE } from '../../constants';
 type AttributeControlProps = {
 	value: EnhancedProductAttribute[];
 	onAdd?: ( attribute: EnhancedProductAttribute[] ) => void;
+	onAddAnother?: () => void;
 	onChange: ( value: ProductAttribute[] ) => void;
 	onEdit?: ( attribute: ProductAttribute ) => void;
 	onRemove?: ( attribute: ProductAttribute ) => void;
@@ -71,6 +72,7 @@ type AttributeControlProps = {
 export const AttributeControl: React.FC< AttributeControlProps > = ( {
 	value,
 	onAdd = () => {},
+	onAddAnother = () => {},
 	onChange,
 	onEdit = () => {},
 	onNewModalCancel = () => {},
@@ -183,13 +185,6 @@ export const AttributeControl: React.FC< AttributeControlProps > = ( {
 						getAttributeId( newAttr ) === getAttributeId( current )
 				)
 		);
-		recordEvent( 'product_options_add', {
-			source: TRACKS_SOURCE,
-			options: addedAttributesOnly.map( ( attribute ) => ( {
-				attribute: attribute.name,
-				values: attribute.options,
-			} ) ),
-		} );
 		handleChange( [ ...value, ...addedAttributesOnly ] );
 		onAdd( newAttributes );
 		closeNewModal();
@@ -244,9 +239,6 @@ export const AttributeControl: React.FC< AttributeControlProps > = ( {
 				className="woocommerce-add-attribute-list-item__add-button"
 				onClick={ () => {
 					openNewModal();
-					recordEvent( 'product_options_add_button_click', {
-						source: TRACKS_SOURCE,
-					} );
 				} }
 			>
 				{ uiStrings.newAttributeListItemLabel }
@@ -305,6 +297,7 @@ export const AttributeControl: React.FC< AttributeControlProps > = ( {
 						onNewModalCancel();
 					} }
 					onAdd={ handleAdd }
+					onAddAnother={ onAddAnother }
 					selectedAttributeIds={ value.map( ( attr ) => attr.id ) }
 					createNewAttributesAsGlobal={ createNewAttributesAsGlobal }
 					disabledAttributeIds={ disabledAttributeIds }

--- a/packages/js/product-editor/src/components/attribute-control/attribute-control.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/attribute-control.tsx
@@ -37,6 +37,7 @@ type AttributeControlProps = {
 	value: EnhancedProductAttribute[];
 	onAdd?: ( attribute: EnhancedProductAttribute[] ) => void;
 	onAddAnother?: () => void;
+	onRemoveItem?: () => void;
 	onChange: ( value: ProductAttribute[] ) => void;
 	onEdit?: ( attribute: ProductAttribute ) => void;
 	onRemove?: ( attribute: ProductAttribute ) => void;
@@ -73,6 +74,7 @@ export const AttributeControl: React.FC< AttributeControlProps > = ( {
 	value,
 	onAdd = () => {},
 	onAddAnother = () => {},
+	onRemoveItem = () => {},
 	onChange,
 	onEdit = () => {},
 	onNewModalCancel = () => {},
@@ -298,6 +300,7 @@ export const AttributeControl: React.FC< AttributeControlProps > = ( {
 					} }
 					onAdd={ handleAdd }
 					onAddAnother={ onAddAnother }
+					onRemoveItem={ onRemoveItem }
 					selectedAttributeIds={ value.map( ( attr ) => attr.id ) }
 					createNewAttributesAsGlobal={ createNewAttributesAsGlobal }
 					disabledAttributeIds={ disabledAttributeIds }

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
@@ -44,6 +44,7 @@ type NewAttributeModalProps = {
 	addLabel?: string;
 	onCancel: () => void;
 	onAdd: ( newCategories: EnhancedProductAttribute[] ) => void;
+	onAddAnother?: () => void;
 	selectedAttributeIds?: number[];
 	createNewAttributesAsGlobal?: boolean;
 	disabledAttributeIds?: number[];
@@ -75,6 +76,7 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 	addLabel = __( 'Add', 'woocommerce' ),
 	onCancel,
 	onAdd,
+	onAddAnother = () => {},
 	selectedAttributeIds = [],
 	createNewAttributesAsGlobal = false,
 	disabledAttributeIds = [],
@@ -102,6 +104,7 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 	) => {
 		setValue( 'attributes', [ ...values.attributes, null ] );
 		scrollAttributeIntoView( values.attributes.length );
+		onAddAnother();
 	};
 
 	const hasTermsOrOptions = ( attribute: EnhancedProductAttribute ) => {
@@ -453,9 +456,6 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 									variant="tertiary"
 									label={ addAnotherAccessibleLabel }
 									onClick={ () => {
-										recordEvent(
-											'product_add_attributes_modal_add_another_attribute_button_click'
-										);
 										addAnother( values, setValue );
 									} }
 								>

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
@@ -14,7 +14,6 @@ import {
 	ProductAttribute,
 	ProductAttributeTerm,
 } from '@woocommerce/data';
-import { recordEvent } from '@woocommerce/tracks';
 import { Button, Modal, Notice } from '@wordpress/components';
 
 /**

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
@@ -45,6 +45,7 @@ type NewAttributeModalProps = {
 	onCancel: () => void;
 	onAdd: ( newCategories: EnhancedProductAttribute[] ) => void;
 	onAddAnother?: () => void;
+	onRemoveItem?: () => void;
 	selectedAttributeIds?: number[];
 	createNewAttributesAsGlobal?: boolean;
 	disabledAttributeIds?: number[];
@@ -77,6 +78,7 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 	onCancel,
 	onAdd,
 	onAddAnother = () => {},
+	onRemoveItem = () => {},
 	selectedAttributeIds = [],
 	createNewAttributesAsGlobal = false,
 	disabledAttributeIds = [],
@@ -167,9 +169,7 @@ export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 			value: AttributeForm[ keyof AttributeForm ]
 		) => void
 	) => {
-		recordEvent(
-			'product_add_attributes_modal_remove_attribute_button_click'
-		);
+		onRemoveItem();
 		if ( values.attributes.length > 1 ) {
 			setValue(
 				'attributes',

--- a/packages/js/product-editor/src/components/attributes/attributes.tsx
+++ b/packages/js/product-editor/src/components/attributes/attributes.tsx
@@ -62,6 +62,11 @@ export const Attributes: React.FC< AttributesProps > = ( {
 					'product_add_attributes_modal_add_another_attribute_button_click'
 				);
 			} }
+			onRemoveItem={ () => {
+				recordEvent(
+					'product_add_attributes_modal_remove_attribute_button_click'
+				);
+			} }
 			onRemove={ () =>
 				recordEvent(
 					'product_remove_attribute_confirmation_confirm_click'

--- a/packages/js/product-editor/src/components/attributes/attributes.tsx
+++ b/packages/js/product-editor/src/components/attributes/attributes.tsx
@@ -57,6 +57,11 @@ export const Attributes: React.FC< AttributesProps > = ( {
 				}
 				recordEvent( 'product_add_attribute_button' );
 			} }
+			onAddAnother={ () => {
+				recordEvent(
+					'product_add_attributes_modal_add_another_attribute_button_click'
+				);
+			} }
 			onRemove={ () =>
 				recordEvent(
 					'product_remove_attribute_confirmation_confirm_click'


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This pull request addresses the addition of missing tracking events to both the attribute and variation options modals.
Closes #40502.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the product blocks editor under WooCommerce -> Settings -> Advanced -> Features.
2. Ensure the feature `product-variation-management` is enabled under the `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper`. Enable wc-admin Tracking under the `Tools` tab.
3. Navigate to the `All Products` page and press `Add New`.
4. Go to the `Organization` tab and press the `Add new` button under `Attributes`.
5. The event `wcadmin_product_add_first_attribute_button_click` will be tracked.
6. Press `+ Add another`, the event `wcadmin_product_add_attributes_modal_add_another_attribute_button_click` should be recorded.
7. Click the trash can icon on the same line that has been added. The event `wcadmin_product_add_attributes_modal_remove_attribute_button_click` should be recorded.
8. Click `Cancel`. The event `wcadmin_product_add_attributes_modal_cancel_button_click` should be recorded. The same event will be recorded if you click outside the modal.
9. Create an attribute with a few Values and press `Add`. The event `wcadmin_product_add_attributes_modal_add_button_click` should be recorded.
10. The new attribute will be added to the list. Press the `X` next to it and then do not confirm (press `Cancel`). The event `wcadmin_product_remove_attribute_confirmation_cancel_click` should be recorded. Repeat this step, but now confirm the deletion. The event `wcadmin_product_remove_attribute_confirmation_confirm_click` will be recorded.
11. Now, go to the `Variations` tab and press `Add variation options`. The event `wcadmin_product_options_add_first_option` should be recorded.
12. Follow the same steps (in the same order) from step 6. The following events should be recorded:

```
6. `wcadmin_product_add_options_modal_add_another_option_button_click`
7. `wcadmin_product_add_options_modal_remove_option_button_click`
8. `wcadmin_product_options_modal_cancel_button_click`
9. `wcadmin_product_options_add`
10. `wcadmin_product_remove_option_confirmation_cancel_click`
11. `wcadmin_product_remove_option_confirmation_confirm_click`
```
13. Create another `Variation option` while checking that the events are still being tracked (repeat the steps from steps 6 to 9).
14. Then press the `Add new` button. The event `wcadmin_product_options_add_option` should be recorded.
15. Return to the `Organization` tab and press `Add new`. The event `wcadmin_product_add_attribute_button` should be recorded.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
