### PR TITLE
Add wca test tool to reset Customize Your Store task

### DIFF
--- a/plugins/woocommerce-beta-tester/api/api.php
+++ b/plugins/woocommerce-beta-tester/api/api.php
@@ -52,6 +52,7 @@ require 'options/rest-api.php';
 require 'tools/delete-all-products.php';
 require 'tools/disable-wc-email.php';
 require 'tools/trigger-update-callbacks.php';
+require 'tools/reset-cys.php';
 require 'tracks/class-tracks-debug-log.php';
 require 'features/features.php';
 require 'rest-api-filters/class-wca-test-helper-rest-api-filters.php';

--- a/plugins/woocommerce-beta-tester/api/tools/reset-cys.php
+++ b/plugins/woocommerce-beta-tester/api/tools/reset-cys.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Reset CYS API initialization for beta testing.
+ *
+ * @package WC_Beta_Tester
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+register_woocommerce_admin_test_helper_rest_route(
+	'/tools/reset-cys',
+	'tools_reset_cys'
+);
+
+/**
+ * A tool to delete all products.
+ */
+function tools_reset_cys() {
+	global $wpdb;
+
+	// Reset the home template.
+	$current_theme = wp_get_theme();
+	$template      = get_block_file_template( $current_theme->template . '//home', 'wp_template' );
+	if ( $template->id ) {
+		wp_delete_post( $template->wp_id, true );
+	}
+
+	// Reset the custom styles.
+	$stylesheet = get_stylesheet();
+	$user_data  = WP_Theme_JSON_Resolver::get_user_data_from_wp_global_styles( $stylesheet );
+	// wp_update_post(
+	// array(
+	// 'styles'   => array(),
+	// 'settings' => array(),
+	// ),
+	// true,
+	// false
+	// );
+
+	$wpdb->delete(
+		$wpdb->prefix . 'posts',
+		array(
+			'post_type'  => 'revision',
+			'post_title' => 'Custom Styles',
+		),
+		array( '%s', '%s' )
+	);
+
+	return true;
+}

--- a/plugins/woocommerce-beta-tester/api/tools/reset-cys.php
+++ b/plugins/woocommerce-beta-tester/api/tools/reset-cys.php
@@ -20,7 +20,7 @@ function tools_reset_cys() {
 
 	// Reset the home template.
 	$current_theme = wp_get_theme();
-	$template      = get_block_file_template( $current_theme->template . '//home', 'wp_template' );
+	$template      = get_block_template( $current_theme->template . '//home', 'wp_template' );
 	if ( $template->id ) {
 		wp_delete_post( $template->wp_id, true );
 	}

--- a/plugins/woocommerce-beta-tester/api/tools/reset-cys.php
+++ b/plugins/woocommerce-beta-tester/api/tools/reset-cys.php
@@ -26,16 +26,14 @@ function tools_reset_cys() {
 	}
 
 	// Reset the custom styles.
-	$stylesheet = get_stylesheet();
-	$user_data  = WP_Theme_JSON_Resolver::get_user_data_from_wp_global_styles( $stylesheet );
-	// wp_update_post(
-	// array(
-	// 'styles'   => array(),
-	// 'settings' => array(),
-	// ),
-	// true,
-	// false
-	// );
+	$wpdb->delete(
+		$wpdb->prefix . 'posts',
+		array(
+			'post_type'  => 'wp_global_styles',
+			'post_title' => 'Custom Styles',
+		),
+		array( '%s', '%s' )
+	);
 
 	$wpdb->delete(
 		$wpdb->prefix . 'posts',

--- a/plugins/woocommerce-beta-tester/changelog/add-reset-cys-tool
+++ b/plugins/woocommerce-beta-tester/changelog/add-reset-cys-tool
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add rest customize your store tool

--- a/plugins/woocommerce-beta-tester/src/tools/commands/index.js
+++ b/plugins/woocommerce-beta-tester/src/tools/commands/index.js
@@ -64,4 +64,9 @@ export default [
 		description: <TriggerUpdateCallbacks />,
 		action: TRIGGER_UPDATE_CALLBACKS_ACTION_NAME,
 	},
+	{
+		command: 'Reset Customize Your Store',
+		description: 'Resets Customize Your Store changes.',
+		action: 'resetCustomizeYourStore',
+	},
 ];

--- a/plugins/woocommerce-beta-tester/src/tools/data/actions.js
+++ b/plugins/woocommerce-beta-tester/src/tools/data/actions.js
@@ -210,3 +210,22 @@ export function* runDisableEmail() {
 		yield setIsEmailDisabled( response );
 	} );
 }
+
+export function* resetCustomizeYourStore() {
+	yield runCommand( 'Reset Customize Your Store', function* () {
+		const optionsToDelete = [
+			'woocommerce_customize_store_onboarding_tour_hidden',
+			'woocommerce_admin_customize_store_completed',
+			'wc_blocks_patterns_content',
+		];
+		yield apiFetch( {
+			method: 'DELETE',
+			path: `${ API_NAMESPACE }/options/${ optionsToDelete.join( ',' ) }`,
+		} );
+
+		yield apiFetch( {
+			path: API_NAMESPACE + '/tools/reset-cys',
+			method: 'POST',
+		} );
+	} );
+}

--- a/plugins/woocommerce-beta-tester/src/tools/data/actions.js
+++ b/plugins/woocommerce-beta-tester/src/tools/data/actions.js
@@ -216,6 +216,7 @@ export function* resetCustomizeYourStore() {
 		const optionsToDelete = [
 			'woocommerce_customize_store_onboarding_tour_hidden',
 			'woocommerce_admin_customize_store_completed',
+			'woocommerce_admin_customize_store_completed_theme_id',
 			'wc_blocks_patterns_content',
 		];
 		yield apiFetch( {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/40723.

This PR adds a new tool to `WooCommerce Admin Test Helper` to reset Customize Your Store task 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


1. Create a new WooCommerce installation with this version.
2. Install this [woocommerce-beta-tester.zip](https://github.com/woocommerce/woocommerce/files/12880348/woocommerce-beta-tester.zip)
3. Make sure to enable `customize-store` feature flag
4. Install and activate [WooCommerce Blocks nightly build](https://github.com/woocommerce/woocommerce-blocks/releases/tag/nightly) 
5. Go to `WooCommerce -> Home` and click `Customize Store` task
6. Complete the AI wizard and assembler hub flow
7. Go to `WooCommerce -> Home`
8. Confirm the `Customize Store` task is completed
9. Go to `Customize Store` task
10. Click on `Design with AI`
11. Observe that `Are you sure you want to start a new design?` modal is shown.
12. Go to /wp-admin/tools.php?page=woocommerce-admin-test-helper
13. Click on "tools"
14. Click on Reset Customize Your Store > "Run" button
15. Go to `WooCommerce -> Home`
16. Confirm the `Customize Store` task is active task
17. Go to `Customize Store` task
18. Click on `Design with AI`
19.  `Are you sure you want to start a new design?` modal is NOT shown.
20. Go to /wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store%2Fassembler-hub
21. Observe that the onboarding tour is displayed and the preview frame shows a default theme home page.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
