### PR TITLE
Add __experimentalRole: 'content' to block properties

### DIFF
--- a/packages/js/create-product-editor-block/changelog/add-experimental-role
+++ b/packages/js/create-product-editor-block/changelog/add-experimental-role
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add __experimentalRole: 'content' to block properties

--- a/packages/js/create-product-editor-block/index.js
+++ b/packages/js/create-product-editor-block/index.js
@@ -26,8 +26,8 @@ module.exports = {
 			inserter: false,
 		},
 		npmDevDependencies: [
-			'@types/wordpress__block-editor',
-			'@types/wordpress__blocks',
+			'@types/wordpress__block-editor@^7.0.0',
+			'@types/wordpress__blocks@^11.0.9',
 			'@woocommerce/dependency-extraction-webpack-plugin',
 			'@woocommerce/eslint-plugin',
 			'@wordpress/prettier-config',

--- a/packages/js/create-product-editor-block/index.js
+++ b/packages/js/create-product-editor-block/index.js
@@ -16,6 +16,7 @@ module.exports = {
 		attributes: {
 			message: {
 				type: 'string',
+				__experimentalRole: 'content',
 				source: 'text',
 				selector: 'div',
 			},
@@ -25,8 +26,8 @@ module.exports = {
 			inserter: false,
 		},
 		npmDevDependencies: [
-			'@types/wordpress__block-editor@^7.0.0',
-			'@types/wordpress__blocks@^11.0.9',
+			'@types/wordpress__block-editor',
+			'@types/wordpress__blocks',
 			'@woocommerce/dependency-extraction-webpack-plugin',
 			'@woocommerce/eslint-plugin',
 			'@wordpress/prettier-config',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Add __experimentalRole: 'content' to block properties

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Run the command: `npx @wordpress/create-block --template ./woocommerce/packages/js/create-product-editor-block/ my-extension-name` (replace with corresponding path to the create-product-editor-block package)
2. Check the result block.json file in `my-extension-name/src/block.json`
3. Check that "__experimentalRole": "content" is added to the 'message' attribute.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
