### PR TITLE
Remove retry button when offline in CYS

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/intro/intro-banners.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/intro/intro-banners.tsx
@@ -23,9 +23,9 @@ export const BaseIntroBanner = ( {
 	bannerTitle: string;
 	bannerText: string;
 	bannerClass: string;
-	buttonIsLink: boolean;
-	bannerButtonOnClick: () => void;
-	bannerButtonText: string;
+	buttonIsLink?: boolean;
+	bannerButtonOnClick?: () => void;
+	bannerButtonText?: string;
 	children?: React.ReactNode;
 } ) => {
 	return (
@@ -38,12 +38,16 @@ export const BaseIntroBanner = ( {
 			<div className={ `woocommerce-customize-store-banner-content` }>
 				<h1>{ bannerTitle }</h1>
 				<p>{ bannerText }</p>
-				<Button
-					onClick={ () => bannerButtonOnClick() }
-					variant={ buttonIsLink ? 'link' : 'primary' }
-				>
-					{ bannerButtonText }
-				</Button>
+				{ bannerButtonText ? (
+					<Button
+						onClick={ () =>
+							bannerButtonOnClick && bannerButtonOnClick()
+						}
+						variant={ buttonIsLink ? 'link' : 'primary' }
+					>
+						{ bannerButtonText }
+					</Button>
+				) : null }
 				{ children }
 			</div>
 		</div>
@@ -58,13 +62,11 @@ export const NetworkOfflineBanner = () => {
 				'woocommerce'
 			) }
 			bannerText={ __(
-				"Unfortunately, the [AI Store designer] isn't available right now as we can't detect your network. Please check your internet connection and try again.",
+				"Unfortunately, the [AI Store designer] isn't available right now as we can't detect your network. Please check your internet connection.",
 				'woocommerce'
 			) }
 			bannerClass="offline-banner"
-			buttonIsLink={ false }
 			bannerButtonOnClick={ () => {} }
-			bannerButtonText={ __( 'Retry', 'woocommerce' ) }
 		/>
 	);
 };

--- a/plugins/woocommerce-admin/client/customize-store/intro/tests/intro-banner.test.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/intro/tests/intro-banner.test.tsx
@@ -48,9 +48,7 @@ describe( 'Intro Banners', () => {
 		);
 
 		expect(
-			screen.getByText(
-				/Please check your internet connection and try again./i
-			)
+			screen.getByText( /Please check your internet connection./i )
 		).toBeInTheDocument();
 	} );
 

--- a/plugins/woocommerce/changelog/fix-cys-remove-retry-button-offline
+++ b/plugins/woocommerce/changelog/fix-cys-remove-retry-button-offline
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove retry button and update copy when CYS intro page is working offline


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Removes the retry button in CYS intro page when browser is offline
- Set button parameters to be optional in the related component

### How to test the changes in this Pull Request:

1. Use Firefox browser or any browser that has the capability to "work offline".
1. Create a new WooCommerce installation with this version.
2. Make sure to enable `customize-store` feature flag
3. Go to `WooCommerce -> Home` and click `Customize Store` task
4. Set the browser offline. In Firefox, click on "File > Work Offline"
5. Observe the retry button is not shown and the updated copy

<img width="879" alt="image" src="https://github.com/woocommerce/woocommerce/assets/3747241/7ed5b985-5857-42be-b421-1cab87eba5cc">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
