### PR TITLE
Hide "Preview" icon when order is locked

### DIFF
--- a/plugins/woocommerce/changelog/fix-40510
+++ b/plugins/woocommerce/changelog/fix-40510
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Hide "Preview" icon to other users when order is locked for edits.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -2870,6 +2870,10 @@ ul.wc_coupon_list_block {
 			}
 		}
 
+		.wp-locked .order-preview {
+			visibility: hidden;
+		}
+
 		.order-preview.disabled {
 			&::before {
 				content: "";


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
When an order is currently being edited by a user, other users will see it as locked in the list table:

<img width="498" alt="Screenshot 2023-10-12 at 12 58 33" src="https://github.com/woocommerce/woocommerce/assets/184724/d0166cc7-41ec-4634-8c52-15cfec30656d">

Still, the "Preview" icon will remain visible, which means users could click on it and see possibly outdated/incorrect information about the order (as it's being edited somewhere else).

<img width="553" alt="Screenshot 2023-10-12 at 12 59 38" src="https://github.com/woocommerce/woocommerce/assets/184724/97e64fa1-70c5-4ee9-b444-3c47e764422f">

For consistency, it'd be best not to display the icon while the order is locked.

Closes #40510.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure the HPOS datastore is enabled in WC > Settings > Advanced > Features.
2. Make sure you have at least 2 users on the test site with permission to edit orders (admins will do). Let's say, those users are **admin1** and **admin2**.
3. Make sure the legacy assets have been built (`pnpm --filter=woocommerce/client/legacy run build`)
4. As **admin1**, go to WC > Orders and create a new order. Do not navigate away from the order edit screen.
5. Open a new incognito window and:
   1. Log in as **admin2**.
   2. Go to WC > Orders.
   3. Confirm that a lock icon appears next to the order created in step 4.
   4. Confirm that the preview icon is not visible next to this order.
   5. Do not close this window just yet.
6. As **admin1**, navigate away from the order edit screen from step 4 or close the browser window.
7. Back in the window for **admin2**:
   1. Wait for a little while until the WP heartbeat is processed and the lock from the other user is released (which should happen in about 3 mins). There's no need to refresh the page.
   2. After a while, the lock icon should disappear and the preview icon should be back.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
