### PR TITLE
[Customize Your Store]  Add look and feel tags to color choices

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/prompts/colorChoices.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/prompts/colorChoices.ts
@@ -269,7 +269,7 @@ export const defaultColorPalette = {
 
 	// make sure version is updated every time the prompt is changed
 	version: '2023-09-22',
-	prompt: ( businessDescription: string, look: string, tone: string ) => {
+	prompt: ( businessDescription: string, look: Look | '', tone: string ) => {
 		return `
             You are a WordPress theme expert designing a WooCommerce site. Analyse the following store description, merchant's chosen look and tone, and determine the most appropriate color scheme, along with 8 best alternatives.
 			Do not use any palette names that are not part of the color choices provided below.
@@ -279,7 +279,13 @@ export const defaultColorPalette = {
             Business description: ${ businessDescription }
 
             Colors schemes to choose from: 
-            ${ JSON.stringify( colorChoices ) }
+            ${ JSON.stringify(
+				look
+					? colorChoices.filter( ( color ) =>
+							color.lookAndFeel.includes( look )
+					  )
+					: colorChoices
+			) }
         `;
 	},
 	responseValidation: colorPaletteResponseValidator.parse,

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/prompts/colorChoices.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/prompts/colorChoices.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 /**
  * Internal dependencies
  */
-import { ColorPalette } from '../types';
+import { ColorPalette, Look } from '../types';
 
 const colorChoices: ColorPalette[] = [
 	{
@@ -14,6 +14,7 @@ const colorChoices: ColorPalette[] = [
 		secondary: '#8C8369',
 		foreground: '#11163d',
 		background: '#ffffff',
+		lookAndFeel: [ 'Contemporary', 'Classic' ] as Look[],
 	},
 	{
 		name: 'Crimson Tide',
@@ -21,6 +22,7 @@ const colorChoices: ColorPalette[] = [
 		secondary: '#234B57',
 		foreground: '#871C37',
 		background: '#ffffff',
+		lookAndFeel: [ 'Bold' ] as Look[],
 	},
 	{
 		name: 'Purple Twilight',
@@ -28,6 +30,7 @@ const colorChoices: ColorPalette[] = [
 		secondary: '#6a5eb7',
 		foreground: '#090909',
 		background: '#fefbff',
+		lookAndFeel: [ 'Bold' ] as Look[],
 	},
 	{
 		name: 'Midnight Citrus',
@@ -35,6 +38,7 @@ const colorChoices: ColorPalette[] = [
 		secondary: '#7E76A3',
 		foreground: '#1B1736',
 		background: '#ffffff',
+		lookAndFeel: [ 'Bold' ] as Look[],
 	},
 	{
 		name: 'Lemon Myrtle',
@@ -42,6 +46,7 @@ const colorChoices: ColorPalette[] = [
 		secondary: '#FC9B00',
 		foreground: '#325C5D',
 		background: '#ffffff',
+		lookAndFeel: [ 'Contemporary' ] as Look[],
 	},
 	{
 		name: 'Green Thumb',
@@ -49,6 +54,7 @@ const colorChoices: ColorPalette[] = [
 		secondary: '#4B7B4D',
 		foreground: '#164A41',
 		background: '#ffffff',
+		lookAndFeel: [ 'Contemporary' ] as Look[],
 	},
 	{
 		name: 'Golden Haze',
@@ -56,6 +62,7 @@ const colorChoices: ColorPalette[] = [
 		secondary: '#EBB54F',
 		foreground: '#515151',
 		background: '#ffffff',
+		lookAndFeel: [ 'Contemporary', 'Bold' ] as Look[],
 	},
 	{
 		name: 'Golden Indigo',
@@ -63,6 +70,7 @@ const colorChoices: ColorPalette[] = [
 		secondary: '#C09F50',
 		foreground: '#405AA7',
 		background: '#ffffff',
+		lookAndFeel: [ 'Contemporary', 'Classic' ] as Look[],
 	},
 	{
 		name: 'Arctic Dawn',
@@ -70,6 +78,7 @@ const colorChoices: ColorPalette[] = [
 		secondary: '#DE5853',
 		foreground: '#243156',
 		background: '#ffffff',
+		lookAndFeel: [ 'Contemporary' ] as Look[],
 	},
 	{
 		name: 'Jungle Sunrise',
@@ -77,6 +86,7 @@ const colorChoices: ColorPalette[] = [
 		secondary: '#ed774e',
 		foreground: '#0a271d',
 		background: '#fefbec',
+		lookAndFeel: [ 'Classic' ] as Look[],
 	},
 	{
 		name: 'Berry Grove',
@@ -84,6 +94,7 @@ const colorChoices: ColorPalette[] = [
 		secondary: '#DE76DE',
 		foreground: '#1f351a',
 		background: '#fdfaf1',
+		lookAndFeel: [ 'Classic' ] as Look[],
 	},
 	{
 		name: 'Fuchsia',
@@ -91,6 +102,7 @@ const colorChoices: ColorPalette[] = [
 		secondary: '#18020C',
 		foreground: '#b7127f',
 		background: '#f7edf6',
+		lookAndFeel: [ 'Bold' ] as Look[],
 	},
 	{
 		name: 'Raspberry Chocolate',
@@ -98,6 +110,7 @@ const colorChoices: ColorPalette[] = [
 		secondary: '#d64d68',
 		foreground: '#241d1a',
 		background: '#eeeae6',
+		lookAndFeel: [ 'Contemporary', 'Classic' ] as Look[],
 	},
 	{
 		name: 'Canary',
@@ -105,6 +118,7 @@ const colorChoices: ColorPalette[] = [
 		secondary: '#353535',
 		foreground: '#0F0F05',
 		background: '#FCFF9B',
+		lookAndFeel: [ 'Bold' ] as Look[],
 	},
 	{
 		name: 'Gumtree Sunset',
@@ -112,6 +126,7 @@ const colorChoices: ColorPalette[] = [
 		secondary: '#EFB071',
 		foreground: '#476C77',
 		background: '#edf4f4',
+		lookAndFeel: [ 'Contemporary' ] as Look[],
 	},
 	{
 		name: 'Ice',
@@ -119,6 +134,7 @@ const colorChoices: ColorPalette[] = [
 		secondary: '#3473FE',
 		foreground: '#12123F',
 		background: '#F1F4FA',
+		lookAndFeel: [ 'Contemporary' ] as Look[],
 	},
 	{
 		name: 'Cinder',
@@ -126,6 +142,7 @@ const colorChoices: ColorPalette[] = [
 		secondary: '#2F2D2D',
 		foreground: '#863119',
 		background: '#f1f2f2',
+		lookAndFeel: [ 'Contemporary', 'Classic' ] as Look[],
 	},
 	{
 		name: 'Blue Lagoon',
@@ -133,6 +150,7 @@ const colorChoices: ColorPalette[] = [
 		secondary: '#0496FF',
 		foreground: '#0036A3',
 		background: '#FEFDF8',
+		lookAndFeel: [ 'Bold', 'Contemporary' ] as Look[],
 	},
 	{
 		name: 'Sandalwood Oasis',
@@ -140,6 +158,7 @@ const colorChoices: ColorPalette[] = [
 		secondary: '#DF9785',
 		foreground: '#ffffff',
 		background: '#2a2a16',
+		lookAndFeel: [ 'Contemporary', 'Classic' ] as Look[],
 	},
 	{
 		name: 'Rustic Rosewood',
@@ -147,6 +166,7 @@ const colorChoices: ColorPalette[] = [
 		secondary: '#EE797C',
 		foreground: '#ffffff',
 		background: '#1A1A1A',
+		lookAndFeel: [ 'Contemporary', 'Classic' ] as Look[],
 	},
 	{
 		name: 'Cinnamon Latte',
@@ -154,6 +174,7 @@ const colorChoices: ColorPalette[] = [
 		secondary: '#BC8034',
 		foreground: '#FFFFFF',
 		background: '#3C3F4D',
+		lookAndFeel: [ 'Contemporary', 'Classic' ] as Look[],
 	},
 	{
 		name: 'Lilac Nightshade',
@@ -161,6 +182,7 @@ const colorChoices: ColorPalette[] = [
 		secondary: '#C48DDA',
 		foreground: '#ffffff',
 		background: '#000000',
+		lookAndFeel: [ 'Contemporary', 'Classic' ] as Look[],
 	},
 	{
 		name: 'Lightning',
@@ -168,6 +190,7 @@ const colorChoices: ColorPalette[] = [
 		secondary: '#fefefe',
 		foreground: '#ebffd2',
 		background: '#0e1fb5',
+		lookAndFeel: [ 'Bold' ] as Look[],
 	},
 	{
 		name: 'Aquamarine Night',
@@ -175,6 +198,7 @@ const colorChoices: ColorPalette[] = [
 		secondary: '#56fbb9',
 		foreground: '#ffffff',
 		background: '#091C48',
+		lookAndFeel: [ 'Bold' ] as Look[],
 	},
 	{
 		name: 'Charcoal',
@@ -182,6 +206,7 @@ const colorChoices: ColorPalette[] = [
 		secondary: '#efefef',
 		foreground: '#dbdbdb',
 		background: '#1e1e1e',
+		lookAndFeel: [ 'Contemporary', 'Classic' ] as Look[],
 	},
 	{
 		name: 'Evergreen Twilight',
@@ -189,6 +214,7 @@ const colorChoices: ColorPalette[] = [
 		secondary: '#8EE978',
 		foreground: '#ffffff',
 		background: '#181818',
+		lookAndFeel: [ 'Contemporary', 'Classic' ] as Look[],
 	},
 	{
 		name: 'Slate',
@@ -196,6 +222,7 @@ const colorChoices: ColorPalette[] = [
 		secondary: '#FFDF6D',
 		foreground: '#EFF2F9',
 		background: '#13161E',
+		lookAndFeel: [ 'Contemporary', 'Classic' ] as Look[],
 	},
 ];
 const allowedNames: string[] = colorChoices.map( ( palette ) => palette.name );
@@ -220,6 +247,7 @@ export const colorPaletteValidator = z.object( {
 	background: z
 		.string()
 		.regex( hexColorRegex, { message: 'Invalid background color' } ),
+	lookAndFeel: z.array( z.enum( [ 'Contemporary', 'Classic', 'Bold' ] ) ),
 } );
 
 export const colorPaletteResponseValidator = z

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/prompts/test/colorChoices.test.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/prompts/test/colorChoices.test.ts
@@ -11,6 +11,7 @@ describe( 'colorPaletteValidator', () => {
 			secondary: '#8C8369',
 			foreground: '#11163d',
 			background: '#ffffff',
+			lookAndFeel: [ 'Contemporary', 'Classic' ],
 		};
 
 		const parsedResult = colorPaletteValidator.parse( validPalette );
@@ -24,6 +25,7 @@ describe( 'colorPaletteValidator', () => {
 			secondary: '#8C8369',
 			foreground: '#11163d',
 			background: '#ffffff',
+			lookAndFeel: [ 'Contemporary', 'Classic' ],
 		};
 		expect( () => colorPaletteValidator.parse( invalidPalette ) )
 			.toThrowErrorMatchingInlineSnapshot( `
@@ -46,6 +48,7 @@ describe( 'colorPaletteValidator', () => {
 			secondary: '#8C8369',
 			foreground: '#11163d',
 			background: '#ffffff',
+			lookAndFeel: [ 'Contemporary', 'Classic' ],
 		};
 		expect( () => colorPaletteValidator.parse( invalidPalette ) )
 			.toThrowErrorMatchingInlineSnapshot( `
@@ -69,6 +72,7 @@ describe( 'colorPaletteValidator', () => {
 			secondary: 'invalidColor',
 			foreground: '#11163d',
 			background: '#ffffff',
+			lookAndFeel: [ 'Contemporary', 'Classic' ],
 		};
 		expect( () => colorPaletteValidator.parse( invalidPalette ) )
 			.toThrowErrorMatchingInlineSnapshot( `
@@ -92,6 +96,7 @@ describe( 'colorPaletteValidator', () => {
 			secondary: '11163d',
 			foreground: '#invalid_color',
 			background: '#ffffff',
+			lookAndFeel: [ 'Contemporary', 'Classic' ],
 		};
 		expect( () => colorPaletteValidator.parse( invalidPalette ) )
 			.toThrowErrorMatchingInlineSnapshot( `
@@ -123,6 +128,7 @@ describe( 'colorPaletteValidator', () => {
 			secondary: '#11163d',
 			foreground: '#11163d',
 			background: '#fffff',
+			lookAndFeel: [ 'Contemporary', 'Classic' ],
 		};
 		expect( () => colorPaletteValidator.parse( invalidPalette ) )
 			.toThrowErrorMatchingInlineSnapshot( `
@@ -134,6 +140,36 @@ describe( 'colorPaletteValidator', () => {
 		    \\"path\\": [
 		      \\"background\\"
 		    ]
+		  }
+		]"
+	` );
+	} );
+
+	it( 'should fail for an invalid Look and Feel', () => {
+		const invalidPalette = {
+			name: 'Ancient Bronze',
+			primary: '#11163d',
+			secondary: '#11163d',
+			foreground: '#11163d',
+			background: '#ffffff',
+			lookAndFeel: [ 'Contemporary', 'Classic', 'Invalid Look' ],
+		};
+		expect( () => colorPaletteValidator.parse( invalidPalette ) )
+			.toThrowErrorMatchingInlineSnapshot( `
+		"[
+		  {
+		    \\"received\\": \\"Invalid Look\\",
+		    \\"code\\": \\"invalid_enum_value\\",
+		    \\"options\\": [
+		      \\"Contemporary\\",
+		      \\"Classic\\",
+		      \\"Bold\\"
+		    ],
+		    \\"path\\": [
+		      \\"lookAndFeel\\",
+		      2
+		    ],
+		    \\"message\\": \\"Invalid enum value. Expected 'Contemporary' | 'Classic' | 'Bold', received 'Invalid Look'\\"
 		  }
 		]"
 	` );

--- a/plugins/woocommerce/changelog/update-cys-color-ai
+++ b/plugins/woocommerce/changelog/update-cys-color-ai
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add look and feel tags to color choices


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


Mrk6SERPZ4KrFHSjM0a8TK-fi-5044_192704

This PR adds `lookAndFeel` tag to color choices to improve AI suggestion results.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

This feature is part of the larger customize your store development and behind a feature flag, hence QA review can be deferred until the call for testing before release.

Review the changes and make sure the tags added are the same as the Figma.

1. Create a new WooCommerce installation with this version.
2. Make sure to enable `customize-store` feature flag
3. Install and activate [WooCommerce Blocks nightly build](https://github.com/woocommerce/woocommerce-blocks/releases/tag/nightly) 
4. Go to `WooCommerce -> Home` and click `Customize Store` task
5. Click `Design with AI` button
6. Continue to Look and Feel step
7. Choose`Contemporary`
8. Follow through the flow all the way till the assembler hub shows up
9. Click on `Change the color palette`
10. Make sure that the color displayed roughly matches the contemporary colors

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>