### PR TITLE
Added default stock amount filter and function

### DIFF
--- a/plugins/woocommerce/changelog/Added default stock amount function and filter.
+++ b/plugins/woocommerce/changelog/Added default stock amount function and filter.
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Added default stock amount function and filter.

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-data-inventory.php
@@ -56,7 +56,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			woocommerce_wp_text_input(
 				array(
 					'id'                => '_stock',
-					'value'             => wc_stock_amount( $product_object->get_stock_quantity( 'edit' ) ?? 1 ),
+					'value'             => wc_stock_amount( $product_object->get_stock_quantity( 'edit' ) ?? wc_get_default_stock_amount() ),
 					'label'             => __( 'Quantity', 'woocommerce' ),
 					'desc_tip'          => true,
 					'description'       => __( 'Stock quantity. If this is a variable product this value will be used to control stock for all variations, unless you define stock at variation level.', 'woocommerce' ),

--- a/plugins/woocommerce/includes/wc-stock-functions.php
+++ b/plugins/woocommerce/includes/wc-stock-functions.php
@@ -428,11 +428,15 @@ function wc_get_low_stock_amount( WC_Product $product ) {
 /**
  * Return default stock amount. (Default: 1)
  *
+ * @since x.x.x
+ *
  * @return int
  */
 function wc_get_default_stock_amount() {
 	/**
 	 * Filters default stock amount. (Default: 1)
+	 *
+	 * @since x.x.x
 	 *
 	 * @return int
 	 */

--- a/plugins/woocommerce/includes/wc-stock-functions.php
+++ b/plugins/woocommerce/includes/wc-stock-functions.php
@@ -424,3 +424,17 @@ function wc_get_low_stock_amount( WC_Product $product ) {
 
 	return (int) $low_stock_amount;
 }
+
+/**
+ * Return default stock amount. (Default: 1)
+ *
+ * @return int
+ */
+function wc_get_default_stock_amount() {
+	/**
+	 * Filters default stock amount. (Default: 1)
+	 *
+	 * @return int
+	 */
+	return (int) apply_filters( 'woocommerce_default_stock_amount', 1 );
+}

--- a/plugins/woocommerce/tests/php/includes/wc-stock-functions-tests.php
+++ b/plugins/woocommerce/tests/php/includes/wc-stock-functions-tests.php
@@ -357,4 +357,10 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 		$this->assertIsIntAndEquals( $site_wide_low_stock_amount, wc_get_low_stock_amount( $var1 ) );
 	}
 
+	/**
+	 * Test wc_get_default_stock_amount() which should always return 1.
+	 */
+	public function test_wc_get_default_stock_amount() {
+		$this->assertIsIntAndEquals( 1, wc_get_default_stock_amount() );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/wc-stock-functions-tests.php
+++ b/plugins/woocommerce/tests/php/includes/wc-stock-functions-tests.php
@@ -362,5 +362,11 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 	 */
 	public function test_wc_get_default_stock_amount() {
 		$this->assertIsIntAndEquals( 1, wc_get_default_stock_amount() );
+
+		add_filter( 'woocommerce_default_stock_amount', function( $amount ) {
+			return '200abc';
+		});
+
+		$this->assertIsIntAndEquals( 200, wc_get_default_stock_amount() );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/wc-stock-functions-tests.php
+++ b/plugins/woocommerce/tests/php/includes/wc-stock-functions-tests.php
@@ -363,9 +363,12 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 	public function test_wc_get_default_stock_amount() {
 		$this->assertIsIntAndEquals( 1, wc_get_default_stock_amount() );
 
-		add_filter( 'woocommerce_default_stock_amount', function( $amount ) {
-			return '200abc';
-		});
+		add_filter(
+			'woocommerce_default_stock_amount',
+			function( $amount ) {
+				return '200abc';
+			}
+		);
 
 		$this->assertIsIntAndEquals( 200, wc_get_default_stock_amount() );
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #39180.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check out the branch `git checkout mi5t4n:add-default-stock-amount-filter`
2. Goto to the new product window, and check the `Track stock quantity for the product`. You will see the default stock quantity of value 1.
![2023-10-06_16-22_1](https://github.com/woocommerce/woocommerce/assets/8264719/1118a4ac-3196-4499-868d-06ddde2aefd3)
3. Create a plugin at `wp-content/plugins/test/test.php` with following code.
```php
<?php
/**
 * Plugin Name: Test Code
 * Description: Can be used to test https://github.com/woocommerce/woocommerce/pull/40614. Remove after the test.
 * WC Tested up to: 8.3.0-dev
 */

add_filter( 'woocommerce_default_stock_amount', function( $amount ) {
	return 200;
});
```
4. Activate the test plugin.
5. Go to the new product window again, and check the `Track stock quantity for the product`. You will see the default stock quantity of value 200
![2023-10-06_16-22](https://github.com/woocommerce/woocommerce/assets/8264719/6469f3e0-06bf-4fb3-9634-eeb57657abb5)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

Added a function `wc_get_default_stock_amount` along with the filter to allow change of the default stock amount.

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
