### PR TITLE
[Customize Your Store] Add "Inter + Inter" font pairing & Set default font pairing

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/constants.ts
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/constants.ts
@@ -8,6 +8,62 @@ export const SYSTEM_FONT_SLUG = 'system-font';
 // TODO: Consider creating an API endpoint for this data
 export const FONT_PAIRINGS = [
 	{
+		title: 'Inter + Inter',
+		version: 2,
+		settings: {
+			typography: {
+				fontFamilies: {
+					theme: [
+						{
+							fontFamily: 'Inter',
+							slug: 'inter',
+						},
+					],
+				},
+			},
+		},
+		styles: {
+			elements: {
+				button: {
+					typography: {
+						fontFamily: 'var(--wp--preset--font-family--inter)',
+						fontWeight: '400',
+						lineHeight: '1',
+					},
+				},
+				heading: {
+					typography: {
+						fontFamily: 'var(--wp--preset--font-family--inter)',
+						fontStyle: 'normal',
+						fontWeight: '600',
+						lineHeight: '1.2',
+					},
+				},
+			},
+			blocks: {
+				'core/site-title': {
+					typography: {
+						fontFamily: 'var(--wp--preset--font-family--inter)',
+						fontSize: 'var(--wp--preset--font-size--medium)',
+						fontStyle: 'normal',
+					},
+				},
+				'core/post-navigation-link': {
+					typography: {
+						fontFamily: 'var(--wp--preset--font-family--inter)',
+					},
+				},
+			},
+			typography: {
+				fontFamily: 'var(--wp--preset--font-family--inter)',
+				fontSize: 'var(--wp--preset--font-size--medium)',
+				fontStyle: 'normal',
+				fontWeight: '400',
+				lineHeight: '1.6',
+			},
+		},
+	},
+	{
 		title: 'Bodoni Moda + Overpass',
 		version: 2,
 		settings: {

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/actions.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/actions.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { assign, spawn } from 'xstate';
+import { assign, spawn, EventObject } from 'xstate';
 import {
 	getQuery,
 	updateQueryString,
@@ -106,6 +106,28 @@ const assignFontPairing = assign<
 	designWithAiStateMachineEvents
 >( {
 	aiSuggestions: ( context, event: unknown ) => {
+		if ( ( event as EventObject ).type === 'xstate.error' ) {
+			let fontPairing = context.aiSuggestions.fontPairing;
+			const choice = context.lookAndFeel.choice;
+
+			switch ( true ) {
+				case choice === 'Contemporary':
+					fontPairing = 'Inter + Inter';
+					break;
+				case choice === 'Classic':
+					fontPairing = 'Bodoni Moda + Overpass';
+					break;
+				case choice === 'Bold':
+					fontPairing = 'Rubik + Inter';
+					break;
+			}
+
+			return {
+				...context.aiSuggestions,
+				fontPairing,
+			};
+		}
+
 		return {
 			...context.aiSuggestions,
 			fontPairing: (

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/prompts/fontPairings.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/prompts/fontPairings.ts
@@ -7,6 +7,13 @@ import { z } from 'zod';
 /** Original source: plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/constants.ts */
 const fontChoices = [
 	{
+		pair_name: 'Inter + Inter',
+		fonts: {
+			Inter: 'A highly legible sans-serif, optimized for UI design.',
+		},
+		settings: 'Inter is used for buttons and general typography.',
+	},
+	{
 		pair_name: 'Bodoni Moda + Overpass',
 		fonts: {
 			'Bodoni Moda':

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/state-machine.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/state-machine.tsx
@@ -347,6 +347,9 @@ export const designWithAiStateMachineDefinition = createMachine(
 											},
 											// If there's an error we don't want to block the user from proceeding.
 											onError: {
+												actions: [
+													'assignFontPairing',
+												],
 												target: 'success',
 											},
 										},

--- a/plugins/woocommerce/changelog/update-set-default-font-pairing
+++ b/plugins/woocommerce/changelog/update-set-default-font-pairing
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Set Set default font pairing for CYS


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #40539.

Default to the following pairing when failing to get AI response 

| Look and Feel Choice | Font|
|--------|--------|
| Contemporary | Inter, Inter |
| Classic | Bodoni moda, Overpass |
| Bold | Rubik, Inter |


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

This feature is part of the larger customize your store development and behind a feature flag, hence QA review can be deferred until the call for testing before release.



**Make sure you are testing this with a Jetpack connected instance of WooCommerce, as the AI text completion endpoint can only be called with a Jetpack connected account.**

1. Create a new WooCommerce installation with this version.
2. Make sure to enable `customize-store` feature flag
3. Install and activate [WooCommerce Blocks nightly build](https://github.com/woocommerce/woocommerce-blocks/releases/tag/nightly) 
4. Go to `WooCommerce -> Home` and click `Customize Store` task
5. Click `Design with AI` button
6. Open dev console > Network tab and tick "preserve log" option
7. Follow through the flow all the way till the assembler hub shows up
8. Click on `Change fonts`
9. Observe that there is an `Inter + Inter` option
10. Block `/wpcom/v2/text-completion`  network request URL (https://tweak-extension.com/blog/how-to-block-http-request)
11. Go to `/wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store%2Fdesign-with-ai%2Flook-and-feel`
12. Select `Contemporary`
13. Follow through the flow all the way till the assembler hub shows up
14. Confirm the font pair is set to ` Inter, Inter.`
15. Repeat the steps 12-14 with different choices and confirmed the font pair is set as expected.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
