### PR TITLE
fix: cys intro screen parallelised network calls

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/intro/services.ts
+++ b/plugins/woocommerce-admin/client/customize-store/intro/services.ts
@@ -18,15 +18,53 @@ export const fetchThemeCards = async () => {
 };
 
 export const fetchIntroData = async () => {
-	let currentThemeIsAiGenerated = false;
-	const currentTemplate = await resolveSelect(
-		coreStore
+	const currentTemplatePromise =
 		// @ts-expect-error No types for this exist yet.
-	).__experimentalGetTemplateForLink( '/' );
-	const maybePreviousTemplate = await resolveSelect(
+		resolveSelect( coreStore ).__experimentalGetTemplateForLink( '/' );
+
+	const maybePreviousTemplatePromise = resolveSelect(
 		OPTIONS_STORE_NAME
 	).getOption( 'woocommerce_admin_customize_store_completed_theme_id' );
 
+	const styleRevsPromise =
+		// @ts-expect-error No types for this exist yet.
+		resolveSelect( coreStore ).getCurrentThemeGlobalStylesRevisions();
+
+	// @ts-expect-error No types for this exist yet.
+	const hasModifiedPagesPromise = resolveSelect( coreStore ).getEntityRecords(
+		'postType',
+		'page',
+		{
+			per_page: 100,
+			_fields: [ 'id', '_links.version-history' ],
+			orderby: 'menu_order',
+			order: 'asc',
+		}
+	);
+
+	const getTaskPromise = resolveSelect( ONBOARDING_STORE_NAME ).getTask(
+		'customize-store'
+	);
+
+	const themeDataPromise = fetchThemeCards();
+
+	const [
+		currentTemplate,
+		maybePreviousTemplate,
+		styleRevs,
+		rawPages,
+		task,
+		themeData,
+	] = await Promise.all( [
+		currentTemplatePromise,
+		maybePreviousTemplatePromise,
+		styleRevsPromise,
+		hasModifiedPagesPromise,
+		getTaskPromise,
+		themeDataPromise,
+	] );
+
+	let currentThemeIsAiGenerated = false;
 	if (
 		maybePreviousTemplate &&
 		currentTemplate?.id === maybePreviousTemplate
@@ -34,33 +72,18 @@ export const fetchIntroData = async () => {
 		currentThemeIsAiGenerated = true;
 	}
 
-	const styleRevs = await resolveSelect(
-		coreStore
-		// @ts-expect-error No types for this exist yet.
-	).getCurrentThemeGlobalStylesRevisions();
-
-	const hasModifiedPages = (
-		await resolveSelect( coreStore )
-			// @ts-expect-error No types for this exist yet.
-			.getEntityRecords( 'postType', 'page', {
-				per_page: 100,
-				_fields: [ 'id', '_links.version-history' ],
-				orderby: 'menu_order',
-				order: 'asc',
-			} )
-	 )?.some( ( page: { _links: { [ key: string ]: string[] } } ) => {
-		return page._links?.[ 'version-history' ]?.length > 1;
-	} );
-
-	const { getTask } = resolveSelect( ONBOARDING_STORE_NAME );
+	const hasModifiedPages = rawPages?.some(
+		( page: { _links: { [ key: string ]: string[] } } ) => {
+			return page._links?.[ 'version-history' ]?.length > 1;
+		}
+	);
 
 	const activeThemeHasMods =
 		!! currentTemplate?.modified ||
 		styleRevs?.length > 0 ||
 		hasModifiedPages;
-	const customizeStoreTaskCompleted = ( await getTask( 'customize-store' ) )
-		?.isComplete;
-	const themeData = await fetchThemeCards();
+
+	const customizeStoreTaskCompleted = task?.isComplete;
 
 	return {
 		activeThemeHasMods,

--- a/plugins/woocommerce/changelog/fix-cys-intro-parallelise-network-calls
+++ b/plugins/woocommerce/changelog/fix-cys-intro-parallelise-network-calls
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Parallelised the independent network calls on the intro screen so that they become much faster


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/40793

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

This feature is part of the larger customize your store development and behind a feature flag, hence QA review can be deferred until the call for testing before release.

Make sure you are testing this with a Jetpack connected instance of WooCommerce, as the AI text completion endpoint can only be called with a Jetpack connected account.

1. Create a new WooCommerce installation with this version. 
2. Install  WooCommerce Block [Nightly](https://github.com/woocommerce/woocommerce-blocks/releases/tag/nightly)
3. Make sure to enable `customize-store` feature flag
3. Navigate to the CYS task
4. Observe that the Intro screen loads much, much faster than before


https://github.com/woocommerce/woocommerce/assets/27843274/dd68123a-74c9-4061-b0a4-5f7c44089a79



<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
