### PR TITLE
Return to new subscriptions page after action

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
@@ -19,7 +19,6 @@ import { getAdminSetting } from '../../../utils/admin-settings';
 import Discover from '../discover/discover';
 import Products from '../products/products';
 import SearchResults from '../search-results/search-results';
-import Themes from '../themes/themes';
 import MySubscriptions from '../my-subscriptions/my-subscriptions';
 import { MarketplaceContext } from '../../contexts/marketplace-context';
 

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.scss
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.scss
@@ -16,7 +16,6 @@
 		}
 
 		.woocommerce-marketplace__my-subscriptions__tooltip-external-link::after {
-			// stylelint-disable-next-line declaration-block-semicolon-newline-after
 			background: url(data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2024%2024%22%20width%3D%2224%22%20height%3D%2224%22%20aria-hidden%3D%22true%22%20focusable%3D%22false%22%3E%3Cpath%20d%3D%22M19.5%204.5h-7V6h4.44l-5.97%205.97%201.06%201.06L18%207.06v4.44h1.5v-7Zm-13%201a2%202%200%200%200-2%202v10a2%202%200%200%200%202%202h10a2%202%200%200%200%202-2v-3H17v3a.5.5%200%200%201-.5.5h-10a.5.5%200%200%201-.5-.5v-10a.5.5%200%200%201%20.5-.5h3V5.5h-3Z%22%20fill%3D%22%230073aa%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E);
 			background-position: 0 3px;
 			background-repeat: no-repeat;

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.scss
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.scss
@@ -16,6 +16,7 @@
 		}
 
 		.woocommerce-marketplace__my-subscriptions__tooltip-external-link::after {
+			// stylelint-disable-next-line declaration-block-semicolon-newline-after
 			background: url(data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2024%2024%22%20width%3D%2224%22%20height%3D%2224%22%20aria-hidden%3D%22true%22%20focusable%3D%22false%22%3E%3Cpath%20d%3D%22M19.5%204.5h-7V6h4.44l-5.97%205.97%201.06%201.06L18%207.06v4.44h1.5v-7Zm-13%201a2%202%200%200%200-2%202v10a2%202%200%200%200%202%202h10a2%202%200%200%200%202-2v-3H17v3a.5.5%200%200%201-.5.5h-10a.5.5%200%200%201-.5-.5v-10a.5.5%200%200%201%20.5-.5h3V5.5h-3Z%22%20fill%3D%22%230073aa%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E);
 			background-position: 0 3px;
 			background-repeat: no-repeat;

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.tsx
@@ -43,6 +43,7 @@ export default function MySubscriptions(): JSX.Element {
 			filter: 'all',
 			'wc-helper-refresh': 1,
 			'wc-helper-nonce': getAdminSetting( 'wc_helper_nonces' ).refresh,
+			'redirect-to-wc-admin': 1,
 		},
 		''
 	);

--- a/plugins/woocommerce/changelog/update-connect-redirect-to-new-subscriptions
+++ b/plugins/woocommerce/changelog/update-connect-redirect-to-new-subscriptions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+Comment: Redirect old subscriptions page to new page when action requests are made from the new page.
+

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-admin.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-admin.php
@@ -74,7 +74,7 @@ class WC_Helper_Admin {
 			$connect_url_args['wc-helper-nonce']   = wp_create_nonce( 'connect' );
 		}
 
