### PR TITLE
add: core profiler email marketing opt in

### DIFF
--- a/packages/js/data/changelog/add-export-wcuser-type
+++ b/packages/js/data/changelog/add-export-wcuser-type
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Export WCUser type for consumption in wcadmin

--- a/packages/js/data/src/index.ts
+++ b/packages/js/data/src/index.ts
@@ -108,6 +108,7 @@ export {
 } from './product-categories/types';
 export { TaxClass } from './tax-classes/types';
 export { ProductTag, Query } from './product-tags/types';
+export { WCUser } from './user/types';
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce-admin/client/core-profiler/actions/tracks.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/actions/tracks.tsx
@@ -76,12 +76,58 @@ const recordTracksSkipBusinessLocationCompleted = () => {
 	} );
 };
 
+// Temporarily expand the step viewed track for BusinessInfo so that we can include the experiment assignment
+// Remove this and change the action back to recordTracksStepViewed when the experiment is over
+const recordTracksStepViewedBusinessInfo = (
+	context: CoreProfilerStateMachineContext,
+	_event: unknown,
+	{ action }: { action: unknown }
+) => {
+	const { step } = action as { step: string };
+	recordEvent( 'coreprofiler_step_view', {
+		step,
+		email_marketing_experiment_assignment:
+			context.emailMarketingExperimentAssignment,
+		wc_version: getSetting( 'wcVersion' ),
+	} );
+};
+
+const recordTracksIsEmailChanged = (
+	context: CoreProfilerStateMachineContext,
+	event: BusinessInfoEvent
+) => {
+	if ( context.emailMarketingExperimentAssignment === 'treatment' ) {
+		let emailSource, isEmailChanged;
+		if ( context.onboardingProfile.store_email ) {
+			emailSource = 'onboarding_profile_store_email'; // from previous entry
+			isEmailChanged =
+				event.payload.storeEmailAddress !==
+				context.onboardingProfile.store_email;
+		} else if ( context.currentUserEmail ) {
+			emailSource = 'current_user_email'; // from currentUser
+			isEmailChanged =
+				event.payload.storeEmailAddress !== context.currentUserEmail;
+		} else {
+			emailSource = 'was_empty';
+			isEmailChanged = event.payload.storeEmailAddress?.length > 0;
+		}
+
+		recordEvent( 'coreprofiler_email_marketing', {
+			opt_in: event.payload.isOptInMarketing,
+			email_field_prefilled_source: emailSource,
+			email_field_modified: isEmailChanged,
+		} );
+	}
+};
+
 const recordTracksBusinessInfoCompleted = (
-	_context: CoreProfilerStateMachineContext,
+	context: CoreProfilerStateMachineContext,
 	event: Extract< BusinessInfoEvent, { type: 'BUSINESS_INFO_COMPLETED' } >
 ) => {
 	recordEvent( 'coreprofiler_step_complete', {
 		step: 'business_info',
+		email_marketing_experiment_assignment:
+			context.emailMarketingExperimentAssignment,
 		wc_version: getSetting( 'wcVersion' ),
 	} );
 
@@ -92,8 +138,8 @@ const recordTracksBusinessInfoCompleted = (
 			) === -1,
 		industry: event.payload.industry,
 		store_location_previously_set:
-			_context.onboardingProfile.is_store_country_set || false,
-		geolocation_success: _context.geolocatedLocation !== undefined,
+			context.onboardingProfile.is_store_country_set || false,
+		geolocation_success: context.geolocatedLocation !== undefined,
 		geolocation_overruled: event.payload.geolocationOverruled,
 	} );
 };
@@ -180,4 +226,6 @@ export default {
 	recordFailedPluginInstallations,
 	recordSuccessfulPluginInstallation,
 	recordTracksPluginsInstallationRequest,
+	recordTracksIsEmailChanged,
+	recordTracksStepViewedBusinessInfo,
 };

