### PR TITLE
Hide header on variation edit page and remove use of `:has()` CSS selector

### DIFF
--- a/packages/js/product-editor/changelog/fix-40842_hide_header
+++ b/packages/js/product-editor/changelog/fix-40842_hide_header
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Remove use of :has() css selector as it is not compatible with FireFox.

--- a/packages/js/product-editor/src/components/block-editor/style.scss
+++ b/packages/js/product-editor/src/components/block-editor/style.scss
@@ -145,15 +145,6 @@
 	}
 }
 
-.woocommerce-layout:has(.woocommerce-product-block-editor) {
-	.woocommerce-layout__primary {
-		margin-top: calc($gap-largest + $gap-smaller);
-	}
-	.woocommerce-layout__header {
-		display: none;
-	}
-}
-
 .wp-admin.woocommerce-feature-enabled-product-block-editor {
 	.components-modal {
 		&__frame {

--- a/plugins/woocommerce-admin/client/layout/controller.js
+++ b/plugins/woocommerce-admin/client/layout/controller.js
@@ -280,6 +280,9 @@ export const getPages = () => {
 			navArgs: {
 				id: 'woocommerce-edit-product',
 			},
+			layout: {
+				header: false,
+			},
 			wpOpenMenu: 'menu-posts-product',
 			capability: 'edit_products',
 		} );

--- a/plugins/woocommerce/changelog/fix-40842_hide_header
+++ b/plugins/woocommerce/changelog/fix-40842_hide_header
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Disable the rendering of the header on the variation edit page, as it has its own header.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR makes two small changes:
- Sets `header` to false for the variation edit page, to make sure we don't render it.
- Removes use of `:has()` css selector, as this was previously hiding the header also, but doesn't work on Firefox.

Closes #40842  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. **Use FireFox as your browser**
2. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
3. Make sure feature `product-variation-management` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper` (WooCommerce Beta Tester plugin) is required
4. Go to `/wp-admin/admin.php?page=wc-admin&path=/add-product&tab=variations` and add some attributes (at-least more then 1 )
5. Wait until variations get generated
6. Scroll down to the variation list and click **Edit**
7. It should redirect to the variation edit page
8. Make sure the header looks correct with the update buttons and the **Main product** button on the left to go back.
9. Refresh the page, you should not see a glimpse of the old header before this one is loaded.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
