### PR TITLE
Manage single variation as virtual

### DIFF
--- a/packages/js/product-editor/changelog/add-40805
+++ b/packages/js/product-editor/changelog/add-40805
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Let the toogle block to use inverted value to be checked

--- a/packages/js/product-editor/src/blocks/generic/toggle/block.json
+++ b/packages/js/product-editor/src/blocks/generic/toggle/block.json
@@ -22,6 +22,12 @@
 		"disabledCopy": {
 			"type": "string",
 			"__experimentalRole": "content"
+		},
+		"checkedValue": {
+			"type": "object"
+		},
+		"uncheckedValue": {
+			"type": "object"
 		}
 	},
 	"supports": {

--- a/packages/js/product-editor/src/blocks/generic/toggle/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/toggle/edit.tsx
@@ -18,19 +18,41 @@ export function Edit( {
 	context: { postType },
 }: ProductEditorBlockEditProps< ToggleBlockAttributes > ) {
 	const blockProps = useWooBlockProps( attributes );
-	const { label, property, disabled, disabledCopy } = attributes;
+	const {
+		label,
+		property,
+		disabled,
+		disabledCopy,
+		checkedValue,
+		uncheckedValue,
+	} = attributes;
 	const [ value, setValue ] = useProductEntityProp< boolean >( property, {
 		postType,
 		fallbackValue: false,
 	} );
 
+	function isChecked() {
+		if ( checkedValue !== undefined ) {
+			return checkedValue === value;
+		}
+		return value as boolean;
+	}
+
+	function handleChange( checked: boolean ) {
+		if ( checked ) {
+			setValue( checkedValue !== undefined ? checkedValue : checked );
+		} else {
+			setValue( uncheckedValue !== undefined ? uncheckedValue : checked );
+		}
+	}
+
 	return (
 		<div { ...blockProps }>
 			<ToggleControl
 				label={ label }
-				checked={ value }
+				checked={ isChecked() }
 				disabled={ disabled }
-				onChange={ setValue }
+				onChange={ handleChange }
 			/>
 			{ disabled && (
 				<p

--- a/packages/js/product-editor/src/blocks/generic/toggle/types.ts
+++ b/packages/js/product-editor/src/blocks/generic/toggle/types.ts
@@ -7,4 +7,6 @@ export interface ToggleBlockAttributes extends BlockAttributes {
 	label: string;
 	property: string;
 	disabled?: boolean;
+	checkedValue?: never;
+	uncheckedValue?: never;
 }

--- a/plugins/woocommerce/changelog/add-40805
+++ b/plugins/woocommerce/changelog/add-40805
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add virtual section to the product variation template

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/ProductVariationTemplate.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/ProductVariationTemplate.php
@@ -467,8 +467,10 @@ class ProductVariationTemplate extends AbstractProductFormTemplate implements Pr
 				'blockName'  => 'woocommerce/product-toggle-field',
 				'order'      => 10,
 				'attributes' => [
-					'property' => 'virtual',
-					'label'    => __( 'This variation requires shipping or pickup', 'woocommerce' ),
+					'property'       => 'virtual',
+					'checkedValue'   => false,
+					'uncheckedValue' => true,
+					'label'          => __( 'This variation requires shipping or pickup', 'woocommerce' ),
 				],
 			]
 		);

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/ProductVariationTemplate.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/ProductVariationTemplate.php
@@ -455,11 +455,28 @@ class ProductVariationTemplate extends AbstractProductFormTemplate implements Pr
 				],
 			]
 		);
+		// Virtual section.
+		$shipping_group->add_section(
+			[
+				'id'    => 'product-variation-virtual-section',
+				'order' => 20,
+			]
+		)->add_block(
+			[
+				'id'         => 'product-variation-virtual',
+				'blockName'  => 'woocommerce/product-toggle-field',
+				'order'      => 10,
+				'attributes' => [
+					'property' => 'virtual',
+					'label'    => __( 'This variation requires shipping or pickup', 'woocommerce' ),
+				],
+			]
+		);
 		// Product Shipping Section.
 		$product_fee_and_dimensions_section = $shipping_group->add_section(
 			[
 				'id'         => 'product-variation-fee-and-dimensions-section',
-				'order'      => 20,
+				'order'      => 30,
 				'attributes' => [
 					'title'       => __( 'Fees & dimensions', 'woocommerce' ),
 					'description' => sprintf(

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -776,8 +776,10 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 				'blockName'  => 'woocommerce/product-toggle-field',
 				'order'      => 10,
 				'attributes' => [
-					'property' => 'virtual',
-					'label'    => __( 'This product requires shipping or pickup', 'woocommerce' ),
+					'property'       => 'virtual',
+					'checkedValue'   => false,
+					'uncheckedValue' => true,
+					'label'          => __( 'This product requires shipping or pickup', 'woocommerce' ),
 				],
 			]
 		);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #40805

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure feature `product-variation-management` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper` (WooCommerce Beta Tester plugin) is required
3. Make sure feature `product-virtual-downloadable` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper` (WooCommerce Beta Tester plugin) is required
4. Go to `/wp-admin/admin.php?page=wc-admin&path=/add-product&tab=variations` and add some attributes
5. Wait until variations get generated and then publish the product
7. Under the `Variations` section click the `Edit` button of any of the listed variations
8. You should be redirected to the single variation edition page
9. In that page and under the `Shipping` tab, a new `This product requires shipping or pickup` checkbox should be shown.
10. When it is on then all the fields in that tab should be enabled 
<img width="624" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/a52eeea6-869c-449c-be02-a7e3a2815d0f">

11. When it is off the all the fields in that tab should be disabled 
<img width="615" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/01c1d11a-9d1d-4f4a-84a3-ca95c1b405cc">



<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
