### PR TITLE
Add edit button to each variation to redirect to the single variation page

### DIFF
--- a/packages/js/product-editor/changelog/add-40708
+++ b/packages/js/product-editor/changelog/add-40708
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add edit button to each variation to redirect to the single variation page

--- a/packages/js/product-editor/config/block-entry-points.js
+++ b/packages/js/product-editor/config/block-entry-points.js
@@ -64,7 +64,9 @@ const getBlockName = ( blockMetaData ) => {
  * @return {string} The entry point name.
  */
 const getEntryPointName = ( entryFilePath, blockMetaData ) => {
-	const filePathParts = entryFilePath.split( '/' );
+	const filePathParts = entryFilePath
+		.split( '/' )
+		.filter( ( dir ) => dir !== 'blocks' );
 	filePathParts[ filePathParts.length - 2 ] = getBlockName( blockMetaData );
 	return filePathParts
 		.join( '/' )

--- a/packages/js/product-editor/src/blocks/generic/tab/index.ts
+++ b/packages/js/product-editor/src/blocks/generic/tab/index.ts
@@ -19,7 +19,7 @@ export const settings = {
 };
 
 export function init() {
-	registerWooBlockType( {
+	return registerWooBlockType( {
 		name,
 		metadata: metadata as never,
 		settings: settings as never,

--- a/packages/js/product-editor/src/blocks/product-fields/catalog-visibility/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/catalog-visibility/block.json
@@ -26,6 +26,5 @@
 		"inserter": false,
 		"lock": false,
 		"__experimentalToolbar": false
-	},
-	"editorStyle": "file:./editor.css"
+	}
 }

--- a/packages/js/product-editor/src/blocks/product-fields/inventory-quantity/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/inventory-quantity/block.json
@@ -22,6 +22,5 @@
 		"lock": false,
 		"__experimentalToolbar": false
 	},
-	"editorStyle": "file:./editor.css",
 	"usesContext": [ "postType" ]
 }

--- a/packages/js/product-editor/src/blocks/product-fields/notice/index.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/notice/index.ts
@@ -16,7 +16,7 @@ export { metadata, name };
 export const settings = { example: {}, edit: Edit };
 
 export function init() {
-	registerWooBlockType( {
+	return registerWooBlockType( {
 		name,
 		metadata: metadata as never,
 		settings: settings as never,

--- a/packages/js/product-editor/src/blocks/product-fields/shipping-class/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/shipping-class/block.json
@@ -22,6 +22,5 @@
 		"lock": false,
 		"__experimentalToolbar": false
 	},
-	"editorStyle": "file:./editor.css",
 	"usesContext": [ "postType" ]
 }

--- a/packages/js/product-editor/src/components/variations-table/variations-table.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variations-table.tsx
@@ -15,6 +15,7 @@ import {
 } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { ListItem, Sortable, Tag } from '@woocommerce/components';
+import { getNewPath } from '@woocommerce/navigation';
 import {
 	useContext,
 	useState,
@@ -496,6 +497,17 @@ export const VariationsTable = forwardRef<
 									</div>
 								</Tooltip>
 							) }
+
+							<Button
+								href={ getNewPath(
+									{},
+									`/product/${ productId }/variation/${ variation.id }`,
+									{}
+								) }
+							>
+								{ __( 'Edit', 'woocommerce' ) }
+							</Button>
+
 							<VariationActionsMenu
 								selection={ variation }
 								onChange={ ( value ) =>

--- a/packages/js/product-editor/src/components/variations-table/variations-table.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variations-table.tsx
@@ -15,7 +15,7 @@ import {
 } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { ListItem, Sortable, Tag } from '@woocommerce/components';
-import { getNewPath } from '@woocommerce/navigation';
+import { getNewPath, navigateTo } from '@woocommerce/navigation';
 import {
 	useContext,
 	useState,
@@ -48,6 +48,7 @@ import { useSelection } from '../../hooks/use-selection';
 import { VariationsActionsMenu } from './variations-actions-menu';
 import HiddenIcon from '../../icons/hidden-icon';
 import { Pagination } from './pagination';
+import { MouseEvent } from 'react';
 
 const NOT_VISIBLE_TEXT = __( 'Not visible to customers', 'woocommerce' );
 
@@ -74,6 +75,14 @@ type VariationResponseProps = {
 	update?: Partial< ProductVariation >[];
 	delete?: Partial< ProductVariation >[];
 };
+
+function getEditVariationLink( variation: ProductVariation ) {
+	return getNewPath(
+		{},
+		`/product/${ variation.parent_id }/variation/${ variation.id }`,
+		{}
+	);
+}
 
 export const VariationsTable = forwardRef<
 	HTMLDivElement,
@@ -321,6 +330,18 @@ export const VariationsTable = forwardRef<
 			} );
 	}
 
+	function editVariationClickHandler( variation: ProductVariation ) {
+		const url = getEditVariationLink( variation );
+
+		return function handleEditVariationClick(
+			event: MouseEvent< HTMLAnchorElement >
+		) {
+			event.preventDefault();
+
+			navigateTo( { url } );
+		};
+	}
+
 	return (
 		<div className="woocommerce-product-variations" ref={ ref }>
 			{ ( isLoading || isGeneratingVariations ) && (
@@ -499,10 +520,9 @@ export const VariationsTable = forwardRef<
 							) }
 
 							<Button
-								href={ getNewPath(
-									{},
-									`/product/${ productId }/variation/${ variation.id }`,
-									{}
+								href={ getEditVariationLink( variation ) }
+								onClick={ editVariationClickHandler(
+									variation
 								) }
 							>
 								{ __( 'Edit', 'woocommerce' ) }

--- a/packages/js/product-editor/src/components/variations-table/variations-table.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variations-table.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { MouseEvent } from 'react';
 import { __, sprintf } from '@wordpress/i18n';
 import {
 	Button,
@@ -48,7 +49,6 @@ import { useSelection } from '../../hooks/use-selection';
 import { VariationsActionsMenu } from './variations-actions-menu';
 import HiddenIcon from '../../icons/hidden-icon';
 import { Pagination } from './pagination';
-import { MouseEvent } from 'react';
 
 const NOT_VISIBLE_TEXT = __( 'Not visible to customers', 'woocommerce' );
 

--- a/plugins/woocommerce-admin/client/header/index.js
+++ b/plugins/woocommerce-admin/client/header/index.js
@@ -50,7 +50,7 @@ export const Header = ( { sections, isEmbedded = false, query } ) => {
 				return;
 			}
 
-			wpBody.style.marginTop = `${ headerElement.current.offsetHeight }px`;
+			wpBody.style.marginTop = `${ headerElement.current.height }px`;
 		}, 200 );
 	};
 

--- a/plugins/woocommerce-admin/client/products/add-product-page.tsx
+++ b/plugins/woocommerce-admin/client/products/add-product-page.tsx
@@ -16,7 +16,6 @@ import {
 import { ProductForm } from './product-form';
 import { ProductTourContainer } from './tour';
 import './add-edit-product-page.scss';
-import './fills';
 
 const AddProductPage: React.FC = () => {
 	const { isLoading } = useSelect( ( select: WCDataSelector ) => {

--- a/plugins/woocommerce-admin/client/products/edit-product-page.tsx
+++ b/plugins/woocommerce-admin/client/products/edit-product-page.tsx
@@ -22,7 +22,6 @@ import { ProductForm } from './product-form';
 import { ProductFormLayout } from './layout/product-form-layout';
 import { ProductVariationForm } from './product-variation-form';
 import './add-edit-product-page.scss';
-import './fills';
 
 const EditProductPage: React.FC = () => {
 	const { productId, variationId } = useParams();

--- a/plugins/woocommerce-admin/client/products/index.ts
+++ b/plugins/woocommerce-admin/client/products/index.ts
@@ -1,1 +1,0 @@
-export * from './add-product-page';

--- a/plugins/woocommerce-admin/client/products/product-page.tsx
+++ b/plugins/woocommerce-admin/client/products/product-page.tsx
@@ -14,7 +14,7 @@ import {
 import { recordEvent } from '@woocommerce/tracks';
 import { Spinner } from '@wordpress/components';
 import { useEffect } from '@wordpress/element';
-import { registerPlugin } from '@wordpress/plugins';
+import { registerPlugin, unregisterPlugin } from '@wordpress/plugins';
 import { useParams } from 'react-router-dom';
 import { WooFooterItem } from '@woocommerce/admin-layout';
 
@@ -36,7 +36,26 @@ export default function ProductPage() {
 	const product = useProductEntityRecord( productId );
 
 	useEffect( () => {
-		return initBlocks();
+		registerPlugin( 'wc-admin-more-menu', {
+			// @ts-expect-error 'scope' does exist. @types/wordpress__plugins is outdated.
+			scope: 'woocommerce-product-block-editor',
+			render: () => (
+				<>
+					<WooProductMoreMenuItem>
+						{ ( { onClose }: { onClose: () => void } ) => (
+							<MoreMenuFill onClose={ onClose } />
+						) }
+					</WooProductMoreMenuItem>
+				</>
+			),
+		} );
+
+		const unregisterBlocks = initBlocks();
+
+		return () => {
+			unregisterPlugin( 'wc-admin-more-menu' );
+			unregisterBlocks();
+		};
 	}, [] );
 
 	useEffect(
@@ -77,17 +96,3 @@ export default function ProductPage() {
 		</>
 	);
 }
-
-registerPlugin( 'wc-admin-more-menu', {
-	// @ts-expect-error 'scope' does exist. @types/wordpress__plugins is outdated.
-	scope: 'woocommerce-product-block-editor',
-	render: () => (
-		<>
-			<WooProductMoreMenuItem>
-				{ ( { onClose }: { onClose: () => void } ) => (
-					<MoreMenuFill onClose={ onClose } />
-				) }
-			</WooProductMoreMenuItem>
-		</>
-	),
-} );

--- a/plugins/woocommerce-admin/client/products/product-variation-page.tsx
+++ b/plugins/woocommerce-admin/client/products/product-variation-page.tsx
@@ -15,7 +15,7 @@ import { recordEvent } from '@woocommerce/tracks';
 import { Spinner } from '@wordpress/components';
 import { useEffect } from '@wordpress/element';
 import { WooFooterItem } from '@woocommerce/admin-layout';
-import { registerPlugin } from '@wordpress/plugins';
+import { registerPlugin, unregisterPlugin } from '@wordpress/plugins';
 import { useParams } from 'react-router-dom';
 
 /**
@@ -36,7 +36,32 @@ export default function ProductPage() {
 	const variation = useProductVariationEntityRecord( variationId as string );
 
 	useEffect( () => {
-		return initBlocks();
+		registerPlugin( 'wc-admin-more-menu', {
+			// @ts-expect-error 'scope' does exist. @types/wordpress__plugins is outdated.
+			scope: 'woocommerce-product-block-editor',
+			render: () => (
+				<>
+					<WooProductMoreMenuItem>
+						{ ( { onClose }: { onClose: () => void } ) => (
+							<>
+								<DeleteVariationMenuItem onClose={ onClose } />
+								<MoreMenuFill
+									productType="product_variation"
+									onClose={ onClose }
+								/>
+							</>
+						) }
+					</WooProductMoreMenuItem>
+				</>
+			),
+		} );
+
+		const unregisterBlocks = initBlocks();
+
+		return () => {
+			unregisterPlugin( 'wc-admin-more-menu' );
+			unregisterBlocks();
+		};
 	}, [] );
 
 	useEffect(
@@ -81,23 +106,3 @@ export default function ProductPage() {
 		</>
 	);
 }
-
-registerPlugin( 'wc-admin-more-menu', {
-	// @ts-expect-error 'scope' does exist. @types/wordpress__plugins is outdated.
-	scope: 'woocommerce-product-block-editor',
-	render: () => (
-		<>
-			<WooProductMoreMenuItem>
-				{ ( { onClose }: { onClose: () => void } ) => (
-					<>
-						<DeleteVariationMenuItem onClose={ onClose } />
-						<MoreMenuFill
-							productType="product_variation"
-							onClose={ onClose }
-						/>
-					</>
-				) }
-			</WooProductMoreMenuItem>
-		</>
-	),
-} );

--- a/plugins/woocommerce/changelog/add-40708
+++ b/plugins/woocommerce/changelog/add-40708
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix block registration and variation styles conflicts


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #40708

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure feature `product-variation-management` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper` (WooCommerce Beta Tester plugin) is required
3. Go to `/wp-admin/admin.php?page=wc-admin&path=/add-product&tab=variations` and add some attributes
4. Wait until variations get generated
5. Then publish the product
6. Under the `Variations` section, in each variation row a new `Edit` button should be shown 
<img width="679" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/a20da8f4-6541-4e6e-8655-95b99853aa43">

7. If you click it, you should be redirected to a new page where you will be able to edit the selected variation

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
