### PR TITLE
Adding product image count to tracks events

### DIFF
--- a/plugins/woo-ai/changelog/add-background-removal-add-image-count-40743
+++ b/plugins/woo-ai/changelog/add-background-removal-add-image-count-40743
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Adding number of images to tracks events for background removal.

--- a/plugins/woo-ai/src/image-background-removal/background-removal-link.tsx
+++ b/plugins/woo-ai/src/image-background-removal/background-removal-link.tsx
@@ -12,7 +12,7 @@ import { Notice } from '@wordpress/components';
 import MagicIcon from '../../assets/images/icons/magic.svg';
 import { FILENAME_APPEND } from './constants';
 import { useFeedbackSnackbar } from '../hooks';
-import { recordTracksFactory, getPostId } from '../utils';
+import { recordTracksFactory, getPostId, getProductImageCount } from '../utils';
 import {
 	uploadImageToLibrary,
 	getCurrentAttachmentDetails,
@@ -35,6 +35,7 @@ const recordBgRemovalTracks = recordTracksFactory(
 	'background_removal',
 	() => ( {
 		post_id: getPostId(),
+		image_count: getProductImageCount().total,
 	} )
 );
 

--- a/plugins/woo-ai/src/utils/productData.ts
+++ b/plugins/woo-ai/src/utils/productData.ts
@@ -125,3 +125,19 @@ export const isProductVirtual = () =>
 
 export const isProductDownloadable = () =>
 	( document.querySelector( '#_downloadable' ) as HTMLInputElement )?.checked;
+
+export const getProductImageCount = () => {
+	const gallery = document.querySelectorAll(
+		'.product_images li.image'
+	).length;
+
+	const featured = document.querySelectorAll(
+		'#set-post-thumbnail img'
+	).length;
+
+	return {
+		gallery,
+		featured,
+		total: gallery + featured,
+	};
+};


### PR DESCRIPTION
* Add hook for AI Image Background Removal API requests.### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Pedro requested that we include the number of images that have been added to a product in tracks events for this feature.

Closes #40743

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout branch.
2. Go to products -> add new.
3. Run `localStorage.setItem( 'debug', '*tracks*' );` in your console.
4. Click on the featured image link to open the modal, and click the "Remove background" link for an image. 
5. Look at the resulting tracks events in the console and ensure that it reports the correct number of images.
6. Add or subtract images from your product, repeat steps 4-5.
