### PR TITLE
Address possible performance regression with new defer strategy

### DIFF
--- a/plugins/woocommerce/changelog/40877-add-script-strategy-pt2
+++ b/plugins/woocommerce/changelog/40877-add-script-strategy-pt2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Ensure the script defer strategy added in #40686 doesn't cause a possible performance regression in WP 6.3.
+

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -126,7 +126,7 @@ class WC_Frontend_Scripts {
 		// therefore keep the script in the footer for those cases - see see https://core.trac.wordpress.org/ticket/59599.
 		if ( version_compare( $GLOBALS['wp_version'], '6.4', '<' ) && array( 'strategy' => 'defer' ) === $in_footer ) {
 			$in_footer = array(
-				'strategy' => 'defer',
+				'strategy'  => 'defer',
 				'in_footer' => true,
 			);
 		}

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -122,6 +122,11 @@ class WC_Frontend_Scripts {
 	 */
 	private static function register_script( $handle, $path, $deps = array( 'jquery' ), $version = WC_VERSION, $in_footer = array( 'strategy' => 'defer' ) ) {
 		self::$scripts[] = $handle;
+		// Before WordPress 6.4 defer could cause a regression with non deferrable dependencies,
+		// therefore keep the script in the footer for those cases - see see https://core.trac.wordpress.org/ticket/59599.
+		if ( version_compare( $GLOBALS['wp_version'], '6.4', '<' ) && array( 'strategy' => 'defer' ) === $in_footer ) {
+			$in_footer = array( 'strategy' => 'defer', 'in_footer' => true );
+		}
 		wp_register_script( $handle, $path, $deps, $version, $in_footer );
 	}
 

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -125,7 +125,10 @@ class WC_Frontend_Scripts {
 		// Before WordPress 6.4 defer could cause a regression with non deferrable dependencies,
 		// therefore keep the script in the footer for those cases - see see https://core.trac.wordpress.org/ticket/59599.
 		if ( version_compare( $GLOBALS['wp_version'], '6.4', '<' ) && array( 'strategy' => 'defer' ) === $in_footer ) {
-			$in_footer = array( 'strategy' => 'defer', 'in_footer' => true );
+			$in_footer = array(
+				'strategy' => 'defer',
+				'in_footer' => true,
+			);
 		}
 		wp_register_script( $handle, $path, $deps, $version, $in_footer );
 	}

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -124,7 +124,7 @@ class WC_Frontend_Scripts {
 		self::$scripts[] = $handle;
 		// Before WordPress 6.4 defer could cause a regression with non deferrable dependencies,
 		// therefore keep the script in the footer for those cases - see see https://core.trac.wordpress.org/ticket/59599.
-		if ( version_compare( $GLOBALS['wp_version'], '6.4', '<' ) && array( 'strategy' => 'defer' ) === $in_footer ) {
+		if ( version_compare( get_bloginfo( 'version' ), '6.4', '<' ) && array( 'strategy' => 'defer' ) === $in_footer ) {
 			$in_footer = array(
 				'strategy'  => 'defer',
 				'in_footer' => true,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Follow up to https://github.com/woocommerce/woocommerce/pull/40686, this PR addresses a possible regression - see https://core.trac.wordpress.org/ticket/59599.

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add a script that depends on woocommerce front end scripts, using `in_footer => true`
2. Check that the woo scripts placement and defer status

Expected result: 
woo script no longer deferred, but printed in footer above dependency

Actual result:
woo script still in header and not deferred, therefore becoming a blocking script

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment

Ensure the script defer strategy added in #40686 doesn't cause a possible performance regression in WP 6.3.

</details>
