### PR TITLE
Skip combining translation files without comment.reference

### DIFF
--- a/plugins/woocommerce/changelog/update-38191-fix-german-translation-error-on-reactivation
+++ b/plugins/woocommerce/changelog/update-38191-fix-german-translation-error-on-reactivation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Skip combining translation files without comment.reference

--- a/plugins/woocommerce/src/Internal/Admin/Translations.php
+++ b/plugins/woocommerce/src/Internal/Admin/Translations.php
@@ -81,6 +81,10 @@ class Translations {
 				continue;
 			}
 
+			if ( ! isset( $chunk_data['comment']['reference'] ) ) {
+				continue;
+			}
+
 			$reference_file = $chunk_data['comment']['reference'];
 
 			// Only combine "app" files (not scripts registered with WP).


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #38191  .

This PR fixes a PHP warning when a translation has an invalid format. 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Let's first reproduce the error.

1. Use the latest WooCommerce build and create a new JN site.
2. Go to `Settings -> General`
3. Change `Site Language` to `Deutsch`
4. Go to `Dashboard -> Aktualisierungen `
5. Upgrade `en_US` translation

![Screen Shot 2023-10-05 at 2 13 18 PM](https://github.com/woocommerce/woocommerce/assets/4723145/9072096d-2666-4818-91bc-a8b08e4b13a6)

6. Go back to `Dashboard -> Aktualisierungen`
7. Upgrade `de_DE`. 
![Screen Shot 2023-10-05 at 2 14 38 PM](https://github.com/woocommerce/woocommerce/assets/4723145/416addb0-d4f3-44fe-bcfa-7211df9fd5e9)

8. Go to `Plugins`
9. Deactivate `WooCommerce`
10. Activate `WooCommerce` again
11. You should see the following errors.
![Screen Shot 2023-10-05 at 2 16 01 PM](https://github.com/woocommerce/woocommerce/assets/4723145/0db0a873-06c9-425f-bd01-863d40c86e0d)

12. Create a new JN site with this branch and run the test again. 
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Skip combining translation files without comment.reference

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
