### PR TITLE
Save the session data before proceeding with order payment

### DIFF
--- a/plugins/woocommerce/changelog/pr-40964
+++ b/plugins/woocommerce/changelog/pr-40964
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Save the session data before proceeding with order payment

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -1046,6 +1046,11 @@ class WC_Checkout {
 		// Store Order ID in session so it can be re-used after payment failure.
 		WC()->session->set( 'order_awaiting_payment', $order_id );
 
+		// We save the session early because if the payment gateway hangs
+		// the request will never finish, thus the session data will neved be saved,
+		// and this can lead to duplicate orders if the user submits the order again.
+		WC()->session->save_data();
+
 		// Process Payment.
 		$result = $available_gateways[ $payment_method ]->process_payment( $order_id );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

As part of the checkout process an order is created right away, and the order id is stored in a session variable right before requesting payment processing to the appropriate payment gateway. Thus if the payment fails and the user submits the order again, the order id will be picked from the session so the existing order can be retrieved and updated.

However if the payment process hangs (instead of returning an error) and the request never finishes, the session data will never actually be stored (the session data is normally stored during the `shutdown` action), and the next time the user submits the order a duplicate of the first order will be created.

This pull request simply does `WC()->session->save_data()` after the `WC()->session->set` that stores the order id, so that the session is effectively updated even if the request hangs.

Alleviates (probably doesn't fix completely) #14541.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Install https://github.com/woocommerce/woocommerce-gateway-dummy (clone the repository into your `wordpress/wp-content/plugins` directory and follow the instructions in the README), activate it from the WordPress plugins page, and make it available as a payment method for new orders (in WooCommerce - Settings - Payments).
2. Add the following line at the beginning of the `process_payment` method in the `includes/class-wc-gateway-dummy.php` file of the plugin: `while(true);`
3. Go to the store and try to place an order using the dummy gateway to pay. The spinner will pop up and the page will freeze forever.
4. Remove the `while(true);` line, reload the checkout page, and submit the order again: this time it will succeed.
5. Open the orders page in WooCommerce. Without the fix you will see that two identical orders will have been created, with the fix only one order will have been created.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
`