### PR TITLE
Fix double scroll in General tab and image upload overlapping

### DIFF
--- a/packages/js/product-editor/changelog/fix-image-file-upload
+++ b/packages/js/product-editor/changelog/fix-image-file-upload
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix double scroll in General tab and image upload overlapping with other blocks

--- a/packages/js/product-editor/src/blocks/product-fields/images/editor.scss
+++ b/packages/js/product-editor/src/blocks/product-fields/images/editor.scss
@@ -3,7 +3,8 @@
 		text-align: left;
 
 		.components-drop-zone {
-			min-height: 222px;
+			// This height cannot be higher than this, otherwise it will invade the area from the block below.
+			min-height: 84px;
 		}
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #40974 .

That CSS rule is used to increase the drop area for image upload. Since it was too big, it was overflowing and creating a scroll where it wasn't supposed to, in cases where it's the last block on the column, and invading the below's block (Downloads) area when it's enabled.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. With WCA Test Helper, disable the feature flag 'product-virtual-downloadable'
2. Enable the new product editor at /wp-admin/admin.php?page=wc-settings&tab=advanced&section=features
3. Go to Product > Add New
4. Check that you only see one vertical scroll
5. Enable the feature flag 'product-virtual-downloadable'
6. Go to Product > Add New
7. Drag an image and drop it on top of the "Choose an Image" button
8. Check that the animation when you hover on top of the button doesn't invade the "Downloads" block

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
