### PR TITLE
Fix: HPOS keeping disabled when the database tables were created via enabling the setting (for Woo 8.2)

### DIFF
--- a/plugins/woocommerce/changelog/fix-hpos-being-disabled-on-tables-creation-8.2
+++ b/plugins/woocommerce/changelog/fix-hpos-being-disabled-on-tables-creation-8.2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Fix: HPOS keeping disabled when the database tables were created via enabling the setting

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/CustomOrdersTableController.php
@@ -249,23 +249,6 @@ class CustomOrdersTableController {
 	}
 
 	/**
-	 * Create the custom orders tables in response to the user pressing the tool button.
-	 *
-	 * @param bool $verify_nonce True to perform the nonce verification, false to skip it.
-	 *
-	 * @throws \Exception Can't create the tables.
-	 */
-	private function create_custom_orders_tables( bool $verify_nonce = true ) {
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput
-		if ( $verify_nonce && ( ! isset( $_REQUEST['_wpnonce'] ) || wp_verify_nonce( $_REQUEST['_wpnonce'], 'debug_action' ) === false ) ) {
-			throw new \Exception( 'Invalid nonce' );
-		}
-
-		$this->data_synchronizer->create_database_tables();
-		update_option( self::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, 'no' );
-	}
-
-	/**
 	 * Delete the custom orders tables and any related options and data in response to the user pressing the tool button.
 	 *
 	 * @throws \Exception Can't delete the tables.
@@ -365,7 +348,10 @@ class CustomOrdersTableController {
 		}
 
 		if ( ! $this->data_synchronizer->check_orders_table_exists() ) {
-			$this->create_custom_orders_tables( false );
+			$success = $this->data_synchronizer->create_database_tables();
+			if ( ! $success ) {
+				update_option( self::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION, 'no' );
+			}
 		}
 	}
 
@@ -461,7 +447,7 @@ class CustomOrdersTableController {
 			'disabled'    => $disabled_option,
 			'desc'        => $plugin_incompat_warning,
 			'desc_at_end' => true,
-			'row_class' => self::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION,
+			'row_class'   => self::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION,
 		);
 	}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/DataSynchronizer.php
@@ -155,7 +155,13 @@ class DataSynchronizer implements BatchProcessorInterface {
 	 */
 	public function create_database_tables() {
 		$this->database_util->dbdelta( $this->data_store->get_database_schema() );
-		$this->check_orders_table_exists();
+		$success = $this->check_orders_table_exists();
+		if ( ! $success ) {
+			$missing_tables = $this->database_util->get_missing_tables( $this->data_store->get_database_schema() );
+			$missing_tables = implode( ', ', $missing_tables );
+			$this->error_logger->error( "HPOS tables are missing in the database and couldn't be created. The missing tables are: $missing_tables" );
+		}
+		return $success;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Utilities/DatabaseUtil.php
+++ b/plugins/woocommerce/src/Internal/Utilities/DatabaseUtil.php
@@ -52,7 +52,7 @@ class DatabaseUtil {
 
 		foreach ( $dbdelta_output as $table_name => $result ) {
 			if ( "Created table $table_name" === $result ) {
-				$created_tables[] = $table_name;
+				$created_tables[] = str_replace( '(', '', $table_name );
 			}
 		}
 


### PR DESCRIPTION
This pull request is the same as https://github.com/woocommerce/woocommerce/pull/40466, but targetting the WooCommerce 8.2 release branch (there were merge conflicts when trying to cherry-pick 3974f7444375bbec8bc6fea69078d63f8abb3de8 into the `release/8.2` branch). Note that that commit isn't actually included in this pull request, instead a new one is created with the same changeset.