### PR TITLE
Shipping Settings: Add classes cost link to Flat rate methods

### DIFF
--- a/plugins/woocommerce/changelog/add-shipping-settings-flat-rate-add-classes-link
+++ b/plugins/woocommerce/changelog/add-shipping-settings-flat-rate-add-classes-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+Comment: Improvement on existing unreleased functionality
+

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -3997,6 +3997,14 @@ table.wc_shipping {
 		
 	}
 
+	.wc-shipping-method-add-class-costs {
+		margin-top: -24px;
+		text-decoration: none;
+		color: #3858E9;
+		font-size: 12px;
+		line-height: 16px;
+	}
+
 	.wc-shipping-zone-method-input {
 		input {
 			clip: rect(0 0 0 0);

--- a/plugins/woocommerce/client/legacy/js/admin/wc-shipping-classes.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-shipping-classes.js
@@ -92,7 +92,6 @@
 					$tr.find( '.edit' ).hide();
 					$tr.find( '.wc-shipping-class-edit' ).on( 'click', { view: this }, this.onEditRow );
 					$tr.find( '.wc-shipping-class-delete' ).on( 'click', { view: this }, this.onDeleteRow );
-					// $tr.find( '.wc-shipping-class-cancel-edit' ).on( 'click', { view: this }, this.onCancelEditRow );
 				},
 				configureNewShippingClass: function( event ) {
 					event.preventDefault();

--- a/plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js
@@ -498,16 +498,13 @@
 										);
 									}
 								}
-								// Trigger save if there are changes, or just re-render
-								if ( _.size( shippingMethodView.model.changes ) ) {
-									shippingMethodView.model.set( 'methods', response.data.methods );
-									shippingMethodView.model.trigger( 'change:methods' );
-									shippingMethodView.model.trigger( 'rerender' );
-								} else {
-									shippingMethodView.model.set( 'methods', response.data.methods );
-									shippingMethodView.model.trigger( 'change:methods' );
-									shippingMethodView.model.trigger( 'saved:methods' );
-								}
+
+								// Avoid triggering a rerender here because we don't want to show the method in the table in case merchant doesn't finish flow.
+								
+								shippingMethodView.model.set( 'methods', response.data.methods );
+
+								// Close original modal
+								closeModal();
 							}
 							var instance_id = response.data.instance_id, 
 							    method      = response.data.methods[ instance_id ];
@@ -534,9 +531,6 @@
 							}
 		
 							$( document.body ).trigger( 'init_tooltips' );
-
-							// Close original modal
-							closeModal();
 						}, 'json' );
 					}
 				},
