### PR TITLE
Hide `Switch to draft` button on single variation page

### DIFF
--- a/packages/js/product-editor/changelog/fix-40845_header_buttons
+++ b/packages/js/product-editor/changelog/fix-40845_header_buttons
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Hide `Switch to draft` button in single variation page #40856
+Hide `Switch to draft` button on single variation page #40856

--- a/packages/js/product-editor/changelog/fix-40845_header_buttons
+++ b/packages/js/product-editor/changelog/fix-40845_header_buttons
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Hide `Switch to draft` button in single variation page #40856

--- a/packages/js/product-editor/src/components/header/header.tsx
+++ b/packages/js/product-editor/src/components/header/header.tsx
@@ -65,6 +65,8 @@ export function Header( {
 		return null;
 	}
 
+	const isVariation = lastPersistedProduct?.parent_id > 0;
+
 	return (
 		<div
 			className="woocommerce-product-header"
@@ -73,7 +75,7 @@ export function Header( {
 			tabIndex={ -1 }
 		>
 			<div className="woocommerce-product-header__inner">
-				{ lastPersistedProduct?.parent_id > 0 ? (
+				{ isVariation ? (
 					<div className="woocommerce-product-header__back">
 						<Tooltip
 							// @ts-expect-error className is missing in TS, should remove this when it is included.
@@ -108,7 +110,7 @@ export function Header( {
 				) }
 
 				<h1 className="woocommerce-product-header__title">
-					{ lastPersistedProduct?.parent_id > 0 ? (
+					{ isVariation ? (
 						<div className="woocommerce-product-header__variable-product-title">
 							<Icon icon={ group } />
 							<span className="woocommerce-product-header__variable-product-name">
@@ -127,10 +129,12 @@ export function Header( {
 				</h1>
 
 				<div className="woocommerce-product-header__actions">
-					<SaveDraftButton
-						productType={ productType }
-						productStatus={ lastPersistedProduct.status }
-					/>
+					{ ! isVariation && (
+						<SaveDraftButton
+							productType={ productType }
+							productStatus={ lastPersistedProduct.status }
+						/>
+					) }
 
 					<PreviewButton
 						productType={ productType }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #40845.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a WooCommerce store with this branch and enable the product editor using **WooCommerce > Settings > Advanced > Features**
2. Go to **Products > Add New**
3. Go to `/wp-admin/admin.php?page=wc-admin&path=/add-product&tab=variations` and add some attributes
4. Wait until variations get generated
5. Then publish the product and edit a single variation
6. Verify the `Switch to draft` button is not visible on the single variation page

![Screenshot 2023-10-19 at 18 49 08](https://github.com/woocommerce/woocommerce/assets/1314156/490cb417-3189-49fe-8a07-ac5b6c1f1e79)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
