### PR TITLE
Fix badge size issue when a number larger than 3 digits is used

### DIFF
--- a/packages/js/components/changelog/fix-34015-badge-design-fix
+++ b/packages/js/components/changelog/fix-34015-badge-design-fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix badge size issue when a number larger than 3 digits is used.

--- a/packages/js/components/src/badge/style.scss
+++ b/packages/js/components/src/badge/style.scss
@@ -8,7 +8,7 @@
 	font-size: 14px;
 	line-height: 27px;
 	align-items: center;
-	width: auto;
-	height: auto;
+    min-width: 32px;
+    height: 28px;
 	padding: 0 6px;
 }

--- a/packages/js/components/src/badge/style.scss
+++ b/packages/js/components/src/badge/style.scss
@@ -8,6 +8,7 @@
 	font-size: 14px;
 	line-height: 27px;
 	align-items: center;
-	width: 32px;
-	height: 28px;
+	width: auto;
+	height: auto;
+	padding: 0 6px;
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34015 .

This PR fixes badge size issue when a number larger than 3 digits is used.

Credit to @aezazs-multidots for the fix.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new JN site with this branch.
2. Go to `WooCommerce -> Home`
3. Right click on the badge next to `Thigns to do next` and choose `Inspect`
4. Change the number to 9999
5. Confirm the badge expands.


![Screen Shot 2023-10-05 at 3 24 47 PM](https://github.com/woocommerce/woocommerce/assets/4723145/a72c4b2a-0769-4087-8018-5b6c8137f5a7)


Before:

![Screen Shot 2023-10-05 at 3 25 06 PM](https://github.com/woocommerce/woocommerce/assets/4723145/a0cd891b-843e-4f92-8ed5-49d8c480cfc8)

After:

![Screen Shot 2023-10-05 at 3 25 30 PM](https://github.com/woocommerce/woocommerce/assets/4723145/b29c499b-9f55-4f47-9258-e92a5a995b02)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix badge size issue when a number larger than 3 digits is used.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
