### PR TITLE
[Customize Your Store] Fix preview opacity style does not reset after saving changes

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/save-hub.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/save-hub.tsx
@@ -30,6 +30,7 @@ import { recordEvent } from '@woocommerce/tracks';
  * Internal dependencies
  */
 import { CustomizeStoreContext } from '../';
+import { HighlightedBlockContext } from '../context/highlighted-block-context';
 
 const PUBLISH_ON_SAVE_ENTITIES = [
 	{
@@ -43,7 +44,9 @@ export const SaveHub = () => {
 	const { sendEvent } = useContext( CustomizeStoreContext );
 	const [ isResolving, setIsResolving ] = useState< boolean >( false );
 	const navigator = useNavigator();
-
+	const { resetHighlightedBlockIndex } = useContext(
+		HighlightedBlockContext
+	);
 	// @ts-ignore No types for this exist yet.
 	const { __unstableMarkLastChangeAsPersistent } =
 		useDispatch( blockEditorStore );
@@ -125,6 +128,7 @@ export const SaveHub = () => {
 
 		try {
 			await save();
+			resetHighlightedBlockIndex();
 			navigator.goToParent();
 		} catch ( error ) {
 			createErrorNotice(

--- a/plugins/woocommerce/changelog/fix-cys-opacity-issue
+++ b/plugins/woocommerce/changelog/fix-cys-opacity-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix cys opacity style does not reset after saving


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fix preview opacity style does not reset after saving changes

Before

https://github.com/woocommerce/woocommerce/assets/4344253/1b9232ea-ff5c-4621-8585-fa31d069b594


After:


https://github.com/woocommerce/woocommerce/assets/4344253/c6ddd9a0-53c5-4244-8b05-2d239f2df15b



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

This feature is part of the larger customize your store development and behind a feature flag, hence QA review can be deferred until the call for testing before release.


1. Create a new WooCommerce installation with this version.
2. Make sure to enable `customize-store` feature flag
3. Go to /wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store%2Fassembler-hub
4. Click on `Change your header`
5. Select a header
6. Click on "Save" button
7. Observe that the preview iframe has no opacity style applied.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
