### PR TITLE
Fix legacy order data PHP 8 compatibility issue

### DIFF
--- a/plugins/woocommerce/changelog/fix-39489
+++ b/plugins/woocommerce/changelog/fix-39489
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+fix legacy order data PHP 8 compatibility issue

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -2030,7 +2030,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 
 		if ( is_callable( array( $item, 'get_total' ) ) ) {
 			// Check if we need to add line tax to the line total.
-			$total = $inc_tax ? $item->get_total() + $item->get_total_tax() : $item->get_total();
+			$total = $inc_tax ? floatval( $item->get_total() ) + floatval( $item->get_total_tax() ) : floatval( $item->get_total() );
 
 			// Check if we need to round.
 			$total = $round ? NumberUtil::round( $total, wc_get_price_decimals() ) : $total;

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -1375,7 +1375,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 
 					// If the order originally had prices including tax, remove the discount + discount tax.
 					if ( $this->get_prices_include_tax() ) {
-						$coupon_object->set_amount( $coupon_item->get_discount() + $coupon_item->get_discount_tax() );
+						$coupon_object->set_amount( (float) $coupon_item->get_discount() + (float) $coupon_item->get_discount_tax() );
 					} else {
 						$coupon_object->set_amount( $coupon_item->get_discount() );
 					}
@@ -1620,7 +1620,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		$shipping_total = 0;
 
 		foreach ( $this->get_shipping_methods() as $shipping ) {
-			$shipping_total += $shipping->get_total();
+			$shipping_total += (float) $shipping->get_total();
 		}
 
 		$this->set_shipping_total( $shipping_total );
@@ -1783,7 +1783,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		return array_reduce(
 			$this->get_fees(),
 			function( $carry, $item ) {
-				return $carry + $item->get_total();
+				return $carry + (float) $item->get_total();
 			}
 		);
 	}
@@ -1815,7 +1815,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 					$tax_amount = wc_round_tax_total( $tax_amount );
 				}
 
-				$shipping_taxes[ $tax_rate_id ] = isset( $shipping_taxes[ $tax_rate_id ] ) ? $shipping_taxes[ $tax_rate_id ] + $tax_amount : $tax_amount;
+				$shipping_taxes[ $tax_rate_id ] = isset( $shipping_taxes[ $tax_rate_id ] ) ? (float) $shipping_taxes[ $tax_rate_id ] + $tax_amount : $tax_amount;
 			}
 		}
 
@@ -1893,7 +1893,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		$cart_total_tax    = 0;
 
 		$cart_subtotal = $this->get_cart_subtotal_for_order();
-		$cart_total    = $this->get_cart_total_for_order();
+		$cart_total    = (float) $this->get_cart_total_for_order();
 
 		// Sum shipping costs.
 		foreach ( $this->get_shipping_methods() as $shipping ) {
@@ -1904,7 +1904,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 
 		// Sum fee costs.
 		foreach ( $this->get_fees() as $item ) {
-			$fee_total = $item->get_total();
+			$fee_total = (float) $item->get_total();
 
 			if ( 0 > $fee_total ) {
 				$max_discount = NumberUtil::round( $cart_total + $fees_total + $shipping_total, wc_get_price_decimals() ) * -1;
@@ -1913,7 +1913,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 					$item->set_total( $max_discount );
 				}
 			}
-			$fees_total += $item->get_total();
+			$fees_total += (float) $item->get_total();
 		}
 
 		// Calculate taxes for items, shipping, discounts. Note; this also triggers save().
@@ -1936,7 +1936,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 
 		$this->set_discount_total( NumberUtil::round( $cart_subtotal - $cart_total, wc_get_price_decimals() ) );
 		$this->set_discount_tax( wc_round_tax_total( $cart_subtotal_tax - $cart_total_tax ) );
-		$this->set_total( NumberUtil::round( $cart_total + $fees_total + $this->get_shipping_total() + $this->get_cart_tax() + $this->get_shipping_tax(), wc_get_price_decimals() ) );
+		$this->set_total( NumberUtil::round( $cart_total + $fees_total + (float) $this->get_shipping_total() + (float) $this->get_cart_tax() + (float) $this->get_shipping_tax(), wc_get_price_decimals() ) );
 
 		do_action( 'woocommerce_order_after_calculate_totals', $and_taxes, $this );
 
