### PR TITLE
Convert Cart and Checkout pages to shortcodes during setup phase of E2E, API, and k6 perf tests.

### DIFF
--- a/plugins/woocommerce/tests/api-core-tests/global-setup.js
+++ b/plugins/woocommerce/tests/api-core-tests/global-setup.js
@@ -229,6 +229,6 @@ module.exports = async ( config ) => {
 			}
 		}
 
-		await site.maybeUseCartCheckoutShortcodes( config );
+		await site.useCartCheckoutShortcodes( config );
 	}
 };

--- a/plugins/woocommerce/tests/api-core-tests/global-setup.js
+++ b/plugins/woocommerce/tests/api-core-tests/global-setup.js
@@ -1,10 +1,15 @@
 const { ENABLE_HPOS, GITHUB_TOKEN, UPDATE_WC } = process.env;
 const { downloadZip, deleteZip } = require( './utils/plugin-utils' );
 const axios = require( 'axios' ).default;
-const playwrightConfig = require('./playwright.config');
+const playwrightConfig = require( './playwright.config' );
+const { site } = require( './utils' );
 
+
+/**
+ *
+ * @param {import('@playwright/test').FullConfig} config
+ */
 module.exports = async ( config ) => {
-
 	// If API_BASE_URL is configured and doesn't include localhost, running on daily host
 	if (
 		process.env.API_BASE_URL &&
@@ -223,5 +228,7 @@ module.exports = async ( config ) => {
 				process.exit( 1 );
 			}
 		}
+
+		await site.maybeUseCartCheckoutShortcodes( config );
 	}
 };

