### PR TITLE
Fix CYS JS conflict error latest Gutenberg version

### DIFF
--- a/plugins/woocommerce-admin/bin/modified-editsite-lock-unlock.js
+++ b/plugins/woocommerce-admin/bin/modified-editsite-lock-unlock.js
@@ -3,16 +3,27 @@
  */
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 
-let consentString =
+const oldConsentString =
 	'I know using unstable features means my plugin or theme will inevitably break on the next WordPress release.';
+const newConsentString =
+	'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.';
 
-if ( window.wcSettings && window.wcSettings.wpVersion ) {
-	// Parse the version string as a floating-point number
-	const wpVersion = parseFloat( window.wcSettings.wpVersion );
-	if ( ! isNaN( wpVersion ) && wpVersion >= 6.4 ) {
-		consentString =
-			'I know using unstable features means my theme or plugin will inevitably break in the next version of WordPress.';
-	}
+let consentString = oldConsentString;
+const wcSettings = window.wcSettings;
+const admin = wcSettings?.admin;
+
+const wpVersion = parseFloat( wcSettings?.wpVersion );
+const gutenbergVersion = parseFloat( admin?.gutenberg_version );
+
+// Use the new consent string if the WP version is 6.4 and above
+if ( ! isNaN( wpVersion ) && wpVersion >= 6.4 ) {
+	consentString = newConsentString;
+}
+
+// Users can install the latest Gutenberg plugin manually
+// Use the new consent string for Gutenberg 16.9 and above
+if ( ! isNaN( gutenbergVersion ) && gutenbergVersion >= 16.9 ) {
+	consentString = newConsentString;
 }
 
 export const { lock, unlock } =

--- a/plugins/woocommerce/changelog/41052-update-40840-customize-blank-issue-with-wp-6.4-followup
+++ b/plugins/woocommerce/changelog/41052-update-40840-customize-blank-issue-with-wp-6.4-followup
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix blank assember hub (CYS) issue on WPCOM and WP 6.3 + latest Gutenberg.

--- a/plugins/woocommerce/changelog/41052-update-40840-customize-blank-issue-with-wp-6.4-followup
+++ b/plugins/woocommerce/changelog/41052-update-40840-customize-blank-issue-with-wp-6.4-followup
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Fix blank assember hub (CYS) issue on WP 6.3 + latest Gutenberg.
+Fix blank assember hub (CYS) issue on WPCOM and WP 6.3 + latest Gutenberg.

--- a/plugins/woocommerce/changelog/41052-update-40840-customize-blank-issue-with-wp-6.4-followup
+++ b/plugins/woocommerce/changelog/41052-update-40840-customize-blank-issue-with-wp-6.4-followup
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Fix blank assember hub (CYS) issue on WPCOM and WP 6.3 + latest Gutenberg.
+Fix blank assember hub (CYS) issue on WP 6.3 + latest Gutenberg.

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/CustomizeStore.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/CustomizeStore.php
@@ -19,14 +19,6 @@ class CustomizeStore extends Task {
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'possibly_add_site_editor_scripts' ) );
 
-		// wpcom.editor.js conflicts with CYS scripts due to double registration of the private-apis
-		// dequeue it on CYS pages.
-		add_action( 'admin_print_scripts', function() {
-			if ( str_contains( $_GET['path'], '/customize-store/' ) ) {
-				wp_dequeue_script( 'wpcom-block-editor-wpcom-editor-script' );
-			}
-		}, 9999);
-
 		// Use "switch_theme" instead of "after_switch_theme" because the latter is fired after the next WP load and we don't want to trigger action when switching theme to TT3 via onboarding theme API.
 		global $_GET;
 		$theme_switch_via_cys_ai_loader = isset( $_GET['theme_switch_via_cys_ai_loader'] ) ? 1 === absint( $_GET['theme_switch_via_cys_ai_loader'] ) : false;

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/CustomizeStore.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/CustomizeStore.php
@@ -19,6 +19,14 @@ class CustomizeStore extends Task {
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'possibly_add_site_editor_scripts' ) );
 
+		// wpcom.editor.js conflicts with CYS scripts due to double registration of the private-apis
+		// dequeue it on CYS pages.
+		add_action( 'admin_print_scripts', function() {
+			if ( str_contains( $_GET['path'], '/customize-store/' ) ) {
+				wp_dequeue_script( 'wpcom-block-editor-wpcom-editor-script' );
+			}
+		}, 9999);
+
 		// Use "switch_theme" instead of "after_switch_theme" because the latter is fired after the next WP load and we don't want to trigger action when switching theme to TT3 via onboarding theme API.
 		global $_GET;
 		$theme_switch_via_cys_ai_loader = isset( $_GET['theme_switch_via_cys_ai_loader'] ) ? 1 === absint( $_GET['theme_switch_via_cys_ai_loader'] ) : false;

--- a/plugins/woocommerce/src/Internal/Admin/Settings.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings.php
@@ -239,6 +239,8 @@ class Settings {
 
 		$settings['isWooPayEligible'] = WCPayPromotionInit::is_woopay_eligible();
 
+		$settings['gutenberg_version']	= defined( 'GUTENBERG_VERSION' ) ? constant('GUTENBERG_VERSION') : 0;
+
 		return $settings;
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/Settings.php
+++ b/plugins/woocommerce/src/Internal/Admin/Settings.php
@@ -239,7 +239,7 @@ class Settings {
 
 		$settings['isWooPayEligible'] = WCPayPromotionInit::is_woopay_eligible();
 
-		$settings['gutenberg_version']	= defined( 'GUTENBERG_VERSION' ) ? constant('GUTENBERG_VERSION') : 0;
+		$settings['gutenberg_version'] = defined( 'GUTENBERG_VERSION' ) ? constant( 'GUTENBERG_VERSION' ) : 0;
 
 		return $settings;
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This is a follow-up to https://github.com/woocommerce/woocommerce/issues/40850.

This PR fixes blank CYS assember hub page.

-  [Use the new consent string for Gutenberg 16.9 and above](https://github.com/woocommerce/woocommerce/commit/064a238cf719c1bce44146f8c84980846939fcad) This commit addresses WP 6.3 and the latest Gutenberg issue by comparing the Gutenberg version and using the updated consent string.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Create a new JN site with this branch.
2. Downgrade to WP 6.3 if necessary.
3. Enable`customize-store` flag with WCA test helper.
4. Install the latest Gutenberg 
5. Complete the Core Profiler and connect Jetpack
6. Start CYS and confirm the intro screen displays.
7. Choose Design with AI
8. Complete the AI wizard and ensure the loading screen transitions to the pattern assembler

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>