### PR TITLE
Add Shipping tab to the single variation page

### DIFF
--- a/packages/js/product-editor/changelog/add-40595
+++ b/packages/js/product-editor/changelog/add-40595
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add support for context post type to blocks related to the ProductVariationTemplate

--- a/packages/js/product-editor/src/blocks/product-fields/shipping-class/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/shipping-class/block.json
@@ -22,5 +22,6 @@
 		"lock": false,
 		"__experimentalToolbar": false
 	},
-	"editorStyle": "file:./editor.css"
+	"editorStyle": "file:./editor.css",
+	"usesContext": [ "postType" ]
 }

--- a/packages/js/product-editor/src/blocks/product-fields/shipping-class/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/shipping-class/edit.tsx
@@ -71,6 +71,7 @@ function extractDefaultShippingClassFromProduct(
 
 export function Edit( {
 	attributes,
+	context,
 }: ProductEditorBlockEditProps< ShippingClassBlockAttributes > ) {
 	const [ showShippingClassModal, setShowShippingClassModal ] =
 		useState( false );
@@ -90,7 +91,7 @@ export function Edit( {
 	);
 	const [ shippingClass, setShippingClass ] = useEntityProp< string >(
 		'postType',
-		'product',
+		context.postType,
 		'shipping_class'
 	);
 

--- a/packages/js/product-editor/src/blocks/product-fields/shipping-dimensions/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/shipping-dimensions/block.json
@@ -22,5 +22,6 @@
 		"lock": false,
 		"__experimentalToolbar": false
 	},
-	"editorStyle": "file:./editor.css"
+	"editorStyle": "file:./editor.css",
+	"usesContext": [ "postType" ]
 }

--- a/packages/js/product-editor/src/blocks/product-fields/shipping-dimensions/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/shipping-dimensions/edit.tsx
@@ -38,19 +38,20 @@ import { ProductEditorBlockEditProps } from '../../../types';
 export function Edit( {
 	attributes,
 	clientId,
+	context,
 }: ProductEditorBlockEditProps< ShippingDimensionsBlockAttributes > ) {
 	const blockProps = useWooBlockProps( attributes );
 
 	const [ dimensions, setDimensions ] =
 		useEntityProp< Partial< ProductDimensions > | null >(
 			'postType',
-			'product',
+			context.postType,
 			'dimensions'
 		);
 
 	const [ weight, setWeight ] = useEntityProp< string | null >(
 		'postType',
-		'product',
+		context.postType,
 		'weight'
 	);
 

--- a/plugins/woocommerce/changelog/add-40595
+++ b/plugins/woocommerce/changelog/add-40595
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Register the shipping section for product variation template

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/ProductVariationTemplate.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/ProductVariationTemplate.php
@@ -529,22 +529,10 @@ class ProductVariationTemplate extends AbstractProductFormTemplate implements Pr
 	 */
 	private function add_shipping_group_blocks() {
 		$shipping_group = $this->get_group_by_id( $this::GROUP_IDS['SHIPPING'] );
-		$shipping_group->add_block(
-			[
-				'id'         => 'product_variation_notice_shipping_tab',
-				'blockName'  => 'woocommerce/product-has-variations-notice',
-				'order'      => 10,
-				'attributes' => [
-					'content'    => __( 'This product has options, such as size or color. You can now manage each variation\'s price and other details individually.', 'woocommerce' ),
-					'buttonText' => __( 'Go to Variations', 'woocommerce' ),
-					'type'       => 'info',
-				],
-			]
-		);
-		// Product Pricing Section.
+		// Product Shipping Section.
 		$product_fee_and_dimensions_section = $shipping_group->add_section(
 			[
-				'id'         => 'product-fee-and-dimensions-section',
+				'id'         => 'product-variation-fee-and-dimensions-section',
 				'order'      => 20,
 				'attributes' => [
 					'title'       => __( 'Fees & dimensions', 'woocommerce' ),
@@ -559,14 +547,14 @@ class ProductVariationTemplate extends AbstractProductFormTemplate implements Pr
 		);
 		$product_fee_and_dimensions_section->add_block(
 			[
-				'id'        => 'product-shipping-class',
+				'id'        => 'product-variation-shipping-class',
 				'blockName' => 'woocommerce/product-shipping-class-field',
 				'order'     => 10,
 			]
 		);
 		$product_fee_and_dimensions_section->add_block(
 			[
-				'id'        => 'product-shipping-dimensions',
+				'id'        => 'product-variation-shipping-dimensions',
 				'blockName' => 'woocommerce/product-shipping-dimensions-fields',
 				'order'     => 20,
 			]


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #40595

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure feature `product-variation-management` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper` (WooCommerce Beta Tester plugin) is required
3. Go to `/wp-admin/admin.php?page=wc-admin&path=/add-product&tab=variations` and add some attributes
4. Wait until variations get generated
5. Then publish the product and save its `productId` and one `variationId` you like
6. Then go to `/wp-admin/admin.php?page=wc-admin&path=/product/{productId}/variation/{variationId}&tab=shipping` (replace the `{productId}` and `{variationId}` with the values picked in point 5)
7. The `Shipping` tab everything should behave as in the parent product `Shipping` section 
<img width="689" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/ac528c7b-3a92-428b-942e-40ac2e11f0a6">

8. To check that the changes did take effect after saving the variation click `Preview` button on the top of the screen.
9. You should be redirected to the storefront screen where the variation is presented to the user 
<img width="862" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/b85fa06f-10b4-4007-97a7-1f97684723ac">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
