### PR TITLE
Fix order confirmation page styles

### DIFF
--- a/plugins/woocommerce/changelog/fix-order-confirmation-page-styles
+++ b/plugins/woocommerce/changelog/fix-order-confirmation-page-styles
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fixed styling of list items on the order confirmation page when using a block theme.

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -978,20 +978,6 @@ ul.wc-tabs {
 		margin-bottom: var(--wp--style--block-gap);
 	}
 
-	// Improves the presentation of order overview (order #, date, email, etc, not the line items) on the Thank you page.
-	ul.woocommerce-order-overview {
-
-		li {
-			display: inline;
-			text-transform: uppercase;
-
-			strong {
-				text-transform: none;
-				display: block;
-			}
-		}
-	}
-
 	// Bottom section of the Thank you page---customer details: align, add border, make it look nice.
 	.woocommerce-customer-details {
 		address {

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
@@ -1015,19 +1015,6 @@ ul.wc-tabs {
 		margin-bottom: var(--wp--style--block-gap);
 	}
 
-	ul.woocommerce-order-overview {
-
-		li {
-			display: inline;
-			text-transform: uppercase;
-
-			strong {
-				text-transform: none;
-				display: block;
-			}
-		}
-	}
-
 	.woocommerce-customer-details {
 		address {
 			border: 1px solid var(--wp--preset--color--black);

--- a/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
@@ -347,7 +347,6 @@ a.added_to_cart {
 
 	ul.woocommerce-order-overview {
 		// Display order overview items next to each other.
-		list-style: none;
 		display: flex;
 		width: 100%;
 		padding-left: 0;
@@ -361,6 +360,13 @@ a.added_to_cart {
 			flex-grow: 1;
 			margin-bottom: 1rem;
 			border: none;
+			display: inline;
+			text-transform: uppercase;
+
+			strong {
+				text-transform: none;
+				display: block;
+			}
 		}
 	}
 

--- a/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss
@@ -347,6 +347,7 @@ a.added_to_cart {
 
 	ul.woocommerce-order-overview {
 		// Display order overview items next to each other.
+		list-style: none;
 		display: flex;
 		width: 100%;
 		padding-left: 0;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

While testing the order confirmation page against WordPress 6.4 and the Twenty Twenty-Four theme, @alexflorisca noticed that the list items of the order data are prefixed with bullet points. For the Twenty Twenty-Two and the Twenty Twenty-Three themes, we've introduced the following CSS code in the past:

https://github.com/woocommerce/woocommerce/blob/914a1dfd09307ab40e6c90fc9a0c82ba7f07705b/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss#L1018-L1029

https://github.com/woocommerce/woocommerce/blob/914a1dfd09307ab40e6c90fc9a0c82ba7f07705b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss#L982-L993

I've merged the mentioned code into [woocommerce-blocktheme.scss](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss) instead of creating a new twenty-twenty-four.scss. This removed redundancy from [twenty-twenty-two.scss](https://github.com/woocommerce/woocommerce/blob/914a1dfd09307ab40e6c90fc9a0c82ba7f07705b/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss) and [twenty-twenty-three.scss](https://github.com/woocommerce/woocommerce/blob/914a1dfd09307ab40e6c90fc9a0c82ba7f07705b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss), and ensures future block themes inherit the classic order confirmation styles, if the classic order confirmation page hasn't been deprecated by then.

Closes #40663.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install [WordPress 6.4 Beta 1](https://wordpress.org/news/2023/09/wordpress-6-4-beta-1/).
2. Ensure that the Twenty Twenty-Four theme is active.
3. Go to `WP Admin » Appearance » Editor » Templates » Order Confirmation`.
4. Verify that the list items with the order data do not show bullet points.
5. Repeat the last step with the Twenty Twenty-Three and the Twenty Twenty-Two themes, to verify that this PR did not introduce a regression.

### Screenshots

<table>
<tr>
<td>Before:
<br><br>
<img width="1238" alt="Screenshot 2023-10-10 at 15 56 51" src="https://github.com/woocommerce/woocommerce/assets/3323310/2c71fd95-2e22-45ec-b068-10163ed75bf5">
</td>
<td>After:
<br><br>
<img width="1192" alt="Screenshot 2023-10-10 at 15 55 44" src="https://github.com/woocommerce/woocommerce/assets/3323310/31f129a2-09b9-4cab-8600-0739422f479b">
</td>
</tr>
</table>

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Fixed styling of list items on the order confirmation page when using a block theme.

</details>
