### PR TITLE
Shipping Settings: Fix shipping zones tour copy

### DIFF
--- a/plugins/woocommerce-admin/client/guided-tours/shipping-tour.tsx
+++ b/plugins/woocommerce-admin/client/guided-tours/shipping-tour.tsx
@@ -132,7 +132,6 @@ const spotlitElementsSelectors: Array< NonEmptySelectorArray > = [
 ];
 
 const TourFloaterWrapper = ( { step }: { step: number } ) => {
-	console.log('wrapping');
 	const thisRef = useRef< HTMLDivElement >( null );
 	useLayoutEffect( () => {
 		// this moves the element to the correct place which is right before the table element
@@ -252,7 +251,7 @@ export const ShippingTour: React.FC< {
 							<>
 								<span>
 									{ __(
-										'Specify the areas you\'d like to ship to! Give each zone a name, select the region(s) you\'d like to include, and add available shipping methods. Your shipping regions can be as specific as a zip code, or as broad as a country.',
+										"Specify the areas you'd like to ship to! Give each zone a name, select the region(s) you'd like to include, and add available shipping methods. Your shipping regions can be as specific as a zip code, or as broad as a country.",
 										'woocommerce'
 									) }
 								</span>
@@ -287,7 +286,7 @@ export const ShippingTour: React.FC< {
 							<>
 								<span>
 									{ __(
-										'Add one or more shipping methods that you\'d like to make available to customers in your zones.',
+										"Add one or more shipping methods that you'd like to make available to customers in your zones.",
 										'woocommerce'
 									) }
 								</span>

--- a/plugins/woocommerce-admin/client/guided-tours/shipping-tour.tsx
+++ b/plugins/woocommerce-admin/client/guided-tours/shipping-tour.tsx
@@ -122,16 +122,17 @@ const spotlitElementsSelectors: Array< NonEmptySelectorArray > = [
 		// top left = table header cell for sort handles
 		'th.wc-shipping-zone-sort',
 		// bottom right = worldwide region cell
-		'tr.wc-shipping-zone-worldwide > td.wc-shipping-zone-region',
+		'tfoot.wc-shipping-zone-worldwide tr > td.wc-shipping-zone-region',
 	],
 	[
 		// selectors for rightmost column (shipping methods)
 		'th.wc-shipping-zone-methods',
-		'tr.wc-shipping-zone-worldwide > td.wc-shipping-zone-methods',
+		'tfoot.wc-shipping-zone-worldwide tr > td.wc-shipping-zone-methods',
 	],
 ];
 
 const TourFloaterWrapper = ( { step }: { step: number } ) => {
+	console.log('wrapping');
 	const thisRef = useRef< HTMLDivElement >( null );
 	useLayoutEffect( () => {
 		// this moves the element to the correct place which is right before the table element
@@ -251,14 +252,21 @@ export const ShippingTour: React.FC< {
 							<>
 								<span>
 									{ __(
-										'We added a few shipping zones for you based on your location, but you can manage them at any time.',
+										'Specify the areas you\'d like to ship to! Give each zone a name, select the region(s) you\'d like to include, and add available shipping methods. Your shipping regions can be as specific as a zip code, or as broad as a country.',
 										'woocommerce'
 									) }
 								</span>
 								<br />
 								<span>
 									{ __(
-										'A shipping zone is a geographic area where a certain set of shipping methods are offered.',
+										'Your customers will only see the methods available to their region, and can only match one zone.',
+										'woocommerce'
+									) }
+								</span>
+								<br />
+								<span>
+									{ __(
+										'We\'ve added some shipping zones to get you started — you can add or edit them by clicking on "Edit | Delete".',
 										'woocommerce'
 									) }
 								</span>
@@ -275,9 +283,22 @@ export const ShippingTour: React.FC< {
 					name: 'shipping-methods',
 					heading: __( 'Shipping methods', 'woocommerce' ),
 					descriptions: {
-						desktop: __(
-							'We defaulted to some recommended shipping methods based on your store location, but you can manage them at any time within each shipping zone settings.',
-							'woocommerce'
+						desktop: (
+							<>
+								<span>
+									{ __(
+										'Add one or more shipping methods that you\'d like to make available to customers in your zones.',
+										'woocommerce'
+									) }
+								</span>
+								<br />
+								<span>
+									{ __(
+										'For example, in the default settings we\'ve provided, free shipping is offered to customers in your country. You can edit these or add more shipping methods by clicking on "Edit | Delete".',
+										'woocommerce'
+									) }
+								</span>
+							</>
 						),
 					},
 				},
@@ -323,7 +344,7 @@ export const ShippingTour: React.FC< {
 				heading: __( 'WooCommerce Shipping', 'woocommerce' ),
 				descriptions: {
 					desktop: __(
-						'Print USPS and DHL labels straight from your WooCommerce dashboard and save on shipping thanks to discounted rates. You can manage WooCommerce Shipping in this section.',
+						'Print USPS and DHL labels straight from your Woo dashboard and save on shipping thanks to discounted rates. You can manage WooCommerce Shipping in this section.',
 						'woocommerce'
 					),
 				},
@@ -341,7 +362,7 @@ export const ShippingTour: React.FC< {
 				heading: __( 'WooCommerce Shipping', 'woocommerce' ),
 				descriptions: {
 					desktop: __(
-						'If you’d like to speed up your process and print your shipping label straight from your WooCommerce dashboard, WooCommerce Shipping may be for you! ',
+						'If you’d like to speed up your process and print your shipping label straight from your Woo dashboard, WooCommerce Shipping may be for you! ',
 						'woocommerce'
 					),
 				},

--- a/plugins/woocommerce-admin/client/guided-tours/shipping-tour.tsx
+++ b/plugins/woocommerce-admin/client/guided-tours/shipping-tour.tsx
@@ -251,7 +251,7 @@ export const ShippingTour: React.FC< {
 							<>
 								<span>
 									{ __(
-										"Specify the areas you'd like to ship to! Give each zone a name, select the region(s) you'd like to include, and add available shipping methods. Your shipping regions can be as specific as a zip code, or as broad as a country.",
+										"Specify the areas you'd like to ship to! We added a few shipping zones for you based on your location, but you can manage them at any time. Give each zone a name, select the region(s) you'd like to include, and add available shipping methods. Your shipping regions can be as specific as a zip code, or as broad as a country.",
 										'woocommerce'
 									) }
 								</span>

--- a/plugins/woocommerce/changelog/fix-shipping-settings-homescreen-tour
+++ b/plugins/woocommerce/changelog/fix-shipping-settings-homescreen-tour
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+Comment: Updating unreleased changes
+

--- a/plugins/woocommerce/src/Internal/Admin/Homescreen.php
+++ b/plugins/woocommerce/src/Internal/Admin/Homescreen.php
@@ -133,7 +133,19 @@ class Homescreen {
 			$zone = new \WC_Shipping_Zone();
 			$zone->set_zone_name( $country_name );
 			$zone->add_location( $country_code, 'country' );
-			$zone->add_shipping_method( 'free_shipping' );
+
+			// Method creation has no default title, use the REST API to add a title.
+			$instance_id = $zone->add_shipping_method( 'free_shipping' );
+			$request = new WP_REST_Request( 'POST', '/wc/v2/shipping/zones/' . $zone->get_id() . '/methods/' . $instance_id );
+			$request->set_body_params(
+				array(
+					'settings' => array(
+						'title' => 'Free shipping',
+					),
+				)
+			);
+			rest_do_request( $request );
+
 			update_option( 'woocommerce_admin_created_default_shipping_zones', 'yes' );
 			Shipping::delete_zone_count_transient();
 		}

--- a/plugins/woocommerce/src/Internal/Admin/Homescreen.php
+++ b/plugins/woocommerce/src/Internal/Admin/Homescreen.php
@@ -136,7 +136,7 @@ class Homescreen {
 
 			// Method creation has no default title, use the REST API to add a title.
 			$instance_id = $zone->add_shipping_method( 'free_shipping' );
-			$request = new WP_REST_Request( 'POST', '/wc/v2/shipping/zones/' . $zone->get_id() . '/methods/' . $instance_id );
+			$request = new \WP_REST_Request( 'POST', '/wc/v2/shipping/zones/' . $zone->get_id() . '/methods/' . $instance_id );
 			$request->set_body_params(
 				array(
 					'settings' => array(

--- a/plugins/woocommerce/src/Internal/Admin/Homescreen.php
+++ b/plugins/woocommerce/src/Internal/Admin/Homescreen.php
@@ -136,7 +136,7 @@ class Homescreen {
 
 			// Method creation has no default title, use the REST API to add a title.
 			$instance_id = $zone->add_shipping_method( 'free_shipping' );
-			$request = new \WP_REST_Request( 'POST', '/wc/v2/shipping/zones/' . $zone->get_id() . '/methods/' . $instance_id );
+			$request     = new \WP_REST_Request( 'POST', '/wc/v2/shipping/zones/' . $zone->get_id() . '/methods/' . $instance_id );
 			$request->set_body_params(
 				array(
 					'settings' => array(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes https://github.com/woocommerce/woocommerce/issues/40984

This PR updates the copy found in the Shipping Settings tour as well as handles the case of pre-populating a shipping zone with a method. Previously, the method had no name since the defaults were removed in https://github.com/woocommerce/woocommerce/pull/40838

@laurajohnsonwoo can you take a look at the copy?

<img width="1326" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1922453/e46e1805-38ba-4592-8c75-4d5efb359f4e">

<img width="1330" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1922453/fcbbfb99-c36e-4775-b9ee-ac5387bb9cc4">

<img width="1330" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1922453/20ab75b3-3b8a-419b-bd05-799f14c8530c">

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a JN site from this branch
2. Go through the onboarding flow, skipping it won't fire the tour
3. Be sure to choose a US location
4. Unselect all the additional plugins like Jetpack and WooCommerce Services and continue
5. Head to `/wp-admin/admin.php?page=wc-settings&tab=shipping` and see the tour kick off.
6. Compare the copy against TgDI6pJuBmnPyZ810B7uzX-fi
7. Make sure the Automatically added Shipping Zone has a method with a name.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

Updating unreleased changes

</details>
