### PR TITLE
Filter an importing row.

### DIFF
--- a/plugins/woocommerce/changelog/41089-feature-41087
+++ b/plugins/woocommerce/changelog/41089-feature-41087
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Add a `woocommerce_product_importer_read_file_row` hook to filter each row from an importing CSV file.

--- a/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
+++ b/plugins/woocommerce/includes/import/class-wc-product-csv-importer.php
@@ -116,7 +116,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 						$row = array_map( array( $this, 'adjust_character_encoding' ), $row );
 					}
 
-					$this->raw_data[]                                 = $row;
+					$this->raw_data[]                                 = apply_filters( 'woocommerce_product_importer_read_file_row', $row, $this );
 					$this->file_positions[ count( $this->raw_data ) ] = ftell( $handle );
 
 					if ( ( $this->params['end_pos'] > 0 && ftell( $handle ) >= $this->params['end_pos'] ) || 0 === --$this->params['lines'] ) {


### PR DESCRIPTION
Ref: 41087

### Changes proposed in this Pull Request:

Include a new filter on the importing row as read from the CSV file.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #41087 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

This is just a new filter, no further or special testing steps are required. But in

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [x] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Add a `woocommerce_product_importer_read_file_row` hook to filter each row from an importing CSV file.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
