### PR TITLE
Customize your store - Link site icon to Woo Home

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/site-hub.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/site-hub.tsx
@@ -21,7 +21,8 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { forwardRef } from '@wordpress/element';
 // @ts-ignore No types for this exist yet.
 import SiteIcon from '@wordpress/edit-site/build-module/components/site-icon';
-
+import { getNewPath } from '@woocommerce/navigation';
+import { Link } from '@woocommerce/components';
 /**
  * Internal dependencies
  */
@@ -93,7 +94,12 @@ export const SiteHub = forwardRef(
 								ease: 'easeOut',
 							} }
 						>
-							<SiteIcon className="edit-site-layout__view-mode-toggle-icon" />
+							<Link
+								href={ getNewPath( {}, '/', {} ) }
+								type="wp-admin"
+							>
+								<SiteIcon className="edit-site-layout__view-mode-toggle-icon" />
+							</Link>
 						</motion.div>
 
 						<AnimatePresence>

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
@@ -53,6 +53,12 @@
 	}
 }
 
+.woocommerce-customize-store {
+	.edit-site-site-hub__view-mode-toggle-container a {
+		color: unset;
+	}
+}
+
 .woocommerce-customize-store__step-assemblerHub {
 	a {
 		text-decoration: none;

--- a/plugins/woocommerce/changelog/update-40879-transitional-page-site-icon-link
+++ b/plugins/woocommerce/changelog/update-40879-transitional-page-site-icon-link
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+This PR links SiteIcon on the CYS pages to Woo Home.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #40879  .

This PR links SiteIcon on the CYS pages to Woo Home.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new JN site with this branch (Using WooCommerce Beta tester)
2. Go to `Tools -> WCA Test Helper -> Features` and enable `customize-store` feature.
3. Go to https://YOUR-JN-SITE/wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store%2Fassembler-hub
4. Click on the site icon in the upper left-hand corner and confirm it redirects you to Woo Home


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

This PR links SiteIcon on the CYS pages to Woo Home.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
