### PR TITLE
Allow for $item_name filtering

### DIFF
--- a/plugins/woocommerce/changelog/trunk
+++ b/plugins/woocommerce/changelog/trunk
@@ -1,4 +1,4 @@
 Significance: patch
-Type: fix
+Type: tweak
 
-Escape the default 'thank you' text instead of the filtered message.
+ensure item name filtering via `woocommerce_order_item_name` works in `includes/admin/meta-boxes/views/html-order-item.php`

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item.php
@@ -13,14 +13,15 @@ $product      = $item->get_product();
 $product_link = $product ? admin_url( 'post.php?post=' . $item->get_product_id() . '&action=edit' ) : '';
 $thumbnail    = $product ? apply_filters( 'woocommerce_admin_order_item_thumbnail', $product->get_image( 'thumbnail', array( 'title' => '' ), false ), $item_id, $item ) : '';
 $row_class    = apply_filters( 'woocommerce_admin_html_order_item_class', ! empty( $class ) ? $class : '', $item, $order );
+$item_name    = apply_filters( 'woocommerce_order_item_name', $item->get_name(), $item, $is_visible );
 ?>
 <tr class="item <?php echo esc_attr( $row_class ); ?>" data-order_item_id="<?php echo esc_attr( $item_id ); ?>">
 	<td class="thumb">
 		<?php echo '<div class="wc-order-item-thumbnail">' . wp_kses_post( $thumbnail ) . '</div>'; ?>
 	</td>
-	<td class="name" data-sort-value="<?php echo esc_attr( $item->get_name() ); ?>">
+	<td class="name" data-sort-value="<?php echo esc_attr( $item_name ); ?>">
 		<?php
-		echo $product_link ? '<a href="' . esc_url( $product_link ) . '" class="wc-order-item-name">' . wp_kses_post( $item->get_name() ) . '</a>' : '<div class="wc-order-item-name">' . wp_kses_post( $item->get_name() ) . '</div>';
+		echo $product_link ? '<a href="' . esc_url( $product_link ) . '" class="wc-order-item-name">' . wp_kses_post( $item_name() ) . '</a>' : '<div class="wc-order-item-name">' . wp_kses_post( $item_name ) . '</div>';
 
 		if ( $product && $product->get_sku() ) {
 			echo '<div class="wc-order-item-sku"><strong>' . esc_html__( 'SKU:', 'woocommerce' ) . '</strong> ' . esc_html( $product->get_sku() ) . '</div>';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

$item name ($item->get_name()) is not filterable under /woocommerce/includes/admin/meta-boxes/views/html-order-item.php, while it is filterable in other files

For example, if I use this PHP:

```
add_filter( 'woocommerce_order_item_name', 'bbloomer_rename_variation_name_cart', 9999 );

function bbloomer_rename_variation_name_cart( $html ) {
	if ( strpos( $html, ' - ' ) !== false ) {
		$html = str_replace(
			[ "Yellow", "Green" ],
			[ "Test 1", "Test 3" ],
			$html
		);
	}
	return $html;
}
```

... the item name is correctly filtered inside emails, thank you page, single customer order view page, BUT it's not filtered in the admin edit single order page. This little edit should do the trick

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

ensure item name filtering via `woocommerce_order_item_name` works in `includes/admin/meta-boxes/views/html-order-item.php`

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