-		if ( ! empty( $current_screen->id ) && 'woocommerce_page_wc-admin' === $current_screen->id ) {
+		if ( isset( $current_screen->id ) && 'woocommerce_page_wc-admin' === $current_screen->id ) {
 			$connect_url_args['redirect-to-wc-admin'] = 1;
 		}
 

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-admin.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-admin.php
@@ -58,28 +58,28 @@ class WC_Helper_Admin {
 	 * @return string
 	 */
 	public static function get_connection_url() {
-		// No active connection.
-		if ( ! WC_Helper::is_site_connected() ) {
-			$connect_url = add_query_arg(
-				array(
-					'page'              => 'wc-addons',
-					'section'           => 'helper',
-					'wc-helper-connect' => 1,
-					'wc-helper-nonce'   => wp_create_nonce( 'connect' ),
-				),
-				admin_url( 'admin.php' )
-			);
+		global $current_screen;
 
-			return $connect_url;
+		$connect_url_args = array(
+			'page'                 => 'wc-addons',
+			'section'              => 'helper',
+		);
+
+		// No active connection.
+		if ( WC_Helper::is_site_connected() ) {
+			$connect_url_args['wc-helper-disconnect'] = 1;
+			$connect_url_args['wc-helper-nonce']      = wp_create_nonce( 'disconnect' );
+		} else {
+			$connect_url_args['wc-helper-connect'] = 1;
+			$connect_url_args['wc-helper-nonce']   = wp_create_nonce( 'connect' );
+		}
+
+		if ( ! empty( $current_screen->id ) && 'woocommerce_page_wc-admin' === $current_screen->id ) {
+			$connect_url_args['redirect-to-wc-admin'] = 1;
 		}
 
 		$connect_url = add_query_arg(
-			array(
-				'page'                 => 'wc-addons',
-				'section'              => 'helper',
-				'wc-helper-disconnect' => 1,
-				'wc-helper-nonce'      => wp_create_nonce( 'disconnect' ),
-			),
+			$connect_url_args,
 			admin_url( 'admin.php' )
 		);
 

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-admin.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-admin.php
@@ -78,12 +78,10 @@ class WC_Helper_Admin {
 			$connect_url_args['redirect-to-wc-admin'] = 1;
 		}
 
-		$connect_url = add_query_arg(
+		return add_query_arg(
 			$connect_url_args,
 			admin_url( 'admin.php' )
 		);
-
-		return $connect_url;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-admin.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-admin.php
@@ -61,8 +61,8 @@ class WC_Helper_Admin {
 		global $current_screen;
 
 		$connect_url_args = array(
-			'page'                 => 'wc-addons',
-			'section'              => 'helper',
+			'page'    => 'wc-addons',
+			'section' => 'helper',
 		);
 
 		// No active connection.

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -114,7 +114,7 @@ class WC_Helper {
 		$woo_themes  = self::get_local_woo_themes();
 
 		$subscriptions_list_data   = self::get_subscription_list_data();
-		$subscriptions			   = array_filter(
+		$subscriptions             = array_filter(
 			$subscriptions_list_data,
 			function( $subscription ) {
 				return ! empty( $subscription['product_key'] );
@@ -683,10 +683,11 @@ class WC_Helper {
 
 	/**
 	 * Get helper redirect URL.
+	 * 
 	 * @param array $args Query args.
 	 * @return string
 	 */
-	private static function _get_helper_redirect_url( $args = array() ) {
+	private static function get_helper_redirect_url( $args = array() ) {
 		global $current_screen;
 		if ( isset( $_GET['redirect-to-wc-admin'] ) && $current_screen->id === 'woocommerce_page_wc-addons' ) {		
 			return add_query_arg(
@@ -698,7 +699,7 @@ class WC_Helper {
 				admin_url( 'admin.php' )
 			);
 		}
-		
+
 		return add_query_arg(
 			$args,
 			admin_url( 'admin.php' )
@@ -841,7 +842,7 @@ class WC_Helper {
 		}
 
 		wp_safe_redirect(
-			self::_get_helper_redirect_url(
+			self::get_helper_redirect_url(
 				array(
 					'page'             => 'wc-addons',
 					'section'          => 'helper',
@@ -866,7 +867,7 @@ class WC_Helper {
 		 */
 		do_action( 'woocommerce_helper_disconnected' );
 
-		$redirect_uri = self::_get_helper_redirect_url(
+		$redirect_uri = self::get_helper_redirect_url(
 			array(
 				'page'             => 'wc-addons',
 				'section'          => 'helper',
@@ -891,7 +892,7 @@ class WC_Helper {
 
 		self::refresh_helper_subscriptions();
 
-		$redirect_uri = self::_get_helper_redirect_url(
+		$redirect_uri = self::get_helper_redirect_url(
 			array(
 				'page'             => 'wc-addons',
 				'section'          => 'helper',

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -689,7 +689,7 @@ class WC_Helper {
 	 */
 	private static function get_helper_redirect_url( $args = array() ) {
 		global $current_screen;
-		if ( isset( $_GET['redirect-to-wc-admin'] ) && $current_screen->id === 'woocommerce_page_wc-addons' ) {		
+		if ( isset( $_GET['redirect-to-wc-admin'] ) && $current_screen->id === 'woocommerce_page_wc-addons' ) {
 			return add_query_arg(
 				array(
 					'page' => 'wc-admin',

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -683,7 +683,7 @@ class WC_Helper {
 
 	/**
 	 * Get helper redirect URL.
-	 * 
+	 *
 	 * @param array $args Query args.
 	 * @return string
 	 */

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -686,20 +686,21 @@ class WC_Helper {
 	 * @param array $args Query args.
 	 * @return string
 	 */
-	private static function _get_helper_redirect_url( $args ) {
+	private static function _get_helper_redirect_url( $args = array() ) {
 		global $current_screen;
-		if ( ! empty( $current_screen->id ) && 'woocommerce_page_wc-addons' === $current_screen->id ) {
+		if ( isset( $_GET['redirect-to-wc-admin'] ) && $current_screen->id === 'woocommerce_page_wc-addons' ) {		
 			return add_query_arg(
-				$args,
+				array(
+					'page' => 'wc-admin',
+					'tab'  => 'my-subscriptions',
+					'path' => urlencode( '/extensions' ),
+				),
 				admin_url( 'admin.php' )
 			);
 		}
+		
 		return add_query_arg(
-			array(
-				'page' => 'wc-admin',
-				'tab'  => 'my-subscriptions',
-				'path' => urlencode( '/extensions' ),
-			),
+			$args,
 			admin_url( 'admin.php' )
 		);
 	}
@@ -713,13 +714,20 @@ class WC_Helper {
 			wp_die( 'Could not verify nonce' );
 		}
 
-		$redirect_uri = self::_get_helper_redirect_url(
-			array(
-				'page'             => 'wc-addons',
-				'section'          => 'helper',
-				'wc-helper-return' => 1,
-				'wc-helper-nonce'  => wp_create_nonce( 'connect' ),
-			)
+		$redirect_url_args = array(
+			'page'             => 'wc-addons',
+			'section'          => 'helper',
+			'wc-helper-return' => 1,
+			'wc-helper-nonce'  => wp_create_nonce( 'connect' ),
+		);
+
+		if ( isset( $_GET['redirect-to-wc-admin'] ) ) {
+			$redirect_url_args['redirect-to-wc-admin'] = 1;
+		}
+
+		$redirect_uri = add_query_arg(
+			$redirect_url_args,
+			admin_url( 'admin.php' )
 		);
 
 		$request = WC_Helper_API::post(

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -682,6 +682,29 @@ class WC_Helper {
 	}
 
 	/**
+	 * Get helper redirect URL.
+	 * @param array $args Query args.
+	 * @return string
+	 */
+	private static function _get_helper_redirect_url( $args ) {
+		global $current_screen;
+		if ( ! empty( $current_screen->id ) && 'woocommerce_page_wc-addons' === $current_screen->id ) {
+			return add_query_arg(
+				$args,
+				admin_url( 'admin.php' )
+			);
+		}
+		return add_query_arg(
+			array(
+				'page' => 'wc-admin',
+				'tab'  => 'my-subscriptions',
+				'path' => urlencode( '/extensions' ),
+			),
+			admin_url( 'admin.php' )
+		);
+	}
+
+	/**
 	 * Initiate a new OAuth connection.
 	 */
 	private static function _helper_auth_connect() {
@@ -690,14 +713,13 @@ class WC_Helper {
 			wp_die( 'Could not verify nonce' );
 		}
 
-		$redirect_uri = add_query_arg(
+		$redirect_uri = self::_get_helper_redirect_url(
 			array(
 				'page'             => 'wc-addons',
 				'section'          => 'helper',
 				'wc-helper-return' => 1,
 				'wc-helper-nonce'  => wp_create_nonce( 'connect' ),
-			),
-			admin_url( 'admin.php' )
+			)
 		);
 
 		$request = WC_Helper_API::post(
@@ -811,13 +833,12 @@ class WC_Helper {
 		}
 
 		wp_safe_redirect(
-			add_query_arg(
+			self::_get_helper_redirect_url(
 				array(
 					'page'             => 'wc-addons',
 					'section'          => 'helper',
 					'wc-helper-status' => 'helper-connected',
-				),
-				admin_url( 'admin.php' )
+				)
 			)
 		);
 		die();
@@ -837,13 +858,12 @@ class WC_Helper {
 		 */
 		do_action( 'woocommerce_helper_disconnected' );
 
-		$redirect_uri = add_query_arg(
+		$redirect_uri = self::_get_helper_redirect_url(
 			array(
 				'page'             => 'wc-addons',
 				'section'          => 'helper',
 				'wc-helper-status' => 'helper-disconnected',
-			),
-			admin_url( 'admin.php' )
+			)
 		);
 
 		self::disconnect();
@@ -863,14 +883,13 @@ class WC_Helper {
 
 		self::refresh_helper_subscriptions();
 
-		$redirect_uri = add_query_arg(
+		$redirect_uri = self::_get_helper_redirect_url(
 			array(
 				'page'             => 'wc-addons',
 				'section'          => 'helper',
 				'filter'           => self::get_current_filter(),
 				'wc-helper-status' => 'helper-refreshed',
-			),
-			admin_url( 'admin.php' )
+			)
 		);
 
 		wp_safe_redirect( $redirect_uri );

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -695,7 +695,7 @@ class WC_Helper {
 				array(
 					'page' => 'wc-admin',
 					'tab'  => 'my-subscriptions',
-					'path' => urlencode( '/extensions' ),
+					'path' => rawurlencode( '/extensions' ),
 				),
 				admin_url( 'admin.php' )
 			);

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -685,6 +685,7 @@ class WC_Helper {
 	 * Get helper redirect URL.
 	 *
 	 * @param array $args Query args.
+	 * @param bool  $redirect_to_wc_admin Whether to redirect to WC Admin.
 	 * @return string
 	 */
 	private static function get_helper_redirect_url( $args = array(), $redirect_to_wc_admin = false ) {

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper.php
@@ -687,9 +687,9 @@ class WC_Helper {
 	 * @param array $args Query args.
 	 * @return string
 	 */
-	private static function get_helper_redirect_url( $args = array() ) {
+	private static function get_helper_redirect_url( $args = array(), $redirect_to_wc_admin = false ) {
 		global $current_screen;
-		if ( isset( $_GET['redirect-to-wc-admin'] ) && $current_screen->id === 'woocommerce_page_wc-addons' ) {
+		if ( true === $redirect_to_wc_admin && 'woocommerce_page_wc-addons' === $current_screen->id ) {
 			return add_query_arg(
 				array(
 					'page' => 'wc-admin',
@@ -847,7 +847,8 @@ class WC_Helper {
 					'page'             => 'wc-addons',
 					'section'          => 'helper',
 					'wc-helper-status' => 'helper-connected',
-				)
+				),
+				isset( $_GET['redirect-to-wc-admin'] )
 			)
 		);
 		die();
@@ -872,7 +873,8 @@ class WC_Helper {
 				'page'             => 'wc-addons',
 				'section'          => 'helper',
 				'wc-helper-status' => 'helper-disconnected',
-			)
+			),
+			isset( $_GET['redirect-to-wc-admin'] )
 		);
 
 		self::disconnect();
@@ -898,7 +900,8 @@ class WC_Helper {
 				'section'          => 'helper',
 				'filter'           => self::get_current_filter(),
 				'wc-helper-status' => 'helper-refreshed',
-			)
+			),
+			isset( $_GET['redirect-to-wc-admin'] )
 		);
 
 		wp_safe_redirect( $redirect_uri );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Redirect old subscriptions page to new page when action requests are made from the new page.
This will ensure connect, disconnect, and refresh work from both pages.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Open the [new subscriptions page](http://localhost:8086/wp-admin/admin.php?page=wc-admin&tab=my-subscriptions&path=%2Fextensions)
2. Test connecting, disconnecting, and refreshing
3. All should work and return to the new subscriptions page
4. Open the [old subscriptions page](http://localhost:8086/wp-admin/admin.php?page=wc-addons&section=helper)
5. Test connecting, disconnecting, and refreshing
6. All should work and return to the old subscriptions page

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

Redirect old subscriptions page to new page when action requests are made from the new page.

</details>
