### PR TITLE
Delete variations from the single page does not reflect correctly in the parent product

### DIFF
--- a/packages/js/product-editor/changelog/fix-40897
+++ b/packages/js/product-editor/changelog/fix-40897
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Invalidate resolution for paginated variations after removing any from the single variation page

--- a/packages/js/product-editor/src/hooks/use-variation-switcher.ts
+++ b/packages/js/product-editor/src/hooks/use-variation-switcher.ts
@@ -75,6 +75,9 @@ export function useVariationSwitcher( {
 			parentId,
 		] );
 		invalidateResolutionForStoreSelector( 'getProductVariations' );
+		invalidateResolutionForStoreSelector(
+			'getProductVariationsTotalCount'
+		);
 	}
 
 	function goToVariation( id: number ) {

--- a/packages/js/product-editor/src/hooks/use-variation-switcher.ts
+++ b/packages/js/product-editor/src/hooks/use-variation-switcher.ts
@@ -2,7 +2,10 @@
  * External dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import { Product } from '@woocommerce/data';
+import {
+	EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME,
+	Product,
+} from '@woocommerce/data';
 import { getNewPath, navigateTo } from '@woocommerce/navigation';
 
 type VariationSwitcherProps = {
@@ -17,6 +20,9 @@ export function useVariationSwitcher( {
 	parentProductType,
 }: VariationSwitcherProps ) {
 	const { invalidateResolution } = useDispatch( 'core' );
+	const { invalidateResolutionForStoreSelector } = useDispatch(
+		EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME
+	);
 	const variationValues = useSelect(
 		( select ) => {
 			if ( parentId === undefined ) {
@@ -68,6 +74,7 @@ export function useVariationSwitcher( {
 			parentProductType || 'product',
 			parentId,
 		] );
+		invalidateResolutionForStoreSelector( 'getProductVariations' );
 	}
 
 	function goToVariation( id: number ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #40897

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure feature `product-variation-management` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper` (WooCommerce Beta Tester plugin) is required
3. Go to `/wp-admin/admin.php?page=wc-admin&path=/add-product&tab=variations` and add enough attributes to generate 6 variations
4. Wait until variations get generated
5. Then publish the product
6. Click `Edit` button from the `Variations` table to edit any variation listed there.
7. You should be redirected to the single variation page to edit it.
8. On the top right corner of the screen the more menu should be shown with a new item called `Delete variation` 
<img width="794" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/615c2bb3-cb22-4418-8efa-69b55a8c9f33">

9. When click it, e confirmation modal should be shown 
<img width="715" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/e233d994-9bc8-4796-952b-ed3629368767">

10. I you click delete button from the modal then right after the variation is deleted a notice should be shown at the bottom left corner of the screen saying the that the variation was deleted and you should be redirected to the variation parent product page.
11. Then go to the parent product using the top left back button on the screen.
12. From the parent product page and under the `Variations` table, the amount of items should be exactly 5.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
