### PR TITLE
[CYS] Fix undefined query id warning

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/save-hub.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/save-hub.tsx
@@ -134,7 +134,7 @@ export const SaveHub = () => {
 
 	const isMainScreen = urlParams.path === '/customize-store/assembler-hub';
 
-	// Trigger a save when the editor is loaded abd there are unsaved changes in main screen.  This is needed to ensure FE is displayed correctly	because some patterns have dynamic attributes that only generate in Editor.
+	// Trigger a save when the editor is loaded and there are unsaved changes in main screen. This is needed to ensure FE is displayed correctly because some patterns have dynamic attributes that only generate in Editor.
 	useEffect( () => {
 		if ( isEditorLoading ) {
 			return;

--- a/plugins/woocommerce/changelog/fix-undefined-queryId-warning
+++ b/plugins/woocommerce/changelog/fix-undefined-queryId-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix Undefined array key "queryId" error


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

p1698329592538919/1698319553.516889-slack-C053716F2H2

This PR fixes `Warning: Undefined array key "queryId" in /srv/users/user6edc3b38/apps/user6edc3b38/public/wp-content/plugins/woocommerce-blocks/src/BlockTypes/ProductCollection.php on line 120`.

The warnings are on the FE when completing the AI wizard without clicking the "Done" button in assembler. This is because some blocks have to load some logic and set attributes dynamically in the editor but when we updates the template during the loading screen, we save the template directly without the editor.

This PR fixes the issue by automatically calling the "save" method once when the editor is loaded.

![Screenshot 2023-10-30 at 17 06 34](https://github.com/woocommerce/woocommerce/assets/4344253/5247b10b-1e41-4214-9dae-82015126f7c0)


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


**Make sure you are testing this with a Jetpack connected instance of WooCommerce, as the AI text completion endpoint can only be called with a Jetpack connected account.**

1. Create a new WooCommerce installation with this version.
2. Make sure to enable `customize-store` feature flag
3. Go to `WooCommerce -> Home` and click `Customize Store` task
4. Click `Design with AI` button
5. Follow through the flow all the way till the assembler hub shows up
6. Go to FE
7. Confirm there is no warning


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>