### PR TITLE
Update WooCommerce Blocks to 11.4.2

### DIFF
--- a/plugins/woocommerce/changelog/2023-10-26-16-21-28-027095
+++ b/plugins/woocommerce/changelog/2023-10-26-16-21-28-027095
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update WooCommerce Blocks to 11.4.2

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -23,7 +23,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.6.4",
-		"woocommerce/woocommerce-blocks": "11.4.1"
+		"woocommerce/woocommerce-blocks": "11.4.2"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.3.0",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fc9ea107b31f1926e5424183bc304de5",
+    "content-hash": "8b8f2c43765686a91b34faa824cb997d",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1004,16 +1004,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "11.4.1",
+            "version": "11.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "2511fa9d20474b6c349af1ce487f93d05d06991a"
+                "reference": "7556d00d6ff6c013540f683c6d65f46405f41741"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/2511fa9d20474b6c349af1ce487f93d05d06991a",
-                "reference": "2511fa9d20474b6c349af1ce487f93d05d06991a",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/7556d00d6ff6c013540f683c6d65f46405f41741",
+                "reference": "7556d00d6ff6c013540f683c6d65f46405f41741",
                 "shasum": ""
             },
             "require": {
@@ -1064,9 +1064,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v11.4.1"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v11.4.2"
             },
-            "time": "2023-10-25T13:08:08+00:00"
+            "time": "2023-10-26T16:18:21+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 11.4.2 and is intended to target WooCommerce 8.3 for release.

## Blocks 11.4.2
*  [Release PR](https://github.com/woocommerce/woocommerce-blocks/pull/11452)
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/34fb0c6e1ba4f66f8e1b0577911d798b2b511e19/docs/internal-developers/testing/releases/1142.md)

### Changelog

```md
- Improve the button size on the "Product Collection 4 Column" pattern. https://github.com/woocommerce/woocommerce-blocks/pull/11433
- Update the patterns content after a plugin update. https://github.com/woocommerce/woocommerce-blocks/pull/11210
- Improve the "Minimal header" pattern spacing and title. https://github.com/woocommerce/woocommerce-blocks/pull/11434
- Store Customization > Ensure dummy products can have AI-generated content. https://github.com/woocommerce/woocommerce-blocks/pull/11155
- Improve the Testimonials 3 columns pattern. https://github.com/woocommerce/woocommerce-blocks/pull/11430
- Add overlay to the "Featured Category Triple" pattern. https://github.com/woocommerce/woocommerce-blocks/pull/11428
- Improve the "Footer with 3 Menus" pattern. https://github.com/woocommerce/woocommerce-blocks/pull/11379
- Update the "Large footer" pattern. https://github.com/woocommerce/woocommerce-blocks/pull/11413
```

### Changelog entry

> Dev - Update WooCommerce Blocks version to 11.4.2