### PR TITLE
Include screen options nonces in HPOS edit form

### DIFF
--- a/plugins/woocommerce/changelog/fix-34490
+++ b/plugins/woocommerce/changelog/fix-34490
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Restore screen options functionality on HPOS edit screen.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
@@ -385,6 +385,9 @@ class Edit {
 		 * @since 8.0.0
 		 */
 		do_action( 'order_edit_form_top', $this->order );
+
+		wp_nonce_field( 'meta-box-order', 'meta-box-order-nonce', false );
+		wp_nonce_field( 'closedpostboxes', 'closedpostboxesnonce', false );
 		?>
 		<input type="hidden" id="hiddenaction" name="action" value="<?php echo esc_attr( $form_action ); ?>"/>
 		<input type="hidden" id="original_order_status" name="original_order_status" value="<?php echo esc_attr( $this->order->get_status() ); ?>"/>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
With HPOS enabled, screen options on the order edit screen are not being persisted. This includes shown/hidden metaboxes as well as their position on screen.

The JS part of this functionality is automatically handled by WordPress, but we were not adding the required nonces to the edit form, which resulted in the AJAX failing to do its job. This PR re-introduces the correct nonce fields.

Closes #34990.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
opm
 ]minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


1. Make sure HPOS is enabled in WC > Settings > Advanced > Features.
2. Go to WC > Orders.
3. If you don't have any existing orders, click on **Add Order** to create a new order. Save this order.
4. If you didn't create a new order on the previous step, just click on any existing order to open the edit form.
5. Click **Screen Options** right below the "Orders" header:
   <img width="1448" alt="Screenshot 2023-10-26 at 15 24 22" src="https://github.com/woocommerce/woocommerce/assets/184724/7f59896f-9e3e-4a66-8dc0-e7af8c32f073">
6. Make any selection you'd like and confirm that the metaboxes are hidden/shown accordingly.
7. Refresh the page and confirm that your selection was preserved.
8. Reposition via drag-and-drop any metabox on screen by clicking its title (e.g. "Order notes" or "Order actions").
9. Refresh the page and confirm that metaboxes appear in the layout you defined in the previous step.