### PR TITLE
Add `@woocommerce/blocks-components` to `dependency-extraction-webpack-plugin` packages list

### DIFF
--- a/packages/js/dependency-extraction-webpack-plugin/assets/packages.js
+++ b/packages/js/dependency-extraction-webpack-plugin/assets/packages.js
@@ -20,6 +20,7 @@ module.exports = [
 	'@woocommerce/tracks',
 	// wc-blocks packages
 	'@woocommerce/blocks-checkout',
+	'@woocommerce/blocks-components',
 	'@woocommerce/block-data',
 	'@woocommerce/blocks-registry',
 	'@woocommerce/settings',

--- a/packages/js/dependency-extraction-webpack-plugin/changelog/41042-update-dependency-extraction-webpack-plugin
+++ b/packages/js/dependency-extraction-webpack-plugin/changelog/41042-update-dependency-extraction-webpack-plugin
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add `@woocommerce/blocks-components` to the list of packages that will be resolved.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds `@woocommerce/blocks-components` to the packages list of  `dependency-extraction-webpack-plugin`.

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

💡  Tip: You can use `npx @wordpress/create-block -t @woocommerce/extend-cart-checkout-block test-plugin` to get a plugin built and set up. There will be an error relating to prettier. Ignore this. cd into the plugin directory and `npm run start`

1. Create a JS script that will be built by webpack and which will be loaded on your site (If you did the above, use `src/js/index.js`. In this script add:

```
import * as blockComponents from '@woocommerce/blocks-components';
console.log( blockComponents );
```

2. Load the page with this script on (Enable the `TestPlugin` plugin on your WP site and go to a page containing the Cart block if following the above) and ensure the console log outputs a list of components.
3. Ensure no build errors occur.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Add `@woocommerce/blocks-components` to the list of packages that will be resolved.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