--- a/plugins/woocommerce/tests/api-core-tests/utils/site.js
+++ b/plugins/woocommerce/tests/api-core-tests/utils/site.js
@@ -250,21 +250,8 @@ const maybeUseCartCheckoutShortcodes = async ( config ) => {
 	 */
 
 	const { request: apiRequest } = require( '@playwright/test' );
-	const { baseURL, userAgent } = config.projects[ 0 ].use;
+	const { baseURL, userAgent, extraHTTPHeaders } = config.projects[ 0 ].use;
 
-	const encodeCredentials = ( username, password ) => {
-		return Buffer.from( `${ username }:${ password }` ).toString(
-			'base64'
-		);
-	};
-
-	const username = process.env.USER_KEY ?? 'admin';
-	const password = process.env.USER_SECRET ?? 'password';
-	const basicAuth = encodeCredentials( username, password );
-	const Authorization = `Basic ${ basicAuth }`;
-	const extraHTTPHeaders = {
-		Authorization,
-	};
 	const options = {
 		baseURL,
 		userAgent,

--- a/plugins/woocommerce/tests/api-core-tests/utils/site.js
+++ b/plugins/woocommerce/tests/api-core-tests/utils/site.js
@@ -241,7 +241,7 @@ const reset = async ( cKey, cSecret ) => {
  * Convert Cart and Checkout pages to shortcode.
  * @param {import('@playwright/test').FullConfig} config
  */
-const maybeUseCartCheckoutShortcodes = async ( config ) => {
+const useCartCheckoutShortcodes = async ( config ) => {
 	/**
 	 * A WordPress page.
 	 * @typedef {Object} WPPage
@@ -300,5 +300,5 @@ const maybeUseCartCheckoutShortcodes = async ( config ) => {
 
 module.exports = {
 	reset,
-	maybeUseCartCheckoutShortcodes,
+	useCartCheckoutShortcodes,
 };

--- a/plugins/woocommerce/tests/e2e-pw/global-setup.js
+++ b/plugins/woocommerce/tests/e2e-pw/global-setup.js
@@ -224,7 +224,7 @@ module.exports = async ( config ) => {
 		}
 	}
 
-	await site.maybeUseCartCheckoutShortcodes( baseURL, userAgent, admin );
+	await site.useCartCheckoutShortcodes( baseURL, userAgent, admin );
 
 	await adminContext.close();
 	await customerContext.close();

--- a/plugins/woocommerce/tests/e2e-pw/global-setup.js
+++ b/plugins/woocommerce/tests/e2e-pw/global-setup.js
@@ -224,7 +224,7 @@ module.exports = async ( config ) => {
 		}
 	}
 
-	await site.setupCartCheckoutShortcodePages( baseURL, userAgent, admin );
+	await site.maybeUseCartCheckoutShortcodes( baseURL, userAgent, admin );
 
 	await adminContext.close();
 	await customerContext.close();

--- a/plugins/woocommerce/tests/e2e-pw/global-setup.js
+++ b/plugins/woocommerce/tests/e2e-pw/global-setup.js
@@ -58,7 +58,7 @@ module.exports = async ( config ) => {
 	for ( let i = 0; i < adminRetries; i++ ) {
 		try {
 			console.log( 'Trying to log-in as admin...' );
-			await adminPage.goto( `/wp-admin` );
+			await adminPage.goto( `/wp-admin`, { waitUntil: 'networkidle' } );
 			await adminPage
 				.locator( 'input[name="log"]' )
 				.fill( admin.username );
@@ -139,7 +139,9 @@ module.exports = async ( config ) => {
 	for ( let i = 0; i < customerRetries; i++ ) {
 		try {
 			console.log( 'Trying to log-in as customer...' );
-			await customerPage.goto( `/wp-admin` );
+			await customerPage.goto( `/wp-admin`, {
+				waitUntil: 'networkidle',
+			} );
 			await customerPage
 				.locator( 'input[name="log"]' )
 				.fill( customer.username );

--- a/plugins/woocommerce/tests/e2e-pw/global-setup.js
+++ b/plugins/woocommerce/tests/e2e-pw/global-setup.js
@@ -219,6 +219,8 @@ module.exports = async ( config ) => {
 		}
 	}
 
+	await site.setupCartCheckoutShortcodePages( baseURL, userAgent, admin );
+
 	await adminContext.close();
 	await customerContext.close();
 	await browser.close();

--- a/plugins/woocommerce/tests/e2e-pw/global-setup.js
+++ b/plugins/woocommerce/tests/e2e-pw/global-setup.js
@@ -5,6 +5,9 @@ const { site } = require( './utils' );
 const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 const { ENABLE_HPOS } = process.env;
 
+/**
+ * @param {import('@playwright/test').FullConfig} config
+ */
 module.exports = async ( config ) => {
 	const { stateDir, baseURL, userAgent } = config.projects[ 0 ].use;
 

--- a/plugins/woocommerce/tests/e2e-pw/global-teardown.js
+++ b/plugins/woocommerce/tests/e2e-pw/global-teardown.js
@@ -18,7 +18,7 @@ module.exports = async ( config ) => {
 	for ( let i = 0; i < keysRetries; i++ ) {
 		try {
 			console.log( 'Trying to clear consumer token... Try:' + i );
-			await adminPage.goto( `/wp-admin` );
+			await adminPage.goto( `/wp-admin`, { waitUntil: 'networkidle' } );
 			await adminPage
 				.locator( 'input[name="log"]' )
 				.fill( admin.username );
@@ -26,6 +26,7 @@ module.exports = async ( config ) => {
 				.locator( 'input[name="pwd"]' )
 				.fill( admin.password );
 			await adminPage.locator( 'text=Log In' ).click();
+			await adminPage.waitForLoadState( 'networkidle' );
 			await adminPage.goto(
 				`/wp-admin/admin.php?page=wc-settings&tab=advanced&section=keys`
 			);

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-simple-product.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-simple-product.spec.js
@@ -58,24 +58,12 @@ test.describe.serial( 'Add New Simple Product Page', () => {
 		await page.locator( '#title' ).fill( virtualProductName );
 		await page.locator( '#_regular_price' ).fill( productPrice );
 		await page.locator( '#_virtual' ).click();
+		await page.getByRole( 'button', { name: 'Save Draft' } ).click();
+		await expect( page.locator( '#sample-permalink' ) ).toBeVisible();
 		await page.locator( '#publish' ).click();
 		await page.waitForLoadState( 'networkidle' );
 
-		// When running in parallel, clicking the publish button sometimes saves products as a draft
-		if (
-			(
-				await page.locator( '#post-status-display' ).innerText()
-			 ).includes( 'Draft' )
-		) {
-			await page.locator( '#publish' ).click();
-			await page.waitForLoadState( 'networkidle' );
-		}
-
-		await expect(
-			page
-				.locator( 'div.notice-success > p' )
-				.filter( { hasText: 'Product published.' } )
-		).toBeVisible();
+		await expect( page.getByText( 'Product published.' ) ).toBeVisible();
 
 		// Save product ID
 		virtualProductId = page.url().match( /(?<=post=)\d+/ );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-simple-product.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-simple-product.spec.js
@@ -58,12 +58,24 @@ test.describe.serial( 'Add New Simple Product Page', () => {
 		await page.locator( '#title' ).fill( virtualProductName );
 		await page.locator( '#_regular_price' ).fill( productPrice );
 		await page.locator( '#_virtual' ).click();
-		await page.getByRole( 'button', { name: 'Save Draft' } ).click();
-		await expect( page.locator( '#sample-permalink' ) ).toBeVisible();
 		await page.locator( '#publish' ).click();
 		await page.waitForLoadState( 'networkidle' );
 
-		await expect( page.getByText( 'Product published.' ) ).toBeVisible();
+		// When running in parallel, clicking the publish button sometimes saves products as a draft
+		if (
+			(
+				await page.locator( '#post-status-display' ).innerText()
+			 ).includes( 'Draft' )
+		) {
+			await page.locator( '#publish' ).click();
+			await page.waitForLoadState( 'networkidle' );
+		}
+
+		await expect(
+			page
+				.locator( 'div.notice-success > p' )
+				.filter( { hasText: 'Product published.' } )
+		).toBeVisible();
 
 		// Save product ID
 		virtualProductId = page.url().match( /(?<=post=)\d+/ );

--- a/plugins/woocommerce/tests/e2e-pw/utils/site.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/site.js
@@ -240,7 +240,7 @@ const reset = async ( cKey, cSecret ) => {
 /**
  * Convert Cart and Checkout pages to shortcode.
  */
-const maybeUseCartCheckoutShortcodes = async ( baseURL, userAgent, admin ) => {
+const useCartCheckoutShortcodes = async ( baseURL, userAgent, admin ) => {
 	/**
 	 * A WordPress page.
 	 * @typedef {Object} WPPage
@@ -304,5 +304,5 @@ const maybeUseCartCheckoutShortcodes = async ( baseURL, userAgent, admin ) => {
 
 module.exports = {
 	reset,
-	maybeUseCartCheckoutShortcodes,
+	useCartCheckoutShortcodes,
 };

--- a/plugins/woocommerce/tests/e2e-pw/utils/site.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/site.js
@@ -242,6 +242,7 @@ const reset = async ( cKey, cSecret ) => {
  */
 const maybeUseCartCheckoutShortcodes = async ( baseURL, userAgent, admin ) => {
 	/**
+	 * A WordPress page.
 	 * @typedef {Object} WPPage
 	 * @property {number} id
 	 * @property {string} slug

--- a/plugins/woocommerce/tests/e2e-pw/utils/site.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/site.js
@@ -238,15 +238,9 @@ const reset = async ( cKey, cSecret ) => {
 };
 
 /**
- * Convert Cart and Checkout pages to shortcode unless DEFAULT_CART_CHECKOUT_BLOCKS is set to true.
+ * Convert Cart and Checkout pages to shortcode.
  */
 const maybeUseCartCheckoutShortcodes = async ( baseURL, userAgent, admin ) => {
-	const { DEFAULT_CART_CHECKOUT_BLOCKS } = process.env;
-
-	if ( DEFAULT_CART_CHECKOUT_BLOCKS === 'true' ) {
-		return;
-	}
-
 	/**
 	 * @typedef {Object} WPPage
 	 * @property {number} id

--- a/plugins/woocommerce/tests/e2e-pw/utils/site.js
+++ b/plugins/woocommerce/tests/e2e-pw/utils/site.js
@@ -237,6 +237,182 @@ const reset = async ( cKey, cSecret ) => {
 	await deleteAllTaxRates();
 };
 
+/**
+ * Set up cart and checkout shortcode pages
+ */
+const setupCartCheckoutShortcodePages = async ( baseURL, userAgent, admin ) => {
+	const { APIRequestContext } = require( '@playwright/test' );
+
+	/**
+	 * @typedef {Object} WPPage
+	 * @property {number} id
+	 * @property {string} slug
+	 * @property {{raw: string}} content
+	 */
+
+	/**
+	 * Construct an API request context.
+	 * @returns {Promise<APIRequestContext>}
+	 */
+	async function createRequestContext() {
+		const { request } = require( '@playwright/test' );
+		const { encodeCredentials } = require( './plugin-utils' );
+		const basicAuth = encodeCredentials( admin.username, admin.password );
+		const Authorization = `Basic ${ basicAuth }`;
+		const extraHTTPHeaders = {
+			Authorization,
+		};
+		const options = {
+			baseURL,
+			userAgent,
+			extraHTTPHeaders,
+		};
+
+		return request.newContext( options );
+	}
+
+	/**
+	 * Create shortcode versions of the cart and checkout pages, except when those pages already exist.
+	 * @param {APIRequestContext} request
+	 * @returns {Promise<[WPPage, WPPage]>}
+	 */
+	async function createWPPages( request ) {
+		/**
+		 * @returns {Promise<WPPage[]>}
+		 */
+		async function listPages() {
+			const response = await request.get( '/wp-json/wp/v2/pages', {
+				params: { context: 'edit' },
+				data: {
+					_fields: [ 'id', 'slug', 'content' ],
+				},
+				failOnStatusCode: true,
+			} );
+
+			return response.json();
+		}
+
+		/**
+		 * @param {WPPage[]} pages
+		 * @returns {(WPPage|undefined)}
+		 */
+		function findExistingShortcodeCartPage( pages ) {
+			const match = pages.find( ( page ) =>
+				page.content.raw.includes( '[woocommerce_cart]' )
+			);
+
+			const message = match
+				? 'Shortcode version of Cart page already exists.'
+				: 'No shortcode version of Cart page found.';
+			console.log( message );
+
+			return match;
+		}
+
+		/**
+		 * @param {WPPage[]} pages
+		 * @returns {(WPPage|undefined)}
+		 */
+		function findExistingShortcodeCheckoutPage( pages ) {
+			const match = pages.find( ( page ) =>
+				page.content.raw.includes( '[woocommerce_checkout]' )
+			);
+
+			const message = match
+				? 'Shortcode version of Checkout page already exists.'
+				: 'No shortcode version of Checkout page found.';
+			console.log( message );
+
+			return match;
+		}
+
+		/**
+		 * @returns {Promise<WPPage>}
+		 */
+		async function createNewShortcodeCartPage() {
+			const response = await request.post( '/wp-json/wp/v2/pages', {
+				data: {
+					slug: 'cart-sc',
+					status: 'publish',
+					title: {
+						raw: 'Cart (shortcode)',
+					},
+					content: {
+						raw: '<!-- wp:shortcode -->[woocommerce_cart]<!-- /wp:shortcode -->',
+					},
+				},
+				failOnStatusCode: true,
+			} );
+
+			console.log( 'New shortcode Cart page created.' );
+
+			return response.json();
+		}
+
+		/**
+		 * @returns {Promise<WPPage>}
+		 */
+		async function createNewShortcodeCheckoutPage() {
+			const response = await request.post( '/wp-json/wp/v2/pages', {
+				data: {
+					slug: 'checkout-sc',
+					status: 'publish',
+					title: {
+						raw: 'Checkout (shortcode)',
+					},
+					content: {
+						raw: '<!-- wp:shortcode -->[woocommerce_checkout]<!-- /wp:shortcode -->',
+					},
+				},
+				failOnStatusCode: true,
+			} );
+
+			console.log( 'New shortcode Checkout page created.' );
+
+			return response.json();
+		}
+
+		const pages = await listPages();
+
+		const cart =
+			findExistingShortcodeCartPage( pages ) ||
+			( await createNewShortcodeCartPage() );
+
+		const checkout =
+			findExistingShortcodeCheckoutPage( pages ) ||
+			( await createNewShortcodeCheckoutPage() );
+
+		return [ cart, checkout ];
+	}
+
+	/**
+	 * Set the WC Cart and Checkout pages to the shortcode versions.
+	 * @param {APIRequestContext} request
+	 * @param {WPPage} cart
+	 * @param {WPPage} checkout
+	 */
+	async function setWCPages( request, cart, checkout ) {
+		await request.put(
+			'/wp-json/wc/v3/settings/advanced/woocommerce_cart_page_id',
+			{ data: { value: `${ cart.id }` }, failOnStatusCode: true }
+		);
+
+		console.log( `WC Cart page set to ID ${ cart.id }` );
+
+		await request.put(
+			'/wp-json/wc/v3/settings/advanced/woocommerce_checkout_page_id',
+			{ data: { value: `${ checkout.id }` }, failOnStatusCode: true }
+		);
+
+		console.log( `WC Checkout page set to ID ${ checkout.id }` );
+	}
+
+	const request = await createRequestContext();
+	const [ cart, checkout ] = await createWPPages( request );
+	await setWCPages( request, cart, checkout );
+};
+
 module.exports = {
 	reset,
+	setupCartCheckoutShortcodePages,
 };

--- a/plugins/woocommerce/tests/performance/setup/cart-checkout-shortcode.js
+++ b/plugins/woocommerce/tests/performance/setup/cart-checkout-shortcode.js
@@ -1,0 +1,116 @@
+/**
+ * k6 dependencies
+ */
+import encoding from 'k6/encoding';
+import http from 'k6/http';
+import { check } from 'k6';
+
+/**
+ * Internal dependencies
+ */
+import { base_url, admin_username, admin_password } from '../config.js';
+
+/**
+ * Convert Cart & Checkout pages to shortcode.
+ */
+export function useCartCheckoutShortcodes() {
+	/**
+	 * A WordPress page.
+	 * @typedef {Object} WPPage
+	 * @property {number} id
+	 * @property {string} slug
+	 */
+
+	let defaultHeaders;
+
+	/**
+	 * @type {WPPage[]}
+	 */
+	let wp_pages;
+
+	/**
+	 * @type {WPPage}
+	 */
+	let cart;
+
+	/**
+	 * @type {WPPage}
+	 */
+	let checkout;
+
+	function setDefaultHeaders() {
+		const credentials = `${ admin_username }:${ admin_password }`;
+		const encodedCredentials = encoding.b64encode( credentials );
+		defaultHeaders = {
+			Authorization: `Basic ${ encodedCredentials }`,
+			'Content-Type': 'application/json',
+		};
+	}
+
+	function listWPPages() {
+		const url = `${ base_url }/wp-json/wp/v2/pages`;
+		const body = {
+			_fields: [ 'id', 'slug' ],
+			context: 'edit',
+		};
+		const params = {
+			headers: defaultHeaders,
+		};
+		const response = http.get( url, body, params );
+		check( response, {
+			'WP pages list obtained': ( r ) => r.status === 200,
+		} );
+		wp_pages = response.json();
+	}
+
+	function findCartCheckoutPage() {
+		cart = wp_pages.find( ( page ) => page.slug === 'cart' );
+		checkout = wp_pages.find( ( page ) => page.slug === 'checkout' );
+	}
+
+	function convertToCartCheckoutShortcode() {
+		const url_cart = `${ base_url }/wp-json/wp/v2/pages/${ cart.id }`;
+		const url_checkout = `${ base_url }/wp-json/wp/v2/pages/${ checkout.id }`;
+
+		const body_cart = {
+			content: {
+				raw: '<!-- wp:shortcode -->[woocommerce_cart]<!-- /wp:shortcode -->',
+			},
+		};
+		const body_checkout = {
+			content: {
+				raw: '<!-- wp:shortcode -->[woocommerce_checkout]<!-- /wp:shortcode -->',
+			},
+		};
+
+		const body_cart_str = JSON.stringify( body_cart );
+		const body_checkout_str = JSON.stringify( body_checkout );
+
+		const params = {
+			headers: defaultHeaders,
+		};
+
+		const response_cart = http.post( url_cart, body_cart_str, params );
+		const response_checkout = http.post(
+			url_checkout,
+			body_checkout_str,
+			params
+		);
+
+		check( response_cart, {
+			'cart shortcode set': ( r ) => r.status >= 200 && r.status < 300,
+		} );
+		check( response_checkout, {
+			'checkout shortcode set': ( r ) =>
+				r.status >= 200 && r.status < 300,
+		} );
+	}
+
+	setDefaultHeaders();
+
+	listWPPages();
+
+	findCartCheckoutPage();
+
+	convertToCartCheckoutShortcode();
+}

--- a/plugins/woocommerce/tests/performance/tests/gh-action-pr-requests.js
+++ b/plugins/woocommerce/tests/performance/tests/gh-action-pr-requests.js
@@ -1,11 +1,4 @@
 /**
- * k6 dependencies
- */
-import encoding from 'k6/encoding';
-import http from 'k6/http';
-import { check } from 'k6';
-
-/**
  * Internal dependencies
  */
 import { homePage } from '../requests/shopper/home.js';
@@ -29,7 +22,7 @@ import { ordersFilter } from '../requests/merchant/orders-filter.js';
 import { addOrder } from '../requests/merchant/add-order.js';
 import { ordersAPI } from '../requests/api/orders.js';
 import { homeWCAdmin } from '../requests/merchant/home-wc-admin.js';
-import { base_url, admin_username, admin_password } from '../config.js';
+import { useCartCheckoutShortcodes } from '../setup/cart-checkout-shortcode.js';
 
 const shopper_request_threshold = 'p(95)<10000';
 const merchant_request_threshold = 'p(95)<10000';
@@ -257,115 +250,7 @@ export const options = {
 };
 
 export function setup() {
-	/**
-	 * Convert Cart & Checkout pages to shortcode
-	 */
-	function useCartCheckoutShortcodes() {
-		/**
-		 * A WordPress page.
-		 * @typedef {Object} WPPage
-		 * @property {number} id
-		 * @property {string} slug
-		 */
-
-		let defaultHeaders;
-
-		/**
-		 * @type {WPPage[]}
-		 */
-		let wp_pages;
-
-		/**
-		 * @type {WPPage}
-		 */
-		let cart;
-
-		/**
-		 * @type {WPPage}
-		 */
-		let checkout;
-
-		function setDefaultHeaders() {
-			const credentials = `${ admin_username }:${ admin_password }`;
-			const encodedCredentials = encoding.b64encode( credentials );
-			defaultHeaders = {
-				Authorization: `Basic ${ encodedCredentials }`,
-				'Content-Type': 'application/json',
-			};
-		}
-
-		function listWPPages() {
-			const url = `${ base_url }/wp-json/wp/v2/pages`;
-			const body = {
-				_fields: [ 'id', 'slug' ],
-				context: 'edit',
-			};
-			const params = {
-				headers: defaultHeaders,
-			};
-			const response = http.get( url, body, params );
-			check( response, {
-				'WP pages list obtained': ( r ) => r.status === 200,
-			} );
-			wp_pages = response.json();
-		}
-
-		function findCartCheckoutPage() {
-			cart = wp_pages.find( ( page ) => page.slug === 'cart' );
-			checkout = wp_pages.find( ( page ) => page.slug === 'checkout' );
-		}
-
-		function convertToCartCheckoutShortcode() {
-			const url_cart = `${ base_url }/wp-json/wp/v2/pages/${ cart.id }`;
-			const url_checkout = `${ base_url }/wp-json/wp/v2/pages/${ checkout.id }`;
-
-			const body_cart = {
-				content: {
-					raw: '<!-- wp:shortcode -->[woocommerce_cart]<!-- /wp:shortcode -->',
-				},
-			};
-			const body_checkout = {
-				content: {
-					raw: '<!-- wp:shortcode -->[woocommerce_checkout]<!-- /wp:shortcode -->',
-				},
-			};
-
-			const body_cart_str = JSON.stringify( body_cart );
-			const body_checkout_str = JSON.stringify( body_checkout );
-
-			const params = {
-				headers: defaultHeaders,
-			};
-
-			const response_cart = http.post( url_cart, body_cart_str, params );
-			const response_checkout = http.post(
-				url_checkout,
-				body_checkout_str,
-				params
-			);
-
-			check( response_cart, {
-				'cart shortcode set': ( r ) =>
-					r.status >= 200 && r.status < 300,
-			} );
-			check( response_checkout, {
-				'checkout shortcode set': ( r ) =>
-					r.status >= 200 && r.status < 300,
-			} );
-		}
-
-		setDefaultHeaders();
-
-		listWPPages();
-
-		findCartCheckoutPage();
-
-		convertToCartCheckoutShortcode();
-	}
-
 	useCartCheckoutShortcodes();
-
-	// Other setup steps in the future
 }
 
 export function shopperBrowseFlow() {

--- a/plugins/woocommerce/tests/performance/tests/gh-action-pr-requests.js
+++ b/plugins/woocommerce/tests/performance/tests/gh-action-pr-requests.js
@@ -1,4 +1,11 @@
 /**
+ * k6 dependencies
+ */
+import encoding from 'k6/encoding';
+import http from 'k6/http';
+import { check } from 'k6';
+
+/**
  * Internal dependencies
  */
 import { homePage } from '../requests/shopper/home.js';
@@ -22,6 +29,7 @@ import { ordersFilter } from '../requests/merchant/orders-filter.js';
 import { addOrder } from '../requests/merchant/add-order.js';
 import { ordersAPI } from '../requests/api/orders.js';
 import { homeWCAdmin } from '../requests/merchant/home-wc-admin.js';
+import { base_url, admin_username, admin_password } from '../config.js';
 
 const shopper_request_threshold = 'p(95)<10000';
 const merchant_request_threshold = 'p(95)<10000';
@@ -247,6 +255,118 @@ export const options = {
 		],
 	},
 };
+
+export function setup() {
+	/**
+	 * Convert Cart & Checkout pages to shortcode
+	 */
+	function useCartCheckoutShortcodes() {
+		/**
+		 * A WordPress page.
+		 * @typedef {Object} WPPage
+		 * @property {number} id
+		 * @property {string} slug
+		 */
+
+		let defaultHeaders;
+
+		/**
+		 * @type {WPPage[]}
+		 */
+		let wp_pages;
+
+		/**
+		 * @type {WPPage}
+		 */
+		let cart;
+
+		/**
+		 * @type {WPPage}
+		 */
+		let checkout;
+
+		function setDefaultHeaders() {
+			const credentials = `${ admin_username }:${ admin_password }`;
+			const encodedCredentials = encoding.b64encode( credentials );
+			defaultHeaders = {
+				Authorization: `Basic ${ encodedCredentials }`,
+				'Content-Type': 'application/json',
+			};
+		}
+
+		function listWPPages() {
+			const url = `${ base_url }/wp-json/wp/v2/pages`;
+			const body = {
+				_fields: [ 'id', 'slug' ],
+				context: 'edit',
+			};
+			const params = {
+				headers: defaultHeaders,
+			};
+			const response = http.get( url, body, params );
+			check( response, {
+				'WP pages list obtained': ( r ) => r.status === 200,
+			} );
+			wp_pages = response.json();
+		}
+
+		function findCartCheckoutPage() {
+			cart = wp_pages.find( ( page ) => page.slug === 'cart' );
+			checkout = wp_pages.find( ( page ) => page.slug === 'checkout' );
+		}
+
+		function convertToCartCheckoutShortcode() {
+			const url_cart = `${ base_url }/wp-json/wp/v2/pages/${ cart.id }`;
+			const url_checkout = `${ base_url }/wp-json/wp/v2/pages/${ checkout.id }`;
+
+			const body_cart = {
+				content: {
+					raw: '<!-- wp:shortcode -->[woocommerce_cart]<!-- /wp:shortcode -->',
+				},
+			};
+			const body_checkout = {
+				content: {
+					raw: '<!-- wp:shortcode -->[woocommerce_checkout]<!-- /wp:shortcode -->',
+				},
+			};
+
+			const body_cart_str = JSON.stringify( body_cart );
+			const body_checkout_str = JSON.stringify( body_checkout );
+
+			const params = {
+				headers: defaultHeaders,
+			};
+
+			const response_cart = http.post( url_cart, body_cart_str, params );
+			const response_checkout = http.post(
+				url_checkout,
+				body_checkout_str,
+				params
+			);
+
+			check( response_cart, {
+				'cart shortcode set': ( r ) =>
+					r.status >= 200 && r.status < 300,
+			} );
+			check( response_checkout, {
+				'checkout shortcode set': ( r ) =>
+					r.status >= 200 && r.status < 300,
+			} );
+		}
+
+		setDefaultHeaders();
+
+		listWPPages();
+
+		findCartCheckoutPage();
+
+		convertToCartCheckoutShortcode();
+	}
+
+	useCartCheckoutShortcodes();
+
+	// Other setup steps in the future
+}
 
 export function shopperBrowseFlow() {
 	homePage();


### PR DESCRIPTION
# Please review this PR but **DO NOT** merge.

### Changes proposed in this Pull Request:

This PR adds a step in the global setup of API and E2E tests to convert the Cart and Checkout pages to their shortcode equivalents.

In the case of the k6 perf tests, this setup was done in the `setup()` function in `plugins/woocommerce/tests/performance/tests/gh-action-pr-requests.js`, since that is the test file that the PR smoke tests use.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure that the E2E, API, and k6 perf tests in this PR passed.
2. Checkout this branch.
3. In your local machine, launch the local e2e environment and run the `basic.spec.js` so that the global setup will be triggered:
    ```bash
    nvm use
    pnpm install
    pnpm run build --filter=woocommerce
    cd plugins/woocommerce
    pnpm env:test
    pnpm test:e2e-pw basic.spec.js
    ```
4. In your browser, login to the local e2e environment and verify that the Cart and Checkout pages are using their respective shortcodes.
5. Destroy the local wp-env environment:
```bash
pnpm env:stop
pnpm wp-env destroy
```
6. Go to `plugins/woocommerce/tests/performance/config.js` and set the variable `cot_status` to `true`.
6. Launch the local environment for k6 tests, and run the `gh-action-pr-requests` test file. It should pass.
```bash
# In the plugins/woocommerce directory
pnpm env:dev --filter=woocommerce
pnpm env:performance-init --filter=woocommerce
k6 run ./tests/performance/tests/gh-action-pr-requests.js
```
7. Log in to the local k6 test environment and verify that the Cart and Checkout pages are using their respective shortcodes.

Note: if you encountered this failure in the k6 tests, don't worry. It's fixed in my other PR - https://github.com/woocommerce/woocommerce/pull/40930

<img width="394" alt="Screenshot 2023-10-24 at 5 33 47 PM" src="https://github.com/woocommerce/woocommerce/assets/4509348/b579810e-eeb3-4841-94ab-5a9479037eb3">



<!-- End testing instructions -->

