### PR TITLE
Remove SlotFillProvider from Editor component

### DIFF
--- a/packages/js/product-editor/changelog/update-remove-slot-fill-provider-product-editor
+++ b/packages/js/product-editor/changelog/update-remove-slot-fill-provider-product-editor
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Remove SlotFillProvider from Editor component. Needs to be provided higher up in the tree.

--- a/packages/js/product-editor/src/components/editor/editor.tsx
+++ b/packages/js/product-editor/src/components/editor/editor.tsx
@@ -17,7 +17,7 @@ import {
 	EditorBlockListSettings,
 } from '@wordpress/block-editor';
 import { Template } from '@wordpress/blocks';
-import { Popover, SlotFillProvider } from '@wordpress/components';
+import { Popover } from '@wordpress/components';
 import { Product } from '@woocommerce/data';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore No types for this exist yet.
@@ -70,35 +70,33 @@ export function Editor( {
 				>
 					<ShortcutProvider>
 						<FullscreenMode isActive={ false } />
-						<SlotFillProvider>
-							<ValidationProvider initialValue={ product }>
-								<InterfaceSkeleton
-									header={
-										<Header
-											onTabSelect={ setSelectedTab }
+						<ValidationProvider initialValue={ product }>
+							<InterfaceSkeleton
+								header={
+									<Header
+										onTabSelect={ setSelectedTab }
+										productType={ productType }
+									/>
+								}
+								content={
+									<>
+										<BlockEditor
+											settings={ settings }
 											productType={ productType }
+											productId={ product.id }
+											context={ {
+												selectedTab,
+												postType: productType,
+												postId: product.id,
+											} }
 										/>
-									}
-									content={
-										<>
-											<BlockEditor
-												settings={ settings }
-												productType={ productType }
-												productId={ product.id }
-												context={ {
-													selectedTab,
-													postType: productType,
-													postId: product.id,
-												} }
-											/>
-											{ /* @ts-expect-error 'scope' does exist. @types/wordpress__plugins is outdated. */ }
-											<PluginArea scope="woocommerce-product-block-editor" />
-										</>
-									}
-								/>
-								<Popover.Slot />
-							</ValidationProvider>
-						</SlotFillProvider>
+										{ /* @ts-expect-error 'scope' does exist. @types/wordpress__plugins is outdated. */ }
+										<PluginArea scope="woocommerce-product-block-editor" />
+									</>
+								}
+							/>
+							<Popover.Slot />
+						</ValidationProvider>
 					</ShortcutProvider>
 				</EntityProvider>
 			</StrictMode>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR removes the `SlotFillProvider` from the Editor component in `@woocommerce/product-editor`.

This is needed in order for plugins to the product editor to be able to fill slots outside of the product editor (like the footer).

A `SlotFillProvider` will need to be provided further up the React tree, which is already being done in WooCommerce.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Verify slot-fills in the product editor still function. One easy thing to verify is that the more menu items still show and function.

1. Enable the **Product Editor** under **WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**.
2. Go to **Products** > **Add New**
3. Click the more menu (the kebab menu) in the upper right of the product editor header and verify the menu items appear and function:

<img width="1093" alt="Screenshot 2023-10-30 at 14 51 56" src="https://github.com/woocommerce/woocommerce/assets/2098816/b422752b-9ece-4bc3-b523-1a82d81bedf9">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
