### PR TITLE
Add pricing tab for variations

### DIFF
--- a/packages/js/components/changelog/add-40593_pricing_tab_for_variations
+++ b/packages/js/components/changelog/add-40593_pricing_tab_for_variations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Small condition change in the date time picker to avoid edge case where inputControl is null.

--- a/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
+++ b/packages/js/components/src/date-time-picker-control/date-time-picker-control.tsx
@@ -265,7 +265,11 @@ export const DateTimePickerControl = forwardRef(
 		}, [ onBlur ] );
 
 		const callOnBlurIfDropdownIsNotOpening = useCallback( ( willOpen ) => {
-			if ( ! willOpen && typeof onBlurRef.current === 'function' ) {
+			if (
+				! willOpen &&
+				typeof onBlurRef.current === 'function' &&
+				inputControl.current
+			) {
 				// in case the component is blurred before a debounced
 				// change has been processed, immediately set the input string
 				// to the current value of the input field, so that

--- a/packages/js/product-editor/changelog/add-40593_pricing_tab_for_variations
+++ b/packages/js/product-editor/changelog/add-40593_pricing_tab_for_variations
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update radio, pricing, and schedule field blocks to use postType context value.

--- a/packages/js/product-editor/changelog/add-40593_pricing_tab_for_variations
+++ b/packages/js/product-editor/changelog/add-40593_pricing_tab_for_variations
@@ -1,4 +1,4 @@
 Significance: minor
 Type: update
 
-Update radio, pricing, and schedule field blocks to use postType context value.
+Update pricing, and schedule field blocks to use postType context value.

--- a/packages/js/product-editor/src/blocks/product-fields/regular-price/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/regular-price/block.json
@@ -14,6 +14,10 @@
 		},
 		"help": {
 			"type": "string"
+		},
+		"isRequired": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"supports": {

--- a/packages/js/product-editor/src/blocks/product-fields/regular-price/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/regular-price/edit.tsx
@@ -9,8 +9,12 @@ import { getNewPath } from '@woocommerce/navigation';
 import { recordEvent } from '@woocommerce/tracks';
 import { useInstanceId } from '@wordpress/compose';
 import { useEntityProp } from '@wordpress/core-data';
-import { createElement, createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import {
+	createElement,
+	createInterpolateElement,
+	useEffect,
+} from '@wordpress/element';
+import { sprintf, __ } from '@wordpress/i18n';
 import {
 	BaseControl,
 	// @ts-expect-error `__experimentalInputControl` does exist.
@@ -31,7 +35,7 @@ export function Edit( {
 	context,
 }: ProductEditorBlockEditProps< SalePriceBlockAttributes > ) {
 	const blockProps = useWooBlockProps( attributes );
-	const { label, help } = attributes;
+	const { label, help, isRequired } = attributes;
 	const [ regularPrice, setRegularPrice ] = useEntityProp< string >(
 		'postType',
 		context.postType || 'product',
@@ -89,10 +93,19 @@ export function Edit( {
 						'woocommerce'
 					);
 				}
+			} else if ( isRequired ) {
+				/* translators: label of required field. */
+				return sprintf( __( '%s is required.', 'woocommerce' ), label );
 			}
 		},
 		[ regularPrice, salePrice ]
 	);
+
+	useEffect( () => {
+		if ( isRequired ) {
+			validateRegularPrice();
+		}
+	}, [] );
 
 	return (
 		<div { ...blockProps }>

--- a/packages/js/product-editor/src/blocks/product-fields/regular-price/types.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/regular-price/types.ts
@@ -6,4 +6,5 @@ import { BlockAttributes } from '@wordpress/blocks';
 export interface SalePriceBlockAttributes extends BlockAttributes {
 	label: string;
 	help?: string;
+	isRequired?: boolean;
 }

--- a/packages/js/product-editor/src/blocks/product-fields/sale-price/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/sale-price/block.json
@@ -25,5 +25,6 @@
 		"lock": false,
 		"__experimentalToolbar": false
 	},
+	"usesContext": [ "postType" ],
 	"editorStyle": "file:./editor.css"
 }

--- a/packages/js/product-editor/src/blocks/product-fields/sale-price/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/sale-price/edit.tsx
@@ -25,17 +25,18 @@ import { ProductEditorBlockEditProps } from '../../../types';
 export function Edit( {
 	attributes,
 	clientId,
+	context,
 }: ProductEditorBlockEditProps< SalePriceBlockAttributes > ) {
 	const blockProps = useWooBlockProps( attributes );
 	const { label, help } = attributes;
 	const [ regularPrice ] = useEntityProp< string >(
 		'postType',
-		'product',
+		context.postType || 'product',
 		'regular_price'
 	);
 	const [ salePrice, setSalePrice ] = useEntityProp< string >(
 		'postType',
-		'product',
+		context.postType || 'product',
 		'sale_price'
 	);
 	const inputProps = useCurrencyInputProps( {

--- a/packages/js/product-editor/src/blocks/product-fields/schedule-sale/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/schedule-sale/block.json
@@ -22,5 +22,6 @@
 		"lock": false,
 		"__experimentalToolbar": false
 	},
-	"editorStyle": "file:./editor.css"
+	"editorStyle": "file:./editor.css",
+	"usesContext": [ "postType" ]
 }

--- a/packages/js/product-editor/src/blocks/product-fields/schedule-sale/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/schedule-sale/edit.tsx
@@ -26,6 +26,7 @@ import { ProductEditorBlockEditProps } from '../../../types';
 export function Edit( {
 	attributes,
 	clientId,
+	context,
 }: ProductEditorBlockEditProps< ScheduleSalePricingBlockAttributes > ) {
 	const blockProps = useWooBlockProps( attributes );
 	const { hasEdit } = useProductEdits();
@@ -36,7 +37,7 @@ export function Edit( {
 
 	const [ salePrice ] = useEntityProp< string | null >(
 		'postType',
-		'product',
+		context.postType || 'product',
 		'sale_price'
 	);
 
@@ -45,11 +46,11 @@ export function Edit( {
 
 	const [ dateOnSaleFromGmt, setDateOnSaleFromGmt ] = useEntityProp<
 		string | null
-	>( 'postType', 'product', 'date_on_sale_from_gmt' );
+	>( 'postType', context.postType || 'product', 'date_on_sale_from_gmt' );
 
 	const [ dateOnSaleToGmt, setDateOnSaleToGmt ] = useEntityProp<
 		string | null
-	>( 'postType', 'product', 'date_on_sale_to_gmt' );
+	>( 'postType', context.postType || 'product', 'date_on_sale_to_gmt' );
 
 	const today = moment().startOf( 'minute' ).toISOString();
 

--- a/plugins/woocommerce/changelog/add-40593_pricing_tab_for_variations
+++ b/plugins/woocommerce/changelog/add-40593_pricing_tab_for_variations
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update variation API to adhere tax class to context, and updated variation template to use tax class field.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
@@ -40,19 +40,19 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 			'/' . $this->rest_base . '/generate',
 			array(
 				'args'   => array(
-					'product_id' => array(
+					'product_id'     => array(
 						'description' => __( 'Unique identifier for the variable product.', 'woocommerce' ),
 						'type'        => 'integer',
 					),
-					'delete' => array(
+					'delete'         => array(
 						'description' => __( 'Deletes unused variations.', 'woocommerce' ),
 						'type'        => 'boolean',
 					),
 					'default_values' => array(
 						'description' => __( 'Default values for generated variations.', 'woocommerce' ),
-						'type' 		 => 'object',
-						'properties' => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
-					)
+						'type'        => 'object',
+						'properties'  => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+					),
 				),
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
@@ -132,6 +132,7 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 		 * The dynamic portion of the hook name, $this->post_type,
 		 * refers to object type being prepared for the response.
 		 *
+		 * @since 4.5.0
 		 * @param WP_REST_Response $response The response object.
 		 * @param WC_Data          $object   Object data.
 		 * @param WP_REST_Request  $request  Request object.
@@ -350,6 +351,7 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 		 * The dynamic portion of the hook name, `$this->post_type`,
 		 * refers to the object type slug.
 		 *
+		 * @since 4.5.0
 		 * @param WC_Data         $variation Object object.
 		 * @param WP_REST_Request $request   Request object.
 		 * @param bool            $creating  If is creating a new object.
@@ -410,6 +412,15 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 				$upload = wc_rest_upload_image_from_url( esc_url_raw( $image['src'] ) );
 
 				if ( is_wp_error( $upload ) ) {
+					/**
+					 * Filter to check if it should supress the image upload error, false by default.
+					 *
+					 * @since 4.5.0
+					 * @param bool false   If it should suppress.
+					 * @param array         $upload Uploaded image array.
+					 * @param int id   Variation id.
+					 * @param array    Array of image to set.
+					 */
 					if ( ! apply_filters( 'woocommerce_rest_suppress_image_upload_error', false, $upload, $variation->get_id(), array( $image ) ) ) {
 						throw new WC_REST_Exception( 'woocommerce_variation_image_upload_error', $upload->get_error_message(), 400 );
 					}
@@ -648,7 +659,7 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'low_stock_amount'       => array(
+				'low_stock_amount'      => array(
 					'description' => __( 'Low Stock amount for the variation.', 'woocommerce' ),
 					'type'        => array( 'integer', 'null' ),
 					'context'     => array( 'view', 'edit' ),
@@ -971,16 +982,16 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 		);
 
 		$params['attributes'] = array(
-			'description'       => __( 'Limit result set to products with specified attributes.', 'woocommerce' ),
-			'type'              => 'array',
-			'items'             => array(
-				'type' 		 => 'object',
+			'description' => __( 'Limit result set to products with specified attributes.', 'woocommerce' ),
+			'type'        => 'array',
+			'items'       => array(
+				'type'       => 'object',
 				'properties' => array(
-					'attribute'           => array(
+					'attribute' => array(
 						'type'        => 'string',
 						'description' => __( 'Attribute slug.', 'woocommerce' ),
 					),
-					'term'  => array(
+					'term'      => array(
 						'type'        => 'string',
 						'description' => __( 'Attribute term.', 'woocommerce' ),
 					),
@@ -1013,7 +1024,7 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 
 		foreach ( $existing_variations as $existing_variation ) {
 			$matching_attribute_key = array_search( $existing_variation->get_attributes(), $possible_attribute_combinations ); // phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
-			if ( $matching_attribute_key !== false ) {
+			if ( false !== $matching_attribute_key ) {
 				// We only want one possible variation for each possible attribute combination.
 				unset( $possible_attribute_combinations[ $matching_attribute_key ] );
 				continue;
@@ -1043,12 +1054,12 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 
 		$response          = array();
 		$product           = wc_get_product( $product_id );
-		$default_values	   = isset( $request['default_values'] ) ? $request['default_values'] : array();
+		$default_values    = isset( $request['default_values'] ) ? $request['default_values'] : array();
 		$data_store        = $product->get_data_store();
 		$response['count'] = $data_store->create_all_product_variations( $product, Constants::get_constant( 'WC_MAX_LINKED_VARIATIONS' ), $default_values );
 
 		if ( isset( $request['delete'] ) && $request['delete'] ) {
-			$deleted_count = $this->delete_unmatched_product_variations( $product );
+			$deleted_count             = $this->delete_unmatched_product_variations( $product );
 			$response['deleted_count'] = $deleted_count;
 		}
 

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
@@ -99,7 +99,7 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 			'download_limit'        => '' !== $object->get_download_limit() ? (int) $object->get_download_limit() : -1,
 			'download_expiry'       => '' !== $object->get_download_expiry() ? (int) $object->get_download_expiry() : -1,
 			'tax_status'            => $object->get_tax_status(),
-			'tax_class'             => $object->get_tax_class(),
+			'tax_class'             => $object->get_tax_class( $context ),
 			'manage_stock'          => $object->managing_stock(),
 			'stock_quantity'        => $object->get_stock_quantity(),
 			'stock_status'          => $object->get_stock_status(),

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/ProductVariationTemplate.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/ProductVariationTemplate.php
@@ -156,18 +156,6 @@ class ProductVariationTemplate extends AbstractProductFormTemplate implements Pr
 	 */
 	private function add_pricing_group_blocks() {
 		$pricing_group = $this->get_group_by_id( $this::GROUP_IDS['PRICING'] );
-		$pricing_group->add_block(
-			[
-				'id'         => 'pricing-has-variations-notice',
-				'blockName'  => 'woocommerce/product-has-variations-notice',
-				'order'      => 10,
-				'attributes' => [
-					'content'    => __( 'This product has options, such as size or color. You can now manage each variation\'s price and other details individually.', 'woocommerce' ),
-					'buttonText' => __( 'Go to Variations', 'woocommerce' ),
-					'type'       => 'info',
-				],
-			]
-		);
 		// Product Pricing Section.
 		$product_pricing_section = $pricing_group->add_section(
 			[
@@ -209,7 +197,7 @@ class ProductVariationTemplate extends AbstractProductFormTemplate implements Pr
 				'order'      => 10,
 				'attributes' => [
 					'name'  => 'regular_price',
-					'label' => __( 'List price', 'woocommerce' ),
+					'label' => __( 'Regular price', 'woocommerce' ),
 				],
 			]
 		);
@@ -240,48 +228,12 @@ class ProductVariationTemplate extends AbstractProductFormTemplate implements Pr
 				'order'     => 20,
 			]
 		);
+		
 		$product_pricing_section->add_block(
-			[
-				'id'         => 'product-sale-tax',
-				'blockName'  => 'woocommerce/product-radio-field',
-				'order'      => 30,
-				'attributes' => [
-					'title'    => __( 'Charge sales tax on', 'woocommerce' ),
-					'property' => 'tax_status',
-					'options'  => [
-						[
-							'label' => __( 'Product and shipping', 'woocommerce' ),
-							'value' => 'taxable',
-						],
-						[
-							'label' => __( 'Only shipping', 'woocommerce' ),
-							'value' => 'shipping',
-						],
-						[
-							'label' => __( "Don't charge tax", 'woocommerce' ),
-							'value' => 'none',
-						],
-					],
-				],
-			]
-		);
-		$pricing_advanced_block = $product_pricing_section->add_block(
-			[
-				'id'         => 'product-pricing-advanced',
-				'blockName'  => 'woocommerce/product-collapsible',
-				'order'      => 40,
-				'attributes' => [
-					'toggleText'       => __( 'Advanced', 'woocommerce' ),
-					'initialCollapsed' => true,
-					'persistRender'    => true,
-				],
-			]
-		);
-		$pricing_advanced_block->add_block(
 			[
 				'id'         => 'product-tax-class',
 				'blockName'  => 'woocommerce/product-radio-field',
-				'order'      => 10,
+				'order'      => 40,
 				'attributes' => [
 					'title'       => __( 'Tax class', 'woocommerce' ),
 					'description' => sprintf(

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/ProductVariationTemplate.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/ProductVariationTemplate.php
@@ -245,6 +245,10 @@ class ProductVariationTemplate extends AbstractProductFormTemplate implements Pr
 					'property'    => 'tax_class',
 					'options'     => [
 						[
+							'label' => __( 'Same as main product', 'woocommerce' ),
+							'value' => 'parent',
+						],
+						[
 							'label' => __( 'Standard', 'woocommerce' ),
 							'value' => '',
 						],

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/ProductVariationTemplate.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/ProductVariationTemplate.php
@@ -198,6 +198,7 @@ class ProductVariationTemplate extends AbstractProductFormTemplate implements Pr
 				'attributes' => [
 					'name'  => 'regular_price',
 					'label' => __( 'Regular price', 'woocommerce' ),
+					'isRequired' => true
 				],
 			]
 		);

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/ProductVariationTemplate.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/ProductVariationTemplate.php
@@ -196,9 +196,9 @@ class ProductVariationTemplate extends AbstractProductFormTemplate implements Pr
 				'blockName'  => 'woocommerce/product-regular-price-field',
 				'order'      => 10,
 				'attributes' => [
-					'name'  => 'regular_price',
-					'label' => __( 'Regular price', 'woocommerce' ),
-					'isRequired' => true
+					'name'       => 'regular_price',
+					'label'      => __( 'Regular price', 'woocommerce' ),
+					'isRequired' => true,
 				],
 			]
 		);
@@ -229,7 +229,7 @@ class ProductVariationTemplate extends AbstractProductFormTemplate implements Pr
 				'order'     => 20,
 			]
 		);
-		
+
 		$product_pricing_section->add_block(
 			[
 				'id'         => 'product-tax-class',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This makes use of the contextType in the pricing and schedule sale fields so that it will work for product variations.
I also updated the API to pass the `$context` into `get_tax_class`. This way it would return `parent` if the tax class was set to parent.

Closes #40593  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure feature `product-variation-management` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper` (WooCommerce Beta Tester plugin) is required
3. Go to `/wp-admin/admin.php?page=wc-admin&path=/add-product&tab=variations` and add some attributes
4. Wait until variations get generated
5. Then publish the product and save its `productId` and one `variationId` you like
6. Then go to `/wp-admin/admin.php?page=wc-admin&path=/product/{productId}/variation/{variationId}&tab=pricing` (replace the `{productId}` and `{variationId}` with the values picked in point 5)
7. Notice how the `Regular price is required` warning already shows up for the blank pricing field.
8. Fill in a price and a sale price
9. Set the schedule sale price and hit **Update**
10. Click **Preview**, the price should be reflected with the correct sale dates ( if in the future ).
11. Toggle the tax class and hit **Update**, this should persist on refresh ( there may also be a way to check if this is set correctly by going through an full order, but I am not to familiar with that ). For the sake of this, making sure it saves and persists correctly should be enough.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
