### PR TITLE
Update WooCommerce Blocks to 11.3.0

### DIFF
--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-11.3.0
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-11.3.0
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update WooCommerce Blocks to 11.3.0

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -23,7 +23,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.6.3",
-		"woocommerce/woocommerce-blocks": "11.2.0"
+		"woocommerce/woocommerce-blocks": "11.3.0"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.3.0",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6dbaa76c3a13dc3d312b2ad734d0bc91",
+    "content-hash": "7a95656e668416bfc351c6b9cfe60259",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1004,16 +1004,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "11.2.0",
+            "version": "11.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "86e93ddd06606100e199fdae049baaa5754c2a17"
+                "reference": "924fcb5aaaf9a0ccf98da8ffcef110dc2dc71c80"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/86e93ddd06606100e199fdae049baaa5754c2a17",
-                "reference": "86e93ddd06606100e199fdae049baaa5754c2a17",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/924fcb5aaaf9a0ccf98da8ffcef110dc2dc71c80",
+                "reference": "924fcb5aaaf9a0ccf98da8ffcef110dc2dc71c80",
                 "shasum": ""
             },
             "require": {
@@ -1028,7 +1028,7 @@
                 "mockery/mockery": "1.6.6",
                 "nikic/php-parser": "4.16.0 as 1.0.0",
                 "phpdocumentor/reflection": "3.0.1",
-                "phpunit/php-code-coverage": "9.2.27",
+                "phpunit/php-code-coverage": "9.2.29",
                 "phpunit/phpunit": "9.6.10",
                 "woocommerce/woocommerce-sniffs": "0.1.3",
                 "wp-hooks/generator": "0.9.0",
@@ -1064,9 +1064,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v11.2.0"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v11.3.0"
             },
-            "time": "2023-09-27T17:36:02+00:00"
+            "time": "2023-10-11T14:31:45+00:00"
         }
     ],
     "packages-dev": [
@@ -3949,5 +3949,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This pull updates the WooCommerce Blocks plugin to 11.3.0. It includes changes from WooCommerce Blocks 11.3.0 and is intended to target WooCommerce 8.3 for release.

Details from all the different releases included in this pull:

## Blocks 11.3.0
* https://github.com/woocommerce/woocommerce-blocks/pull/11183
* [Testing Instructions](https://github.com/woocommerce/woocommerce-blocks/blob/release/11.3.0/docs/internal-developers/testing/releases/1130.md)
* [Release Post](https://developer.woocommerce.com/2023/10/11/woocommerce-blocks-11-3-0-release-notes/)

### Changelog entry

### The following changelog entries are only those that impact existing blocks and functionality surfaced to users:

#### Enhancements

- Introduced condensed address components on checkout for customers with an existing address. (https://github.com/woocommerce/woocommerce-blocks/pull/11167)
- Update aspect ratio, icons and default text for the Social: Follow us on social media pattern. (https://github.com/woocommerce/woocommerce-blocks/pull/11161)
- Add horizontal padding to the Featured Category Triple pattern. (https://github.com/woocommerce/woocommerce-blocks/pull/11160)
- Remove the "no results" placeholder and pagination and set aspect ratio on the Product Collection 3 Columns, Product Collection 4 Columns, Product Collection 5 Columns, and Product Gallery patterns. (https://github.com/woocommerce/woocommerce-blocks/pull/11145)
- Add group and padding to the Product Collection 3 Columns, Featured Category Triple and the Social: Follow us on social media patterns. (https://github.com/woocommerce/woocommerce-blocks/pull/11144)
- New Product Collection Patterns: add the new Product Collection 3 Columns, Product Collection 4 Columns, Product Collection 5 Columns and Product Collection: Featured Products 5 Columns patterns. (https://github.com/woocommerce/woocommerce-blocks/pull/11134)
- Add titles and padding to the Product Collection: Featured Products 5 Columns and the Product Gallery patterns. (https://github.com/woocommerce/woocommerce-blocks/pull/11131)
- Add default image and fixed height to the Just Arrived Full Hero pattern. (https://github.com/woocommerce/woocommerce-blocks/pull/11130)
- Add titles and padding to the Product Collection 4 Columns, Product Collection 5 Columns, and Testimonials 3 Columns patterns. (https://github.com/woocommerce/woocommerce-blocks/pull/11129)
- Add Add to Cart button's product price data attribute. (https://github.com/woocommerce/woocommerce-blocks/pull/11117)
- Just Arrived Full Hero pattern: wireframe the content and adjust the pattern width. (https://github.com/woocommerce/woocommerce-blocks/pull/11115)
- Remove opinionated styles from the Hero Product 3 Split pattern. (https://github.com/woocommerce/woocommerce-blocks/pull/11110)
- Add the Featured Category Cover Image pattern. (https://github.com/woocommerce/woocommerce-blocks/pull/11109)
- Add fee ID to parent cart and checkout block. (https://github.com/woocommerce/woocommerce-blocks/pull/11054)
- Update: Adjust text of incompatibility sidebar notice and show extensions, that explicitly declared incompatibility with the Cart and Checkout blocks. (https://github.com/woocommerce/woocommerce-blocks/pull/10877)

#### Bug Fixes

- Fix Store Notices block breaks page editors. (https://github.com/woocommerce/woocommerce-blocks/pull/11165)
- Ensure the Just Arrived Full Hero pattern can have an AI-selected images assigned to it and add a background dim. (https://github.com/woocommerce/woocommerce-blocks/pull/11159)
- Testimonials 3 Columns pattern > Update the width and fix the PHP warnings that could be triggered if the content saved within the wc_blocks_patterns_content option didn't match the updated patterns dictionary. (https://github.com/woocommerce/woocommerce-blocks/pull/11158)
- Pattern: Fetch product ID with JS to prevent unnecesary queries on every page load. (https://github.com/woocommerce/woocommerce-blocks/pull/11138)
- Fix checkout state/country field width in the site editor. (https://github.com/woocommerce/woocommerce-blocks/pull/11133)
- Fixed PHP notice that would appear if an API endpoint failed to load. (https://github.com/woocommerce/woocommerce-blocks/pull/11128)
- Made error icon on checkout match text color. (https://github.com/woocommerce/woocommerce-blocks/pull/11127)
- Fix a PHP error that was occurring when the WooCommerce Product Add-ons or the WooCommerce Product Bundles plugins were enabled. (https://github.com/woocommerce/woocommerce-blocks/pull/11082)
- Resolved an issue where the Single Product block did not respect the WooCommerce setting for redirecting to the cart page after successful addition. (https://github.com/woocommerce/woocommerce-blocks/pull/11151)

### Changelog entry
> Dev - Update WooCommerce Blocks version to 11.3.0