### PR TITLE
Woo AI - fix empty build dir due to entrypoint file extension match failure.

### DIFF
--- a/plugins/woo-ai/changelog/fix-webpack-build
+++ b/plugins/woo-ai/changelog/fix-webpack-build
@@ -1,0 +1,4 @@
+Significance: patch
+Type: dev
+
+Fix Woo AI webpack build configuration.

--- a/plugins/woo-ai/webpack.config.js
+++ b/plugins/woo-ai/webpack.config.js
@@ -4,7 +4,7 @@ const WooCommerceDependencyExtractionWebpackPlugin = require( '@woocommerce/depe
 module.exports = {
 	...defaultConfig,
 	entry: {
-		...defaultConfig.entry,
+		index: './src/index.ts',
 	},
 	module: {
 		...defaultConfig.module,


### PR DESCRIPTION
### Changes proposed in this Pull Request:
The Woo AI build script is not populating the `/build` directory currently.
The short answer is that this broke when we renamed our main JS file from index.js to index.ts - the entry point definition in Woo AI's webpack.config.js is inherited from the `@wordpress/scripts` webpack config file, which is only matching for .js extensions. It fails to find an entry point and so doesn’t build anything. 

The fix for now is to define our entry point ourselves rather than inherit from `@wordpress/scripts` - I don't personally see anything in there that we need at this time. 🤷 

Longterm, we should update `@wordpress/scripts` which appears to have support for [all the file extensions](https://github.com/WordPress/gutenberg/blob/trunk/packages/scripts/utils/config.js#L307) - I spent some time trying that but it causes some other issues to arise (potentially front-end breaking), so it's not something we can quickly patch.

### How to test the changes in this Pull Request:

1. Run `pnpm run build`.
2. Observe that the `/build` directory is populated. You should have a .js, .css, and index.asset.php file, as well as two .svgs. 
3. Fire up your testing environment and make sure styles and functionality works the same.

### Changelog entry

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

#### Comment Update Woo AI webpack.config.js file to define an explicit entry point.

</details>
