### PR TITLE
Prevent global attribute terms from being automatically selected

### DIFF
--- a/plugins/woocommerce/changelog/issue-40712
+++ b/plugins/woocommerce/changelog/issue-40712
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent global attribute terms from being automatically selected

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -522,15 +522,6 @@ jQuery( function ( $ ) {
 		$attributeListItem.find( 'h3' ).trigger( 'click' );
 	}
 
-	function toggle_selection_of_attribute_list_item_terms( $attributeListItem ) {
-
-		var $attributeListItemSelectAllButton = $attributeListItem.find( 'button.select_all_attributes' );
-
-		if ( $attributeListItemSelectAllButton.length ) {
-			$attributeListItemSelectAllButton.trigger( 'click' );
-		}
-	}
-
 	function add_placeholder_to_attribute_values_field( $attributeListItem ) {
 
 		var $used_for_variations_checkbox = $attributeListItem.find( 'input.woocommerce_attribute_used_for_variations' );
@@ -574,9 +565,6 @@ jQuery( function ( $ ) {
 			update_attribute_row_indexes();
 
 			toggle_expansion_of_attribute_list_item( $attributeListItem );
-
-			// Automatically pre-select all terms when a global Attribute is chosen.
-			toggle_selection_of_attribute_list_item_terms( $attributeListItem );
 
 			// Conditionally change the placeholder of product-level Attributes depending on the value of the "Use for variations" checkbox.
 			if ( 'undefined' === typeof globalAttributeId ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR rolls back the feature that automatically selected all global attribute terms when adding a global attribute to a product.

Closes #40712 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a global Attribute with some terms, under the Products > Attributes tab.
2. Create a Simple Product.
3. Navigate to the Product Data > Attributes tab.
4. Select the global Attribute you previously created.
5. Ensure that none of the Attribute terms are automatically selected.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Prevent global attribute terms from being automatically selected
#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
