### PR TITLE
Fix attributes modal incorrect notice

### DIFF
--- a/packages/js/product-editor/changelog/fix-40113_attributes_modal_incorrect_notice
+++ b/packages/js/product-editor/changelog/fix-40113_attributes_modal_incorrect_notice
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix attributes modal incorrect notice #40976

--- a/packages/js/product-editor/src/components/attribute-control/attribute-control.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/attribute-control.tsx
@@ -60,6 +60,7 @@ type AttributeControlProps = {
 		newAttributeListItemLabel?: string;
 		newAttributeModalTitle?: string;
 		newAttributeModalDescription?: string | React.ReactElement;
+		newAttributeModalNotice?: string;
 		customAttributeHelperMessage?: string;
 		attributeRemoveLabel?: string;
 		attributeRemoveConfirmationMessage?: string;

--- a/packages/js/product-editor/src/components/attribute-control/attribute-control.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/attribute-control.tsx
@@ -60,7 +60,6 @@ type AttributeControlProps = {
 		newAttributeListItemLabel?: string;
 		newAttributeModalTitle?: string;
 		newAttributeModalDescription?: string | React.ReactElement;
-		newAttributeModalNotice?: string;
 		customAttributeHelperMessage?: string;
 		attributeRemoveLabel?: string;
 		attributeRemoveConfirmationMessage?: string;
@@ -97,10 +96,6 @@ export const AttributeControl: React.FC< AttributeControlProps > = ( {
 		newAttributeListItemLabel: __( 'Add new', 'woocommerce' ),
 		globalAttributeHelperMessage: __(
 			`You can change the attribute's name in <link>Attributes</link>.`,
-			'woocommerce'
-		),
-		newAttributeModalNotice: __(
-			'By default, attributes are filterable and visible on the product page. You can change these settings for each attribute separately later.',
 			'woocommerce'
 		),
 		attributeRemoveConfirmationMessage: __(
@@ -293,7 +288,6 @@ export const AttributeControl: React.FC< AttributeControlProps > = ( {
 				<NewAttributeModal
 					title={ uiStrings.newAttributeModalTitle }
 					description={ uiStrings.newAttributeModalDescription }
-					notice={ uiStrings.newAttributeModalNotice }
 					onCancel={ () => {
 						closeNewModal();
 						onNewModalCancel();

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.scss
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.scss
@@ -1,5 +1,5 @@
 .woocommerce-new-attribute-modal {
-	min-width: 50%;
+	min-width: 75%;
 	.components-notice.is-info {
 		margin-left: 0;
 		margin-right: 0;

--- a/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/new-attribute-modal.tsx
@@ -60,10 +60,7 @@ type AttributeForm = {
 export const NewAttributeModal: React.FC< NewAttributeModalProps > = ( {
 	title = __( 'Add attributes', 'woocommerce' ),
 	description = '',
-	notice = __(
-		'By default, attributes are filterable and visible on the product page. You can change these settings for each attribute separately later.',
-		'woocommerce'
-	),
+	notice,
 	attributeLabel = __( 'Attribute', 'woocommerce' ),
 	valueLabel = __( 'Values', 'woocommerce' ),
 	attributePlaceholder = __( 'Search or create attribute', 'woocommerce' ),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Remove the notice displayed in the `Add` (local) attributes modal, as local attributes aren't filterable. This is only applied to global attributes.

<img width="974" alt="Captura de ecrã 2023-09-11, às 14 48 07" src="https://github.com/woocommerce/woocommerce/assets/3380168/e7aebef6-8dd4-4084-833c-0679c948a675">


Closes #40113.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a WooCommerce store with this branch and enable the product editor using **WooCommerce > Settings > Advanced > Features**
2. Go to **Products > Add New**
3. Go to the `Organization` tab and press the `Add new` button below `Attributes`
4. The notice `By default, attributes are filterable and visible on the product page. You can change these settings for each attribute separately later.` won't be visible.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
