### PR TITLE
Fix cys ai font choosing state

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/state-machine.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/state-machine.tsx
@@ -320,8 +320,16 @@ export const designWithAiStateMachineDefinition = createMachine(
 								},
 							},
 							chooseFontPairing: {
-								entry: [ 'assignFontPairing' ],
-								type: 'final',
+								initial: 'pending',
+								states: {
+									pending: {
+										entry: [ 'assignFontPairing' ],
+										always: {
+											target: 'success',
+										},
+									},
+									success: { type: 'final' },
+								},
 							},
 							updateStorePatterns: {
 								initial: 'pending',

--- a/plugins/woocommerce/changelog/fix-cys-ai-state-machine
+++ b/plugins/woocommerce/changelog/fix-cys-ai-state-machine
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix chooseFontPairing state


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Not sure why we didn’t encounter this issue in the previous PR, but it seems that the change in https://github.com/woocommerce/woocommerce/pull/40696 caused the AI loader to not display properly.

This PR just fixes the issue.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new WooCommerce installation with this version.
2. Make sure to enable `customize-store` feature flag
3. Install and activate [WooCommerce Blocks nightly build](https://github.com/woocommerce/woocommerce-blocks/releases/tag/nightly) 
4. Go to `WooCommerce -> Home` and click `Customize Store` task
5. Click `Design with AI` button
6. Follow through the flow all the way till the assembler hub shows up
7. Confirm the AI loader screen is shown

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
