### PR TITLE
[Single Variation] Add missing tracks events

### DIFF
--- a/packages/js/product-editor/changelog/add-single_variation_missing_tracks_events
+++ b/packages/js/product-editor/changelog/add-single_variation_missing_tracks_events
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+[Single Variation] Add missing tracks events #40996

--- a/packages/js/product-editor/src/blocks/generic/toggle/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/toggle/edit.tsx
@@ -37,10 +37,10 @@ export function Edit( {
 		postType,
 		fallbackValue: false,
 	} );
-	const productId = useEntityId( 'postType', 'product' );
+	const productId = useEntityId( 'postType', postType );
 	const [ parentId ] = useEntityProp< number >(
 		'postType',
-		'product_variation',
+		postType,
 		'parent_id'
 	);
 

--- a/packages/js/product-editor/src/blocks/generic/toggle/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/toggle/edit.tsx
@@ -4,6 +4,7 @@
 import { createElement } from '@wordpress/element';
 import { ToggleControl } from '@wordpress/components';
 import { useWooBlockProps } from '@woocommerce/block-templates';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -12,6 +13,7 @@ import { ToggleBlockAttributes } from './types';
 import { sanitizeHTML } from '../../../utils/sanitize-html';
 import { ProductEditorBlockEditProps } from '../../../types';
 import useProductEntityProp from '../../../hooks/use-product-entity-prop';
+import { TRACKS_SOURCE } from '../../../constants';
 
 export function Edit( {
 	attributes,
@@ -19,6 +21,7 @@ export function Edit( {
 }: ProductEditorBlockEditProps< ToggleBlockAttributes > ) {
 	const blockProps = useWooBlockProps( attributes );
 	const {
+		_templateBlockId,
 		label,
 		property,
 		disabled,
@@ -39,6 +42,10 @@ export function Edit( {
 	}
 
 	function handleChange( checked: boolean ) {
+		recordEvent( 'product_toggle_click', {
+			block_id: _templateBlockId,
+			source: TRACKS_SOURCE,
+		} );
 		if ( checked ) {
 			setValue( checkedValue !== undefined ? checkedValue : checked );
 		} else {

--- a/packages/js/product-editor/src/blocks/generic/toggle/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/toggle/edit.tsx
@@ -5,6 +5,10 @@ import { createElement } from '@wordpress/element';
 import { ToggleControl } from '@wordpress/components';
 import { useWooBlockProps } from '@woocommerce/block-templates';
 import { recordEvent } from '@woocommerce/tracks';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore No types for this exist yet.
+// eslint-disable-next-line @woocommerce/dependency-group
+import { useEntityProp, useEntityId } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -33,6 +37,12 @@ export function Edit( {
 		postType,
 		fallbackValue: false,
 	} );
+	const productId = useEntityId( 'postType', 'product' );
+	const [ parentId ] = useEntityProp< number >(
+		'postType',
+		'product_variation',
+		'parent_id'
+	);
 
 	function isChecked() {
 		if ( checkedValue !== undefined ) {
@@ -45,6 +55,7 @@ export function Edit( {
 		recordEvent( 'product_toggle_click', {
 			block_id: _templateBlockId,
 			source: TRACKS_SOURCE,
+			product_id: parentId > 0 ? parentId : productId,
 		} );
 		if ( checked ) {
 			setValue( checkedValue !== undefined ? checkedValue : checked );

--- a/packages/js/product-editor/src/components/header/publish-button/publish-button.tsx
+++ b/packages/js/product-editor/src/components/header/publish-button/publish-button.tsx
@@ -36,19 +36,7 @@ export function PublishButton( {
 			const isPublished = productStatus === 'publish';
 
 			if ( isPublished ) {
-				let propsToRecord = savedProduct as Pick<
-					Product,
-					'type' | 'id'
-				> &
-					Partial< Product >;
-				if ( savedProduct.parent_id > 0 ) {
-					const { description, ...rest } = savedProduct;
-					propsToRecord = {
-						...rest,
-						note: description,
-					};
-				}
-				recordProductEvent( 'product_update', propsToRecord );
+				recordProductEvent( 'product_update', savedProduct );
 			}
 
 			const noticeContent = isPublished

--- a/packages/js/product-editor/src/components/header/publish-button/publish-button.tsx
+++ b/packages/js/product-editor/src/components/header/publish-button/publish-button.tsx
@@ -36,7 +36,19 @@ export function PublishButton( {
 			const isPublished = productStatus === 'publish';
 
 			if ( isPublished ) {
-				recordProductEvent( 'product_update', savedProduct );
+				let propsToRecord = savedProduct as Pick<
+					Product,
+					'type' | 'id'
+				> &
+					Partial< Product >;
+				if ( savedProduct.parent_id > 0 ) {
+					const { description, ...rest } = savedProduct;
+					propsToRecord = {
+						...rest,
+						note: description,
+					};
+				}
+				recordProductEvent( 'product_update', propsToRecord );
 			}
 
 			const noticeContent = isPublished

--- a/packages/js/product-editor/src/utils/record-product-event.ts
+++ b/packages/js/product-editor/src/utils/record-product-event.ts
@@ -44,6 +44,11 @@ export function recordProductEvent(
 		product_type: type,
 	};
 
+	if ( product.parent_id > 0 ) {
+		product.note = product.description;
+		delete product.description;
+	}
+
 	for ( const productValueKey of Object.keys( product ) ) {
 		if ( potentialTrackableProductValueKeys.includes( productValueKey ) ) {
 			const eventPropKey =

--- a/packages/js/product-editor/src/utils/record-product-event.ts
+++ b/packages/js/product-editor/src/utils/record-product-event.ts
@@ -18,6 +18,7 @@ const potentialTrackableProductValueKeys = [
 	'description',
 	'manage_stock',
 	'menu_order',
+	'note',
 	'purchase_note',
 	'sale_price',
 	'short_description',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Add a couple of missing Tracks events:

- `wcadmin_product_toggle_click`: with the props `block_id: "product-variation-track-stock"` and `block_id: "product-variation-virtual"`

Rename prop `description` to `note` for single variations.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a WooCommerce store with this branch and enable the product editor using **WooCommerce > Settings > Advanced > Features**
2. Go to **Products > Add New**
3. Go to `/wp-admin/admin.php?page=wc-admin&path=/add-product&tab=variations` and add some attributes
4. Wait until variations get generated
5. Go to Tools > WCA Test Helper > Tools and run the `Enable wc-admin Tracking`
6. Open the browser toolkit and go to the `Console` tab
7. Press the `Edit` button in one of the variations
8. Go to the `Inventory` tab and press the `Track stock quantity for this product` toggle
9. The event: wcadmin_product_toggle_click should be tracked with the prop `block_id: "product-variation-track-stock"` (it should appear in the console opened in step 6).
10. Go to the `Shipping` tab and press the `This variation requires shipping or pickup` toggle
11. The event: wcadmin_product_toggle_click should be tracked with the prop `block_id: "product-variation-virtual"`.
12. Go to the `General` tab and add a text under `Note`
13. Press `Update` and verify that the event `wcadmin_product_update` is recorded with the prop `note: "yes"`
14. Press `< Main product`, add a description under the `General` tab and press `Update`
15. Verify that the event `wcadmin_product_update` is recorded with the prop `description: "yes"` 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
