### PR TITLE
Store Customization > Replace the Just Arrived Full Hero pattern with the Hero Product Split pattern in the CYS flow

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/data/homepageTemplates.ts
+++ b/plugins/woocommerce-admin/client/customize-store/data/homepageTemplates.ts
@@ -5,7 +5,7 @@ export const HOMEPAGE_TEMPLATES = {
 			'woocommerce-blocks/header-centered-menu-with-search',
 
 			// Body
-			'woocommerce-blocks/just-arrived-full-hero',
+			'woocommerce-blocks/hero-product-split',
 			'woocommerce-blocks/product-collection-5-columns',
 			'woocommerce-blocks/hero-product-3-split',
 			'woocommerce-blocks/product-collection-3-columns',
@@ -36,7 +36,7 @@ export const HOMEPAGE_TEMPLATES = {
 			'woocommerce-blocks/header-essential',
 
 			// Body
-			'woocommerce-blocks/featured-category-cover-image',
+			'woocommerce-blocks/hero-product-split',
 			'woocommerce-blocks/product-collection-4-columns',
 			'woocommerce-blocks/hero-product-chessboard',
 			'woocommerce-blocks/product-collection-5-columns',
@@ -60,7 +60,7 @@ export const HOMEPAGE_TEMPLATES = {
 			'woocommerce-blocks/header-centered-menu-with-search',
 
 			// Body
-			'woocommerce-blocks/featured-category-cover-image',
+			'woocommerce-blocks/hero-product-split',
 			'woocommerce-blocks/product-collection-featured-products-5-columns',
 			'woocommerce-blocks/featured-category-triple',
 			'woocommerce-blocks/product-query-product-gallery',

--- a/plugins/woocommerce/changelog/41109-enhance-update-patterns-list-for-the-assembler
+++ b/plugins/woocommerce/changelog/41109-enhance-update-patterns-list-for-the-assembler
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Replace the **Just Arrived Full Hero** pattern with the **Hero Product Split** in the CYS flow


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

This PR replaces the **Just Arrived Full Hero** pattern with the **Hero Product Split** in the CYS flow, as requested by design.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce-blocks/issues/11503

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new WooCommerce installation with this version.
2. Install and activate the WooCommerce Blocks plugin from this zip file: [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce/files/12806758/woocommerce-gutenberg-products-block.zip)
3. Make sure to enable customize-store feature flag
4. Go to WooCommerce -> Home and click Customize Store task
5. Click Design with AI button
6. Fill out a business description and proceed
7. From the Assembler sidebar, click on "Change Your Homepage":

<img width="619" alt="Screenshot 2023-10-04 at 20 08 15" src="https://github.com/woocommerce/woocommerce/assets/15730971/cd2cb4c6-11cb-4ab8-833c-ef352ee008a1">

8. Make sure you can visualize all three homepage templates as expected, and the first pattern for all of them is:

<img width="1218" alt="Screenshot 2023-10-30 at 21 46 35" src="https://github.com/woocommerce/woocommerce/assets/15730971/c7d4ebeb-b688-4c6b-86f2-f1e4ca6a4cd5">

Note that the images, content and the color of the button are dynamically changed by AI, so those are not expected to be an exact match.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Replace the **Just Arrived Full Hero** pattern with the **Hero Product Split** in the CYS flow

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
