### PR TITLE
Fix coupon codes containing apostrophes

### DIFF
--- a/plugins/woocommerce/changelog/40998-fix-coupon-title-sanitization-39481
+++ b/plugins/woocommerce/changelog/40998-fix-coupon-title-sanitization-39481
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed coupon errors with coupon codes containing apostrophes.

--- a/plugins/woocommerce/changelog/fix-coupon-title-sanitization-39481
+++ b/plugins/woocommerce/changelog/fix-coupon-title-sanitization-39481
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fixed coupon errors with coupon codes containing apostrophes.

--- a/plugins/woocommerce/changelog/fix-coupon-title-sanitization-39481
+++ b/plugins/woocommerce/changelog/fix-coupon-title-sanitization-39481
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed coupon errors with coupon codes containing apostrophes.

--- a/plugins/woocommerce/includes/class-wc-coupon.php
+++ b/plugins/woocommerce/includes/class-wc-coupon.php
@@ -82,6 +82,15 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	protected $cache_group = 'coupons';
 
 	/**
+	 * Sorting.
+	 *
+	 * Used by `get_coupons_from_cart` to sort coupons.
+	 *
+	 * @var int
+	 */
+	public $sort = 0;
+
+	/**
 	 * Coupon constructor. Loads coupon data.
 	 *
 	 * @param mixed $data Coupon data, object, ID or code.

--- a/plugins/woocommerce/includes/wc-formatting-functions.php
+++ b/plugins/woocommerce/includes/wc-formatting-functions.php
@@ -379,7 +379,7 @@ function wc_format_coupon_code( $value ) {
  * @return string
  */
 function wc_sanitize_coupon_code( $value ) {
-	return wp_kses_post( sanitize_post_field( 'post_title', $value ?? '', 0, 'db' ) );
+	return wp_kses( sanitize_post_field( 'post_title', $value ?? '', 0, 'db' ), 'entities' );
 }
 
 /**

--- a/plugins/woocommerce/includes/wc-formatting-functions.php
+++ b/plugins/woocommerce/includes/wc-formatting-functions.php
@@ -232,7 +232,7 @@ function wc_trim_zeros( $price ) {
  * @return float
  */
 function wc_round_tax_total( $value, $precision = null ) {
-	$precision = is_null( $precision ) ? wc_get_price_decimals() : intval( $precision );
+	$precision   = is_null( $precision ) ? wc_get_price_decimals() : intval( $precision );
 	$rounded_tax = NumberUtil::round( $value, $precision, wc_get_tax_rounding_mode() ); // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctionParameters.round_modeFound
 
 	return apply_filters( 'wc_round_tax_total', $rounded_tax, $value, $precision, WC_TAX_ROUNDING_MODE );
@@ -371,15 +371,17 @@ function wc_format_coupon_code( $value ) {
 /**
  * Sanitize a coupon code.
  *
- * Uses sanitize_post_field since coupon codes are stored as
- * post_titles - the sanitization and escaping must match.
+ * Uses sanitize_post_field since coupon codes are stored as post_titles - the sanitization and escaping must match.
+ *
+ * Due to the unfiltered_html captability that some (admin) users have, we need to account for slashes.
  *
  * @since  3.6.0
  * @param  string $value Coupon code to format.
  * @return string
  */
 function wc_sanitize_coupon_code( $value ) {
-	return wp_kses( sanitize_post_field( 'post_title', $value ?? '', 0, 'db' ), 'entities' );
+	$value = wp_kses( sanitize_post_field( 'post_title', $value ?? '', 0, 'db' ), 'entities' );
+	return current_user_can( 'unfiltered_html' ) ? $value : stripslashes( $value );
 }
 
 /**

--- a/plugins/woocommerce/includes/wc-formatting-functions.php
+++ b/plugins/woocommerce/includes/wc-formatting-functions.php
@@ -379,7 +379,7 @@ function wc_format_coupon_code( $value ) {
  * @return string
  */
 function wc_sanitize_coupon_code( $value ) {
-	return wp_filter_kses( sanitize_post_field( 'post_title', $value ?? '', 0, 'db' ) );
+	return wp_kses_post( sanitize_post_field( 'post_title', $value ?? '', 0, 'db' ) );
 }
 
 /**

--- a/plugins/woocommerce/tests/php/includes/wc-formatting-functions-test.php
+++ b/plugins/woocommerce/tests/php/includes/wc-formatting-functions-test.php
@@ -16,6 +16,7 @@ class WC_Formatting_Functions_Test extends \WC_Unit_Test_Case {
 	public function test_wc_sanitize_coupon_code() {
 		$this->assertEquals( 'DUMMYCOUPON', wc_sanitize_coupon_code( 'DUMMYCOUPON' ) );
 		$this->assertEquals( 'a&amp;a', wc_sanitize_coupon_code( 'a&a' ) );
+		$this->assertEquals( "test's", wc_sanitize_coupon_code( "test's" ) );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Updates the `wc_sanitize_coupon_code` function to allow the `'` character. I have included a additional test to cover this case, and I fixed a notice I encountered while testing which prevented me applying coupons (PHP8 notice due to a missing variable).

Closes #39481

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add a coupon called `test's`. Any value is fine.
2. After saving the coupon, the coupon code `test's` should be visible in the coupon table. It should not be `test\'s`.
3. Go to cart on the frontend. Confirm the `test's` coupon can be applied to the cart. Place the order and ensure the coupon continues to function correctly.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fixed coupon errors with coupon codes containing apostrophes.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
