### PR TITLE
Update the version bump command to support accelerated releases

### DIFF
--- a/tools/monorepo-utils/src/code-freeze/commands/version-bump/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/version-bump/index.ts
@@ -88,8 +88,10 @@ export const versionBumpCommand = new Command( 'version-bump' )
 			baseDir: tmpRepoPath,
 			config: [ 'core.hooksPath=/dev/null' ],
 		} );
-		
-		const majorMinor = getIsAccelRelease( version ) ? version : getMajorMinor( version );
+
+		const majorMinor = getIsAccelRelease( version )
+			? version
+			: getMajorMinor( version );
 		const branch = `prep/${ base }-for-next-dev-cycle-${ majorMinor }`;
 
 		try {

--- a/tools/monorepo-utils/src/code-freeze/commands/version-bump/index.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/version-bump/index.ts
@@ -16,7 +16,7 @@ import { createPullRequest } from '../../../core/github/repo';
 import { getEnvVar } from '../../../core/environment';
 import { getMajorMinor } from '../../../core/version';
 import { bumpFiles } from './bump';
-import { validateArgs } from './lib/validate';
+import { validateArgs, getIsAccelRelease } from './lib/validate';
 import { Options } from './types';
 
 export const versionBumpCommand = new Command( 'version-bump' )
@@ -45,6 +45,16 @@ export const versionBumpCommand = new Command( 'version-bump' )
 	.option(
 		'-c --commit-direct-to-base',
 		'Commit directly to the base branch. Do not create a PR just push directly to base branch',
+		false
+	)
+	.option(
+		'-f --force',
+		'Force a version bump, even when the new version is less than the existing version',
+		false
+	)
+	.option(
+		'-a --allow-accel',
+		'Allow accelerated versioning. When this option is not present, versions must be semantically correct',
 		false
 	)
 	.action( async ( version, options: Options ) => {
@@ -78,7 +88,8 @@ export const versionBumpCommand = new Command( 'version-bump' )
 			baseDir: tmpRepoPath,
 			config: [ 'core.hooksPath=/dev/null' ],
 		} );
-		const majorMinor = getMajorMinor( version );
+		
+		const majorMinor = getIsAccelRelease( version ) ? version : getMajorMinor( version );
 		const branch = `prep/${ base }-for-next-dev-cycle-${ majorMinor }`;
 
 		try {

--- a/tools/monorepo-utils/src/code-freeze/commands/version-bump/lib/validate.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/version-bump/lib/validate.ts
@@ -10,6 +10,20 @@ import { readFile } from 'fs/promises';
  */
 import { Logger } from '../../../../core/logger';
 import { Options } from '../types';
+
+/**
+ * Determine whether a version is an accel release.
+ *
+ * @param {string} version Version number
+ * @return {bool} True if the version corresponds with an accel release, otherwise false
+ */
+export const getIsAccelRelease = (
+	version: string
+): boolean => {
+	const isAccelRelease = version.match( /^(?:\d+\.){3}\d+(?:\.\d+)?$/ );
+	return isAccelRelease !== null;
+}
+
 /**
  * Get a plugin's current version.
  *
@@ -57,25 +71,38 @@ export const validateArgs = async (
 	version: string,
 	options: Options
 ): Promise< void > => {
-	const { base } = options;
+	const { allowAccel, base, force } = options;
 	const nextVersion = version;
+	const isAllowedAccelRelease = allowAccel && getIsAccelRelease( nextVersion );
 
-	if ( ! valid( nextVersion ) ) {
-		Logger.error(
-			'Invalid version supplied, please pass in a semantically correct version.'
-		);
+	if ( isAllowedAccelRelease ) {
+		if ( base === 'trunk' ) {
+			Logger.error(
+				`Version ${ nextVersion } is not a development version bump and cannot be applied to trunk, which only accepts development version bumps.`
+			);
+		}
+	} else {
+		if ( ! valid( nextVersion ) ) {
+			Logger.error(
+				'Invalid version supplied, please pass in a semantically correct version or use the correct option for accel releases.'
+			);
+		}
+
+		const prereleaseParameters = prerelease( nextVersion );
+		const isDevVersionBump =
+			prereleaseParameters && prereleaseParameters[ 0 ] === 'dev';
+
+		if ( ! isDevVersionBump && base === 'trunk' ) {
+			Logger.error(
+				`Version ${ nextVersion } is not a development version bump and cannot be applied to trunk, which only accepts development version bumps.`
+			);
+		}
 	}
 
-	const prereleaseParameters = prerelease( nextVersion );
-	const isDevVersionBump =
-		prereleaseParameters && prereleaseParameters[ 0 ] === 'dev';
-
-	if ( ! isDevVersionBump && base === 'trunk' ) {
-		Logger.error(
-			`Version ${ nextVersion } is not a development version bump and cannot be applied to trunk, which only accepts development version bumps.`
-		);
+	if ( force ) {
+		// When the force option is set, we do not compare currentVersion.
+		return;
 	}
-
 	const currentVersion = await getCurrentVersion( tmpRepoPath );
 
 	if ( ! currentVersion ) {

--- a/tools/monorepo-utils/src/code-freeze/commands/version-bump/lib/validate.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/version-bump/lib/validate.ts
@@ -18,7 +18,7 @@ import { Options } from '../types';
  * @return {boolean} True if the version corresponds with an accel release, otherwise false
  */
 export const getIsAccelRelease = ( version: string ): boolean => {
-	const isAccelRelease = version.match( /^(?:\d+\.){3}\d+(?:\.\d+)?$/ );
+	const isAccelRelease = version.match( /^(?:\d+\.){3}\d+?$/ );
 	return isAccelRelease !== null;
 };
 

--- a/tools/monorepo-utils/src/code-freeze/commands/version-bump/lib/validate.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/version-bump/lib/validate.ts
@@ -15,14 +15,12 @@ import { Options } from '../types';
  * Determine whether a version is an accel release.
  *
  * @param {string} version Version number
- * @return {bool} True if the version corresponds with an accel release, otherwise false
+ * @return {boolean} True if the version corresponds with an accel release, otherwise false
  */
-export const getIsAccelRelease = (
-	version: string
-): boolean => {
+export const getIsAccelRelease = ( version: string ): boolean => {
 	const isAccelRelease = version.match( /^(?:\d+\.){3}\d+(?:\.\d+)?$/ );
 	return isAccelRelease !== null;
-}
+};
 
 /**
  * Get a plugin's current version.
@@ -73,7 +71,8 @@ export const validateArgs = async (
 ): Promise< void > => {
 	const { allowAccel, base, force } = options;
 	const nextVersion = version;
-	const isAllowedAccelRelease = allowAccel && getIsAccelRelease( nextVersion );
+	const isAllowedAccelRelease =
+		allowAccel && getIsAccelRelease( nextVersion );
 
 	if ( isAllowedAccelRelease ) {
 		if ( base === 'trunk' ) {

--- a/tools/monorepo-utils/src/code-freeze/commands/version-bump/types.ts
+++ b/tools/monorepo-utils/src/code-freeze/commands/version-bump/types.ts
@@ -4,4 +4,6 @@ export type Options = {
 	base?: string;
 	dryRun?: boolean;
 	commitDirectToBase?: boolean;
+	allowAccel?: boolean;
+	force?: boolean;
 };


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

This PR updates the version bump command to allow for versioning that is used for accelerated releases. This adds two options: `-f`, which allows for version bumps to go backwards, when specified, and `-a`, which allows for versioning that matches that of accelerated releases (4-digit, such as "8.2.0.30").

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout this branch
2. Build the utils changed in this PR: `pnpm --filter=./tools/monorepo-utils build`
3. Fork this repo (if you haven't already).
4. Create a branch named `test/version-bump` within your fork, based on `trunk`.
5. Try updating the version to 6.0.0. This should fail, because you're attempting to "bump" the version backward: `GITHUB_TOKEN=... pnpm utils code-freeze version-bump -o jonathansadowski -b test/version-bump 6.0.0`  (replace `jonathansadowski` with your fork owner, and specify a `GITHUB_TOKEN`)
6. Repeat the previous command, but add the `-f` option, this should succeed and create a PR in your fork to bump the version backward to 6.0.0: `GITHUB_TOKEN=... pnpm utils code-freeze version-bump -f -o jonathansadowski -b test/version-bump 6.0.0`
7. Now try setting the version to a version corresponding to an accelerated release (for example: 6.0.0.10), this should fail, because by default, the command doesn't accept accelerated release versioning: `GITHUB_TOKEN=... pnpm utils code-freeze version-bump -f -o jonathansadowski -b test/version-bump 6.0.0.10`
8. Finally, repeat the command but this time adding the `-a` option, to accept accelerated versioning, this should create a PR updating the versioning throughout the code to 6.0.0.10: `GITHUB_TOKEN=... pnpm utils code-freeze version-bump -af -o jonathansadowski -b test/version-bump 6.0.0.10`

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
