### PR TITLE
Invalidate variations upon generation and fix formatted name

### DIFF
--- a/packages/js/product-editor/changelog/fix-variation_name
+++ b/packages/js/product-editor/changelog/fix-variation_name
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update the variation name, by using the wc_get_formatted_variation.

--- a/packages/js/product-editor/src/components/variations-table/variations-table.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variations-table.tsx
@@ -169,6 +169,8 @@ export const VariationsTable = forwardRef<
 		batchUpdateProductVariations,
 		invalidateResolution,
 	} = useDispatch( EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME );
+	const { invalidateResolution: coreInvalidateResolution } =
+		useDispatch( 'core' );
 
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( 'core/notices' );
@@ -246,6 +248,16 @@ export const VariationsTable = forwardRef<
 				invalidateResolution( 'getProductVariations', [
 					requestParams,
 				] );
+				coreInvalidateResolution( 'getEntityRecord', [
+					'postType',
+					'product',
+					productId,
+				] );
+				coreInvalidateResolution( 'getEntityRecord', [
+					'postType',
+					'product_variation',
+					variationId,
+				] );
 			} )
 			.finally( () => {
 				setIsUpdating( ( prevState ) => ( {
@@ -314,11 +326,24 @@ export const VariationsTable = forwardRef<
 				delete: values.map( ( { id } ) => id ),
 			}
 		)
-			.then( ( response: VariationResponseProps ) =>
+			.then( ( response: VariationResponseProps ) => {
 				invalidateResolution( 'getProductVariations', [
 					requestParams,
-				] ).then( () => response )
-			)
+				] );
+				coreInvalidateResolution( 'getEntityRecord', [
+					'postType',
+					'product',
+					productId,
+				] );
+				values.forEach( ( { id: variationId } ) => {
+					coreInvalidateResolution( 'getEntityRecord', [
+						'postType',
+						'product_variation',
+						variationId,
+					] );
+				} );
+				return response;
+			} )
 			.then( ( response: VariationResponseProps ) => {
 				createSuccessNotice( getSnackbarText( response ) );
 				onVariationTableChange( 'delete' );

--- a/packages/js/product-editor/src/hooks/use-product-variations-helper.ts
+++ b/packages/js/product-editor/src/hooks/use-product-variations-helper.ts
@@ -65,6 +65,8 @@ export function useProductVariationsHelper() {
 		generateProductVariations: _generateProductVariations,
 		invalidateResolutionForStoreSelector,
 	} = useDispatch( EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME );
+	const { invalidateResolution: coreInvalidateResolution } =
+		useDispatch( 'core' );
 
 	const [ isGenerating, setIsGenerating ] = useState( false );
 
@@ -75,7 +77,7 @@ export function useProductVariationsHelper() {
 		) => {
 			setIsGenerating( true );
 
-			const { status: lastStatus } = await resolveSelect(
+			const { status: lastStatus, variations } = await resolveSelect(
 				'core'
 			).getEditedEntityRecord< Product >(
 				'postType',
@@ -111,6 +113,15 @@ export function useProductVariationsHelper() {
 					invalidateResolutionForStoreSelector(
 						'getProductVariations'
 					);
+					if ( variations && variations.length > 0 ) {
+						for ( const variationId of variations ) {
+							coreInvalidateResolution( 'getEntityRecord', [
+								'postType',
+								'product_variation',
+								variationId,
+							] );
+						}
+					}
 					return invalidateResolutionForStoreSelector(
 						'getProductVariationsTotalCount'
 					);

--- a/packages/js/product-editor/src/hooks/use-product-variations-helper.ts
+++ b/packages/js/product-editor/src/hooks/use-product-variations-helper.ts
@@ -122,6 +122,11 @@ export function useProductVariationsHelper() {
 							] );
 						}
 					}
+					coreInvalidateResolution( 'getEntityRecord', [
+						'postType',
+						'product',
+						productId,
+					] );
 					return invalidateResolutionForStoreSelector(
 						'getProductVariationsTotalCount'
 					);

--- a/plugins/woocommerce/changelog/fix-variation_name
+++ b/plugins/woocommerce/changelog/fix-variation_name
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Invalidate variation requests after new product variations are generated.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
@@ -119,7 +119,7 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 			'attributes'            => $this->get_attributes( $object ),
 			'menu_order'            => $object->get_menu_order(),
 			'meta_data'             => $object->get_meta_data(),
-			'name'                  => wc_get_formatted_variation( $object, true, false, true ),
+			'name'                  => wc_get_formatted_variation( $object, true, false, false ),
 			'parent_id'             => $object->get_parent_id(),
 		);
 

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
@@ -119,7 +119,7 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 			'attributes'            => $this->get_attributes( $object ),
 			'menu_order'            => $object->get_menu_order(),
 			'meta_data'             => $object->get_meta_data(),
-			'name'                  => preg_replace( '/' . preg_quote( $object->get_title() . ' - ', '/' ) . '/', '', $object->get_name(), 1 ),
+			'name'                  => wc_get_formatted_variation( $object, true, false, true ),
 			'parent_id'             => $object->get_parent_id(),
 		);
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes two issues:
- The variation name not showing correctly when more then two attributes are used
- The variation names not being updated after navigating back and generating new variations.

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Go to `/wp-admin/admin.php?page=wc-admin&path=/add-product&tab=variations` and add some attributes (at-least more then 1 )
3. Add at-least 3 or more variation options
4. Wait until variations get generated
5. Then publish the product and save its `productId` and one `variationId` you like
6. Then click **Edit** on the first variation in the list
7. Note that the variation name and name in the switcher contain the correct list of attributes ( and not the product name )
8. Click **Main product**
9. Remove or add one a variation option and wait for it to generate them again.
10. Click edit again
11. The variation name should be correct with the added or removed attribute.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
