### PR TITLE
Use fallback color for select2 fields on non WooCommerce pages

### DIFF
--- a/plugins/woocommerce/changelog/fix-admin-select2-fallback-colors
+++ b/plugins/woocommerce/changelog/fix-admin-select2-fallback-colors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Use fallback color for select2 fields on non WooCommerce pages.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -7272,7 +7272,7 @@ table.bar_chart {
 	}
 
 	.select2-dropdown {
-		border-color: #007cba;
+		border-color: var(--wp-admin-theme-color, #007cba);
 
 		&::after {
 			position: absolute;
@@ -7285,7 +7285,7 @@ table.bar_chart {
 	}
 
 	.select2-dropdown--below {
-		box-shadow: 0 0 0 1px #007cba, 0 2px 1px rgba(0, 0, 0, 0.1);
+		box-shadow: 0 0 0 1px var(--wp-admin-theme-color, #007cba), 0 2px 1px rgba(0, 0, 0, 0.1);
 
 		&::after {
 			top: -1px;
@@ -7293,7 +7293,7 @@ table.bar_chart {
 	}
 
 	.select2-dropdown--above {
-		box-shadow: 0 0 0 1px #007cba, 0 -2px 1px rgba(0, 0, 0, 0.1);
+		box-shadow: 0 0 0 1px var(--wp-admin-theme-color, #007cba), 0 -2px 1px rgba(0, 0, 0, 0.1);
 
 		&::after {
 			bottom: -1px;
@@ -7329,7 +7329,7 @@ table.bar_chart {
 				}
 
 				&:hover {
-					color: #007cba;
+					color: var(--wp-admin-theme-color, #007cba);
 				}
 			}
 
@@ -7354,8 +7354,8 @@ table.bar_chart {
 		&.select2-container--focus .select2-selection--single,
 		&.select2-container--open .select2-selection--single,
 		&.select2-container--open .select2-selection--multiple {
-			border-color: #007cba;
-			box-shadow: 0 0 0 1px #007cba;
+			border-color: var(--wp-admin-theme-color, #007cba);
+			box-shadow: 0 0 0 1px var(--wp-admin-theme-color, #007cba);
 		}
 
 		.select2-selection--multiple {
@@ -7398,19 +7398,19 @@ table.bar_chart {
 .wp-admin {
 	&.wc-wp-version-gte-53 {
 		.select2-dropdown {
-			border-color: var(--wp-admin-theme-color);
+			border-color: var(--wp-admin-theme-color, #007cba);
 		}
 
 		.select2-dropdown--below {
-			box-shadow: 0 0 0 1px var(--wp-admin-theme-color), 0 2px 1px rgba(0, 0, 0, 0.1);
+			box-shadow: 0 0 0 1px var(--wp-admin-theme-color, #007cba), 0 2px 1px rgba(0, 0, 0, 0.1);
 		}
 
 		.select2-dropdown--above {
-			box-shadow: 0 0 0 1px var(--wp-admin-theme-color), 0 -2px 1px rgba(0, 0, 0, 0.1);
+			box-shadow: 0 0 0 1px var(--wp-admin-theme-color, #007cba), 0 -2px 1px rgba(0, 0, 0, 0.1);
 		}
 
 		.select2-selection--single .select2-selection__rendered:hover {
-			color: var(--wp-admin-theme-color);
+			color: var(--wp-admin-theme-color, #007cba);
 		}
 
 		.select2-container.select2-container--focus
@@ -7419,15 +7419,15 @@ table.bar_chart {
 		.select2-selection--single,
 		.select2-container.select2-container--open
 		.select2-selection--multiple {
-			border-color: var(--wp-admin-theme-color);
-			box-shadow: 0 0 0 1px var(--wp-admin-theme-color);
+			border-color: var(--wp-admin-theme-color, #007cba);
+			box-shadow: 0 0 0 1px var(--wp-admin-theme-color, #007cba);
 		}
 
 		.select2-container--default
 		.select2-results__option--highlighted[aria-selected],
 		.select2-container--default
 		.select2-results__option--highlighted[data-selected] {
-			background-color: var(--wp-admin-theme-color);
+			background-color: var(--wp-admin-theme-color, #007cba);
 		}
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Select2 fields can be used in non WooCommerce declared pages. With this PR
- https://github.com/woocommerce/woocommerce/pull/39451 
I've introduced the usage of `var(--wp-admin-theme-color)` , so that select2s follow the same color as the admin theme.

In non WooCommerce pages, these variables don't exist, and Select2's hover value, has white text, on white background.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

- [x] On your test site, install WooCommerce 8.1.0
- [x] In your themes's functions.php add the following code

```php
add_action( 'category_edit_form_fields', 'extra_category_fields' );
function extra_category_fields( $tag ) {

	wp_enqueue_style( 'woocommerce_admin_styles' );
	wp_enqueue_script( 'wc-enhanced-select' );

	?>
	<select id="addon-objects" name="addon-objects[]" multiple="multiple" style="width:50%;" data-placeholder="<?php esc_attr_e( 'Choose categories&hellip;', 'woocommerce' ); ?>" class="wc-enhanced-select">
		<option value="1">Category 1</option>
		<option value="2">Category 2</option>
		<option value="3">Category 3</option>
	</select>

	<?php
}
```

- [x] Visit `wp-admin/edit-tags.php?taxonomy=category` and edit a category
- [x] Hover over a category and see white text on white background
![image](https://github.com/woocommerce/woocommerce/assets/2484390/f7b1905a-5ef4-4ee4-9550-8235e3b7ccfa)

- [x] Checkout this branch `fix/admin-select2-fallback-colors` and build WooCommerce - Alternatively, download this zip [woocommerce.zip](https://github.com/woocommerce/woocommerce/files/12801768/woocommerce.zip)
- [x] Reload the page and you should see the select2 with fallback colors
![image](https://github.com/woocommerce/woocommerce/assets/2484390/32ba07ec-33ef-442c-ab12-cf3c0e627f8e)


 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
