### PR TITLE
Replace font ai suggestion with pre-defined rule-based approach

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/constants.ts
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/constants.ts
@@ -1,3 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import { Look } from '~/customize-store/design-with-ai/types';
+
 export const FONT_PREVIEW_LARGE_WIDTH = 136;
 export const FONT_PREVIEW_LARGE_HEIGHT = 106;
 export const FONT_PREVIEW_WIDTH = 120;
@@ -10,7 +15,7 @@ export const FONT_PAIRINGS = [
 	{
 		title: 'Inter + Inter',
 		version: 2,
-		lookAndFeel: [ 'Contemporary', 'Bold' ],
+		lookAndFeel: [ 'Contemporary', 'Bold' ] as Look[],
 		settings: {
 			typography: {
 				fontFamilies: {
@@ -67,7 +72,7 @@ export const FONT_PAIRINGS = [
 	{
 		title: 'Bodoni Moda + Overpass',
 		version: 2,
-		lookAndFeel: [ 'Classic' ],
+		lookAndFeel: [ 'Classic' ] as Look[],
 		settings: {
 			typography: {
 				fontFamilies: {
@@ -128,7 +133,7 @@ export const FONT_PAIRINGS = [
 	{
 		title: 'Commissioner + Crimson Pro',
 		version: 2,
-		lookAndFeel: [ 'Contemporary' ],
+		lookAndFeel: [ 'Contemporary' ] as Look[],
 		settings: {
 			typography: {
 				fontFamilies: {
@@ -191,7 +196,7 @@ export const FONT_PAIRINGS = [
 	{
 		title: 'Libre Baskerville + DM Sans',
 		version: 2,
-		lookAndFeel: [ 'Classic', 'Bold' ],
+		lookAndFeel: [ 'Classic', 'Bold' ] as Look[],
 		settings: {
 			typography: {
 				fontFamilies: {
@@ -252,7 +257,7 @@ export const FONT_PAIRINGS = [
 	{
 		title: 'Libre Franklin + EB Garamond',
 		version: 2,
-		lookAndFeel: [ 'Contemporary', 'Classic', 'Bold' ],
+		lookAndFeel: [ 'Contemporary', 'Classic', 'Bold' ] as Look[],
 		settings: {
 			typography: {
 				fontFamilies: {
@@ -316,7 +321,7 @@ export const FONT_PAIRINGS = [
 	{
 		title: 'Montserrat + Arvo',
 		version: 2,
-		lookAndFeel: [ 'Contemporary', 'Bold' ],
+		lookAndFeel: [ 'Contemporary', 'Bold' ] as Look[],
 		settings: {
 			typography: {
 				fontFamilies: {
@@ -380,7 +385,7 @@ export const FONT_PAIRINGS = [
 	{
 		title: 'Playfair Display + Fira Sans',
 		version: 2,
-		lookAndFeel: [ 'Classic' ],
+		lookAndFeel: [ 'Classic' ] as Look[],
 		settings: {
 			typography: {
 				fontFamilies: {
@@ -445,7 +450,7 @@ export const FONT_PAIRINGS = [
 	{
 		title: 'Rubik + Inter',
 		version: 2,
-		lookAndFeel: [ 'Contemporary', 'Bold' ],
+		lookAndFeel: [ 'Contemporary', 'Bold' ] as Look[],
 		settings: {
 			typography: {
 				fontFamilies: {
@@ -504,7 +509,7 @@ export const FONT_PAIRINGS = [
 	{
 		title: 'Space Mono + Roboto',
 		version: 2,
-		lookAndFeel: [ 'Contemporary', 'Classic' ],
+		lookAndFeel: [ 'Contemporary', 'Classic' ] as Look[],
 		settings: {
 			typography: {
 				fontFamilies: {

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/constants.ts
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/constants.ts
@@ -10,6 +10,7 @@ export const FONT_PAIRINGS = [
 	{
 		title: 'Inter + Inter',
 		version: 2,
+		lookAndFeel: [ 'Contemporary', 'Bold' ],
 		settings: {
 			typography: {
 				fontFamilies: {
@@ -66,6 +67,7 @@ export const FONT_PAIRINGS = [
 	{
 		title: 'Bodoni Moda + Overpass',
 		version: 2,
+		lookAndFeel: [ 'Classic' ],
 		settings: {
 			typography: {
 				fontFamilies: {
@@ -126,6 +128,7 @@ export const FONT_PAIRINGS = [
 	{
 		title: 'Commissioner + Crimson Pro',
 		version: 2,
+		lookAndFeel: [ 'Contemporary' ],
 		settings: {
 			typography: {
 				fontFamilies: {
@@ -188,6 +191,7 @@ export const FONT_PAIRINGS = [
 	{
 		title: 'Libre Baskerville + DM Sans',
 		version: 2,
+		lookAndFeel: [ 'Classic', 'Bold' ],
 		settings: {
 			typography: {
 				fontFamilies: {
@@ -248,6 +252,7 @@ export const FONT_PAIRINGS = [
 	{
 		title: 'Libre Franklin + EB Garamond',
 		version: 2,
+		lookAndFeel: [ 'Contemporary', 'Classic', 'Bold' ],
 		settings: {
 			typography: {
 				fontFamilies: {
@@ -311,6 +316,7 @@ export const FONT_PAIRINGS = [
 	{
 		title: 'Montserrat + Arvo',
 		version: 2,
+		lookAndFeel: [ 'Contemporary', 'Bold' ],
 		settings: {
 			typography: {
 				fontFamilies: {
@@ -374,6 +380,7 @@ export const FONT_PAIRINGS = [
 	{
 		title: 'Playfair Display + Fira Sans',
 		version: 2,
+		lookAndFeel: [ 'Classic' ],
 		settings: {
 			typography: {
 				fontFamilies: {
@@ -438,6 +445,7 @@ export const FONT_PAIRINGS = [
 	{
 		title: 'Rubik + Inter',
 		version: 2,
+		lookAndFeel: [ 'Contemporary', 'Bold' ],
 		settings: {
 			typography: {
 				fontFamilies: {
@@ -496,6 +504,7 @@ export const FONT_PAIRINGS = [
 	{
 		title: 'Space Mono + Roboto',
 		version: 2,
+		lookAndFeel: [ 'Contemporary', 'Classic' ],
 		settings: {
 			typography: {
 				fontFamilies: {

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/index.tsx
@@ -4,7 +4,10 @@
  * External dependencies
  */
 // @ts-ignore No types for this exist yet.
-import { __experimentalGrid as Grid } from '@wordpress/components';
+import { __experimentalGrid as Grid, Spinner } from '@wordpress/components';
+import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { useSelect } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -12,8 +15,40 @@ import { __experimentalGrid as Grid } from '@wordpress/components';
 import { FONT_PAIRINGS } from './constants';
 import { VariationContainer } from '../variation-container';
 import { FontPairingVariationPreview } from './preview';
+import { Look } from '~/customize-store/design-with-ai/types';
 
 export const FontPairing = () => {
+	const { aiSuggestions, isLoading } = useSelect( ( select ) => {
+		const { getOption, hasFinishedResolution } =
+			select( OPTIONS_STORE_NAME );
+		return {
+			aiSuggestions: getOption(
+				'woocommerce_customize_store_ai_suggestions'
+			) as { lookAndFeel: Look },
+			isLoading: ! hasFinishedResolution( 'getOption', [
+				'woocommerce_customize_store_ai_suggestions',
+			] ),
+		};
+	} );
+
+	const fontPairings = useMemo(
+		() =>
+			aiSuggestions?.lookAndFeel
+				? FONT_PAIRINGS.filter( ( font ) =>
+						font.lookAndFeel.includes( aiSuggestions?.lookAndFeel )
+				  )
+				: FONT_PAIRINGS,
+		[ aiSuggestions ]
+	);
+
+	if ( isLoading ) {
+		return (
+			<div className="woocommerce-customize-store_font-pairing-spinner-container">
+				<Spinner />
+			</div>
+		);
+	}
+
 	return (
 		<Grid
 			columns={ 2 }
@@ -24,7 +59,7 @@ export const FontPairing = () => {
 				animation: 'containerFadeIn 1000ms ease-in-out forwards',
 			} }
 		>
-			{ FONT_PAIRINGS.map( ( variation, index ) => (
+			{ fontPairings.map( ( variation, index ) => (
 				<VariationContainer key={ index } variation={ variation }>
 					<FontPairingVariationPreview />
 				</VariationContainer>

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
@@ -388,7 +388,8 @@
 		gap: 7px;
 	}
 
-	.woocommerce-customize-store_color-palette-spinner-container {
+	.woocommerce-customize-store_color-palette-spinner-container,
+	.woocommerce-customize-store_font-pairing-spinner-container, {
 		display: flex;
 		justify-content: center;
 		align-items: center;

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/actions.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/actions.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { assign, spawn, EventObject } from 'xstate';
+import { assign, spawn } from 'xstate';
 import {
 	getQuery,
 	updateQueryString,
@@ -18,7 +18,6 @@ import {
 	ColorPaletteResponse,
 	designWithAiStateMachineContext,
 	designWithAiStateMachineEvents,
-	FontPairing,
 	LookAndToneCompletionResponse,
 	Header,
 	Footer,
@@ -105,38 +104,25 @@ const assignFontPairing = assign<
 	designWithAiStateMachineContext,
 	designWithAiStateMachineEvents
 >( {
-	aiSuggestions: ( context, event: unknown ) => {
-		if ( ( event as EventObject ).type === 'xstate.error' ) {
-			let fontPairing = context.aiSuggestions.fontPairing;
-			const choice = context.lookAndFeel.choice;
+	aiSuggestions: ( context ) => {
+		let fontPairing = context.aiSuggestions.fontPairing;
+		const choice = context.lookAndFeel.choice;
 
-			switch ( true ) {
-				case choice === 'Contemporary':
-					fontPairing = 'Inter + Inter';
-					break;
-				case choice === 'Classic':
-					fontPairing = 'Bodoni Moda + Overpass';
-					break;
-				case choice === 'Bold':
-					fontPairing = 'Rubik + Inter';
-					break;
-			}
-
-			return {
-				...context.aiSuggestions,
-				fontPairing,
-			};
+		switch ( true ) {
+			case choice === 'Contemporary':
+				fontPairing = 'Inter + Inter';
+				break;
+			case choice === 'Classic':
+				fontPairing = 'Bodoni Moda + Overpass';
+				break;
+			case choice === 'Bold':
+				fontPairing = 'Rubik + Inter';
+				break;
 		}
 
 		return {
 			...context.aiSuggestions,
-			fontPairing: (
-				event as {
-					data: {
-						response: FontPairing;
-					};
-				}
-			 ).data.response.pair_name,
+			fontPairing,
 		};
 	},
 } );

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/services.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/services.ts
@@ -400,7 +400,10 @@ const installAndActivateTheme = async () => {
 
 const saveAiResponseToOption = ( context: designWithAiStateMachineContext ) => {
 	return dispatch( OPTIONS_STORE_NAME ).updateOptions( {
-		woocommerce_customize_store_ai_suggestions: context.aiSuggestions,
+		woocommerce_customize_store_ai_suggestions: {
+			...context.aiSuggestions,
+			lookAndFeel: context.lookAndFeel.choice,
+		},
 	} );
 };
 

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/state-machine.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/state-machine.tsx
@@ -22,7 +22,7 @@ import {
 } from './pages';
 import { actions } from './actions';
 import { services } from './services';
-import { defaultColorPalette, fontPairings } from './prompts';
+import { defaultColorPalette } from './prompts';
 
 export const hasStepInUrl = (
 	_ctx: unknown,
@@ -320,42 +320,8 @@ export const designWithAiStateMachineDefinition = createMachine(
 								},
 							},
 							chooseFontPairing: {
-								initial: 'pending',
-								states: {
-									pending: {
-										invoke: {
-											src: 'queryAiEndpoint',
-											data: ( context ) => {
-												return {
-													...fontPairings,
-													prompt: fontPairings.prompt(
-														context
-															.businessInfoDescription
-															.descriptionText,
-														context.lookAndFeel
-															.choice,
-														context.toneOfVoice
-															.choice
-													),
-												};
-											},
-											onDone: {
-												actions: [
-													'assignFontPairing',
-												],
-												target: 'success',
-											},
-											// If there's an error we don't want to block the user from proceeding.
-											onError: {
-												actions: [
-													'assignFontPairing',
-												],
-												target: 'success',
-											},
-										},
-									},
-									success: { type: 'final' },
-								},
+								entry: [ 'assignFontPairing' ],
+								type: 'final',
 							},
 							updateStorePatterns: {
 								initial: 'pending',

--- a/plugins/woocommerce/changelog/update-cys-font-paring
+++ b/plugins/woocommerce/changelog/update-cys-font-paring
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Replace font ai suggestion with pre-defined Look & Feel cluster


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Since the results of the AI ​​suggestions were not as expected, we temporarily decided to use the rules based on Look and Feel choice for fonts.

P2: pdnLyh-4mL-p2#comment-3156
Look & Feel cluster: Mrk6SERPZ4KrFHSjM0a8TK-fi-5084_80862

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

This feature is part of the larger customize your store development and behind a feature flag, hence QA review can be deferred until the call for testing before release.


1. Create a new WooCommerce installation with this version.
2. Make sure to enable `customize-store` feature flag
3. Install and activate [WooCommerce Blocks nightly build](https://github.com/woocommerce/woocommerce-blocks/releases/tag/nightly) 
4. Go to `WooCommerce -> Home` and click `Customize Store` task
5. Click `Design with AI` button
6. Continue to Look and Feel step
7. Choose`Contemporary`
8. Follow through the flow all the way till the assembler hub shows up
9. Click on `Change fonts`
10. Observe that `Inter + Inter` is default font.
11. Observe that the following fonts are shown

```
Contemporary:

Inter, Inter (default)
Commissioner, Crimson Pro
Libre Franklin, EB Garamond
Montserrat, Arvo
Rubik, Inter
Space Mono, Roboto
```

12. Repeat steps 6-11 with different look and feel choice

```
Classic:

Bodoni Moda, Overpass (default)
Libre Baskerville, DM Sans
Libre Franklin, EB Garamond
Playfair Display, Fira Sans
Space Mono, Roboto
```

```
Bold:

Inter, Inter
Libre Baskerville, DM Sans
Libre Franklin, EB Garamond
Montserrat, Arvo
Rubik, Inter (default)
```



<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>