### PR TITLE
Fix intro warning modal copy and button spacing

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/intro/intro.scss
+++ b/plugins/woocommerce-admin/client/customize-store/intro/intro.scss
@@ -277,7 +277,7 @@
 	}
 	.woocommerce-customize-store__design-change-warning-modal-footer {
 		display: flex;
-		gap: 15px;
+		gap: 12px;
 		justify-content: flex-end;
 	}
 }

--- a/plugins/woocommerce-admin/client/customize-store/intro/warning-modals.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/intro/warning-modals.tsx
@@ -35,7 +35,7 @@ export const DesignChangeWarningModal = ( {
 			<p>
 				{ createInterpolateElement(
 					__(
-						"The [AI designer*] will create a new store design for you, and you'll lose any changes you've made to your active theme. If you'd prefer to continue editing your theme, you can do so via the <EditorLink>Editor</EditorLink>.",
+						"The Store Designer will create a new store design for you, and you'll lose any changes you've made to your active theme. If you'd prefer to continue editing your theme, you can do so via the <EditorLink>Editor</EditorLink>.",
 						'woocommerce'
 					),
 					{
@@ -94,7 +94,7 @@ export const StartNewDesignWarningModal = ( {
 			<p>
 				{ createInterpolateElement(
 					__(
-						"The [AI designer*] will create a new store design for you, and you'll lose any changes you've made to your active theme. If you'd prefer to continue editing your theme, you can do so via the <EditorLink>Editor</EditorLink>.",
+						"The Store Designer will create a new store design for you, and you'll lose any changes you've made to your active theme. If you'd prefer to continue editing your theme, you can do so via the <EditorLink>Editor</EditorLink>.",
 						'woocommerce'
 					),
 					{

--- a/plugins/woocommerce/changelog/fix-intro-copy-ui
+++ b/plugins/woocommerce/changelog/fix-intro-copy-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix intro warning modal copy and button spacing


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/41019.

- Update copy `[AI designer*] ` -> `Store Designer`.
- Fix spacing between buttons (Mrk6SERPZ4KrFHSjM0a8TK-fi-3616_276551).

![Screenshot 2023-10-30 at 16 32 09](https://github.com/woocommerce/woocommerce/assets/4344253/5442d11c-a6a8-41da-8bc0-f56949c282f3)

<!-- Begin testing instructions -->


### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Make sure you are testing this with a Jetpack connected instance of WooCommerce, as the AI text completion endpoint can only be called with a Jetpack connected account.**

1. Create a new WooCommerce installation with this version.
2. Make sure to enable `customize-store` feature flag
3. Go to WP > theme page
4. Install and activate a block theme.
5. Go to `WooCommerce -> Home` and click `Customize Store` task
6. Click on `Create a new one` button
7. Observe that the modal copy is updated and the button spacing is 12px.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>