### PR TITLE
Add 'min' and 'max' attributes to number block

### DIFF
--- a/packages/js/product-editor/changelog/add-min-max-number-block
+++ b/packages/js/product-editor/changelog/add-min-max-number-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add 'min' and 'max' attributes to number block

--- a/packages/js/product-editor/src/blocks/generic/number/README.md
+++ b/packages/js/product-editor/src/blocks/generic/number/README.md
@@ -43,6 +43,20 @@ Suffix that can be used for a unit of measure, as an example.
 
 Placeholder text that appears in the field when it's empty.
 
+### min
+
+- **Type:** `Number`
+- **Required:** `No`
+
+The minimum numeric value that can be entered in the field.
+
+### max
+
+- **Type:** `Number`
+- **Required:** `No`
+
+The maximum numeric value that can be entered in the field.
+
 ## Usage
 
 Here's a snippet that adds a field similar to the previous screenshot:

--- a/packages/js/product-editor/src/blocks/generic/number/block.json
+++ b/packages/js/product-editor/src/blocks/generic/number/block.json
@@ -23,6 +23,12 @@
 		},
 		"placeholder": {
 			"type": "string"
+		},
+		"min": {
+			"type": "number"
+		},
+		"max": {
+			"type": "number"
 		}
 	},
 	"supports": {

--- a/packages/js/product-editor/src/blocks/generic/number/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/number/edit.tsx
@@ -3,7 +3,12 @@
  */
 import { createElement } from '@wordpress/element';
 import { useWooBlockProps } from '@woocommerce/block-templates';
+import { Product } from '@woocommerce/data';
+import { __, sprintf } from '@wordpress/i18n';
+import classNames from 'classnames';
+import { useInstanceId } from '@wordpress/compose';
 import {
+	BaseControl,
 	// @ts-expect-error `__experimentalInputControl` does exist.
 	__experimentalInputControl as InputControl,
 } from '@wordpress/components';
@@ -14,13 +19,14 @@ import { ProductEditorBlockEditProps } from '../../../types';
 import useProductEntityProp from '../../../hooks/use-product-entity-prop';
 import { useNumberInputProps } from '../../../hooks/use-number-input-props';
 import { NumberBlockAttributes } from './types';
+import { useValidation } from '../../../contexts/validation-context';
 
 export function Edit( {
 	attributes,
 	context: { postType },
 }: ProductEditorBlockEditProps< NumberBlockAttributes > ) {
 	const blockProps = useWooBlockProps( attributes );
-	const { label, property, suffix, placeholder, help } = attributes;
+	const { label, property, suffix, placeholder, help, min, max } = attributes;
 	const [ value, setValue ] = useProductEntityProp( property, {
 		postType,
 		fallbackValue: '',
@@ -31,16 +37,61 @@ export function Edit( {
 		onChange: setValue,
 	} );
 
+	const id = useInstanceId( BaseControl, 'low_stock_amount' ) as string;
+
+	const { error, validate } = useValidation< Product >(
+		property,
+		async function validator() {
+			if (
+				typeof min === 'number' &&
+				value &&
+				parseFloat( value ) < min
+			) {
+				return sprintf(
+					__(
+						// translators: %d is the minimum value of the number input.
+						'Value must be greater than or equal to %d',
+						'woocommerce'
+					),
+					min
+				);
+			}
+			if (
+				typeof max === 'number' &&
+				value &&
+				parseFloat( value ) > max
+			) {
+				return sprintf(
+					__(
+						// translators: %d is the maximum value of the number input.
+						'Value must be less than or equal to %d',
+						'woocommerce'
+					),
+					max
+				);
+			}
+		},
+		[ value ]
+	);
+
 	return (
 		<div { ...blockProps }>
-			<InputControl
-				{ ...inputProps }
-				__next36pxDefaultSize
+			<BaseControl
+				className={ classNames( {
+					'has-error': error,
+				} ) }
+				id={ id }
 				label={ label }
-				suffix={ suffix }
-				help={ help }
-				placeholder={ placeholder }
-			/>
+				help={ error || help }
+			>
+				<InputControl
+					{ ...inputProps }
+					id={ id }
+					suffix={ suffix }
+					placeholder={ placeholder }
+					onBlur={ validate }
+				/>
+			</BaseControl>
 		</div>
 	);
 }

--- a/packages/js/product-editor/src/blocks/generic/number/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/number/edit.tsx
@@ -37,7 +37,7 @@ export function Edit( {
 		onChange: setValue,
 	} );
 
-	const id = useInstanceId( BaseControl, 'low_stock_amount' ) as string;
+	const id = useInstanceId( BaseControl, 'product_number_field' ) as string;
 
 	const { error, validate } = useValidation< Product >(
 		property,

--- a/packages/js/product-editor/src/blocks/generic/number/types.ts
+++ b/packages/js/product-editor/src/blocks/generic/number/types.ts
@@ -9,4 +9,6 @@ export interface NumberBlockAttributes extends BlockAttributes {
 	help?: string;
 	suffix?: string;
 	placeholder?: string;
+	min?: number;
+	max?: number;
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Add 'min' and 'max' attributes to number block

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Add the following mu-plugin to your installation:
```php
<?php

function add_meta_fields( $basic_details_section )
{
	$general_group = $basic_details_section->get_parent();
	$section = $general_group->add_section(
		[
			'id'         => 'YOUR-PREFIX-section',
			'order'      => $basic_details_section->get_order() + 5,
			'attributes' => [
				'title' => __('My Meta Fields', 'woocommerce'),
				'description' => __('This is a description', 'woocommerce'),
			],
		]
	);
	$section->add_block(
		[
			'id'         => 'example-number-meta',
			'blockName'  => 'woocommerce/product-number-field',
			'order'      => 16,
			'attributes' => [
				'label' => 'Label',
				'property' => 'meta_data.number',
				'suffix' => 'suffix',
				'help' => 'Add additional information here',
				'placeholder' => 'Placeholder',
                                 'min' => 0,
                                 'max' => 5,
			]
		],
	);
}

function example_hook_meta_field()
{
	add_action(
		'woocommerce_block_template_area_product-form_after_add_block_basic-details',
		'add_meta_fields'
	);
}


add_action('init', 'example_hook_meta_field', 0);
```

2. Go to the product editor.
3. Go to the field which was added by the mu-plugin.
4. Try typing -1 (less than the minimum value required) and press Tab.
5. You should see an error message.
6. Try typing 6 (more than the maximum value required) and press Tab.
7. You should see an error message.
8. Try again both with 5 and 0.
9. The error message should clear up.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
