### PR TITLE
Add woocommerce_widget_layered_nav_term_anchor_text filter

### DIFF
--- a/plugins/woocommerce/changelog/40734-patch-2
+++ b/plugins/woocommerce/changelog/40734-patch-2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a filter to allow modifying the attribute term name in the Active Product Filters widget.

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-layered-nav-filters.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-layered-nav-filters.php
@@ -94,7 +94,7 @@ class WC_Widget_Layered_Nav_Filters extends WC_Widget {
 						 * @param WP_Term $term The term object.
 						 * @param string $taxonomy The taxonomy name.
 						 *
-						 * @since 8.7.0
+						 * @since 8.8.0
 						 */
 						$anchor_text = apply_filters( 'woocommerce_widget_layered_nav_term_anchor_text', $term->name, $term, $taxonomy);
 						echo '<li class="' . esc_attr( implode( ' ', $filter_classes ) ) . '"><a rel="nofollow" aria-label="' . esc_attr__( 'Remove filter', 'woocommerce' ) . '" href="' . esc_url( $link ) . '">' . esc_html( $anchor_text ) . '</a></li>';

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-layered-nav-filters.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-layered-nav-filters.php
@@ -87,7 +87,16 @@ class WC_Widget_Layered_Nav_Filters extends WC_Widget {
 						}
 
 						$filter_classes = array( 'chosen', 'chosen-' . sanitize_html_class( str_replace( 'pa_', '', $taxonomy ) ), 'chosen-' . sanitize_html_class( str_replace( 'pa_', '', $taxonomy ) . '-' . $term_slug ) );
-						$anchor_text = apply_filters( 'woocommerce_widget_layered_nav_term_anchor_text', esc_html( $term->name ), $term, $taxonomy);
+						/**
+						 * Allows the attribute term name to be modified before being output.
+						 *
+						 * @param string $term_name The name of the term.
+						 * @param WP_Term $term The term object.
+						 * @param string $taxonomy The taxonomy name.
+						 *
+						 * @since 8.7.0
+						 */
+						$anchor_text = apply_filters( 'woocommerce_widget_layered_nav_term_anchor_text', $term->name, $term, $taxonomy);
 						echo '<li class="' . esc_attr( implode( ' ', $filter_classes ) ) . '"><a rel="nofollow" aria-label="' . esc_attr__( 'Remove filter', 'woocommerce' ) . '" href="' . esc_url( $link ) . '">' . $anchor_text . '</a></li>';
 					}
 				}

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-layered-nav-filters.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-layered-nav-filters.php
@@ -96,7 +96,7 @@ class WC_Widget_Layered_Nav_Filters extends WC_Widget {
 						 *
 						 * @since 8.8.0
 						 */
-						$anchor_text = apply_filters( 'woocommerce_widget_layered_nav_term_anchor_text', $term->name, $term, $taxonomy);
+						$anchor_text = apply_filters( 'woocommerce_widget_layered_nav_term_anchor_text', $term->name, $term, $taxonomy );
 						echo '<li class="' . esc_attr( implode( ' ', $filter_classes ) ) . '"><a rel="nofollow" aria-label="' . esc_attr__( 'Remove filter', 'woocommerce' ) . '" href="' . esc_url( $link ) . '">' . esc_html( $anchor_text ) . '</a></li>';
 					}
 				}

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-layered-nav-filters.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-layered-nav-filters.php
@@ -97,7 +97,7 @@ class WC_Widget_Layered_Nav_Filters extends WC_Widget {
 						 * @since 8.7.0
 						 */
 						$anchor_text = apply_filters( 'woocommerce_widget_layered_nav_term_anchor_text', $term->name, $term, $taxonomy);
-						echo '<li class="' . esc_attr( implode( ' ', $filter_classes ) ) . '"><a rel="nofollow" aria-label="' . esc_attr__( 'Remove filter', 'woocommerce' ) . '" href="' . esc_url( $link ) . '">' . $anchor_text . '</a></li>';
+						echo '<li class="' . esc_attr( implode( ' ', $filter_classes ) ) . '"><a rel="nofollow" aria-label="' . esc_attr__( 'Remove filter', 'woocommerce' ) . '" href="' . esc_url( $link ) . '">' . esc_html( $anchor_text ) . '</a></li>';
 					}
 				}
 			}

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-layered-nav-filters.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-layered-nav-filters.php
@@ -87,8 +87,8 @@ class WC_Widget_Layered_Nav_Filters extends WC_Widget {
 						}
 
 						$filter_classes = array( 'chosen', 'chosen-' . sanitize_html_class( str_replace( 'pa_', '', $taxonomy ) ), 'chosen-' . sanitize_html_class( str_replace( 'pa_', '', $taxonomy ) . '-' . $term_slug ) );
-
-						echo '<li class="' . esc_attr( implode( ' ', $filter_classes ) ) . '"><a rel="nofollow" aria-label="' . esc_attr__( 'Remove filter', 'woocommerce' ) . '" href="' . esc_url( $link ) . '">' . esc_html( $term->name ) . '</a></li>';
+						$anchor_text = apply_filters( 'woocommerce_widget_layered_nav_term_anchor_text', esc_html( $term->name ), $term, $taxonomy);
+						echo '<li class="' . esc_attr( implode( ' ', $filter_classes ) ) . '"><a rel="nofollow" aria-label="' . esc_attr__( 'Remove filter', 'woocommerce' ) . '" href="' . esc_url( $link ) . '">' . $anchor_text . '</a></li>';
 					}
 				}
 			}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Allow developers to change the anchor text of active filters. Often, one would add the taxonomy (`Brand: Adidas`).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Add this code snippet to your test site. This will make it so you can still add legacy widgets that have a modern block equivalent.

```php
use Automattic\WooCommerce\Blocks\{ BlockTypesController, Package };

add_action(
	'widgets_init',
	function() {
		remove_filter(
			'widget_types_to_hide_from_legacy_widget_block',
			array(
				Package::container()->get( BlockTypesController::class ),
				'hide_legacy_widgets_with_block_equivalent'
			)
		);
	}
);
```

2. Switch to a theme that is not block enabled, like Storefront or Twenty Nineteen.
3. Go to Appearance > Widgets. Add a Filter by Attribute widget with a given attribute.
4. Add a Legacy Widget and select "Active Product Filters" from the dropdown.
5. Add this second code snippet to your test site:

```php
add_filter(
	'woocommerce_widget_layered_nav_term_anchor_text',
	function ( $name ) {
		return $name . ' (changed)';
	},
	10
);
```
6. Go to the Shop page on the front end and filter on any attribute.
7. See that " (changed)" is added to items in the Active Product Filters widget.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add a filter to allow modifying the attribute term name in the Active Product Filters widget.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
