### PR TITLE
Legacy shortcodes: block editor compatibility

### DIFF
--- a/plugins/woocommerce/changelog/fix-38169-block-editor-compat
+++ b/plugins/woocommerce/changelog/fix-38169-block-editor-compat
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Improve compatibility of legacy WooCommerce shortcodes with the block editor.

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -235,6 +235,7 @@ final class WooCommerce {
 		add_action( 'admin_notices', array( $this, 'build_dependencies_notice' ) );
 		add_action( 'after_setup_theme', array( $this, 'setup_environment' ) );
 		add_action( 'after_setup_theme', array( $this, 'include_template_functions' ), 11 );
+		add_action( 'load-post.php', array( $this, 'includes' ) );
 		add_action( 'init', array( $this, 'init' ), 0 );
 		add_action( 'init', array( 'WC_Shortcodes', 'init' ) );
 		add_action( 'init', array( 'WC_Emails', 'init_transactional_emails' ) );
@@ -317,7 +318,7 @@ final class WooCommerce {
 		$this->define( 'WC_LOG_DIR', $upload_dir['basedir'] . '/wc-logs/' );
 		$this->define( 'WC_SESSION_CACHE_GROUP', 'wc_session_id' );
 		$this->define( 'WC_TEMPLATE_DEBUG_MODE', false );
-		
+
 		// These three are kept defined for compatibility, but are no longer used.
 		$this->define( 'WC_NOTICE_MIN_PHP_VERSION', '7.2' );
 		$this->define( 'WC_NOTICE_MIN_WP_VERSION', '5.2' );
@@ -417,7 +418,7 @@ final class WooCommerce {
 			case 'cron':
 				return defined( 'DOING_CRON' );
 			case 'frontend':
-				return ( ! is_admin() || defined( 'DOING_AJAX' ) ) && ! defined( 'DOING_CRON' ) && ! $this->is_rest_api_request();
+				return ( ! is_admin() || defined( 'DOING_AJAX' ) ) && ! defined( 'DOING_CRON' );
 		}
 	}
 
@@ -584,7 +585,10 @@ final class WooCommerce {
 			include_once WC_ABSPATH . 'includes/admin/class-wc-admin.php';
 		}
 
-		if ( $this->is_request( 'frontend' ) ) {
+		// We load frontend includes in the post editor, because they may be invoked via pre-loading of blocks.
+		$in_post_editor = doing_action( 'load-post.php' ) || doing_action( 'load-post-new.php' );
+
+		if ( $this->is_request( 'frontend' ) || $in_post_editor ) {
 			$this->frontend_includes();
 		}
 

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -417,8 +417,10 @@ final class WooCommerce {
 				return defined( 'DOING_AJAX' );
 			case 'cron':
 				return defined( 'DOING_CRON' );
+			case 'rest-api':
+				return $this->is_rest_api_request();
 			case 'frontend':
-				return ( ! is_admin() || defined( 'DOING_AJAX' ) ) && ! defined( 'DOING_CRON' );
+				return ( ! is_admin() || defined( 'DOING_AJAX' ) ) && ! defined( 'DOING_CRON' ) && ! $this->is_rest_api_request();
 		}
 	}
 
@@ -588,7 +590,7 @@ final class WooCommerce {
 		// We load frontend includes in the post editor, because they may be invoked via pre-loading of blocks.
 		$in_post_editor = doing_action( 'load-post.php' ) || doing_action( 'load-post-new.php' );
 
-		if ( $this->is_request( 'frontend' ) || $in_post_editor ) {
+		if ( $this->is_request( 'frontend' ) || $this->is_rest_api_request() || $in_post_editor ) {
 			$this->frontend_includes();
 		}
 

--- a/plugins/woocommerce/includes/class-woocommerce.php
+++ b/plugins/woocommerce/includes/class-woocommerce.php
@@ -417,8 +417,6 @@ final class WooCommerce {
 				return defined( 'DOING_AJAX' );
 			case 'cron':
 				return defined( 'DOING_CRON' );
-			case 'rest-api':
-				return $this->is_rest_api_request();
 			case 'frontend':
 				return ( ! is_admin() || defined( 'DOING_AJAX' ) ) && ! defined( 'DOING_CRON' ) && ! $this->is_rest_api_request();
 		}

--- a/plugins/woocommerce/includes/wc-notice-functions.php
+++ b/plugins/woocommerce/includes/wc-notice-functions.php
@@ -137,9 +137,11 @@ function wc_print_notices( $return = false ) {
 		return;
 	}
 
+	$session = WC()->session;
+	
 	// If the session handler has not initialized, there will be no notices for us to read.
-	if ( null === ( $session = WC()->session ) ) {
-		return;
+	if ( null === $session ) {
+		return null;
 	}
 
 	$all_notices  = $session->get( 'wc_notices', array() );

--- a/plugins/woocommerce/includes/wc-notice-functions.php
+++ b/plugins/woocommerce/includes/wc-notice-functions.php
@@ -138,7 +138,7 @@ function wc_print_notices( $return = false ) {
 	}
 
 	$session = WC()->session;
-	
+
 	// If the session handler has not initialized, there will be no notices for us to read.
 	if ( null === $session ) {
 		return null;

--- a/plugins/woocommerce/includes/wc-notice-functions.php
+++ b/plugins/woocommerce/includes/wc-notice-functions.php
@@ -137,7 +137,12 @@ function wc_print_notices( $return = false ) {
 		return;
 	}
 
-	$all_notices  = WC()->session->get( 'wc_notices', array() );
+	// If the session handler has not initialized, there will be no notices for us to read.
+	if ( null === ( $session = WC()->session ) ) {
+		return;
+	}
+
+	$all_notices  = $session->get( 'wc_notices', array() );
 	$notice_types = apply_filters( 'woocommerce_notice_types', array( 'error', 'success', 'notice' ) );
 
 	// Buffer output.

--- a/plugins/woocommerce/includes/wc-notice-functions.php
+++ b/plugins/woocommerce/includes/wc-notice-functions.php
@@ -129,7 +129,7 @@ function wc_clear_notices() {
  *
  * @since 2.1
  * @param bool $return true to return rather than echo. @since 3.5.0.
- * @return string|null
+ * @return string|void
  */
 function wc_print_notices( $return = false ) {
 	if ( ! did_action( 'woocommerce_init' ) ) {
@@ -141,7 +141,7 @@ function wc_print_notices( $return = false ) {
 
 	// If the session handler has not initialized, there will be no notices for us to read.
 	if ( null === $session ) {
-		return null;
+		return;
 	}
 
 	$all_notices  = $session->get( 'wc_notices', array() );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In the pre-Gutenburg world, or when using the classic editor, shortcodes are typically entered in the editor but are only rendered during frontend requests. In the world of blocks, though, shortcodes may be (pre-)rendered in an admin context both when the block editor loads, and when a post is saved (which will happen via the REST API).

For this reason, any functions the shortcode handler might call need to be available, or else the shortcode handler needs to defensively check that they are available first. As described in the linked issue, there are particular problems relating to shortcodes that call our notice functions or that try to interact with the session handler (which is not instantiated for admin or REST requests).

Closes https://github.com/woocommerce/woocommerce/issues/38169.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Start by defining a shortcode. Here's some custom code you can use, which could be added to a location such as `wp-content/mu-plugins/test-40648.php` (once you finish testing, remember to remove it!):

```php
<?php
add_shortcode( 'my_test', function () {
	ob_start();
	wc_print_notices();
	echo '<div>MY CUSTOM SHORTCODE</div>';
	return ob_get_clean();
} );
```

2. Then, create a new page and add the shortcode (just to be extra clear, this should all be done using the block editor):

<div align="center"><img width="700" alt="Screenshot 2023-10-25 at 16 10 18" src="https://github.com/woocommerce/woocommerce/assets/3594411/f1863eb7-2d18-4e2c-a2e8-6d2e0f5a7cd3"></div>

3. With this branch checked out, you should be able to publish and view the page without encountering any errors. 
4. With current `trunk` checked out, you will encounter problems. For instance, if you performed the above steps using this branch first, and then switch to trunk and reload the page editor, you will encounter a fatal error:

```
Fatal error: Uncaught Error: Call to undefined function wc_print_notices()
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>

### Notes

In an ideal world, I think we'd cover this with an E2E test. My attempts to do that so far have been very flaky, though, so I decided not to commit it. We can either move forward without, or pause and (perhaps with help from Solaris) try to get that in place, or possibly circle back and add later.
