### PR TITLE
CYS: Update save and done button loading indicator to use spinner

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/save-hub.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/save-hub.tsx
@@ -159,6 +159,8 @@ export const SaveHub = () => {
 					variant="primary"
 					onClick={ onDone }
 					className="edit-site-save-hub__button"
+					disabled={ isResolving }
+					aria-disabled={ isResolving }
 					// @ts-ignore No types for this exist yet.
 					__next40pxDefaultSize
 				>

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/save-hub.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/save-hub.tsx
@@ -178,14 +178,13 @@ export const SaveHub = () => {
 			<Button
 				variant="primary"
 				onClick={ onClickSaveButton }
-				isBusy={ isSaving }
 				disabled={ isDisabled }
 				aria-disabled={ isDisabled }
 				className="edit-site-save-hub__button"
 				// @ts-ignore No types for this exist yet.
 				__next40pxDefaultSize
 			>
-				{ label }
+				{ isSaving ? <Spinner /> : label }
 			</Button>
 		);
 	};

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
@@ -222,6 +222,10 @@
 			button.is-primary:disabled {
 				opacity: 0.5;
 			}
+
+			button .components-spinner {
+				margin-top: 0;
+			}
 		}
 	}
 

--- a/plugins/woocommerce/changelog/tweak-40821-cys-save-button-spinner
+++ b/plugins/woocommerce/changelog/tweak-40821-cys-save-button-spinner
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Update save and done button loading indicator to use spinner


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #40821.

Changes the `Save` and `Done` button loading indicator to use spinner instead. 

### How to test the changes in this Pull Request:

1. Make sure to enable `customize-store` feature flag
1. Go to `WooCommerce -> Home` and click `Customize Store` task
1. Go through the AI wizard and proceed to the assembler hub
2. Go to `Change the color palette` and select a different color
3. Click on `Save` and observe the loading indicator is changed to a spinner
4. Click on `Done` and observe the loading indicator is changed to a spinner 

<img src="https://github.com/woocommerce/woocommerce/assets/3747241/4d4b1b9a-94ce-4fff-8972-cdfd6bc94ed8" width="250">

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>