@@ -1958,9 +1958,9 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 
 		if ( is_callable( array( $item, 'get_subtotal' ) ) && $item->get_quantity() ) {
 			if ( $inc_tax ) {
-				$subtotal = ( $item->get_subtotal() + $item->get_subtotal_tax() ) / $item->get_quantity();
+				$subtotal = ( (float) $item->get_subtotal() + (float) $item->get_subtotal_tax() ) / $item->get_quantity();
 			} else {
-				$subtotal = floatval( $item->get_subtotal() ) / $item->get_quantity();
+				$subtotal = ( (float) $item->get_subtotal() ) / $item->get_quantity();
 			}
 
 			$subtotal = $round ? NumberUtil::round( $subtotal, wc_get_price_decimals() ) : $subtotal;
@@ -1982,9 +1982,9 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 
 		if ( is_callable( array( $item, 'get_subtotal' ) ) ) {
 			if ( $inc_tax ) {
-				$subtotal = $item->get_subtotal() + $item->get_subtotal_tax();
+				$subtotal = (float) $item->get_subtotal() + (float) $item->get_subtotal_tax();
 			} else {
-				$subtotal = $item->get_subtotal();
+				$subtotal = (float) $item->get_subtotal();
 			}
 
 			$subtotal = $round ? NumberUtil::round( $subtotal, wc_get_price_decimals() ) : $subtotal;
@@ -2006,9 +2006,9 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 
 		if ( is_callable( array( $item, 'get_total' ) ) && $item->get_quantity() ) {
 			if ( $inc_tax ) {
-				$total = ( $item->get_total() + $item->get_total_tax() ) / $item->get_quantity();
+				$total = ( (float) $item->get_total() + (float) $item->get_total_tax() ) / $item->get_quantity();
 			} else {
-				$total = floatval( $item->get_total() ) / $item->get_quantity();
+				$total = ( (float) $item->get_total() ) / $item->get_quantity();
 			}
 
 			$total = $round ? NumberUtil::round( $total, wc_get_price_decimals() ) : $total;
@@ -2030,7 +2030,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 
 		if ( is_callable( array( $item, 'get_total' ) ) ) {
 			// Check if we need to add line tax to the line total.
-			$total = $inc_tax ? floatval( $item->get_total() ) + floatval( $item->get_total_tax() ) : floatval( $item->get_total() );
+			$total = $inc_tax ? (float) $item->get_total() + (float) $item->get_total_tax() : (float) $item->get_total();
 
 			// Check if we need to round.
 			$total = $round ? NumberUtil::round( $total, wc_get_price_decimals() ) : $total;
@@ -2113,14 +2113,14 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 */
 	public function get_subtotal_to_display( $compound = false, $tax_display = '' ) {
 		$tax_display = $tax_display ? $tax_display : get_option( 'woocommerce_tax_display_cart' );
-		$subtotal    = $this->get_cart_subtotal_for_order();
+		$subtotal    = (float) $this->get_cart_subtotal_for_order();
 
 		if ( ! $compound ) {
 
 			if ( 'incl' === $tax_display ) {
 				$subtotal_taxes = 0;
 				foreach ( $this->get_items() as $item ) {
-					$subtotal_taxes += self::round_line_tax( $item->get_subtotal_tax(), false );
+					$subtotal_taxes += self::round_line_tax( (float) $item->get_subtotal_tax(), false );
 				}
 				$subtotal += wc_round_tax_total( $subtotal_taxes );
 			}
@@ -2136,18 +2136,18 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			}
 
 			// Add Shipping Costs.
-			$subtotal += $this->get_shipping_total();
+			$subtotal += (float) $this->get_shipping_total();
 
 			// Remove non-compound taxes.
 			foreach ( $this->get_taxes() as $tax ) {
 				if ( $tax->is_compound() ) {
 					continue;
 				}
-				$subtotal = $subtotal + $tax->get_tax_total() + $tax->get_shipping_tax_total();
+				$subtotal = $subtotal + (float) $tax->get_tax_total() + (float) $tax->get_shipping_tax_total();
 			}
 
 			// Remove discounts.
-			$subtotal = $subtotal - $this->get_total_discount();
+			$subtotal = $subtotal - (float) $this->get_total_discount();
 			$subtotal = wc_price( $subtotal, array( 'currency' => $this->get_currency() ) );
 		}
 
@@ -2276,7 +2276,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 				}
 				$total_rows[ 'fee_' . $fee->get_id() ] = array(
 					'label' => $fee->get_name() . ':',
-					'value' => wc_price( 'excl' === $tax_display ? $fee->get_total() : $fee->get_total() + $fee->get_total_tax(), array( 'currency' => $this->get_currency() ) ),
+					'value' => wc_price( 'excl' === $tax_display ? (float) $fee->get_total() : (float) $fee->get_total() + (float) $fee->get_total_tax(), array( 'currency' => $this->get_currency() ) ),
 				);
 			}
 		}

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-order.php
@@ -1784,7 +1784,8 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			$this->get_fees(),
 			function( $carry, $item ) {
 				return $carry + (float) $item->get_total();
-			}
+			},
+			0.0
 		);
 	}
 

