### PR TITLE
Change the blocks editor header to support variations

### DIFF
--- a/packages/js/product-editor/changelog/dev-40590_change_header_to_support_variation
+++ b/packages/js/product-editor/changelog/dev-40590_change_header_to_support_variation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Change header to support variations #40606

--- a/packages/js/product-editor/changelog/dev-40590_change_header_to_support_variation
+++ b/packages/js/product-editor/changelog/dev-40590_change_header_to_support_variation
@@ -1,4 +1,4 @@
 Significance: minor
 Type: dev
 
-Change header to support variations #40606
+Change the blocks editor header to support variations #40606

--- a/packages/js/product-editor/src/components/header/header.tsx
+++ b/packages/js/product-editor/src/components/header/header.tsx
@@ -7,6 +7,10 @@ import { useEntityProp } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { createElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { Button, Tooltip } from '@wordpress/components';
+import { chevronLeft, group, Icon } from '@wordpress/icons';
+import { getNewPath, navigateTo } from '@woocommerce/navigation';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -17,11 +21,17 @@ import { PreviewButton } from './preview-button';
 import { SaveDraftButton } from './save-draft-button';
 import { PublishButton } from './publish-button';
 import { Tabs } from '../tabs';
+import { TRACKS_SOURCE } from '../../constants';
 
 export type HeaderProps = {
 	onTabSelect: ( tabId: string | null ) => void;
 	productType?: string;
 };
+
+const RETRUN_TO_MAIN_PRODUCT = __(
+	'Return to the main product',
+	'woocommerce'
+);
 
 export function Header( {
 	onTabSelect,
@@ -63,12 +73,56 @@ export function Header( {
 			tabIndex={ -1 }
 		>
 			<div className="woocommerce-product-header__inner">
-				<div />
+				{ productType === 'product_variation' ? (
+					<div className="woocommerce-product-header__back">
+						<Tooltip
+							// @ts-expect-error className is missing in TS, should remove this when it is included.
+							className="woocommerce-product-header__back-tooltip"
+							text={ RETRUN_TO_MAIN_PRODUCT }
+						>
+							<div className="woocommerce-product-header__back-tooltip-wrapper">
+								<Button
+									icon={ chevronLeft }
+									isTertiary={ true }
+									onClick={ () => {
+										recordEvent(
+											'product_variation_back_to_main_product',
+											{
+												source: TRACKS_SOURCE,
+											}
+										);
+										const url = getNewPath(
+											{ tab: 'variations' },
+											`/product/${ lastPersistedProduct.parent_id }`
+										);
+										navigateTo( { url } );
+									} }
+								>
+									{ __( 'Main product', 'woocommerce' ) }
+								</Button>
+							</div>
+						</Tooltip>
+					</div>
+				) : (
+					<div />
+				) }
 
 				<h1 className="woocommerce-product-header__title">
-					{ getHeaderTitle(
-						editedProductName,
-						lastPersistedProduct?.name
+					{ productType === 'product_variation' ? (
+						<div className="woocommerce-product-header__variable-product-title">
+							<Icon icon={ group } />
+							<span className="woocommerce-product-header__variable-product-name">
+								{ lastPersistedProduct?.name }
+							</span>
+							<span className="woocommerce-product-header__variable-product-id">
+								# { lastPersistedProduct.id }
+							</span>
+						</div>
+					) : (
+						getHeaderTitle(
+							editedProductName,
+							lastPersistedProduct.name
+						)
 					) }
 				</h1>
 

--- a/packages/js/product-editor/src/components/header/header.tsx
+++ b/packages/js/product-editor/src/components/header/header.tsx
@@ -28,7 +28,7 @@ export type HeaderProps = {
 	productType?: string;
 };
 
-const RETRUN_TO_MAIN_PRODUCT = __(
+const RETURN_TO_MAIN_PRODUCT = __(
 	'Return to the main product',
 	'woocommerce'
 );
@@ -78,7 +78,7 @@ export function Header( {
 						<Tooltip
 							// @ts-expect-error className is missing in TS, should remove this when it is included.
 							className="woocommerce-product-header__back-tooltip"
-							text={ RETRUN_TO_MAIN_PRODUCT }
+							text={ RETURN_TO_MAIN_PRODUCT }
 						>
 							<div className="woocommerce-product-header__back-tooltip-wrapper">
 								<Button

--- a/packages/js/product-editor/src/components/header/header.tsx
+++ b/packages/js/product-editor/src/components/header/header.tsx
@@ -73,7 +73,7 @@ export function Header( {
 			tabIndex={ -1 }
 		>
 			<div className="woocommerce-product-header__inner">
-				{ productType === 'product_variation' ? (
+				{ lastPersistedProduct?.parent_id > 0 ? (
 					<div className="woocommerce-product-header__back">
 						<Tooltip
 							// @ts-expect-error className is missing in TS, should remove this when it is included.
@@ -108,7 +108,7 @@ export function Header( {
 				) }
 
 				<h1 className="woocommerce-product-header__title">
-					{ productType === 'product_variation' ? (
+					{ lastPersistedProduct?.parent_id > 0 ? (
 						<div className="woocommerce-product-header__variable-product-title">
 							<Icon icon={ group } />
 							<span className="woocommerce-product-header__variable-product-name">

--- a/packages/js/product-editor/src/components/header/style.scss
+++ b/packages/js/product-editor/src/components/header/style.scss
@@ -47,6 +47,27 @@
 			color: #fff;
 		}
 	}
+
+	&__back-tooltip-wrapper {
+		width: fit-content;
+	}
+
+	&__variable-product-title {
+		display: flex;
+		align-items: center;
+		svg {
+			fill: $gray-600;
+		}
+	}
+
+	&__variable-product-name {
+		margin-left: 10px;
+	}
+
+	&__variable-product-id {
+		margin-left: 10px;
+		color: $gray-700;
+	}
 }
 
 .woocommerce-product-header__more-menu {

--- a/plugins/woocommerce/changelog/dev-40590_change_header_to_support_variation
+++ b/plugins/woocommerce/changelog/dev-40590_change_header_to_support_variation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Change the blocks editor header to support variations #40606

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
@@ -119,6 +119,8 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 			'attributes'            => $this->get_attributes( $object ),
 			'menu_order'            => $object->get_menu_order(),
 			'meta_data'             => $object->get_meta_data(),
+			'name'					=> preg_replace( '/' . preg_quote( $object->get_title().' - ', '/') . '/', '', $object->get_name(), 1 ),
+			'parent_id'				=> $object->get_parent_id(),
 		);
 
 		$data     = $this->add_additional_fields_to_object( $data, $request );

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
@@ -119,8 +119,8 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 			'attributes'            => $this->get_attributes( $object ),
 			'menu_order'            => $object->get_menu_order(),
 			'meta_data'             => $object->get_meta_data(),
-			'name'					=> preg_replace( '/' . preg_quote( $object->get_title().' - ', '/') . '/', '', $object->get_name(), 1 ),
-			'parent_id'				=> $object->get_parent_id(),
+			'name'                  => preg_replace( '/' . preg_quote( $object->get_title() . ' - ', '/' ) . '/', '', $object->get_name(), 1 ),
+			'parent_id'             => $object->get_parent_id(),
 		);
 
 		$data     = $this->add_additional_fields_to_object( $data, $request );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #40590.

**Acceptance Criteria**

- [ ] Change the header so it can support the variation name.
- [ ] The title in the header is the combination's name, e.g., White, Small, Cotton. On the left side of the name, we show the group icon in Gutenberg-600. On the right side, we show the variation's ID (same font, but regular weight. Color: Gutenberg-700).
- [ ] On the left, there's a button that says: Main product. On hover, it changes color to primary and shows a tooltip that reads: Return to the main product. AkVNGImLgSqCObTQ3idVn7-fi-7819_444061

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a WooCommerce store with this branch and enable the product editor using **WooCommerce > Settings > Advanced > Features**
2. Go to **Products > Add New**
3. Go to `/wp-admin/admin.php?page=wc-admin&path=/add-product&tab=variations` and add some attributes
4. Wait until variations get generated
5. Then publish the product and save its `productId` and one `variationId` you like
6. Then go to `/wp-admin/admin.php?page=wc-admin&path=/product/{productId}/variation/{variationId}&tab=general` (replace the `{productId}` and `{variationId}` with the values picked in point 5)
7. Now update your URL, removing the `&tab=variations` at the end and replacing it with `/variation/<variation_id>` (replacing the variation id with the one from the three-dot menu ).
8. Verify the button `Main product`, the variation's name, and the variation's id are visible in the header.

![Screenshot 2023-10-05 at 17 14 45](https://github.com/woocommerce/woocommerce/assets/1314156/31efe65e-8162-4af2-85ff-62be4fa35884)
 
9. After pressing `Main product` you should be redirected to the parent product.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
