### PR TITLE
Update variation switcher logic to not loop

### DIFF
--- a/packages/js/product-editor/changelog/update-40896_variation_switcher
+++ b/packages/js/product-editor/changelog/update-40896_variation_switcher
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update Variation Switcher to not loop, but hide next/previous buttons if at the end or beginning.

--- a/packages/js/product-editor/src/components/variation-switcher-footer/variation-switcher-footer.scss
+++ b/packages/js/product-editor/src/components/variation-switcher-footer/variation-switcher-footer.scss
@@ -32,6 +32,13 @@
 		}
 	}
 
+	&__button-next {
+		margin-left: auto;
+	}
+	&__button-previous {
+		margin-right: auto;
+	}
+
 	&__product-image {
 		max-height: 32px;
 		max-width: 32px;

--- a/packages/js/product-editor/src/components/variation-switcher-footer/variation-switcher-footer.tsx
+++ b/packages/js/product-editor/src/components/variation-switcher-footer/variation-switcher-footer.tsx
@@ -46,16 +46,20 @@ export function VariationSwitcherFooter( {
 			const { getEntityRecord } = select( 'core' );
 			if ( numberOfVariations && numberOfVariations > 0 ) {
 				return {
-					previousVariation: getEntityRecord< ProductVariation >(
-						'postType',
-						'product_variation',
-						previousVariationId
-					),
-					nextVariation: getEntityRecord< ProductVariation >(
-						'postType',
-						'product_variation',
-						nextVariationId
-					),
+					previousVariation:
+						previousVariationId !== null &&
+						getEntityRecord< ProductVariation >(
+							'postType',
+							'product_variation',
+							previousVariationId
+						),
+					nextVariation:
+						nextVariationId !== null &&
+						getEntityRecord< ProductVariation >(
+							'postType',
+							'product_variation',
+							nextVariationId
+						),
 				};
 			}
 			return {};
@@ -63,23 +67,27 @@ export function VariationSwitcherFooter( {
 		[ nextVariationId, previousVariationId, numberOfVariations ]
 	);
 	function onPrevious() {
-		recordEvent( 'product_variation_switch_previous', {
-			variation_length: numberOfVariations,
-			variation_id: previousVariation?.id,
-			variation_index: activeVariationIndex,
-			previous_variation_index: previousVariationIndex,
-		} );
-		goToPreviousVariation();
+		if ( previousVariation ) {
+			recordEvent( 'product_variation_switch_previous', {
+				variation_length: numberOfVariations,
+				variation_id: previousVariation?.id,
+				variation_index: activeVariationIndex,
+				previous_variation_index: previousVariationIndex,
+			} );
+			goToPreviousVariation();
+		}
 	}
 
 	function onNext() {
-		recordEvent( 'product_variation_switch_next', {
-			variation_length: numberOfVariations,
-			variation_id: nextVariation?.id,
-			variation_index: activeVariationIndex,
-			next_variation_index: nextVariationIndex,
-		} );
-		goToNextVariation();
+		if ( nextVariation ) {
+			recordEvent( 'product_variation_switch_next', {
+				variation_length: numberOfVariations,
+				variation_id: nextVariation?.id,
+				variation_index: activeVariationIndex,
+				next_variation_index: nextVariationIndex,
+			} );
+			goToNextVariation();
+		}
 	}
 
 	if ( ! numberOfVariations || numberOfVariations < 2 ) {
@@ -88,9 +96,9 @@ export function VariationSwitcherFooter( {
 
 	return (
 		<div className="woocommerce-product-variation-switcher-footer">
-			{ previousVariation ? (
+			{ previousVariation && (
 				<Button
-					className="woocommerce-product-variation-switcher-footer__button"
+					className="woocommerce-product-variation-switcher-footer__button woocommerce-product-variation-switcher-footer__button-previous"
 					label={ __( 'Previous', 'woocommerce' ) }
 					onClick={ onPrevious }
 				>
@@ -106,12 +114,13 @@ export function VariationSwitcherFooter( {
 					) }
 					{ previousVariation.name }
 				</Button>
-			) : (
+			) }
+			{ ! previousVariation && previousVariationId !== null && (
 				<SwitcherLoadingPlaceholder position="left" />
 			) }
-			{ nextVariation ? (
+			{ nextVariation && (
 				<Button
-					className="woocommerce-product-variation-switcher-footer__button"
+					className="woocommerce-product-variation-switcher-footer__button woocommerce-product-variation-switcher-footer__button-next"
 					label={ __( 'Next', 'woocommerce' ) }
 					onClick={ onNext }
 				>
@@ -127,7 +136,8 @@ export function VariationSwitcherFooter( {
 					) }
 					<Icon icon={ arrowRight } size={ 16 } />
 				</Button>
-			) : (
+			) }
+			{ ! nextVariation && nextVariationId !== null && (
 				<SwitcherLoadingPlaceholder position="right" />
 			) }
 		</div>

--- a/packages/js/product-editor/src/hooks/use-variation-switcher.ts
+++ b/packages/js/product-editor/src/hooks/use-variation-switcher.ts
@@ -36,13 +36,11 @@ export function useVariationSwitcher( {
 				const activeVariationIndex =
 					parentProduct.variations.indexOf( variationId );
 				const previousVariationIndex =
-					activeVariationIndex > 0
-						? activeVariationIndex - 1
-						: parentProduct.variations.length - 1;
+					activeVariationIndex > 0 ? activeVariationIndex - 1 : null;
 				const nextVariationIndex =
 					activeVariationIndex !== parentProduct.variations.length - 1
 						? activeVariationIndex + 1
-						: 0;
+						: null;
 
 				return {
 					activeVariationIndex,
@@ -50,9 +48,13 @@ export function useVariationSwitcher( {
 					previousVariationIndex,
 					numberOfVariations: parentProduct.variations.length,
 					previousVariationId:
-						parentProduct.variations[ previousVariationIndex ],
+						previousVariationIndex !== null
+							? parentProduct.variations[ previousVariationIndex ]
+							: null,
 					nextVariationId:
-						parentProduct.variations[ nextVariationIndex ],
+						nextVariationIndex !== null
+							? parentProduct.variations[ nextVariationIndex ]
+							: null,
 				};
 			}
 			return {};
@@ -68,33 +70,38 @@ export function useVariationSwitcher( {
 		] );
 	}
 
-	function goToNextVariation() {
-		if ( variationValues.nextVariationId === undefined ) {
-			return false;
-		}
+	function goToVariation( id: number ) {
 		navigateTo( {
-			url: getNewPath(
-				{},
-				`/product/${ parentId }/variation/${ variationValues.nextVariationId }`
-			),
+			url: getNewPath( {}, `/product/${ parentId }/variation/${ id }` ),
 		} );
 	}
 
-	function goToPreviousVariation() {
-		if ( variationValues.previousVariationId === undefined ) {
+	function goToNextVariation() {
+		if (
+			variationValues.nextVariationId === undefined ||
+			variationValues.nextVariationId === null
+		) {
 			return false;
 		}
-		navigateTo( {
-			url: getNewPath(
-				{},
-				`/product/${ parentId }/variation/${ variationValues.previousVariationId }`
-			),
-		} );
+		goToVariation( variationValues.nextVariationId );
+		return true;
+	}
+
+	function goToPreviousVariation() {
+		if (
+			variationValues.previousVariationId === undefined ||
+			variationValues.previousVariationId === null
+		) {
+			return false;
+		}
+		goToVariation( variationValues.previousVariationId );
+		return true;
 	}
 
 	return {
 		...variationValues,
 		invalidateVariationList,
+		goToVariation,
 		goToNextVariation,
 		goToPreviousVariation,
 	};

--- a/plugins/woocommerce-admin/client/products/fills/more-menu-items/delete-variation-menu-item.tsx
+++ b/plugins/woocommerce-admin/client/products/fills/more-menu-items/delete-variation-menu-item.tsx
@@ -32,11 +32,15 @@ export const DeleteVariationMenuItem = ( {
 
 	const variationId = useEntityId( 'postType', 'product_variation' );
 
-	const { invalidateVariationList, goToNextVariation, numberOfVariations } =
-		useVariationSwitcher( {
-			parentId: productId ? parseInt( productId, 10 ) : undefined,
-			variationId,
-		} );
+	const {
+		invalidateVariationList,
+		goToNextVariation,
+		goToPreviousVariation,
+		numberOfVariations,
+	} = useVariationSwitcher( {
+		parentId: productId ? parseInt( productId, 10 ) : undefined,
+		variationId,
+	} );
 
 	const [ name ] = useEntityProp< string >(
 		'postType',
@@ -93,7 +97,10 @@ export const DeleteVariationMenuItem = ( {
 
 				invalidateVariationList();
 				if ( numberOfVariations && numberOfVariations > 1 ) {
-					goToNextVariation();
+					if ( ! goToNextVariation() ) {
+						// This would only happen when deleting the last variation.
+						goToPreviousVariation();
+					}
 				} else {
 					navigateTo( {
 						url: getNewPath( {}, `/product/${ productId }` ),

--- a/plugins/woocommerce/changelog/update-40896_variation_switcher
+++ b/plugins/woocommerce/changelog/update-40896_variation_switcher
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update logic of deleting variation to go to previous variation if the last one is deleted.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR updates the variation switcher logic, so that it doesn't automatically loop around but instead hides the next or previous button when at the beginning or end.

Closes #40896 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Go to `/wp-admin/admin.php?page=wc-admin&path=/add-product&tab=variations` and add some attributes (at-least more then 1 )
3. Wait until variations get generated
4. Then publish the product and save its `productId` and one `variationId` you like
5. Then click **Edit** on the first variation in the list
6. Note that the variation switcher at the bottom should only contain the 'next' button on the right ( in the footer )
7. Click 'next'
8. Notice how the previous button now shows up
9. Click next until the last one ( the next button should disappear and only the previous button should show )
10. Now click the 3 dot menu and click **Delete variation** and take note of the variation title.
11. Once deleted it should redirect to the previous variation as there is no next variation.
12. The next variation button should still be hidden, given the last one has now been deleted.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