--- a/plugins/woocommerce-admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/index.tsx
@@ -41,7 +41,6 @@ import {
 import { CountryStateOption } from '@woocommerce/onboarding';
 import { getAdminLink } from '@woocommerce/settings';
 import CurrencyFactory from '@woocommerce/currency';
-import moment from 'moment';
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce-admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/index.tsx
@@ -31,11 +31,17 @@ import {
 	GeolocationResponse,
 	PLUGINS_STORE_NAME,
 	SETTINGS_STORE_NAME,
+	USER_STORE_NAME,
+	WCUser,
 } from '@woocommerce/data';
-import { initializeExPlat } from '@woocommerce/explat';
+import {
+	initializeExPlat,
+	loadExperimentAssignment,
+} from '@woocommerce/explat';
 import { CountryStateOption } from '@woocommerce/onboarding';
 import { getAdminLink } from '@woocommerce/settings';
 import CurrencyFactory from '@woocommerce/currency';
+import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -99,6 +105,8 @@ export type BusinessInfoEvent = {
 		industry?: IndustryChoice;
 		storeLocation: CountryStateOption[ 'key' ];
 		geolocationOverruled: boolean;
+		isOptInMarketing: boolean;
+		storeEmailAddress: string;
 	};
 };
 
@@ -139,6 +147,8 @@ export type OnboardingProfile = {
 	selling_platforms: SellingPlatform[] | null;
 	skip?: boolean;
 	is_store_country_set: boolean | null;
+	store_email?: string;
+	is_agree_marketing?: boolean;
 };
 
 export type PluginsPageSkippedEvent = {
@@ -195,6 +205,8 @@ export type CoreProfilerStateMachineContext = {
 	persistBusinessInfoRef?: ReturnType< typeof spawn >;
 	spawnUpdateOnboardingProfileOptionRef?: ReturnType< typeof spawn >;
 	spawnGeolocationRef?: ReturnType< typeof spawn >;
+	emailMarketingExperimentAssignment: 'treatment' | 'control';
+	currentUserEmail: string | undefined;
 };
 
 const getAllowTrackingOption = async () =>
@@ -309,11 +321,54 @@ const handleOnboardingProfileOption = assign( {
 	},
 } );
 
+const getMarketingOptInExperimentAssignment = async () => {
+	const momentDate = moment().utc();
+	const year = momentDate.format( 'YYYY' );
+	const month = momentDate.format( 'MM' );
+	return loadExperimentAssignment(
+		`woocommerce_core_profiler_email_marketing_opt_in_${ year }_${ month }`
+	);
+};
+
+const getCurrentUserEmail = async () => {
+	const currentUser: WCUser< 'email' > = await resolveSelect(
+		USER_STORE_NAME
+	).getCurrentUser();
+	return currentUser?.email;
+};
+
+const assignCurrentUserEmail = assign( {
+	currentUserEmail: (
+		_context,
+		event: DoneInvokeEvent< string | undefined >
+	) => {
+		if (
+			event.data &&
+			event.data.length > 0 &&
+			event.data !== 'wordpress@example.com' // wordpress default prefilled email address
+		) {
+			return event.data;
+		}
+		return undefined;
+	},
+} );
+
 const assignOnboardingProfile = assign( {
 	onboardingProfile: (
 		_context,
 		event: DoneInvokeEvent< OnboardingProfile | undefined >
 	) => event.data,
+} );
+
+const assignMarketingOptInExperimentAssignment = assign( {
+	emailMarketingExperimentAssignment: (
+		_context,
+		event: DoneInvokeEvent<
+			Awaited<
+				ReturnType< typeof getMarketingOptInExperimentAssignment >
+			>
+		>
+	) => event.data.variationName ?? 'control',
 } );
 
 const getGeolocation = async ( context: CoreProfilerStateMachineContext ) => {
@@ -499,6 +554,11 @@ const updateBusinessInfo = async (
 			...refreshedOnboardingProfile,
 			is_store_country_set: true,
 			industry: [ event.payload.industry ],
+			is_agree_marketing: event.payload.isOptInMarketing,
+			store_email:
+				event.payload.storeEmailAddress.length > 0
+					? event.payload.storeEmailAddress
+					: null,
 		},
 	} );
 };
