### PR TITLE
Template API: Conditional visibility support

### DIFF
--- a/packages/js/block-templates/changelog/add-template-api-conditional-visibility
+++ b/packages/js/block-templates/changelog/add-template-api-conditional-visibility
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add conditional visibility support to registered blocks.

--- a/packages/js/block-templates/src/utils/register-woo-block-type.ts
+++ b/packages/js/block-templates/src/utils/register-woo-block-type.ts
@@ -7,7 +7,7 @@ import {
 	BlockEditProps,
 	registerBlockType,
 } from '@wordpress/blocks';
-import { useSelect } from '@wordpress/data';
+import { useSelect, select as WPSelect } from '@wordpress/data';
 import { createElement } from '@wordpress/element';
 import { evaluate } from '@woocommerce/expression-evaluation';
 import { ComponentType } from 'react';
@@ -18,14 +18,18 @@ interface BlockRepresentation< T extends Record< string, object > > {
 	settings: Partial< BlockConfiguration< T > >;
 }
 
+type UseEvaluationContext = ( context: Record< string, unknown > ) => {
+	getEvaluationContext: (
+		select: typeof WPSelect
+	) => Record< string, unknown >;
+};
+
 function getEdit<
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	T extends Record< string, object > = Record< string, object >
 >(
 	edit: ComponentType< BlockEditProps< T > >,
-	useEvaluationContext: ( context: any ) => {
-		getEvaluationContext: ( select: any ) => any;
-	}
+	useEvaluationContext: UseEvaluationContext
 ): ComponentType< BlockEditProps< T > > {
 	return ( props ) => {
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -70,9 +74,7 @@ export function registerWooBlockType<
 	T extends Record< string, any > = Record< string, any >
 >(
 	block: BlockRepresentation< T >,
-	useEvaluationContext: ( context: any ) => {
-		getEvaluationContext: ( select: any ) => any;
-	}
+	useEvaluationContext: UseEvaluationContext
 ): Block< T > | undefined {
 	if ( ! block ) {
 		return;

--- a/packages/js/block-templates/src/utils/register-woo-block-type.ts
+++ b/packages/js/block-templates/src/utils/register-woo-block-type.ts
@@ -7,10 +7,15 @@ import {
 	BlockEditProps,
 	registerBlockType,
 } from '@wordpress/blocks';
-import { useSelect, select as WPSelect } from '@wordpress/data';
 import { createElement } from '@wordpress/element';
 import { evaluate } from '@woocommerce/expression-evaluation';
 import { ComponentType } from 'react';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore No types for this exist yet, natively (not until 7.0.0).
+// Including `@types/wordpress__data` as a devDependency causes build issues,
+// so just going type-free for now.
+// eslint-disable-next-line @woocommerce/dependency-group
+import { useSelect, select as WPSelect } from '@wordpress/data';
 
 interface BlockRepresentation< T extends Record< string, object > > {
 	name?: string;
@@ -41,7 +46,7 @@ function getEdit<
 		const { getEvaluationContext } = useEvaluationContext( context );
 
 		const shouldHide = useSelect(
-			( select ) => {
+			( select: typeof WPSelect ) => {
 				if ( ! hideConditions || ! Array.isArray( hideConditions ) ) {
 					return false;
 				}

--- a/packages/js/block-templates/src/utils/register-woo-block-type.ts
+++ b/packages/js/block-templates/src/utils/register-woo-block-type.ts
@@ -29,6 +29,12 @@ type UseEvaluationContext = ( context: Record< string, unknown > ) => {
 	) => Record< string, unknown >;
 };
 
+function defaultUseEvaluationContext( context: Record< string, unknown > ) {
+	return {
+		getEvaluationContext: () => context,
+	};
+}
+
 function getEdit<
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	T extends Record< string, object > = Record< string, object >
@@ -104,7 +110,7 @@ export function registerWooBlockType<
 	T extends Record< string, any > = Record< string, any >
 >(
 	block: BlockRepresentation< T >,
-	useEvaluationContext: UseEvaluationContext
+	useEvaluationContext?: UseEvaluationContext
 ): Block< T > | undefined {
 	if ( ! block ) {
 		return;
@@ -123,6 +129,12 @@ export function registerWooBlockType<
 
 	return registerBlockType< T >(
 		{ name, ...augmentedMetadata },
-		{ ...settings, edit: getEdit< T >( edit, useEvaluationContext ) }
+		{
+			...settings,
+			edit: getEdit< T >(
+				edit,
+				useEvaluationContext ?? defaultUseEvaluationContext
+			),
+		}
 	);
 }

--- a/packages/js/block-templates/src/utils/register-woo-block-type.ts
+++ b/packages/js/block-templates/src/utils/register-woo-block-type.ts
@@ -29,31 +29,36 @@ function getEdit<
 	edit?: ComponentType< BlockEditProps< T > >
 ): ComponentType< BlockEditProps< T > > {
 	return ( props ) => {
+		// @ts-ignore context is added to the block props by the block editor.
+		const { context } = props;
+		const { productType } = context;
 		const { _templateBlockHideConditions: hideConditions } =
 			props.attributes;
 
-		const productId = useEntityId( 'postType', 'product' );
-		const shouldHide = useSelect( ( select ) => {
-			if ( ! hideConditions || ! Array.isArray( hideConditions ) ) {
-				return false;
-			}
+		const productId = useEntityId( 'postType', productType );
+		const shouldHide = useSelect(
+			( select ) => {
+				if ( ! hideConditions || ! Array.isArray( hideConditions ) ) {
+					return false;
+				}
 
-			const editedProduct = select( 'core' ).getEditedEntityRecord(
-				'postType',
-				'product',
-				productId
-			);
+				const editedProduct = select( 'core' ).getEditedEntityRecord(
+					'postType',
+					productType,
+					productId
+				);
 
-			const evaluationContext = {
-				editedProduct,
-			};
+				const evaluationContext = {
+					...context,
+					editedProduct,
+				};
 
-			console.log( '*** in useSelect ***' );
-
-			return hideConditions.some( ( condition ) =>
-				evaluate( condition.expression, evaluationContext )
-			);
-		} );
+				return hideConditions.some( ( condition ) =>
+					evaluate( condition.expression, evaluationContext )
+				);
+			},
+			[ productType, productId, context, hideConditions ]
+		);
 
 		if ( ! edit || shouldHide ) {
 			return null;

--- a/packages/js/block-templates/src/utils/register-woo-block-type.ts
+++ b/packages/js/block-templates/src/utils/register-woo-block-type.ts
@@ -63,6 +63,31 @@ function getEdit<
 	};
 }
 
+function augmentAttributes<
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	T extends Record< string, any > = Record< string, any >
+>( attributes: T ) {
+	// Note: If you modify this function, also update the server-side
+	// Automattic\WooCommerce\Admin\Features\ProductBlockEditor\BlockRegistry::augment_attributes() function.
+	return {
+		...attributes,
+		...{
+			_templateBlockId: {
+				type: 'string',
+				__experimentalRole: 'content',
+			},
+			_templateBlockOrder: {
+				type: 'integer',
+				__experimentalRole: 'content',
+			},
+			_templateBlockHideConditions: {
+				type: 'array',
+				__experimentalRole: 'content',
+			},
+		},
+	};
+}
+
 /**
  * Function to register an individual block.
  *
@@ -86,27 +111,9 @@ export function registerWooBlockType<
 		return;
 	}
 
-	const templateBlockAttributes = {
-		_templateBlockId: {
-			type: 'string',
-			__experimentalRole: 'content',
-		},
-		_templateBlockOrder: {
-			type: 'integer',
-			__experimentalRole: 'content',
-		},
-		_templateBlockHideConditions: {
-			type: 'array',
-			__experimentalRole: 'content',
-		},
-	};
-
 	const augmentedMetadata = {
 		...metadata,
-		attributes: {
-			...metadata.attributes,
-			...templateBlockAttributes,
-		},
+		attributes: augmentAttributes( metadata.attributes ),
 	};
 
 	return registerBlockType< T >(

--- a/packages/js/block-templates/src/utils/test/register-woo-block-type.test.ts
+++ b/packages/js/block-templates/src/utils/test/register-woo-block-type.test.ts
@@ -26,6 +26,7 @@ describe( 'registerWooBlockType', () => {
 			},
 			settings: {
 				foo: 'bar',
+				edit: jest.fn(),
 			},
 		};
 
@@ -49,10 +50,15 @@ describe( 'registerWooBlockType', () => {
 						type: 'integer',
 						__experimentalRole: 'content',
 					},
+					_templateBlockHideConditions: {
+						type: 'array',
+						__experimentalRole: 'content',
+					},
 				},
 			},
 			{
 				foo: 'bar',
+				edit: expect.any( Function ),
 			}
 		);
 	} );

--- a/packages/js/product-editor/changelog/add-template-api-conditional-visibility
+++ b/packages/js/product-editor/changelog/add-template-api-conditional-visibility
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Update block registration calls.

--- a/packages/js/product-editor/src/blocks/generic/checkbox/index.ts
+++ b/packages/js/product-editor/src/blocks/generic/checkbox/index.ts
@@ -1,13 +1,9 @@
 /**
- * External dependencies
- */
-import { registerWooBlockType } from '@woocommerce/block-templates';
-
-/**
  * Internal dependencies
  */
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
+import { registerProductEditorBlockType } from '../../../utils';
 
 const { name, ...metadata } = blockConfiguration;
 
@@ -19,7 +15,7 @@ export const settings = {
 };
 
 export const init = () =>
-	registerWooBlockType( {
+	registerProductEditorBlockType( {
 		name,
 		metadata: metadata as never,
 		settings: settings as never,

--- a/packages/js/product-editor/src/blocks/generic/collapsible/index.ts
+++ b/packages/js/product-editor/src/blocks/generic/collapsible/index.ts
@@ -1,7 +1,7 @@
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { registerWooBlockType } from '@woocommerce/block-templates';
+import { registerProductEditorBlockType } from '../../../utils';
 
 /**
  * Internal dependencies
@@ -19,7 +19,7 @@ export const settings = {
 };
 
 export const init = () =>
-	registerWooBlockType( {
+	registerProductEditorBlockType( {
 		name,
 		metadata: metadata as never,
 		settings: settings as never,

--- a/packages/js/product-editor/src/blocks/generic/conditional/block.json
+++ b/packages/js/product-editor/src/blocks/generic/conditional/block.json
@@ -16,7 +16,6 @@
 			"default": []
 		}
 	},
-	"usesContext": [ "editedProduct" ],
 	"supports": {
 		"align": false,
 		"html": false,

--- a/packages/js/product-editor/src/blocks/generic/conditional/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/conditional/edit.tsx
@@ -2,10 +2,16 @@
  * External dependencies
  */
 import type { BlockAttributes } from '@wordpress/blocks';
-import { createElement, useMemo } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { createElement } from '@wordpress/element';
 import { InnerBlocks } from '@wordpress/block-editor';
 import { useWooBlockProps } from '@woocommerce/block-templates';
 import { DisplayState } from '@woocommerce/components';
+import { Product } from '@woocommerce/data';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore No types for this exist yet.
+// eslint-disable-next-line @woocommerce/dependency-group
+import { useEntityId } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -20,19 +26,29 @@ export function Edit( {
 	attributes,
 	context,
 }: ProductEditorBlockEditProps< ConditionalBlockAttributes > ) {
+	const { productType } = context;
 	const blockProps = useWooBlockProps( attributes );
 	const { mustMatch } = attributes;
 
-	const product = context.editedProduct;
+	const productId = useEntityId( 'postType', productType );
 
-	const displayBlocks = useMemo( () => {
-		for ( const [ prop, values ] of Object.entries( mustMatch ) ) {
-			if ( ! values.includes( product[ prop ] ) ) {
-				return false;
+	const displayBlocks = useSelect(
+		( select ) => {
+			const product: Product = select( 'core' ).getEditedEntityRecord(
+				'postType',
+				productType,
+				productId
+			);
+
+			for ( const [ prop, values ] of Object.entries( mustMatch ) ) {
+				if ( ! values.includes( product[ prop ] ) ) {
+					return false;
+				}
 			}
-		}
-		return true;
-	}, [ mustMatch, product ] );
+			return true;
+		},
+		[ productType, productId, mustMatch ]
+	);
 
 	return (
 		<div { ...blockProps }>

--- a/packages/js/product-editor/src/blocks/generic/conditional/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/conditional/edit.tsx
@@ -26,17 +26,17 @@ export function Edit( {
 	attributes,
 	context,
 }: ProductEditorBlockEditProps< ConditionalBlockAttributes > ) {
-	const { productType } = context;
+	const { postType } = context;
 	const blockProps = useWooBlockProps( attributes );
 	const { mustMatch } = attributes;
 
-	const productId = useEntityId( 'postType', productType );
+	const productId = useEntityId( 'postType', postType );
 
 	const displayBlocks = useSelect(
 		( select ) => {
 			const product: Product = select( 'core' ).getEditedEntityRecord(
 				'postType',
-				productType,
+				postType,
 				productId
 			);
 
@@ -47,7 +47,7 @@ export function Edit( {
 			}
 			return true;
 		},
-		[ productType, productId, mustMatch ]
+		[ postType, productId, mustMatch ]
 	);
 
 	return (

--- a/packages/js/product-editor/src/blocks/generic/conditional/index.ts
+++ b/packages/js/product-editor/src/blocks/generic/conditional/index.ts
@@ -1,7 +1,7 @@
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { registerWooBlockType } from '@woocommerce/block-templates';
+import { registerProductEditorBlockType } from '../../../utils';
 
 /**
  * Internal dependencies
@@ -19,7 +19,7 @@ export const settings = {
 };
 
 export const init = () =>
-	registerWooBlockType( {
+	registerProductEditorBlockType( {
 		name,
 		metadata: metadata as never,
 		settings: settings as never,

--- a/packages/js/product-editor/src/blocks/generic/number/index.ts
+++ b/packages/js/product-editor/src/blocks/generic/number/index.ts
@@ -1,7 +1,7 @@
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { registerWooBlockType } from '@woocommerce/block-templates';
+import { registerProductEditorBlockType } from '../../../utils';
 
 /**
  * Internal dependencies
@@ -19,7 +19,7 @@ export const settings = {
 };
 
 export const init = () =>
-	registerWooBlockType( {
+	registerProductEditorBlockType( {
 		name,
 		metadata: metadata as never,
 		settings: settings as never,

--- a/packages/js/product-editor/src/blocks/generic/pricing/index.ts
+++ b/packages/js/product-editor/src/blocks/generic/pricing/index.ts
@@ -1,7 +1,7 @@
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { registerWooBlockType } from '@woocommerce/block-templates';
+import { registerProductEditorBlockType } from '../../../utils';
 
 /**
  * Internal dependencies
@@ -19,7 +19,7 @@ export const settings = {
 };
 
 export function init() {
-	return registerWooBlockType( {
+	return registerProductEditorBlockType( {
 		name,
 		metadata: metadata as never,
 		settings: settings as never,

--- a/packages/js/product-editor/src/blocks/generic/radio/index.ts
+++ b/packages/js/product-editor/src/blocks/generic/radio/index.ts
@@ -1,7 +1,7 @@
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { registerWooBlockType } from '@woocommerce/block-templates';
+import { registerProductEditorBlockType } from '../../../utils';
 
 /**
  * Internal dependencies
@@ -19,7 +19,7 @@ export const settings = {
 };
 
 export function init() {
-	return registerWooBlockType( {
+	return registerProductEditorBlockType( {
 		name,
 		metadata: metadata as never,
 		settings: settings as never,

--- a/packages/js/product-editor/src/blocks/generic/section/index.ts
+++ b/packages/js/product-editor/src/blocks/generic/section/index.ts
@@ -1,7 +1,7 @@
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { registerWooBlockType } from '@woocommerce/block-templates';
+import { registerProductEditorBlockType } from '../../../utils';
 
 /**
  * Internal dependencies
@@ -19,7 +19,7 @@ export const settings = {
 };
 
 export function init() {
-	return registerWooBlockType( {
+	return registerProductEditorBlockType( {
 		name,
 		metadata: metadata as never,
 		settings: settings as never,

--- a/packages/js/product-editor/src/blocks/generic/tab/block.json
+++ b/packages/js/product-editor/src/blocks/generic/tab/block.json
@@ -13,9 +13,6 @@
 		},
 		"title": {
 			"type": "string"
-		},
-		"order": {
-			"type": "number"
 		}
 	},
 	"supports": {

--- a/packages/js/product-editor/src/blocks/generic/tab/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/tab/edit.tsx
@@ -26,7 +26,12 @@ export function Edit( {
 	context,
 }: ProductEditorBlockEditProps< TabBlockAttributes > ) {
 	const blockProps = useWooBlockProps( attributes );
-	const { id, title, order, isSelected: contextIsSelected } = attributes;
+	const {
+		id,
+		title,
+		_templateBlockOrder: order,
+		isSelected: contextIsSelected,
+	} = attributes;
 	const isSelected = context.selectedTab === id;
 	if ( isSelected !== contextIsSelected ) {
 		setAttributes( { isSelected } );

--- a/packages/js/product-editor/src/blocks/generic/tab/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/tab/edit.tsx
@@ -16,7 +16,6 @@ import { ProductEditorBlockEditProps } from '../../../types';
 export interface TabBlockAttributes extends BlockAttributes {
 	id: string;
 	title: string;
-	order: number;
 	isSelected?: boolean;
 }
 

--- a/packages/js/product-editor/src/blocks/generic/tab/index.ts
+++ b/packages/js/product-editor/src/blocks/generic/tab/index.ts
@@ -1,7 +1,7 @@
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { registerWooBlockType } from '@woocommerce/block-templates';
+import { registerProductEditorBlockType } from '../../../utils';
 
 /**
  * Internal dependencies
@@ -19,7 +19,7 @@ export const settings = {
 };
 
 export function init() {
-	return registerWooBlockType( {
+	return registerProductEditorBlockType( {
 		name,
 		metadata: metadata as never,
 		settings: settings as never,

--- a/packages/js/product-editor/src/blocks/generic/taxonomy/index.ts
+++ b/packages/js/product-editor/src/blocks/generic/taxonomy/index.ts
@@ -1,7 +1,7 @@
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { registerWooBlockType } from '@woocommerce/block-templates';
+import { registerProductEditorBlockType } from '../../../utils';
 
 /**
  * Internal dependencies
@@ -19,7 +19,7 @@ export const settings = {
 };
 
 export const init = () =>
-	registerWooBlockType( {
+	registerProductEditorBlockType( {
 		name,
 		metadata: metadata as never,
 		settings: settings as never,

--- a/packages/js/product-editor/src/blocks/generic/text/index.ts
+++ b/packages/js/product-editor/src/blocks/generic/text/index.ts
@@ -2,7 +2,11 @@
  * External dependencies
  */
 import { BlockConfiguration } from '@wordpress/blocks';
-import { registerWooBlockType } from '@woocommerce/block-templates';
+
+/**
+ * Internal dependencies
+ */
+import { registerProductEditorBlockType } from '../../../utils';
 
 /**
  * Internal dependencies
@@ -22,7 +26,7 @@ export const settings = {
 };
 
 export const init = () =>
-	registerWooBlockType( {
+	registerProductEditorBlockType( {
 		name,
 		metadata: metadata as never,
 		settings: settings as never,

--- a/packages/js/product-editor/src/blocks/generic/toggle/index.ts
+++ b/packages/js/product-editor/src/blocks/generic/toggle/index.ts
@@ -1,13 +1,9 @@
 /**
- * External dependencies
- */
-import { registerWooBlockType } from '@woocommerce/block-templates';
-
-/**
  * Internal dependencies
  */
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
+import { registerProductEditorBlockType } from '../../../utils';
 
 const { name, ...metadata } = blockConfiguration;
 
@@ -19,7 +15,7 @@ export const settings = {
 };
 
 export function init() {
-	return registerWooBlockType( {
+	return registerProductEditorBlockType( {
 		name,
 		metadata: metadata as never,
 		settings: settings as never,

--- a/packages/js/product-editor/src/blocks/product-fields/attributes/index.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/attributes/index.ts
@@ -1,13 +1,9 @@
 /**
- * External dependencies
- */
-import { registerWooBlockType } from '@woocommerce/block-templates';
-
-/**
  * Internal dependencies
  */
 import metadata from './block.json';
 import { Edit } from './edit';
+import { registerProductEditorBlockType } from '../../../utils';
 
 const { name } = metadata;
 
@@ -19,7 +15,7 @@ export const settings = {
 };
 
 export const init = () =>
-	registerWooBlockType( {
+	registerProductEditorBlockType( {
 		name,
 		metadata: metadata as never,
 		settings: settings as never,

--- a/packages/js/product-editor/src/blocks/product-fields/catalog-visibility/index.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/catalog-visibility/index.ts
@@ -1,13 +1,9 @@
 /**
- * External dependencies
- */
-import { registerWooBlockType } from '@woocommerce/block-templates';
-
-/**
  * Internal dependencies
  */
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
+import { registerProductEditorBlockType } from '../../../utils';
 
 const { name, ...metadata } = blockConfiguration;
 
@@ -19,7 +15,7 @@ export const settings = {
 };
 
 export function init() {
-	return registerWooBlockType( {
+	return registerProductEditorBlockType( {
 		name,
 		metadata: metadata as never,
 		settings: settings as never,

--- a/packages/js/product-editor/src/blocks/product-fields/description/index.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/description/index.ts
@@ -1,13 +1,9 @@
 /**
- * External dependencies
- */
-import { registerWooBlockType } from '@woocommerce/block-templates';
-
-/**
  * Internal dependencies
  */
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
+import { registerProductEditorBlockType } from '../../../utils';
 
 const { name, ...metadata } = blockConfiguration;
 
@@ -19,7 +15,7 @@ export const settings = {
 };
 
 export const init = () =>
-	registerWooBlockType( {
+	registerProductEditorBlockType( {
 		name,
 		metadata: metadata as never,
 		settings: settings as never,

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/index.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/index.ts
@@ -15,5 +15,9 @@ export const settings = {
 };
 
 export function init() {
-	return registerProductEditorBlockType( { name, metadata, settings } );
+	return registerProductEditorBlockType( {
+		name,
+		metadata: metadata as never,
+		settings: settings as never,
+	} );
 }

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/index.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/index.ts
@@ -1,13 +1,9 @@
 /**
- * External dependencies
- */
-import { registerWooBlockType } from '@woocommerce/block-templates';
-
-/**
  * Internal dependencies
  */
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
+import { registerProductEditorBlockType } from '../../../utils';
 
 const { name, ...metadata } = blockConfiguration;
 
@@ -19,9 +15,5 @@ export const settings = {
 };
 
 export function init() {
-	return registerWooBlockType( {
-		name,
-		metadata: metadata as never,
-		settings: settings as never,
-	} );
+	return registerProductEditorBlockType( { name, metadata, settings } );
 }

--- a/packages/js/product-editor/src/blocks/product-fields/images/index.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/images/index.ts
@@ -1,13 +1,9 @@
 /**
- * External dependencies
- */
-import { registerWooBlockType } from '@woocommerce/block-templates';
-
-/**
  * Internal dependencies
  */
 import metadata from './block.json';
 import { Edit } from './edit';
+import { registerProductEditorBlockType } from '../../../utils';
 
 const { name } = metadata;
 
@@ -19,7 +15,7 @@ export const settings = {
 };
 
 export const init = () =>
-	registerWooBlockType( {
+	registerProductEditorBlockType( {
 		name,
 		metadata: metadata as never,
 		settings: settings as never,

--- a/packages/js/product-editor/src/blocks/product-fields/inventory-email/index.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/inventory-email/index.ts
@@ -1,13 +1,9 @@
 /**
- * External dependencies
- */
-import { registerWooBlockType } from '@woocommerce/block-templates';
-
-/**
  * Internal dependencies
  */
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
+import { registerProductEditorBlockType } from '../../../utils';
 
 const { name, ...metadata } = blockConfiguration;
 
@@ -19,7 +15,7 @@ export const settings = {
 };
 
 export function init() {
-	return registerWooBlockType( {
+	return registerProductEditorBlockType( {
 		name,
 		metadata: metadata as never,
 		settings: settings as never,

--- a/packages/js/product-editor/src/blocks/product-fields/inventory-quantity/index.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/inventory-quantity/index.ts
@@ -1,13 +1,9 @@
 /**
- * External dependencies
- */
-import { registerWooBlockType } from '@woocommerce/block-templates';
-
-/**
  * Internal dependencies
  */
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
+import { registerProductEditorBlockType } from '../../../utils';
 
 const { name, ...metadata } = blockConfiguration;
 
@@ -19,7 +15,7 @@ export const settings = {
 };
 
 export function init() {
-	return registerWooBlockType( {
+	return registerProductEditorBlockType( {
 		name,
 		metadata: metadata as never,
 		settings: settings as never,

--- a/packages/js/product-editor/src/blocks/product-fields/inventory-sku/index.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/inventory-sku/index.ts
@@ -1,13 +1,9 @@
 /**
- * External dependencies
- */
-import { registerWooBlockType } from '@woocommerce/block-templates';
-
-/**
  * Internal dependencies
  */
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
+import { registerProductEditorBlockType } from '../../../utils';
 
 const { name, ...metadata } = blockConfiguration;
 
@@ -19,7 +15,7 @@ export const settings = {
 };
 
 export const init = () =>
-	registerWooBlockType( {
+	registerProductEditorBlockType( {
 		name,
 		metadata: metadata as never,
 		settings: settings as never,

--- a/packages/js/product-editor/src/blocks/product-fields/name/index.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/name/index.ts
@@ -1,13 +1,9 @@
 /**
- * External dependencies
- */
-import { registerWooBlockType } from '@woocommerce/block-templates';
-
-/**
  * Internal dependencies
  */
 import metadata from './block.json';
 import { Edit } from './edit';
+import { registerProductEditorBlockType } from '../../../utils';
 
 const { name } = metadata;
 
@@ -19,7 +15,7 @@ export const settings = {
 };
 
 export const init = () =>
-	registerWooBlockType( {
+	registerProductEditorBlockType( {
 		name,
 		metadata: metadata as never,
 		settings: settings as never,

--- a/packages/js/product-editor/src/blocks/product-fields/notice-edit-single-variation/index.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/notice-edit-single-variation/index.ts
@@ -1,13 +1,9 @@
 /**
- * External dependencies
- */
-import { registerWooBlockType } from '@woocommerce/block-templates';
-
-/**
  * Internal dependencies
  */
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
+import { registerProductEditorBlockType } from '../../../utils';
 
 const { name, ...metadata } = blockConfiguration;
 
@@ -16,7 +12,7 @@ export { metadata, name };
 export const settings = { example: {}, edit: Edit };
 
 export function init() {
-	return registerWooBlockType( {
+	return registerProductEditorBlockType( {
 		name,
 		metadata: metadata as never,
 		settings: settings as never,

--- a/packages/js/product-editor/src/blocks/product-fields/notice-has-variations/index.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/notice-has-variations/index.ts
@@ -1,13 +1,9 @@
 /**
- * External dependencies
- */
-import { registerWooBlockType } from '@woocommerce/block-templates';
-
-/**
  * Internal dependencies
  */
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
+import { registerProductEditorBlockType } from '../../../utils';
 
 const { name, ...metadata } = blockConfiguration;
 
@@ -16,7 +12,7 @@ export { metadata, name };
 export const settings = { example: {}, edit: Edit };
 
 export function init() {
-	return registerWooBlockType( {
+	return registerProductEditorBlockType( {
 		name,
 		metadata: metadata as never,
 		settings: settings as never,

--- a/packages/js/product-editor/src/blocks/product-fields/password/index.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/password/index.ts
@@ -1,13 +1,9 @@
 /**
- * External dependencies
- */
-import { registerWooBlockType } from '@woocommerce/block-templates';
-
-/**
  * Internal dependencies
  */
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
+import { registerProductEditorBlockType } from '../../../utils';
 
 const { name, ...metadata } = blockConfiguration;
 
@@ -18,7 +14,7 @@ export const settings = {
 };
 
 export function init() {
-	return registerWooBlockType( {
+	return registerProductEditorBlockType( {
 		name,
 		metadata: metadata as never,
 		settings: settings as never,

--- a/packages/js/product-editor/src/blocks/product-fields/regular-price/index.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/regular-price/index.ts
@@ -1,13 +1,9 @@
 /**
- * External dependencies
- */
-import { registerWooBlockType } from '@woocommerce/block-templates';
-
-/**
  * Internal dependencies
  */
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
+import { registerProductEditorBlockType } from '../../../utils';
 
 const { name, ...metadata } = blockConfiguration;
 
@@ -19,7 +15,7 @@ export const settings = {
 };
 
 export function init() {
-	return registerWooBlockType( {
+	return registerProductEditorBlockType( {
 		name,
 		metadata: metadata as never,
 		settings: settings as never,

--- a/packages/js/product-editor/src/blocks/product-fields/sale-price/index.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/sale-price/index.ts
@@ -1,13 +1,9 @@
 /**
- * External dependencies
- */
-import { registerWooBlockType } from '@woocommerce/block-templates';
-
-/**
  * Internal dependencies
  */
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
+import { registerProductEditorBlockType } from '../../../utils';
 
 const { name, ...metadata } = blockConfiguration;
 
@@ -19,7 +15,7 @@ export const settings = {
 };
 
 export function init() {
-	return registerWooBlockType( {
+	return registerProductEditorBlockType( {
 		name,
 		metadata: metadata as never,
 		settings: settings as never,

--- a/packages/js/product-editor/src/blocks/product-fields/schedule-sale/index.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/schedule-sale/index.ts
@@ -1,13 +1,9 @@
 /**
- * External dependencies
- */
-import { registerWooBlockType } from '@woocommerce/block-templates';
-
-/**
  * Internal dependencies
  */
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
+import { registerProductEditorBlockType } from '../../../utils';
 
 const { name, ...metadata } = blockConfiguration;
 
@@ -19,7 +15,7 @@ export const settings = {
 };
 
 export function init() {
-	return registerWooBlockType( {
+	return registerProductEditorBlockType( {
 		name,
 		metadata: metadata as never,
 		settings: settings as never,

--- a/packages/js/product-editor/src/blocks/product-fields/shipping-class/index.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/shipping-class/index.ts
@@ -1,13 +1,9 @@
 /**
- * External dependencies
- */
-import { registerWooBlockType } from '@woocommerce/block-templates';
-
-/**
  * Internal dependencies
  */
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
+import { registerProductEditorBlockType } from '../../../utils';
 
 const { name, ...metadata } = blockConfiguration;
 
@@ -19,7 +15,7 @@ export const settings = {
 };
 
 export function init() {
-	return registerWooBlockType( {
+	return registerProductEditorBlockType( {
 		name,
 		metadata: metadata as never,
 		settings: settings as never,

--- a/packages/js/product-editor/src/blocks/product-fields/shipping-dimensions/index.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/shipping-dimensions/index.ts
@@ -1,13 +1,9 @@
 /**
- * External dependencies
- */
-import { registerWooBlockType } from '@woocommerce/block-templates';
-
-/**
  * Internal dependencies
  */
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
+import { registerProductEditorBlockType } from '../../../utils';
 
 const { name, ...metadata } = blockConfiguration;
 
@@ -19,7 +15,7 @@ export const settings = {
 };
 
 export function init() {
-	return registerWooBlockType( {
+	return registerProductEditorBlockType( {
 		name,
 		metadata: metadata as never,
 		settings: settings as never,

--- a/packages/js/product-editor/src/blocks/product-fields/summary/index.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/summary/index.ts
@@ -1,13 +1,9 @@
 /**
- * External dependencies
- */
-import { registerWooBlockType } from '@woocommerce/block-templates';
-
-/**
  * Internal dependencies
  */
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
+import { registerProductEditorBlockType } from '../../../utils';
 
 const { name, ...metadata } = blockConfiguration;
 
@@ -19,7 +15,7 @@ export const settings = {
 };
 
 export function init() {
-	return registerWooBlockType( {
+	return registerProductEditorBlockType( {
 		name,
 		metadata: metadata as never,
 		settings: settings as never,

--- a/packages/js/product-editor/src/blocks/product-fields/tag/index.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/tag/index.ts
@@ -1,13 +1,9 @@
 /**
- * External dependencies
- */
-import { registerWooBlockType } from '@woocommerce/block-templates';
-
-/**
  * Internal dependencies
  */
 import metadata from './block.json';
 import { Edit } from './edit';
+import { registerProductEditorBlockType } from '../../../utils';
 
 const { name } = metadata;
 
@@ -19,7 +15,7 @@ export const settings = {
 };
 
 export const init = () =>
-	registerWooBlockType( {
+	registerProductEditorBlockType( {
 		name,
 		metadata: metadata as never,
 		settings: settings as never,

--- a/packages/js/product-editor/src/blocks/product-fields/variation-items/index.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/variation-items/index.ts
@@ -1,13 +1,9 @@
 /**
- * External dependencies
- */
-import { registerWooBlockType } from '@woocommerce/block-templates';
-
-/**
  * Internal dependencies
  */
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
+import { registerProductEditorBlockType } from '../../../utils';
 
 const { name, ...metadata } = blockConfiguration;
 
@@ -19,7 +15,7 @@ export const settings = {
 };
 
 export function init() {
-	return registerWooBlockType( {
+	return registerProductEditorBlockType( {
 		name,
 		metadata: metadata as never,
 		settings: settings as never,

--- a/packages/js/product-editor/src/blocks/product-fields/variation-options/index.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/variation-options/index.ts
@@ -1,13 +1,9 @@
 /**
- * External dependencies
- */
-import { registerWooBlockType } from '@woocommerce/block-templates';
-
-/**
  * Internal dependencies
  */
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
+import { registerProductEditorBlockType } from '../../../utils';
 
 const { name, ...metadata } = blockConfiguration;
 
@@ -19,7 +15,7 @@ export const settings = {
 };
 
 export function init() {
-	return registerWooBlockType( {
+	return registerProductEditorBlockType( {
 		name,
 		metadata: metadata as never,
 		settings: settings as never,

--- a/packages/js/product-editor/src/blocks/product-fields/variations/index.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/variations/index.ts
@@ -1,13 +1,9 @@
 /**
- * External dependencies
- */
-import { registerWooBlockType } from '@woocommerce/block-templates';
-
-/**
  * Internal dependencies
  */
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
+import { registerProductEditorBlockType } from '../../../utils';
 
 const { name, ...metadata } = blockConfiguration;
 
@@ -19,7 +15,7 @@ export const settings = {
 };
 
 export function init() {
-	return registerWooBlockType( {
+	return registerProductEditorBlockType( {
 		name,
 		metadata: metadata as never,
 		settings: settings as never,

--- a/packages/js/product-editor/src/components/block-editor/block-editor.tsx
+++ b/packages/js/product-editor/src/components/block-editor/block-editor.tsx
@@ -100,21 +100,13 @@ export function BlockEditor( {
 		updateEditorSettings( _settings ?? {} );
 	}, [ productType, productId ] );
 
-	const editedProduct: Product = useSelect( ( select ) =>
-		select( 'core' ).getEditedEntityRecord(
-			'postType',
-			productType,
-			productId
-		)
-	);
-
 	if ( ! blocks ) {
 		return null;
 	}
 
 	return (
 		<div className="woocommerce-product-block-editor">
-			<BlockContextProvider value={ { ...context, editedProduct } }>
+			<BlockContextProvider value={ { ...context, productType } }>
 				<BlockEditorProvider
 					value={ blocks }
 					onInput={ onInput }

--- a/packages/js/product-editor/src/components/block-editor/block-editor.tsx
+++ b/packages/js/product-editor/src/components/block-editor/block-editor.tsx
@@ -3,7 +3,6 @@
  */
 import { synchronizeBlocksWithTemplate, Template } from '@wordpress/blocks';
 import { createElement, useMemo, useLayoutEffect } from '@wordpress/element';
-import { Product } from '@woocommerce/data';
 import { useDispatch, useSelect, select as WPSelect } from '@wordpress/data';
 import { uploadMedia } from '@wordpress/media-utils';
 import {

--- a/packages/js/product-editor/src/components/block-editor/block-editor.tsx
+++ b/packages/js/product-editor/src/components/block-editor/block-editor.tsx
@@ -53,13 +53,6 @@ export function BlockEditor( {
 }: BlockEditorProps ) {
 	useConfirmUnsavedProductChanges( productType );
 
-	const blockContext = useMemo( () => {
-		return {
-			...context,
-			productType,
-		};
-	}, [ context, productType ] );
-
 	const canUserCreateMedia = useSelect( ( select: typeof WPSelect ) => {
 		const { canUser } = select( 'core' );
 		return canUser( 'create', 'media', '' ) !== false;
@@ -112,7 +105,7 @@ export function BlockEditor( {
 
 	return (
 		<div className="woocommerce-product-block-editor">
-			<BlockContextProvider value={ blockContext }>
+			<BlockContextProvider value={ context }>
 				<BlockEditorProvider
 					value={ blocks }
 					onInput={ onInput }

--- a/packages/js/product-editor/src/components/block-editor/block-editor.tsx
+++ b/packages/js/product-editor/src/components/block-editor/block-editor.tsx
@@ -54,6 +54,13 @@ export function BlockEditor( {
 }: BlockEditorProps ) {
 	useConfirmUnsavedProductChanges( productType );
 
+	const blockContext = useMemo( () => {
+		return {
+			...context,
+			productType,
+		};
+	}, [ context, productType ] );
+
 	const canUserCreateMedia = useSelect( ( select: typeof WPSelect ) => {
 		const { canUser } = select( 'core' );
 		return canUser( 'create', 'media', '' ) !== false;
@@ -106,7 +113,7 @@ export function BlockEditor( {
 
 	return (
 		<div className="woocommerce-product-block-editor">
-			<BlockContextProvider value={ { ...context, productType } }>
+			<BlockContextProvider value={ blockContext }>
 				<BlockEditorProvider
 					value={ blocks }
 					onInput={ onInput }

--- a/packages/js/product-editor/src/types.ts
+++ b/packages/js/product-editor/src/types.ts
@@ -6,7 +6,6 @@ import { BlockEditProps } from '@wordpress/blocks';
 export interface ProductEditorContext {
 	postId: number;
 	postType: string;
-	productType: string;
 	selectedTab: string | null;
 }
 

--- a/packages/js/product-editor/src/types.ts
+++ b/packages/js/product-editor/src/types.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { BlockEditProps } from '@wordpress/blocks';
-import { Product } from '@woocommerce/data';
 
 export interface ProductEditorContext {
 	postId: number;

--- a/packages/js/product-editor/src/types.ts
+++ b/packages/js/product-editor/src/types.ts
@@ -5,9 +5,9 @@ import { BlockEditProps } from '@wordpress/blocks';
 import { Product } from '@woocommerce/data';
 
 export interface ProductEditorContext {
-	editedProduct: Product;
 	postId: number;
 	postType: string;
+	productType: string;
 	selectedTab: string | null;
 }
 

--- a/packages/js/product-editor/src/utils/index.ts
+++ b/packages/js/product-editor/src/utils/index.ts
@@ -23,6 +23,7 @@ import { isValidEmail } from './validate-email';
 
 export * from './create-ordered-children';
 export * from './sort-fills-by-order';
+export * from './register-product-editor-block-type';
 export * from './init-block';
 export * from './product-apifetch-middleware';
 export * from './sift';

--- a/packages/js/product-editor/src/utils/init-block.ts
+++ b/packages/js/product-editor/src/utils/init-block.ts
@@ -3,7 +3,11 @@
  */
 import { Block, BlockConfiguration } from '@wordpress/blocks';
 import deprecated from '@wordpress/deprecated';
-import { registerWooBlockType } from '@woocommerce/block-templates';
+
+/**
+ * Internal dependencies
+ */
+import { registerProductEditorBlockType } from './register-product-editor-block-type';
 
 interface BlockRepresentation< T extends Record< string, object > > {
 	name?: string;
@@ -22,12 +26,12 @@ export function initBlock<
 	T extends Record< string, any > = Record< string, any >
 >( block: BlockRepresentation< T > ): Block< T > | undefined {
 	deprecated( 'initBlock()', {
-		alternative: 'registerWooBlockType() from @woocommerce/block-templates',
+		alternative: 'registerProductEditorBlockType()',
 	} );
 
 	if ( ! block ) {
 		return;
 	}
 
-	return registerWooBlockType( block );
+	return registerProductEditorBlockType( block );
 }

--- a/packages/js/product-editor/src/utils/register-product-editor-block-type.ts
+++ b/packages/js/product-editor/src/utils/register-product-editor-block-type.ts
@@ -16,14 +16,14 @@ interface BlockRepresentation< T extends Record< string, object > > {
 }
 
 function useEvaluationContext( context: Record< string, unknown > ) {
-	const { productType } = context;
+	const { postType } = context;
 
-	const productId = useEntityId( 'postType', productType );
+	const productId = useEntityId( 'postType', postType );
 
 	const getEvaluationContext = ( select: typeof WPSelect ) => {
 		const editedProduct = select( 'core' ).getEditedEntityRecord(
 			'postType',
-			productType,
+			postType,
 			productId
 		);
 
@@ -41,7 +41,7 @@ function useEvaluationContext( context: Record< string, unknown > ) {
 function augmentUsesContext( usesContext?: string[] ) {
 	// Note: If you modify this function, also update the server-side
 	// Automattic\WooCommerce\Admin\Features\ProductBlockEditor\BlockRegistry::augment_uses_context() function.
-	return [ ...( usesContext || [] ), 'productType' ];
+	return [ ...( usesContext || [] ), 'postType' ];
 }
 
 export function registerProductEditorBlockType<

--- a/packages/js/product-editor/src/utils/register-product-editor-block-type.ts
+++ b/packages/js/product-editor/src/utils/register-product-editor-block-type.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { Block, BlockConfiguration } from '@wordpress/blocks';
+import { select as WPSelect } from '@wordpress/data';
 import { registerWooBlockType } from '@woocommerce/block-templates';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore No types for this exist yet.
@@ -14,12 +15,12 @@ interface BlockRepresentation< T extends Record< string, object > > {
 	settings: Partial< BlockConfiguration< T > >;
 }
 
-function useEvaluationContext( context: any ) {
+function useEvaluationContext( context: Record< string, unknown > ) {
 	const { productType } = context;
 
 	const productId = useEntityId( 'postType', productType );
 
-	const getEvaluationContext = ( select: any ) => {
+	const getEvaluationContext = ( select: typeof WPSelect ) => {
 		const editedProduct = select( 'core' ).getEditedEntityRecord(
 			'postType',
 			productType,
@@ -32,7 +33,7 @@ function useEvaluationContext( context: any ) {
 		};
 	};
 
-	console.log( 'hi there!' );
+	console.log( 'yo!' );
 
 	return {
 		getEvaluationContext,

--- a/packages/js/product-editor/src/utils/register-product-editor-block-type.ts
+++ b/packages/js/product-editor/src/utils/register-product-editor-block-type.ts
@@ -22,7 +22,7 @@ export function registerProductEditorBlockType<
 
 	const augmentedMetadata = {
 		...metadata,
-		usesContext: [ ...( metadata.usesContext || [] ), 'editedProduct' ],
+		usesContext: [ ...( metadata.usesContext || [] ), 'productType' ],
 	};
 
 	return registerWooBlockType( {

--- a/packages/js/product-editor/src/utils/register-product-editor-block-type.ts
+++ b/packages/js/product-editor/src/utils/register-product-editor-block-type.ts
@@ -33,8 +33,6 @@ function useEvaluationContext( context: Record< string, unknown > ) {
 		};
 	};
 
-	console.log( 'yo!' );
-
 	return {
 		getEvaluationContext,
 	};

--- a/packages/js/product-editor/src/utils/register-product-editor-block-type.ts
+++ b/packages/js/product-editor/src/utils/register-product-editor-block-type.ts
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { Block, BlockConfiguration } from '@wordpress/blocks';
+
+/**
+ * External dependencies
+ */
+import { registerWooBlockType } from '@woocommerce/block-templates';
+
+interface BlockRepresentation< T extends Record< string, object > > {
+	name?: string;
+	metadata: BlockConfiguration< T >;
+	settings: Partial< BlockConfiguration< T > >;
+}
+
+export function registerProductEditorBlockType<
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	T extends Record< string, any > = Record< string, any >
+>( block: BlockRepresentation< T > ): Block< T > | undefined {
+	const { metadata, settings, name } = block;
+
+	const augmentedMetadata = {
+		...metadata,
+		usesContext: [ ...( metadata.usesContext || [] ), 'editedProduct' ],
+	};
+
+	return registerWooBlockType( {
+		name,
+		metadata: augmentedMetadata,
+		settings,
+	} );
+}

--- a/packages/js/product-editor/src/utils/register-product-editor-block-type.ts
+++ b/packages/js/product-editor/src/utils/register-product-editor-block-type.ts
@@ -2,16 +2,41 @@
  * External dependencies
  */
 import { Block, BlockConfiguration } from '@wordpress/blocks';
-
-/**
- * External dependencies
- */
 import { registerWooBlockType } from '@woocommerce/block-templates';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore No types for this exist yet.
+// eslint-disable-next-line @woocommerce/dependency-group
+import { useEntityId } from '@wordpress/core-data';
 
 interface BlockRepresentation< T extends Record< string, object > > {
 	name?: string;
 	metadata: BlockConfiguration< T >;
 	settings: Partial< BlockConfiguration< T > >;
+}
+
+function useEvaluationContext( context: any ) {
+	const { productType } = context;
+
+	const productId = useEntityId( 'postType', productType );
+
+	const getEvaluationContext = ( select: any ) => {
+		const editedProduct = select( 'core' ).getEditedEntityRecord(
+			'postType',
+			productType,
+			productId
+		);
+
+		return {
+			...context,
+			editedProduct,
+		};
+	};
+
+	console.log( 'hi there!' );
+
+	return {
+		getEvaluationContext,
+	};
 }
 
 export function registerProductEditorBlockType<
@@ -25,9 +50,12 @@ export function registerProductEditorBlockType<
 		usesContext: [ ...( metadata.usesContext || [] ), 'productType' ],
 	};
 
-	return registerWooBlockType( {
-		name,
-		metadata: augmentedMetadata,
-		settings,
-	} );
+	return registerWooBlockType(
+		{
+			name,
+			metadata: augmentedMetadata,
+			settings,
+		},
+		useEvaluationContext
+	);
 }

--- a/packages/js/product-editor/src/utils/register-product-editor-block-type.ts
+++ b/packages/js/product-editor/src/utils/register-product-editor-block-type.ts
@@ -38,6 +38,12 @@ function useEvaluationContext( context: Record< string, unknown > ) {
 	};
 }
 
+function augmentUsesContext( usesContext?: string[] ) {
+	// Note: If you modify this function, also update the server-side
+	// Automattic\WooCommerce\Admin\Features\ProductBlockEditor\BlockRegistry::augment_uses_context() function.
+	return [ ...( usesContext || [] ), 'productType' ];
+}
+
 export function registerProductEditorBlockType<
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	T extends Record< string, any > = Record< string, any >
@@ -46,7 +52,7 @@ export function registerProductEditorBlockType<
 
 	const augmentedMetadata = {
 		...metadata,
-		usesContext: [ ...( metadata.usesContext || [] ), 'productType' ],
+		usesContext: augmentUsesContext( metadata.usesContext ),
 	};
 
 	return registerWooBlockType(

--- a/plugins/woocommerce/changelog/add-template-api-conditional-visibility
+++ b/plugins/woocommerce/changelog/add-template-api-conditional-visibility
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add conditional visibilty support to the Block Template API.

--- a/plugins/woocommerce/src/Admin/BlockTemplates/BlockInterface.php
+++ b/plugins/woocommerce/src/Admin/BlockTemplates/BlockInterface.php
@@ -27,6 +27,11 @@ interface BlockInterface {
 	public const ATTRIBUTES_KEY = 'attributes';
 
 	/**
+	 * Key for the block hide conditions in the block configuration.
+	 */
+	public const HIDE_CONDITIONS_KEY = 'hideConditions';
+
+	/**
 	 * Get the block name.
 	 */
 	public function get_name(): string;
@@ -81,6 +86,29 @@ interface BlockInterface {
 	 * @return bool True if the block is detached from its parent or root template.
 	 */
 	public function is_detached(): bool;
+
+	/**
+	 * Add a hide condition to the block.
+	 *
+	 * The hide condition is a JavaScript-like expression that will be evaluated on the client to determine if the block should be hidden.
+	 * See [@woocommerce/expression-evaluation](https://github.com/woocommerce/woocommerce/blob/trunk/packages/js/expression-evaluation/README.md) for more details.
+	 *
+	 * @param string $expression An expression, which if true, will hide the block.
+	 * @return string The key of the hide condition, which can be used to remove the hide condition.
+	 */
+	public function add_hide_condition( string $expression ): string;
+
+	/**
+	 * Remove a hide condition from the block.
+	 *
+	 * @param string $key The key of the hide condition to remove.
+	 */
+	public function remove_hide_condition( string $key );
+
+	/**
+	 * Get the hide conditions of the block.
+	 */
+	public function get_hide_conditions(): array;
 
 	/**
 	 * Get the block configuration as a formatted template.

--- a/plugins/woocommerce/src/Admin/BlockTemplates/README.md
+++ b/plugins/woocommerce/src/Admin/BlockTemplates/README.md
@@ -203,6 +203,20 @@ Removes the block from its parent. When a block is removed from its parent, it i
 
 Check if the block is detached from its parent or root template. A detached block is no longer a part of the template and will not be included in the formatted template.
 
+##### `add_hide_condition( string $expression ): string`
+
+Adds a hide condition to the block. The hide condition is a JavaScript-like expression that is evaluated at runtime on the client to determine if the block should be hidden.
+
+See [@woocommerce/expression-evaluation](../../../../../packages/js/expression-evaluation/README.md) for more information on the expression syntax.
+
+##### `remove_hide_condition( string $key )`
+
+Removes a hide condition from the block, referenced by the key returned from `add_hide_condition()`.
+
+##### `get_hide_conditions(): array`
+
+Get the hide conditions for the block.
+
 ##### `get_formatted_template(): array`
 
 Get the block configuration as a formatted template.

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
@@ -154,7 +154,34 @@ class BlockRegistry {
 			$registry->unregister( $metadata['name'] );
 		}
 
-		return register_block_type_from_metadata( $block_json_file );
+		return register_block_type_from_metadata(
+			$block_json_file,
+			[
+				'attributes'   => array_merge(
+					$metadata['attributes'],
+					[
+						'_templateBlockId'             => [
+							'type'               => 'string',
+							'__experimentalRole' => 'content',
+						],
+						'_templateBlockOrder'          => [
+							'type'               => 'integer',
+							'__experimentalRole' => 'content',
+						],
+						'_templateBlockHideConditions' => [
+							'type'               => 'array',
+							'__experimentalRole' => 'content',
+						],
+					],
+				),
+				'uses_context' => array_merge(
+					isset( $metadata['usesContext'] ) ? $metadata['usesContext'] : [],
+					[
+						'productType',
+					]
+				),
+			]
+		);
 	}
 
 }

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
@@ -200,8 +200,8 @@ class BlockRegistry {
 		return register_block_type_from_metadata(
 			$block_json_file,
 			[
-				'attributes'   => $this->augment_attributes( $metadata['attributes'] ),
-				'uses_context' => $this->augment_uses_context( $metadata['usesContext'] ),
+				'attributes'   => $this->augment_attributes( isset( $metadata['attributes'] ) ? $metadata['attributes'] : [] ),
+				'uses_context' => $this->augment_uses_context( isset( $metadata['usesContext'] ) ? $metadata['usesContext'] : [] ),
 			]
 		);
 	}

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
@@ -164,7 +164,7 @@ class BlockRegistry {
 		return array_merge(
 			isset( $uses_context ) ? $uses_context : [],
 			[
-				'productType',
+				'postType',
 			]
 		);
 	}

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
@@ -127,6 +127,49 @@ class BlockRegistry {
 	}
 
 	/**
+	 * Augment the attributes of a block by adding attributes that are used by the product editor.
+	 *
+	 * @param array $attributes Block attributes.
+	 */
+	private function augment_attributes( $attributes ) {
+		// Note: If you modify this function, also update the client-side
+		// registerWooBlockType function in @woocommerce/block-templates.
+		return array_merge(
+			$attributes,
+			[
+				'_templateBlockId'             => [
+					'type'               => 'string',
+					'__experimentalRole' => 'content',
+				],
+				'_templateBlockOrder'          => [
+					'type'               => 'integer',
+					'__experimentalRole' => 'content',
+				],
+				'_templateBlockHideConditions' => [
+					'type'               => 'array',
+					'__experimentalRole' => 'content',
+				],
+			]
+		);
+	}
+
+	/**
+	 * Augment the uses_context of a block by adding attributes that are used by the product editor.
+	 *
+	 * @param array $uses_context Block uses_context.
+	 */
+	private function augment_uses_context( $uses_context ) {
+		// Note: If you modify this function, also update the client-side
+		// registerProductEditorBlockType function in @woocommerce/product-editor.
+		return array_merge(
+			isset( $uses_context ) ? $uses_context : [],
+			[
+				'productType',
+			]
+		);
+	}
+
+	/**
 	 * Register a single block.
 	 *
 	 * @param string $block_name Block name.
@@ -157,29 +200,8 @@ class BlockRegistry {
 		return register_block_type_from_metadata(
 			$block_json_file,
 			[
-				'attributes'   => array_merge(
-					$metadata['attributes'],
-					[
-						'_templateBlockId'             => [
-							'type'               => 'string',
-							'__experimentalRole' => 'content',
-						],
-						'_templateBlockOrder'          => [
-							'type'               => 'integer',
-							'__experimentalRole' => 'content',
-						],
-						'_templateBlockHideConditions' => [
-							'type'               => 'array',
-							'__experimentalRole' => 'content',
-						],
-					],
-				),
-				'uses_context' => array_merge(
-					isset( $metadata['usesContext'] ) ? $metadata['usesContext'] : [],
-					[
-						'productType',
-					]
-				),
+				'attributes'   => $this->augment_attributes( $metadata['attributes'] ),
+				'uses_context' => $this->augment_uses_context( $metadata['usesContext'] ),
 			]
 		);
 	}

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplates/AbstractBlock.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplates/AbstractBlock.php
@@ -40,7 +40,18 @@ class AbstractBlock implements BlockInterface {
 	 */
 	private $attributes = [];
 
+	/**
+	 * The block hide conditions.
+	 *
+	 * @var array
+	 */
 	private $hide_conditions = [];
+
+	/**
+	 * The block hide conditions counter.
+	 *
+	 * @var int
+	 */
 	private $hide_conditions_counter = 0;
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplates/AbstractBlock.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplates/AbstractBlock.php
@@ -40,6 +40,9 @@ class AbstractBlock implements BlockInterface {
 	 */
 	private $attributes = [];
 
+	private $hide_conditions = [];
+	private $hide_conditions_counter = 0;
+
 	/**
 	 * The block template that this block belongs to.
 	 *
@@ -84,6 +87,12 @@ class AbstractBlock implements BlockInterface {
 
 		if ( isset( $config[ self::ATTRIBUTES_KEY ] ) ) {
 			$this->attributes = $config[ self::ATTRIBUTES_KEY ];
+		}
+
+		if ( isset( $config[ self::HIDE_CONDITIONS_KEY ] ) ) {
+			foreach ( $config[ self::HIDE_CONDITIONS_KEY ] as $hide_condition ) {
+				$this->add_hide_condition( $hide_condition['expression'] );
+			}
 		}
 	}
 
@@ -192,5 +201,42 @@ class AbstractBlock implements BlockInterface {
 		$is_in_root_template = $this->get_root_template()->get_block( $this->id ) === $this;
 
 		return ! ( $is_in_parent && $is_in_root_template );
+	}
+
+	/**
+	 * Add a hide condition to the block.
+	 *
+	 * The hide condition is a JavaScript-like expression that will be evaluated on the client to determine if the block should be hidden.
+	 * See [@woocommerce/expression-evaluation](https://github.com/woocommerce/woocommerce/blob/trunk/packages/js/expression-evaluation/README.md) for more details.
+	 *
+	 * @param string $expression An expression, which if true, will hide the block.
+	 */
+	public function add_hide_condition( string $expression ): string {
+		$key = 'k' . $this->hide_conditions_counter;
+		$this->hide_conditions_counter++;
+
+		// Storing the expression in an array to allow for future expansion
+		// (such as adding the plugin that added the condition).
+		$this->hide_conditions[ $key ] = [
+			'expression' => $expression,
+		];
+
+		return $key;
+	}
+
+	/**
+	 * Remove a hide condition from the block.
+	 *
+	 * @param string $key The key of the hide condition to remove.
+	 */
+	public function remove_hide_condition( string $key ) {
+		unset( $this->hide_conditions[ $key ] );
+	}
+
+	/**
+	 * Get the hide conditions of the block.
+	 */
+	public function get_hide_conditions(): array {
+		return $this->hide_conditions;
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockFormattedTemplateTrait.php
+++ b/plugins/woocommerce/src/Internal/Admin/BlockTemplates/BlockFormattedTemplateTrait.php
@@ -19,10 +19,29 @@ trait BlockFormattedTemplateTrait {
 				[
 					'_templateBlockId'    => $this->get_id(),
 					'_templateBlockOrder' => $this->get_order(),
-				]
+				],
+				! empty( $this->get_hide_conditions() ) ? [
+					'_templateBlockHideConditions' => $this->get_formatted_hide_conditions(),
+				] : []
 			),
 		];
 
 		return $arr;
+	}
+
+	/**
+	 * Get the block hide conditions formatted for inclusion in a formatted template.
+	 */
+	private function get_formatted_hide_conditions(): array {
+		$formatted_hide_conditions = array_map(
+			function( $hide_condition ) {
+				return [
+					'expression' => $hide_condition['expression'],
+				];
+			},
+			array_values( $this->get_hide_conditions() )
+		);
+
+		return $formatted_hide_conditions;
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/BlockTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/BlockTest.php
@@ -353,6 +353,9 @@ class BlockTest extends WC_Unit_Test_Case {
 		);
 	}
 
+	/**
+	 * Test that hide conditions can be passed in when creating a block.
+	 */
 	public function test_hide_conditions_in_constructor() {
 		$template = new BlockTemplate();
 
@@ -378,6 +381,9 @@ class BlockTest extends WC_Unit_Test_Case {
 		);
 	}
 
+	/**
+	 * Test that hide conditions can be added to a block.
+	 */
 	public function test_add_hide_condition() {
 		$template = new BlockTemplate();
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/BlockTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/BlockTemplates/BlockTest.php
@@ -353,6 +353,62 @@ class BlockTest extends WC_Unit_Test_Case {
 		);
 	}
 
+	public function test_hide_conditions_in_constructor() {
+		$template = new BlockTemplate();
+
+		$block = $template->add_block(
+			[
+				'blockName'      => 'test-block-name',
+				'hideConditions' => [
+					[
+						'expression' => 'foo === bar',
+					],
+				],
+			]
+		);
+
+		$this->assertSame(
+			[
+				'k0' => [
+					'expression' => 'foo === bar',
+				],
+			],
+			$block->get_hide_conditions(),
+			'Failed asserting that the hide conditions are set correctly in the constructor.'
+		);
+	}
+
+	public function test_add_hide_condition() {
+		$template = new BlockTemplate();
+
+		$block = $template->add_block(
+			[
+				'blockName' => 'test-block-name',
+			]
+		);
+
+		$condition_1_key = $block->add_hide_condition( 'editedProduct.manage_stock === true' );
+
+		$condition_2_key = $block->add_hide_condition( 'true' );
+
+		$condition_3_key = $block->add_hide_condition( 'foo > 10' );
+
+		$block->remove_hide_condition( $condition_2_key );
+
+		$this->assertSame(
+			[
+				$condition_1_key => [
+					'expression' => 'editedProduct.manage_stock === true',
+				],
+				$condition_3_key => [
+					'expression' => 'foo > 10',
+				],
+			],
+			$block->get_hide_conditions(),
+			'Failed asserting that the hide conditions are added correctly.'
+		);
+	}
+
 	/**
 	 * Test that getting the block as a formatted template is structured correctly.
 	 */
@@ -369,6 +425,8 @@ class BlockTest extends WC_Unit_Test_Case {
 				],
 			]
 		);
+
+		$block->add_hide_condition( 'foo === bar' );
 
 		$block->add_block(
 			[
@@ -394,10 +452,15 @@ class BlockTest extends WC_Unit_Test_Case {
 			[
 				'test-block-name',
 				[
-					'attr-1'              => 'value-1',
-					'attr-2'              => 'value-2',
-					'_templateBlockId'    => 'test-block-id',
-					'_templateBlockOrder' => 10,
+					'attr-1'                       => 'value-1',
+					'attr-2'                       => 'value-2',
+					'_templateBlockId'             => 'test-block-id',
+					'_templateBlockOrder'          => 10,
+					'_templateBlockHideConditions' => [
+						[
+							'expression' => 'foo === bar',
+						],
+					],
 				],
 				[
 					[


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR implements the following:
- Conditional visibility support for all blocks
- Server-side block attribute augmentation (see below for manual test that attributes exist)
- Change to how `woocommerce/conditional` block gets edited product for evaluation

Closes #40232.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

#### Automated unit tests (run locally or just verify they pass in GH on this PR):

1. PHP unit tests:

```
pnpm --filter=woocommerce env:test
pnpm test:unit:env --filter 'Automattic\\WooCommerce\\Tests\\Internal\\Admin\\BlockTemplates'
```

#### Manual testing:

1. Enable the **Product Block Editor** under **WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**.
2. Go to **Products** > **Add New**
3. Verify each block has the `data-template-block-id` and `data-template-block-order` DOM attributes. You can do this one of two ways:
    - The hard way: view the Elements tab of the browser developer tools and look for these DOM attributes
    - The easy way: Install the [WooCommerce Block Template Inspector plugin](https://github.com/woocommerce/woocommerce-block-template-inspector) and focus (click) on each field.
4. Check that the uses of the `woocommerce/conditional` block are correct (no functional regression/change). The "Inventory" tab makes use of this block:

<details>

<summary>
Screenshots of inventory tab
</summary>

Track stock quantity disabled:

<img width="1255" alt="Screenshot 2023-10-10 at 15 10 19" src="https://github.com/woocommerce/woocommerce/assets/2098816/69bfb276-53c3-486f-ab83-be200bc61425">

Track stock quantity enabled:
<img width="1255" alt="Screenshot 2023-10-10 at 15 10 39" src="https://github.com/woocommerce/woocommerce/assets/2098816/26818e00-88bf-490a-92ef-3b6022d327b3">

</details>

5. Put the following code in an mu-plugin:

<details>

<summary>
Conditional visibility example code
</summary>

```php
use Automattic\WooCommerce\Admin\BlockTemplates\BlockInterface;

if ( ! function_exists( 'example_hook_up_block_template_conditional_visibility_modifications' ) ) {
	/**
	 * Hook up the block template after hooks.
	 */
	function example_hook_up_block_template_conditional_visibility_modifications() {
		add_action(
			'woocommerce_block_template_after_add_block',
			'example_hide_all_fields'
		);

		add_action(
			'woocommerce_block_template_area_product-form_after_add_block_product-sale-price',
			'example_hide_sale_price'
		);

		add_action(
			'woocommerce_block_template_area_product-form_after_add_block_product-fee-and-dimensions-section',
			'example_hide_shipping_fields'
		);
	}
}

add_action( 'init', 'example_hook_up_block_template_conditional_visibility_modifications', 0 );

if ( ! function_exists( 'example_hide_all_fields' ) ) {
	/**
	 * Hide the summary field.
	 *
	 * @param BlockInterface $block The block.
	 */
	function example_hide_all_fields( BlockInterface $block ) {
		if ( ! method_exists( $block, 'add_hide_condition' ) ) {
			return;
		}

		if (
			( $block->get_id() === 'product-name' ) ||
			( $block->get_id() === 'basic-details' ) ||
			( $block->get_id() === 'general' ) ) {
			// Don't hide the name field (or it's containers)!
			return;
		}

		$block->add_hide_condition( 'editedProduct.name === "boo"' );
	}
}

if ( ! function_exists( 'example_hide_sale_price' ) ) {
	/**
	 * Hide the summary field.
	 *
	 * @param BlockInterface $sale_price_block The block.
	 */
	function example_hide_sale_price( BlockInterface $sale_price_block ) {
		if ( ! method_exists( $sale_price_block, 'add_hide_condition' ) ) {
			return;
		}

		$sale_price_block->add_hide_condition(
			'editedProduct.regular_price >= 13 && editedProduct.regular_price < 14'
		);
	}
}

if ( ! function_exists( 'example_hide_shipping_fields' ) ) {
	/**
	 * Hide the summary field.
	 *
	 * @param BlockInterface $shipping_section The block.
	 */
	function example_hide_shipping_fields( BlockInterface $shipping_section ) {
		if ( ! method_exists( $shipping_section, 'add_hide_condition' ) ) {
			return;
		}

		$shipping_section->add_hide_condition(
			'editedProduct.virtual === true'
		);
	}
}
```

</details>

6. Verify the following conditional visibility happens:
    - All blocks except for the product name field are hidden when the name equals "boo"
    - The sale price field is hidden if the regular price is between $13-13.99
    - The shipping fields are hidden if the toggle at the top of the shipping tab is not enabled (marking the product as virtual)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
