### PR TITLE
Add Downloads section to the single variation page

### DIFF
--- a/packages/js/product-editor/changelog/add-40804
+++ b/packages/js/product-editor/changelog/add-40804
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add support to downloads block to use the context postType

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/block.json
@@ -22,5 +22,6 @@
 		"lock": false,
 		"__experimentalToolbar": false
 	},
-	"editorStyle": "file:./editor.css"
+	"editorStyle": "file:./editor.css",
+	"usesContext": [ "postType" ]
 }

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/edit.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { BlockEditProps } from '@wordpress/blocks';
 import { Button, Spinner } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
@@ -26,6 +25,7 @@ import { useEntityProp } from '@wordpress/core-data';
 import { UploadsBlockAttributes } from './types';
 import { UploadImage } from './upload-image';
 import { DownloadsMenu } from './downloads-menu';
+import { ProductEditorBlockEditProps } from '../../../types';
 
 function getFileName( url?: string ) {
 	const [ name ] = url?.split( '/' ).reverse() ?? [];
@@ -42,16 +42,17 @@ function stringifyEntityId< ID, T extends { id?: ID } >( entity: T ): T {
 
 export function Edit( {
 	attributes,
-}: BlockEditProps< UploadsBlockAttributes > ) {
+	context: { postType },
+}: ProductEditorBlockEditProps< UploadsBlockAttributes > ) {
 	const blockProps = useWooBlockProps( attributes );
 	const [ , setDownloadable ] = useEntityProp< Product[ 'downloadable' ] >(
 		'postType',
-		'product',
+		postType,
 		'downloadable'
 	);
 	const [ downloads, setDownloads ] = useEntityProp< Product[ 'downloads' ] >(
 		'postType',
-		'product',
+		postType,
 		'downloads'
 	);
 

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/index.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/index.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { BlockConfiguration } from '@wordpress/blocks';
 import { registerWooBlockType } from '@woocommerce/block-templates';
 
 /**
@@ -9,19 +8,19 @@ import { registerWooBlockType } from '@woocommerce/block-templates';
  */
 import blockConfiguration from './block.json';
 import { Edit } from './edit';
-import { UploadsBlockAttributes } from './types';
 
-const { name, ...metadata } =
-	blockConfiguration as BlockConfiguration< UploadsBlockAttributes >;
+const { name, ...metadata } = blockConfiguration;
 
 export { metadata, name };
 
-export const settings: Partial< BlockConfiguration< UploadsBlockAttributes > > =
-	{
-		example: {},
-		edit: Edit,
-	};
+export const settings = {
+	example: {},
+	edit: Edit,
+};
 
-export function init() {
-	return registerWooBlockType( { name, metadata, settings } );
-}
+export const init = () =>
+	registerWooBlockType( {
+		name,
+		metadata: metadata as never,
+		settings: settings as never,
+	} );

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/index.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/index.ts
@@ -18,9 +18,10 @@ export const settings = {
 	edit: Edit,
 };
 
-export const init = () =>
-	registerWooBlockType( {
+export function init() {
+	return registerWooBlockType( {
 		name,
 		metadata: metadata as never,
 		settings: settings as never,
 	} );
+}

--- a/plugins/woocommerce/changelog/add-40804
+++ b/plugins/woocommerce/changelog/add-40804
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Register the downloads block into the ProductVariationTemplate

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/ProductVariationTemplate.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/ProductVariationTemplate.php
@@ -182,6 +182,26 @@ class ProductVariationTemplate extends AbstractProductFormTemplate implements Pr
 				],
 			]
 		);
+
+		// Downloads section.
+		if ( Features::is_enabled( 'product-virtual-downloadable' ) ) {
+			$general_group->add_section(
+				[
+					'id'         => 'product-variation-downloads-section',
+					'order'      => 40,
+					'attributes' => [
+						'title'       => __( 'Downloads', 'woocommerce' ),
+						'description' => __( "Add any files you'd like to make available for the customer to download after purchasing, such as instructions or warranty info.", 'woocommerce' ),
+					],
+				]
+			)->add_block(
+				[
+					'id'        => 'product-variation-downloads',
+					'blockName' => 'woocommerce/product-downloads-field',
+					'order'     => 10,
+				]
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #40804

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure feature `product-variation-management` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper` (WooCommerce Beta Tester plugin) is required
3. Make sure feature `product-virtual-downloadable` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper` (WooCommerce Beta Tester plugin) is required
4. Go to `/wp-admin/admin.php?page=wc-admin&path=/add-product&tab=variations` and add some attributes
5. Wait until variations get generated and then publish the product
7. Under the `Variations` section click the `Edit` button of any of the listed variations
8. You should be redirected to the single variation edition page
9. In that page and under the `General` tab, a new `Downloads` section should be shown. 
<img width="611" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/f6ac479f-3336-4f57-b48c-2273815de055">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
