### PR TITLE
Fix when adding new attributes, input fields keep the focus styling

### DIFF
--- a/packages/js/components/changelog/fix-40171
+++ b/packages/js/components/changelog/fix-40171
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix invalid focus state of the experimental select control

--- a/packages/js/components/src/experimental-select-control/menu.scss
+++ b/packages/js/components/src/experimental-select-control/menu.scss
@@ -17,13 +17,14 @@
 }
 .woocommerce-experimental-select-control__popover-menu {
 	.components-popover__content {
-		max-height: 300px;
-		overflow-y: scroll;
+		overflow: hidden;
 	}
 }
 .woocommerce-experimental-select-control__popover-menu-container {
 	margin: 0;
 	width: 100%;
+	max-height: 300px;
+	overflow-y: scroll;
 
 	> .category-field-dropdown__item:not(:first-child) {
 		.category-field-dropdown__item-content {

--- a/packages/js/components/src/experimental-select-control/select-control.tsx
+++ b/packages/js/components/src/experimental-select-control/select-control.tsx
@@ -15,6 +15,7 @@ import {
 	useEffect,
 	createElement,
 	Fragment,
+	useRef,
 } from '@wordpress/element';
 import { chevronDown } from '@wordpress/icons';
 
@@ -138,10 +139,12 @@ function SelectControl< ItemType = DefaultItemType >( {
 	const instanceId = useInstanceId(
 		SelectControl,
 		'woocommerce-experimental-select-control'
-	);
+	) as string;
 
 	const innerInputClassName =
 		'woocommerce-experimental-select-control__input';
+
+	const selectControlWrapperRef = useRef< HTMLDivElement >( null );
 
 	let selectedItems = selected === null ? [] : selected;
 	selectedItems = Array.isArray( selectedItems )
@@ -186,6 +189,7 @@ function SelectControl< ItemType = DefaultItemType >( {
 		openMenu,
 		closeMenu,
 	} = useCombobox< ItemType | null >( {
+		id: instanceId,
 		initialSelectedItem: singleSelectedItem,
 		inputValue,
 		items: filteredItems,
@@ -246,12 +250,15 @@ function SelectControl< ItemType = DefaultItemType >( {
 	} );
 
 	const isEventOutside = ( event: React.FocusEvent ) => {
-		const inputClasses = event?.target?.className;
+		const selectControlWrapperElement = selectControlWrapperRef.current;
+		const menuElement = document.getElementById( `${ instanceId }-menu` );
+		const parentPopoverMenuElement = menuElement?.closest(
+			'.woocommerce-experimental-select-control__popover-menu'
+		);
+
 		return (
-			! document
-				.querySelector( '.' + instanceId )
-				?.contains( event.relatedTarget ) &&
-			! inputClasses.includes( innerInputClassName )
+			! selectControlWrapperElement?.contains( event.relatedTarget ) &&
+			! parentPopoverMenuElement?.contains( event.relatedTarget )
 		);
 	};
 
@@ -276,10 +283,11 @@ function SelectControl< ItemType = DefaultItemType >( {
 
 	return (
 		<div
+			id={ instanceId }
+			ref={ selectControlWrapperRef }
 			className={ classnames(
 				'woocommerce-experimental-select-control',
 				className,
-				instanceId,
 				{
 					'is-read-only': isReadOnly,
 					'is-focused': isFocused,

--- a/packages/js/product-editor/changelog/fix-40171
+++ b/packages/js/product-editor/changelog/fix-40171
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix regression setting readOnlyWhenClosed to false by default on attribute term input field

--- a/packages/js/product-editor/src/components/attribute-control/edit-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/edit-attribute-modal.tsx
@@ -193,7 +193,6 @@ export const EditAttributeModal: React.FC< EditAttributeModalProps > = ( {
 									terms: val,
 								} );
 							} }
-							readOnlyWhenClosed={ false }
 						/>
 					) : (
 						<CustomAttributeTermInputField

--- a/packages/js/product-editor/src/components/attribute-term-input-field/attribute-term-input-field.tsx
+++ b/packages/js/product-editor/src/components/attribute-term-input-field/attribute-term-input-field.tsx
@@ -61,7 +61,7 @@ export const AttributeTermInputField: React.FC<
 	attributeId,
 	label = '',
 	autoCreateOnSelect = true,
-	readOnlyWhenClosed = true,
+	readOnlyWhenClosed = false,
 } ) => {
 	const attributeTermInputId = useRef(
 		`woocommerce-attribute-term-field-${ ++uniqueId }`


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #40171

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure feature `product-variation-management` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper` (WooCommerce Beta Tester plugin) is required
3. Go to `/wp-admin/admin.php?page=wc-admin&path=/add-product&tab=variations`.
4. Click `Add variation options`, from the modal, if you focus the `Attribute` combobox and add a new attribute, the focus should be set to the `Values` combobox and the `Attribute` one should not looks like it has the focus.
Before 
<img width="712" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/3bad8184-e4e3-4d6d-ad28-ac22ff655708">

After 
<img width="764" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/c1c01a8a-0acd-49b6-92ad-f8e4a9335caa">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