@@ -644,6 +704,8 @@ const coreProfilerMachineActions = {
 	handleCountries,
 	handleOnboardingProfileOption,
 	assignOnboardingProfile,
+	assignMarketingOptInExperimentAssignment,
+	assignCurrentUserEmail,
 	persistBusinessInfo,
 	spawnUpdateOnboardingProfileOption,
 	redirectToWooHome,
@@ -657,6 +719,8 @@ const coreProfilerMachineServices = {
 	getCountries,
 	getGeolocation,
 	getOnboardingProfileOption,
+	getMarketingOptInExperimentAssignment,
+	getCurrentUserEmail,
 	getPlugins,
 	browserPopstateHandler,
 	updateBusinessInfo,
@@ -693,6 +757,8 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 		loader: {},
 		onboardingProfile: {} as OnboardingProfile,
 		jetpackAuthUrl: undefined,
+		emailMarketingExperimentAssignment: 'control',
+		currentUserEmail: undefined,
 	} as CoreProfilerStateMachineContext,
 	states: {
 		navigate: {
@@ -1026,6 +1092,45 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 								},
 							},
 						},
+						marketingOptInExperiment: {
+							initial: 'fetching',
+							states: {
+								fetching: {
+									invoke: {
+										src: 'getMarketingOptInExperimentAssignment',
+										onDone: {
+											target: 'done',
+											actions: [
+												'assignMarketingOptInExperimentAssignment',
+											],
+										},
+									},
+								},
+								done: { type: 'final' },
+							},
+						},
+						currentUserEmail: {
+							initial: 'fetching',
+							states: {
+								fetching: {
+									invoke: {
+										src: 'getCurrentUserEmail',
+										onDone: {
+											target: 'done',
+											actions: [
+												'assignCurrentUserEmail',
+											],
+										},
+										onError: {
+											target: 'done',
+										},
+									},
+								},
+								done: {
+									type: 'final',
+								},
+							},
+						},
 					},
 					// onDone is reached when child parallel states fo fetching are resolved (reached final states)
 					onDone: {
@@ -1039,14 +1144,17 @@ export const coreProfilerStateMachineDefinition = createMachine( {
 					},
 					entry: [
 						{
-							type: 'recordTracksStepViewed',
+							type: 'recordTracksStepViewedBusinessInfo',
 							step: 'business_info',
 						},
 					],
 					on: {
 						BUSINESS_INFO_COMPLETED: {
 							target: 'postBusinessInfo',
-							actions: [ 'recordTracksBusinessInfoCompleted' ],
+							actions: [
+								'recordTracksBusinessInfoCompleted',
+								'recordTracksIsEmailChanged',
+							],
 						},
 					},
 				},

--- a/plugins/woocommerce-admin/client/core-profiler/index.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/index.tsx
@@ -322,11 +322,8 @@ const handleOnboardingProfileOption = assign( {
 } );
 
 const getMarketingOptInExperimentAssignment = async () => {
-	const momentDate = moment().utc();
-	const year = momentDate.format( 'YYYY' );
-	const month = momentDate.format( 'MM' );
 	return loadExperimentAssignment(
-		`woocommerce_core_profiler_email_marketing_opt_in_${ year }_${ month }`
+		`woocommerce_core_profiler_email_marketing_opt_in_2023_Q4_V1`
 	);
 };
 

--- a/plugins/woocommerce-admin/client/core-profiler/pages/BusinessInfo.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/pages/BusinessInfo.tsx
@@ -2,7 +2,13 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button, TextControl, Notice, Spinner } from '@wordpress/components';
+import {
+	Button,
+	TextControl,
+	Notice,
+	Spinner,
+	CheckboxControl,
+} from '@wordpress/components';
 import { SelectControl } from '@woocommerce/components';
 import { Icon, chevronDown } from '@wordpress/icons';
 import {
@@ -83,9 +89,18 @@ export type BusinessInfoContextProps = Pick<
 > & {
 	onboardingProfile: Pick<
 		CoreProfilerStateMachineContext[ 'onboardingProfile' ],
-		'industry' | 'business_choice' | 'is_store_country_set'
+		| 'industry'
+		| 'business_choice'
+		| 'is_store_country_set'
+		| 'is_agree_marketing'
+		| 'store_email'
 	>;
-};
+} & Partial<
+		Pick<
+			CoreProfilerStateMachineContext,
+			'emailMarketingExperimentAssignment' | 'currentUserEmail'
+		>
+	>;
 
 export const BusinessInfo = ( {
 	context,
@@ -105,7 +120,11 @@ export const BusinessInfo = ( {
 			is_store_country_set: isStoreCountrySet,
 			industry: industryFromOnboardingProfile,
 			business_choice: businessChoiceFromOnboardingProfile,
+			is_agree_marketing: isOptInMarketingFromOnboardingProfile,
+			store_email: storeEmailAddressFromOnboardingProfile,
 		},
+		emailMarketingExperimentAssignment,
+		currentUserEmail,
 	} = context;
 
 	const [ storeName, setStoreName ] = useState(
@@ -175,6 +194,14 @@ export const BusinessInfo = ( {
 		useState( false );
 
 	const [ hasSubmitted, setHasSubmitted ] = useState( false );
+
+	const [ storeEmailAddress, setEmailAddress ] = useState(
+		storeEmailAddressFromOnboardingProfile || currentUserEmail || ''
+	);
+
+	const [ isOptInMarketing, setIsOptInMarketing ] = useState< boolean >(
+		isOptInMarketingFromOnboardingProfile || false
+	);
 
 	return (
 		<div
@@ -345,12 +372,55 @@ export const BusinessInfo = ( {
 							</ul>
 						</Notice>
 					) }
+					{ emailMarketingExperimentAssignment === 'treatment' && (
+						<>
+							<TextControl
+								className="woocommerce-profiler-business-info-email-adddress"
+								onChange={ ( value ) => {
+									setEmailAddress( value );
+								} }
+								value={ decodeEntities( storeEmailAddress ) }
+								label={
+									<>
+										{ __(
+											'Your email address',
+											'woocommerce'
+										) }
+										{ isOptInMarketing && (
+											<span className="woocommerce-profiler-question-required">
+												{ '*' }
+											</span>
+										) }
+									</>
+								}
+								placeholder={ __(
+									'wordpress@example.com',
+									'woocommerce'
+								) }
+							/>
+							<CheckboxControl
+								className="core-profiler__checkbox"
+								label={ __(
+									'Opt-in to receive tips, discounts, and recommendations from the Woo team directly in your inbox.',
+									'woocommerce'
+								) }
+								checked={ isOptInMarketing }
+								onChange={ setIsOptInMarketing }
+							/>
+						</>
+					) }
 				</form>
 				<div className="woocommerce-profiler-button-container">
 					<Button
 						className="woocommerce-profiler-button"
 						variant="primary"
-						disabled={ ! storeCountry.key }
+						disabled={
+							! storeCountry.key ||
+							( emailMarketingExperimentAssignment ===
+								'treatment' &&
+								isOptInMarketing &&
+								storeEmailAddress.length === 0 )
+						}
 						onClick={ () => {
 							sendEvent( {
 								type: 'BUSINESS_INFO_COMPLETED',
@@ -360,6 +430,8 @@ export const BusinessInfo = ( {
 									storeLocation: storeCountry.key,
 									geolocationOverruled:
 										geolocationOverruled || false,
+									isOptInMarketing,
+									storeEmailAddress,
 								},
 							} );
 							setHasSubmitted( true );

--- a/plugins/woocommerce-admin/client/core-profiler/pages/tests/business-info.test.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/pages/tests/business-info.test.tsx
@@ -173,6 +173,8 @@ describe( 'BusinessInfo', () => {
 				industry: 'other',
 				storeLocation: 'AU:VIC',
 				storeName: '',
+				isOptInMarketing: false,
+				storeEmailAddress: '',
 			},
 			type: 'BUSINESS_INFO_COMPLETED',
 		} );
@@ -224,6 +226,8 @@ describe( 'BusinessInfo', () => {
 				industry: 'other',
 				storeLocation: 'AW',
 				storeName: '',
+				isOptInMarketing: false,
+				storeEmailAddress: '',
 			},
 			type: 'BUSINESS_INFO_COMPLETED',
 		} );
@@ -273,6 +277,8 @@ describe( 'BusinessInfo', () => {
 				industry: 'food_and_drink',
 				storeLocation: 'AU:VIC',
 				storeName: 'Test Store Name',
+				isOptInMarketing: false,
+				storeEmailAddress: '',
 			},
 			type: 'BUSINESS_INFO_COMPLETED',
 		} );
@@ -301,8 +307,106 @@ describe( 'BusinessInfo', () => {
 				industry: 'food_and_drink',
 				storeLocation: 'AU:VIC',
 				storeName: 'Test Store Name',
+				isOptInMarketing: false,
+				storeEmailAddress: '',
 			},
 			type: 'BUSINESS_INFO_COMPLETED',
+		} );
+	} );
+
+	describe( 'business info page, email marketing variant', () => {
+		beforeEach( () => {
+			props.context.emailMarketingExperimentAssignment = 'treatment';
+		} );
+
+		it( 'should correctly render the experiment variant with the email field', () => {
+			render( <BusinessInfo { ...props } /> );
+			expect(
+				screen.getByText( /Your email address/i )
+			).toBeInTheDocument();
+		} );
+
+		it( 'should not disable the continue field when experiment variant is shown, opt in checkbox is not checked and email field is empty', () => {
+			props.context.businessInfo.location = 'AW';
+			props.context.onboardingProfile.is_store_country_set = true;
+			render( <BusinessInfo { ...props } /> );
+			const continueButton = screen.getByRole( 'button', {
+				name: /Continue/i,
+			} );
+			expect( continueButton ).not.toBeDisabled();
+		} );
+
+		it( 'should disable the continue field when experiment variant is shown, opt in checkbox is checked and email field is empty', () => {
+			props.context.businessInfo.location = 'AW';
+			props.context.onboardingProfile.is_store_country_set = true;
+			render( <BusinessInfo { ...props } /> );
+			const checkbox = screen.getByRole( 'checkbox', {
+				name: /Opt-in to receive tips, discounts, and recommendations from the Woo team directly in your inbox./i,
+			} );
+			userEvent.click( checkbox );
+			const continueButton = screen.getByRole( 'button', {
+				name: /Continue/i,
+			} );
+			expect( continueButton ).toBeDisabled();
+		} );
+
+		it( 'should correctly send event with opt-in true when experiment variant is shown, opt in checkbox is checked and email field is filled', () => {
+			props.context.businessInfo.location = 'AW';
+			props.context.onboardingProfile.is_store_country_set = true;
+			render( <BusinessInfo { ...props } /> );
+			const checkbox = screen.getByRole( 'checkbox', {
+				name: /Opt-in to receive tips, discounts, and recommendations from the Woo team directly in your inbox./i,
+			} );
+			userEvent.click( checkbox );
+			const emailInput = screen.getByRole( 'textbox', {
+				name: /Your email address/i,
+			} );
+			userEvent.type( emailInput, 'wordpress@automattic.com' );
+			const continueButton = screen.getByRole( 'button', {
+				name: /Continue/i,
+			} );
+			userEvent.click( continueButton );
+			expect( props.sendEvent ).toHaveBeenCalledWith( {
+				payload: {
+					geolocationOverruled: false,
+					industry: 'other',
+					storeLocation: 'AW',
+					storeName: '',
+					isOptInMarketing: true,
+					storeEmailAddress: 'wordpress@automattic.com',
+				},
+				type: 'BUSINESS_INFO_COMPLETED',
+			} );
+		} );
+
+		it( 'should correctly prepopulate the email field if populated in the onboarding profile', () => {
+			props.context.onboardingProfile.store_email =
+				'wordpress@automattic.com';
+			render( <BusinessInfo { ...props } /> );
+			const emailInput = screen.getByRole( 'textbox', {
+				name: /Your email address/i,
+			} );
+			expect( emailInput ).toHaveValue( 'wordpress@automattic.com' );
+		} );
+
+		it( 'should correctly prepopulate the email field if populated in the current user', () => {
+			props.context.currentUserEmail = 'currentUser@automattic.com';
+			render( <BusinessInfo { ...props } /> );
+			const emailInput = screen.getByRole( 'textbox', {
+				name: /Your email address/i,
+			} );
+			expect( emailInput ).toHaveValue( 'currentUser@automattic.com' );
+		} );
+
+		it( 'should correctly favor the onboarding profile email over the current user email', () => {
+			props.context.currentUserEmail = 'currentUser@automattic.com';
+			props.context.onboardingProfile.store_email =
+				'wordpress@automattic.com';
+			render( <BusinessInfo { ...props } /> );
+			const emailInput = screen.getByRole( 'textbox', {
+				name: /Your email address/i,
+			} );
+			expect( emailInput ).toHaveValue( 'wordpress@automattic.com' );
 		} );
 	} );
 } );

--- a/plugins/woocommerce-admin/client/core-profiler/style.scss
+++ b/plugins/woocommerce-admin/client/core-profiler/style.scss
@@ -419,6 +419,8 @@
 		}
 
 		.woocommerce-profiler-question-label,
