### PR TITLE
REST API : PUT/POST HTML Product Description and Product Short Description

### DIFF
--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -407,11 +407,25 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 			$product->set_description( wp_filter_post_kses( $request['description'] ) );
 		}
 
+		// Post content (- HTML Format -).
+		if ( isset( $request['description'] ) ) {
+			if ( isset( $request['enable_html_description'] ) && true === $request['enable_html_description'] ) {
+				$product->set_description( html_entity_decode( wp_filter_post_kses( $request['description'] ) ) );
+			}
+		}
+		
 		// Post excerpt.
 		if ( isset( $request['short_description'] ) ) {
 			$product->set_short_description( wp_filter_post_kses( $request['short_description'] ) );
 		}
 
+		// Post excerpt (- HTML Format -).
+		if ( isset( $request['short_description'] ) ) {
+			if ( isset( $request['enable_html_short_description'] ) && true === $request['enable_html_short_description'] ) {
+				$product->set_short_description( html_entity_decode( wp_filter_post_kses( $request['short_description'] ) ) );
+			}
+		}
+		
 		// Post status.
 		if ( isset( $request['status'] ) ) {
 			$product->set_status( get_post_status_object( $request['status'] ) ? $request['status'] : 'draft' );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The implemented change allows you to send the product description, or the short description of the product, in pure HTML format, during REST API calls for creating and/or updating products.

Therefore, by sending the encoded HTML value, it will be correctly saved on the product database and, consequently, published appropriately on the front-end.

To do this, two parameters have been added to the payload, already present in Legacy API implementations, which allow you to specify that the product description or short product description is in encoded HTML format.

The two parameters to pass in the body are "enable_html_description" and "enable_html_short_description" which inform the API that these fields are in encoded HTML format.

On the other hand, therefore, the procedure will use HTML decoding before storing them in the database.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new product by sending a POST command to the standard API: POST ==> https://myip/wp-json/wc/v3/products
2. See an example JSON where both the "description" and "short_description" fields are sent with the html tags sending the word "TEST" in bold. Below is the example JSON: 
![image](https://github.com/woocommerce/woocommerce/assets/38110250/b4a78928-2efd-4dd5-a914-73ee9fb37535)
3. After making the call you will be able to verify that the field is correctly displayed on the front-end with the correct HTML attribute sent.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

In the Body of the JSON request it is now possible to add two new fields, called "enable_html_description" and "enable_html_short_description" which allow you to send the "description" and "short_description" fields of the products, in HTML format.

HTML must be encoded using the "htmlentities()" function because, when data is received, it is then decoded by the opposite function, "html_entity_decode()", before being stored in the database.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
