### PR TITLE
Mark Set up WooPayments task completed only after onboarding is complete

### DIFF
--- a/plugins/woocommerce/changelog/fix-wcpay-7119-payments-task-completed-after-onboarding
+++ b/plugins/woocommerce/changelog/fix-wcpay-7119-payments-task-completed-after-onboarding
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Mark Set up WooPayments task completed only after onboarding is complete

--- a/plugins/woocommerce/src/Admin/API/Plugins.php
+++ b/plugins/woocommerce/src/Admin/API/Plugins.php
@@ -603,8 +603,8 @@ class Plugins extends \WC_REST_Data_Controller {
 
 		$args = WooCommercePayments::is_account_partially_onboarded() ? [
 			'wcpay-login' => '1',
-			'_wpnonce'      => wp_create_nonce( 'wcpay-login' ),
-		]: [
+			'_wpnonce'    => wp_create_nonce( 'wcpay-login' ),
+		] : [
 			'wcpay-connect' => 'WCADMIN_PAYMENT_TASK',
 			'_wpnonce'      => wp_create_nonce( 'wcpay-connect' ),
 		];

--- a/plugins/woocommerce/src/Admin/API/Plugins.php
+++ b/plugins/woocommerce/src/Admin/API/Plugins.php
@@ -8,6 +8,7 @@
 namespace Automattic\WooCommerce\Admin\API;
 
 use Automattic\WooCommerce\Internal\Admin\Onboarding\OnboardingProfile;
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\WooCommercePayments;
 use Automattic\WooCommerce\Admin\PaymentMethodSuggestionsDataSourcePoller;
 use Automattic\WooCommerce\Admin\PluginsHelper;
 use Automattic\WooCommerce\Internal\Admin\Notes\InstallJPAndWCSPlugins;
@@ -600,16 +601,16 @@ class Plugins extends \WC_REST_Data_Controller {
 			return new \WP_Error( 'woocommerce_rest_helper_connect', __( 'There was an error communicating with the WooPayments plugin.', 'woocommerce' ), 500 );
 		}
 
-		$connect_url = add_query_arg(
-			array(
-				'wcpay-connect' => 'WCADMIN_PAYMENT_TASK',
-				'_wpnonce'      => wp_create_nonce( 'wcpay-connect' ),
-			),
-			admin_url()
-		);
+		$args = WooCommercePayments::is_account_partially_onboarded() ? [
+			'wcpay-login' => '1',
+			'_wpnonce'      => wp_create_nonce( 'wcpay-login' ),
+		]: [
+			'wcpay-connect' => 'WCADMIN_PAYMENT_TASK',
+			'_wpnonce'      => wp_create_nonce( 'wcpay-connect' ),
+		];
 
 		return( array(
-			'connectUrl' => $connect_url,
+			'connectUrl' => add_query_arg( $args, admin_url() ),
 		) );
 	}
 

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/WooCommercePayments.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/WooCommercePayments.php
@@ -108,7 +108,7 @@ class WooCommercePayments extends Task {
 	 */
 	public function is_complete() {
 		if ( null === $this->is_complete_result ) {
-			$this->is_complete_result = self::is_connected();
+			$this->is_complete_result = self::is_connected() && ! self::is_account_partially_onboarded();
 		}
 
 		return $this->is_complete_result;
@@ -161,6 +161,23 @@ class WooCommercePayments extends Task {
 			$wc_payments_gateway = \WC_Payments::get_gateway();
 			return method_exists( $wc_payments_gateway, 'is_connected' )
 				? $wc_payments_gateway->is_connected()
+				: false;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Check if WooCommerce Payments needs setup.
+	 * Errored data or payments not enabled.
+	 *
+	 * @return bool
+	 */
+	public static function is_account_partially_onboarded() {
+		if ( class_exists( '\WC_Payments' ) ) {
+			$wc_payments_gateway = \WC_Payments::get_gateway();
+			return method_exists( $wc_payments_gateway, 'is_account_partially_onboarded' )
+				? $wc_payments_gateway->is_account_partially_onboarded()
 				: false;
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Partially Closes https://github.com/Automattic/woocommerce-payments/issues/7119

- Update `WooCommercePayments→is_complete` to also check for the new `is_account_partially_onboarded` to ensure it's only marked as completed after a completed onboarding, rather than after account creation.
- Update `Plugins→connect_wcpay` to use the login instead of connect as `connectUrl` to ensure it allows merchants to continue with the onboarding. Otherwise, they will be redirected to the connection which is not available anymore.

### How to test the changes in this Pull Request:

>[!Note]
> Due to [the way we check for WooPayments](https://github.com/woocommerce/woocommerce/blob/abc1445de1561dbdae025fd74612f68633555e99/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/WooCommercePayments.php#L151) to be installed, you need to be sure to install it under `woocommerce` and `woocommerce-payments`. Beta testing plugins alter the folder name.

- Create a new JN site with WC from this PR, WooPayments from https://github.com/Automattic/woocommerce-payments/pull/7443, and WCPay dev tools.
- Enable `Progressive Onboarding` and dev mode from WCPay Dev.
- Set store country to a WooPayments supported one. (US)
- Go to **Payments** and complete the onboarding until you're redirected to Stripe.
- Click on `Return to WooPayments` or just go back to your site admin.
- Go to **WooCommerce → Home**
- **Set up payments** task should be still pending.
- Click on the task.
- Should successfully redirect to Stripe to finish the onboarding.
- Finish the onboarding.
- The task should be marked as completed now.