+		.woocommerce-profiler-business-info-email-adddress
+		.components-base-control__label,
 		.woocommerce-profiler-business-info-store-name
 		.components-base-control__label {
 			text-transform: uppercase;
@@ -430,11 +432,15 @@
 		}
 
 		.woocommerce-profiler-question-label
+		.woocommerce-profiler-question-required,
+		.woocommerce-profiler-business-info-email-adddress
 		.woocommerce-profiler-question-required {
 			color: #cc1818;
 			padding-left: 3px;
 		}
 
+		.woocommerce-profiler-business-info-email-adddress
+		.components-text-control__input,
 		.woocommerce-profiler-business-info-store-name
 		.components-text-control__input {
 			height: 40px;
@@ -445,6 +451,29 @@
 			&:focus {
 				border-color: transparent;
 				box-shadow: 0 0 0 2px var(--wp-admin-theme-color, #006088);
+			}
+		}
+
+		.woocommerce-profiler-select-control__country-spacer + .woocommerce-profiler-business-info-email-adddress {
+			margin-top: 8px;
+		}
+
+		.woocommerce-profiler-business-info-email-adddress {
+			margin-top: 20px;
+		}
+
+		.core-profiler__checkbox {
+			margin-top: 4px;
+
+			.components-checkbox-control__input-container {
+				margin-right: 16px;
+			}
+
+			.components-checkbox-control__label {
+				color: $gray-700;
+				font-size: 12px;
+				line-height: 16px;
+				font-weight: 400;
 			}
 		}
 

--- a/plugins/woocommerce/changelog/add-core-profiler-email-marketing-opt-in
+++ b/plugins/woocommerce/changelog/add-core-profiler-email-marketing-opt-in
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Added A/B test setup for email marketing opt in for core profiler

--- a/plugins/woocommerce/src/Internal/Admin/Events.php
+++ b/plugins/woocommerce/src/Internal/Admin/Events.php
@@ -156,7 +156,7 @@ class Events {
 			MerchantEmailNotifications::run();
 		}
 
-		if ( Features::is_enabled( 'onboarding' ) ) {
+		if ( Features::is_enabled( 'core-profiler' ) ) {
 			( new MailchimpScheduler() )->run();
 		}
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds the experimental setup for including the email marketing opt in inside the Core Profiler.
The goal of this experiment is to determine the falloff rates by including this marketing opt in screen, and also determine the conversion rate of the opt in.

The events `wcadmin_coreprofiler_step_view` and `wcadmin_coreprofiler_step_complete` have been augmented with a `email_marketing_experiment_assignment` key that takes the values `"treatment" | "control"`.

The difference between these two events can be used to calculate the dropoff rates.

A new tracks event has been added `wcadmin_coreprofiler_email_marketing` to determine the conversion rate of the opt in.

It looks like:

```
recordEvent( 'coreprofiler_email_marketing', {
	opt_in: event.payload.isOptInMarketing,
	email_field_prefilled_source: emailSource,
	email_field_modified: isEmailChanged,
} );
```

`opt_in` : this is true when the checkbox is checked, and false when its not
`email_field_prefilled_source`: this can be `"onboarding_profile_store_email"` | `'was_empty'` | `'current_user_email'` , depending on how the field was prefilled. "onboarding_profile_store_email" most likely means that you previously filled it in, through this core profiler. It takes the value from the `store_email` key in the option `woocommerce_onboarding_profile`.

Closes https://github.com/woocommerce/woocommerce/issues/39939.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


#### Treatment vs Control


1. Set up a WooCommerce installation or use the live branch JN instance
2. Make sure you have WC Test helper so that you can toggle the experiment assignments. Note that the status in WC Test helper doesn't update after you toggle it, but its working. Refreshing the WC Test helper page will show the updated value, but it still works even if you don't refresh.
3. Visit the core profiler 'Tell us a bit about your store' page so that the experiment is recognised in WC Test helper. Alternatively, manually add it in WC Test helper: `woocommerce_core_profiler_email_marketing_opt_in_2023_Q4_V1`
3. Toggle experiment and observe that you see the correct designs in the Business Info step of the core profiler, with email field for 'treatment' and without for 'control'



<img width="854" alt="image" src="https://github.com/woocommerce/woocommerce/assets/27843274/28deb9f6-7842-4b50-8799-29d6c4b87767">

Control:

![image](https://github.com/woocommerce/woocommerce/assets/27843274/44fdcd0a-4417-4be8-8a61-401d919db27e)

Treatment:

![image](https://github.com/woocommerce/woocommerce/assets/27843274/7b3b086d-5b62-47ae-8394-7c4ee93c0293)



#### Various combinations of email marketing entry

There are a few combinations of the workflow that can be tested, and ensure that the tracks events are correctly recorded for all of them.

1. Follow the setup steps as above
1. Enable logging in your devtools console so that you can see the tracks events: `localStorage.debug="*"`
1. Test out the following combinations:

##### Control
1. Toggle the experiment to 'control'
1. Fill out your country if necessary and note that the tracks event is:

`recordevent wcadmin_coreprofiler_step_view 
Object { step: "business_info", email_marketing_experiment_assignment: "control", wc_version: "8.3.0" }`
and
`recordevent wcadmin_coreprofiler_step_complete 
Object { step: "business_info", email_marketing_experiment_assignment: "control", wc_version: "8.3.0" }
`
##### Treatment + opt in
1. Toggle the experiment to 'treatment'
2. Note that the page load event is:
`recordevent wcadmin_coreprofiler_step_view 
Object { step: "business_info", email_marketing_experiment_assignment: "treatment", wc_version: "8.3.0" }`

- Observe that if opt-in is not checked, the 'Continue' button is not disabled when the email is not filled in
- Observe that if opt-in is checked, the 'Continue' button is disabled when the email is not filled in
- Observe that if opt-in is checked and the email is filled in, the continue button becomes enabled

- If you are using live branches or jurassic ninja, the core profiler should correctly pick up your login email, linked to your a8c account.

- If you are using a self hosted install, the default admin email address is probably `wordpress@example.com`.

- This specific default email is ignored and the field should show up as empty.

- Observe that submitting this page should record a tracks event with the properties correctly filled in:
`recordevent wcadmin_coreprofiler_email_marketing 
Object { opt_in: true, email_field_prefilled_source: "onboarding_profile_store_email", email_field_modified: true }`

`opt_in` : this is true when the checkbox is checked, and false when its not
`email_field_prefilled_source`: this can be `"onboarding_profile_store_email"` | `'was_empty'` | `'current_user_email'` , depending on how the field was prefilled. "onboarding_profile_store_email" most likely means that you previously filled it in, through this core profiler. It takes the value from the `store_email` key in the option `woocommerce_onboarding_profile`.


##### Testing mailchimp subscription
1. The job that subscribes the above provided email runs daily, as part of `wc_admin_daily` cron.
2. So if you just leave it naturally, you'll find an email in the provided email within a day
3. If you wish to speed it up, you can manually trigger the `wc_admin_daily` job by using WC Test Helper -> Tools -> Run a cron job
4. You can check that this succeeded by looking up the option `woocommerce_onboarding_subscribed_to_mailchimp`. It should say 'yes'
5. You will find the email welcoming you to Woo within a period of time, it took about 10-15 minutes for me.

![image](https://github.com/woocommerce/woocommerce/assets/27843274/4b8cc30d-78a9-4dfe-88dc-77149f1488a2)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
