### PR TITLE
Increase sidebar back button z-index to 2

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
@@ -445,7 +445,7 @@
 	/* Layout sidebar */
 	.block-editor-block-patterns-list__item {
 		.block-editor-block-preview__container {
-			border-radius: 2px;
+			border-radius: 4px;
 			border: 1.5px solid transparent;
 		}
 

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
@@ -84,6 +84,7 @@
 		padding-bottom: 0;
 		gap: 0;
 		width: 348px;
+		z-index: 2;
 	}
 
 	.edit-site-sidebar-navigation-screen-patterns__group-header {

--- a/plugins/woocommerce/changelog/fix-back-button-misclick
+++ b/plugins/woocommerce/changelog/fix-back-button-misclick
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix sidebar title back button z-index

--- a/plugins/woocommerce/changelog/tweak-thumbnail-border-radius
+++ b/plugins/woocommerce/changelog/tweak-thumbnail-border-radius
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Update thumbnail border radius to 4px in pattern assembler


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/40898.

Increase the sidebar back button `z-index` to 2 to fix the issue that users may click on the pattern accidentally.

I didn't increase the spacing because I think that would make the UI different from the design

Before:

https://github.com/woocommerce/woocommerce/assets/4344253/4b15f4bb-01a5-457e-adbf-9c3a88c518a8

After:

https://github.com/woocommerce/woocommerce/assets/4344253/7b8b177c-c495-4e8f-8262-a8779c7cbeba



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new WooCommerce installation with this version.
2. Make sure to enable `customize-store` feature flag
2. Go to  `/wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store%2Fassembler-hub%2Fhomepage`
3. Scroll down on the sidebar
4. Confirm that `Change your homepage` is not clickable.
5. Confirm that patten items will not be accidentally selected when clicking the back button

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