@@ -582,6 +576,16 @@
 					if ( method.id === 'flat_rate' && shippingClassesCount === 0 ) {
 						const link = article.find( '.wc-shipping-method-add-class-costs' );
 						link.css( 'display', 'block' );
+						link.click( () => {
+							$.post( {
+								url: ajaxurl + ( ajaxurl.indexOf( '?' ) > 0 ? '&' : '?') + 'action=woocommerce_shipping_zone_remove_method',
+								data: {
+									wc_shipping_zones_nonce: data.wc_shipping_zones_nonce,
+									instance_id: instance_id,
+									zone_id: data.zone_id,
+								}
+							});
+						} );
 					}
 				},
 				validateFormArguments: function( event, target, data ) {

--- a/plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js
@@ -577,19 +577,6 @@
 					if ( method.id === 'flat_rate' && shippingClassesCount === 0 ) {
 						const link = article.find( '.wc-shipping-method-add-class-costs' );
 						link.css( 'display', 'block' );
-						
-						if ( status === 'new' ) {
-							link.click( () => {
-								$.post( {
-									url: ajaxurl + ( ajaxurl.indexOf( '?' ) > 0 ? '&' : '?') + 'action=woocommerce_shipping_zone_remove_method',
-									data: {
-										wc_shipping_zones_nonce: data.wc_shipping_zones_nonce,
-										instance_id: instance_id,
-										zone_id: data.zone_id,
-									}
-								});
-							} );
-						}
 					}
 				},
 				validateFormArguments: function( event, target, data ) {

--- a/plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js
@@ -567,6 +567,21 @@
 						if ( select.length > 0 ) {
 							event.data.view.possiblyHideFreeShippingRequirements( { woocommerce_free_shipping_requires: select.val() } );
 						}
+
+						event.data.view.possiblyAddShippingClassLink( event );
+					}
+				},
+				possiblyAddShippingClassLink: function( event ) {
+					const article = $( 'article.wc-modal-shipping-method-settings' );
+					const shippingClassesCount = article.data( 'shipping-classes-count' );
+					const instance_id = article.data( 'id' );
+					const model = event.data.view.model;
+					const methods = _.indexBy( model.get( 'methods' ), 'instance_id' );
+					const method = methods[ instance_id ];
+
+					if ( method.id === 'flat_rate' && shippingClassesCount === 0 ) {
+						const link = article.find( '.wc-shipping-method-add-class-costs' );
+						link.css( 'display', 'block' );
 					}
 				},
 				validateFormArguments: function( event, target, data ) {

--- a/plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js
@@ -568,6 +568,7 @@
 				possiblyAddShippingClassLink: function( event ) {
 					const article = $( 'article.wc-modal-shipping-method-settings' );
 					const shippingClassesCount = article.data( 'shipping-classes-count' );
+					const status = article.data( 'status' );
 					const instance_id = article.data( 'id' );
 					const model = event.data.view.model;
 					const methods = _.indexBy( model.get( 'methods' ), 'instance_id' );
@@ -576,16 +577,19 @@
 					if ( method.id === 'flat_rate' && shippingClassesCount === 0 ) {
 						const link = article.find( '.wc-shipping-method-add-class-costs' );
 						link.css( 'display', 'block' );
-						link.click( () => {
-							$.post( {
-								url: ajaxurl + ( ajaxurl.indexOf( '?' ) > 0 ? '&' : '?') + 'action=woocommerce_shipping_zone_remove_method',
-								data: {
-									wc_shipping_zones_nonce: data.wc_shipping_zones_nonce,
-									instance_id: instance_id,
-									zone_id: data.zone_id,
-								}
-							});
-						} );
+						
+						if ( status === 'new' ) {
+							link.click( () => {
+								$.post( {
+									url: ajaxurl + ( ajaxurl.indexOf( '?' ) > 0 ? '&' : '?') + 'action=woocommerce_shipping_zone_remove_method',
+									data: {
+										wc_shipping_zones_nonce: data.wc_shipping_zones_nonce,
+										instance_id: instance_id,
+										zone_id: data.zone_id,
+									}
+								});
+							} );
+						}
 					}
 				},
 				validateFormArguments: function( event, target, data ) {

--- a/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
+++ b/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
@@ -145,7 +145,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 						{{{ data.method.settings_html }}}
 						<input type="hidden" name="instance_id" value="{{{ data.instance_id }}}" />
 					</form>
-					<a class="wc-shipping-method-add-class-costs" style="display:none;" href="<?php echo esc_url( admin_url( 'admin.php?page=wc-settings&tab=shipping&section=classes' ) ); ?>"><?php esc_html_e( 'Add shipping class costs', 'woocommerce' ); ?></a>
+					<a class="wc-shipping-method-add-class-costs" style="display:none;" target="_blank" href="<?php echo esc_url( admin_url( 'admin.php?page=wc-settings&tab=shipping&section=classes' ) ); ?>"><?php esc_html_e( 'Add shipping class costs', 'woocommerce' ); ?></a>
 				</article>
 				<footer>
 					<div class="inner">

--- a/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
+++ b/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
@@ -140,7 +140,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 						<span class="screen-reader-text"><?php esc_html_e( 'Close modal panel', 'woocommerce' ); ?></span>
 					</button>
 				</header>
-				<article class="wc-modal-shipping-method-settings" data-id="{{{ data.instance_id }}}"  data-shipping-classes-count="<?php echo count( WC()->shipping()->get_shipping_classes() ); ?>">
+				<article class="wc-modal-shipping-method-settings" data-id="{{{ data.instance_id }}}" data-status="{{{ data.status }}}"  data-shipping-classes-count="<?php echo count( WC()->shipping()->get_shipping_classes() ); ?>">
 					<form action="" method="post">
 						{{{ data.method.settings_html }}}
 						<input type="hidden" name="instance_id" value="{{{ data.instance_id }}}" />

--- a/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
+++ b/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
@@ -140,11 +140,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 						<span class="screen-reader-text"><?php esc_html_e( 'Close modal panel', 'woocommerce' ); ?></span>
 					</button>
 				</header>
-				<article class="wc-modal-shipping-method-settings">
+				<article class="wc-modal-shipping-method-settings" data-id="{{{ data.instance_id }}}"  data-shipping-classes-count="<?php echo count( WC()->shipping()->get_shipping_classes() ); ?>">
 					<form action="" method="post">
 						{{{ data.method.settings_html }}}
 						<input type="hidden" name="instance_id" value="{{{ data.instance_id }}}" />
 					</form>
+					<a class="wc-shipping-method-add-class-costs" style="display:none;" href="<?php echo esc_url( admin_url( 'admin.php?page=wc-settings&tab=shipping&section=classes' ) ); ?>"><?php esc_html_e( 'Add shipping class costs', 'woocommerce' ); ?></a>
 				</article>
 				<footer>
 					<div class="inner">


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes https://github.com/woocommerce/woocommerce/issues/40736

This PR adds a link to the Flat rate method create/edit screen if no shipping classes are present.

<img width="579" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1922453/990d854b-c5d7-4ac2-a1b1-f47679b6b3e1">

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. On a JN site, create a Shipping Zone `/wp-admin/admin.php?page=wc-settings&tab=shipping&zone_id=new`. Make sure you have no Shipping Classes configured at this time.
2. Add shipping Method > Flat rate > Continue
3. See the "Add shipping class costs" link
4. Click on it, and confirm the destination is correct.
5. Go back to editing your shipping zone. Note the Flat rate method has not been saved.
6. Now create a Flat rate method and save it, making sure to give it a name.
7. Create a shipping class `/wp-admin/admin.php?page=wc-settings&tab=shipping&section=classes`
8. Now go back and edit your existing Flat rate method or create a new one.
9. See the additional cost fields visible and the link no longer there. Note: The extra long help text in the additional fields is a known issue tracked by https://github.com/woocommerce/woocommerce/issues/40741

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

Improvement on existing unreleased functionality
</details>
