### PR TITLE
Add flags to control visibility of Header, StoreAlerts, Notices, and PluginsArea from a page

### DIFF
--- a/plugins/woocommerce-admin/client/layout/controller.js
+++ b/plugins/woocommerce-admin/client/layout/controller.js
@@ -338,6 +338,8 @@ export const getPages = () => {
 			layout: {
 				header: false,
 				footer: false,
+				showNotices: false,
+				showStoreAlerts: false,
 			},
 			capability: 'manage_woocommerce',
 		} );

--- a/plugins/woocommerce-admin/client/layout/controller.js
+++ b/plugins/woocommerce-admin/client/layout/controller.js
@@ -335,6 +335,10 @@ export const getPages = () => {
 				...initialBreadcrumbs,
 				__( 'Customize Your Store', 'woocommerce' ),
 			],
+			layout: {
+				header: false,
+				footer: false,
+			},
 			capability: 'manage_woocommerce',
 		} );
 	}

--- a/plugins/woocommerce-admin/client/layout/controller.js
+++ b/plugins/woocommerce-admin/client/layout/controller.js
@@ -340,6 +340,7 @@ export const getPages = () => {
 				footer: false,
 				showNotices: false,
 				showStoreAlerts: false,
+				showPluginArea: false,
 			},
 			capability: 'manage_woocommerce',
 		} );

--- a/plugins/woocommerce-admin/client/layout/index.js
+++ b/plugins/woocommerce-admin/client/layout/index.js
@@ -192,7 +192,11 @@ function _Layout( {
 	}
 
 	const { breadcrumbs, layout = { header: true, footer: true } } = page;
-	const { header: showHeader = true, footer: showFooter = true } = layout;
+	const {
+		header: showHeader = true,
+		footer: showFooter = true,
+		showPluginArea = true,
+	} = layout;
 
 	const query = getQuery();
 
@@ -248,11 +252,15 @@ function _Layout( {
 					{ showFooter && <Footer /> }
 					<CustomerEffortScoreModalContainer />
 				</div>
-				<PluginArea scope="woocommerce-admin" />
-				{ window.wcAdminFeatures.navigation && (
-					<PluginArea scope="woocommerce-navigation" />
+				{ showPluginArea && (
+					<>
+						<PluginArea scope="woocommerce-admin" />
+						{ window.wcAdminFeatures.navigation && (
+							<PluginArea scope="woocommerce-navigation" />
+						) }
+						<PluginArea scope="woocommerce-tasks" />
+					</>
 				) }
-				<PluginArea scope="woocommerce-tasks" />
 			</SlotFillProvider>
 		</LayoutContextProvider>
 	);

--- a/plugins/woocommerce-admin/client/layout/index.js
+++ b/plugins/woocommerce-admin/client/layout/index.js
@@ -62,18 +62,24 @@ const WCPayUsageModal = lazy( () =>
 
 export class PrimaryLayout extends Component {
 	render() {
-		const { children } = this.props;
+		const {
+			children,
+			showStoreAlerts = true,
+			showNotices = true,
+		} = this.props;
+
 		return (
 			<div
 				className="woocommerce-layout__primary"
 				id="woocommerce-layout__primary"
 			>
-				{ window.wcAdminFeatures[ 'store-alerts' ] && (
-					<Suspense fallback={ null }>
-						<StoreAlerts />
-					</Suspense>
-				) }
-				<Notices />
+				{ window.wcAdminFeatures[ 'store-alerts' ] &&
+					showStoreAlerts && (
+						<Suspense fallback={ null }>
+							<StoreAlerts />
+						</Suspense>
+					) }
+				{ showNotices && <Notices /> }
 				{ children }
 			</div>
 		);
@@ -220,7 +226,10 @@ function _Layout( {
 					) }
 					<TransientNotices />
 					{ ! isEmbedded && (
-						<PrimaryLayout>
+						<PrimaryLayout
+							showNotices={ page?.layout?.showNotices }
+							showStoreAlerts={ page?.layout?.showStoreAlerts }
+						>
 							<div className="woocommerce-layout__main">
 								<Controller
 									page={ page }

--- a/plugins/woocommerce/changelog/41014-update-unexpected-api-calls-on-cys
+++ b/plugins/woocommerce/changelog/41014-update-unexpected-api-calls-on-cys
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Add flags to control visibility of  Header, StoreAlerts, Notices, and PluginArea components at the page configuration level.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #41012 

This pull request adds the following flags to the page [configuration](https://github.com/woocommerce/woocommerce/blob/d3489e8270673ab44f398cd82fb5d647b101cb70/plugins/woocommerce-admin/client/layout/controller.js#L338) in order to control the visibility of the Header, StoreAlerts, Notices, and PluginArea. This is useful for pages where we do not want to display the aforementioned components. It also helps to reduce # of API calls that are not needed. 

- header (bool)
- footer (bool
- showNotices (bool)
- showStoreAlerts (bool)
- showPluginArea (bool)


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Let's first test with trunk. 
2. Setup a new JN site with trunk branch using WooCommerce Beta Tester
3. Go to Tools -> WCA Test Helper -> Features and turn `customize-store` on.
4. Go to `WooCommerce -> Home` and click on `Customize your  store` task.
5. Open your browser insepctor and refresh
6. Notice API call to notes endpoint.

Repeat the test again, but with `update/unexpected-api-calls-on-cys` branch this time and confirm notes API is not being requested.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add flags to control visibility of  Header, StoreAlerts, Notices, and PluginArea components at the page configuration level.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
