### PR TITLE
Add preview and replace button to downloads edit

### DIFF
--- a/packages/js/product-editor/changelog/dev-35143_add_preview_to_downloads_edit
+++ b/packages/js/product-editor/changelog/dev-35143_add_preview_to_downloads_edit
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add preview and replace button to downloads edit #40835

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/edit-downloads-modal/edit-downloads-modal.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/edit-downloads-modal/edit-downloads-modal.tsx
@@ -65,6 +65,15 @@ export const EditDownloadsModal: React.FC< EditDownloadsModalProps > = ( {
 		);
 	};
 
+	const isImage = ( filename = '' ) => {
+		if ( ! filename ) return;
+		const imageExtensions = [ 'jpg', 'jpeg', 'png', 'gif', 'webp' ];
+		const fileExtension = (
+			filename.split( '.' ).pop() || ''
+		).toLowerCase();
+		return imageExtensions.includes( fileExtension );
+	};
+
 	async function copyTextToClipboard( text: string ) {
 		if ( 'clipboard' in navigator ) {
 			await navigator.clipboard.writeText( text );
@@ -122,15 +131,17 @@ export const EditDownloadsModal: React.FC< EditDownloadsModalProps > = ( {
 			className="woocommerce-edit-downloads-modal"
 		>
 			<div className="woocommerce-edit-downloads-modal__preview">
-				<ImageGallery allowDragging={ false }>
-					<ImageGalleryItem
-						key={ id }
-						alt={ name }
-						src={ file }
-						id={ `${ id }` }
-						isCover={ false }
-					/>
-				</ImageGallery>
+				{ isImage( file ) && (
+					<ImageGallery allowDragging={ false }>
+						<ImageGalleryItem
+							key={ id }
+							alt={ name }
+							src={ file }
+							id={ `${ id }` }
+							isCover={ false }
+						/>
+					</ImageGallery>
+				) }
 				<FormFileUpload
 					onChange={ handleFormFileUploadChange }
 					render={ ( { openFileDialog } ) => (

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/edit-downloads-modal/edit-downloads-modal.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/edit-downloads-modal/edit-downloads-modal.tsx
@@ -44,6 +44,8 @@ export const EditDownloadsModal: React.FC< EditDownloadsModalProps > = ( {
 	const { createNotice } = useDispatch( 'core/notices' );
 	const [ isCopingToClipboard, setIsCopingToClipboard ] =
 		useState< boolean >( false );
+	const [ isFileUploading, setIsFileUploading ] =
+		useState< boolean >( false );
 
 	const { allowedMimeTypes } = useSelect( ( select ) => {
 		const { getEditorSettings } = select( 'core/editor' );
@@ -84,18 +86,19 @@ export const EditDownloadsModal: React.FC< EditDownloadsModalProps > = ( {
 		setIsCopingToClipboard( false );
 	}
 
-	function handleFormFileUploadChange(
+	async function handleFormFileUploadChange(
 		event: ChangeEvent< HTMLInputElement >
 	) {
+		setIsFileUploading( true );
 		const filesList = event.currentTarget.files as FileList;
-
-		uploadMedia( {
+		await uploadMedia( {
 			allowedTypes,
 			filesList,
 			maxUploadFileSize,
 			onFileChange: onUploadSuccess,
 			onError: onUploadError,
 		} );
+		setIsFileUploading( false );
 	}
 
 	return (
@@ -133,7 +136,11 @@ export const EditDownloadsModal: React.FC< EditDownloadsModalProps > = ( {
 					render={ ( { openFileDialog } ) => (
 						<div>
 							<p>{ name }</p>
-							<Button onClick={ openFileDialog }>
+							<Button
+								onClick={ openFileDialog }
+								isBusy={ isFileUploading }
+								disabled={ isFileUploading }
+							>
 								{ __( 'Replace', 'woocommerce' ) }
 							</Button>
 						</div>

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/edit-downloads-modal/edit-downloads-modal.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/edit-downloads-modal/edit-downloads-modal.tsx
@@ -132,7 +132,7 @@ export const EditDownloadsModal: React.FC< EditDownloadsModalProps > = ( {
 		>
 			<div className="woocommerce-edit-downloads-modal__preview">
 				{ isImage( file ) && (
-					<ImageGallery allowDragging={ false }>
+					<ImageGallery allowDragging={ false } columns={ 1 }>
 						<ImageGalleryItem
 							key={ id }
 							alt={ name }

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/edit-downloads-modal/style.scss
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/edit-downloads-modal/style.scss
@@ -1,3 +1,5 @@
+$gutenberg-blue: var(--wp-admin-theme-color);
+
 .woocommerce-edit-downloads-modal {
 	&__buttons {
 		display: flex;
@@ -35,6 +37,15 @@
 		}
 		button:hover:not(.is-busy) {
 			background: rgba(var(--wp-admin-theme-color--rgb), .04);
+		}
+		.woocommerce-image-gallery__item {
+			width: $gap-larger * 2;
+			height: $gap-larger * 2;
+			img {
+				width: $gap-larger * 2;
+				height: $gap-larger * 2;
+				border-color: #fff;
+			}
 		}
 	}
 }

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/edit-downloads-modal/style.scss
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/edit-downloads-modal/style.scss
@@ -15,7 +15,26 @@
 		padding-bottom: $gap-large;
 	}
 
+	&__preview {
+		margin-bottom: $gap;
+	}
+
 	.components-input-control__suffix {
 		cursor: pointer;
+	}
+
+	.woocommerce-image-gallery, .components-form-file-upload {
+		display: inline-block;
+		vertical-align: middle;
+		p {
+			margin-bottom: $gap-smallest;
+		}
+		button {
+			color: $gutenberg-blue;
+			padding: 0;
+		}
+		button:hover:not(.is-busy) {
+			background: rgba(var(--wp-admin-theme-color--rgb), .04);
+		}
 	}
 }

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/edit-downloads-modal/style.scss
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/edit-downloads-modal/style.scss
@@ -29,7 +29,7 @@ $gutenberg-blue: var(--wp-admin-theme-color);
 	.components-form-file-upload {
 		display: inline-block;
 		vertical-align: middle;
-		padding-left: $gap-large;
+		padding-left: $gap;
 		p {
 			margin-bottom: $gap-smallest;
 		}

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/edit-downloads-modal/style.scss
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/edit-downloads-modal/style.scss
@@ -29,7 +29,6 @@ $gutenberg-blue: var(--wp-admin-theme-color);
 	.components-form-file-upload {
 		display: inline-block;
 		vertical-align: middle;
-		padding-left: $gap;
 		p {
 			margin-bottom: $gap-smallest;
 		}
@@ -49,5 +48,8 @@ $gutenberg-blue: var(--wp-admin-theme-color);
 				border-color: #fff;
 			}
 		}
+	}
+	.components-form-file-upload {
+		padding-left: $gap;
 	}
 }

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/edit-downloads-modal/style.scss
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/edit-downloads-modal/style.scss
@@ -25,9 +25,11 @@ $gutenberg-blue: var(--wp-admin-theme-color);
 		cursor: pointer;
 	}
 
-	.woocommerce-image-gallery, .components-form-file-upload {
+	.woocommerce-image-gallery,
+	.components-form-file-upload {
 		display: inline-block;
 		vertical-align: middle;
+		padding-left: $gap-large;
 		p {
 			margin-bottom: $gap-smallest;
 		}
@@ -36,7 +38,7 @@ $gutenberg-blue: var(--wp-admin-theme-color);
 			padding: 0;
 		}
 		button:hover:not(.is-busy) {
-			background: rgba(var(--wp-admin-theme-color--rgb), .04);
+			background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
 		}
 		.woocommerce-image-gallery__item {
 			width: $gap-larger * 2;

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/edit-downloads-modal/style.scss
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/edit-downloads-modal/style.scss
@@ -29,6 +29,7 @@ $gutenberg-blue: var(--wp-admin-theme-color);
 	.components-form-file-upload {
 		display: inline-block;
 		vertical-align: middle;
+		padding-right: $gap;
 		p {
 			margin-bottom: $gap-smallest;
 		}
@@ -48,8 +49,5 @@ $gutenberg-blue: var(--wp-admin-theme-color);
 				border-color: #fff;
 			}
 		}
-	}
-	.components-form-file-upload {
-		padding-left: $gap;
 	}
 }

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/edit-downloads-modal/types.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/edit-downloads-modal/types.ts
@@ -2,11 +2,15 @@
  * External dependencies
  */
 import { ProductDownload } from '@woocommerce/data';
+import { MediaItem } from '@wordpress/media-utils';
 
 export type EditDownloadsModalProps = {
 	downloableItem: ProductDownload;
+	maxUploadFileSize?: number;
 	onCancel: () => void;
 	onRemove: () => void;
 	onSave: () => void;
 	onChange: ( name: string ) => void;
+	onUploadSuccess( files: MediaItem[] ): void;
+	onUploadError( error: unknown ): void;
 };

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/edit.tsx
@@ -336,6 +336,8 @@ export function Edit( {
 						setDownloads( newDownloads );
 						setSelectedDownload( null );
 					} }
+					onUploadSuccess={ handleFileUpload }
+					onUploadError={ handleUploadError }
 				/>
 			) }
 		</div>

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/edit.tsx
@@ -143,6 +143,39 @@ export function Edit( {
 		}
 	}
 
+	function handleFileReplace( files: MediaItem | MediaItem[] ) {
+		if (
+			! Array.isArray( files ) ||
+			! files?.length ||
+			files[ 0 ]?.id === undefined
+		) {
+			return;
+		}
+
+		if ( ! downloads.length ) {
+			setDownloadable( true );
+		}
+
+		const uploadedFile = {
+			id: stringifyId( files[ 0 ].id ),
+			file: files[ 0 ].url,
+			name:
+				files[ 0 ].title ||
+				files[ 0 ].alt ||
+				files[ 0 ].caption ||
+				getFileName( files[ 0 ].url ),
+		};
+		const stringifyIds = downloads.map( ( download ) => {
+			if ( download.file === selectedDownload?.file ) {
+				return stringifyEntityId( uploadedFile );
+			}
+			return stringifyEntityId( download );
+		} );
+
+		setDownloads( stringifyIds );
+		setSelectedDownload( uploadedFile );
+	}
+
 	function removeDownload( download: ProductDownload ) {
 		const otherDownloads = downloads.reduce< ProductDownload[] >(
 			function removeDownloadElement(
@@ -336,7 +369,7 @@ export function Edit( {
 						setDownloads( newDownloads );
 						setSelectedDownload( null );
 					} }
-					onUploadSuccess={ handleFileUpload }
+					onUploadSuccess={ handleFileReplace }
 					onUploadError={ handleUploadError }
 				/>
 			) }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR is a follow-up to [PR 40599](https://github.com/woocommerce/woocommerce/pull/40599). This PR adds a preview of the uploaded file and a replace button [that opens the system file picker](https://github.com/woocommerce/woocommerce/issues/35143#issuecomment-1770212954).

![Screenshot 2023-10-20 at 15 33 46](https://github.com/woocommerce/woocommerce/assets/1314156/9057480f-cde2-45b0-90e4-f1382d7fd451)


Closes #35143.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a WooCommerce store with this branch and enable the product editor and the virtual-downloadable products (`product-virtual-downloadable`) using **WooCommerce > Settings > Advanced > Features**
2. Go to **Products > Add New**
3. In the `General` tab, scroll to the bottom of the page where a new `Downloads` section should appear.
4. By default, the list displays files with their actual names, including the extension/format, after uploading one or more files.
Each file is listed as a separate item with options to remove (using `X`) and `Edit` them.
6. Click the `Edit` button. A modal will be visible.
7. If the uploaded file was an image, confirm that the modal displays it.
8. Verify the `Replace` button works as expected.
9. After replacing a file, it should be loaded in the modal and updated in the list after closing the modal.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
