### PR TITLE
E2E action scheduler runner

### DIFF
--- a/plugins/woocommerce/.wp-env.json
+++ b/plugins/woocommerce/.wp-env.json
@@ -10,6 +10,7 @@
 	"mappings": {
 		"wp-cli.yml": "./tests/wp-cli.yml",
 		"wp-content/plugins/filter-setter.php": "./tests/e2e-pw/bin/filter-setter.php",
+		"wp-content/plugins/process-waiting-actions.php": "./tests/e2e-pw/bin/process-waiting-actions.php",
 		"wp-content/plugins/test-helper-apis.php": "./tests/e2e-pw/bin/test-helper-apis.php"
 	},
 	"lifecycleScripts": {

--- a/plugins/woocommerce/changelog/add-e2e-action-scheduler-runner
+++ b/plugins/woocommerce/changelog/add-e2e-action-scheduler-runner
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: No changelog needed, this is to support E2E work in another PR.
+
+

--- a/plugins/woocommerce/tests/e2e-pw/bin/process-waiting-actions.php
+++ b/plugins/woocommerce/tests/e2e-pw/bin/process-waiting-actions.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Plugin name: Process Waiting Actions
+ * Description: Utility intended to be used during E2E testing, to make it easy to process any pending scheduled actions.
+ *
+ * Intended to function as a (mu-)plugin while tests are running.
+ *
+ * @package Automattic\WooCommerce\E2EPlaywright
+ */
+
+add_action(
+	'init',
+	function () {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ! isset( $_GET['process-waiting-actions'] ) ) {
+			return;
+		}
+
+		if ( ! class_exists( ActionScheduler_QueueRunner::class ) ) {
+			return;
+		}
+
+		exit( ActionScheduler_QueueRunner::instance()->run( 'E2E Tests' ) ? 1 : 0 );
+	}
+);

--- a/plugins/woocommerce/tests/e2e-pw/bin/process-waiting-actions.php
+++ b/plugins/woocommerce/tests/e2e-pw/bin/process-waiting-actions.php
@@ -3,7 +3,9 @@
  * Plugin name: Process Waiting Actions
  * Description: Utility intended to be used during E2E testing, to make it easy to process any pending scheduled actions.
  *
- * Intended to function as a (mu-)plugin while tests are running.
+ * Intended to function as a (mu-)plugin while tests are running. It listens for requests made with the
+ * 'process-waiting-actions' query parameter and then starts an Action Scheduler queue runner. It exits immediately
+ * after this, to avoid overhead of building up a full response.
  *
  * @package Automattic\WooCommerce\E2EPlaywright
  */

--- a/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
+++ b/plugins/woocommerce/tests/e2e-pw/bin/test-env-setup.sh
@@ -12,6 +12,9 @@ wp-env run tests-cli wp rewrite structure '/%postname%/' --hard
 echo -e 'Activate Filter Setter utility plugin \n'
 wp-env run tests-cli wp plugin activate filter-setter
 
+echo -e 'Activate Process Waiting Actions utility plugin \n'
+wp-env run tests-cli wp plugin activate process-waiting-actions
+
 echo -e 'Activate Test Helper APIs utility plugin \n'
 wp-env run tests-cli wp plugin activate test-helper-apis
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/admin-analytics/analytics-data.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/admin-analytics/analytics-data.spec.js
@@ -141,19 +141,7 @@ test.describe.serial( 'Analytics-related tests', () => {
 	test.beforeEach( async( { page } ) => {
 		// need to make sure the scheduled actions are run for analytics to display
 		// this really slows down the test, but analytics doesn't display properly without
-		await page.goto( '/wp-admin/admin.php?page=wc-status&tab=action-scheduler&status=pending' );
-
-		// click all of the 'run' links
-		const links = await page.locator( '[title="Process the action now as if it were run as part of a queue"]' );
-		const schedTasks = await page.locator( '.hook' );
-		let count = await schedTasks.count();
-		// there is always one scheduled task pending, but once we get down to one, we can move on
-		while ( count > 1 ) {
-			await page.locator( '.hook' ).first().hover();
-			await links.nth(0).click();
-			await page.waitForLoadState( 'networkidle' );
-			count = await schedTasks.count();
-		}
+		await page.goto( '?process-waiting-actions' );
 	} );
 
 	test.afterAll( async( { baseURL } ) => {

--- a/plugins/woocommerce/tests/e2e/docker/initialize.sh
+++ b/plugins/woocommerce/tests/e2e/docker/initialize.sh
@@ -24,8 +24,9 @@ wp plugin install https://github.com/woocommerce/woocommerce-reset/zipball/trunk
 # install the WP Mail Logging plugin to test emails
 wp plugin install wp-mail-logging --activate
 
-# Activate our Filter Setter utility.
+# Activate our E2E helper plugins to facilitate server-side interaction.
 wp plugin activate filter-setter
+wp plugin activate process-waiting-actions
 
 # initialize pretty permalinks
 wp rewrite structure /%postname%/


### PR DESCRIPTION
- Adds a mu-plugin that can be used to create a new Action Scheduler queue runner.
- See https://github.com/woocommerce/woocommerce/pull/40504/ for context.
- This is only for use in the context of E2E tests.

### Notes

- Because tests are currently failing in the parent PR, the CI checks for this PR aren't super helpful.
- If you run locally, though, and if in particular you run `pnpm test:e2e-pw ./tests/e2e-pw/tests/admin-analytics/analytics-data.spec.js` then, logging in to the wp-env site, you should be able to see:
    - "Process Waiting Actions" plugin, activated, in the plugin admin screen.
    - After running the above test if you navigate to **Tools ▸ Scheduled Actions** you should see that various scheduled actions have successfully run (look for the E2E context, which tells you they were invoked via our new utility):

<div align="center"><img width="725" alt="Screenshot 2023-10-10 at 15 50 48" src="https://github.com/woocommerce/woocommerce/assets/3594411/e5838343-1b5c-471b-9d6b-7733feba0e23"></div>
