### PR TITLE
Fix CYS iframe not firing pushstate events

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/utils.js
+++ b/plugins/woocommerce-admin/client/customize-store/utils.js
@@ -63,6 +63,7 @@ export function attachIframeListeners( iframe ) {
 
 	// Listen for pushstate event
 	if ( iframeWindow?.history ) {
+		const originalPushState = iframeWindow.history.pushState;
 		iframeWindow.history.pushState = function ( state, title, url ) {
 			const urlString = url?.toString();
 			if ( urlString ) {
@@ -71,6 +72,7 @@ export function attachIframeListeners( iframe ) {
 					window.location.href = urlString;
 				} else {
 					window.history.pushState( state, title, url ); // Update the main window's history
+					originalPushState( state, title, url );
 				}
 			}
 		};

--- a/plugins/woocommerce/changelog/fix-cys-iframe-pushstate
+++ b/plugins/woocommerce/changelog/fix-cys-iframe-pushstate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix pushstate event in CYS not called in iframe


### PR DESCRIPTION
### Changes proposed in this Pull Request:

p1698424417007999-slack-C01SFMVEYAK

> The Done button doesn’t switch to Save when I change the sidebar item.

This fixes CYS' pattern assembler button does not change state if iframe is used due to pushstate being overridden by parent frame.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Test this in WordPress.com environment
1. Make sure to enable `customize-store` feature flag
1. Go to `WooCommerce -> Home` and click `Customize Store` task
2. Go through the AI steps until the assembler and make sure to not refresh so that iframe is used to view pattern assembler
3. Click on `Add your logo`
4. Observe the `Done` button is changed to `Save`


https://github.com/woocommerce/woocommerce/assets/3747241/392425a4-252a-4ea2-aee4-540c3f679788



<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>