### PR TITLE
Check if $data['billing_email'] is set

### DIFF
--- a/plugins/woocommerce/changelog/fix-41097
+++ b/plugins/woocommerce/changelog/fix-41097
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Check if $data['billing_email'] is set in the create_order function.

--- a/plugins/woocommerce/includes/class-wc-checkout.php
+++ b/plugins/woocommerce/includes/class-wc-checkout.php
@@ -421,7 +421,10 @@ class WC_Checkout {
 				}
 			}
 
-			$order->hold_applied_coupons( $data['billing_email'] );
+			if ( isset( $data['billing_email'] ) ) {
+				$order->hold_applied_coupons( $data['billing_email'] );
+			}
+
 			$order->set_created_via( 'checkout' );
 			$order->set_cart_hash( $cart_hash );
 			/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:
- checks if `$data['billing_email']` is set in the `create_order` function, which prevents php warnings if the WooCommerce instance is using a custom checkout experience (e.g. custom checkout fields).
- adds a changelog entry
- closes #41097.

### Testing instructions:
- Use a non-blocks theme (e.g. Twenty Twenty).
- Remove the billing email checkout field using the following code snippet (or a plugin like [Checkout Field Editor](https://wordpress.org/plugins/woo-checkout-field-editor-pro/)):
```
function pr41098_remove_billing_email( $fields ) {
    unset( $fields['billing']['billing_email'] );

    return $fields;
}
add_filter( 'woocommerce_checkout_fields', 'pr41098_remove_billing_email' );
```
- Complete a purchase as usual.
- Check the error log and see no php warning related to an undefined array key "billing_email".
- Just for reference; here's an example of an error message when running the test with the latest WooCommerce release or trunk:
```
PHP Warning: Undefined array key "billing_email" in .../wp-content/plugins/woocommerce/includes/class-wc-checkout.php on line 424', referer: https://example.com/checkout/
```