### PR TITLE
Product Editor: Add PostTypeContext and blocks access to plugins

### DIFF
--- a/packages/js/product-editor/changelog/update-add-post-type-context-product-editor
+++ b/packages/js/product-editor/changelog/update-add-post-type-context-product-editor
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Add PostTypeContext so that plugins can get post type.

--- a/packages/js/product-editor/changelog/update-add-post-type-context-product-editor
+++ b/packages/js/product-editor/changelog/update-add-post-type-context-product-editor
@@ -1,4 +1,4 @@
 Significance: minor
 Type: update
 
-Add PostTypeContext so that plugins can get post type.
+Allow plugins to access PostTypeContext and blocks (through core/block-editor data store).

--- a/packages/js/product-editor/src/components/block-editor/block-editor.tsx
+++ b/packages/js/product-editor/src/components/block-editor/block-editor.tsx
@@ -5,6 +5,7 @@ import { synchronizeBlocksWithTemplate, Template } from '@wordpress/blocks';
 import { createElement, useMemo, useLayoutEffect } from '@wordpress/element';
 import { useDispatch, useSelect, select as WPSelect } from '@wordpress/data';
 import { uploadMedia } from '@wordpress/media-utils';
+import { PluginArea } from '@wordpress/plugins';
 import {
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore No types for this exist yet.
@@ -32,6 +33,7 @@ import {
  */
 import { useConfirmUnsavedProductChanges } from '../../hooks/use-confirm-unsaved-product-changes';
 import { ProductEditorContext } from '../../types';
+import { PostTypeContext } from '../../contexts/post-type-context';
 
 type BlockEditorProps = {
 	context: Partial< ProductEditorContext >;
@@ -120,6 +122,11 @@ export function BlockEditor( {
 							<BlockList className="woocommerce-product-block-editor__block-list" />
 						</ObserveTyping>
 					</BlockTools>
+					{ /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */ }
+					<PostTypeContext.Provider value={ context.postType! }>
+						{ /* @ts-expect-error 'scope' does exist. @types/wordpress__plugins is outdated. */ }
+						<PluginArea scope="woocommerce-product-block-editor" />
+					</PostTypeContext.Provider>
 				</BlockEditorProvider>
 			</BlockContextProvider>
 		</div>

--- a/packages/js/product-editor/src/components/editor/editor.tsx
+++ b/packages/js/product-editor/src/components/editor/editor.tsx
@@ -37,6 +37,7 @@ import { FullscreenMode, InterfaceSkeleton } from '@wordpress/interface';
  */
 import { Header } from '../header';
 import { BlockEditor } from '../block-editor';
+import { PostTypeContext } from '../../contexts/post-type-context';
 import { ValidationProvider } from '../../contexts/validation-context';
 
 export type ProductEditorSettings = Partial<
@@ -90,8 +91,12 @@ export function Editor( {
 												postId: product.id,
 											} }
 										/>
-										{ /* @ts-expect-error 'scope' does exist. @types/wordpress__plugins is outdated. */ }
-										<PluginArea scope="woocommerce-product-block-editor" />
+										<PostTypeContext.Provider
+											value={ productType }
+										>
+											{ /* @ts-expect-error 'scope' does exist. @types/wordpress__plugins is outdated. */ }
+											<PluginArea scope="woocommerce-product-block-editor" />
+										</PostTypeContext.Provider>
 									</>
 								}
 							/>

--- a/packages/js/product-editor/src/components/editor/editor.tsx
+++ b/packages/js/product-editor/src/components/editor/editor.tsx
@@ -7,7 +7,6 @@ import {
 	Fragment,
 	useState,
 } from '@wordpress/element';
-import { PluginArea } from '@wordpress/plugins';
 import {
 	LayoutContextProvider,
 	useExtendLayout,
@@ -37,7 +36,6 @@ import { FullscreenMode, InterfaceSkeleton } from '@wordpress/interface';
  */
 import { Header } from '../header';
 import { BlockEditor } from '../block-editor';
-import { PostTypeContext } from '../../contexts/post-type-context';
 import { ValidationProvider } from '../../contexts/validation-context';
 
 export type ProductEditorSettings = Partial<
@@ -91,12 +89,6 @@ export function Editor( {
 												postId: product.id,
 											} }
 										/>
-										<PostTypeContext.Provider
-											value={ productType }
-										>
-											{ /* @ts-expect-error 'scope' does exist. @types/wordpress__plugins is outdated. */ }
-											<PluginArea scope="woocommerce-product-block-editor" />
-										</PostTypeContext.Provider>
 									</>
 								}
 							/>

--- a/packages/js/product-editor/src/contexts/post-type-context/index.ts
+++ b/packages/js/product-editor/src/contexts/post-type-context/index.ts
@@ -1,0 +1,6 @@
+/**
+ * External dependencies
+ */
+import { createContext } from '@wordpress/element';
+
+export const PostTypeContext = createContext( 'product' );

--- a/packages/js/product-editor/src/index.ts
+++ b/packages/js/product-editor/src/index.ts
@@ -20,5 +20,6 @@ export * from './utils';
  * Hooks
  */
 export * from './hooks';
+export { PostTypeContext } from './contexts/post-type-context';
 export { useValidation, useValidations } from './contexts/validation-context';
 export * from './contexts/validation-context/types';


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds `PostTypeContext` to the product editor and makes it available to plugins registered in the `woocommerce-product-block-editor` scope. It also moves the plugin area so that plugins can access the product editor's blocks.

**Note: There is an existing bug where the product name block is not selected initially, even though the field in it is focused. This results in the footer in this test showing "undefined" initially for the selected block. This will be addressed in a follow-up PR after this one is merged (so that it will be easy to test).**

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Add the following to a `mu-plugin`:

```php
<?php

function YOUR_PREFIX_enqueue_footer_script() {
    wp_enqueue_script(
        'your-prefix-footer',
        plugin_dir_url( __FILE__ ) . 'your-prefix-footer.js',
        [],
        filemtime( dirname( __FILE__ ) . '/your-prefix-footer.js' ),
        true,
    );
}

add_action( 'admin_enqueue_scripts', 'YOUR_PREFIX_enqueue_footer_script' );

```

Add the following to a file in the same folder as the `mu-plugin`:

```js
wp.plugins.registerPlugin( 'your-prefix-footer', {
    scope: 'woocommerce-product-block-editor',
    render: function() {
        const postType = wp.element.useContext( wc.productEditor.PostTypeContext );

        const [ id ] = wp.coreData.useEntityProp( 'postType', postType, 'id' );

        const selectedBlock = wp.data.useSelect( (select) => 
            select( 'core/block-editor' ).getSelectedBlock()
        );

        return wp.element.createElement(
            wp.element.Fragment,
            {},
            wp.element.createElement(
                wc.adminLayout.WooFooterItem,
                {
                    order: 1000,
                },
                wp.element.createElement(
                    'div',
                    {
                        style: {
                            padding: '32px',
                            textAlign: 'center',
                            backgroundColor: 'black',
                            color: 'white',
                        }
                    },
                    wp.element.createElement(
                        'p',
                        {},
                        `Post type: ${ postType }`, 
                    ),
                    wp.element.createElement(
                        'p',
                        {},
                        `Post id: ${ id }`, 
                    ),
                    wp.element.createElement(
                        'p',
                        {},
                        `Selected block: ${ selectedBlock?.name }`, 
                    ),
                )
            ),
        );
    }
} );
```

1. Enable the **Product Editor** under **WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**.
2. Go to **Products** > **Add New**
3. Verify the custom footer says `product` for the post type, shows the post id, and shows the selected block name when you focus on a block:

<img width="1095" alt="Screenshot 2023-11-02 at 08 11 38" src="https://github.com/woocommerce/woocommerce/assets/2098816/b5af4b33-3915-4777-a748-4eaf29695834">

4. Add some variation options on the Variations tab.
5. Click Edit on a variation.
6. Verify the custom footer says `product_variation` for the post type, shows the post id, and shows the selected block name when you focus on a block:

<img width="1095" alt="Screenshot 2023-11-02 at 08 12 32" src="https://github.com/woocommerce/woocommerce/assets/2098816/fe43b66d-0822-4de0-9973-1671a6c30771">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
