### PR TITLE
fixed error Trying to get property 'ID' of non-object on line 620 class-wc-admin-post-types.php

### DIFF
--- a/plugins/woocommerce/changelog/admin-print-scripts-defensive-coding
+++ b/plugins/woocommerce/changelog/admin-print-scripts-defensive-coding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Reduce the possibility of errors if the global `$post` object has been set to an unexpected value.

--- a/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-post-types.php
@@ -617,7 +617,7 @@ class WC_Admin_Post_Types {
 	public function disable_autosave() {
 		global $post;
 
-		if ( $post && in_array( get_post_type( $post->ID ), wc_get_order_types( 'order-meta-boxes' ), true ) ) {
+		if ( $post instanceof WP_Post && in_array( get_post_type( $post->ID ), wc_get_order_types( 'order-meta-boxes' ), true ) ) {
 			wp_dequeue_script( 'autosave' );
 		}
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We have code that is hooked into the `admin_print_scripts` action, and its job is to disable autosave for orders.

Under some circumstances (possibly the result of a plugin conflict), the global `$post` object may be set to an unexpected value and the code in question fails (or at least, generates a warning).

This change introduces some extra protections against that possibility.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Start by testing without this change. You should also ensure HPOS is enabled (which is the default if you have created a brand new installation).
2. Add the following snippet to a suitable location, such as `wp-content/mu-plugins/test-40886.php`:

```php
<?php

add_action(
	'admin_print_scripts',
	function () { $GLOBALS['post'] = true; },
	5
);
```

3. Now visit any admin screen, including the main dashboard.
4. Via Query Monitor, or by inspecting your error logs, you should notice an error like this one:

```
Attempt to read property "ID" on bool
/.../plugins/woocommerce/includes/admin/class-wc-admin-post-types.php:628
```

5. If you checkout this branch and repeat the test, the problem should be solved.

**Advanced**

1. Remove the snippet provided above (necessary to prevent a fatal error which would otherwise occur for a different reason).
2. Disable HPOS by visiting **WooCommerce ▸ Settings ▸ Advanced ▸ Features** and enabling **WordPress posts storage**.
3. Open an order for editing.
4. There should be no errors and, if you set a breakpoint inside `WC_Admin_Post_Types::disable_autosave()` (or manually add some logging, etc) you should be able to confirm that the call to `wp_dequeue_script( 'autosave' )` is still invoked.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
