### PR TITLE
[Enhancement]: Added a new parameter $status_transition to the woocommerce_order_status_$status_transition["to"] hook.

### DIFF
--- a/plugins/woocommerce/changelog/fix-39602
+++ b/plugins/woocommerce/changelog/fix-39602
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Added a new parameter $status_transition to the woocommerce_order_status_$status_transition["to"] hook.

--- a/plugins/woocommerce/includes/class-wc-order.php
+++ b/plugins/woocommerce/includes/class-wc-order.php
@@ -400,12 +400,12 @@ class WC_Order extends WC_Abstract_Order {
 				 * @param int Order ID.
 				 * @param WC_Order $order Order object.
 				 * @param array $status_transition {
-				 * 		Status transition data.
+				 *      Status transition data.
 				 *
-				 * 		@type string $from Order status from.
-				 *		@type string $to Order status to
-				 *		@type string $note Order note.
-				 *		@type boolean $manual True if the order is manually changed.
+				 *      @type string $from Order status from.
+				 *      @type string $to Order status to
+				 *      @type string $note Order note.
+				 *      @type boolean $manual True if the order is manually changed.
 				 * }
 				 */
 				do_action( 'woocommerce_order_status_' . $status_transition['to'], $this->get_id(), $this, $status_transition );

--- a/plugins/woocommerce/includes/class-wc-order.php
+++ b/plugins/woocommerce/includes/class-wc-order.php
@@ -395,7 +395,7 @@ class WC_Order extends WC_Abstract_Order {
 				/**
 				 * Fires when order status is changed.
 				 *
-				 * @since x.x.x Added $status_transition parameter.
+				 * @since 1.0.0
 				 *
 				 * @param int Order ID.
 				 * @param WC_Order $order Order object.

--- a/plugins/woocommerce/includes/class-wc-order.php
+++ b/plugins/woocommerce/includes/class-wc-order.php
@@ -392,7 +392,23 @@ class WC_Order extends WC_Abstract_Order {
 
 		if ( $status_transition ) {
 			try {
-				do_action( 'woocommerce_order_status_' . $status_transition['to'], $this->get_id(), $this );
+				/**
+				 * Fires when order status is changed.
+				 *
+				 * @since x.x.x Added $status_transition parameter.
+				 *
+				 * @param int Order ID.
+				 * @param WC_Order $order Order object.
+				 * @param array $status_transition {
+				 * 		Status transition data.
+				 *
+				 * 		@type string $from Order status from.
+				 *		@type string $to Order status to
+				 *		@type string $note Order note.
+				 *		@type boolean $manual True if the order is manually changed.
+				 * }
+				 */
+				do_action( 'woocommerce_order_status_' . $status_transition['to'], $this->get_id(), $this, $status_transition );
 
 				if ( ! empty( $status_transition['from'] ) ) {
 					/* translators: 1: old order status 2: new order status */


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #39602 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check out the branch `git checkout trunk`.
2. Create an order `wp-admin/admin.php?page=wc-orders&action=new` with `Processing` as status.
3. Create a plugin at `wp-content/plugins/test/test.php` with the following code.
```php
<?php
/**
 * Plugin Name: Test Code
 * Description: Can be used to test https://github.com/woocommerce/woocommerce/pull/40614. Remove after the test.
 * WC Tested up to: 8.3.0-dev
 */
add_action( 'woocommerce_order_status_processing', function( $order_id, $order, $status_transition ) {
	error_log( 'Order ID = ' . $order_id );
	error_log( 'Status Transition = ' . print_r( $status_transition, true ) );
}, 10, 3 );
```
4. Check the `wp-content/debug.log` file to view the `Order ID` and `Status Transition` data.
Example:
```
[26-Oct-2023 17:54:55 UTC] Order ID = 174
[26-Oct-2023 17:54:55 UTC] Status Transition = Array
(
    [from] => pending
    [to] => processing
    [note] => 
    [manual] => 1
)
```
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
