### PR TITLE
Marketplace: Implement the subscriptions table row

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
@@ -22,6 +22,7 @@ import SearchResults from '../search-results/search-results';
 import Themes from '../themes/themes';
 import MySubscriptions from '../my-subscriptions/my-subscriptions';
 import { MarketplaceContext } from '../../contexts/marketplace-context';
+import { SubscriptionsContextProvider } from '../../contexts/subscriptions-context';
 
 export default function Content(): JSX.Element {
 	const marketplaceContextValue = useContext( MarketplaceContext );
@@ -135,7 +136,11 @@ export default function Content(): JSX.Element {
 			case 'discover':
 				return <Discover />;
 			case 'my-subscriptions':
-				return <MySubscriptions />;
+				return (
+					<SubscriptionsContextProvider>
+						<MySubscriptions />
+					</SubscriptionsContextProvider>
+				);
 			default:
 				return <></>;
 		}

--- a/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
@@ -19,7 +19,6 @@ import { getAdminSetting } from '../../../utils/admin-settings';
 import Discover from '../discover/discover';
 import Products from '../products/products';
 import SearchResults from '../search-results/search-results';
-import Themes from '../themes/themes';
 import MySubscriptions from '../my-subscriptions/my-subscriptions';
 import { MarketplaceContext } from '../../contexts/marketplace-context';
 import { SubscriptionsContextProvider } from '../../contexts/subscriptions-context';

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.scss
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.scss
@@ -85,7 +85,7 @@
 	border: none;
 	color: var(--wp-red-red-70, #8a2424);
 	background: var(--wp-red-red-0, #fcf0f1);
-	padding: 0 8px;
+	padding: 2px 8px;
 
 	& > svg {
 		margin-right: 2px;
@@ -94,6 +94,8 @@
 }
 
 .woocommerce-marketplace__my-subscriptions__status-popover .components-popover__content {
+	border: 1px solid $gray-400;
+	width: 300px;
 	border-radius: 2px;
 	padding: 12px;
 	color: $gray-900;

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.scss
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.scss
@@ -65,6 +65,13 @@
 		border-radius: 4px;
 		width: 40px;
 	}
+
+	svg {
+		border-radius: 4px;
+		padding: 8px;
+		fill: $gray-600;
+		background-color: $gray-200;
+	}
 }
 
 .woocommerce-marketplace__my-subscriptions__product {

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.scss
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.scss
@@ -1,3 +1,5 @@
+@import '@wordpress/base-styles/_colors.native.scss';
+
 /* Tooltip doesn't look exactly like a standard <Tooltip> */
 .woocommerce-marketplace__my-subscriptions {
 	.components-tooltip .components-popover__content {
@@ -26,4 +28,70 @@
 			width: 15px;
 		}
 	}
+}
+
+.woocommerce-marketplace__my-subscriptions__header {
+	font-size: 20px;
+	color: $gray-900;
+	font-weight: 400;
+	margin-top: $grid-unit-40;
+}
+
+.woocommerce-marketplace__my-subscriptions__table-description {
+	display: flex;
+	align-items: center;
+	font-size: 13px;
+	margin-top: $grid-unit-05;
+}
+
+.woocommerce-marketplace__my-subscriptions__table {
+	font-size: 13px;
+	line-height: 20px;
+	margin-top: $grid-unit-30;
+}
+
+.woocommerce-marketplace__my-subscriptions__product {
+	display: flex;
+	align-items: center;
+
+	&-name {
+		margin-left: 12px;
+		line-height: 18px;
+		font-weight: 600;
+		color: $gray-900;
+	}
+
+	&-icon {
+		border-radius: 4px;
+		width: 40px;
+	}
+}
+
+.woocommerce-marketplace__my-subscriptions__product {
+	color: $gray-700;
+}
+
+.woocommerce-marketplace__my-subscriptions__status-warning {
+	display: flex;
+	align-items: center;
+	border-radius: 2px;
+	border: none;
+	color: var(--wp-red-red-70, #8a2424);
+	background: var(--wp-red-red-0, #fcf0f1);
+	padding: 0 8px;
+
+	& > svg {
+		margin-right: 2px;
+		fill: var(--wp-red-red-70, #8a2424);
+	}
+}
+
+.woocommerce-marketplace__my-subscriptions__status-popover .components-popover__content {
+	border-radius: 2px;
+	padding: 12px;
+	color: $gray-900;
+}
+
+.components-base-control.woocommerce-marketplace__my-subscriptions__activation {
+	margin-bottom: 0;
 }

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.scss
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.scss
@@ -53,9 +53,10 @@
 .woocommerce-marketplace__my-subscriptions__product {
 	display: flex;
 	align-items: center;
+	color: $gray-700;
 
 	&-name {
-		margin-left: 12px;
+		margin-left: $grid-unit-15;
 		line-height: 18px;
 		font-weight: 600;
 		color: $gray-900;
@@ -68,14 +69,10 @@
 
 	svg {
 		border-radius: 4px;
-		padding: 8px;
+		padding: $grid-unit-10;
 		fill: $gray-600;
 		background-color: $gray-200;
 	}
-}
-
-.woocommerce-marketplace__my-subscriptions__product {
-	color: $gray-700;
 }
 
 .woocommerce-marketplace__my-subscriptions__status-warning {
@@ -97,7 +94,7 @@
 	border: 1px solid $gray-400;
 	width: 300px;
 	border-radius: 2px;
-	padding: 12px;
+	padding: $grid-unit-15; 
 	color: $gray-900;
 }
 

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.tsx
@@ -5,7 +5,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { Button, Tooltip } from '@wordpress/components';
 import { getNewPath } from '@woocommerce/navigation';
 import { help } from '@wordpress/icons';
-import { useContext, useEffect, useState } from '@wordpress/element';
+import { useContext } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -13,8 +13,6 @@ import { useContext, useEffect, useState } from '@wordpress/element';
 import { getAdminSetting } from '../../../utils/admin-settings';
 import { Subscription } from './types';
 import './my-subscriptions.scss';
-import { MarketplaceContext } from '../../contexts/marketplace-context';
-import { fetchSubscriptions } from '../../../marketplace/utils/functions';
 import {
 	InstalledSubscriptionsTable,
 	AvailableSubscriptionsTable,
@@ -23,26 +21,10 @@ import {
 	installedSubscriptionRow,
 	availableSubscriptionRow,
 } from './table/table-rows';
+import { SubscriptionsContext } from '../../contexts/subscriptions-context';
 
 export default function MySubscriptions(): JSX.Element {
-	const [ subscriptions, setSubscriptions ] = useState<
-		Array< Subscription >
-	>( [] );
-	const marketplaceContextValue = useContext( MarketplaceContext );
-	const { isLoading, setIsLoading } = marketplaceContextValue;
-
-	// Get the content for this screen
-	useEffect( () => {
-		setIsLoading( true );
-
-		fetchSubscriptions()
-			.then( ( subscriptionResponse ) => {
-				setSubscriptions( subscriptionResponse );
-			} )
-			.finally( () => {
-				setIsLoading( false );
-			} );
-	}, [] );
+	const { subscriptions, isLoading } = useContext( SubscriptionsContext );
 
 	const updateConnectionUrl = getNewPath(
 		{

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.tsx
@@ -5,7 +5,6 @@ import { __, sprintf } from '@wordpress/i18n';
 import { Button, Tooltip } from '@wordpress/components';
 import { getNewPath } from '@woocommerce/navigation';
 import { help } from '@wordpress/icons';
-import { Table } from '@woocommerce/components';
 import { useContext, useEffect, useState } from '@wordpress/element';
 
 /**
@@ -16,12 +15,21 @@ import { Subscription } from './types';
 import './my-subscriptions.scss';
 import { MarketplaceContext } from '../../contexts/marketplace-context';
 import { fetchSubscriptions } from '../../../marketplace/utils/functions';
+import {
+	InstalledSubscriptionsTable,
+	AvailableSubscriptionsTable,
+} from './table/table';
+import {
+	installedSubscriptionRow,
+	availableSubscriptionRow,
+} from './table/table-rows';
 
 export default function MySubscriptions(): JSX.Element {
 	const [ subscriptions, setSubscriptions ] = useState<
 		Array< Subscription >
 	>( [] );
-	const { setIsLoading } = useContext( MarketplaceContext );
+	const marketplaceContextValue = useContext( MarketplaceContext );
+	const { isLoading, setIsLoading } = marketplaceContextValue;
 
 	// Get the content for this screen
 	useEffect( () => {
@@ -55,110 +63,22 @@ export default function MySubscriptions(): JSX.Element {
 		updateConnectionUrl
 	);
 
-	const tableHeadersInstalled = [
-		{
-			key: 'name',
-			label: __( 'Name', 'woocommerce' ),
-		},
-		{
-			key: 'status',
-			label: __( 'Status', 'woocommerce' ),
-		},
-		{
-			key: 'expiry',
-			label: __( 'Expiry/Renewal date', 'woocommerce' ),
-		},
-		{
-			key: 'autoRenew',
-			label: __( 'Auto-renew', 'woocommerce' ),
-		},
-		{
-			key: 'version',
-			label: __( 'Version', 'woocommerce' ),
-			isNumeric: true,
-		},
-		{
-			key: 'activated',
-			label: __( 'Activated', 'woocommerce' ),
-		},
-		{
-			key: 'actions',
-			label: __( 'Actions', 'woocommerce' ),
-		},
-	];
 	const subscriptionsInstalled: Array< Subscription > = subscriptions.filter(
 		( subscription: Subscription ) => subscription.local.installed
 	);
 
-	const tableHeadersAvailable = [
-		{
-			key: 'name',
-			label: __( 'Name', 'woocommerce' ),
-		},
-		{
-			key: 'status',
-			label: __( 'Status', 'woocommerce' ),
-		},
-		{
-			key: 'expiry',
-			label: __( 'Expiry/Renewal date', 'woocommerce' ),
-		},
-		{
-			key: 'autoRenew',
-			label: __( 'Auto-renew', 'woocommerce' ),
-		},
-		{
-			key: 'version',
-			label: __( 'Version', 'woocommerce' ),
-			isNumeric: true,
-		},
-		{
-			key: 'install',
-			label: __( 'Install', 'woocommerce' ),
-		},
-		{
-			key: 'actions',
-			label: __( 'Actions', 'woocommerce' ),
-		},
-	];
 	const subscriptionsAvailable: Array< Subscription > = subscriptions.filter(
 		( subscription: Subscription ) =>
 			! subscriptionsInstalled.includes( subscription )
 	);
 
-	const getStatus = ( subscription: Subscription ): string => {
-		// TODO add statuses for subscriptions
-		if ( subscription.product_key === '' ) {
-			return __( 'Not found', 'woocommerce' );
-		} else if ( subscription.expired ) {
-			return __( 'Expired', 'woocommerce' );
-		} else if ( subscription.active ) {
-			return __( 'Active', 'woocommerce' );
-		}
-		return __( 'Inactive', 'woocommerce' );
-	};
-
-	const getVersion = ( subscription: Subscription ): string => {
-		if ( subscription.local.version === subscription.version ) {
-			return subscription.local.version;
-		}
-		if ( subscription.local.version && subscription.version ) {
-			return subscription.local.version + ' > ' + subscription.version;
-		}
-		if ( subscription.version ) {
-			return subscription.version;
-		}
-		if ( subscription.local.version ) {
-			return subscription.local.version;
-		}
-		return '';
-	};
-
 	return (
 		<div className="woocommerce-marketplace__my-subscriptions">
 			<section>
-				<h2>{ __( 'Installed on this store', 'woocommerce' ) }</h2>
-				<p>
+				<h2 className="woocommerce-marketplace__my-subscriptions__header">
+					{ __( 'Installed on this store', 'woocommerce' ) }
+				</h2>
+				<p className="woocommerce-marketplace__my-subscriptions__table-description">
 					<span
 						dangerouslySetInnerHTML={ {
 							__html: updateConnectionHTML,
@@ -192,43 +112,46 @@ export default function MySubscriptions(): JSX.Element {
 						/>
 					</Tooltip>
 				</p>
-				<Table
-					headers={ tableHeadersInstalled }
+				<InstalledSubscriptionsTable
+					isLoading={ isLoading }
 					rows={ subscriptionsInstalled.map( ( item ) => {
-						return [
-							{ display: item.product_name },
-							{ display: getStatus( item ) },
-							{ display: item.expires },
-							{ display: item.autorenew ? 'true' : 'false' },
-							{ display: getVersion( item ) },
-							{ display: item.active ? 'true' : 'false' },
-							{ display: '...' },
-						];
+						return installedSubscriptionRow( item );
 					} ) }
 				/>
 			</section>
 
 			<section>
-				<h2>{ __( 'Available', 'woocommerce' ) }</h2>
-				<p>
+				<h2 className="woocommerce-marketplace__my-subscriptions__header">
+					{ __( 'Not in use', 'woocommerce' ) }
+				</h2>
+				<p className="woocommerce-marketplace__my-subscriptions__table-description">
 					{ __(
-						'Your unused and free WooCommerce.com subscriptions.',
+						'Your unused WooCommerce.com subscriptions.',
 						'woocommerce'
 					) }
 				</p>
-				<Table
-					headers={ tableHeadersAvailable }
+				<AvailableSubscriptionsTable
+					isLoading={ isLoading }
 					rows={ subscriptionsAvailable.map( ( item ) => {
-						return [
-							{ display: item.product_name },
-							{ display: getStatus( item ) },
-							{ display: item.expires },
-							{ display: item.autorenew ? 'true' : 'false' },
-							{ display: getVersion( item ) },
-							{ display: '...' },
-							{ display: '...' },
-						];
+						return availableSubscriptionRow( item );
 					} ) }
+				/>
+			</section>
+
+			<section>
+				<h2 className="woocommerce-marketplace__my-subscriptions__header">
+					{ __( 'Free to install', 'woocommerce' ) }
+				</h2>
+				<p className="woocommerce-marketplace__my-subscriptions__table-description">
+					{ __(
+						'Easily install your existing free to install WooCommerce.com subscriptions across sites.',
+						'woocommerce'
+					) }
+				</p>
+				<AvailableSubscriptionsTable
+					isLoading={ isLoading }
+					// TODO: fetch free and uninstalled subscriptions.
+					rows={ [] }
 				/>
 			</section>
 		</div>

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/rows/actions-dropdown-menu.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/rows/actions-dropdown-menu.tsx
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import { DropdownMenu } from '@wordpress/components';
+import { moreVertical, external, plugins } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+
+export default function ActionsDropdownMenu() {
+	return (
+		<DropdownMenu
+			icon={ moreVertical }
+			label="Select a direction"
+			controls={ [
+				{
+					title: __( 'Manage in WooCommerce.com', 'woocommerce' ),
+					icon: external,
+					onClick: () => {},
+				},
+				{
+					title: __( 'Manage in Pluins', 'woocommerce' ),
+					icon: plugins,
+					onClick: () => {},
+				},
+			] }
+		/>
+	);
+}

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/rows/actions-dropdown-menu.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/rows/actions-dropdown-menu.tsx
@@ -9,7 +9,10 @@ export default function ActionsDropdownMenu() {
 	return (
 		<DropdownMenu
 			icon={ moreVertical }
-			label={ __( 'See more things you can do with this subscription', 'woocommerce' ) }
+			label={ __(
+				'See more things you can do with this subscription',
+				'woocommerce'
+			) }
 			controls={ [
 				{
 					title: __( 'Manage in WooCommerce.com', 'woocommerce' ),

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/rows/actions-dropdown-menu.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/rows/actions-dropdown-menu.tsx
@@ -14,12 +14,17 @@ export default function ActionsDropdownMenu() {
 				{
 					title: __( 'Manage in WooCommerce.com', 'woocommerce' ),
 					icon: external,
-					onClick: () => {},
+					onClick: () => {
+						window.location.href =
+							'https://woocommerce.com/my-account/my-subscriptions';
+					},
 				},
 				{
 					title: __( 'Manage in Pluins', 'woocommerce' ),
 					icon: plugins,
-					onClick: () => {},
+					onClick: () => {
+						window.location.href = '/wp-admin/plugins.php';
+					},
 				},
 			] }
 		/>

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/rows/actions-dropdown-menu.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/rows/actions-dropdown-menu.tsx
@@ -9,7 +9,7 @@ export default function ActionsDropdownMenu() {
 	return (
 		<DropdownMenu
 			icon={ moreVertical }
-			label="Select a direction"
+			label={ __( 'See more things you can do with this subscription', 'woocommerce' ) }
 			controls={ [
 				{
 					title: __( 'Manage in WooCommerce.com', 'woocommerce' ),
@@ -20,7 +20,7 @@ export default function ActionsDropdownMenu() {
 					},
 				},
 				{
-					title: __( 'Manage in Pluins', 'woocommerce' ),
+					title: __( 'Manage in Plugins', 'woocommerce' ),
 					icon: plugins,
 					onClick: () => {
 						window.location.href = '/wp-admin/plugins.php';

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/rows/activation-toggle.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/rows/activation-toggle.tsx
@@ -2,16 +2,24 @@
  * External dependencies
  */
 import { ToggleControl } from '@wordpress/components';
-import { useState } from '@wordpress/element';
 
-export default function ActivationToggle( props: { checked: boolean } ) {
-	const [ value, setValue ] = useState( props.checked );
+/**
+ * Internal dependencies
+ */
+import { Subscription } from '../../types';
+import Install from './install';
 
-	return (
-		<ToggleControl
-			checked={ value }
-			onChange={ () => setValue( ( state ) => ! state ) }
-			className="woocommerce-marketplace__my-subscriptions__activation"
-		/>
-	);
+interface ActivationToggleProps {
+	subscription: Subscription;
+}
+
+export default function ActivationToggle( props: ActivationToggleProps ) {
+	if (
+		props.subscription.local.installed === false &&
+		props.subscription.maxed === false
+	) {
+		return <Install subscription={ props.subscription } />;
+	}
+
+	return <ToggleControl checked={ props.subscription.active } />;
 }

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/rows/activation-toggle.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/rows/activation-toggle.tsx
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import { ToggleControl } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+
+export default function ActivationToggle( props: { checked: boolean } ) {
+	const [ value, setValue ] = useState( props.checked );
+
+	return (
+		<ToggleControl
+			checked={ value }
+			onChange={ () => setValue( ( state ) => ! state ) }
+			className="woocommerce-marketplace__my-subscriptions__activation"
+		/>
+	);
+}

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/rows/functions.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/rows/functions.tsx
@@ -177,22 +177,10 @@ export function version( subscription: Subscription ): TableRow {
 }
 
 export function activation( subscription: Subscription ): TableRow {
-	const displayElement = (
-		<ActivationToggle checked={ subscription.autorenew } />
-	);
+	const displayElement = <ActivationToggle subscription={ subscription } />;
 
 	return {
 		display: displayElement,
-	};
-}
-
-export function install(): TableRow {
-	return {
-		display: (
-			<Button variant="primary">
-				{ __( 'Install', 'woocommerce' ) }
-			</Button>
-		),
 	};
 }
 

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/rows/functions.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/rows/functions.tsx
@@ -5,7 +5,6 @@ import { __, sprintf } from '@wordpress/i18n';
 import { TableRow } from '@woocommerce/components/build-types/table/types';
 import { Icon, plugins } from '@wordpress/icons';
 import { gmdateI18n } from '@wordpress/date';
-import { Button } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -15,12 +14,12 @@ import StatusPopover from './status-popover';
 import ActivationToggle from './activation-toggle';
 import ActionsDropdownMenu from './actions-dropdown-menu';
 
+// TODO: Add explanations.
 function getStatus( subscription: Subscription ): {
 	text: string;
 	warning: boolean;
 	explanation?: string;
 } {
-	// TODO add statuses for subscriptions
 	if ( subscription.active ) {
 		return {
 			text: __( 'Active', 'woocommerce' ),

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/rows/functions.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/rows/functions.tsx
@@ -1,0 +1,203 @@
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { TableRow } from '@woocommerce/components/build-types/table/types';
+import { Icon, plugins } from '@wordpress/icons';
+import { gmdateI18n } from '@wordpress/date';
+import { Button } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { Subscription } from '../../types';
+import StatusPopover from './status-popover';
+import ActivationToggle from './activation-toggle';
+import ActionsDropdownMenu from './actions-dropdown-menu';
+
+function getStatus( subscription: Subscription ): {
+	text: string;
+	warning: boolean;
+	explanation?: string;
+} {
+	// TODO add statuses for subscriptions
+	if ( subscription.active ) {
+		return {
+			text: __( 'Active', 'woocommerce' ),
+			warning: false,
+		};
+	}
+
+	if ( subscription.product_key === '' ) {
+		return {
+			text: __( 'Not found', 'woocommerce' ),
+			warning: true,
+			explanation: __( 'This subscription is not found.', 'woocommerce' ),
+		};
+	}
+
+	if ( subscription.expired ) {
+		return {
+			text: __( 'Expired', 'woocommerce' ),
+			warning: true,
+			explanation: __(
+				'To receive updates and support for this extension, you need to purchase a new subscription or consolidate your extensions to one connected account by sharing or transferring this extension to this connected account.',
+				'woocommerce'
+			),
+		};
+	}
+
+	return {
+		text: __( 'Inactive', 'woocommerce' ),
+		warning: true,
+		explanation: __(
+			'To receive updates and support for this extension, you need to purchase a new subscription or consolidate your extensions to one connected account by sharing or transferring this extension to this connected account.',
+			'woocommerce'
+		),
+	};
+}
+
+function getVersion( subscription: Subscription ): string {
+	if ( subscription.local.version === subscription.version ) {
+		return subscription.local.version;
+	}
+
+	if ( subscription.local.version && subscription.version ) {
+		return subscription.local.version + ' > ' + subscription.version;
+	}
+
+	if ( subscription.version ) {
+		return subscription.version;
+	}
+
+	if ( subscription.local.version ) {
+		return subscription.local.version;
+	}
+
+	return '';
+}
+
+export function productName( subscription: Subscription ): TableRow {
+	// This is the fallback icon element with products without an icon.
+	let iconElement = <Icon icon={ plugins } size={ 40 } />;
+
+	// If the product has an icon, use that instead.
+	if ( subscription.product_icon !== '' ) {
+		iconElement = (
+			<img
+				src={ subscription.product_icon }
+				alt={ sprintf(
+					/* translators: %s is the product name. */
+					__( '%s icon', 'woocommerce' ),
+					subscription.product_name
+				) }
+				className="woocommerce-marketplace__my-subscriptions__product-icon"
+			/>
+		);
+	}
+
+	const displayElement = (
+		<div className="woocommerce-marketplace__my-subscriptions__product">
+			{ iconElement }
+			<span className="woocommerce-marketplace__my-subscriptions__product-name">
+				{ subscription.product_name }
+			</span>
+		</div>
+	);
+
+	return {
+		display: displayElement,
+		value: subscription.product_name,
+	};
+}
+
+export function status( subscription: Subscription ): TableRow {
+	const subscriptionStatus = getStatus( subscription );
+
+	let statusElement = <>{ subscriptionStatus.text }</>;
+
+	if ( subscriptionStatus.warning ) {
+		statusElement = (
+			<StatusPopover
+				text={ subscriptionStatus.text }
+				explanation={ subscriptionStatus.explanation ?? '' }
+			/>
+		);
+	}
+
+	const displayElement = (
+		<span className="woocommerce-marketplace__my-subscriptions__status">
+			{ statusElement }
+		</span>
+	);
+
+	return {
+		display: displayElement,
+		value: subscriptionStatus.text,
+	};
+}
+
+export function expiry( subscription: Subscription ): TableRow {
+	const expiryDate = subscription.expires;
+
+	let expiryDateElement = __( 'Never expires', 'woocommerce' );
+
+	if ( expiryDate ) {
+		expiryDateElement = gmdateI18n(
+			'j M, Y',
+			new Date( expiryDate * 1000 )
+		);
+	}
+
+	const displayElement = (
+		<span className="woocommerce-marketplace__my-subscriptions__expiry-date">
+			{ expiryDateElement }
+		</span>
+	);
+
+	return {
+		display: displayElement,
+		value: expiryDate,
+	};
+}
+
+export function autoRenew( subscription: Subscription ): TableRow {
+	return {
+		display: subscription.autorenew
+			? __( 'On', 'woocommerce' )
+			: __( 'Off', 'woocommerce' ),
+		value: subscription.autorenew,
+	};
+}
+
+export function version( subscription: Subscription ): TableRow {
+	return {
+		display: getVersion( subscription ),
+	};
+}
+
+export function activation( subscription: Subscription ): TableRow {
+	const displayElement = (
+		<ActivationToggle checked={ subscription.autorenew } />
+	);
+
+	return {
+		display: displayElement,
+	};
+}
+
+export function install(): TableRow {
+	return {
+		display: (
+			<Button variant="primary">
+				{ __( 'Install', 'woocommerce' ) }
+			</Button>
+		),
+	};
+}
+
+export function actions(): TableRow {
+	return {
+		display: <ActionsDropdownMenu />,
+	};
+}

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/rows/functions.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/rows/functions.tsx
@@ -41,7 +41,7 @@ function getStatus( subscription: Subscription ): {
 			text: __( 'Expired', 'woocommerce' ),
 			warning: true,
 			explanation: __(
-				'To receive updates and support for this extension, you need to purchase a new subscription or consolidate your extensions to one connected account by sharing or transferring this extension to this connected account.',
+				'To get updates and support for this extension, you need to purchase a new subscription, or else share or transfer a subscription for this extension from another account.',
 				'woocommerce'
 			),
 		};

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/rows/functions.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/rows/functions.tsx
@@ -82,7 +82,7 @@ export function productName( subscription: Subscription ): TableRow {
 	let iconElement = <Icon icon={ plugins } size={ 40 } />;
 
 	// If the product has an icon, use that instead.
-	if ( subscription.product_icon !== '' ) {
+	if ( subscription.product_icon ) {
 		iconElement = (
 			<img
 				src={ subscription.product_icon }

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/rows/install.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/rows/install.tsx
@@ -1,0 +1,82 @@
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { Button, Icon } from '@wordpress/components';
+import { useContext, useState } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { Subscription } from '../../types';
+import { installProduct } from '../../../../utils/functions';
+import { SubscriptionsContext } from '../../../../contexts/subscriptions-context';
+
+interface ActivationToggleProps {
+	subscription: Subscription;
+}
+
+export default function Install( props: ActivationToggleProps ) {
+	const [ loading, setLoading ] = useState( false );
+	const { createWarningNotice, createSuccessNotice } =
+		useDispatch( 'core/notices' );
+	const { loadSubscriptions } = useContext( SubscriptionsContext );
+
+	const install = () => {
+		setLoading( true );
+		installProduct( props.subscription.product_key )
+			.then( () => {
+				loadSubscriptions( false );
+				createSuccessNotice(
+					sprintf(
+						// translators: %s is the product name.
+						__( '%s successfully installed.', 'woocommerce' ),
+						props.subscription.product_name
+					),
+					{
+						icon: <Icon icon="yes" />,
+					}
+				);
+			} )
+			.catch( () => {
+				createWarningNotice(
+					sprintf(
+						// translators: %s is the product name.
+						__( '%s couldn’t be installed.', 'woocommerce' ),
+						props.subscription.product_name
+					),
+					{
+						actions: [
+							{
+								label: __( 'Try again', 'woocommerce' ),
+								onClick: install,
+							},
+						],
+					}
+				);
+			} )
+			.finally( () => {
+				setLoading( false );
+			} );
+	};
+
+	function installButtonLabel( installing: boolean ) {
+		if ( installing ) {
+			return __( 'Installing…', 'woocommerce' );
+		}
+
+		return __( 'Install', 'woocommerce' );
+	}
+
+	return (
+		<Button
+			variant="primary"
+			isBusy={ loading }
+			disabled={ loading }
+			onClick={ install }
+		>
+			{ installButtonLabel( loading ) }
+		</Button>
+	);
+}

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/rows/status-popover.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/rows/status-popover.tsx
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import { Popover } from '@wordpress/components';
+import { Icon, info } from '@wordpress/icons';
+import { useState } from '@wordpress/element';
+
+export default function StatusPopover( props: {
+	text: string;
+	explanation: string;
+} ) {
+	const [ isVisible, setIsVisible ] = useState( false );
+
+	function shouldShowExplanation() {
+		if ( props.explanation === '' ) {
+			return false;
+		}
+
+		return isVisible;
+	}
+
+	return (
+		<button
+			onClick={ () => {
+				setIsVisible( ! isVisible );
+			} }
+			className="woocommerce-marketplace__my-subscriptions__status-warning"
+		>
+			<Icon icon={ info } size={ 16 } />
+			{ props.text }
+			{ shouldShowExplanation() && (
+				<Popover className="woocommerce-marketplace__my-subscriptions__status-popover">
+					{ props.explanation }
+				</Popover>
+			) }
+		</button>
+	);
+}

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/table-rows.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/table-rows.tsx
@@ -13,7 +13,6 @@ import {
 	autoRenew,
 	version,
 	activation,
-	install,
 	actions,
 } from './rows/functions';
 
@@ -24,7 +23,7 @@ export function availableSubscriptionRow( item: Subscription ): TableRow[] {
 		expiry( item ),
 		autoRenew( item ),
 		version( item ),
-		install(),
+		activation( item ),
 		actions(),
 	];
 }

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/table-rows.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/table-rows.tsx
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import { TableRow } from '@woocommerce/components/build-types/table/types';
+/**
+ * Internal dependencies
+ */
+import { Subscription } from '../types';
+import {
+	productName,
+	status,
+	expiry,
+	autoRenew,
+	version,
+	activation,
+	install,
+	actions,
+} from './rows/functions';
+
+export function availableSubscriptionRow( item: Subscription ): TableRow[] {
+	return [
+		productName( item ),
+		status( item ),
+		expiry( item ),
+		autoRenew( item ),
+		version( item ),
+		install(),
+		actions(),
+	];
+}
+
+export function installedSubscriptionRow( item: Subscription ): TableRow[] {
+	return [
+		productName( item ),
+		status( item ),
+		expiry( item ),
+		autoRenew( item ),
+		version( item ),
+		activation( item ),
+		actions(),
+	];
+}

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/table.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/table.tsx
@@ -1,0 +1,105 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Table, TablePlaceholder } from '@woocommerce/components';
+import {
+	TableHeader,
+	TableRow,
+} from '@woocommerce/components/build-types/table/types';
+
+const tableHeadersDefault = [
+	{
+		key: 'name',
+		label: __( 'Name', 'woocommerce' ),
+	},
+	{
+		key: 'status',
+		label: __( 'Status', 'woocommerce' ),
+	},
+	{
+		key: 'expiry',
+		label: __( 'Expiry/Renewal date', 'woocommerce' ),
+	},
+	{
+		key: 'autoRenew',
+		label: __( 'Auto-renew', 'woocommerce' ),
+	},
+	{
+		key: 'version',
+		label: __( 'Version', 'woocommerce' ),
+	},
+];
+
+function SubscriptionsTable( props: {
+	rows?: TableRow[][];
+	headers: TableHeader[];
+	isLoading: boolean;
+} ) {
+	if ( props.isLoading ) {
+		return (
+			<TablePlaceholder
+				caption={ __( 'Loading your subscriptions', 'woocommerce' ) }
+				headers={ props.headers }
+			/>
+		);
+	}
+
+	return (
+		<Table
+			className="woocommerce-marketplace__my-subscriptions__table"
+			headers={ props.headers }
+			rows={ props.rows }
+		/>
+	);
+}
+
+export function InstalledSubscriptionsTable( props: {
+	rows?: TableRow[][];
+	isLoading: boolean;
+} ) {
+	const headers = [
+		...tableHeadersDefault,
+		{
+			key: 'activated',
+			label: __( 'Activated', 'woocommerce' ),
+		},
+		{
+			key: 'actions',
+			label: __( 'Actions', 'woocommerce' ),
+		},
+	];
+
+	return (
+		<SubscriptionsTable
+			rows={ props.rows }
+			isLoading={ props.isLoading }
+			headers={ headers }
+		/>
+	);
+}
+
+export function AvailableSubscriptionsTable( props: {
+	rows?: TableRow[][];
+	isLoading: boolean;
+} ) {
+	const headers = [
+		...tableHeadersDefault,
+		{
+			key: 'install',
+			label: __( 'Install', 'woocommerce' ),
+		},
+		{
+			key: 'actions',
+			label: __( 'Actions', 'woocommerce' ),
+		},
+	];
+
+	return (
+		<SubscriptionsTable
+			rows={ props.rows }
+			isLoading={ props.isLoading }
+			headers={ headers }
+		/>
+	);
+}

--- a/plugins/woocommerce-admin/client/marketplace/contexts/subscriptions-context.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/contexts/subscriptions-context.tsx
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import { useState, createContext, useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { SubscriptionsContextType } from './types';
+import { Subscription } from '../components/my-subscriptions/types';
+import { fetchSubscriptions } from '../utils/functions';
+
+export const SubscriptionsContext = createContext< SubscriptionsContextType >( {
+	subscriptions: [],
+	setSubscriptions: () => {},
+	loadSubscriptions: () => {},
+	isLoading: true,
+	setIsLoading: () => {},
+} );
+
+export function SubscriptionsContextProvider( props: {
+	children: JSX.Element;
+} ): JSX.Element {
+	const [ subscriptions, setSubscriptions ] = useState<
+		Array< Subscription >
+	>( [] );
+	const [ isLoading, setIsLoading ] = useState( true );
+
+	const loadSubscriptions = ( toggleLoading?: boolean ) => {
+		if ( toggleLoading === true ) {
+			setIsLoading( true );
+		}
+
+		fetchSubscriptions()
+			.then( ( subscriptionResponse ) => {
+				setSubscriptions( subscriptionResponse );
+			} )
+			.finally( () => {
+				if ( toggleLoading ) {
+					setIsLoading( false );
+				}
+			} );
+	};
+
+	useEffect( () => loadSubscriptions( true ), [] );
+
+	const contextValue = {
+		subscriptions,
+		setSubscriptions,
+		loadSubscriptions,
+		isLoading,
+		setIsLoading,
+	};
+
+	return (
+		<SubscriptionsContext.Provider value={ contextValue }>
+			{ props.children }
+		</SubscriptionsContext.Provider>
+	);
+}

--- a/plugins/woocommerce-admin/client/marketplace/contexts/types.ts
+++ b/plugins/woocommerce-admin/client/marketplace/contexts/types.ts
@@ -1,6 +1,19 @@
+/**
+ * Internal dependencies
+ */
+import { Subscription } from '../components/my-subscriptions/types';
+
 export type MarketplaceContextType = {
 	isLoading: boolean;
 	setIsLoading: ( isLoading: boolean ) => void;
 	selectedTab: string;
 	setSelectedTab: ( tab: string ) => void;
+};
+
+export type SubscriptionsContextType = {
+	subscriptions: Subscription[];
+	setSubscriptions: ( subscriptions: Subscription[] ) => void;
+	loadSubscriptions: ( toggleLoading?: boolean ) => void;
+	isLoading: boolean;
+	setIsLoading: ( isLoading: boolean ) => void;
 };

--- a/plugins/woocommerce-admin/client/marketplace/utils/functions.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/utils/functions.tsx
@@ -72,6 +72,20 @@ async function fetchSubscriptions(): Promise< Array< Subscription > > {
 	return await apiFetch( { path: url.toString() } );
 }
 
+function installProduct( productKey: string ): Promise< void > {
+	const url = '/wc/v3/marketplace/subscriptions/install';
+	const data = new URLSearchParams();
+	data.append( 'product_key', productKey );
+	return apiFetch( {
+		path: url.toString(),
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/x-www-form-urlencoded',
+		},
+		body: data,
+	} );
+}
+
 // Append UTM parameters to a URL, being aware of existing query parameters
 const appendURLParams = (
 	url: string,
@@ -95,6 +109,7 @@ export {
 	fetchDiscoverPageData,
 	fetchCategories,
 	fetchSubscriptions,
+	installProduct,
 	ProductGroup,
 	appendURLParams,
 };

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-subscriptions-api.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-subscriptions-api.php
@@ -189,7 +189,7 @@ class WC_Helper_Subscriptions_API {
 	}
 
 	/**
-	 * Install a WooCommerce.com produc
+	 * Install a WooCommerce.com product.
 	 */
 	public static function install( $request ) {
 		$product_key = $request->get_param('product_key');
@@ -248,7 +248,7 @@ class WC_Helper_Subscriptions_API {
 			WC_Helper::deactivate_helper_subscription( $product_key );
 			wp_send_json_error(
 				array(
-					'message' => __( 'We couldn\'t install your subscription.', 'woocommerce' )
+					'message' => __( 'We couldn\'t install the extension.', 'woocommerce' )
 				),
 				400
 			);
@@ -256,7 +256,7 @@ class WC_Helper_Subscriptions_API {
 
 		wp_send_json(
 			array(
-				'message' => __( 'Your subscription has been installed.', 'woocommerce' )
+				'message' => __( 'The extension has been installed.', 'woocommerce' )
 			)
 		);
 	}

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-subscriptions-api.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-subscriptions-api.php
@@ -56,6 +56,12 @@ class WC_Helper_Subscriptions_API {
 				'methods'             => 'POST',
 				'callback'            => array( __CLASS__, 'activate' ),
 				'permission_callback' => array( __CLASS__, 'get_permission' ),
+				'args'                => array(
+					'product_key' => array(
+						'required' => true,
+						'type'     => 'string',
+					),
+				),
 			)
 		);
 		register_rest_route(
@@ -65,6 +71,27 @@ class WC_Helper_Subscriptions_API {
 				'methods'             => 'POST',
 				'callback'            => array( __CLASS__, 'deactivate' ),
 				'permission_callback' => array( __CLASS__, 'get_permission' ),
+				'args'                => array(
+					'product_key' => array(
+						'required' => true,
+						'type'     => 'string',
+					),
+				),
+			)
+		);
+		register_rest_route(
+			'wc/v3',
+			'/marketplace/subscriptions/install',
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( __CLASS__, 'install' ),
+				'permission_callback' => array( __CLASS__, 'get_permission' ),
+				'args'                => array(
+					'product_key' => array(
+						'required' => true,
+						'type'     => 'string',
+					),
+				),
 			)
 		);
 	}
@@ -124,7 +151,8 @@ class WC_Helper_Subscriptions_API {
 			wp_send_json_error(
 				array(
 					'message' => __( 'There was an error activating your subscription. Please try again.', 'woocommerce' )
-				)
+				),
+				400
 			);
 		}
 	}
@@ -154,9 +182,83 @@ class WC_Helper_Subscriptions_API {
 			wp_send_json_error(
 				array(
 					'message' => __( 'There was an error deactivating your subscription. Please try again.', 'woocommerce' )
-				)
+				),
+				400
 			);
 		}
+	}
+
+	/**
+	 * Install a WooCommerce.com produc
+	 */
+	public static function install( $request ) {
+		$product_key = $request->get_param('product_key');
+		$subscriptions = WC_Helper::get_subscription( $product_key );
+
+		if ( empty( $subscriptions ) ) {
+			wp_send_json_error(
+				array(
+					'message' => __( 'We couldn\'t find this subscription.', 'woocommerce' )
+				),
+				404
+			);
+		}
+
+		if ( $subscriptions['expired'] === true ) {
+			wp_send_json_error(
+				array(
+					'message' => __( 'This subscription has expired.', 'woocommerce' )
+				),
+				402
+			);
+		}
+
+		if ( $subscriptions['maxed'] === true ) {
+			wp_send_json_error(
+				array(
+					'message' => __( 'All licenses for this subscription are already in use.', 'woocommerce' )
+				),
+				402
+			);
+		}
+
+		$activation_success = WC_Helper::activate_helper_subscription( $product_key );
+		if ( ! $activation_success ) {
+			wp_send_json_error(
+				array(
+					'message' => __( 'We couldn\'t activate your subscription.', 'woocommerce' )
+				),
+				400
+			);
+		}
+
+		$product_id = $subscriptions['product_id'];
+
+		// Delete any existing state for this product.
+		$state = WC_WCCOM_Site_Installation_State_Storage::get_state( $product_id );
+		if ( $state !== null ) {
+			WC_WCCOM_Site_Installation_State_Storage::delete_state( $state );
+		}
+
+		// Run the installation.
+		$installation_manager = new WC_WCCOM_Site_Installation_Manager( $product_id, $product_id );
+		$installation_success = $installation_manager->run_installation( 'activate_product' );
+
+		if ( ! $installation_success ) {
+			WC_Helper::deactivate_helper_subscription( $product_key );
+			wp_send_json_error(
+				array(
+					'message' => __( 'We couldn\'t install your subscription.', 'woocommerce' )
+				),
+				400
+			);
+		}
+
+		wp_send_json(
+			array(
+				'message' => __( 'Your subscription has been installed.', 'woocommerce' )
+			)
+		);
 	}
 }
 

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -114,7 +114,7 @@ class WC_Helper {
 		$woo_themes  = self::get_local_woo_themes();
 
 		$subscriptions_list_data   = self::get_subscription_list_data();
-		$subscriptions			   = array_filter(
+		$subscriptions             = array_filter(
 			$subscriptions_list_data,
 			function( $subscription ) {
 				return ! empty( $subscription['product_key'] );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:
- Add table loading animation using `TablePlaceholder`
- Implement components for cells in a row
    - product name
    - status
    - expiry
    - Auto-renew information
    - Version number
    - Activate/Install
    - Actions

### How to test the changes in this Pull Request:

1. Checkout this branch and build WooCommerce Admin assets (`cd plugins/woocommerce-admin && pnpm run start`)
2. Make sure you connect a WooCommerce.com account that has some subscriptions
3. Visit **WooCommerce > Extensions > My Subscriptions**
4. See the three tables: Installed on this store, Not in use, and Free to install. ~~The Free to install table will be missing data, and it will be fixed later. Please see the logged issue on the project board.~~ The free to install table is now gone.
    - [ ] Remove free to install table (@raicem)
6. See the table row that has new components. This now has outdated designs because we made some tweaks. Please see the logged issue on the project board.
    - So there is not much to validate in terms of designs. But we can review the code as it'll lay the foundation for later changes.
7. Click on the **Install** button on the **Not in use** table and confirm it installs the plugin (basically re-testing #40630 so that nothing is broken)
8. Please test around this issue.

**Screenshot**
![image](https://github.com/woocommerce/woocommerce/assets/10389957/ec19e58f-6a8f-44d4-9d88-786afd310ca1)

