### PR TITLE
Update order locators to allow for hpos and non hpos in test

### DIFF
--- a/plugins/woocommerce/changelog/e2e-update-order-locator-to-allow-for-hpos-and-non-hpos
+++ b/plugins/woocommerce/changelog/e2e-update-order-locator-to-allow-for-hpos-and-non-hpos
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Update order locators to allow for hpos and non hpos in test 

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-bulk-edit.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-bulk-edit.spec.js
@@ -66,24 +66,24 @@ test.describe( 'Bulk edit orders', () => {
 
 	test( 'can bulk update order status', async ( { page } ) => {
 		await page.goto( 'wp-admin/admin.php?page=wc-orders' );
-
+		
 		// expect order status 'processing' to show
-		await expect( page.locator( `#order-${ orderId1 }`).getByText( 'Processing') ).toBeVisible();
-		await expect( page.locator( `#order-${ orderId2 }`).getByText( 'Processing') ).toBeVisible();
-		await expect( page.locator( `#order-${ orderId3 }`).getByText( 'Processing') ).toBeVisible();
-		await expect( page.locator( `#order-${ orderId4 }`).getByText( 'Processing') ).toBeVisible();
-		await expect( page.locator( `#order-${ orderId5 }`).getByText( 'Processing') ).toBeVisible();
+		await expect( page.locator( `:is(#order-${ orderId1 }, #post-${ orderId1 })` ).getByText( 'Processing' ) ).toBeVisible();
+		await expect( page.locator( `:is(#order-${ orderId2 }, #post-${ orderId2 })` ).getByText( 'Processing' ) ).toBeVisible();
+		await expect( page.locator( `:is(#order-${ orderId3 }, #post-${ orderId3 })` ).getByText( 'Processing' ) ).toBeVisible();
+		await expect( page.locator( `:is(#order-${ orderId4 }, #post-${ orderId4 })` ).getByText( 'Processing' ) ).toBeVisible();
+		await expect( page.locator( `:is(#order-${ orderId5 }, #post-${ orderId5 })` ).getByText( 'Processing' ) ).toBeVisible();
 
 		await page.locator( '#cb-select-all-1' ).click();
 		await page.locator( '#bulk-action-selector-top' ).selectOption( 'Change status to completed' );
 		await page.locator('#doaction').click();
 
 		// expect order status 'completed' to show
-		await expect( page.locator( `#order-${ orderId1 }`).getByText( 'Completed') ).toBeVisible();
-		await expect( page.locator( `#order-${ orderId2 }`).getByText( 'Completed') ).toBeVisible();
-		await expect( page.locator( `#order-${ orderId3 }`).getByText( 'Completed') ).toBeVisible();
-		await expect( page.locator( `#order-${ orderId4 }`).getByText( 'Completed') ).toBeVisible();
-		await expect( page.locator( `#order-${ orderId5 }`).getByText( 'Completed') ).toBeVisible();
+		await expect( page.locator( `:is(#order-${ orderId1 }, #post-${ orderId1 })`).getByText( 'Completed' ) ).toBeVisible();
+		await expect( page.locator( `:is(#order-${ orderId2 }, #post-${ orderId2 })`).getByText( 'Completed' ) ).toBeVisible();
+		await expect( page.locator( `:is(#order-${ orderId3 }, #post-${ orderId3 })`).getByText( 'Completed' ) ).toBeVisible();
+		await expect( page.locator( `:is(#order-${ orderId4 }, #post-${ orderId4 })`).getByText( 'Completed' ) ).toBeVisible();
+		await expect( page.locator( `:is(#order-${ orderId5 }, #post-${ orderId5 })`).getByText( 'Completed' ) ).toBeVisible();
 	} );
 
 } );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-edit.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/order-edit.spec.js
@@ -78,7 +78,7 @@ test.describe( 'Edit order', () => {
 		// load the orders listing and confirm order is completed
 		await page.goto( 'wp-admin/admin.php?page=wc-orders' );
 
-		await expect( page.locator( `#order-${ orderId }` ).getByRole( 'cell', { name: 'Completed' }) ).toBeVisible();
+		await expect( page.locator( `:is(#order-${orderId}, #post-${orderId})` ).getByRole( 'cell', { name: 'Completed' }) ).toBeVisible();
 	} );
 
 	test( 'can update order status to cancelled', async ( { page } ) => {
@@ -98,7 +98,7 @@ test.describe( 'Edit order', () => {
 		// load the orders listing and confirm order is cancelled
 		await page.goto( 'wp-admin/admin.php?page=wc-orders' );
 
-		await expect( page.locator( `#order-${ orderToCancel }` ).getByRole( 'cell', { name: 'Cancelled' }) ).toBeVisible();
+		await expect( page.locator( `:is(#order-${orderToCancel}, #post-${orderToCancel})` ).getByRole( 'cell', { name: 'Cancelled' }) ).toBeVisible();
 	} );
 
 	test( 'can update order details', async ( { page } ) => {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Update order locators to allow for tests to execute against HPOS or non HPOS environement

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves issue discussed p1698089841462799-slack-C03CPM3UXDJ

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. create test environment with `pnpm env:test`
2. navigate to `plugins/woocommerce`
3. execute updated tests with `pnpm test:e2e-pw ./tests/e2e-pw/tests/merchant/order-bulk-edit.spec.js` and `pnpm test:e2e-pw ./tests/e2e-pw/tests/merchant/order-edit.spec.js`
4. all tests should pass
5. update environment to enable `WordPress posts storage (legacy)` at Woocommerce >> Settings >> Advanced
6.  execute updated tests with `pnpm test:e2e-pw ./tests/e2e-pw/tests/merchant/order-bulk-edit.spec.js` and `pnpm test:e2e-pw ./tests/e2e-pw/tests/merchant/order-edit.spec.js`
7. all tests should pass
8. Tests should pass in CI

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>