### PR TITLE
Skip assembler-hub e2e tests on daily run

### DIFF
--- a/plugins/woocommerce/changelog/e2e-temp-fix-for-daily-e2e
+++ b/plugins/woocommerce/changelog/e2e-temp-fix-for-daily-e2e
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Skip the assembler-hub e2e tests on the daily run

--- a/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler-hub.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/customize-store/assembler-hub.spec.js
@@ -1,10 +1,27 @@
 const { test, expect, request } = require( '@playwright/test' );
+const { BASE_URL } = process.env;
 const { features } = require( '../../utils' );
 const { activateTheme } = require( '../../utils/themes' );
 const { setOption } = require( '../../utils/options' );
 
 const ASSEMBLER_HUB_URL =
 	'/wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store%2Fassembler-hub';
+
+const skipTestIfUndefined = () => {
+	const skipMessage = `Skipping this test on daily run. Environment not compatible.`;
+
+	test.skip( () => {
+		const shouldSkip = BASE_URL != undefined;
+
+		if ( shouldSkip ) {
+			console.log( skipMessage );
+		}
+
+		return shouldSkip;
+	}, skipMessage );
+};
+
+skipTestIfUndefined();
 
 test.describe( 'Store owner can view Assembler Hub for store customization', () => {
 	test.use( { storageState: process.env.ADMINSTATE } );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

(For now?) skip the e2e tests that run in `customize-store/assembler-hub.spec.js` because they involve additional setup that is happening in wp-env, but that (may not?) be possible on our daily test site.  This test has been failing on the daily run since it's introduction.

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Ensure that CI passes.
2. Pull branch.
3. `pnpm env:start`
4. `pnpm test:e2e-pw customize-store/assembler-hub.spec.js` (the tests should run, and pass)
5. Create a `.env` file in the root of the e2e test folder containing the info for the daily test site - BASE_URL, admin login in and customer login info
6. `pnpm test:e2e-pw customize-store/assembler-hub.spec.js` (the tests should be skipped)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
