### PR TITLE
Fix marketplace tab reset state

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
@@ -26,6 +26,7 @@ export default function Content(): JSX.Element {
 
 	// Get the content for this screen
 	useEffect( () => {
+		const abortController = new AbortController();
 		if ( [ '', 'discover' ].includes( selectedTab ) ) {
 			return;
 		}
@@ -62,7 +63,7 @@ export default function Content(): JSX.Element {
 			params.toString();
 
 		// Fetch data from WCCOM API
-		fetch( wccomSearchEndpoint )
+		fetch( wccomSearchEndpoint, { signal: abortController.signal } )
 			.then( ( response ) => response.json() )
 			.then( ( response ) => {
 				/**
@@ -96,6 +97,9 @@ export default function Content(): JSX.Element {
 			.finally( () => {
 				setIsLoading( false );
 			} );
+		return () => {
+			abortController.abort();
+		};
 	}, [ query.term, query.category, selectedTab, setIsLoading ] );
 
 	const renderContent = (): JSX.Element => {

--- a/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx
@@ -60,14 +60,12 @@ const tabs: Tabs = {
 };
 
 const setUrlTabParam = ( tabKey: string ) => {
-	if ( tabKey === DEFAULT_TAB_KEY ) {
-		navigateTo( {
-			url: getNewPath( {}, MARKETPLACE_PATH, {} ),
-		} );
-		return;
-	}
 	navigateTo( {
-		url: getNewPath( { tab: tabKey } ),
+		url: getNewPath(
+			{ tab: tabKey === DEFAULT_TAB_KEY ? undefined : tabKey },
+			MARKETPLACE_PATH,
+			{}
+		),
 	} );
 };
 

--- a/plugins/woocommerce/changelog/fix-marketplace-tab-reset-state
+++ b/plugins/woocommerce/changelog/fix-marketplace-tab-reset-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Fix content rendering issues with changing Marketplace tabs.
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes content rendering issues with changing Marketplace tabs.
Clicking on a tab will reset all url state params.
Content requests will be aborted after the component is removed.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Open the Extensions tab
2. Click on a category
3. Click on the Themes tab
4. Confirm that the `category` query string is removed
5. Now repeat the above steps but fast, so that the category request can't complete
6. You should see the themes tab load correctly
7. In the Dev tools Network tab, see that the category search API request was aborted with `NS_BINDING_ABORTED`

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

Fix content rendering issues with changing Marketplace tabs.

</details>
