### PR TITLE
Improve CYS font/color performance

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/font-pairing-variations/index.tsx
@@ -21,7 +21,7 @@ export const FontPairing = () => {
 			className="woocommerce-customize-store_font-pairing-container"
 			style={ {
 				opacity: 0,
-				animation: 'containerFadeIn 1000ms ease-in-out forwards',
+				animation: 'containerFadeIn 300ms ease-in-out forwards',
 			} }
 		>
 			{ FONT_PAIRINGS.map( ( variation, index ) => (

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/global-styles-variation-iframe/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/global-styles-variation-iframe/index.tsx
@@ -5,7 +5,6 @@
  * External dependencies
  */
 import {
-	__unstableIframe as Iframe,
 	__unstableEditorStyles as EditorStyles,
 	privateApis as blockEditorPrivateApis,
 	// @ts-ignore no types exist yet.
@@ -19,6 +18,7 @@ import { unlock } from '@wordpress/edit-site/build-module/lock-unlock';
  * Internal dependencies
  */
 import './style.scss';
+import Iframe from '../iframe';
 
 const { useGlobalStylesOutput } = unlock( blockEditorPrivateApis );
 

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/iframe.jsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/iframe.jsx
@@ -1,0 +1,149 @@
+// Reference: https://github.com/WordPress/gutenberg/blob/f91b4fb4a12e41dd39c9594f24ea1a1a4e23dade/packages/block-editor/src/components/iframe/index.js#L1
+// We fork the code from the above link to reduce the unnecessary network requests and improve the performance.
+
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import {
+	useState,
+	createPortal,
+	forwardRef,
+	useMemo,
+	useEffect,
+} from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import {
+	useResizeObserver,
+	useMergeRefs,
+	useRefEffect,
+	useDisabled,
+} from '@wordpress/compose';
+import { __experimentalStyleProvider as StyleProvider } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+
+import { store as blockEditorStore } from '@wordpress/block-editor';
+
+function Iframe( {
+	contentRef,
+	children,
+	tabIndex = 0,
+	scale = 1,
+	frameSize = 0,
+	expand = false,
+	readonly,
+	forwardedRef: ref,
+	...props
+} ) {
+	const [ iframeDocument, setIframeDocument ] = useState();
+
+	const [ contentResizeListener, { height: contentHeight } ] =
+		useResizeObserver();
+	const setRef = useRefEffect( ( node ) => {
+		node._load = () => {
+			setIframeDocument( node.contentDocument );
+		};
+	}, [] );
+
+	const disabledRef = useDisabled( { isDisabled: ! readonly } );
+	const bodyRef = useMergeRefs( [ contentRef, disabledRef ] );
+
+	// Correct doctype is required to enable rendering in standards
+	// mode. Also preload the styles to avoid a flash of unstyled
+	// content.
+	const html = `<!doctype html>
+<html>
+	<head>
+		<script>window.frameElement._load()</script>
+		<style>html{height:auto!important;min-height:100%;}body{margin:0}</style>
+
+	</head>
+	<body>
+		<script>document.currentScript.parentElement.remove()</script>
+	</body>
+</html>`;
+
+	const [ src, cleanup ] = useMemo( () => {
+		const _src = URL.createObjectURL(
+			new window.Blob( [ html ], { type: 'text/html' } )
+		);
+		return [ _src, () => URL.revokeObjectURL( _src ) ];
+	}, [ html ] );
+
+	useEffect( () => cleanup, [ cleanup ] );
+
+	// We need to counter the margin created by scaling the iframe. If the scale
+	// is e.g. 0.45, then the top + bottom margin is 0.55 (1 - scale). Just the
+	// top or bottom margin is 0.55 / 2 ((1 - scale) / 2).
+	const marginFromScaling = ( contentHeight * ( 1 - scale ) ) / 2;
+
+	return (
+		<>
+			<iframe
+				{ ...props }
+				style={ {
+					...props.style,
+					height: expand ? contentHeight : props.style?.height,
+					marginTop:
+						scale !== 1
+							? -marginFromScaling + frameSize
+							: props.style?.marginTop,
+					marginBottom:
+						scale !== 1
+							? -marginFromScaling + frameSize
+							: props.style?.marginBottom,
+					transform:
+						scale !== 1
+							? `scale( ${ scale } )`
+							: props.style?.transform,
+					transition: 'all .3s',
+				} }
+				ref={ useMergeRefs( [ ref, setRef ] ) }
+				tabIndex={ tabIndex }
+				// Correct doctype is required to enable rendering in standards
+				// mode. Also preload the styles to avoid a flash of unstyled
+				// content.
+				src={ src }
+				title={ __( 'Editor canvas', 'woocommerce' ) }
+			>
+				{ iframeDocument &&
+					createPortal(
+						<body
+							ref={ bodyRef }
+							className={ classnames(
+								'block-editor-iframe__body',
+								'editor-styles-wrapper'
+							) }
+						>
+							{ contentResizeListener }
+							<StyleProvider document={ iframeDocument }>
+								{ children }
+							</StyleProvider>
+						</body>,
+						iframeDocument.documentElement
+					) }
+			</iframe>
+		</>
+	);
+}
+
+function IframeIfReady( props, ref ) {
+	const isInitialised = useSelect(
+		( select ) =>
+			select( blockEditorStore ).getSettings().__internalIsInitialized,
+		[]
+	);
+
+	// We shouldn't render the iframe until the editor settings are initialised.
+	// The initial settings are needed to get the styles for the srcDoc, which
+	// cannot be changed after the iframe is mounted. srcDoc is used to to set
+	// the initial iframe HTML, which is required to avoid a flash of unstyled
+	// content.
+	if ( ! isInitialised ) {
+		return null;
+	}
+
+	return <Iframe { ...props } forwardedRef={ ref } />;
+}
+
+export default forwardRef( IframeIfReady );

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/variation-container.jsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/variation-container.jsx
@@ -6,10 +6,13 @@ import classnames from 'classnames';
 import { useMemo, useContext } from '@wordpress/element';
 import { ENTER } from '@wordpress/keycodes';
 import { __, sprintf } from '@wordpress/i18n';
-import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+import {
+	privateApis as blockEditorPrivateApis,
+	BlockEditorProvider,
+} from '@wordpress/block-editor';
 import { mergeBaseAndUserConfigs } from '@wordpress/edit-site/build-module/components/global-styles/global-styles-provider';
 import { unlock } from '@wordpress/edit-site/build-module/lock-unlock';
-import { isEqual } from 'lodash';
+import { isEqual, noop } from 'lodash';
 
 const { GlobalStylesContext } = unlock( blockEditorPrivateApis );
 
@@ -89,25 +92,32 @@ export const VariationContainer = ( { variation, children } ) => {
 	}
 
 	return (
-		<GlobalStylesContext.Provider value={ context }>
-			<div
-				className={ classnames(
-					'woocommerce-customize-store_global-styles-variations_item',
-					{
-						'is-active': isActive,
-					}
-				) }
-				role="button"
-				onClick={ selectVariation }
-				onKeyDown={ selectOnEnter }
-				tabIndex="0"
-				aria-label={ label }
-				aria-current={ isActive }
-			>
-				<div className="woocommerce-customize-store_global-styles-variations_item-preview">
-					{ children }
+		<BlockEditorProvider
+			onChange={ noop }
+			onInput={ noop }
+			settings={ {} }
+			useSubRegistry={ true }
+		>
+			<GlobalStylesContext.Provider value={ context }>
+				<div
+					className={ classnames(
+						'woocommerce-customize-store_global-styles-variations_item',
+						{
+							'is-active': isActive,
+						}
+					) }
+					role="button"
+					onClick={ selectVariation }
+					onKeyDown={ selectOnEnter }
+					tabIndex="0"
+					aria-label={ label }
+					aria-current={ isActive }
+				>
+					<div className="woocommerce-customize-store_global-styles-variations_item-preview">
+						{ children }
+					</div>
 				</div>
-			</div>
-		</GlobalStylesContext.Provider>
+			</GlobalStylesContext.Provider>
+		</BlockEditorProvider>
 	);
 };

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-color-palette.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-color-palette.tsx
@@ -6,14 +6,6 @@
 import { __ } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
 import { Link } from '@woocommerce/components';
-import { useSelect } from '@wordpress/data';
-// @ts-ignore no types exist yet.
-import { BlockEditorProvider } from '@wordpress/block-editor';
-import { noop } from 'lodash';
-// @ts-ignore No types for this exist yet.
-import { unlock } from '@wordpress/edit-site/build-module/lock-unlock';
-// @ts-ignore No types for this exist yet.
-import { store as editSiteStore } from '@wordpress/edit-site/build-module/store';
 import { PanelBody } from '@wordpress/components';
 import { recordEvent } from '@woocommerce/tracks';
 
@@ -25,14 +17,6 @@ import { ADMIN_URL } from '~/utils/admin-settings';
 import { ColorPalette, ColorPanel } from './global-styles';
 
 const SidebarNavigationScreenColorPaletteContent = () => {
-	const { storedSettings } = useSelect( ( select ) => {
-		const { getSettings } = unlock( select( editSiteStore ) );
-
-		return {
-			storedSettings: getSettings( false ),
-		};
-	}, [] );
-
 	// Wrap in a BlockEditorProvider to ensure that the Iframe's dependencies are
 	// loaded. This is necessary because the Iframe component waits until
 	// the block editor store's `__internalIsInitialized` is true before
@@ -43,24 +27,17 @@ const SidebarNavigationScreenColorPaletteContent = () => {
 			className="woocommerce-customize-store_sidebar-color-content"
 			style={ {
 				opacity: 0,
-				animation: 'containerFadeIn 1000ms ease-in-out forwards',
+				animation: 'containerFadeIn 300ms ease-in-out forwards',
 			} }
 		>
-			<BlockEditorProvider
-				settings={ storedSettings }
-				onChange={ noop }
-				onInput={ noop }
+			<ColorPalette />
+			<PanelBody
+				className="woocommerce-customize-store__color-panel-container"
+				title={ __( 'or create your own', 'woocommerce' ) }
+				initialOpen={ false }
 			>
-				<ColorPalette />
-
-				<PanelBody
-					className="woocommerce-customize-store__color-panel-container"
-					title={ __( 'or create your own', 'woocommerce' ) }
-					initialOpen={ false }
-				>
-					<ColorPanel />
-				</PanelBody>
-			</BlockEditorProvider>
+				<ColorPanel />
+			</PanelBody>
 		</div>
 	);
 };

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-typography.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-typography.tsx
@@ -6,14 +6,6 @@
 import { __ } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
 import { Link } from '@woocommerce/components';
-import { useSelect } from '@wordpress/data';
-// @ts-ignore no types exist yet.
-import { BlockEditorProvider } from '@wordpress/block-editor';
-import { noop } from 'lodash';
-// @ts-ignore No types for this exist yet.
-import { store as editSiteStore } from '@wordpress/edit-site/build-module/store';
-// @ts-ignore No types for this exist yet.
-import { unlock } from '@wordpress/edit-site/build-module/lock-unlock';
 import { recordEvent } from '@woocommerce/tracks';
 
 /**
@@ -24,14 +16,6 @@ import { ADMIN_URL } from '~/utils/admin-settings';
 import { FontPairing } from './global-styles';
 
 export const SidebarNavigationScreenTypography = () => {
-	const { storedSettings } = useSelect( ( select ) => {
-		const { getSettings } = unlock( select( editSiteStore ) );
-
-		return {
-			storedSettings: getSettings( false ),
-		};
-	}, [] );
-
 	return (
 		<SidebarNavigationScreen
 			title={ __( 'Change your font', 'woocommerce' ) }
@@ -81,13 +65,7 @@ export const SidebarNavigationScreenTypography = () => {
 			) }
 			content={
 				<div className="woocommerce-customize-store_sidebar-typography-content">
-					<BlockEditorProvider
-						settings={ storedSettings }
-						onChange={ noop }
-						onInput={ noop }
-					>
-						<FontPairing />
-					</BlockEditorProvider>
+					<FontPairing />
 				</div>
 			}
 		/>

--- a/plugins/woocommerce/changelog/update-improve-font-color-performance
+++ b/plugins/woocommerce/changelog/update-improve-font-color-performance
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Improve CYS font/color performance


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

GB's Iframe component loads many styles/scripts, causing performance problems. Since we don't need those assets to display fonts and colors, this PR uses an iframe component to reduce the number of requests (from thousands to less than 50 requests) and some unnecessary functions.

In addition, this PR removes the unnecessary `getSettings()` calls and decreases the animation time.

Since the Header, Home page, and Footer require some assets, we can not simply use the same way to solve the performance issue. However, we could continue investigating how to reduce unnecessary requests as a follow up.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new WooCommerce installation with this version.
2. Make sure to enable `customize-store` feature flag
3. Go to /wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store%2Fassembler-hub
4. Open dev tool > network tab
5. Click on `Change the color palette`
6. Observe that there are only about a few dozen network requests sent
7. Go back
8. Click on `Change fonts`
9. Observe that there are about ~35 network requests sent

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
