### PR TITLE
Use async loading strategy for woo-tracks script

### DIFF
--- a/plugins/woocommerce/changelog/patch-1
+++ b/plugins/woocommerce/changelog/patch-1
@@ -1,0 +1,4 @@
+Significance: minor
+Type: performance
+
+Use `async` loading strategy for the `woo-tracks` script.

--- a/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
+++ b/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php
@@ -51,6 +51,7 @@ class WC_Site_Tracking {
 	 */
 	public static function register_scripts() {
 		wp_register_script( 'woo-tracks', 'https://stats.wp.com/w.js', array( 'wp-hooks' ), gmdate( 'YW' ), false );
+		wp_script_add_data( 'woo-tracks', 'strategy', 'async' );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In WordPress 6.3, script loading strategies were introduced to enable scripts to safely improve performance with the `async` and `defer` attributes. See [Core Trac #12009](https://core.trac.wordpress.org/ticket/12009). See also [dev note](https://make.wordpress.org/core/2023/07/14/registering-scripts-with-async-and-defer-attributes-in-wordpress-6-3/).

Using `async` for the woo-tracks script is important because the script currently blocks rendering in the `head`. Granted, there are other blocking scripts from WooCommerce in the `head`, but this at least starts moving in the right direction.

### How to test the changes in this Pull Request:

With the changes in this PR, the `woo-tracks` script gets updated as follows when printed:

```diff
- <script src='https://stats.wp.com/w.js?ver=202341' id='woo-tracks-js'></script>
+ <script src='https://stats.wp.com/w.js?ver=202341' id='woo-tracks-js' async data-wp-strategy='async'></script>
```

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

<!--
Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1.
2.
3.
-->

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [x] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Use `async` loading strategy for the `woo-tracks` script.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
