### PR TITLE
Variation switching when deleting

### DIFF
--- a/packages/js/product-editor/changelog/update-40591_validation
+++ b/packages/js/product-editor/changelog/update-40591_validation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add unregister function to the validation provider and trigger this from the useValidation hook.

--- a/packages/js/product-editor/changelog/update-40591_variation_switching_when_deleting
+++ b/packages/js/product-editor/changelog/update-40591_variation_switching_when_deleting
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add useVariationSwitcher hook and make use of it in the VariationSwitcherFooter.

--- a/packages/js/product-editor/src/contexts/validation-context/types.ts
+++ b/packages/js/product-editor/src/contexts/validation-context/types.ts
@@ -11,6 +11,7 @@ export type ValidationContextProps< T > = {
 		validatorId: string,
 		validator: Validator< T >
 	): React.Ref< HTMLElement >;
+	unRegisterValidator( validatorId: string ): void;
 	validateField( name: string ): ValidatorResponse;
 	validateAll( newData?: Partial< T > ): Promise< ValidationErrors >;
 };

--- a/packages/js/product-editor/src/contexts/validation-context/use-validation.ts
+++ b/packages/js/product-editor/src/contexts/validation-context/use-validation.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useContext, useMemo, useState } from '@wordpress/element';
+import { useContext, useMemo, useState, useEffect } from '@wordpress/element';
 import { DependencyList } from 'react';
 
 /**
@@ -22,6 +22,12 @@ export function useValidation< T >(
 		() => context.registerValidator( validatorId, validator ),
 		[ validatorId, ...deps ]
 	);
+
+	useEffect( () => {
+		return () => {
+			context.unRegisterValidator( validatorId );
+		};
+	}, [] );
 
 	return {
 		ref,

--- a/packages/js/product-editor/src/contexts/validation-context/validation-context.ts
+++ b/packages/js/product-editor/src/contexts/validation-context/validation-context.ts
@@ -13,6 +13,7 @@ export const ValidationContext = createContext< ValidationContextProps< any > >(
 	{
 		errors: {},
 		registerValidator: () => () => {},
+		unRegisterValidator: () => () => {},
 		validateField: () => Promise.resolve( undefined ),
 		validateAll: () => Promise.resolve( {} ),
 	}

--- a/packages/js/product-editor/src/contexts/validation-context/validation-provider.tsx
+++ b/packages/js/product-editor/src/contexts/validation-context/validation-provider.tsx
@@ -38,6 +38,15 @@ export function ValidationProvider< T >( {
 		};
 	}
 
+	function unRegisterValidator( validatorId: string ): void {
+		if ( validatorsRef.current[ validatorId ] ) {
+			delete validatorsRef.current[ validatorId ];
+		}
+		if ( fieldRefs.current[ validatorId ] ) {
+			delete fieldRefs.current[ validatorId ];
+		}
+	}
+
 	async function validateField(
 		validatorId: string,
 		newData?: Partial< T >
@@ -89,6 +98,7 @@ export function ValidationProvider< T >( {
 			value={ {
 				errors,
 				registerValidator,
+				unRegisterValidator,
 				validateField,
 				validateAll,
 			} }

--- a/packages/js/product-editor/src/hooks/index.ts
+++ b/packages/js/product-editor/src/hooks/index.ts
@@ -2,3 +2,4 @@ export { useProductHelper as __experimentalUseProductHelper } from './use-produc
 export { useFeedbackBar as __experimentalUseFeedbackBar } from './use-feedback-bar';
 export { useVariationsOrder as __experimentalUseVariationsOrder } from './use-variations-order';
 export { useCurrencyInputProps as __experimentalUseCurrencyInputProps } from './use-currency-input-props';
+export { useVariationSwitcher as __experimentalUseVariationSwitcher } from './use-variation-switcher';

--- a/packages/js/product-editor/src/hooks/use-variation-switcher.ts
+++ b/packages/js/product-editor/src/hooks/use-variation-switcher.ts
@@ -1,0 +1,101 @@
+/**
+ * External dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+import { Product } from '@woocommerce/data';
+import { getNewPath, navigateTo } from '@woocommerce/navigation';
+
+type VariationSwitcherProps = {
+	parentProductType?: string;
+	variationId?: number;
+	parentId?: number;
+};
+
+export function useVariationSwitcher( {
+	variationId,
+	parentId,
+	parentProductType,
+}: VariationSwitcherProps ) {
+	const { invalidateResolution } = useDispatch( 'core' );
+	const variationValues = useSelect(
+		( select ) => {
+			if ( parentId === undefined ) {
+				return {};
+			}
+			const { getEntityRecord } = select( 'core' );
+			const parentProduct = getEntityRecord< Product >(
+				'postType',
+				parentProductType || 'product',
+				parentId
+			);
+			if (
+				variationId !== undefined &&
+				parentProduct &&
+				parentProduct.variations
+			) {
+				const activeVariationIndex =
+					parentProduct.variations.indexOf( variationId );
+				const previousVariationIndex =
+					activeVariationIndex > 0
+						? activeVariationIndex - 1
+						: parentProduct.variations.length - 1;
+				const nextVariationIndex =
+					activeVariationIndex !== parentProduct.variations.length - 1
+						? activeVariationIndex + 1
+						: 0;
+
+				return {
+					activeVariationIndex,
+					nextVariationIndex,
+					previousVariationIndex,
+					numberOfVariations: parentProduct.variations.length,
+					previousVariationId:
+						parentProduct.variations[ previousVariationIndex ],
+					nextVariationId:
+						parentProduct.variations[ nextVariationIndex ],
+				};
+			}
+			return {};
+		},
+		[ variationId, parentId ]
+	);
+
+	function invalidateVariationList() {
+		invalidateResolution( 'getEntityRecord', [
+			'postType',
+			parentProductType || 'product',
+			parentId,
+		] );
+	}
+
+	function goToNextVariation() {
+		if ( variationValues.nextVariationId === undefined ) {
+			return false;
+		}
+		navigateTo( {
+			url: getNewPath(
+				{},
+				`/product/${ parentId }/variation/${ variationValues.nextVariationId }`
+			),
+		} );
+	}
+
+	function goToPreviousVariation() {
+		if ( variationValues.previousVariationId === undefined ) {
+			return false;
+		}
+		navigateTo( {
+			url: getNewPath(
+				{},
+				`/product/${ parentId }/variation/${ variationValues.previousVariationId }`
+			),
+		} );
+	}
+
+	return {
+		...variationValues,
+		invalidateVariationList,
+		goToNextVariation,
+		goToPreviousVariation,
+	};
+}

--- a/packages/js/product-editor/src/utils/get-product-error-message.ts
+++ b/packages/js/product-editor/src/utils/get-product-error-message.ts
@@ -19,7 +19,6 @@ export type WPError = {
 };
 
 export function getProductErrorMessage( error: WPError ) {
-	console.log( error );
 	switch ( error.code ) {
 		case 'variable_product_no_variation_prices':
 			return error.message;

--- a/packages/js/product-editor/src/utils/get-product-error-message.ts
+++ b/packages/js/product-editor/src/utils/get-product-error-message.ts
@@ -19,6 +19,7 @@ export type WPError = {
 };
 
 export function getProductErrorMessage( error: WPError ) {
+	console.log( error );
 	switch ( error.code ) {
 		case 'variable_product_no_variation_prices':
 			return error.message;

--- a/plugins/woocommerce-admin/client/products/fills/more-menu-items/delete-variation-menu-item.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/more-menu-items/delete-variation-menu-item.tsx
@@ -11,7 +11,10 @@ import {
 	ProductVariation,
 } from '@woocommerce/data';
 import { getNewPath, navigateTo } from '@woocommerce/navigation';
-import { RemoveConfirmationModal } from '@woocommerce/product-editor';
+import {
+	RemoveConfirmationModal,
+	__experimentalUseVariationSwitcher as useVariationSwitcher,
+} from '@woocommerce/product-editor';
 import { recordEvent } from '@woocommerce/tracks';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore No types for this exist yet.
@@ -28,6 +31,12 @@ export const DeleteVariationMenuItem = ( {
 	const { productId } = useParams();
 
 	const variationId = useEntityId( 'postType', 'product_variation' );
+
+	const { invalidateVariationList, goToNextVariation, numberOfVariations } =
+		useVariationSwitcher( {
+			parentId: productId ? parseInt( productId, 10 ) : undefined,
+			variationId,
+		} );
 
 	const [ name ] = useEntityProp< string >(
 		'postType',
@@ -82,9 +91,14 @@ export const DeleteVariationMenuItem = ( {
 				setShowModal( false );
 				onClose();
 
-				navigateTo( {
-					url: getNewPath( {}, `/product/${ productId }` ),
-				} );
+				invalidateVariationList();
+				if ( numberOfVariations && numberOfVariations > 1 ) {
+					goToNextVariation();
+				} else {
+					navigateTo( {
+						url: getNewPath( {}, `/product/${ productId }` ),
+					} );
+				}
 			} )
 			.catch( () => {
 				createErrorNotice(

--- a/plugins/woocommerce/changelog/update-40591_variation_switching_when_deleting
+++ b/plugins/woocommerce/changelog/update-40591_variation_switching_when_deleting
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Redirect to next variation if deleting a variation on the edit variation page.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR addresses two things:
- Redirects the user to the next variation if deleting one on the variation edit screen (previously it redirected to the parent ).
- Adds an unregister function to the validation provider, so validations don't stick around across multiple variations.

Closes #40591  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure feature `product-variation-management` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper` (WooCommerce Beta Tester plugin) is required
3. Go to `/wp-admin/admin.php?page=wc-admin&path=/add-product&tab=variations` and add some attributes (at-least more then 1 )
4. Wait until variations get generated
5. Then publish the product and save its `productId` and one `variationId` you like
6. Then go to `/wp-admin/admin.php?page=wc-admin&path=/product/{productId}/variation/{variationId}&tab=general` (replace the `{productId}` and `{variationId}` with the values picked in point 5)
7. Now click the 3 dot menu and click **Delete variation** and take note of the variation title.
8. Once deleted it should redirect to the next variation in the list and showing a notice that the current variation is deleted.
9. Look at the previous variation in the switcher ( in the footer ), this should **not** be pointing at the deleted variation, but work as expected.
10. Continue to delete variations until there is one left
11. The variation switcher bar should disappear.
12. Delete the last variation, it should now redirect to the parent product again.
13. Now generate some new variations again without adding a price
14. Go to the edit screen of one variation and click **Update** ( it should fail, because the price field is required ).
15. Now go to the next variation and update it's price
16. Click **Update**, it should save correctly ( previously this would also error ).

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
