### PR TITLE
Manually prepare packages for release 

### DIFF
--- a/packages/js/components/CHANGELOG.md
+++ b/packages/js/components/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [12.2.0](https://www.npmjs.com/package/@woocommerce/components/v/12.2.0) - 2023-10-17
+
+-   Patch - Add class back in for increase specificity of css for dropdown button. [#40494]
+-   Minor - Categories dropdown display error #39810 [#39811]
+-   Patch - Fixed empty component logo color, used generic rather than old pink [#39182]
+-   Patch - Fix invalid focus state of the experimental select control [#40519]
+-   Minor - Fix new category name field [#39857]
+-   Patch - Fix select control dropdown menu double scroll and width [#39989]
+-   Minor - Select attribute after pressing their names #39456 [#39574]
+-   Patch - TreeSelectControl Component - Make sure individuallySelectParent prop is respected [#40301]
+-   Minor - Add AI wizard business info step for Customize Your Store task [#39979]
+-   Minor - Add customize store assembler hub onboarding tour [#39981]
+-   Minor - Add ProgressBar component [#39979]
+-   Minor - Add tags (or general taxonomy ) block [#39966]
+-   Minor - Add Tooltip to each list item when need it [#39770]
+-   Minor - An international phone number input with country selection, and mobile phone numbers validation. [#40335]
+-   Minor - Image gallery and media uploader now support initial selected images. [#40633]
+-   Minor - Refactor Pagination component and split out into multiple re-usable components. Also added a `usePagination` hook. [#39967]
+-   Minor - Set button optional in MediaUploader component [#40526]
+-   Minor - Update ImageGallery block toolbar, moving some options to an ellipsis dropdown menu. [#39753]
+-   Minor - Allow users to select multiple items from the media library while adding images #39741 [#39741]
+-   Patch - Make eslint emit JSON report for annotating PRs. [#39704]
+-   Minor - Update pnpm to 8.6.7 [#39245]
+-   Patch - Upgraded Storybook to 6.5.17-alpha.0 for TypeScript 5 compatibility [#39745]
+-   Minor - Upgrade TypeScript to 5.1.6 [#39531]
+-   Patch - Add z-index=1 to tour-kit close btn to ensure it's clickable [#40456]
+-   Minor - Remove unnecessary use of woocommerce-page selector for DropdownButton styling. [#40218]
+-   Patch - Small condition change in the date time picker to avoid edge case where inputControl is null. [#40642]
+
 ## [12.1.0](https://www.npmjs.com/package/@woocommerce/components/v/12.1.0) - 2023-07-13
 
 -   Patch - Altering styles to correctly target fields within slot fills on product editor. [#36500]
@@ -157,7 +186,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 -   Minor - Fix DateTimePickerControl's onChange date arg to only be a string (TypeScript). [#35140]
 -   Minor - Improve experimental SelectControl accessibility [#35140]
 -   Minor - Improve Sortable component acessibility [#35140]
--   -   Create new experimental SelectControl component [#35140]
+-   Major - Create new experimental SelectControl component [#35140]
 
 ## [10.3.0](https://www.npmjs.com/package/@woocommerce/components/v/10.3.0) - 2022-08-12
 

--- a/packages/js/components/changelog/add-35142
+++ b/packages/js/components/changelog/add-35142
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Set button optional in MediaUploader component

--- a/packages/js/components/changelog/add-39126_add_tags_to_product_editor
+++ b/packages/js/components/changelog/add-39126_add_tags_to_product_editor
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add tags (or general taxonomy ) block

--- a/packages/js/components/changelog/add-39499
+++ b/packages/js/components/changelog/add-39499
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add Tooltip to each list item when need it

--- a/packages/js/components/changelog/add-39709-ai-wizard-business-info-step
+++ b/packages/js/components/changelog/add-39709-ai-wizard-business-info-step
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add AI wizard business info step for Customize Your Store task

--- a/packages/js/components/changelog/add-39875
+++ b/packages/js/components/changelog/add-39875
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix select control dropdown menu double scroll and width

--- a/packages/js/components/changelog/add-40592
+++ b/packages/js/components/changelog/add-40592
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Image gallery and media uploader now support initial selected images.

--- a/packages/js/components/changelog/add-40593_pricing_tab_for_variations
+++ b/packages/js/components/changelog/add-40593_pricing_tab_for_variations
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Small condition change in the date time picker to avoid edge case where inputControl is null.

--- a/packages/js/components/changelog/add-customize-store-assembler-hub-onboarding
+++ b/packages/js/components/changelog/add-customize-store-assembler-hub-onboarding
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add customize store assembler hub onboarding tour

--- a/packages/js/components/changelog/add-phone-number-input-component
+++ b/packages/js/components/changelog/add-phone-number-input-component
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-An international phone number input with country selection, and mobile phone numbers validation.

--- a/packages/js/components/changelog/add-progress-bar-component
+++ b/packages/js/components/changelog/add-progress-bar-component
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add ProgressBar component

--- a/packages/js/components/changelog/dev-38345_allow_select_multiple_items
+++ b/packages/js/components/changelog/dev-38345_allow_select_multiple_items
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Allow users to select multiple items from the media library while adding images #39741

--- a/packages/js/components/changelog/dev-include-eslint-annotations
+++ b/packages/js/components/changelog/dev-include-eslint-annotations
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Make eslint emit JSON report for annotating PRs.

--- a/packages/js/components/changelog/dev-sync-pnpm
+++ b/packages/js/components/changelog/dev-sync-pnpm
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Update pnpm to 8.6.7

--- a/packages/js/components/changelog/dev-upgrade-storybook-6-5-17
+++ b/packages/js/components/changelog/dev-upgrade-storybook-6-5-17
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-
-Upgraded Storybook to 6.5.17-alpha.0 for TypeScript 5 compatibility

--- a/packages/js/components/changelog/dev-upgrade-ts-5
+++ b/packages/js/components/changelog/dev-upgrade-ts-5
@@ -1,4 +1,0 @@
-Significance: minor
-Type: dev
-
-Upgrade TypeScript to 5.1.6

--- a/packages/js/components/changelog/fix-38954_set_as_cover
+++ b/packages/js/components/changelog/fix-38954_set_as_cover
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Update ImageGallery block toolbar, moving some options to an ellipsis dropdown menu.

--- a/packages/js/components/changelog/fix-39456_select_attribute_values_name
+++ b/packages/js/components/changelog/fix-39456_select_attribute_values_name
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fix
-
-Select attribute after pressing their names #39456

--- a/packages/js/components/changelog/fix-39544_description_styling
+++ b/packages/js/components/changelog/fix-39544_description_styling
@@ -1,4 +1,0 @@
-Significance: minor
-Type: tweak
-
-Remove unnecessary use of woocommerce-page selector for DropdownButton styling.

--- a/packages/js/components/changelog/fix-39810_categories_dropdown_visibility
+++ b/packages/js/components/changelog/fix-39810_categories_dropdown_visibility
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fix
-
-Categories dropdown display error #39810

--- a/packages/js/components/changelog/fix-39825_new_category_name_persists
+++ b/packages/js/components/changelog/fix-39825_new_category_name_persists
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fix
-
-Fix new category name field

--- a/packages/js/components/changelog/fix-40171
+++ b/packages/js/components/changelog/fix-40171
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix invalid focus state of the experimental select control

--- a/packages/js/components/changelog/fix-admin-colors-use-theme
+++ b/packages/js/components/changelog/fix-admin-colors-use-theme
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fixed empty component logo color, used generic rather than old pink

--- a/packages/js/components/changelog/fix-category-escape-characters
+++ b/packages/js/components/changelog/fix-category-escape-characters
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fix
-Comment: Decode HTML escaped string for tree-item and selected-items components
-
-

--- a/packages/js/components/changelog/fix-cys-ui-issues
+++ b/packages/js/components/changelog/fix-cys-ui-issues
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Add z-index=1 to tour-kit close btn to ensure it's clickable

--- a/packages/js/components/changelog/fix-dropdown-css-conflict
+++ b/packages/js/components/changelog/fix-dropdown-css-conflict
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Add class back in for increase specificity of css for dropdown button.

--- a/packages/js/components/changelog/fix-missed-lints
+++ b/packages/js/components/changelog/fix-missed-lints
@@ -1,5 +1,0 @@
-Significance: patch
-Type: dev
-Comment: Applied lint auto fixes across monorepo
-
-

--- a/packages/js/components/changelog/fix-taxonomy-special-characters
+++ b/packages/js/components/changelog/fix-taxonomy-special-characters
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fix
-Comment: Decode html characters in SelectTree
-
-

--- a/packages/js/components/changelog/fix-tree-select-control-individuallySelectParent
+++ b/packages/js/components/changelog/fix-tree-select-control-individuallySelectParent
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-TreeSelectControl Component - Make sure individuallySelectParent prop is respected

--- a/packages/js/components/changelog/fix-tree-select-control-individuallySelectParent-includeParent
+++ b/packages/js/components/changelog/fix-tree-select-control-individuallySelectParent-includeParent
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fix
-Comment: Fixes and earlier unreleaed change, not changelog required
-
-

--- a/packages/js/components/changelog/update-39885_variation_pagination_table
+++ b/packages/js/components/changelog/update-39885_variation_pagination_table
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Refactor Pagination component and split out into multiple re-usable components. Also added a `usePagination` hook.

--- a/packages/js/components/changelog/update-component-readme
+++ b/packages/js/components/changelog/update-component-readme
@@ -1,5 +1,0 @@
-Significance: patch
-Type: tweak
-Comment: Just a minor README change.
-
-

--- a/packages/js/components/changelog/update-separate-php-and-js-tests
+++ b/packages/js/components/changelog/update-separate-php-and-js-tests
@@ -1,4 +1,0 @@
-Significance: patch
-Type: dev
-Comment: This is just a change to developer commands.
-

--- a/packages/js/components/package.json
+++ b/packages/js/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/components",
-	"version": "12.1.0",
+	"version": "12.2.0",
 	"description": "UI components for WooCommerce.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",


### PR DESCRIPTION
# Prepare @woocommerce/components for release.

Prepared by manually running `./tools/package-release/bin/dev prepare @woocommerce/components` to generate the new changelog entries, and using only the new section `12.2.0`. Because the automated workflow (and script) was causing some changes on previous release entries.

More details: p1697528121174759-slack-C01SFMVEYAK