### PR TITLE
Remove Creative Mail from woocommerce defaults.

### DIFF
--- a/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
+++ b/plugins/woocommerce/src/Internal/Admin/RemoteFreeExtensions/DefaultFreeExtensions.php
@@ -50,7 +50,6 @@ class DefaultFreeExtensions {
 					self::get_plugin( 'mailpoet:alt' ),
 					self::get_plugin( 'mailchimp-for-woocommerce' ),
 					self::get_plugin( 'klaviyo' ),
-					self::get_plugin( 'creative-mail-by-constant-contact' ),
 				),
 			),
 			array(
@@ -174,13 +173,6 @@ class DefaultFreeExtensions {
 				'description'    => __( 'Grow and retain customers with intelligent, impactful email and SMS marketing automation and a consolidated view of customer interactions.', 'woocommerce' ),
 				'image_url'      => plugins_url( '/assets/images/onboarding/klaviyo.png', WC_PLUGIN_FILE ),
 				'manage_url'     => 'admin.php?page=klaviyo_settings',
-				'is_built_by_wc' => false,
-			),
-			'creative-mail-by-constant-contact' => array(
-				'name'           => __( 'Creative Mail for WooCommerce', 'woocommerce' ),
-				'description'    => __( 'Create on-brand store campaigns, fast email promotions and customer retargeting with Creative Mail.', 'woocommerce' ),
-				'image_url'      => plugins_url( '/assets/images/onboarding/creative-mail-by-constant-contact.png', WC_PLUGIN_FILE ),
-				'manage_url'     => 'admin.php?page=creativemail',
 				'is_built_by_wc' => false,
 			),
 			'codistoconnect'                    => array(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #40966.

Removing defaults for Creative Mail extension as a part of the request to remove Creative Mail extensions from recommendations and WooCommerce task list.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


_Being at `develop` or `trunk` branch follow the steps below:_

1. Go to WooCommerce Settings and make sure to disable suggestions from WooCommerce.com website.

<img width="1280" alt="WooCommerce_settings_‹_WordPress_Pinterest_—_WordPress-2" src="https://github.com/woocommerce/woocommerce/assets/9010963/55438693-3a90-4d83-9fe9-8e77aab2be49">

## If it is already _OFF_ then turn in _ON_ and check steps _3._ and _4._ first before starting the test. We need to make sure we get Creative Mail from remote (WooCommerce.com) first before turning off the remote and checking local defaults.

2. Remove `_transient_woocommerce_admin_remote_free_extensions_specs` from `wp_options` database table.
3. Go to **WooCommerce** - **Home** and go to **You added sales channels**

<img width="1280" alt="Home_‹_WooCommerce_‹_WordPress_Pinterest_—_WooCommerce" src="https://github.com/woocommerce/woocommerce/assets/9010963/44acac71-145e-46ef-8371-1f0aea533cc4">

4. See the list of **Recommended marketing extensions**

<img width="1280" alt="Home_‹_WooCommerce_‹_WordPress_Pinterest_—_WooCommerce" src="https://github.com/woocommerce/woocommerce/assets/9010963/2cfc1473-2ea5-4204-93e2-73704df49533">

Now when we have suggestions from WooCommerce.com turned off and transient removed (it won't re-appear if remote suggestions are off) we get suggestions from local to WooCommerce extension's `DefaultFreeExtensions.php` class.

5. Checkout `remote/creative-mail` branch
6. Visit suggestions page again and check **Creative Mail for WooCommerce** is no longer there.

<img width="1280" alt="Home_‹_WooCommerce_‹_WordPress_Pinterest_—_WooCommerce" src="https://github.com/woocommerce/woocommerce/assets/9010963/ecf9ae81-f793-4531-80b9-b353c63523ac">

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Remove Creative Mail for WooCommerce from recommended.

</details>