### PR TITLE
Fix core editor store available in classic

### DIFF
--- a/plugins/woocommerce/changelog/fix-core-editor-store-in-classic
+++ b/plugins/woocommerce/changelog/fix-core-editor-store-in-classic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix core-editor Redux store available in classic editor

--- a/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php
@@ -298,8 +298,7 @@ class WCAdminAssets {
 				$script_assets_filename = self::get_script_asset_filename( $script_path_name, 'index' );
 				$script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . $script_path_name . '/' . $script_assets_filename;
 
-				global
-				$wp_version;
+				global $wp_version;
 				if ( 'app' === $script_path_name && version_compare( $wp_version, '6.3', '<' ) ) {
 					// Remove wp-router dependency for WordPress versions < 6.3 because wp-router is not included in those versions. We only use wp-router in customize store pages and the feature is only available in WordPress 6.3+.
 					// We can remove this once our minimum support is WP 6.3.

--- a/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php
@@ -298,11 +298,22 @@ class WCAdminAssets {
 				$script_assets_filename = self::get_script_asset_filename( $script_path_name, 'index' );
 				$script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . $script_path_name . '/' . $script_assets_filename;
 
-				global $wp_version;
+				global
+				$wp_version;
 				if ( 'app' === $script_path_name && version_compare( $wp_version, '6.3', '<' ) ) {
 					// Remove wp-router dependency for WordPress versions < 6.3 because wp-router is not included in those versions. We only use wp-router in customize store pages and the feature is only available in WordPress 6.3+.
 					// We can remove this once our minimum support is WP 6.3.
 					$script_assets['dependencies'] = array_diff( $script_assets['dependencies'], array( 'wp-router' ) );
+				}
+
+				// Remove wp-editor dependency if we're not on a customize store page since we don't use wp-editor in other pages.
+				$is_customize_store_page = (
+					PageController::is_admin_page() &&
+					isset( $_GET['path'] ) &&
+					str_starts_with( wc_clean( wp_unslash( $_GET['path'] ) ), '/customize-store' )
+				);
+				if ( ! $is_customize_store_page ) {
+					$script_assets['dependencies'] = array_diff( $script_assets['dependencies'], array( 'wp-editor' ) );
 				}
 
 				wp_register_script(

--- a/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php
+++ b/plugins/woocommerce/src/Internal/Admin/WCAdminAssets.php
@@ -311,7 +311,7 @@ class WCAdminAssets {
 					isset( $_GET['path'] ) &&
 					str_starts_with( wc_clean( wp_unslash( $_GET['path'] ) ), '/customize-store' )
 				);
-				if ( ! $is_customize_store_page ) {
+				if ( ! $is_customize_store_page && WC_ADMIN_APP === $script ) {
 					$script_assets['dependencies'] = array_diff( $script_assets['dependencies'], array( 'wp-editor' ) );
 				}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

p1696248781817279-slack-C7KF0SHHQ

In the 8.2.0-beta, the core-editor Redux store is available in the classic product editor but it’s non-functional. This doesn't cause bugs for users but affects some plugins because they rely on the logic of whether the wp-editor store exists.

Since we only use it in customize your store area, this PR removes `wp-editor` from the dependencies array if we're not on a customize store page.



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to /wp-admin/post-new.php?post_type=product
2. Open dev console
3. Enter `wp.data.select('core/editor')`
4. Should return `undefined`.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>