### PR TITLE
Add `store_id` to WC_Tracker and Tracks

### DIFF
--- a/plugins/woocommerce/changelog/40705-add-store-id-to-wc-tracker-and-tracks
+++ b/plugins/woocommerce/changelog/40705-add-store-id-to-wc-tracker-and-tracks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a `store_id` to WC Tracker snapshots and Tracks events.

--- a/plugins/woocommerce/changelog/add-store-id-to-wc-tracker-and-tracks
+++ b/plugins/woocommerce/changelog/add-store-id-to-wc-tracker-and-tracks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a `store_id` to WC Tracker snapshots and Tracks events.

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -621,7 +621,7 @@ class WC_Install {
 	/**
 	 * Set the Store ID if not already present.
 	 *
-	 * @since 8.2.0
+	 * @since 8.4.0
 	 */
 	public static function maybe_set_store_id() {
 		if ( ! get_option( self::STORE_ID_OPTION, false ) ) {

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -1239,11 +1239,10 @@ class WC_Install {
 		$product_attributes_lookup_table_creation_sql = wc_get_container()->get( DataRegenerator::class )->get_table_creation_sql();
 
 		$feature_controller = wc_get_container()->get( FeaturesController::class );
-		$hpos_enabled =
+		$hpos_enabled       =
 			$feature_controller->feature_is_enabled( DataSynchronizer::ORDERS_DATA_SYNC_ENABLED_OPTION ) || $feature_controller->feature_is_enabled( CustomOrdersTableController::CUSTOM_ORDERS_TABLE_USAGE_ENABLED_OPTION ) ||
-			self::should_enable_hpos_for_new_shop()
-		;
-		$hpos_table_schema = $hpos_enabled ? wc_get_container()->get( OrdersTableDataStore::class )->get_database_schema() : '';
+			self::should_enable_hpos_for_new_shop();
+		$hpos_table_schema  = $hpos_enabled ? wc_get_container()->get( OrdersTableDataStore::class )->get_database_schema() : '';
 
 		$tables = "
 CREATE TABLE {$wpdb->prefix}woocommerce_sessions (

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -625,7 +625,7 @@ class WC_Install {
 	 */
 	public static function maybe_set_store_id() {
 		if ( ! get_option( self::STORE_ID_OPTION, false ) ) {
-			add_option( self::STORE_ID_OPTION, wp_generate_uuid4());
+			add_option( self::STORE_ID_OPTION, wp_generate_uuid4() );
 		}
 	}
 

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -624,12 +624,9 @@ class WC_Install {
 	 * @since 8.2.0
 	 */
 	public static function maybe_set_store_id() {
-		$store_id = get_option( self::STORE_ID_OPTION, false );
-		if ( ! $store_id ) {
-			$store_id = wp_generate_uuid4();
-			add_option( self::STORE_ID_OPTION, $store_id );
+		if ( ! get_option( self::STORE_ID_OPTION, false ) ) {
+			add_option( self::STORE_ID_OPTION, wp_generate_uuid4());
 		}
-		return $store_id;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-install.php
+++ b/plugins/woocommerce/includes/class-wc-install.php
@@ -250,6 +250,13 @@ class WC_Install {
 	const NEWLY_INSTALLED_OPTION = 'woocommerce_newly_installed';
 
 	/**
+	 * Option name used to uniquely identify installations of WooCommerce.
+	 *
+	 * @var string
+	 */
+	const STORE_ID_OPTION = 'woocommerce_store_id';
+
+	/**
 	 * Hook in tabs.
 	 */
 	public static function init() {
@@ -438,6 +445,7 @@ class WC_Install {
 		self::set_paypal_standard_load_eligibility();
 		self::update_wc_version();
 		self::maybe_update_db_version();
+		self::maybe_set_store_id();
 
 		delete_transient( 'wc_installing' );
 
@@ -608,6 +616,20 @@ class WC_Install {
 		} else {
 			self::update_db_version();
 		}
+	}
+
+	/**
+	 * Set the Store ID if not already present.
+	 *
+	 * @since 8.2.0
+	 */
+	public static function maybe_set_store_id() {
+		$store_id = get_option( self::STORE_ID_OPTION, false );
+		if ( ! $store_id ) {
+			$store_id = wp_generate_uuid4();
+			add_option( self::STORE_ID_OPTION, $store_id );
+		}
+		return $store_id;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -134,8 +134,8 @@ class WC_Tracker {
 
 		// General site info.
 		$data['url'] = home_url();
-		$data['store_id'] = self::get_store_id();
-		$data['blog_id'] = self::get_blog_id();
+		$data['store_id'] = get_option( 'woocommerce_store_id', null);
+		$data['blog_id'] = self::get_jetpack_blog_id();
 
 		/**
 		 * Filter the admin email that's sent with data.
@@ -213,24 +213,6 @@ class WC_Tracker {
 		 * @since 2.3.0
 		 */
 		return apply_filters( 'woocommerce_tracker_data', $data );
-	}
-
-	/**
-	 * Get the store ID which is set on install/update.
-	 *
-	 * @return string
-	 */
-	public static function get_store_id() {
-		return get_option( 'woocommerce_store_id', null);
-	}
-
-	/**
-	 * Get the blog ID for Jetpack sites.
-	 *
-	 * @return string
-	 */
-	public static function get_blog_id() {
-		return class_exists( 'Jetpack_Options' ) ? Jetpack_Options::get_option( 'id' ) : null;
 	}
 
 	/**
@@ -320,6 +302,19 @@ class WC_Tracker {
 		$server_data['php_curl']             = function_exists( 'curl_init' ) ? 'Yes' : 'No';
 
 		return $server_data;
+	}
+
+	/**
+	 * Get Jetpack blog_id ensuring null is returned when id is not present.
+	 *
+	 * @return string
+	 */
+	private static function get_jetpack_blog_id() {
+		if (class_exists( 'Jetpack_Options' ) ) {
+			$blog_id = Jetpack_Options::get_option( 'id' );
+			return $blog_id ? $blog_id : null;
+		}
+		return null;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -135,7 +135,7 @@ class WC_Tracker {
 		// General site info.
 		$data['url'] = home_url();
 		$data['store_id'] = get_option( 'woocommerce_store_id', null);
-		$data['blog_id'] = self::get_jetpack_blog_id();
+		$data['blog_id'] = class_exists( 'Jetpack_Options' ) ? Jetpack_Options::get_option( 'id' ) : null;
 
 		/**
 		 * Filter the admin email that's sent with data.
@@ -302,19 +302,6 @@ class WC_Tracker {
 		$server_data['php_curl']             = function_exists( 'curl_init' ) ? 'Yes' : 'No';
 
 		return $server_data;
-	}
-
-	/**
-	 * Get Jetpack blog_id ensuring null is returned when id is not present.
-	 *
-	 * @return string
-	 */
-	private static function get_jetpack_blog_id() {
-		if (class_exists( 'Jetpack_Options' ) ) {
-			$blog_id = Jetpack_Options::get_option( 'id' );
-			return $blog_id ? $blog_id : null;
-		}
-		return null;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -134,7 +134,7 @@ class WC_Tracker {
 
 		// General site info.
 		$data['url']      = home_url();
-		$data['store_id'] = get_option( 'woocommerce_store_id', null );
+		$data['store_id'] = get_option( \WC_Install::STORE_ID_OPTION, null );
 		$data['blog_id']  = class_exists( 'Jetpack_Options' ) ? Jetpack_Options::get_option( 'id' ) : null;
 
 		/**

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -134,6 +134,9 @@ class WC_Tracker {
 
 		// General site info.
 		$data['url'] = home_url();
+		$data['store_id'] = self::get_store_id();
+		$data['blog_id'] = self::get_blog_id();
+
 		/**
 		 * Filter the admin email that's sent with data.
 		 *
@@ -210,6 +213,24 @@ class WC_Tracker {
 		 * @since 2.3.0
 		 */
 		return apply_filters( 'woocommerce_tracker_data', $data );
+	}
+
+	/**
+	 * Get the store ID which is set on install/update.
+	 *
+	 * @return string
+	 */
+	public static function get_store_id() {
+		return get_option( 'woocommerce_store_id', null);
+	}
+
+	/**
+	 * Get the blog ID for Jetpack sites.
+	 *
+	 * @return string
+	 */
+	public static function get_blog_id() {
+		return class_exists( 'Jetpack_Options' ) ? Jetpack_Options::get_option( 'id' ) : null;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-tracker.php
+++ b/plugins/woocommerce/includes/class-wc-tracker.php
@@ -133,9 +133,9 @@ class WC_Tracker {
 		$data = array();
 
 		// General site info.
-		$data['url'] = home_url();
-		$data['store_id'] = get_option( 'woocommerce_store_id', null);
-		$data['blog_id'] = class_exists( 'Jetpack_Options' ) ? Jetpack_Options::get_option( 'id' ) : null;
+		$data['url']      = home_url();
+		$data['store_id'] = get_option( 'woocommerce_store_id', null );
+		$data['blog_id']  = class_exists( 'Jetpack_Options' ) ? Jetpack_Options::get_option( 'id' ) : null;
 
 		/**
 		 * Filter the admin email that's sent with data.

--- a/plugins/woocommerce/includes/tracks/class-wc-tracks.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-tracks.php
@@ -37,7 +37,7 @@ class WC_Tracks {
 			$blog_details = array(
 				'url'            => home_url(),
 				'blog_lang'      => get_user_locale( $user_id ),
-				'blog_id'        => self::get_jetpack_blog_id(),
+				'blog_id'        => class_exists( 'Jetpack_Options' ) ? Jetpack_Options::get_option( 'id' ) : null,
 				'store_id'		 => get_option( 'woocommerce_store_id' , null),
 				'products_count' => self::get_products_count(),
 				'wc_version'     => WC()->version,
@@ -65,19 +65,6 @@ class WC_Tracks {
 		$data['_dl'] = isset( $_SERVER['REQUEST_SCHEME'] ) ? wc_clean( wp_unslash( $_SERVER['REQUEST_SCHEME'] ) ) . '://' . $host . $uri : '';
 
 		return $data;
-	}
-
-	/**
-	 * Get Jetpack blog_id ensuring null is returned when id is not present.
-	 *
-	 * @return string
-	 */
-	private static function get_jetpack_blog_id() {
-		if ( class_exists( 'Jetpack_Options' ) ) {
-			$blog_id = Jetpack_Options::get_option( 'id' );
-			return $blog_id ? $blog_id : null;
-		}
-		return null;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/tracks/class-wc-tracks.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-tracks.php
@@ -37,7 +37,7 @@ class WC_Tracks {
 			$blog_details = array(
 				'url'            => home_url(),
 				'blog_lang'      => get_user_locale( $user_id ),
-				'blog_id'        => class_exists( 'Jetpack_Options' ) ? Jetpack_Options::get_option( 'id' ) : null,
+				'blog_id'        => self::get_jetpack_blog_id(),
 				'store_id'		 => get_option( 'woocommerce_store_id' , null),
 				'products_count' => self::get_products_count(),
 				'wc_version'     => WC()->version,
@@ -65,6 +65,19 @@ class WC_Tracks {
 		$data['_dl'] = isset( $_SERVER['REQUEST_SCHEME'] ) ? wc_clean( wp_unslash( $_SERVER['REQUEST_SCHEME'] ) ) . '://' . $host . $uri : '';
 
 		return $data;
+	}
+
+	/**
+	 * Get Jetpack blog_id ensuring null is returned when id is not present.
+	 *
+	 * @return string
+	 */
+	private static function get_jetpack_blog_id() {
+		if (class_exists( 'Jetpack_Options' ) ) {
+			$blog_id = Jetpack_Options::get_option( 'id' );
+			return $blog_id ? $blog_id : null;
+		}
+		return null;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/tracks/class-wc-tracks.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-tracks.php
@@ -38,7 +38,7 @@ class WC_Tracks {
 				'url'            => home_url(),
 				'blog_lang'      => get_user_locale( $user_id ),
 				'blog_id'        => class_exists( 'Jetpack_Options' ) ? Jetpack_Options::get_option( 'id' ) : null,
-				'store_id'		 => get_option( 'woocommerce_store_id' , null),
+				'store_id'       => get_option( 'woocommerce_store_id', null ),
 				'products_count' => self::get_products_count(),
 				'wc_version'     => WC()->version,
 			);

--- a/plugins/woocommerce/includes/tracks/class-wc-tracks.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-tracks.php
@@ -73,7 +73,7 @@ class WC_Tracks {
 	 * @return string
 	 */
 	private static function get_jetpack_blog_id() {
-		if (class_exists( 'Jetpack_Options' ) ) {
+		if ( class_exists( 'Jetpack_Options' ) ) {
 			$blog_id = Jetpack_Options::get_option( 'id' );
 			return $blog_id ? $blog_id : null;
 		}

--- a/plugins/woocommerce/includes/tracks/class-wc-tracks.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-tracks.php
@@ -38,6 +38,7 @@ class WC_Tracks {
 				'url'            => home_url(),
 				'blog_lang'      => get_user_locale( $user_id ),
 				'blog_id'        => class_exists( 'Jetpack_Options' ) ? Jetpack_Options::get_option( 'id' ) : null,
+				'store_id'		 => get_option( 'woocommerce_store_id' , null),
 				'products_count' => self::get_products_count(),
 				'wc_version'     => WC()->version,
 			);

--- a/plugins/woocommerce/includes/tracks/class-wc-tracks.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-tracks.php
@@ -38,7 +38,7 @@ class WC_Tracks {
 				'url'            => home_url(),
 				'blog_lang'      => get_user_locale( $user_id ),
 				'blog_id'        => class_exists( 'Jetpack_Options' ) ? Jetpack_Options::get_option( 'id' ) : null,
-				'store_id'       => get_option( 'woocommerce_store_id', null ),
+				'store_id'       => get_option( \WC_Install::STORE_ID_OPTION, null ),
 				'products_count' => self::get_products_count(),
 				'wc_version'     => WC()->version,
 			);

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -564,15 +564,15 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 				'blockName'  => 'woocommerce/product-toggle-field',
 				'order'      => 20,
 				'attributes' => [
-					'label'    => __( 'Track stock quantity for this product', 'woocommerce' ),
-					'property' => 'manage_stock',
-					'disabled' => 'yes' !== get_option( 'woocommerce_manage_stock' ),
+					'label'        => __( 'Track stock quantity for this product', 'woocommerce' ),
+					'property'     => 'manage_stock',
+					'disabled'     => 'yes' !== get_option( 'woocommerce_manage_stock' ),
 					'disabledCopy' => sprintf(
 						/* translators: %1$s: Learn more link opening tag. %2$s: Learn more link closing tag.*/
-							__( 'Per your %1$sstore settings%2$s, inventory management is <strong>disabled</strong>.', 'woocommerce' ),
-							'<a href="' . admin_url( 'admin.php?page=wc-settings&tab=products&section=inventory' ) . '" target="_blank" rel="noreferrer">',
-							'</a>'
-						),
+						__( 'Per your %1$sstore settings%2$s, inventory management is <strong>disabled</strong>.', 'woocommerce' ),
+						'<a href="' . admin_url( 'admin.php?page=wc-settings&tab=products&section=inventory' ) . '" target="_blank" rel="noreferrer">',
+						'</a>'
+					),
 				],
 			]
 		);
@@ -782,7 +782,7 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 		if ( ! $variation_group ) {
 			return;
 		}
-		$variation_fields = $variation_group->add_block(
+		$variation_fields          = $variation_group->add_block(
 			[
 				'id'         => 'product_variation-field-group',
 				'blockName'  => 'woocommerce/product-variations-fields',

--- a/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
@@ -171,13 +171,14 @@ class WC_Install_Test extends \WC_Unit_Test_Case {
 
 		// simulate a store ID not being set.
 		delete_option( \WC_Install::STORE_ID_OPTION );
-		$store_id = \WC_Install::maybe_set_store_id();
-		$this->assertSame( $store_id, get_option( \WC_Install::STORE_ID_OPTION ) );
+		\WC_Install::maybe_set_store_id();
+		$store_id = get_option( \WC_Install::STORE_ID_OPTION );
 		// uuid4 is 36 characters long.
 		$this->assertSame( 36, strlen( $store_id ) );
 
 		// simulate a store ID already being set.
-		$existing_store_id = \WC_Install::maybe_set_store_id();
+		\WC_Install::maybe_set_store_id();
+		$existing_store_id = get_option( \WC_Install::STORE_ID_OPTION );
 		$this->assertSame( $store_id, $existing_store_id );
 		// cleanup.
 		delete_option( \WC_Install::STORE_ID_OPTION );

--- a/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
@@ -173,9 +173,13 @@ class WC_Install_Test extends \WC_Unit_Test_Case {
 		delete_option(\WC_Install::STORE_ID_OPTION);
 		$store_id = \WC_Install::maybe_set_store_id();
 		$this->assertSame( $store_id, get_option(\WC_Install::STORE_ID_OPTION) );
+		// uuid4 is 36 characters long
+		$this->assertSame(36, strlen($store_id));
 
 		// simulate a store ID already being set.
 		$existing_store_id = \WC_Install::maybe_set_store_id();
 		$this->assertSame( $store_id, $existing_store_id );
+		// cleanup
+		delete_option(\WC_Install::STORE_ID_OPTION);
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
@@ -164,4 +164,18 @@ class WC_Install_Test extends \WC_Unit_Test_Case {
 		$data_store->delete( $note_2 );
 	}
 
+	/**
+	 * Test that maybe_set_store_id only sets an ID when it isn't already present.
+	 */
+	public function test_maybe_set_store_id() {
+
+		// simulate a store ID not being set
+		delete_option(\WC_Install::STORE_ID_OPTION);
+		$store_id = \WC_Install::maybe_set_store_id();
+		$this->assertSame( $store_id, get_option(\WC_Install::STORE_ID_OPTION) );
+
+		// simulate a store ID already being set.
+		$existing_store_id = \WC_Install::maybe_set_store_id();
+		$this->assertSame( $store_id, $existing_store_id );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
@@ -169,17 +169,17 @@ class WC_Install_Test extends \WC_Unit_Test_Case {
 	 */
 	public function test_maybe_set_store_id() {
 
-		// simulate a store ID not being set
+		// simulate a store ID not being set.
 		delete_option( \WC_Install::STORE_ID_OPTION );
 		$store_id = \WC_Install::maybe_set_store_id();
 		$this->assertSame( $store_id, get_option( \WC_Install::STORE_ID_OPTION ) );
-		// uuid4 is 36 characters long
+		// uuid4 is 36 characters long.
 		$this->assertSame( 36, strlen( $store_id ) );
 
 		// simulate a store ID already being set.
 		$existing_store_id = \WC_Install::maybe_set_store_id();
 		$this->assertSame( $store_id, $existing_store_id );
-		// cleanup
+		// cleanup.
 		delete_option( \WC_Install::STORE_ID_OPTION );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-install-test.php
@@ -170,16 +170,16 @@ class WC_Install_Test extends \WC_Unit_Test_Case {
 	public function test_maybe_set_store_id() {
 
 		// simulate a store ID not being set
-		delete_option(\WC_Install::STORE_ID_OPTION);
+		delete_option( \WC_Install::STORE_ID_OPTION );
 		$store_id = \WC_Install::maybe_set_store_id();
-		$this->assertSame( $store_id, get_option(\WC_Install::STORE_ID_OPTION) );
+		$this->assertSame( $store_id, get_option( \WC_Install::STORE_ID_OPTION ) );
 		// uuid4 is 36 characters long
-		$this->assertSame(36, strlen($store_id));
+		$this->assertSame( 36, strlen( $store_id ) );
 
 		// simulate a store ID already being set.
 		$existing_store_id = \WC_Install::maybe_set_store_id();
 		$this->assertSame( $store_id, $existing_store_id );
 		// cleanup
-		delete_option(\WC_Install::STORE_ID_OPTION);
+		delete_option( \WC_Install::STORE_ID_OPTION );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
@@ -231,32 +231,4 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 		$this->assertEquals( '12345', $tracking_data['store_id'] );
 		delete_option( 'woocommerce_store_id' );
 	}
-
-	/**
-	 * @testDox Test blog_id is null in tracking data when Jetpack_Options is not present
-	 */
-	public function test_get_tracking_data_blog_id_is_null_when_jetpack_is_not_present() {
-		$tracking_data = WC_Tracker::get_tracking_data();
-		$this->assertArrayHasKey( 'blog_id', $tracking_data );
-		$this->assertNull( $tracking_data['blog_id'] );
-	}
-
-	/**
-	 * @testDox Test blog_id is included in tracking data when Jetpack_Options are present
-	 */
-	public function test_get_tracking_data_blog_id_is_included_when_jetpack_is_present() {
-		$blog_id = 12345;
-		$handler = $this
-			->getMockBuilder( Jetpack_Options::class )
-			->setMethods( array( 'get_option' ) )
-			->getMock();
-
-		$handler
-			->method( 'get_option' )
-			->willReturn( $blog_id );
-
-		$tracking_data = WC_Tracker::get_tracking_data();
-		$this->assertArrayHasKey( 'blog_id', $tracking_data );
-		$this->assertSame( $blog_id, $tracking_data['blog_id'] );
-	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
@@ -220,4 +220,24 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 
 		$this->assertIsArray( $tracking_data['enabled_features'] );
 	}
+
+	/**
+	 * @testDox Test store_id is included in tracking data.
+	 */
+	public function test_get_tracking_data_store_id() {
+		update_option( 'woocommerce_store_id', '12345' );
+		$tracking_data = WC_Tracker::get_tracking_data();
+		$this->assertArrayHasKey( 'store_id', $tracking_data );
+		$this->assertEquals( '12345', $tracking_data['store_id'] );
+		delete_option( 'woocommerce_store_id' );
+	}
+
+	/**
+	 * @testDox Test blog_id is included in tracking data.
+	 */
+	public function test_get_tracking_data_blog_id_is_null_when_jetpack_is_not_present() {
+		$tracking_data = WC_Tracker::get_tracking_data();
+		$this->assertArrayHasKey( 'blog_id', $tracking_data );
+		$this->assertNull( $tracking_data['blog_id'] );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
@@ -225,10 +225,10 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 	 * @testDox Test store_id is included in tracking data.
 	 */
 	public function test_get_tracking_data_store_id() {
-		update_option( 'woocommerce_store_id', '12345' );
+		update_option( \WC_Install::STORE_ID_OPTION, '12345' );
 		$tracking_data = WC_Tracker::get_tracking_data();
 		$this->assertArrayHasKey( 'store_id', $tracking_data );
 		$this->assertEquals( '12345', $tracking_data['store_id'] );
-		delete_option( 'woocommerce_store_id' );
+		delete_option( \WC_Install::STORE_ID_OPTION );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tracker-test.php
@@ -233,11 +233,30 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testDox Test blog_id is included in tracking data.
+	 * @testDox Test blog_id is null in tracking data when Jetpack_Options is not present
 	 */
 	public function test_get_tracking_data_blog_id_is_null_when_jetpack_is_not_present() {
 		$tracking_data = WC_Tracker::get_tracking_data();
 		$this->assertArrayHasKey( 'blog_id', $tracking_data );
 		$this->assertNull( $tracking_data['blog_id'] );
+	}
+
+	/**
+	 * @testDox Test blog_id is included in tracking data when Jetpack_Options are present
+	 */
+	public function test_get_tracking_data_blog_id_is_included_when_jetpack_is_present() {
+		$blog_id = 12345;
+		$handler = $this
+			->getMockBuilder( Jetpack_Options::class )
+			->setMethods( array( 'get_option' ) )
+			->getMock();
+
+		$handler
+			->method( 'get_option' )
+			->willReturn( $blog_id );
+
+		$tracking_data = WC_Tracker::get_tracking_data();
+		$this->assertArrayHasKey( 'blog_id', $tracking_data );
+		$this->assertSame( $blog_id, $tracking_data['blog_id'] );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-tracks-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tracks-test.php
@@ -129,4 +129,20 @@ class WC_Tracks_Test extends \WC_Unit_Test_Case {
 		$this->assertTrue( is_wp_error( $event ) );
 		$this->assertEquals( $event->get_error_code(), 'invalid_prop_name' );
 	}
+
+	/**
+	 * Test that the store_id is added to the properties.
+	 */
+	public function test_store_id_is_added_to_properties() {
+		update_option('woocommerce_store_id', '12345');
+		$properties = \WC_Tracks::get_properties(
+			'test_event',
+			array(
+				'test_property' => 5,
+			)
+		);
+		$this->assertContains( 'store_id', array_keys( $properties ) );
+		$this->assertEquals( '12345', $properties['store_id'] );
+		delete_option('woocommerce_store_id');
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-tracks-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tracks-test.php
@@ -145,4 +145,18 @@ class WC_Tracks_Test extends \WC_Unit_Test_Case {
 		$this->assertEquals( '12345', $properties['store_id'] );
 		delete_option('woocommerce_store_id');
 	}
+
+	/**
+	 * Test that the blog_id is null when not present.
+	 */
+	public function test_blog_id_is_null_when_jetpack_not_present() {
+		$properties = \WC_Tracks::get_properties(
+			'test_event',
+			array(
+				'test_property' => 5,
+			)
+		);
+		$this->assertContains( 'blog_id', array_keys( $properties ) );
+		$this->assertNull( $properties['blog_id'] );
+	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-tracks-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tracks-test.php
@@ -134,7 +134,7 @@ class WC_Tracks_Test extends \WC_Unit_Test_Case {
 	 * Test that the store_id is added to the properties.
 	 */
 	public function test_store_id_is_added_to_properties() {
-		update_option( 'woocommerce_store_id', '12345' );
+		update_option( \WC_Install::STORE_ID_OPTION, '12345' );
 		$properties = \WC_Tracks::get_properties(
 			'test_event',
 			array(
@@ -143,6 +143,6 @@ class WC_Tracks_Test extends \WC_Unit_Test_Case {
 		);
 		$this->assertContains( 'store_id', array_keys( $properties ) );
 		$this->assertEquals( '12345', $properties['store_id'] );
-		delete_option( 'woocommerce_store_id' );
+		delete_option( \WC_Install::STORE_ID_OPTION );
 	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-tracks-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tracks-test.php
@@ -145,18 +145,4 @@ class WC_Tracks_Test extends \WC_Unit_Test_Case {
 		$this->assertEquals( '12345', $properties['store_id'] );
 		delete_option( 'woocommerce_store_id' );
 	}
-
-	/**
-	 * Test that the blog_id is null when not present.
-	 */
-	public function test_blog_id_is_null_when_jetpack_not_present() {
-		$properties = \WC_Tracks::get_properties(
-			'test_event',
-			array(
-				'test_property' => 5,
-			)
-		);
-		$this->assertContains( 'blog_id', array_keys( $properties ) );
-		$this->assertNull( $properties['blog_id'] );
-	}
 }

--- a/plugins/woocommerce/tests/php/includes/class-wc-tracks-test.php
+++ b/plugins/woocommerce/tests/php/includes/class-wc-tracks-test.php
@@ -134,7 +134,7 @@ class WC_Tracks_Test extends \WC_Unit_Test_Case {
 	 * Test that the store_id is added to the properties.
 	 */
 	public function test_store_id_is_added_to_properties() {
-		update_option('woocommerce_store_id', '12345');
+		update_option( 'woocommerce_store_id', '12345' );
 		$properties = \WC_Tracks::get_properties(
 			'test_event',
 			array(
@@ -143,7 +143,7 @@ class WC_Tracks_Test extends \WC_Unit_Test_Case {
 		);
 		$this->assertContains( 'store_id', array_keys( $properties ) );
 		$this->assertEquals( '12345', $properties['store_id'] );
-		delete_option('woocommerce_store_id');
+		delete_option( 'woocommerce_store_id' );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds a unique `store_id` to WC Tracker snapshots and Tracks events. This ID is meant to aid the process of tracking merchants over time even if they change their store's URL. For now, **this change does not handle the case when an admin may copy an installations database to create a new store**.  We'll attempt to address that edge case in a future PR. 

This PR also adds the Jetpack `blog_id` to WC Tracker snapshots which is already included in Tracks events.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

There are three separate pathways for testing:

#### Testing the addition of the `store_id` to WC Tracker

1. Setup a local testing environment, for instance via `pnpm -- wp-env start`
2. Execute the `wp-cli` command `wc tracker snapshot`: `pnpm -- wp-env run cli wp wc tracker snapshot --format=json`. You should see a uuid4-formatted `store_id` in the output. You can use [`jq`](https://jqlang.github.io/jq/) to more quickly access this key: `pnpm -- wp-env run cli wp wc tracker snapshot --format=json | jq '.[0].store_id'`


#### Testing the addition of the `store_id` to Tracks

1. Start a local environment, eg: `pnpm -- wp-env start`
2. Enable WooCommerce tracking in the admin by going to `WooCommerce > Settings > Advanced > WooCommerce.com` and clicking the checkbox for `Allow usage of WooCommerce to be tracked`.
3. Open your browser's network tab and add a filter for requests that include `t.gif`.
4. Click around the WooCommerce admin (for instance by navigating to `WooCommerce > Home` and you should see some Tracks events being transmitted with the `store_id` in the payload:

<img width="512" alt="Screenshot 2023-10-11 at 3 30 46 PM" src="https://github.com/woocommerce/woocommerce/assets/1621721/cec18a93-6991-4ef3-9365-a181c87b5d45">

#### Testing the addition of the Jetpack `blog_id` to WC Tracker

1. Start an environment via Jurassic Ninja using this branch (`add/store-id-to-wc-tracker-and-tracks`) and make sure Jetpack is installed.
2. Once the environment is up, go through the store setup process ensuring that you've enabled WooCommerce tracking. Alternatively, enable WooCommerce tracking in the admin by going to `WooCommerce > Settings > Advanced > WooCommerce.com` and clicking the checkbox for `Allow usage of WooCommerce to be tracked`.
3. Connect Jetpack to your WPCom account. 
4. Use the ssh connection details in Jurassic Ninja to connect to its server and navigate to the specified `public` directory.
5. Run `wp wc tracker snapshot --format=json` and confirm that the `blog_id` is present in the output.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Add a `store_id` to WC Tracker snapshots and Tracks events.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
