### PR TITLE
Do not override pagination args if `woocommerce_hpos_pre_query` doesn't override query

### DIFF
--- a/plugins/woocommerce/changelog/fix-40548
+++ b/plugins/woocommerce/changelog/fix-40548
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix backwards compatibility issue with `wc_get_orders()` when HPOS is active and the pagination bit is set.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php
@@ -230,21 +230,26 @@ class OrdersTableQuery {
 		 * @param OrdersTableQuery   $query The OrdersTableQuery instance.
 		 * @param string             $sql The OrdersTableQuery instance.
 		 */
-		list( $this->orders, $this->found_orders, $this->max_num_pages ) = apply_filters( 'woocommerce_hpos_pre_query', null, $this, $this->sql );
-		// If the filter set the orders, make sure the others values are set as well and skip running the query.
-		if ( is_array( $this->orders ) ) {
-			if ( ! is_int( $this->found_orders ) || $this->found_orders < 1 ) {
-				$this->found_orders = count( $this->orders );
-			}
-			if ( ! is_int( $this->max_num_pages ) || $this->max_num_pages < 1 ) {
-				if ( ! $this->arg_isset( 'limit' ) || ! is_int( $this->args['limit'] ) || $this->args['limit'] < 1 ) {
-					$this->args['limit'] = 10;
-				}
-				$this->max_num_pages = (int) ceil( $this->found_orders / $this->args['limit'] );
-			}
-			return true;
+		$pre_query = apply_filters( 'woocommerce_hpos_pre_query', null, $this, $this->sql );
+		if ( ! $pre_query || ! isset( $pre_query[0] ) || ! is_array( $pre_query[0] ) ) {
+			return false;
 		}
-		return false;
+
+		// If the filter set the orders, make sure the others values are set as well and skip running the query.
+		list( $this->orders, $this->found_orders, $this->max_num_pages ) = $pre_query;
+
+		if ( ! is_int( $this->found_orders ) || $this->found_orders < 1 ) {
+			$this->found_orders = count( $this->orders );
+		}
+
+		if ( ! is_int( $this->max_num_pages ) || $this->max_num_pages < 1 ) {
+			if ( ! $this->arg_isset( 'limit' ) || ! is_int( $this->args['limit'] ) || $this->args['limit'] < 1 ) {
+				$this->args['limit'] = 10;
+			}
+			$this->max_num_pages = (int) ceil( $this->found_orders / $this->args['limit'] );
+		}
+
+		return true;
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
@@ -351,15 +351,21 @@ class OrdersTableQueryTests extends WC_Unit_Test_Case {
 	 * @testdox A regular query will still work even if the pre-query escape hook returns null for the whole 3-tuple.
 	 */
 	public function test_pre_query_escape_hook_return_null() {
+		add_filter( 'woocommerce_hpos_pre_query', '__return_null', 10, 3 );
+
+		// Query with no results.
+		$query = new OrdersTableQuery();
+		$this->assertNotNull( $query->orders );
+		$this->assertNotNull( $query->found_orders );
+		$this->assertNotNull( $query->max_num_pages );
+		$this->assertCount( 0, $query->orders );
+		$this->assertEquals( 0, $query->found_orders );
+		$this->assertEquals( 0, $query->max_num_pages );
+
+		// Query with 1 result.
 		$order1 = new \WC_Order();
 		$order1->set_date_created( time() - HOUR_IN_SECONDS );
 		$order1->save();
-
-		$callback = function( $result, $query_object, $sql ) use ( $order1 ) {
-			// Just return null.
-			return null;
-		};
-		add_filter( 'woocommerce_hpos_pre_query', $callback, 10, 3 );
 
 		$query = new OrdersTableQuery();
 		$this->assertCount( 1, $query->orders );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
In #39945 we introduced a filter (`woocommerce_hpos_pre_query`) that allows overriding of HPOS queries, but it currently sets internal pagination variables to `NULL` even when not actually being used:

https://github.com/woocommerce/woocommerce/blob/8a6fcd8b2a3cdba2a250d2954c136f54c713e209/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableQuery.php#L233

This is incorrect as those variables have default values (of `0`) which should be preserved _unless_ the query is, in fact, overridden.

Closes #40548.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Start with HPOS enabled in WC > Settings > Advanced > Features.
2. Run the following snippet using WP-CLI (either `wp run-eval` or `wp shell`):
   ```php
   wc_get_orders(
	   [
		   'status'   => 'all',
		   'type'     => 'shop_order',
		   'post__in' => [0],
		   'limit'    => 1,
		   'return'   => 'ids',
		   'paginate' => true,
	   ]
   );
   ```
3. Confirm that the output is as follows:
   ```
   stdClass Object(
      [orders] => Array()
      [total] => 0
      [max_num_pages] => 0
   )
   ```
   In particular, `total` and `max_num_pages` should be 0.
4. Go back to WC > Settings > Advanced > Features and disable HPOS.
5. Repeat step 2 and confirm that the output is again that of step 3.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
