### PR TITLE
Add fullscreen class to body when CYS component is shown

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/hooks/use-body-class.ts
+++ b/plugins/woocommerce-admin/client/customize-store/hooks/use-body-class.ts
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+
+// Counter to keep track of the number of components using a particular class
+const classCounter: Record< string, number > = {};
+
+const useBodyClass = ( className: string ) => {
+	useEffect( () => {
+		if ( typeof document === 'undefined' ) return;
+
+		// Initialize or increment the counter for this class
+		classCounter[ className ] = ( classCounter[ className ] || 0 ) + 1;
+
+		// Add the class if this is the first component to request it
+		if ( classCounter[ className ] === 1 ) {
+			document.body.classList.add( className );
+		}
+
+		// Cleanup: Decrement the counter and remove the class if this is the last component to use it
+		return () => {
+			classCounter[ className ]--;
+			if ( classCounter[ className ] === 0 ) {
+				document.body.classList.remove( className );
+			}
+		};
+	}, [ className ] );
+};
+
+export default useBodyClass;

--- a/plugins/woocommerce-admin/client/customize-store/hooks/use-body-class.ts
+++ b/plugins/woocommerce-admin/client/customize-store/hooks/use-body-class.ts
@@ -1,4 +1,7 @@
-import { useEffect } from 'react';
+/**
+ * External dependencies
+ */
+import { useEffect } from '@wordpress/element';
 
 // Counter to keep track of the number of components using a particular class
 const classCounter: Record< string, number > = {};

--- a/plugins/woocommerce-admin/client/customize-store/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/index.tsx
@@ -39,6 +39,7 @@ import {
 import { ThemeCard } from './intro/types';
 import './style.scss';
 import { navigateOrParent, attachParentListeners } from './utils';
+import useBodyClass from './hooks/use-body-class';
 
 export type customizeStoreStateMachineEvents =
 	| introEvents
@@ -367,6 +368,8 @@ export const CustomizeStoreController = ( {
 		const removeListener = attachParentListeners();
 		return removeListener;
 	}, [] );
+
+	useBodyClass( 'is-fullscreen-mode' );
 
 	const currentNodeCssLabel =
 		state.value instanceof Object

--- a/plugins/woocommerce/changelog/fix-cys-add-fullscreen-body-class
+++ b/plugins/woocommerce/changelog/fix-cys-add-fullscreen-body-class
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Add fullscreen class to body when CYS component is shown


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In some environments, CYS screen is shown with unwanted elements hovering over and disrupting layout.

This PR forces CYS into fullscreen when in intro screen: p1698391366850569/1698374901.359259-slack-C01SFMVEYAK

### How to test the changes in this Pull Request:

1. Test this in WordPress.com environment
1. Make sure to enable `customize-store` feature flag
1. Go to `WooCommerce -> Home` and click `Customize Store` task
2. Observe that the `Screen Options` tab on the top right is no longer shown


Before:
<img width="878" alt="image" src="https://github.com/woocommerce/woocommerce/assets/3747241/818f0468-75cc-41ee-8e22-3cbcdbdc49ea">


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>