### PR TITLE
Fire action if order line item has been restored

### DIFF
--- a/plugins/woocommerce/changelog/2024-06-14-18-11-56-915980
+++ b/plugins/woocommerce/changelog/2024-06-14-18-11-56-915980
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Added 'woocommerce_restore_order_item_stock' filter for restored line item stock on canceled orders

--- a/plugins/woocommerce/includes/wc-stock-functions.php
+++ b/plugins/woocommerce/includes/wc-stock-functions.php
@@ -316,6 +316,7 @@ function wc_increase_stock_levels( $order_id ) {
          * @param int $new_stock  New stock.
          * @param int $old_stock Old stock.
          * @param WC_Order $order  Order data.
+         * @since 9.1.0
          */
         do_action( 'woocommerce_restore_order_item_stock', $item, $new_stock, $old_stock, $order );
 	}

--- a/plugins/woocommerce/includes/wc-stock-functions.php
+++ b/plugins/woocommerce/includes/wc-stock-functions.php
@@ -318,7 +318,7 @@ function wc_increase_stock_levels( $order_id ) {
 		 * @param int $old_stock Old stock.
 		 * @param WC_Order $order  Order data.
 		 */
-        do_action( 'woocommerce_restore_order_item_stock', $item, $new_stock, $old_stock, $order );
+		do_action( 'woocommerce_restore_order_item_stock', $item, $new_stock, $old_stock, $order );
 	}
 
 	if ( $changes ) {

--- a/plugins/woocommerce/includes/wc-stock-functions.php
+++ b/plugins/woocommerce/includes/wc-stock-functions.php
@@ -296,7 +296,7 @@ function wc_increase_stock_levels( $order_id ) {
 
 		$item_name = $product->get_formatted_name();
 		$new_stock = wc_update_product_stock( $product, $item_stock_reduced, 'increase' );
-        $old_stock = $new_stock - $item_stock_reduced;
+		$old_stock = $new_stock - $item_stock_reduced;
 
 		if ( is_wp_error( $new_stock ) ) {
 			/* translators: %s item name. */

--- a/plugins/woocommerce/includes/wc-stock-functions.php
+++ b/plugins/woocommerce/includes/wc-stock-functions.php
@@ -309,15 +309,15 @@ function wc_increase_stock_levels( $order_id ) {
 
 		$changes[] = $item_name . ' ' . $old_stock . '&rarr;' . $new_stock;
 
-        /**
-         * Fires when stock restored to a specific line item
-         *
-         * @since 9.1.0
-         * @param WC_Order_Item_Product $item Order item data.
-         * @param int $new_stock  New stock.
-         * @param int $old_stock Old stock.
-         * @param WC_Order $order  Order data.
-         */
+		/**
+		 * Fires when stock restored to a specific line item
+		 *
+		 * @since 9.1.0
+		 * @param WC_Order_Item_Product $item Order item data.
+		 * @param int $new_stock  New stock.
+		 * @param int $old_stock Old stock.
+		 * @param WC_Order $order  Order data.
+		 */
         do_action( 'woocommerce_restore_order_item_stock', $item, $new_stock, $old_stock, $order );
 	}
 

--- a/plugins/woocommerce/includes/wc-stock-functions.php
+++ b/plugins/woocommerce/includes/wc-stock-functions.php
@@ -296,6 +296,7 @@ function wc_increase_stock_levels( $order_id ) {
 
 		$item_name = $product->get_formatted_name();
 		$new_stock = wc_update_product_stock( $product, $item_stock_reduced, 'increase' );
+        $old_stock = $new_stock - $item_stock_reduced;
 
 		if ( is_wp_error( $new_stock ) ) {
 			/* translators: %s item name. */
@@ -306,7 +307,17 @@ function wc_increase_stock_levels( $order_id ) {
 		$item->delete_meta_data( '_reduced_stock' );
 		$item->save();
 
-		$changes[] = $item_name . ' ' . ( $new_stock - $item_stock_reduced ) . '&rarr;' . $new_stock;
+		$changes[] = $item_name . ' ' . $old_stock . '&rarr;' . $new_stock;
+
+        /**
+         * Fires when stock restored to a specific line item
+         *
+         * @param WC_Order_Item_Product $item Order item data.
+         * @param int $new_stock  New stock.
+         * @param int $old_stock Old stock.
+         * @param WC_Order $order  Order data.
+         */
+        do_action( 'woocommerce_restore_order_item_stock', $item, $new_stock, $old_stock, $order );
 	}
 
 	if ( $changes ) {

--- a/plugins/woocommerce/includes/wc-stock-functions.php
+++ b/plugins/woocommerce/includes/wc-stock-functions.php
@@ -312,11 +312,11 @@ function wc_increase_stock_levels( $order_id ) {
         /**
          * Fires when stock restored to a specific line item
          *
+         * @since 9.1.0
          * @param WC_Order_Item_Product $item Order item data.
          * @param int $new_stock  New stock.
          * @param int $old_stock Old stock.
          * @param WC_Order $order  Order data.
-         * @since 9.1.0
          */
         do_action( 'woocommerce_restore_order_item_stock', $item, $new_stock, $old_stock, $order );
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

There is an existing action `woocommerce_reduce_order_item_stock` in the `wc_reduce_stock_levels()` function.
The corresponding `wc_increase_stock_levels()` function does not have such an action.
It only has a more general action after all items have been restored, but it is not possible to know which items have been restored.
This new action will trigger for each restored line item.

### How to test the changes in this Pull Request:

You can test as follows:
```
add_action( 'woocommerce_restore_order_item_stock', function($item, $new_stock, $old_stock, $order) {
    $product  = $item->get_product();
    $item_name = $product->get_formatted_name();
    error_log('Stock level of ' . $item_name . ' has been increased from ' . $old_stock . ' to ' . $new_stock . ' from order ' . $order->get_id());
}, 10, 4);
```
Then cancel an existing order that previously had the stock reduced (e.g. with status on-hold or processing) and check your log file :)

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Add action hook 'woocommerce_restore_order_item_stock' triggered when order line items are restored.

</details>
