### PR TITLE
Product Shipping: New class should automatically create a slug

### DIFF
--- a/packages/js/product-editor/changelog/fix-40844
+++ b/packages/js/product-editor/changelog/fix-40844
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove empty values from the shipping class request so slug can be generated server side

--- a/packages/js/product-editor/src/blocks/product-fields/shipping-class/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/shipping-class/edit.tsx
@@ -86,7 +86,7 @@ export function Edit( {
 
 	const [ categories ] = useEntityProp< PartialProduct[ 'categories' ] >(
 		'postType',
-		'product',
+		context.postType,
 		'categories'
 	);
 	const [ shippingClass, setShippingClass ] = useEntityProp< string >(

--- a/packages/js/product-editor/src/components/add-new-shipping-class-modal/add-new-shipping-class-modal.tsx
+++ b/packages/js/product-editor/src/components/add-new-shipping-class-modal/add-new-shipping-class-modal.tsx
@@ -111,6 +111,21 @@ export function AddNewShippingClassModal( {
 	onAdd,
 	onCancel,
 }: AddNewShippingClassModalProps ) {
+	function handleSubmit( values: Partial< ProductShippingClass > ) {
+		return onAdd(
+			Object.entries( values ).reduce( function removeEmptyValue(
+				current,
+				[ name, value ]
+			) {
+				return {
+					...current,
+					[ name ]: value === '' ? undefined : value,
+				};
+			},
+			{} )
+		);
+	}
+
 	return (
 		<Modal
 			title={ __( 'New shipping class', 'woocommerce' ) }
@@ -121,7 +136,7 @@ export function AddNewShippingClassModal( {
 				initialValues={ shippingClass ?? INITIAL_VALUES }
 				validate={ validateForm }
 				errors={ {} }
-				onSubmit={ onAdd }
+				onSubmit={ handleSubmit }
 			>
 				{ ( childrenProps: {
 					handleSubmit: () => Promise< ProductShippingClass >;


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #40844

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure feature `product-variation-management` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper` (WooCommerce Beta Tester plugin) is required
4. Go to `/wp-admin/admin.php?page=wc-admin&path=/add-product&tab=variations` and add some attributes
5. Wait until variations get generated and then publish the product
7. Under the `Variations` section click the `Edit` button of any of the listed variations
8. You should be redirected to the single variation edition page
9. In that page and under the `Shipping` tab from the `Shipping class` select `Add new shipping class`
10. From the modal, create a new shipping class without the slug or the description, only set the name which is the only required field.
11. After clicking the `Add` button the modal should hides and the new shipping class should be shown as the selected item of the `Shipping class` select. 
<img width="602" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/ac7c6f4b-369a-426e-b5a0-b6cc5ef474d9">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
