### PR TITLE
Logging: Add a list table to browse log files

### DIFF
--- a/plugins/woocommerce/changelog/40662-try-log-file-browser
+++ b/plugins/woocommerce/changelog/40662-try-log-file-browser
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a view to the Logs screen for browsing log files.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -11,6 +11,8 @@ use Automattic\WooCommerce\Admin\PageController;
 use Automattic\WooCommerce\Internal\Admin\Marketplace;
 use Automattic\WooCommerce\Internal\Admin\Orders\COTRedirectionController;
 use Automattic\WooCommerce\Internal\Admin\Orders\PageController as Custom_Orders_PageController;
+use Automattic\WooCommerce\Internal\Admin\Logging\PageController as LoggingPageController;
+use Automattic\WooCommerce\Internal\Admin\Logging\FileV2\ListTable as LoggingListTable;
 use Automattic\WooCommerce\Internal\Admin\WCAdminAssets;
 use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
@@ -184,7 +186,18 @@ class WC_Admin_Menus {
 	 * Add menu item.
 	 */
 	public function status_menu() {
-		add_submenu_page( 'woocommerce', __( 'WooCommerce status', 'woocommerce' ), __( 'Status', 'woocommerce' ), 'manage_woocommerce', 'wc-status', array( $this, 'status_page' ) );
+		$status_page = add_submenu_page( 'woocommerce', __( 'WooCommerce status', 'woocommerce' ), __( 'Status', 'woocommerce' ), 'manage_woocommerce', 'wc-status', array( $this, 'status_page' ) );
+
+		add_action(
+			'load-' . $status_page,
+			function() {
+				if ( 'logs' === filter_input( INPUT_GET, 'tab' ) ) {
+					// Initialize the logging page controller early so that it can hook into things.
+					wc_get_container()->get( LoggingPageController::class );
+				}
+			},
+			1
+		);
 	}
 
 	/**
@@ -308,7 +321,13 @@ class WC_Admin_Menus {
 	 * @param int      $value  The number of rows to use.
 	 */
 	public function set_screen_option( $status, $option, $value ) {
-		if ( in_array( $option, array( 'woocommerce_keys_per_page', 'woocommerce_webhooks_per_page' ), true ) ) {
+		$screen_options = array(
+			'woocommerce_keys_per_page',
+			'woocommerce_webhooks_per_page',
+			LoggingListTable::PER_PAGE_USER_OPTION_KEY,
+		);
+
+		if ( in_array( $option, $screen_options, true ) ) {
 			return $value;
 		}
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-status.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-status.php
@@ -7,6 +7,7 @@
  */
 
 use Automattic\Jetpack\Constants;
+use Automattic\WooCommerce\Internal\Admin\Logging\PageController as LoggingPageController;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -104,13 +105,7 @@ class WC_Admin_Status {
 	 * Show the logs page.
 	 */
 	public static function status_logs() {
-		$log_handler = Constants::get_constant( 'WC_LOG_HANDLER' );
-
-		if ( 'WC_Log_Handler_DB' === $log_handler ) {
-			self::status_logs_db();
-		} else {
-			self::status_logs_file();
-		}
+		wc_get_container()->get( LoggingPageController::class )->render();
 	}
 
 	/**

--- a/plugins/woocommerce/src/Container.php
+++ b/plugins/woocommerce/src/Container.php
@@ -10,6 +10,7 @@ use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\COTMig
 use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\DownloadPermissionsAdjusterServiceProvider;
 use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\AssignDefaultCategoryServiceProvider;
 use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\FeaturesServiceProvider;
+use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\LoggingServiceProvider;
 use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\MarketingServiceProvider;
 use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\MarketplaceServiceProvider;
 use Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders\OrdersControllersServiceProvider;
@@ -71,6 +72,7 @@ final class Container {
 		MarketingServiceProvider::class,
 		MarketplaceServiceProvider::class,
 		BlockTemplatesServiceProvider::class,
+		LoggingServiceProvider::class,
 	);
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Automattic\WooCommerce\Internal\Admin\Logging\FileV2;
+
+class File {
+	/**
+	 * @var string The absolute path of the file.
+	 */
+	protected $path;
+
+	/**
+	 * Class File
+	 *
+	 * @param string $path The absolute path of the file.
+	 */
+	public function __construct( $path ) {
+		$this->path = $path;
+	}
+
+	/**
+	 * Get the name of the file, sans path.
+	 *
+	 * @return string
+	 */
+	public function get_filename() {
+		return basename( $this->path );
+	}
+
+	/**
+	 * Get the size of the file in bytes. Or false if the file isn't readable.
+	 *
+	 * @return int|false
+	 */
+	public function get_file_size() {
+		if ( ! is_readable( $this->path ) ) {
+			return false;
+		}
+
+		return filesize( $this->path );
+	}
+
+	/**
+	 * Get the time of the last modification of the file, as a Unix timestamp. Or false if the file isn't readable.
+	 *
+	 * @return int|false
+	 */
+	public function get_modified_timestamp() {
+		return filemtime( $this->path );
+	}
+}

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
@@ -9,21 +9,92 @@ class File {
 	protected $path;
 
 	/**
+	 * @var string The source property of the file, derived from the filename.
+	 */
+	protected $source;
+
+	/**
+	 * @var int The date the file was created, as a Unix timestamp, derived from the filename.
+	 */
+	protected $created;
+
+	/**
+	 * @var string The key property of the file, derived from the filename.
+	 */
+	protected $key;
+
+	/**
 	 * Class File
 	 *
 	 * @param string $path The absolute path of the file.
 	 */
 	public function __construct( $path ) {
 		$this->path = $path;
+		$this->parse_filename();
 	}
 
 	/**
-	 * Get the name of the file, sans path.
+	 * Parse the log filename to derive certain properties of the file.
+	 *
+	 * This makes assumptions about the structure of the log file's name. Using `-` to separate the name into segments,
+	 * if there are at least 5 segments, it assumes that the last segment is the "key" (i.e. hash), and the three
+	 * segments before that make up the date when the file was created in YYYY-MM-DD format. Any segments left after
+	 * that are the "source" that generated the log entries. If the filename doesn't have enough segments, it falls
+	 * back to the source and the key both being the entire filename, and using the last modified time as the creation
+	 * date.
+	 *
+	 * @return void
+	 */
+	protected function parse_filename() {
+		$info     = pathinfo( $this->path );
+		$filename = $info['filename'];
+		$segments = explode( '-', $filename );
+
+		if ( count( $segments ) >= 5 ) {
+			$this->source  = implode( '-', array_slice( $segments, 0, -4 ) );
+			$this->created = strtotime( implode( '-', array_slice( $segments, -4, 3 ) ) );
+			$this->key     = array_slice( $segments, -1 )[0];
+		} else {
+			$this->source  = implode( '-', $segments );
+			$this->created = filemtime( $this->path );
+			$this->key     = $this->source;
+		}
+	}
+
+	/**
+	 * Get the file's source property.
 	 *
 	 * @return string
 	 */
-	public function get_filename() {
-		return basename( $this->path );
+	public function get_source() {
+		return $this->source;
+	}
+
+	/**
+	 * Get the file's key property.
+	 *
+	 * @return string
+	 */
+	public function get_key() {
+		return $this->key;
+	}
+
+	/**
+	 * Get the file's created property.
+	 *
+	 * @return int
+	 */
+	public function get_created_timestamp() {
+		return $this->created;
+	}
+
+	/**
+	 * Get the time of the last modification of the file, as a Unix timestamp. Or false if the file isn't readable.
+	 *
+	 * @return int|false
+	 */
+	public function get_modified_timestamp() {
+		return filemtime( $this->path );
 	}
 
 	/**
@@ -37,14 +108,5 @@ class File {
 		}
 
 		return filesize( $this->path );
-	}
-
-	/**
-	 * Get the time of the last modification of the file, as a Unix timestamp. Or false if the file isn't readable.
-	 *
-	 * @return int|false
-	 */
-	public function get_modified_timestamp() {
-		return filemtime( $this->path );
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
@@ -62,6 +62,15 @@ class File {
 	}
 
 	/**
+	 * Get the name of the file, with extension, but without full path.
+	 *
+	 * @return string
+	 */
+	public function get_basename() {
+		return basename( $this->path );
+	}
+
+	/**
 	 * Get the file's source property.
 	 *
 	 * @return string

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
@@ -30,11 +30,11 @@ class File {
 	protected $created;
 
 	/**
-	 * The key property of the file, derived from the filename.
+	 * The hash property of the file, derived from the filename.
 	 *
 	 * @var string
 	 */
-	protected $key;
+	protected $hash;
 
 	/**
 	 * Class File
@@ -66,11 +66,11 @@ class File {
 		if ( count( $segments ) >= 5 ) {
 			$this->source  = implode( '-', array_slice( $segments, 0, -4 ) );
 			$this->created = strtotime( implode( '-', array_slice( $segments, -4, 3 ) ) );
-			$this->key     = array_slice( $segments, -1 )[0];
+			$this->hash    = array_slice( $segments, -1 )[0];
 		} else {
 			$this->source  = implode( '-', $segments );
 			$this->created = filemtime( $this->path );
-			$this->key     = $this->source;
+			$this->hash    = $this->source;
 		}
 	}
 
@@ -93,12 +93,12 @@ class File {
 	}
 
 	/**
-	 * Get the file's key property.
+	 * Get the file's hash property.
 	 *
 	 * @return string
 	 */
-	public function get_key() {
-		return $this->key;
+	public function get_hash() {
+		return $this->hash;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
@@ -2,24 +2,37 @@
 
 namespace Automattic\WooCommerce\Internal\Admin\Logging\FileV2;
 
+/**
+ * File class.
+ *
+ * An object representation of a single log file.
+ */
 class File {
 	/**
-	 * @var string The absolute path of the file.
+	 * The absolute path of the file.
+	 *
+	 * @var string
 	 */
 	protected $path;
 
 	/**
-	 * @var string The source property of the file, derived from the filename.
+	 * The source property of the file, derived from the filename.
+	 *
+	 * @var string
 	 */
 	protected $source;
 
 	/**
-	 * @var int The date the file was created, as a Unix timestamp, derived from the filename.
+	 * The date the file was created, as a Unix timestamp, derived from the filename.
+	 *
+	 * @var int
 	 */
 	protected $created;
 
 	/**
-	 * @var string The key property of the file, derived from the filename.
+	 * The key property of the file, derived from the filename.
+	 *
+	 * @var string
 	 */
 	protected $key;
 
@@ -125,6 +138,6 @@ class File {
 	 * @return bool
 	 */
 	public function delete() {
-		return @unlink( $this->path );
+		return @unlink( $this->path ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
@@ -1,4 +1,5 @@
 <?php
+declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Internal\Admin\Logging\FileV2;
 
@@ -20,7 +21,7 @@ class File {
 	 *
 	 * @var string
 	 */
-	protected $source;
+	protected $source = '';
 
 	/**
 	 * The 0-based increment of the file, if it has been rotated. Derived from the filename. Can only be 0-9.
@@ -32,16 +33,16 @@ class File {
 	/**
 	 * The date the file was created, as a Unix timestamp, derived from the filename.
 	 *
-	 * @var int
+	 * @var int|false
 	 */
-	protected $created;
+	protected $created = false;
 
 	/**
 	 * The hash property of the file, derived from the filename.
 	 *
 	 * @var string
 	 */
-	protected $hash;
+	protected $hash = '';
 
 	/**
 	 * Class File
@@ -65,7 +66,7 @@ class File {
 	 *
 	 * @return void
 	 */
-	protected function parse_filename() {
+	protected function parse_filename(): void {
 		$info     = pathinfo( $this->path );
 		$filename = $info['filename'];
 		$segments = explode( '-', $filename );
@@ -82,8 +83,12 @@ class File {
 
 		$rotation_marker = strrpos( $this->source, '.', -1 );
 		if ( false !== $rotation_marker ) {
-			$this->rotation = substr( $this->source, -1 );
-			$this->source   = substr( $this->source, 0, $rotation_marker );
+			$rotation = substr( $this->source, -1 );
+			if ( is_numeric( $rotation ) ) {
+				$this->rotation = intval( $rotation );
+			}
+
+			$this->source = substr( $this->source, 0, $rotation_marker );
 		}
 	}
 
@@ -92,7 +97,7 @@ class File {
 	 *
 	 * @return string
 	 */
-	public function get_basename() {
+	public function get_basename(): string {
 		return basename( $this->path );
 	}
 
@@ -101,16 +106,16 @@ class File {
 	 *
 	 * @return string
 	 */
-	public function get_source() {
+	public function get_source(): string {
 		return $this->source;
 	}
 
 	/**
 	 * Get the file's rotation property.
 	 *
-	 * @return int
+	 * @return int|null
 	 */
-	public function get_rotation() {
+	public function get_rotation(): ?int {
 		return $this->rotation;
 	}
 
@@ -119,14 +124,14 @@ class File {
 	 *
 	 * @return string
 	 */
-	public function get_hash() {
+	public function get_hash(): string {
 		return $this->hash;
 	}
 
 	/**
 	 * Get the file's created property.
 	 *
-	 * @return int
+	 * @return int|false
 	 */
 	public function get_created_timestamp() {
 		return $this->created;
@@ -151,15 +156,15 @@ class File {
 			return false;
 		}
 
-		return filesize( $this->path );
+		return @filesize( $this->path ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 	}
 
 	/**
 	 * Delete the file from the filesystem.
 	 *
-	 * @return bool
+	 * @return bool True on success, false on failure.
 	 */
-	public function delete() {
+	public function delete(): bool {
 		return @unlink( $this->path ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
@@ -89,6 +89,9 @@ class File {
 			}
 
 			$this->source = substr( $this->source, 0, $rotation_marker );
+			if ( count( $segments ) < 5 ) {
+				$this->hash = $this->source;
+			}
 		}
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
@@ -118,4 +118,13 @@ class File {
 
 		return filesize( $this->path );
 	}
+
+	/**
+	 * Delete the file from the filesystem.
+	 *
+	 * @return bool
+	 */
+	public function delete() {
+		return @unlink( $this->path );
+	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
@@ -23,6 +23,13 @@ class File {
 	protected $source;
 
 	/**
+	 * The 0-based increment of the file, if it has been rotated. Derived from the filename. Can only be 0-9.
+	 *
+	 * @var int|null
+	 */
+	protected $rotation;
+
+	/**
 	 * The date the file was created, as a Unix timestamp, derived from the filename.
 	 *
 	 * @var int
@@ -72,6 +79,12 @@ class File {
 			$this->created = filemtime( $this->path );
 			$this->hash    = $this->source;
 		}
+
+		$rotation_marker = strrpos( $this->source, '.', -1 );
+		if ( false !== $rotation_marker ) {
+			$this->rotation = substr( $this->source, -1 );
+			$this->source   = substr( $this->source, 0, $rotation_marker );
+		}
 	}
 
 	/**
@@ -90,6 +103,15 @@ class File {
 	 */
 	public function get_source() {
 		return $this->source;
+	}
+
+	/**
+	 * Get the file's rotation property.
+	 *
+	 * @return int
+	 */
+	public function get_rotation() {
+		return $this->rotation;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
@@ -58,11 +58,18 @@ class File {
 	 * Parse the log filename to derive certain properties of the file.
 	 *
 	 * This makes assumptions about the structure of the log file's name. Using `-` to separate the name into segments,
-	 * if there are at least 5 segments, it assumes that the last segment is the "key" (i.e. hash), and the three
-	 * segments before that make up the date when the file was created in YYYY-MM-DD format. Any segments left after
-	 * that are the "source" that generated the log entries. If the filename doesn't have enough segments, it falls
-	 * back to the source and the key both being the entire filename, and using the last modified time as the creation
-	 * date.
+	 * if there are at least 5 segments, it assumes that the last segment is the hash, and the three segments before
+	 * that make up the date when the file was created in YYYY-MM-DD format. Any segments left after that are the
+	 * "source" that generated the log entries. If the filename doesn't have enough segments, it falls back to the
+	 * source and the hash both being the entire filename, and using the inode change time as the creation date.
+	 *
+	 * Example:
+	 *     my-custom-plugin.2-2025-01-01-a1b2c3d4e5f.log
+	 *           |          |       |         |
+	 *   'my-custom-plugin' | '2025-01-01'    |
+	 *        (source)      |   (created)     |
+	 *                     '2'          'a1b2c3d4e5f'
+	 *                 (rotation)           (hash)
 	 *
 	 * @return void
 	 */

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
@@ -77,7 +77,7 @@ class File {
 			$this->hash    = array_slice( $segments, -1 )[0];
 		} else {
 			$this->source  = implode( '-', $segments );
-			$this->created = filemtime( $this->path );
+			$this->created = filectime( $this->path );
 			$this->hash    = $this->source;
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Automattic\WooCommerce\Internal\Admin\Logging\FileV2;
+
+use Automattic\Jetpack\Constants;
+use WP_Error;
+
+class FileController {
+	/**
+	 * @var string The absolute path to the log directory.
+	 */
+	private $log_directory;
+
+	/**
+	 * Class FileController
+	 */
+	public function __construct() {
+		$this->log_directory = trailingslashit( realpath( Constants::get_constant( 'WC_LOG_DIR' ) ) );
+	}
+
+	/**
+	 * Get an array of log files.
+	 *
+	 * @param array $args      {
+	 *     Optional. Arguments to filter and sort the files that are returned.
+	 *
+	 *     @type int    $offset   Omit this number of files from the beginning of the list. Works with $per_page to do pagination.
+	 *     @type string $order    The sort direction. 'asc' or 'desc'.
+	 *     @type string $orderby  The property to sort the list by. 'filename', 'modified', 'size'. Defaults to 'filename'.
+	 *     @type int    $per_page The number of files to include in the list. Works with $offset to do pagination.
+	 *     @type string $source   Only include files from this source.
+	 * }
+	 * @param bool  $count_only Optional. True to return a total count of the files.
+	 *
+	 * @return File[]|int|WP_Error
+	 */
+	public function get_files( array $args = array(), bool $count_only = false ) {
+		$defaults = array(
+			'offset'   => 0,
+			'order'    => 'asc',
+			'orderby'  => 'filename',
+			'per_page' => 10,
+			'source'   => '',
+		);
+		$args = wp_parse_args( $args, $defaults );
+
+		$pattern = $args['source'] . '*' . '.log';
+		$files   = glob( $this->log_directory . $pattern );
+
+		if ( false === $files ) {
+			return new WP_Error(
+				'wc_log_directory_error',
+				__( 'Could not access the log file directory.', 'woocommerce' )
+			);
+		}
+
+		if ( true === $count_only ) {
+			return count( $files );
+		}
+
+		$files = array_map(
+			function( $file_path ) {
+				if ( ! is_readable( $file_path ) ) {
+					return null;
+				}
+
+				return new File( $file_path );
+			},
+			$files
+		);
+		$files = array_filter( $files );
+
+		$sort_callback = function( $a, $b ) use ( $args ) {
+			if ( $a === $b ) {
+				return 0;
+			}
+
+			$compare = $a < $b;
+
+			if ( 'desc' === $args['order'] ) {
+				return $compare ? 1 : -1;
+			}
+
+			return $compare ? -1 : 1;
+		};
+
+		switch ( $args['orderby'] ) {
+			case 'filename':
+				usort(
+					$files,
+					function( $a, $b ) use ( $sort_callback ) {
+						return $sort_callback( $a->get_filename(), $b->get_filename() );
+					}
+				);
+				break;
+			case 'modified':
+				usort(
+					$files,
+					function( $a, $b ) use ( $sort_callback ) {
+						return $sort_callback( $a->get_modified_timestamp(), $b->get_modified_timestamp() );
+					}
+				);
+				break;
+			case 'size':
+				usort(
+					$files,
+					function( $a, $b ) use ( $sort_callback ) {
+						return $sort_callback( $a->get_file_size(), $b->get_file_size() );
+					}
+				);
+				break;
+		}
+
+		return array_slice( $files, $args['offset'], $args['per_page'] );
+	}
+}

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
@@ -141,4 +141,22 @@ class FileController {
 
 		return array_slice( $files, $args['offset'], $args['per_page'] );
 	}
+
+	/**
+	 * Get a list of sources for existing log files.
+	 *
+	 * @return array
+	 */
+	public function get_file_sources() {
+		$files       = glob( $this->log_directory . '*.log' );
+		$all_sources = array_map(
+			function( $path ) {
+				$file = new File( $path );
+				return $file->get_source();
+			},
+			$files
+		);
+
+		return array_unique( $all_sources );
+	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
@@ -183,7 +183,7 @@ class FileController {
 	 *
 	 * @return int
 	 */
-	public function delete_files( $files ): int {
+	public function delete_files( array $files ): int {
 		$deleted = 0;
 
 		foreach ( $files as $basename ) {

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
@@ -10,7 +10,9 @@ use WP_Error;
  */
 class FileController {
 	/**
-	 * @const array Default values for arguments for the get_files method.
+	 * Default values for arguments for the get_files method.
+	 *
+	 * @const array
 	 */
 	public const DEFAULTS_GET_FILES = array(
 		'offset'   => 0,
@@ -21,7 +23,9 @@ class FileController {
 	);
 
 	/**
-	 * @var string The absolute path to the log directory.
+	 * The absolute path to the log directory.
+	 *
+	 * @var string
 	 */
 	private $log_directory;
 
@@ -51,7 +55,7 @@ class FileController {
 	public function get_files( array $args = array(), bool $count_only = false ) {
 		$args = wp_parse_args( $args, self::DEFAULTS_GET_FILES );
 
-		$pattern = $args['source'] . '*' . '.log';
+		$pattern = $args['source'] . '*.log';
 		$files   = glob( $this->log_directory . $pattern );
 
 		if ( false === $files ) {
@@ -90,7 +94,7 @@ class FileController {
 					$comparison = $set[0] <=> $set[1];
 				}
 
-				if ( $comparison !== 0 ) {
+				if ( 0 !== $comparison ) {
 					break;
 				}
 			}
@@ -101,7 +105,7 @@ class FileController {
 		switch ( $args['orderby'] ) {
 			case 'created':
 				$sort_callback = function( $a, $b ) use ( $args, $multi_sorter ) {
-					$sort_sets = array(
+					$sort_sets  = array(
 						array( $a->get_created_timestamp(), $b->get_created_timestamp() ),
 						array( $a->get_source(), $b->get_source() ),
 					);
@@ -111,7 +115,7 @@ class FileController {
 				break;
 			case 'modified':
 				$sort_callback = function( $a, $b ) use ( $args, $multi_sorter ) {
-					$sort_sets = array(
+					$sort_sets  = array(
 						array( $a->get_modified_timestamp(), $b->get_modified_timestamp() ),
 						array( $a->get_source(), $b->get_source() ),
 					);
@@ -121,7 +125,7 @@ class FileController {
 				break;
 			case 'source':
 				$sort_callback = function( $a, $b ) use ( $args, $multi_sorter ) {
-					$sort_sets = array(
+					$sort_sets  = array(
 						array( $a->get_source(), $b->get_source() ),
 						array( $a->get_created_timestamp(), $b->get_created_timestamp() ),
 					);
@@ -131,7 +135,7 @@ class FileController {
 				break;
 			case 'size':
 				$sort_callback = function( $a, $b ) use ( $args, $multi_sorter ) {
-					$sort_sets = array(
+					$sort_sets  = array(
 						array( $a->get_file_size(), $b->get_file_size() ),
 						array( $a->get_source(), $b->get_source() ),
 					);

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
@@ -109,8 +109,9 @@ class FileController {
 					$sort_sets  = array(
 						array( $a->get_created_timestamp(), $b->get_created_timestamp() ),
 						array( $a->get_source(), $b->get_source() ),
+						array( $a->get_rotation() || -1, $b->get_rotation() || -1 ),
 					);
-					$order_sets = array( $args['order'], 'asc' );
+					$order_sets = array( $args['order'], 'asc', 'asc' );
 					return $multi_sorter( $sort_sets, $order_sets );
 				};
 				break;
@@ -119,8 +120,9 @@ class FileController {
 					$sort_sets  = array(
 						array( $a->get_modified_timestamp(), $b->get_modified_timestamp() ),
 						array( $a->get_source(), $b->get_source() ),
+						array( $a->get_rotation() || -1, $b->get_rotation() || -1 ),
 					);
-					$order_sets = array( $args['order'], 'asc' );
+					$order_sets = array( $args['order'], 'asc', 'asc' );
 					return $multi_sorter( $sort_sets, $order_sets );
 				};
 				break;
@@ -129,8 +131,9 @@ class FileController {
 					$sort_sets  = array(
 						array( $a->get_source(), $b->get_source() ),
 						array( $a->get_created_timestamp(), $b->get_created_timestamp() ),
+						array( $a->get_rotation() || -1, $b->get_rotation() || -1 ),
 					);
-					$order_sets = array( $args['order'], 'desc' );
+					$order_sets = array( $args['order'], 'desc', 'asc' );
 					return $multi_sorter( $sort_sets, $order_sets );
 				};
 				break;
@@ -139,8 +142,9 @@ class FileController {
 					$sort_sets  = array(
 						array( $a->get_file_size(), $b->get_file_size() ),
 						array( $a->get_source(), $b->get_source() ),
+						array( $a->get_rotation() || -1, $b->get_rotation() || -1 ),
 					);
-					$order_sets = array( $args['order'], 'asc' );
+					$order_sets = array( $args['order'], 'asc', 'asc' );
 					return $multi_sorter( $sort_sets, $order_sets );
 				};
 				break;

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
@@ -10,6 +10,17 @@ use WP_Error;
  */
 class FileController {
 	/**
+	 * @const array Default values for arguments for the get_files method.
+	 */
+	public const DEFAULTS_GET_FILES = array(
+		'offset'   => 0,
+		'order'    => 'desc',
+		'orderby'  => 'modified',
+		'per_page' => 20,
+		'source'   => '',
+	);
+
+	/**
 	 * @var string The absolute path to the log directory.
 	 */
 	private $log_directory;
@@ -38,14 +49,7 @@ class FileController {
 	 * @return File[]|int|WP_Error
 	 */
 	public function get_files( array $args = array(), bool $count_only = false ) {
-		$defaults = array(
-			'offset'   => 0,
-			'order'    => 'desc',
-			'orderby'  => 'modified',
-			'per_page' => 10,
-			'source'   => '',
-		);
-		$args = wp_parse_args( $args, $defaults );
+		$args = wp_parse_args( $args, self::DEFAULTS_GET_FILES );
 
 		$pattern = $args['source'] . '*' . '.log';
 		$files   = glob( $this->log_directory . $pattern );
@@ -158,5 +162,27 @@ class FileController {
 		);
 
 		return array_unique( $all_sources );
+	}
+
+	/**
+	 * Delete one or more files from the filesystem.
+	 *
+	 * @param array $files An array of file basenames (filename without the path).
+	 *
+	 * @return int
+	 */
+	public function delete_files( $files ) {
+		$deleted = 0;
+
+		foreach ( $files as $basename ) {
+			$file   = new File( $this->log_directory . $basename );
+			$result = $file->delete();
+
+			if ( true === $result ) {
+				$deleted ++;
+			}
+		}
+
+		return $deleted;
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
@@ -201,4 +201,15 @@ class FileController {
 
 		return $deleted;
 	}
+
+	/**
+	 * Sanitize the source property of a log file.
+	 *
+	 * @param string $source The source property of a log file.
+	 *
+	 * @return string
+	 */
+	public function sanitize_source( string $source ): string {
+		return sanitize_file_name( $source );
+	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
@@ -1,4 +1,5 @@
 <?php
+declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Internal\Admin\Logging\FileV2;
 
@@ -153,10 +154,17 @@ class FileController {
 	/**
 	 * Get a list of sources for existing log files.
 	 *
-	 * @return array
+	 * @return array|WP_Error
 	 */
 	public function get_file_sources() {
-		$files       = glob( $this->log_directory . '*.log' );
+		$files = glob( $this->log_directory . '*.log' );
+		if ( false === $files ) {
+			return new WP_Error(
+				'wc_log_directory_error',
+				__( 'Could not access the log file directory.', 'woocommerce' )
+			);
+		}
+
 		$all_sources = array_map(
 			function( $path ) {
 				$file = new File( $path );
@@ -175,7 +183,7 @@ class FileController {
 	 *
 	 * @return int
 	 */
-	public function delete_files( $files ) {
+	public function delete_files( $files ): int {
 		$deleted = 0;
 
 		foreach ( $files as $basename ) {

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/ListTable.php
@@ -11,7 +11,7 @@ class ListTable extends WP_List_Table {
 	/**
 	 * @const string
 	 */
-	private const PER_PAGE_USER_OPTION_KEY = 'woocommerce_logging_file_list_per_page';
+	public const PER_PAGE_USER_OPTION_KEY = 'woocommerce_logging_file_list_per_page';
 
 	/**
 	 * @var FileController
@@ -21,7 +21,9 @@ class ListTable extends WP_List_Table {
 	/**
 	 * ListTable class.
 	 */
-	public function __construct() {
+	public function __construct( FileController $file_controller ) {
+		$this->file_controller = $file_controller;
+
 		parent::__construct(
 			array(
 				'singular' => 'log-file',
@@ -32,16 +34,26 @@ class ListTable extends WP_List_Table {
 	}
 
 	/**
-	 * Initialize dependencies.
-	 *
-	 * @param FileController $file_controller
+	 * Render message when there are no items.
 	 *
 	 * @return void
 	 */
-	final public function init(
-		FileController $file_controller
-	) {
-		$this->file_controller = $file_controller;
+	public function no_items() {
+		esc_html_e( 'No log files found.', 'woocommerce' );
+	}
+
+	/**
+	 * Set up the column header info.
+	 *
+	 * @return void
+	 */
+	public function prepare_column_headers() {
+		$this->_column_headers = array(
+			$this->get_columns(),
+			get_hidden_columns( $this->screen ),
+			$this->get_sortable_columns(),
+			$this->get_primary_column(),
+		);
 	}
 
 	/**
@@ -87,13 +99,6 @@ class ListTable extends WP_List_Table {
 		$items       = $this->file_controller->get_files( $file_args );
 
 		$this->items = $items;
-
-		$this->_column_headers = array(
-			$this->get_columns(),
-			array(),
-			$this->get_sortable_columns(),
-			$this->get_primary_column(),
-		);
 
 		$this->set_pagination_args(
 			array(

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/ListTable.php
@@ -2,6 +2,8 @@
 
 namespace Automattic\WooCommerce\Internal\Admin\Logging\FileV2;
 
+use Automattic\WooCommerce\Internal\Admin\Logging\PageController;
+
 use WP_List_Table;
 
 /**
@@ -19,10 +21,16 @@ class ListTable extends WP_List_Table {
 	private $file_controller;
 
 	/**
+	 * @var PageController
+	 */
+	private $page_controller;
+
+	/**
 	 * ListTable class.
 	 */
-	public function __construct( FileController $file_controller ) {
+	public function __construct( FileController $file_controller, PageController $page_controller ) {
 		$this->file_controller = $file_controller;
+		$this->page_controller = $page_controller;
 
 		parent::__construct(
 			array(
@@ -170,7 +178,20 @@ class ListTable extends WP_List_Table {
 	 * @return string
 	 */
 	public function column_source( $item ) {
-		return $item->get_source();
+		$log_file        = sanitize_title( $item->get_basename() );
+		$single_file_url = add_query_arg(
+			array(
+				'view'     => 'single_file',
+				'log_file' => $log_file,
+			),
+			$this->page_controller->get_logs_tab_url()
+		);
+
+		return sprintf(
+			'<a href="%1$s">%2$s</a>',
+			$single_file_url,
+			$item->get_source()
+		);
 	}
 
 	/**
@@ -183,7 +204,7 @@ class ListTable extends WP_List_Table {
 	public function column_created( $item ) {
 		$timestamp = $item->get_created_timestamp();
 
-		return date( 'Y-m-d H:i:s', $timestamp );
+		return date( 'Y-m-d', $timestamp );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/ListTable.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace Automattic\WooCommerce\Internal\Admin\Logging\FileV2;
+
+use WP_List_Table;
+
+/**
+ * ListTable class.
+ */
+class ListTable extends WP_List_Table {
+	/**
+	 * @const string
+	 */
+	private const PER_PAGE_USER_OPTION_KEY = 'woocommerce_logging_file_list_per_page';
+
+	/**
+	 * @var FileController
+	 */
+	private $file_controller;
+
+	/**
+	 * ListTable class.
+	 */
+	public function __construct() {
+		parent::__construct(
+			array(
+				'singular' => 'log-file',
+				'plural'   => 'log-files',
+				'ajax'     => false,
+			)
+		);
+	}
+
+	/**
+	 * Initialize dependencies.
+	 *
+	 * @param FileController $file_controller
+	 *
+	 * @return void
+	 */
+	final public function init(
+		FileController $file_controller
+	) {
+		$this->file_controller = $file_controller;
+	}
+
+	/**
+	 * Prepares the list of items for displaying.
+	 *
+	 * @return void
+	 */
+	public function prepare_items() {
+		$per_page = $this->get_items_per_page( self::PER_PAGE_USER_OPTION_KEY );
+		$offset   = ( $this->get_pagenum() - 1 ) * $per_page;
+		$orderby  = filter_input(
+			INPUT_GET,
+			'orderby',
+			FILTER_VALIDATE_REGEXP,
+			array(
+				'options' => array(
+					'regexp'  => '/^(created|modified|source|size)$/',
+					'default' => 'modified'
+				),
+			)
+		);
+		$order    = filter_input(
+			INPUT_GET,
+			'order',
+			FILTER_VALIDATE_REGEXP,
+			array(
+				'options' => array(
+					'regexp'  => '/^(asc|desc)$/i',
+					'default' => 'desc'
+				),
+			)
+		);
+
+		$file_args = array(
+			'per_page' => $per_page,
+			'offset'   => $offset,
+			'orderby'  => $orderby,
+			'order'    => $order,
+		);
+
+		$total_items = $this->file_controller->get_files( $file_args, true );
+		$total_pages = ceil( $total_items / $per_page );
+		$items       = $this->file_controller->get_files( $file_args );
+
+		$this->items = $items;
+
+		$this->_column_headers = array(
+			$this->get_columns(),
+			array(),
+			$this->get_sortable_columns(),
+			$this->get_primary_column(),
+		);
+
+		$this->set_pagination_args(
+			array(
+				'per_page'    => $per_page,
+				'total_items' => $total_items,
+				'total_pages' => $total_pages,
+			)
+		);
+	}
+
+	/**
+	 * Gets a list of columns.
+	 *
+	 * @return array
+	 */
+	public function get_columns() {
+		$columns = array(
+			'cb'       => '<input type="checkbox" />',
+			'source'   => __( 'Source', 'woocommerce' ),
+			'created'  => __( 'Date created', 'woocommerce' ),
+			'modified' => __( 'Date modified', 'woocommerce' ),
+			'size'     => __( 'File size', 'woocommerce' ),
+		);
+
+		return $columns;
+	}
+
+	/**
+	 * Gets a list of sortable columns.
+	 *
+	 * @return array
+	 */
+	protected function get_sortable_columns() {
+		$sortable = array(
+			'source'   => array( 'source' ),
+			'created'  => array( 'created' ),
+			'modified' => array( 'modified', true ),
+			'size'     => array( 'size' ),
+		);
+
+		return $sortable;
+	}
+
+	/**
+	 * Render the checkbox column.
+	 *
+	 * @param File $item
+	 *
+	 * @return string
+	 */
+	public function column_cb( $item ) {
+		ob_start();
+		?>
+		<input
+			id="cb-select-<?php echo esc_attr( $item->get_key() ); ?>"
+			type="checkbox"
+			name="id[]"
+			value="<?php echo esc_attr( $item->get_key() ); ?>"
+		/>
+		<?php
+		return ob_get_clean();
+	}
+
+	/**
+	 * Render the source column.
+	 *
+	 * @param File $item
+	 *
+	 * @return string
+	 */
+	public function column_source( $item ) {
+		return $item->get_source();
+	}
+
+	/**
+	 * Render the created column.
+	 *
+	 * @param File $item
+	 *
+	 * @return string
+	 */
+	public function column_created( $item ) {
+		$timestamp = $item->get_created_timestamp();
+
+		return date( 'Y-m-d H:i:s', $timestamp );
+	}
+
+	/**
+	 * Render the modified column.
+	 *
+	 * @param File $item
+	 *
+	 * @return string
+	 */
+	public function column_modified( $item ) {
+		$timestamp = $item->get_modified_timestamp();
+
+		return date( 'Y-m-d H:i:s', $timestamp );
+	}
+
+	/**
+	 * Render the size column.
+	 *
+	 * @param File $item
+	 *
+	 * @return string
+	 */
+	public function column_size( $item ) {
+		$size = $item->get_file_size();
+
+		return size_format( $size );
+	}
+}

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/ListTable.php
@@ -262,7 +262,7 @@ class ListTable extends WP_List_Table {
 			),
 			$this->page_controller->get_logs_tab_url()
 		);
-		$rotation = '';
+		$rotation        = '';
 		if ( ! is_null( $item->get_rotation() ) ) {
 			$rotation = sprintf(
 				' &ndash; <span class="post-state">%d</span>',

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/ListTable.php
@@ -257,11 +257,19 @@ class ListTable extends WP_List_Table {
 			),
 			$this->page_controller->get_logs_tab_url()
 		);
+		$rotation = '';
+		if ( ! is_null( $item->get_rotation() ) ) {
+			$rotation = sprintf(
+				' &ndash; <span class="post-state">%d</span>',
+				$item->get_rotation()
+			);
+		}
 
 		return sprintf(
-			'<a href="%1$s">%2$s</a>',
+			'<a class="row-title" href="%1$s">%2$s</a>%3$s',
 			$single_file_url,
-			$item->get_source()
+			$item->get_source(),
+			$rotation
 		);
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/ListTable.php
@@ -95,7 +95,9 @@ class ListTable extends WP_List_Table {
 	 * @return void
 	 */
 	protected function extra_tablenav( $which ): void {
-		$all_sources    = $this->get_sources_list();
+		$all_sources = $this->get_sources_list();
+
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$current_source = $this->file_controller->sanitize_source( wp_unslash( $_GET['source'] ?? '' ) );
 
 		?>

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/ListTable.php
@@ -1,4 +1,5 @@
 <?php
+declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Internal\Admin\Logging\FileV2;
 
@@ -55,7 +56,7 @@ class ListTable extends WP_List_Table {
 	 *
 	 * @return void
 	 */
-	public function no_items() {
+	public function no_items(): void {
 		esc_html_e( 'No log files found.', 'woocommerce' );
 	}
 
@@ -64,7 +65,7 @@ class ListTable extends WP_List_Table {
 	 *
 	 * @return array
 	 */
-	protected function get_bulk_actions() {
+	protected function get_bulk_actions(): array {
 		return array(
 			'delete' => __( 'Delete permanently', 'woocommerce' ),
 		);
@@ -75,8 +76,12 @@ class ListTable extends WP_List_Table {
 	 *
 	 * @return array
 	 */
-	protected function get_sources_list() {
+	protected function get_sources_list(): array {
 		$sources = $this->file_controller->get_file_sources();
+		if ( is_wp_error( $sources ) ) {
+			return array();
+		}
+
 		sort( $sources );
 
 		return $sources;
@@ -89,7 +94,7 @@ class ListTable extends WP_List_Table {
 	 *
 	 * @return void
 	 */
-	protected function extra_tablenav( $which ) {
+	protected function extra_tablenav( $which ): void {
 		$all_sources    = $this->get_sources_list();
 		$current_source = filter_input( INPUT_GET, 'source', FILTER_SANITIZE_STRING ) ?? '';
 
@@ -126,7 +131,7 @@ class ListTable extends WP_List_Table {
 	 *
 	 * @return void
 	 */
-	public function prepare_column_headers() {
+	public function prepare_column_headers(): void {
 		$this->_column_headers = array(
 			$this->get_columns(),
 			get_hidden_columns( $this->screen ),
@@ -140,7 +145,7 @@ class ListTable extends WP_List_Table {
 	 *
 	 * @return void
 	 */
-	public function prepare_items() {
+	public function prepare_items(): void {
 		$per_page = $this->get_items_per_page(
 			self::PER_PAGE_USER_OPTION_KEY,
 			$this->file_controller::DEFAULTS_GET_FILES['per_page']
@@ -181,7 +186,7 @@ class ListTable extends WP_List_Table {
 	 *
 	 * @return array
 	 */
-	public function get_columns() {
+	public function get_columns(): array {
 		$columns = array(
 			'cb'       => '<input type="checkbox" />',
 			'source'   => __( 'Source', 'woocommerce' ),
@@ -198,7 +203,7 @@ class ListTable extends WP_List_Table {
 	 *
 	 * @return array
 	 */
-	protected function get_sortable_columns() {
+	protected function get_sortable_columns(): array {
 		$sortable = array(
 			'source'   => array( 'source' ),
 			'created'  => array( 'created' ),
@@ -216,7 +221,7 @@ class ListTable extends WP_List_Table {
 	 *
 	 * @return string
 	 */
-	public function column_cb( $item ) {
+	public function column_cb( $item ): string {
 		ob_start();
 		?>
 		<input
@@ -248,7 +253,7 @@ class ListTable extends WP_List_Table {
 	 *
 	 * @return string
 	 */
-	public function column_source( $item ) {
+	public function column_source( $item ): string {
 		$log_file        = sanitize_title( $item->get_basename() );
 		$single_file_url = add_query_arg(
 			array(
@@ -280,7 +285,7 @@ class ListTable extends WP_List_Table {
 	 *
 	 * @return string
 	 */
-	public function column_created( $item ) {
+	public function column_created( $item ): string {
 		$timestamp = $item->get_created_timestamp();
 
 		return gmdate( 'Y-m-d', $timestamp );
@@ -293,7 +298,7 @@ class ListTable extends WP_List_Table {
 	 *
 	 * @return string
 	 */
-	public function column_modified( $item ) {
+	public function column_modified( $item ): string {
 		$timestamp = $item->get_modified_timestamp();
 
 		return gmdate( 'Y-m-d H:i:s', $timestamp );
@@ -306,7 +311,7 @@ class ListTable extends WP_List_Table {
 	 *
 	 * @return string
 	 */
-	public function column_size( $item ) {
+	public function column_size( $item ): string {
 		$size = $item->get_file_size();
 
 		return size_format( $size );

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/ListTable.php
@@ -97,7 +97,7 @@ class ListTable extends WP_List_Table {
 	protected function extra_tablenav( $which ): void {
 		$all_sources = $this->get_sources_list();
 
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended
 		$current_source = $this->file_controller->sanitize_source( wp_unslash( $_GET['source'] ?? '' ) );
 
 		?>

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/ListTable.php
@@ -12,6 +12,7 @@ use WP_List_Table;
 class ListTable extends WP_List_Table {
 	/**
 	 * The user option key for saving the preferred number of files displayed per page.
+	 *
 	 * @const string
 	 */
 	public const PER_PAGE_USER_OPTION_KEY = 'woocommerce_logging_file_list_per_page';

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/ListTable.php
@@ -67,7 +67,7 @@ class ListTable extends WP_List_Table {
 	 */
 	protected function get_bulk_actions(): array {
 		return array(
-			'delete' => __( 'Delete permanently', 'woocommerce' ),
+			'delete' => esc_html__( 'Delete permanently', 'woocommerce' ),
 		);
 	}
 
@@ -191,10 +191,10 @@ class ListTable extends WP_List_Table {
 	public function get_columns(): array {
 		$columns = array(
 			'cb'       => '<input type="checkbox" />',
-			'source'   => __( 'Source', 'woocommerce' ),
-			'created'  => __( 'Date created', 'woocommerce' ),
-			'modified' => __( 'Date modified', 'woocommerce' ),
-			'size'     => __( 'File size', 'woocommerce' ),
+			'source'   => esc_html__( 'Source', 'woocommerce' ),
+			'created'  => esc_html__( 'Date created', 'woocommerce' ),
+			'modified' => esc_html__( 'Date modified', 'woocommerce' ),
+			'size'     => esc_html__( 'File size', 'woocommerce' ),
 		);
 
 		return $columns;

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/ListTable.php
@@ -11,22 +11,30 @@ use WP_List_Table;
  */
 class ListTable extends WP_List_Table {
 	/**
+	 * The user option key for saving the preferred number of files displayed per page.
 	 * @const string
 	 */
 	public const PER_PAGE_USER_OPTION_KEY = 'woocommerce_logging_file_list_per_page';
 
 	/**
+	 * Instance of FileController.
+	 *
 	 * @var FileController
 	 */
 	private $file_controller;
 
 	/**
+	 * Instance of PageController.
+	 *
 	 * @var PageController
 	 */
 	private $page_controller;
 
 	/**
 	 * ListTable class.
+	 *
+	 * @param FileController $file_controller Instance of FileController.
+	 * @param PageController $page_controller Instance of PageController.
 	 */
 	public function __construct( FileController $file_controller, PageController $page_controller ) {
 		$this->file_controller = $file_controller;
@@ -76,7 +84,7 @@ class ListTable extends WP_List_Table {
 	/**
 	 * Displays extra controls between bulk actions and pagination.
 	 *
-	 * @param string $which
+	 * @param string $which The location of the tablenav being rendered. 'top' or 'bottom'.
 	 *
 	 * @return void
 	 */
@@ -91,7 +99,7 @@ class ListTable extends WP_List_Table {
 				<select name="source" id="filter-by-source">
 					<option<?php selected( $current_source, '' ); ?> value=""><?php esc_html_e( 'All sources', 'woocommerce' ); ?></option>
 					<?php foreach ( $all_sources as $source ) : ?>
-						<option<?php selected( $current_source, $source ); ?> value="<?php echo esc_attr( $source ) ?>">
+						<option<?php selected( $current_source, $source ); ?> value="<?php echo esc_attr( $source ); ?>">
 							<?php echo esc_html( $source ); ?>
 						</option>
 					<?php endforeach; ?>
@@ -137,7 +145,7 @@ class ListTable extends WP_List_Table {
 			$this->file_controller::DEFAULTS_GET_FILES['per_page']
 		);
 
-		$defaults = array(
+		$defaults  = array(
 			'per_page' => $per_page,
 			'offset'   => ( $this->get_pagenum() - 1 ) * $per_page,
 		);
@@ -203,7 +211,7 @@ class ListTable extends WP_List_Table {
 	/**
 	 * Render the checkbox column.
 	 *
-	 * @param File $item
+	 * @param File $item The current log file being rendered.
 	 *
 	 * @return string
 	 */
@@ -220,8 +228,9 @@ class ListTable extends WP_List_Table {
 			<span class="screen-reader-text">
 				<?php
 				printf(
+					// translators: 1. a date, 2. a slug-style name for a file.
 					esc_html__( 'Select the %1$s log file for %2$s', 'woocommerce' ),
-					esc_html( date( get_option( 'date_format' ), $item->get_created_timestamp() ) ),
+					esc_html( gmdate( get_option( 'date_format' ), $item->get_created_timestamp() ) ),
 					esc_html( $item->get_source() )
 				);
 				?>
@@ -234,7 +243,7 @@ class ListTable extends WP_List_Table {
 	/**
 	 * Render the source column.
 	 *
-	 * @param File $item
+	 * @param File $item The current log file being rendered.
 	 *
 	 * @return string
 	 */
@@ -258,33 +267,33 @@ class ListTable extends WP_List_Table {
 	/**
 	 * Render the created column.
 	 *
-	 * @param File $item
+	 * @param File $item The current log file being rendered.
 	 *
 	 * @return string
 	 */
 	public function column_created( $item ) {
 		$timestamp = $item->get_created_timestamp();
 
-		return date( 'Y-m-d', $timestamp );
+		return gmdate( 'Y-m-d', $timestamp );
 	}
 
 	/**
 	 * Render the modified column.
 	 *
-	 * @param File $item
+	 * @param File $item The current log file being rendered.
 	 *
 	 * @return string
 	 */
 	public function column_modified( $item ) {
 		$timestamp = $item->get_modified_timestamp();
 
-		return date( 'Y-m-d H:i:s', $timestamp );
+		return gmdate( 'Y-m-d H:i:s', $timestamp );
 	}
 
 	/**
 	 * Render the size column.
 	 *
-	 * @param File $item
+	 * @param File $item The current log file being rendered.
 	 *
 	 * @return string
 	 */

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/ListTable.php
@@ -96,7 +96,7 @@ class ListTable extends WP_List_Table {
 	 */
 	protected function extra_tablenav( $which ): void {
 		$all_sources    = $this->get_sources_list();
-		$current_source = filter_input( INPUT_GET, 'source', FILTER_SANITIZE_STRING ) ?? '';
+		$current_source = $this->file_controller->sanitize_source( wp_unslash( $_GET['source'] ?? '' ) );
 
 		?>
 		<div class="alignleft actions">

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/ListTable.php
@@ -220,12 +220,12 @@ class ListTable extends WP_List_Table {
 		ob_start();
 		?>
 		<input
-			id="cb-select-<?php echo esc_attr( $item->get_key() ); ?>"
+			id="cb-select-<?php echo esc_attr( $item->get_hash() ); ?>"
 			type="checkbox"
 			name="file[]"
 			value="<?php echo esc_attr( $item->get_basename() ); ?>"
 		/>
-		<label for="cb-select-<?php echo esc_attr( $item->get_key() ); ?>">
+		<label for="cb-select-<?php echo esc_attr( $item->get_hash() ); ?>">
 			<span class="screen-reader-text">
 				<?php
 				printf(

--- a/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Automattic\WooCommerce\Internal\Admin\Logging;
+
+use WC_Log_Handler_File;
+
+class LogHandlerFileV2 extends WC_Log_Handler_File {}

--- a/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
@@ -4,4 +4,7 @@ namespace Automattic\WooCommerce\Internal\Admin\Logging;
 
 use WC_Log_Handler_File;
 
+/**
+ * LogHandlerFileV2 class.
+ */
 class LogHandlerFileV2 extends WC_Log_Handler_File {}

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -49,6 +49,21 @@ class PageController {
 	}
 
 	/**
+	 * Get the canonical URL for the Logs tab of the Status admin page.
+	 *
+	 * @return string
+	 */
+	public function get_logs_tab_url() {
+		return add_query_arg(
+			array(
+				'page' => 'wc-status',
+				'tab'  => 'logs',
+			),
+			admin_url( 'admin.php' )
+		);
+	}
+
+	/**
 	 * Determine the default log handler.
 	 *
 	 * @return string
@@ -144,7 +159,7 @@ class PageController {
 			return $this->list_table;
 		}
 
-		$this->list_table = new ListTable( $this->file_controller );
+		$this->list_table = new ListTable( $this->file_controller, $this );
 
 		return $this->list_table;
 	}

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Automattic\WooCommerce\Internal\Admin\Logging;
+
+use Automattic\Jetpack\Constants;
+use Automattic\WooCommerce\Internal\Admin\Logging\FileV2\{ FileController, ListTable };
+use Automattic\WooCommerce\Internal\Traits\AccessiblePrivateMethods;
+use WC_Admin_Status;
+
+/**
+ * PageController class.
+ */
+class PageController {
+
+	use AccessiblePrivateMethods;
+
+	/**
+	 * @var FileController
+	 */
+	private $file_controller;
+
+	/**
+	 * @var ListTable
+	 */
+	private $file_list_table;
+
+	/**
+	 * Initialize dependencies.
+	 *
+	 * @param FileController $file_controller
+	 * @param ListTable $file_list_table
+	 *
+	 * @return void
+	 */
+	final public function init(
+		FileController $file_controller,
+		ListTable $file_list_table
+	) {
+		$this->file_controller = $file_controller;
+		$this->file_list_table = $file_list_table;
+
+		$this->init_hooks();
+	}
+
+	/**
+	 * Add callbacks to hooks.
+	 *
+	 * @return void
+	 */
+	private function init_hooks() {
+
+	}
+
+	/**
+	 * Determine the default log handler.
+	 *
+	 * @return string
+	 */
+	public function get_default_handler() {
+		$handler = Constants::get_constant( 'WC_LOG_HANDLER' );
+
+		if ( is_null( $handler ) || ! class_exists( $handler ) ) {
+			$handler = \WC_Log_Handler_File::class;
+		}
+
+		return $handler;
+	}
+
+	/**
+	 * Render the "Logs" tab, depending on the current default log handler.
+	 *
+	 * @return void
+	 */
+	public function render() {
+		$handler = $this->get_default_handler();
+
+		switch ( $handler ) {
+			case LogHandlerFileV2::class:
+				$args = $this->get_filev2_query_params();
+				$this->render_filev2( $args );
+				break;
+			case 'WC_Log_Handler_DB':
+				WC_Admin_Status::status_logs_db();
+				break;
+			default:
+				WC_Admin_Status::status_logs_file();
+				break;
+		}
+	}
+
+	/**
+	 * Render the views for the FileV2 log handler.
+	 *
+	 * @param array $args Args for rendering the views.
+	 *
+	 * @return void
+	 */
+	private function render_filev2( array $args = array() ) {
+		$view = $args['view'] ?? '';
+
+		switch ( $view ) {
+			case 'list_files':
+			default:
+				$this->file_list_table->prepare_items();
+				$this->file_list_table->display();
+				break;
+			case 'single_file':
+				WC_Admin_Status::status_logs_file();
+				break;
+		}
+	}
+
+	/**
+	 * Get and validate URL query params for FileV2 views.
+	 *
+	 * @return array
+	 */
+	private function get_filev2_query_params() {
+		$params = filter_input_array(
+			INPUT_GET,
+			array(
+				'view' => array(
+					'filter'  => FILTER_VALIDATE_REGEXP,
+					'options' => array(
+						'regexp'  => '/^(list_files|single_file)$/',
+						'default' => 'list_files'
+					),
+				),
+			)
+		);
+
+		return $params;
+	}
+}

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -132,6 +132,9 @@ class PageController {
 		$params   = $this->get_query_params();
 
 		?>
+		<h2>
+			<?php esc_html_e( 'Log files', 'woocommerce' ); ?>
+		</h2>
 		<form id="logs-list-table-form" method="get">
 			<input type="hidden" name="page" value="wc-status" />
 			<input type="hidden" name="tab" value="logs" />

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -1,4 +1,5 @@
 <?php
+declare( strict_types = 1 );
 
 namespace Automattic\WooCommerce\Internal\Admin\Logging;
 
@@ -37,7 +38,7 @@ class PageController {
 	 */
 	final public function init(
 		FileController $file_controller
-	) {
+	): void {
 		$this->file_controller = $file_controller;
 
 		$this->init_hooks();
@@ -48,7 +49,7 @@ class PageController {
 	 *
 	 * @return void
 	 */
-	private function init_hooks() {
+	private function init_hooks(): void {
 		self::add_action( 'load-woocommerce_page_wc-status', array( $this, 'setup_screen_options' ) );
 		self::add_action( 'load-woocommerce_page_wc-status', array( $this, 'handle_list_table_bulk_actions' ) );
 	}
@@ -58,7 +59,7 @@ class PageController {
 	 *
 	 * @return string
 	 */
-	public function get_logs_tab_url() {
+	public function get_logs_tab_url(): string {
 		return add_query_arg(
 			array(
 				'page' => 'wc-status',
@@ -73,7 +74,7 @@ class PageController {
 	 *
 	 * @return string
 	 */
-	public function get_default_handler() {
+	public function get_default_handler(): string {
 		$handler = Constants::get_constant( 'WC_LOG_HANDLER' );
 
 		if ( is_null( $handler ) || ! class_exists( $handler ) ) {
@@ -88,7 +89,7 @@ class PageController {
 	 *
 	 * @return void
 	 */
-	public function render() {
+	public function render(): void {
 		$handler = $this->get_default_handler();
 
 		switch ( $handler ) {
@@ -112,7 +113,7 @@ class PageController {
 	 *
 	 * @return void
 	 */
-	private function render_filev2( array $args = array() ) {
+	private function render_filev2( array $args = array() ): void {
 		$view = $args['view'] ?? '';
 
 		switch ( $view ) {
@@ -131,7 +132,7 @@ class PageController {
 	 *
 	 * @return void
 	 */
-	private function render_file_list_page() {
+	private function render_file_list_page(): void {
 		$defaults = $this->get_query_param_defaults();
 		$params   = $this->get_query_params();
 
@@ -162,7 +163,7 @@ class PageController {
 	 *
 	 * @return string[]
 	 */
-	public function get_query_param_defaults() {
+	public function get_query_param_defaults(): array {
 		return array(
 			'order'   => $this->file_controller::DEFAULTS_GET_FILES['order'],
 			'orderby' => $this->file_controller::DEFAULTS_GET_FILES['orderby'],
@@ -176,7 +177,7 @@ class PageController {
 	 *
 	 * @return array
 	 */
-	public function get_query_params() {
+	public function get_query_params(): array {
 		$defaults = $this->get_query_param_defaults();
 		$params   = filter_input_array(
 			INPUT_GET,
@@ -216,7 +217,7 @@ class PageController {
 	 *
 	 * @return ListTable
 	 */
-	private function get_list_table() {
+	private function get_list_table(): ListTable {
 		if ( $this->list_table instanceof ListTable ) {
 			return $this->list_table;
 		}
@@ -231,7 +232,7 @@ class PageController {
 	 *
 	 * @return void
 	 */
-	private function setup_screen_options() {
+	private function setup_screen_options(): void {
 		$params = $this->get_query_params();
 
 		if ( 'list_files' === $params['view'] ) {
@@ -253,7 +254,7 @@ class PageController {
 	 *
 	 * @return void
 	 */
-	private function handle_list_table_bulk_actions() {
+	private function handle_list_table_bulk_actions(): void {
 		$action = $this->get_list_table()->current_action();
 
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -32,6 +32,8 @@ class PageController {
 	/**
 	 * Initialize dependencies.
 	 *
+	 * @internal
+	 *
 	 * @param FileController $file_controller Instance of FileController.
 	 *
 	 * @return void

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -15,11 +15,15 @@ class PageController {
 	use AccessiblePrivateMethods;
 
 	/**
+	 * Instance of FileController.
+	 *
 	 * @var FileController
 	 */
 	private $file_controller;
 
 	/**
+	 * Instance of ListTable.
+	 *
 	 * @var ListTable
 	 */
 	private $list_table;
@@ -27,7 +31,7 @@ class PageController {
 	/**
 	 * Initialize dependencies.
 	 *
-	 * @param FileController $file_controller
+	 * @param FileController $file_controller Instance of FileController.
 	 *
 	 * @return void
 	 */
@@ -177,7 +181,7 @@ class PageController {
 		$params   = filter_input_array(
 			INPUT_GET,
 			array(
-				'view' => array(
+				'view'    => array(
 					'filter'  => FILTER_VALIDATE_REGEXP,
 					'options' => array(
 						'regexp'  => '/^(list_files|single_file)$/',
@@ -185,20 +189,20 @@ class PageController {
 					),
 				),
 				'orderby' => array(
-					'filter' => FILTER_VALIDATE_REGEXP,
+					'filter'  => FILTER_VALIDATE_REGEXP,
 					'options' => array(
 						'regexp'  => '/^(created|modified|source|size)$/',
-						'default' => $defaults['orderby']
+						'default' => $defaults['orderby'],
 					),
 				),
-				'order' => array(
-					'filter' => FILTER_VALIDATE_REGEXP,
+				'order'   => array(
+					'filter'  => FILTER_VALIDATE_REGEXP,
 					'options' => array(
 						'regexp'  => '/^(asc|desc)$/i',
-						'default' => $defaults['order']
+						'default' => $defaults['order'],
 					),
 				),
-				'source' => FILTER_SANITIZE_STRING,
+				'source'  => FILTER_SANITIZE_STRING,
 			),
 			false
 		);
@@ -252,6 +256,8 @@ class PageController {
 	private function handle_list_table_bulk_actions() {
 		$action = $this->get_list_table()->current_action();
 
+		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : $this->get_logs_tab_url();
+
 		if ( $action ) {
 			check_admin_referer( 'bulk-log-files' );
 
@@ -264,7 +270,7 @@ class PageController {
 
 			switch ( $action ) {
 				case 'delete':
-					$deleted = $this->file_controller->delete_files( $files );
+					$deleted  = $this->file_controller->delete_files( $files );
 					$sendback = add_query_arg( 'deleted', $deleted, $sendback );
 					break;
 			}
@@ -275,7 +281,7 @@ class PageController {
 			exit;
 		} elseif ( ! empty( $_REQUEST['_wp_http_referer'] ) ) {
 			$removable_args = array( '_wp_http_referer', '_wpnonce', 'action', 'action2', 'filter_action' );
-			wp_safe_redirect( remove_query_arg( $removable_args, wp_unslash( $_SERVER['REQUEST_URI'] ) ) );
+			wp_safe_redirect( remove_query_arg( $removable_args, $request_uri ) );
 			exit;
 		}
 
@@ -292,7 +298,7 @@ class PageController {
 							printf(
 								// translators: %s is a number of files.
 								esc_html( _n( '%s log file deleted.', '%s log files deleted.', $deleted, 'woocommerce' ) ),
-								number_format_i18n( $deleted )
+								esc_html( number_format_i18n( $deleted ) )
 							);
 							?>
 						</p>
@@ -302,6 +308,6 @@ class PageController {
 			);
 		}
 
-		$_SERVER['REQUEST_URI'] = remove_query_arg( array( 'deleted' ), wp_unslash( $_SERVER['REQUEST_URI'] ) );
+		$_SERVER['REQUEST_URI'] = remove_query_arg( array( 'deleted' ), $request_uri );
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -326,7 +326,5 @@ class PageController {
 				}
 			);
 		}
-
-		$_SERVER['REQUEST_URI'] = remove_query_arg( array( 'deleted' ), $request_uri );
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -94,8 +94,8 @@ class PageController {
 
 		switch ( $handler ) {
 			case LogHandlerFileV2::class:
-				$args = $this->get_query_params();
-				$this->render_filev2( $args );
+				$params = $this->get_query_params();
+				$this->render_filev2( $params );
 				break;
 			case 'WC_Log_Handler_DB':
 				WC_Admin_Status::status_logs_db();
@@ -109,17 +109,17 @@ class PageController {
 	/**
 	 * Render the views for the FileV2 log handler.
 	 *
-	 * @param array $args Args for rendering the views.
+	 * @param array $params Args for rendering the views.
 	 *
 	 * @return void
 	 */
-	private function render_filev2( array $args = array() ): void {
-		$view = $args['view'] ?? '';
+	private function render_filev2( array $params = array() ): void {
+		$view = $params['view'] ?? '';
 
 		switch ( $view ) {
 			case 'list_files':
 			default:
-				$this->render_file_list_page();
+				$this->render_file_list_page( $params );
 				break;
 			case 'single_file':
 				WC_Admin_Status::status_logs_file();
@@ -130,11 +130,12 @@ class PageController {
 	/**
 	 * Render the file list view.
 	 *
+	 * @param array $params Args for rendering the views.
+	 *
 	 * @return void
 	 */
-	private function render_file_list_page(): void {
+	private function render_file_list_page( array $params = array() ): void {
 		$defaults = $this->get_query_param_defaults();
-		$params   = $this->get_query_params();
 
 		?>
 		<h2>

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -256,6 +256,7 @@ class PageController {
 	private function handle_list_table_bulk_actions() {
 		$action = $this->get_list_table()->current_action();
 
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : $this->get_logs_tab_url();
 
 		if ( $action ) {

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/LoggingServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/LoggingServiceProvider.php
@@ -17,7 +17,6 @@ class LoggingServiceProvider extends AbstractServiceProvider {
 	 */
 	protected $provides = array(
 		FileController::class,
-		ListTable::class,
 		PageController::class,
 	);
 
@@ -29,16 +28,9 @@ class LoggingServiceProvider extends AbstractServiceProvider {
 	public function register() {
 		$this->share( FileController::class );
 
-		$this->share( ListTable::class )->addArguments(
-			array(
-				FileController::class,
-			)
-		);
-
 		$this->share( PageController::class )->addArguments(
 			array(
 				FileController::class,
-				ListTable::class,
 			)
 		);
 	}

--- a/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/LoggingServiceProvider.php
+++ b/plugins/woocommerce/src/Internal/DependencyManagement/ServiceProviders/LoggingServiceProvider.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders;
+
+use Automattic\WooCommerce\Internal\Admin\Logging\PageController;
+use Automattic\WooCommerce\Internal\Admin\Logging\FileV2\{ FileController, ListTable };
+use Automattic\WooCommerce\Internal\DependencyManagement\AbstractServiceProvider;
+
+/**
+ * LoggingServiceProvider class.
+ */
+class LoggingServiceProvider extends AbstractServiceProvider {
+	/**
+	 * List services provided by this class.
+	 *
+	 * @var string[]
+	 */
+	protected $provides = array(
+		FileController::class,
+		ListTable::class,
+		PageController::class,
+	);
+
+	/**
+	 * Registers services provided by this class.
+	 *
+	 * @return void
+	 */
+	public function register() {
+		$this->share( FileController::class );
+
+		$this->share( ListTable::class )->addArguments(
+			array(
+				FileController::class,
+			)
+		);
+
+		$this->share( PageController::class )->addArguments(
+			array(
+				FileController::class,
+				ListTable::class,
+			)
+		);
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileControllerTest.php
@@ -19,8 +19,22 @@ class FileControllerTest extends WC_Unit_Test_Case {
 	 */
 	private $handler;
 
-
+	/**
+	 * "System Under Test", an instance of the class to be tested.
+	 *
+	 * @var FileController
+	 */
 	private $sut;
+
+	/**
+	 * Set up to do before running any of these tests.
+	 *
+	 * @return void
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		self::delete_all_log_files();
+	}
 
 	/**
 	 * Set up before each test.
@@ -40,13 +54,20 @@ class FileControllerTest extends WC_Unit_Test_Case {
 	 * @return void
 	 */
 	public function tearDown(): void {
-		// Delete all created log files.
+		self::delete_all_log_files();
+		parent::tearDown();
+	}
+
+	/**
+	 * Delete all existing log files.
+	 *
+	 * @return void
+	 */
+	private static function delete_all_log_files(): void {
 		$files = glob( trailingslashit( realpath( Constants::get_constant( 'WC_LOG_DIR' ) ) ) . '*.log' );
 		foreach ( $files as $file ) {
 			@unlink( $file );
 		}
-
-		parent::tearDown();
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileControllerTest.php
@@ -66,7 +66,7 @@ class FileControllerTest extends WC_Unit_Test_Case {
 	private static function delete_all_log_files(): void {
 		$files = glob( trailingslashit( realpath( Constants::get_constant( 'WC_LOG_DIR' ) ) ) . '*.log' );
 		foreach ( $files as $file ) {
-			@unlink( $file );
+			unlink( $file );
 		}
 	}
 
@@ -76,6 +76,7 @@ class FileControllerTest extends WC_Unit_Test_Case {
 	public function test_get_files_with_files(): void {
 		$this->handler->handle( time(), 'debug', '1', array() ); // No source defaults to "log" as source.
 		$this->handler->handle( time(), 'debug', '2', array( 'source' => 'unit-testing' ) );
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_wp_debug_backtrace_summary -- Unit test.
 		$this->handler->handle( time(), 'debug', wp_debug_backtrace_summary(), array( 'source' => 'unit-testing' ) ); // Increase file size.
 
 		$files = $this->sut->get_files();
@@ -86,13 +87,23 @@ class FileControllerTest extends WC_Unit_Test_Case {
 		$second_file = array_shift( $files );
 		$this->assertInstanceOf( 'Automattic\\WooCommerce\\Internal\\Admin\\Logging\\FileV2\\File', $second_file );
 
-		$files = $this->sut->get_files( array( 'orderby' => 'source', 'order' => 'asc' ) );
+		$files      = $this->sut->get_files(
+			array(
+				'orderby' => 'source',
+				'order'   => 'asc',
+			)
+		);
 		$first_file = array_shift( $files );
 		$this->assertEquals( 'log', $first_file->get_source() );
 		$second_file = array_shift( $files );
 		$this->assertEquals( 'unit-testing', $second_file->get_source() );
 
-		$files = $this->sut->get_files( array( 'orderby' => 'size', 'order' => 'desc' ) );
+		$files      = $this->sut->get_files(
+			array(
+				'orderby' => 'size',
+				'order'   => 'desc',
+			)
+		);
 		$first_file = array_shift( $files );
 		$this->assertEquals( 'unit-testing', $first_file->get_source() );
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileControllerTest.php
@@ -1,0 +1,127 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Admin\Logging\FileV2;
+
+use Automattic\Jetpack\Constants;
+use Automattic\WooCommerce\Internal\Admin\Logging\FileV2\FileController;
+use WC_Log_Handler_File;
+use WC_Unit_Test_Case;
+
+/**
+ * FileControllerTest class.
+ */
+class FileControllerTest extends WC_Unit_Test_Case {
+	/**
+	 * Instance of the logging class.
+	 *
+	 * @var WC_Log_Handler_File|null
+	 */
+	private $handler;
+
+
+	private $sut;
+
+	/**
+	 * Set up before each test.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->handler = new WC_Log_Handler_File();
+		$this->sut     = new FileController();
+	}
+
+	/**
+	 * Tear down after each test.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		// Delete all created log files.
+		$files = glob( trailingslashit( realpath( Constants::get_constant( 'WC_LOG_DIR' ) ) ) . '*.log' );
+		foreach ( $files as $file ) {
+			@unlink( $file );
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox The get_files method should retrieve log files as File instances, in a specified order.
+	 */
+	public function test_get_files_with_files(): void {
+		$this->handler->handle( time(), 'debug', '1', array() ); // No source defaults to "log" as source.
+		$this->handler->handle( time(), 'debug', '2', array( 'source' => 'unit-testing' ) );
+		$this->handler->handle( time(), 'debug', wp_debug_backtrace_summary(), array( 'source' => 'unit-testing' ) ); // Increase file size.
+
+		$files = $this->sut->get_files();
+		$this->assertCount( 2, $files );
+
+		$first_file = array_shift( $files );
+		$this->assertInstanceOf( 'Automattic\\WooCommerce\\Internal\\Admin\\Logging\\FileV2\\File', $first_file );
+		$second_file = array_shift( $files );
+		$this->assertInstanceOf( 'Automattic\\WooCommerce\\Internal\\Admin\\Logging\\FileV2\\File', $second_file );
+
+		$files = $this->sut->get_files( array( 'orderby' => 'source', 'order' => 'asc' ) );
+		$first_file = array_shift( $files );
+		$this->assertEquals( 'log', $first_file->get_source() );
+		$second_file = array_shift( $files );
+		$this->assertEquals( 'unit-testing', $second_file->get_source() );
+
+		$files = $this->sut->get_files( array( 'orderby' => 'size', 'order' => 'desc' ) );
+		$first_file = array_shift( $files );
+		$this->assertEquals( 'unit-testing', $first_file->get_source() );
+	}
+
+	/**
+	 * @testdox The get_files method should return a count of files that meet the filtering criteria.
+	 */
+	public function test_get_files_count_only(): void {
+		$this->handler->handle( time(), 'debug', '1', array() ); // No source defaults to "log" as source.
+		$this->handler->handle( time(), 'debug', '2', array( 'source' => 'unit-testing' ) );
+
+		$count = $this->sut->get_files( array( 'source' => 'unit-testing' ), true );
+		$this->assertEquals( 1, $count );
+	}
+
+	/**
+	 * @testdox The get_file_sources method should return a unique array of sources.
+	 */
+	public function test_get_file_sources(): void {
+		$this->handler->handle( time(), 'debug', '1', array() ); // No source defaults to "log" as source.
+		$this->handler->handle( time(), 'debug', '2', array( 'source' => 'unit-testing' ) );
+		$this->handler->handle( time(), 'debug', '3', array( 'source' => 'unit-testing' ) );
+
+		$sources = $this->sut->get_file_sources();
+		$this->assertCount( 2, $sources );
+		$this->assertContains( 'log', $sources );
+		$this->assertContains( 'unit-testing', $sources );
+	}
+
+	/**
+	 * @testdox The delete_files method should delete files from the filesystem and return the number of deleted files.
+	 */
+	public function test_delete_files(): void {
+		$this->handler->handle( time(), 'debug', '1', array() ); // No source defaults to "log" as source.
+		$this->handler->handle( time(), 'debug', '2', array( 'source' => 'unit-testing' ) );
+		$this->handler->handle( time(), 'debug', '3', array( 'source' => 'raspberry' ) );
+
+		$this->assertEquals( 3, $this->sut->get_files( array(), true ) );
+
+		$files    = $this->sut->get_files( array( 'source' => 'log' ) );
+		$filename = $files[0]->get_basename();
+		$deleted  = $this->sut->delete_files( array( $filename ) );
+		$this->assertEquals( 1, $deleted );
+		$this->assertEquals( 2, $this->sut->get_files( array(), true ) );
+		$this->assertEquals( 0, $this->sut->get_files( array( 'source' => 'log' ), true ) );
+
+		$files     = $this->sut->get_files();
+		$filenames = array_map( fn( $file ) => $file->get_basename(), $files );
+		$deleted   = $this->sut->delete_files( $filenames );
+		$this->assertEquals( 2, $deleted );
+		$this->assertEquals( 0, $this->sut->get_files( array(), true ) );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileTest.php
@@ -7,6 +7,8 @@ use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Internal\Admin\Logging\FileV2\File;
 use WC_Unit_Test_Case;
 
+// phpcs:disable WordPress.WP.AlternativeFunctions.file_system_read_fopen, WordPress.WP.AlternativeFunctions.file_system_read_fclose
+
 /**
  * FileTest class.
  */
@@ -20,7 +22,7 @@ class FileTest extends WC_Unit_Test_Case {
 		// Delete all created log files.
 		$files = glob( trailingslashit( realpath( Constants::get_constant( 'WC_LOG_DIR' ) ) ) . '*.log' );
 		foreach ( $files as $file ) {
-			@unlink( $file );
+			unlink( $file );
 		}
 
 		parent::tearDown();
@@ -108,3 +110,5 @@ class FileTest extends WC_Unit_Test_Case {
 		$this->assertCount( 0, $files );
 	}
 }
+
+// phpcs:enable WordPress.WP.AlternativeFunctions.file_system_read_fopen, WordPress.WP.AlternativeFunctions.file_system_read_fclose

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileTest.php
@@ -1,0 +1,110 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Admin\Logging\FileV2;
+
+use Automattic\Jetpack\Constants;
+use Automattic\WooCommerce\Internal\Admin\Logging\FileV2\File;
+use WC_Unit_Test_Case;
+
+/**
+ * FileTest class.
+ */
+class FileTest extends WC_Unit_Test_Case {
+	/**
+	 * Tear down after each test.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		// Delete all created log files.
+		$files = glob( trailingslashit( realpath( Constants::get_constant( 'WC_LOG_DIR' ) ) ) . '*.log' );
+		foreach ( $files as $file ) {
+			@unlink( $file );
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @testdox Check that all properties are populated correctly when a File instance receives a filename in the standard format.
+	 */
+	public function test_initialize_file_standard() {
+		$filename = Constants::get_constant( 'WC_LOG_DIR' ) . 'test-Source_1-1-2023-10-23-' . wp_hash( 'cheddar' ) . '.log';
+		$resource = fopen( $filename, 'a' ); // phpcs:ignore WordPress.PHP.NoSilencedErrors
+		fclose( $resource );
+		$file = new File( $filename );
+
+		$this->assertEquals( 'test-Source_1-1-2023-10-23-' . wp_hash( 'cheddar' ) . '.log', $file->get_basename() );
+		$this->assertEquals( 'test-Source_1-1', $file->get_source() );
+		$this->assertNull( $file->get_rotation() );
+		$this->assertEquals( strtotime( '2023-10-23' ), $file->get_created_timestamp() );
+		$this->assertEquals( wp_hash( 'cheddar' ), $file->get_hash() );
+	}
+
+	/**
+	 * @testdox Check that all properties are populated correctly when a File instance receives a rotated filename in the standard format.
+	 */
+	public function test_initialize_file_standard_rotated() {
+		$filename = Constants::get_constant( 'WC_LOG_DIR' ) . 'test-Source_1-1.3-2023-10-23-' . wp_hash( 'cheddar' ) . '.log';
+		$resource = fopen( $filename, 'a' ); // phpcs:ignore WordPress.PHP.NoSilencedErrors
+		fclose( $resource );
+		$file = new File( $filename );
+
+		$this->assertEquals( 'test-Source_1-1.3-2023-10-23-' . wp_hash( 'cheddar' ) . '.log', $file->get_basename() );
+		$this->assertEquals( 'test-Source_1-1', $file->get_source() );
+		$this->assertEquals( 3, $file->get_rotation() );
+		$this->assertEquals( strtotime( '2023-10-23' ), $file->get_created_timestamp() );
+		$this->assertEquals( wp_hash( 'cheddar' ), $file->get_hash() );
+	}
+
+	/**
+	 * @testdox Check that all properties are populated correctly when a File instance receives a filename in a non-standard format.
+	 */
+	public function test_initialize_file_non_standard() {
+		$filename = Constants::get_constant( 'WC_LOG_DIR' ) . 'test-Source_1-1-' . wp_hash( 'cheddar' ) . '.log';
+		$resource = fopen( $filename, 'a' ); // phpcs:ignore WordPress.PHP.NoSilencedErrors
+		fclose( $resource );
+		$file = new File( $filename );
+
+		$this->assertEquals( 'test-Source_1-1-' . wp_hash( 'cheddar' ) . '.log', $file->get_basename() );
+		$this->assertEquals( 'test-Source_1-1-' . wp_hash( 'cheddar' ), $file->get_source() );
+		$this->assertNull( $file->get_rotation() );
+		$this->assertEquals( filemtime( $filename ), $file->get_created_timestamp() );
+		$this->assertEquals( 'test-Source_1-1-' . wp_hash( 'cheddar' ), $file->get_hash() );
+	}
+
+	/**
+	 * @testdox Check that all properties are populated correctly when a File instance receives a rotated filename in a non-standard format.
+	 */
+	public function test_initialize_file_non_standard_rotated() {
+		$filename = Constants::get_constant( 'WC_LOG_DIR' ) . 'test-Source_1-1-' . wp_hash( 'cheddar' ) . '.5.log';
+		$resource = fopen( $filename, 'a' ); // phpcs:ignore WordPress.PHP.NoSilencedErrors
+		fclose( $resource );
+		$file = new File( $filename );
+
+		$this->assertEquals( 'test-Source_1-1-' . wp_hash( 'cheddar' ) . '.5.log', $file->get_basename() );
+		$this->assertEquals( 'test-Source_1-1-' . wp_hash( 'cheddar' ), $file->get_source() );
+		$this->assertEquals( 5, $file->get_rotation() );
+		$this->assertEquals( filemtime( $filename ), $file->get_created_timestamp() );
+		$this->assertEquals( 'test-Source_1-1-' . wp_hash( 'cheddar' ), $file->get_hash() );
+	}
+
+	/**
+	 * @testdox The delete method should delete the file from the filesystem.
+	 */
+	public function test_delete() {
+		$filename = Constants::get_constant( 'WC_LOG_DIR' ) . 'test-Source_1-1-' . wp_hash( 'cheddar' ) . '.5.log';
+		$resource = fopen( $filename, 'a' ); // phpcs:ignore WordPress.PHP.NoSilencedErrors
+		fclose( $resource );
+		$file = new File( $filename );
+
+		$files = glob( trailingslashit( realpath( Constants::get_constant( 'WC_LOG_DIR' ) ) ) . '*.log' );
+		$this->assertCount( 1, $files );
+
+		$file->delete();
+
+		$files = glob( trailingslashit( realpath( Constants::get_constant( 'WC_LOG_DIR' ) ) ) . '*.log' );
+		$this->assertCount( 0, $files );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds a new file browsing view for Logs and sets the stage for other UI improvements described in #40644. In this view, the list of log files can be sorted by several different parameters and also filtered by the log's "source" (which is essentially the prefix on the log's filename). It has the standard list table feature of being able to select multiple rows at once and perform a bulk action. In this case, the only bulk action is currently to delete files. Clicking on one of the files brings you to the single file view, which at this point is just the old log file view.

Fixes #40915

### Screen shot

![Screen Shot 2023-10-25 at 11 50 06](https://github.com/woocommerce/woocommerce/assets/916023/73ef0b61-b42d-47e3-b6c1-82403bda1719)

### How to test the changes in this Pull Request:

#### Setup

1. After checking this branch out, you'll need to run `composer dump-autoload` since there are new classes that need to be added to the autoloader.
2. In your test site's **wp-config.php** file, add this line: `define( 'WC_LOG_HANDLER', 'Automattic\\WooCommerce\\Internal\\Admin\\Logging\\LogHandlerFileV2' );`. This is what allows you to see the new view.
3. Install [this plugin](https://gist.github.com/coreymckrill/2968911c8b63c556e7787f2cdc65f966) on your test site for generating test log files. Probably easiest to copy the file into the mu-plugins directory.
4. Open two browser tabs: the Logs screen (WP Admin > WooCommerce > Status > Logs) and the WooCommerce Tools screen (WP Admin > WooCommerce > Status > Tools). On the Tools screen you should see the **Debug Log Generator** tool at the top of the list.

#### Tests

1. On the Logs screen, you should see a list table, which may already have some log files listed in it. Even if there are some, go ahead and generate some additional logs on the Tools screen so that we have enough different log files and sources.
2. Try clicking on the column headers to sort the log files by different parameters.
3. Choose a source from the "All Sources" dropdown and click Filter. The list table should now only display log files from that source. Sorting the files via the column headers again should maintain the filter, while still sorting accurately.
4. After using the Debug Log Generator tool, you should have at least three different log files. Click the Screen Options tab at the top of the Logs screen and change the "Number of items per page" field to a small number, such as `2`, so you can test pagination. After applying this change, try navigating between pages in the list table. Filters and sorting should be maintained when you do this.
5. Also on the Screen Options tab, you can try toggling various columns on/off.
6. View the contents of a log file by clicking on its link in the "Source" column. This should take you to a view of that log file, which is also the current production UI for logs when using the file handler (as opposed to the database handler). Improvements to this view will be made in a separate PR, so the important thing for now is just that you can reach this view and see the contents of the file.
7. Back on the list table view, try deleting multiple log files. Check the boxes next to a couple of them and then choose "Delete permanently" from the "Bulk actions" dropdown, and click "Apply".
8. The current handler that generates log files has a mechanism for "rotating" log files, so that any one log file doesn't get too big. It does this by renaming a file that has reached the threshold with a suffix like`.0` at the end of the source segment of the filename. To see how this is represented in the list table, try generating two or three batches of test logs at once. You should then see that at least one of the logs, probably `debug-log-generator`, has more than one entry in the list table. The one with the most recently modified date should just have the source name, but any others should be followed by an N dash and then a number (`- 6`). There's something buggy going on with the way log rotation works, so the rotation suffix may not be in numerical order (i.e. you may have a `6` but not any of the other numbers preceding that). I haven't dug into that bug yet, but it's not related to this PR as far as I can tell, so we'll figure it out later.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Add a view to the Logs screen for browsing log files.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