--- a/plugins/woocommerce/tests/legacy/unit-tests/order-items/class-wc-tests-order-item-product.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/order-items/class-wc-tests-order-item-product.php
@@ -43,11 +43,34 @@ class WC_Tests_Order_Item_Product extends WC_Unit_Test_Case {
 		$product_item->set_total( '10.00' );
 		$this->assertEquals( '10.00', $product_item->get_total() );
 
+		$product_item->set_total( '' );
+		$this->assertEquals( '0.00', $product_item->get_total() );
+
 		$product_item->set_subtotal_tax( '0.50' );
 		$this->assertEquals( '0.50', $product_item->get_subtotal_tax() );
 
 		$product_item->set_total_tax( '0.30' );
 		$this->assertEquals( '0.30', $product_item->get_total_tax() );
+	}
+
+	/**
+	 * Test get item shipping total
+	 */
+	public function test_get_item_shipping_total() {
+		$order = WC_Helper_Order::create_order_with_fees_and_shipping();
+		$order_id = $order->get_id();
+
+		array_values( $order->get_items( 'shipping' ) )[0]->set_total( '10.17' );
+		$order->save();
+
+		$order = wc_get_order( $order_id );
+		$this->assertEquals( '10.17', $order->get_line_total(  array_values( $order->get_items( 'shipping' ) )[0], true ) );
+
+		array_values( $order->get_items( 'shipping' ) )[0]->set_total( '' );
+		$order->save();
+
+		$order = wc_get_order( $order_id );
+		$this->assertEquals( '0.00', $order->get_line_total(  array_values( $order->get_items( 'shipping' ) )[0], true ) );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/legacy/unit-tests/order-items/class-wc-tests-order-item-product.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/order-items/class-wc-tests-order-item-product.php
@@ -57,20 +57,20 @@ class WC_Tests_Order_Item_Product extends WC_Unit_Test_Case {
 	 * Test get item shipping total
 	 */
 	public function test_get_item_shipping_total() {
-		$order = WC_Helper_Order::create_order_with_fees_and_shipping();
+		$order    = WC_Helper_Order::create_order_with_fees_and_shipping();
 		$order_id = $order->get_id();
 
 		array_values( $order->get_items( 'shipping' ) )[0]->set_total( '10.17' );
 		$order->save();
 
 		$order = wc_get_order( $order_id );
-		$this->assertEquals( '10.17', $order->get_line_total(  array_values( $order->get_items( 'shipping' ) )[0], true ) );
+		$this->assertEquals( '10.17', $order->get_line_total( array_values( $order->get_items( 'shipping' ) )[0], true ) );
 
 		array_values( $order->get_items( 'shipping' ) )[0]->set_total( '' );
 		$order->save();
 
 		$order = wc_get_order( $order_id );
-		$this->assertEquals( '0.00', $order->get_line_total(  array_values( $order->get_items( 'shipping' ) )[0], true ) );
+		$this->assertEquals( '0.00', $order->get_line_total( array_values( $order->get_items( 'shipping' ) )[0], true ) );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

As detailed in #39489, it was possible to set some values like shipping to the empty string, which would then lead to problems under PHP 8 when trying to calculate with totals derived from such values. This PR adds a failing test for the case discussed in #39489, adds a solution that makes the test pass, and for good measure adds a few additional casts to float where we calculate with values that we can't definitely guarantee to not be strings. 

Closes #39489.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. checkout this branch
2. step back a few commits so that only the failing test is being added
3. start `wp-env` with PHP 8.1 like so: `WP_ENV_PHP_VERSION=8.1 wp-env start`
4. run `pnpm --filter=woocommerce test:unit:env --filter=WC_Tests_Order_Item_Product::test_get_item_shipping_total`
5. note that the test fails ("TypeError: Unsupported operand types: string + string")
6. move the commit pointer forward again so that all commits from this branch are applied
7. re-run the test and see that it passes; optionally run the whole test suite by removing the filter but the CI should take care of that anyway

<!-- End testing instructions -→

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -→

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -→

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -→

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -→

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -→

</details>
