### PR TITLE
Add notices about the removal of the Legacy API in WooCommerce 9.0

### DIFF
--- a/plugins/woocommerce/changelog/pr-40535
+++ b/plugins/woocommerce/changelog/pr-40535
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add notices about the removal of the Legacy API in WooCommerce 9.0

--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -130,7 +130,7 @@ class WC_Admin_Notices {
 	 * TODO: Change this method in WooCommerce 9.0 so that it checks if the Legacy REST API extension is installed, and if not, it points to the extension URL in the WordPress plugins directory.
 	 */
 	private static function maybe_add_legacy_api_removal_notice() {
-		if ( 'yes' !== get_option( 'woocommerce_api_enabled' ) ) {
+		if ( ! self::must_show_legacy_api_removal_notice() ) {
 			return;
 		}
 
@@ -158,9 +158,20 @@ class WC_Admin_Notices {
 	 * TODO: Change this method in WooCommerce 9.0 so that the notice gets removed if the Legacy REST API extension is installed and active.
 	 */
 	private static function maybe_remove_legacy_api_removal_notice() {
-		if ( 'yes' !== get_option( 'woocommerce_api_enabled' ) && self::has_notice( 'legacy_api_removed_in_woo_90' ) ) {
+		if ( self::has_notice( 'legacy_api_removed_in_woo_90' ) && ! self::must_show_legacy_api_removal_notice() ) {
 			self::remove_notice( 'legacy_api_removed_in_woo_90' );
 		}
+	}
+
+	/**
+	 * Is it needed to display the legacy API removal notice?
+	 *
+	 * TODO: Change or remove this method in WooCommerce 9.0 accordingly, depending on the changes to maybe_add/remove_legacy_api_removal_notice.
+	 *
+	 * @return bool True if the legacy API removal notice must be displayed.
+	 */
+	private static function must_show_legacy_api_removal_notice() {
+		return 'yes' === get_option( 'woocommerce_api_enabled' ) && ! is_plugin_active( 'woocommerce-legacy-rest-api/woocommerce-legacy-rest-api.php' );
 	}
 
 	// phpcs:enable Generic.Commenting.Todo.TaskFound

--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -122,10 +122,12 @@ class WC_Admin_Notices {
 		self::maybe_add_legacy_api_removal_notice();
 	}
 
+	// phpcs:disable Generic.Commenting.Todo.TaskFound
+
 	/**
 	 * Add an admin notice about the removal of the Legacy REST API if the said API is enabled.
 	 *
-	 * TODO: Remove this method in WooCommerce 9.0.
+	 * TODO: Change this method in WooCommerce 9.0 so that it checks if the Legacy REST API extension is installed, and if not, it points to the extension URL in the WordPress plugins directory.
 	 */
 	private static function maybe_add_legacy_api_removal_notice() {
 		if ( 'yes' !== get_option( 'woocommerce_api_enabled' ) ) {
@@ -153,13 +155,15 @@ class WC_Admin_Notices {
 	/**
 	 * Remove the admin notice about the removal of the Legacy REST API if the said API is disabled.
 	 *
-	 * TODO: Remove this method in WooCommerce 9.0.
+	 * TODO: Change this method in WooCommerce 9.0 so that the notice gets removed if the Legacy REST API extension is installed and active.
 	 */
 	private static function maybe_remove_legacy_api_removal_notice() {
 		if ( 'yes' !== get_option( 'woocommerce_api_enabled' ) && self::has_notice( 'legacy_api_removed_in_woo_90' ) ) {
 			self::remove_notice( 'legacy_api_removed_in_woo_90' );
 		}
 	}
+
+	// phpcs:enable Generic.Commenting.Todo.TaskFound
 
 	/**
 	 * Show a notice.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -7,6 +7,7 @@
  */
 
 use Automattic\Jetpack\Constants;
+use Automattic\WooCommerce\Internal\Traits\AccessiblePrivateMethods;
 use Automattic\WooCommerce\Internal\Utilities\Users;
 
 defined( 'ABSPATH' ) || exit;
@@ -15,6 +16,8 @@ defined( 'ABSPATH' ) || exit;
  * WC_Admin_Notices Class.
  */
 class WC_Admin_Notices {
+
+	use AccessiblePrivateMethods;
 
 	/**
 	 * Stores notices.
@@ -53,6 +56,7 @@ class WC_Admin_Notices {
 		add_action( 'woocommerce_installed', array( __CLASS__, 'reset_admin_notices' ) );
 		add_action( 'wp_loaded', array( __CLASS__, 'add_redirect_download_method_notice' ) );
 		add_action( 'admin_init', array( __CLASS__, 'hide_notices' ), 20 );
+		self::add_action( 'admin_init', array( __CLASS__, 'maybe_remove_legacy_api_removal_notice' ), 20 );
 
 		// @TODO: This prevents Action Scheduler async jobs from storing empty list of notices during WC installation.
 		// That could lead to OBW not starting and 'Run setup wizard' notice not appearing in WP admin, which we want
@@ -115,6 +119,46 @@ class WC_Admin_Notices {
 		self::add_notice( 'template_files' );
 		self::add_min_version_notice();
 		self::add_maxmind_missing_license_key_notice();
+		self::maybe_add_legacy_api_removal_notice();
+	}
+
+	/**
+	 * Add an admin notice about the removal of the Legacy REST API if the said API is enabled.
+	 *
+	 * TODO: Remove this method in WooCommerce 9.0.
+	 */
+	private static function maybe_add_legacy_api_removal_notice() {
+		if ( 'yes' !== get_option( 'woocommerce_api_enabled' ) ) {
+			return;
+		}
+
+		self::add_custom_notice(
+			'legacy_api_removed_in_woo_90',
+			sprintf(
+				'%s%s',
+				sprintf(
+					'<h4>%s</h4>',
+					esc_html__( 'WooCommerce Legacy API to be removed soon', 'woocommerce' )
+				),
+				sprintf(
+					// translators: Placeholders are URLs.
+					wpautop( wp_kses_data( __( 'The WooCommerce Legacy REST API, <a href="%1$s">currently enabled in this site</a>, will be removed in WooCommerce 9.0. A separate WooCommerce extension will be available to re-enable it. <b><a target=”_blank” href="%2$s">Learn more about this change</a></b>', 'woocommerce' ) ) ),
+					admin_url( 'admin.php?page=wc-settings&tab=advanced&section=legacy_api' ),
+					'https://developer.woocommerce.com/2023/10/03/the-legacy-rest-api-will-move-to-a-dedicated-extension-in-woocommerce-9-0/'
+				)
+			)
+		);
+	}
+
+	/**
+	 * Remove the admin notice about the removal of the Legacy REST API if the said API is disabled.
+	 *
+	 * TODO: Remove this method in WooCommerce 9.0.
+	 */
+	private static function maybe_remove_legacy_api_removal_notice() {
+		if ( 'yes' !== get_option( 'woocommerce_api_enabled' ) && self::has_notice( 'legacy_api_removed_in_woo_90' ) ) {
+			self::remove_notice( 'legacy_api_removed_in_woo_90' );
+		}
 	}
 
 	/**
@@ -424,7 +468,7 @@ class WC_Admin_Notices {
 
 	/**
 	 * Notice about WordPress and PHP minimum requirements.
-	 * 
+	 *
 	 * @deprecated 8.2.0 WordPress and PHP minimum requirements notices are no longer shown.
 	 *
 	 * @since 3.6.5

--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -138,11 +138,11 @@ class WC_Admin_Notices {
 				'%s%s',
 				sprintf(
 					'<h4>%s</h4>',
-					esc_html__( 'WooCommerce Legacy API to be removed soon', 'woocommerce' )
+					esc_html__( 'The WooCommerce Legacy REST API will be removed soon', 'woocommerce' )
 				),
 				sprintf(
 					// translators: Placeholders are URLs.
-					wpautop( wp_kses_data( __( 'The WooCommerce Legacy REST API, <a href="%1$s">currently enabled in this site</a>, will be removed in WooCommerce 9.0. A separate WooCommerce extension will be available to re-enable it. <b><a target=”_blank” href="%2$s">Learn more about this change</a></b>', 'woocommerce' ) ) ),
+					wpautop( wp_kses_data( __( 'The WooCommerce Legacy REST API, <a href="%1$s">currently enabled in this site</a>, will be removed in WooCommerce 9.0. A separate WooCommerce extension will be available to keep it enabled. <b><a target=”_blank” href="%2$s">Learn more about this change</a></b>', 'woocommerce' ) ) ),
 					admin_url( 'admin.php?page=wc-settings&tab=advanced&section=legacy_api' ),
 					'https://developer.woocommerce.com/2023/10/03/the-legacy-rest-api-will-move-to-a-dedicated-extension-in-woocommerce-9-0/'
 				)

--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -144,7 +144,7 @@ class WC_Admin_Notices {
 				),
 				sprintf(
 					// translators: Placeholders are URLs.
-					wpautop( wp_kses_data( __( 'The WooCommerce Legacy REST API, <a href="%1$s">currently enabled in this site</a>, will be removed in WooCommerce 9.0. A separate WooCommerce extension will be available to keep it enabled. <b><a target=”_blank” href="%2$s">Learn more about this change</a></b>', 'woocommerce' ) ) ),
+					wpautop( wp_kses_data( __( 'The WooCommerce Legacy REST API, <a href="%1$s">currently enabled in this site</a>, will be removed in WooCommerce 9.0. A separate WooCommerce extension will be available to keep it enabled. <b><a target=”_blank” href="%2$s">Learn more about this change.</a></b>', 'woocommerce' ) ) ),
 					admin_url( 'admin.php?page=wc-settings&tab=advanced&section=legacy_api' ),
 					'https://developer.woocommerce.com/2023/10/03/the-legacy-rest-api-will-move-to-a-dedicated-extension-in-woocommerce-9-0/'
 				)

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-advanced.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-advanced.php
@@ -392,11 +392,19 @@ class WC_Settings_Advanced extends WC_Settings_Page {
 					'id'    => 'legacy_api_options',
 				),
 				array(
-					'title'   => __( 'Legacy API', 'woocommerce' ),
-					'desc'    => __( 'Enable the legacy REST API', 'woocommerce' ),
-					'id'      => 'woocommerce_api_enabled',
-					'type'    => 'checkbox',
-					'default' => 'no',
+					'title'    => __( 'Legacy API', 'woocommerce' ),
+					'desc'     => __( 'Enable the legacy REST API', 'woocommerce' ),
+					'id'       => 'woocommerce_api_enabled',
+					'type'     => 'checkbox',
+					'default'  => 'no',
+					'desc_tip' => sprintf(
+						// translators: Placeholder is a URL.
+						__(
+							'⚠<b>️ The Legacy REST API will be removed in WooCommerce 9.0.</b> A separate WooCommerce extension will be available to re-enable it. <b><a target=”_blank” href="%s">Learn more about this change</a></b>',
+							'woocommerce'
+						),
+						'https://developer.woocommerce.com/2023/10/03/the-legacy-rest-api-will-move-to-a-dedicated-extension-in-woocommerce-9-0/'
+					),
 				),
 				array(
 					'type' => 'sectionend',

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-advanced.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-advanced.php
@@ -400,7 +400,7 @@ class WC_Settings_Advanced extends WC_Settings_Page {
 					'desc_tip' => sprintf(
 						// translators: Placeholder is a URL.
 						__(
-							'⚠<b>️ The Legacy REST API will be removed in WooCommerce 9.0.</b> A separate WooCommerce extension will be available to re-enable it. <b><a target=”_blank” href="%s">Learn more about this change</a></b>',
+							'⚠️ <b>️The Legacy REST API will be removed in WooCommerce 9.0.</b> A separate WooCommerce extension will soon be available to keep it enabled. <b><a target=”_blank” href="%s">Learn more about this change</a></b>',
 							'woocommerce'
 						),
 						'https://developer.woocommerce.com/2023/10/03/the-legacy-rest-api-will-move-to-a-dedicated-extension-in-woocommerce-9-0/'

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-advanced.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-advanced.php
@@ -383,6 +383,25 @@ class WC_Settings_Advanced extends WC_Settings_Page {
 	 * @return array
 	 */
 	protected function get_settings_for_legacy_api_section() {
+		$enable_legacy_api_setting = array(
+			'title'   => __( 'Legacy API', 'woocommerce' ),
+			'desc'    => __( 'Enable the legacy REST API', 'woocommerce' ),
+			'id'      => 'woocommerce_api_enabled',
+			'type'    => 'checkbox',
+			'default' => 'no',
+		);
+
+		if ( ! is_plugin_active( 'woocommerce-legacy-rest-api/woocommerce-legacy-rest-api.php' ) ) {
+			$enable_legacy_api_setting['desc_tip'] = sprintf(
+			// translators: Placeholder is a URL.
+				__(
+					'⚠️ <b>️The Legacy REST API will be removed in WooCommerce 9.0.</b> A separate WooCommerce extension will soon be available to keep it enabled. <b><a target=”_blank” href="%s">Learn more about this change</a></b>',
+					'woocommerce'
+				),
+				'https://developer.woocommerce.com/2023/10/03/the-legacy-rest-api-will-move-to-a-dedicated-extension-in-woocommerce-9-0/'
+			);
+		}
+
 		$settings =
 			array(
 				array(
@@ -391,21 +410,7 @@ class WC_Settings_Advanced extends WC_Settings_Page {
 					'desc'  => '',
 					'id'    => 'legacy_api_options',
 				),
-				array(
-					'title'    => __( 'Legacy API', 'woocommerce' ),
-					'desc'     => __( 'Enable the legacy REST API', 'woocommerce' ),
-					'id'       => 'woocommerce_api_enabled',
-					'type'     => 'checkbox',
-					'default'  => 'no',
-					'desc_tip' => sprintf(
-						// translators: Placeholder is a URL.
-						__(
-							'⚠️ <b>️The Legacy REST API will be removed in WooCommerce 9.0.</b> A separate WooCommerce extension will soon be available to keep it enabled. <b><a target=”_blank” href="%s">Learn more about this change</a></b>',
-							'woocommerce'
-						),
-						'https://developer.woocommerce.com/2023/10/03/the-legacy-rest-api-will-move-to-a-dedicated-extension-in-woocommerce-9-0/'
-					),
-				),
+				$enable_legacy_api_setting,
 				array(
 					'type' => 'sectionend',
 					'id'   => 'legacy_api_options',

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-advanced.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-advanced.php
@@ -395,7 +395,7 @@ class WC_Settings_Advanced extends WC_Settings_Page {
 			$enable_legacy_api_setting['desc_tip'] = sprintf(
 			// translators: Placeholder is a URL.
 				__(
-					'⚠️ <b>️The Legacy REST API will be removed in WooCommerce 9.0.</b> A separate WooCommerce extension will soon be available to keep it enabled. <b><a target=”_blank” href="%s">Learn more about this change</a></b>',
+					'⚠️ <b>️The Legacy REST API will be removed in WooCommerce 9.0.</b> A separate WooCommerce extension will soon be available to keep it enabled. <b><a target=”_blank” href="%s">Learn more about this change.</a></b>',
 					'woocommerce'
 				),
 				'https://developer.woocommerce.com/2023/10/03/the-legacy-rest-api-will-move-to-a-dedicated-extension-in-woocommerce-9-0/'


### PR DESCRIPTION
### Changes proposed in this Pull Request:

[The WooCommerce Legacy REST API will be moved to a separate plugin as of version 9.0](https://developer.woocommerce.com/2023/10/02/the-legacy-rest-api-will-move-to-a-dedicated-extension-in-woocommerce-9-0/). This pull request adds two notices about it in the admin area:

1. A permanent notice in WooCommerce - Settings - Advanced - Legacy API:

![image](https://github.com/woocommerce/woocommerce/assets/937723/3bf887d6-6579-41a5-9c2c-a63945912237)

2. A dismissable admin notice only if the Legacy API is enabled (disappears if it gets disabled):

![image](https://github.com/woocommerce/woocommerce/assets/937723/b6c36a85-0341-4b65-b55c-6bb8a307b119)

The "currently enabled in this site" link points to the Legacy API settings page.

None of these will appear if the dedicated extension is already installed and active (we assume its name will be `woocommerce-legacy-rest-api`).


### How to test the changes in this Pull Request:

1. Make sure that the Legacy API is disabled, via UI (WooCommerce - Settings - Advanced - Legacy API) or command line: `wp option update woocommerce_api_enabled no`

2. Run the following to simulate a WooCommerce update from the point of view of the admin notices: `wp eval 'WC_Admin_Notices::reset_admin_notices();'` This is required every time that the notice isn't being shown and you changed something that should make it appear (if you dismissed the notice manually see 9 below).

3. Load any admin page, nothing should have changed.

4. Notice that the warning about the removal is visible in the Legacy API settings page.

5. Enable the Legacy API via UI or command line: `wp option update woocommerce_api_enabled yes`

6. Reload any admin page, the dismissable notice should appear.

7. Disable the Legacy API.

8. Reload the admin page, the dismissable notice should have disappeared by itself.

9. Try again but this time dismiss the admin notice manually and verify that it doesn't appear anymore. The notice dismissal can be undone if needed by running the following: `wp db query "delete from wp_usermeta where meta_key='dismissed_legacy_api_removed_in_woo_90_notice'"`

10. Make sure that you have the legacy API enabled and the notice is being shown.

11. Create a `/wp-content/plugins/woocommerce-legacy-rest-api/woocommerce-legacy-rest-api.php` file in your WordPress install with the following content:

```php
<?php

/**
 * Plugin Name: WooCommerce Legacy REST API (Test)
 * Description: Just a dummy plugin for testing.
 */
```

12. Reload any admin page and make sure that that the admin notice and the warning in the Legacy API settings page are still there.

13. Activate the dummy plugin you just added via UI or via command line: `wp plugin activate woocommerce-legacy-rest-api/woocommerce-legacy-rest-api.php`

14. Reload the admin page, both the notice and the warning in the settings page should be gone.

Note that if from that point the (for now dummy) plugin is deactivated, the warning in the settings page will reappear but the admin notice won't (that's fine, if the user is playing around with the plugin we can consider him appropriately notified already).


### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Add notices about the removal of the Legacy API in WooCommerce 9.0

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
