### PR TITLE
Logging: New, improved view for a single log file

### DIFF
--- a/plugins/woocommerce/changelog/41114-try-log-file-view
+++ b/plugins/woocommerce/changelog/41114-try-log-file-view
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a new single file view to the Logs screen for viewing the contents of a log file.

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1305,61 +1305,101 @@ table.wc_status_table--tools {
 }
 
 /**
-  * DB log viewer
-  */
-.wp-list-table.logs {
-	.log-level {
-		display: inline;
-		padding: 0.2em 0.6em 0.3em;
-		font-size: 80%;
-		font-weight: bold;
-		line-height: 1;
-		color: #fff;
-		text-align: center;
-		white-space: nowrap;
-		vertical-align: baseline;
-		border-radius: 0.2em;
+ * FileV2 logs
+ */
+#log-entries {
+	background: #fff;
+	border: 1px solid #e5e5e5;
+	font-family: monospace;
+	word-wrap: break-word;
+	line-height: 2.3;
+	counter-reset: line;
 
-		&:empty {
-			display: none;
+	.line {
+		display: block;
+		color: inherit;
+		text-decoration: none;
+		width: 100%;
+		scroll-margin-top: 6em;
+
+		&:before {
+			counter-increment: line;
+			content: counter(line);
+			display: block;
+			padding: 0 1em;
+			float: left;
+			width: 2em;
+			text-align: right;
 		}
 	}
 
-	/**
-	  * Add color to levels
-	  *
-	  * Descending severity:
-	  *   emergency, alert -> red
-	  *   critical, error  -> orange
-	  *   warning, notice  -> yellow
-	  *   info             -> blue
-	  *   debug            -> gree
-	  */
-
-	.log-level--emergency,
-	.log-level--alert {
-		background-color: #ff4136;
+	.line-content {
+		display: block;
+		overflow: hidden;
+		padding: 0 1em;
+		border-left: 1px solid #ddd;
 	}
 
-	.log-level--critical,
-	.log-level--error {
-		background-color: #ff851b;
+	.log-timestamp {
+		font-weight: 700;
 	}
+}
 
-	.log-level--warning,
-	.log-level--notice {
-		color: #222;
-		background-color: #ffdc00;
+/**
+ * Log severity level colors.
+ *
+ * Descending severity:
+ *   emergency, alert -> red
+ *   critical, error  -> orange
+ *   warning, notice  -> yellow
+ *   info             -> blue
+ *   debug            -> gree
+ */
+.log-level {
+	display: inline;
+	padding: 0.2em 0.6em 0.3em;
+	font-size: 80%;
+	font-weight: bold;
+	line-height: 1;
+	color: #fff;
+	text-align: center;
+	white-space: nowrap;
+	vertical-align: baseline;
+	border-radius: 0.2em;
+
+	&:empty {
+		display: none;
 	}
+}
 
-	.log-level--info {
-		background-color: #0074d9;
-	}
+.log-level--emergency,
+.log-level--alert {
+	background-color: #ff4136;
+}
 
-	.log-level--debug {
-		background-color: #3d9970;
-	}
+.log-level--critical,
+.log-level--error {
+	background-color: #ff851b;
+}
 
+.log-level--warning,
+.log-level--notice {
+	color: #222;
+	background-color: #ffdc00;
+}
+
+.log-level--info {
+	background-color: #0074d9;
+}
+
+.log-level--debug {
+	background-color: #3d9970;
+}
+
+/**
+  * DB log viewer
+  */
+.wp-list-table.logs {
 	// Adjust log table columns only when table is not collapsed
 	@media screen and (min-width: 783px) {
 		.column-timestamp {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1348,6 +1348,12 @@ table.wc_status_table--tools {
 	}
 }
 
+.wc-logs-single-file-actions {
+	margin-left: auto;
+	display: flex;
+	gap: 0.5em;
+}
+
 .wc-logs-entries {
 	background: #f6f7f7;
 	border: 1px solid #c3c4c7;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1307,7 +1307,15 @@ table.wc_status_table--tools {
 /**
  * FileV2 logs
  */
-#log-entries {
+.wc-logs-header {
+	.file-id {
+		padding: 3px 5px;
+		background: rgba( 0, 0, 0, 0.07 );
+		font-family: Consolas, Monaco, monospace;
+	}
+}
+
+.wc-logs-entries {
 	background: #f6f7f7;
 	border: 1px solid #c3c4c7;
 	font-family: Consolas, Monaco, monospace;
@@ -1351,6 +1359,10 @@ table.wc_status_table--tools {
 
 	.log-timestamp {
 		font-weight: 700;
+	}
+
+	.log-level {
+		font-size: 100%;
 	}
 }
 
@@ -1406,7 +1418,7 @@ table.wc_status_table--tools {
 }
 
 /**
-  * DB log viewer
+  * Legacy file/DB log viewers
   */
 .wp-list-table.logs {
 	// Adjust log table columns only when table is not collapsed
@@ -1447,6 +1459,9 @@ table.wc_status_table--tools {
 	}
 }
 
+/**
+ * Inline edit
+ */
 .inline-edit-product.quick-edit-row {
 	.inline-edit-col-center,
 	.inline-edit-col-right {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1377,6 +1377,19 @@ table.wc_status_table--tools {
 			width: 3em;
 			text-align: right;
 		}
+
+		&:target {
+			box-shadow: 0 0.16em 0.16em -0.16em #c3c4c7, 0 -0.16em 0.16em -0.16em #c3c4c7;
+			z-index: 1;
+
+			.line-content {
+				background: #fff8c5;
+			}
+
+			.log-level:before {
+				color: #fff8c5;
+			}
+		}
 	}
 
 	.line-anchor {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1313,6 +1313,7 @@ table.wc_status_table--tools {
 	font-family: Consolas, Monaco, monospace;
 	word-wrap: break-word;
 	line-height: 2.3;
+	counter-reset: line;
 
 	.line {
 		display: block;
@@ -1321,10 +1322,13 @@ table.wc_status_table--tools {
 		position: relative;
 
 		&:before {
-			content: '\00A0';
+			counter-increment: line;
+			content: counter(line);
 			display: block;
 			float: left;
-			width: 3.5em;
+			padding: 0 1em 0 0.5em;
+			width: 3em;
+			text-align: right;
 		}
 	}
 
@@ -1334,9 +1338,7 @@ table.wc_status_table--tools {
 		text-decoration: none;
 		display: block;
 		height: 100%;
-		padding: 0 1em 0 0.5em;
-		width: 2em;
-		text-align: right;
+		width: 4.5em;
 	}
 
 	.line-content {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1313,7 +1313,6 @@ table.wc_status_table--tools {
 	font-family: Consolas, Monaco, monospace;
 	word-wrap: break-word;
 	line-height: 2.3;
-	//counter-reset: line;
 
 	.line {
 		display: block;
@@ -1322,8 +1321,6 @@ table.wc_status_table--tools {
 		position: relative;
 
 		&:before {
-			//counter-increment: line;
-			//content: counter(line);
 			content: '\00A0';
 			display: block;
 			float: left;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1308,7 +1308,7 @@ table.wc_status_table--tools {
  * FileV2 logs
  */
 #log-entries {
-	background: #ffffff;
+	background: #f6f7f7;
 	border: 1px solid #c3c4c7;
 	font-family: Consolas, Monaco, monospace;
 	word-wrap: break-word;
@@ -1324,11 +1324,10 @@ table.wc_status_table--tools {
 		&:before {
 			//counter-increment: line;
 			//content: counter(line);
+			content: '\00A0';
 			display: block;
-			padding: 0 1em 0 0.5em;
 			float: left;
-			width: 2em;
-			text-align: right;
+			width: 3.5em;
 		}
 	}
 
@@ -1338,8 +1337,9 @@ table.wc_status_table--tools {
 		text-decoration: none;
 		display: block;
 		height: 100%;
-		width: 3.5em;
-		background: rgba(200,200,200,0.2);
+		padding: 0 1em 0 0.5em;
+		width: 2em;
+		text-align: right;
 	}
 
 	.line-content {
@@ -1347,6 +1347,7 @@ table.wc_status_table--tools {
 		overflow: hidden;
 		padding: 0 1em;
 		border-left: 1px solid #c3c4c7;
+		background: #ffffff;
 	}
 
 	.log-timestamp {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1413,7 +1413,7 @@ table.wc_status_table--tools {
  *   critical, error  -> orange
  *   warning, notice  -> yellow
  *   info             -> blue
- *   debug            -> gree
+ *   debug            -> green
  */
 .log-level {
 	display: inline;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1417,15 +1417,26 @@ table.wc_status_table--tools {
  */
 .log-level {
 	display: inline;
-	padding: 0.2em 0.6em 0.3em;
+	padding: 0 0.5em;
 	font-size: 80%;
-	font-weight: bold;
+	font-weight: 700;
 	line-height: 1;
-	color: #fff;
+	color: #000000;
+	background: #ffffff;
 	text-align: center;
 	white-space: nowrap;
 	vertical-align: baseline;
-	border-radius: 0.2em;
+	border-style: solid;
+	border-width: 0.16em 0.16em 0.16em 1em;
+	border-top-left-radius: 0.5em;
+	border-bottom-left-radius: 0.5em;
+
+	&:before {
+		content: "•";
+		color: #ffffff;
+		margin-left: -1.3em;
+		margin-right: 0.7em;
+	}
 
 	&:empty {
 		display: none;
@@ -1434,26 +1445,26 @@ table.wc_status_table--tools {
 
 .log-level--emergency,
 .log-level--alert {
-	background-color: #ff4136;
+	border-color: #ff4136;
 }
 
 .log-level--critical,
 .log-level--error {
-	background-color: #ff851b;
+	border-color: #ff851b;
 }
 
 .log-level--warning,
 .log-level--notice {
 	color: #222;
-	background-color: #ffdc00;
+	border-color: #ffdc00;
 }
 
 .log-level--info {
-	background-color: #0074d9;
+	border-color: #0074d9;
 }
 
 .log-level--debug {
-	background-color: #3d9970;
+	border-color: #3d9970;
 }
 
 /**

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1308,36 +1308,44 @@ table.wc_status_table--tools {
  * FileV2 logs
  */
 #log-entries {
-	background: #fff;
-	border: 1px solid #e5e5e5;
-	font-family: monospace;
+	background: #ffffff;
+	border: 1px solid #c3c4c7;
+	font-family: Consolas, Monaco, monospace;
 	word-wrap: break-word;
 	line-height: 2.3;
 	counter-reset: line;
 
 	.line {
 		display: block;
-		color: inherit;
-		text-decoration: none;
 		width: 100%;
 		scroll-margin-top: 6em;
+		position: relative;
 
 		&:before {
 			counter-increment: line;
 			content: counter(line);
 			display: block;
-			padding: 0 1em;
+			padding: 0 1em 0 0.5em;
 			float: left;
 			width: 2em;
 			text-align: right;
 		}
 	}
 
+	.line-anchor {
+		position: absolute;
+		color: inherit;
+		text-decoration: none;
+		display: block;
+		height: 100%;
+		width: 3.5em;
+	}
+
 	.line-content {
 		display: block;
 		overflow: hidden;
 		padding: 0 1em;
-		border-left: 1px solid #ddd;
+		border-left: 1px solid #c3c4c7;
 	}
 
 	.log-timestamp {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1308,10 +1308,43 @@ table.wc_status_table--tools {
  * FileV2 logs
  */
 .wc-logs-header {
+	margin: 1em 0;
+	display: flex;
+	flex-flow: row wrap;
+	align-items: center;
+	gap: 1em;
+
+	h2 {
+		margin: 0;
+	}
+
 	.file-id {
 		padding: 3px 5px;
 		background: rgba( 0, 0, 0, 0.07 );
 		font-family: Consolas, Monaco, monospace;
+	}
+}
+
+.wc-logs-single-file-rotations {
+	display: flex;
+	align-items: center;
+	gap: 0.5em;
+
+	h3 {
+		font-size: inherit;
+		margin: 0;
+	}
+
+	.wc-logs-rotation-links {
+		list-style: none;
+		margin: 0;
+		display: flex;
+		gap: 0.5em;
+
+		li {
+			display: block;
+			margin: 0;
+		}
 	}
 }
 

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1308,7 +1308,7 @@ table.wc_status_table--tools {
  * FileV2 logs
  */
 .wc-logs-header {
-	margin: 1em 0;
+	margin: 1.5em 0 2em;
 	display: flex;
 	flex-flow: row wrap;
 	align-items: center;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1313,7 +1313,7 @@ table.wc_status_table--tools {
 	font-family: Consolas, Monaco, monospace;
 	word-wrap: break-word;
 	line-height: 2.3;
-	counter-reset: line;
+	//counter-reset: line;
 
 	.line {
 		display: block;
@@ -1322,8 +1322,8 @@ table.wc_status_table--tools {
 		position: relative;
 
 		&:before {
-			counter-increment: line;
-			content: counter(line);
+			//counter-increment: line;
+			//content: counter(line);
 			display: block;
 			padding: 0 1em 0 0.5em;
 			float: left;
@@ -1339,6 +1339,7 @@ table.wc_status_table--tools {
 		display: block;
 		height: 100%;
 		width: 3.5em;
+		background: rgba(200,200,200,0.2);
 	}
 
 	.line-content {

--- a/plugins/woocommerce/includes/class-wc-log-levels.php
+++ b/plugins/woocommerce/includes/class-wc-log-levels.php
@@ -93,6 +93,15 @@ abstract class WC_Log_Levels {
 	}
 
 	/**
+	 * Get an associative array with `level name => numerical severity` key/value pairs.
+	 *
+	 * @return int[]
+	 */
+	public static function get_all_level_severities() {
+		return self::$level_to_severity;
+	}
+
+	/**
 	 * Translate severity integer to level string.
 	 *
 	 * @param int $severity Severity level.
@@ -105,4 +114,12 @@ abstract class WC_Log_Levels {
 		return self::$severity_to_level[ $severity ];
 	}
 
+	/**
+	 * Get an associative array with `numerical severity => level name` key/value pairs.
+	 *
+	 * @return string[]
+	 */
+	public static function get_all_severity_levels() {
+		return self::$severity_to_level;
+	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
@@ -139,6 +139,28 @@ class File {
 	}
 
 	/**
+	 * Get the file's public ID.
+	 *
+	 * The file ID is the basename of the file without the hash part. It allows us to identify a file without revealing
+	 * its full name in the filesystem, so that it's difficult to access the file directly with an HTTP request.
+	 *
+	 * @return string
+	 */
+	public function get_file_id(): string {
+		$file_id = $this->get_source();
+
+		if ( ! is_null( $this->get_rotation() ) ) {
+			$file_id .= '.' . $this->get_rotation();
+		}
+
+		if ( $this->get_source() !== $this->get_hash() ) {
+			$file_id .= '-' . gmdate( 'Y-m-d', $this->get_created_timestamp() );
+		}
+
+		return $file_id;
+	}
+
+	/**
 	 * Get the file's created property.
 	 *
 	 * @return int|false

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
@@ -73,6 +73,7 @@ class File {
 	 */
 	public function __destruct() {
 		if ( is_resource( $this->stream ) ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fclose -- No suitable alternative.
 			fclose( $this->stream );
 		}
 	}
@@ -158,6 +159,7 @@ class File {
 	 */
 	public function get_stream() {
 		if ( ! is_resource( $this->stream ) ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fopen -- No suitable alternative.
 			$this->stream = fopen( $this->path, 'rb' );
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
@@ -103,6 +103,24 @@ class File {
 	}
 
 	/**
+	 * Check if the file represented by the class instance is a file and is readable.
+	 *
+	 * @return bool
+	 */
+	public function is_readable(): bool {
+		return is_file( $this->path ) && is_readable( $this->path );
+	}
+
+	/**
+	 * Check if the file represented by the class instance is a file and is writable.
+	 *
+	 * @return bool
+	 */
+	public function is_writable(): bool {
+		return is_file( $this->path ) && is_writable( $this->path );
+	}
+
+	/**
 	 * Get the name of the file, with extension, but without full path.
 	 *
 	 * @return string

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
@@ -181,7 +181,7 @@ class FileController {
 		if ( count( $result ) < 1 ) {
 			return new WP_Error(
 				'wc_log_file_error',
-				esc_html__( 'Could not read the specified file.', 'woocommerce' )
+				esc_html__( 'This file does not exist.', 'woocommerce' )
 			);
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
@@ -176,11 +176,8 @@ class FileController {
 	private function convert_paths_to_objects( array $paths ): array {
 		$files = array_map(
 			function( $path ) {
-				if ( ! is_readable( $path ) ) {
-					return null;
-				}
-
-				return new File( $path );
+				$file = new File( $path );
+				return $file->is_readable() ? $file : null;
 			},
 			$paths
 		);
@@ -205,12 +202,12 @@ class FileController {
 		$all_sources = array_map(
 			function( $path ) {
 				$file = new File( $path );
-				return $file->get_source();
+				return $file->is_readable() ? $file->get_source() : null;
 			},
 			$paths
 		);
 
-		return array_unique( $all_sources );
+		return array_unique( array_filter( $all_sources ) );
 	}
 
 	/**
@@ -225,7 +222,10 @@ class FileController {
 
 		$files = $this->get_files_by_id( $file_ids );
 		foreach ( $files as $file ) {
-			$result = $file->delete();
+			$result = false;
+			if ( $file->is_readable() ) {
+				$result = $file->delete();
+			}
 
 			if ( true === $result ) {
 				$deleted ++;

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
@@ -167,6 +167,26 @@ class FileController {
 	}
 
 	/**
+	 * Get a File instance from a file ID.
+	 *
+	 * @param string $file_id A file ID (file basename without the hash).
+	 *
+	 * @return File|WP_Error
+	 */
+	public function get_file_by_id( string $file_id ) {
+		$result = $this->get_files_by_id( array( $file_id ) );
+
+		if ( count( $result ) < 1 ) {
+			return new WP_Error(
+				'wc_log_file_error',
+				esc_html__( 'Could not read the specified file.', 'woocommerce' )
+			);
+		}
+
+		return reset( $result );
+	}
+
+	/**
 	 * Helper method to get an array of File instances.
 	 *
 	 * @param array $paths An array of absolute file paths.

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/ListTable.php
@@ -227,10 +227,10 @@ class ListTable extends WP_List_Table {
 		ob_start();
 		?>
 		<input
-			id="cb-select-<?php echo esc_attr( $item->get_hash() ); ?>"
+			id="cb-select-<?php echo esc_attr( $item->get_file_id() ); ?>"
 			type="checkbox"
 			name="file[]"
-			value="<?php echo esc_attr( $item->get_basename() ); ?>"
+			value="<?php echo esc_attr( $item->get_file_id() ); ?>"
 		/>
 		<label for="cb-select-<?php echo esc_attr( $item->get_hash() ); ?>">
 			<span class="screen-reader-text">
@@ -256,7 +256,7 @@ class ListTable extends WP_List_Table {
 	 * @return string
 	 */
 	public function column_source( $item ): string {
-		$log_file        = sanitize_title( $item->get_basename() );
+		$log_file        = $item->get_file_id();
 		$single_file_url = add_query_arg(
 			array(
 				'view'     => 'single_file',
@@ -274,8 +274,8 @@ class ListTable extends WP_List_Table {
 
 		return sprintf(
 			'<a class="row-title" href="%1$s">%2$s</a>%3$s',
-			$single_file_url,
-			$item->get_source(),
+			esc_url( $single_file_url ),
+			esc_html( $item->get_source() ),
 			$rotation
 		);
 	}

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/ListTable.php
@@ -229,7 +229,7 @@ class ListTable extends WP_List_Table {
 		<input
 			id="cb-select-<?php echo esc_attr( $item->get_file_id() ); ?>"
 			type="checkbox"
-			name="file[]"
+			name="file_id[]"
 			value="<?php echo esc_attr( $item->get_file_id() ); ?>"
 		/>
 		<label for="cb-select-<?php echo esc_attr( $item->get_hash() ); ?>">

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/ListTable.php
@@ -259,8 +259,8 @@ class ListTable extends WP_List_Table {
 		$log_file        = $item->get_file_id();
 		$single_file_url = add_query_arg(
 			array(
-				'view'     => 'single_file',
-				'log_file' => $log_file,
+				'view'    => 'single_file',
+				'file_id' => $log_file,
 			),
 			$this->page_controller->get_logs_tab_url()
 		);

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -211,12 +211,6 @@ class PageController {
 				?>
 			<?php endwhile; ?>
 		</div>
-		<script>
-			( function() {
-				let line = document.querySelectorAll( '.line' );
-				console.log(line);
-			} )();
-		</script>
 		<?php
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -215,7 +215,7 @@ class PageController {
 			<h2>
 				<?php
 				printf(
-				// translators: %s is the name of a log file.
+					// translators: %s is the name of a log file.
 					esc_html__( 'Viewing log file %s', 'woocommerce' ),
 					sprintf(
 						'<span class="file-id">%s</span>',

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -141,9 +141,11 @@ class PageController {
 		$defaults = $this->get_query_param_defaults();
 
 		?>
-		<h2>
-			<?php esc_html_e( 'Browse log files', 'woocommerce' ); ?>
-		</h2>
+		<header id="logs-header" class="wc-logs-header">
+			<h2>
+				<?php esc_html_e( 'Browse log files', 'woocommerce' ); ?>
+			</h2>
+		</header>
 		<form id="logs-list-table-form" method="get">
 			<input type="hidden" name="page" value="wc-status" />
 			<input type="hidden" name="tab" value="logs" />
@@ -188,19 +190,21 @@ class PageController {
 		$line_number = 1;
 
 		?>
-		<h2>
-			<?php
-			printf(
+		<header id="logs-header" class="wc-logs-header">
+			<h2>
+				<?php
+				printf(
 				// translators: %s is the name of a log file.
-				esc_html__( 'Viewing log file %s', 'woocommerce' ),
-				sprintf(
-					'<code>%s</code>',
-					esc_html( $file->get_file_id() )
-				)
-			);
-			?>
-		</h2>
-		<div id="log-entries">
+					esc_html__( 'Viewing log file %s', 'woocommerce' ),
+					sprintf(
+						'<span class="file-id">%s</span>',
+						esc_html( $file->get_file_id() )
+					)
+				);
+				?>
+			</h2>
+		</header>
+		<div id="logs-entries" class="wc-logs-entries">
 			<?php while ( ! feof( $stream ) ) : ?>
 				<?php
 				$line = fgets( $stream );

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -205,6 +205,11 @@ class PageController {
 		$stream      = $file->get_stream();
 		$line_number = 1;
 
+		$delete_confirmation_js = sprintf(
+			"return window.confirm( '%s' )",
+			esc_js( __( 'Delete this log file permanently?', 'woocommerce' ) )
+		);
+
 		?>
 		<header id="logs-header" class="wc-logs-header">
 			<h2>
@@ -251,8 +256,9 @@ class PageController {
 				<?php
 				// Delete button.
 				printf(
-					'<a href="%1$s" class="button button-secondary">%2$s</a>',
+					'<a href="%1$s" class="button button-secondary" onclick="%2$s">%3$s</a>',
 					esc_url( $delete_url ),
+					esc_attr( $delete_confirmation_js ),
 					esc_html__( 'Delete permanently', 'woocommerce' )
 				);
 				?>

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -186,6 +186,9 @@ class PageController {
 			return;
 		}
 
+		$rotations         = $this->file_controller->get_file_rotations( $file->get_file_id() );
+		$rotation_url_base = add_query_arg( 'view', 'single_file', $this->get_logs_tab_url() );
+
 		$stream      = $file->get_stream();
 		$line_number = 1;
 
@@ -203,8 +206,36 @@ class PageController {
 				);
 				?>
 			</h2>
+			<?php if ( count( $rotations ) > 1 ) : ?>
+				<nav class="wc-logs-single-file-rotations">
+					<h3><?php esc_html_e( 'File rotations:', 'woocommerce' ); ?></h3>
+					<ul class="wc-logs-rotation-links">
+						<?php if ( isset( $rotations['current'] ) ) : ?>
+							<?php
+							printf(
+								'<li><a href="%1$s" class="button button-small button-%2$s">%3$s</a></li>',
+								esc_url( add_query_arg( 'file_id', $rotations['current']->get_file_id(), $rotation_url_base ) ),
+								$file->get_file_id() === $rotations['current']->get_file_id() ? 'primary' : 'secondary',
+								esc_html__( 'Current', 'woocommerce' )
+							);
+							unset( $rotations['current'] );
+							?>
+						<?php endif; ?>
+						<?php foreach ( $rotations as $rotation ) : ?>
+							<?php
+							printf(
+								'<li><a href="%1$s" class="button button-small button-%2$s">%3$s</a></li>',
+								esc_url( add_query_arg( 'file_id', $rotation->get_file_id(), $rotation_url_base ) ),
+								$file->get_file_id() === $rotation->get_file_id() ? 'primary' : 'secondary',
+								absint( $rotation->get_rotation() )
+							);
+							?>
+						<?php endforeach; ?>
+					</ul>
+				</nav>
+			<?php endif; ?>
 		</header>
-		<div id="logs-entries" class="wc-logs-entries">
+		<section id="logs-entries" class="wc-logs-entries">
 			<?php while ( ! feof( $stream ) ) : ?>
 				<?php
 				$line = fgets( $stream );
@@ -215,7 +246,7 @@ class PageController {
 				}
 				?>
 			<?php endwhile; ?>
-		</div>
+		</section>
 		<?php
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -408,7 +408,7 @@ class PageController {
 			$severity_levels[] = WC_Log_Levels::get_severity_level( $severity );
 		}
 
-		$text = esc_html( trim( $text ) );
+		$text = trim( $text );
 		if ( empty( $text ) ) {
 			$text = '&nbsp;';
 		}
@@ -427,7 +427,7 @@ class PageController {
 			$segments[1] = sprintf(
 				'<span class="%1$s">%2$s</span>',
 				esc_attr( 'log-level log-level--' . strtolower( $segments[1] ) ),
-				$segments[1]
+				esc_html( $segments[1] )
 			);
 		}
 
@@ -446,7 +446,7 @@ class PageController {
 			),
 			sprintf(
 				'<span class="line-content">%s</span>',
-				$text
+				esc_html( $text )
 			)
 		);
 

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -388,29 +388,6 @@ class PageController {
 	 * @return void
 	 */
 	private function handle_list_table_bulk_actions(): void {
-		$deleted = filter_input( INPUT_GET, 'deleted', FILTER_VALIDATE_INT );
-
-		if ( is_numeric( $deleted ) ) {
-			add_action(
-				'admin_notices',
-				function() use ( $deleted ) {
-					?>
-					<div class="notice notice-info is-dismissible">
-						<p>
-							<?php
-							printf(
-								// translators: %s is a number of files.
-								esc_html( _n( '%s log file deleted.', '%s log files deleted.', $deleted, 'woocommerce' ) ),
-								esc_html( number_format_i18n( $deleted ) )
-							);
-							?>
-						</p>
-					</div>
-					<?php
-				}
-			);
-		}
-
 		// Bail if this is not the list table view.
 		$params = $this->get_query_params();
 		if ( 'list_files' !== $params['view'] ) {
@@ -452,6 +429,12 @@ class PageController {
 				case 'delete':
 					$deleted  = $this->file_controller->delete_files( $file_ids );
 					$sendback = add_query_arg( 'deleted', $deleted, $sendback );
+
+					/**
+					 * If the delete action was triggered on the single file view, don't redirect back there
+					 * since the file doesn't exist anymore.
+					 */
+					$sendback = remove_query_arg( array( 'view', 'file_id' ), $sendback );
 					break;
 			}
 
@@ -463,6 +446,29 @@ class PageController {
 			$removable_args = array( '_wp_http_referer', '_wpnonce', 'action', 'action2', 'filter_action' );
 			wp_safe_redirect( remove_query_arg( $removable_args, $request_uri ) );
 			exit;
+		}
+
+		$deleted = filter_input( INPUT_GET, 'deleted', FILTER_VALIDATE_INT );
+
+		if ( is_numeric( $deleted ) ) {
+			add_action(
+				'admin_notices',
+				function() use ( $deleted ) {
+					?>
+					<div class="notice notice-info is-dismissible">
+						<p>
+							<?php
+							printf(
+							// translators: %s is a number of files.
+								esc_html( _n( '%s log file deleted.', '%s log files deleted.', $deleted, 'woocommerce' ) ),
+								esc_html( number_format_i18n( $deleted ) )
+							);
+							?>
+						</p>
+					</div>
+					<?php
+				}
+			);
 		}
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -205,6 +205,7 @@ class PageController {
 				<?php
 				$line = fgets( $stream );
 				if ( is_string( $line ) ) {
+					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- format_line does the escaping.
 					echo $this->format_line( $line, $line_number );
 					$line_number ++;
 				}
@@ -400,7 +401,7 @@ class PageController {
 	 * @return string
 	 */
 	private function format_line( string $text, int $line_number ): string {
-		$classes  = array( 'line' );
+		$classes = array( 'line' );
 
 		$level_severities = range( 100, 800, 100 );
 		$severity_levels  = array();

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -211,6 +211,12 @@ class PageController {
 				?>
 			<?php endwhile; ?>
 		</div>
+		<script>
+			( function() {
+				let line = document.querySelectorAll( '.line' );
+				console.log(line);
+			} )();
+		</script>
 		<?php
 	}
 
@@ -437,10 +443,17 @@ class PageController {
 
 		$classes = implode( ' ', $classes );
 		$line    = sprintf(
-			'<a id="L%1$d" href="#L%1$d" class="%2$s"><span class="line-content">%3$s</span></a>',
+			'<span id="L%1$d" class="%2$s">%3$s%4$s</span>',
 			absint( $line_number ),
 			esc_attr( $classes ),
-			$text
+			sprintf(
+				'<a href="#L%d" class="line-anchor"></a>',
+				absint( $line_number )
+			),
+			sprintf(
+				'<span class="line-content">%s</span>',
+				$text
+			)
 		);
 
 		return $line;

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -409,7 +409,7 @@ class PageController {
 			$severity_levels[] = WC_Log_Levels::get_severity_level( $severity );
 		}
 
-		$text = trim( $text );
+		$text = esc_html( trim( $text ) );
 		if ( empty( $text ) ) {
 			$text = '&nbsp;';
 		}
@@ -447,7 +447,7 @@ class PageController {
 			),
 			sprintf(
 				'<span class="line-content">%s</span>',
-				esc_html( $text )
+				wp_kses_post( $text )
 			)
 		);
 

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -274,7 +274,7 @@ class PageController {
 			$sendback = remove_query_arg( array( 'deleted' ), wp_get_referer() );
 
 			// Multiple file[] params will be filtered separately, but assigned to $files as an array.
-			$files = filter_input(
+			$file_ids = filter_input(
 				INPUT_GET,
 				'file',
 				FILTER_CALLBACK,
@@ -285,14 +285,14 @@ class PageController {
 				)
 			);
 
-			if ( ! is_array( $files ) || count( $files ) < 1 ) {
+			if ( ! is_array( $file_ids ) || count( $file_ids ) < 1 ) {
 				wp_safe_redirect( $sendback );
 				exit;
 			}
 
 			switch ( $action ) {
 				case 'delete':
-					$deleted  = $this->file_controller->delete_files( $files );
+					$deleted  = $this->file_controller->delete_files( $file_ids );
 					$sendback = add_query_arg( 'deleted', $deleted, $sendback );
 					break;
 			}

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -475,13 +475,8 @@ class PageController {
 	 * @return string
 	 */
 	private function format_line( string $text, int $line_number ): string {
-		$classes = array( 'line' );
-
-		$level_severities = range( 100, 800, 100 );
-		$severity_levels  = array();
-		foreach ( $level_severities as $severity ) {
-			$severity_levels[] = WC_Log_Levels::get_severity_level( $severity );
-		}
+		$severity_levels  = WC_Log_Levels::get_all_severity_levels();
+		$classes          = array( 'line' );
 
 		$text = esc_html( trim( $text ) );
 		if ( empty( $text ) ) {

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -382,6 +382,35 @@ class PageController {
 	 * @return void
 	 */
 	private function handle_list_table_bulk_actions(): void {
+		$deleted = filter_input( INPUT_GET, 'deleted', FILTER_VALIDATE_INT );
+
+		if ( is_numeric( $deleted ) ) {
+			add_action(
+				'admin_notices',
+				function() use ( $deleted ) {
+					?>
+					<div class="notice notice-info is-dismissible">
+						<p>
+							<?php
+							printf(
+								// translators: %s is a number of files.
+								esc_html( _n( '%s log file deleted.', '%s log files deleted.', $deleted, 'woocommerce' ) ),
+								esc_html( number_format_i18n( $deleted ) )
+							);
+							?>
+						</p>
+					</div>
+					<?php
+				}
+			);
+		}
+
+		// Bail if this is not the list table view.
+		$params = $this->get_query_params();
+		if ( 'list_files' !== $params['view'] ) {
+			return;
+		}
+
 		$action = $this->get_list_table()->current_action();
 
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
@@ -428,29 +457,6 @@ class PageController {
 			$removable_args = array( '_wp_http_referer', '_wpnonce', 'action', 'action2', 'filter_action' );
 			wp_safe_redirect( remove_query_arg( $removable_args, $request_uri ) );
 			exit;
-		}
-
-		$deleted = filter_input( INPUT_GET, 'deleted', FILTER_VALIDATE_INT );
-
-		if ( is_numeric( $deleted ) ) {
-			add_action(
-				'admin_notices',
-				function() use ( $deleted ) {
-					?>
-					<div class="notice notice-info is-dismissible">
-						<p>
-							<?php
-							printf(
-								// translators: %s is a number of files.
-								esc_html( _n( '%s log file deleted.', '%s log files deleted.', $deleted, 'woocommerce' ) ),
-								esc_html( number_format_i18n( $deleted ) )
-							);
-							?>
-						</p>
-					</div>
-					<?php
-				}
-			);
 		}
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -481,8 +481,8 @@ class PageController {
 	 * @return string
 	 */
 	private function format_line( string $text, int $line_number ): string {
-		$severity_levels  = WC_Log_Levels::get_all_severity_levels();
-		$classes          = array( 'line' );
+		$severity_levels = WC_Log_Levels::get_all_severity_levels();
+		$classes         = array( 'line' );
 
 		$text = esc_html( trim( $text ) );
 		if ( empty( $text ) ) {

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -442,7 +442,7 @@ class PageController {
 			absint( $line_number ),
 			esc_attr( $classes ),
 			sprintf(
-				'<a href="#L%d" class="line-anchor"></a>',
+				'<a href="#L%1$d" class="line-anchor">%1$d</a>',
 				absint( $line_number )
 			),
 			sprintf(

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -506,7 +506,8 @@ class PageController {
 		}
 
 		$classes = implode( ' ', $classes );
-		$line    = sprintf(
+
+		return sprintf(
 			'<span id="L%1$d" class="%2$s">%3$s%4$s</span>',
 			absint( $line_number ),
 			esc_attr( $classes ),
@@ -519,7 +520,5 @@ class PageController {
 				wp_kses_post( $text )
 			)
 		);
-
-		return $line;
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -442,7 +442,7 @@ class PageController {
 			absint( $line_number ),
 			esc_attr( $classes ),
 			sprintf(
-				'<a href="#L%1$d" class="line-anchor">%1$d</a>',
+				'<a href="#L%1$d" class="line-anchor"></a>',
 				absint( $line_number )
 			),
 			sprintf(

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileControllerTest.php
@@ -158,9 +158,42 @@ class FileControllerTest extends WC_Unit_Test_Case {
 		$this->assertInstanceOf( 'Automattic\\WooCommerce\\Internal\\Admin\\Logging\\FileV2\\File', $file );
 		$this->assertEquals( 'unit-testing2', $file->get_source() );
 
-
 		$file = $this->sut->get_file_by_id( 'zucchini' );
 		$this->assertWPError( $file );
+	}
+
+	/**
+	 * @testdox The get_file_rotations method should return an associative array of File instances.
+	 */
+	public function test_get_file_rotations() {
+		$this->handler->handle( time(), 'debug', '1', array( 'source' => 'unit-testing1' ) );
+		$this->handler->handle( time(), 'debug', '2', array( 'source' => 'unit-testing2' ) );
+		$file_id = 'unit-testing1-' . gmdate( 'Y-m-d', time() );
+
+		$reflection = new \ReflectionClass( get_class( $this->handler ) );
+		$method     = $reflection->getMethod( 'log_rotate' );
+		$method->setAccessible( true );
+
+		// Handler has to be reset after rotating a log file because it caches handles.
+		$method->invoke( $this->handler, 'unit-testing1' );
+		$this->handler = new WC_Log_Handler_File();
+		$this->handler->handle( time(), 'debug', '1', array( 'source' => 'unit-testing1' ) );
+		$method->invoke( $this->handler, 'unit-testing1' );
+		$this->handler = new WC_Log_Handler_File();
+		$this->handler->handle( time(), 'debug', '1', array( 'source' => 'unit-testing1' ) );
+
+		$rotations = $this->sut->get_file_rotations( $file_id );
+
+		$this->assertCount( 3, $rotations );
+		$this->assertArrayHasKey( 'current', $rotations );
+		$this->assertNull( $rotations['current']->get_rotation() );
+		$this->assertEquals( 'unit-testing1', $rotations['current']->get_source() );
+		$this->assertArrayHasKey( 0, $rotations );
+		$this->assertEquals( 0, $rotations[0]->get_rotation() );
+		$this->assertEquals( 'unit-testing1', $rotations[0]->get_source() );
+		$this->assertArrayHasKey( 1, $rotations );
+		$this->assertEquals( 1, $rotations[1]->get_rotation() );
+		$this->assertEquals( 'unit-testing1', $rotations[1]->get_source() );
 	}
 
 	/**
@@ -187,16 +220,16 @@ class FileControllerTest extends WC_Unit_Test_Case {
 
 		$this->assertEquals( 3, $this->sut->get_files( array(), true ) );
 
-		$files    = $this->sut->get_files( array( 'source' => 'log' ) );
-		$filename = $files[0]->get_basename();
-		$deleted  = $this->sut->delete_files( array( $filename ) );
+		$files   = $this->sut->get_files( array( 'source' => 'log' ) );
+		$file_id = $files[0]->get_file_id();
+		$deleted = $this->sut->delete_files( array( $file_id ) );
 		$this->assertEquals( 1, $deleted );
 		$this->assertEquals( 2, $this->sut->get_files( array(), true ) );
 		$this->assertEquals( 0, $this->sut->get_files( array( 'source' => 'log' ), true ) );
 
-		$files     = $this->sut->get_files();
-		$filenames = array_map( fn( $file ) => $file->get_basename(), $files );
-		$deleted   = $this->sut->delete_files( $filenames );
+		$files    = $this->sut->get_files();
+		$file_ids = array_map( fn( $file ) => $file->get_file_id(), $files );
+		$deleted  = $this->sut->delete_files( $file_ids );
 		$this->assertEquals( 2, $deleted );
 		$this->assertEquals( 0, $this->sut->get_files( array(), true ) );
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileControllerTest.php
@@ -120,6 +120,50 @@ class FileControllerTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox The get_files_by_id method should return an array of File instances given an array of valid file IDs.
+	 */
+	public function test_get_files_by_id() {
+		$this->handler->handle( time(), 'debug', '1', array( 'source' => 'unit-testing1' ) );
+		$this->handler->handle( time(), 'debug', '2', array( 'source' => 'unit-testing2' ) );
+		$this->handler->handle( time(), 'debug', '3', array( 'source' => 'unit-testing3' ) );
+		$file_id_1 = 'unit-testing1-' . gmdate( 'Y-m-d', time() );
+		$file_id_2 = 'unit-testing2-' . gmdate( 'Y-m-d', time() );
+
+		$files = $this->sut->get_files_by_id( array( $file_id_1, $file_id_2 ) );
+		$this->assertCount( 2, $files );
+
+		$sources = array_map(
+			function( $file ) {
+				return $file->get_source();
+			},
+			$files
+		);
+		$this->assertContains( 'unit-testing1', $sources );
+		$this->assertContains( 'unit-testing2', $sources );
+
+		$files = $this->sut->get_files_by_id( array( 'pop tart' ) );
+		$this->assertCount( 0, $files );
+	}
+
+	/**
+	 * @testdox The get_file_by_id method should return a File instance given a valid file ID, or a WP_Error.
+	 */
+	public function test_get_file_by_id() {
+		$this->handler->handle( time(), 'debug', '1', array( 'source' => 'unit-testing1' ) );
+		$this->handler->handle( time(), 'debug', '2', array( 'source' => 'unit-testing2' ) );
+		$this->handler->handle( time(), 'debug', '3', array( 'source' => 'unit-testing3' ) );
+		$file_id = 'unit-testing2-' . gmdate( 'Y-m-d', time() );
+
+		$file = $this->sut->get_file_by_id( $file_id );
+		$this->assertInstanceOf( 'Automattic\\WooCommerce\\Internal\\Admin\\Logging\\FileV2\\File', $file );
+		$this->assertEquals( 'unit-testing2', $file->get_source() );
+
+
+		$file = $this->sut->get_file_by_id( 'zucchini' );
+		$this->assertWPError( $file );
+	}
+
+	/**
 	 * @testdox The get_file_sources method should return a unique array of sources.
 	 */
 	public function test_get_file_sources(): void {

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileTest.php
@@ -19,10 +19,14 @@ class FileTest extends WC_Unit_Test_Case {
 	 * @return void
 	 */
 	public function tearDown(): void {
-		// Delete all created log files.
-		$files = glob( trailingslashit( realpath( Constants::get_constant( 'WC_LOG_DIR' ) ) ) . '*.log' );
+		// Delete all created files and directories.
+		$files = glob( trailingslashit( realpath( Constants::get_constant( 'WC_LOG_DIR' ) ) ) . '*' );
 		foreach ( $files as $file ) {
-			unlink( $file );
+			if ( is_dir( $file ) ) {
+				rmdir( $file );
+			} else {
+				unlink( $file );
+			}
 		}
 
 		parent::tearDown();
@@ -33,7 +37,7 @@ class FileTest extends WC_Unit_Test_Case {
 	 */
 	public function test_initialize_file_standard() {
 		$filename = Constants::get_constant( 'WC_LOG_DIR' ) . 'test-Source_1-1-2023-10-23-' . wp_hash( 'cheddar' ) . '.log';
-		$resource = fopen( $filename, 'a' ); // phpcs:ignore WordPress.PHP.NoSilencedErrors
+		$resource = fopen( $filename, 'a' );
 		fclose( $resource );
 		$file = new File( $filename );
 
@@ -50,7 +54,7 @@ class FileTest extends WC_Unit_Test_Case {
 	 */
 	public function test_initialize_file_standard_rotated() {
 		$filename = Constants::get_constant( 'WC_LOG_DIR' ) . 'test-Source_1-1.3-2023-10-23-' . wp_hash( 'cheddar' ) . '.log';
-		$resource = fopen( $filename, 'a' ); // phpcs:ignore WordPress.PHP.NoSilencedErrors
+		$resource = fopen( $filename, 'a' );
 		fclose( $resource );
 		$file = new File( $filename );
 
@@ -67,7 +71,7 @@ class FileTest extends WC_Unit_Test_Case {
 	 */
 	public function test_initialize_file_non_standard() {
 		$filename = Constants::get_constant( 'WC_LOG_DIR' ) . 'test-Source_1-1-' . wp_hash( 'cheddar' ) . '.log';
-		$resource = fopen( $filename, 'a' ); // phpcs:ignore WordPress.PHP.NoSilencedErrors
+		$resource = fopen( $filename, 'a' );
 		fclose( $resource );
 		$file = new File( $filename );
 
@@ -84,7 +88,7 @@ class FileTest extends WC_Unit_Test_Case {
 	 */
 	public function test_initialize_file_non_standard_rotated() {
 		$filename = Constants::get_constant( 'WC_LOG_DIR' ) . 'test-Source_1-1-' . wp_hash( 'cheddar' ) . '.5.log';
-		$resource = fopen( $filename, 'a' ); // phpcs:ignore WordPress.PHP.NoSilencedErrors
+		$resource = fopen( $filename, 'a' );
 		fclose( $resource );
 		$file = new File( $filename );
 
@@ -94,6 +98,42 @@ class FileTest extends WC_Unit_Test_Case {
 		$this->assertEquals( 5, $file->get_rotation() );
 		$this->assertEquals( filemtime( $filename ), $file->get_created_timestamp() );
 		$this->assertEquals( 'test-Source_1-1-' . wp_hash( 'cheddar' ), $file->get_hash() );
+	}
+
+	/**
+	 * @testdox Check that is_readable and is_writable only return true for files.
+	 */
+	public function test_is_readable_writable() {
+		global $wp_filesystem;
+
+		$filename = Constants::get_constant( 'WC_LOG_DIR' ) . 'test-Source_1-1-2023-10-23-' . wp_hash( 'cheddar' ) . '.log';
+		$resource = fopen( $filename, 'a' );
+		fclose( $resource );
+		$file = new File( $filename );
+
+		$this->assertTrue( $file->is_readable() );
+		$this->assertTrue( $file->is_writable() );
+
+		$nonfilename = Constants::get_constant( 'WC_LOG_DIR' ) . 'test_dir';
+		$wp_filesystem->mkdir( $nonfilename );
+		$nonfile = new File( $nonfilename );
+
+		$this->assertFalse( $nonfile->is_readable() );
+		$this->assertFalse( $nonfile->is_writable() );
+	}
+
+	/**
+	 * @testdox Check that get_stream returns a PHP resource representation of the file.
+	 */
+	public function test_get_stream() {
+		$filename = Constants::get_constant( 'WC_LOG_DIR' ) . 'test-Source_1-1-2023-10-23-' . wp_hash( 'cheddar' ) . '.log';
+		$resource = fopen( $filename, 'a' );
+		fclose( $resource );
+		$file = new File( $filename );
+
+		$stream = $file->get_stream();
+
+		$this->assertTrue( is_resource( $stream ) );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileTest.php
@@ -38,6 +38,7 @@ class FileTest extends WC_Unit_Test_Case {
 		$file = new File( $filename );
 
 		$this->assertEquals( 'test-Source_1-1-2023-10-23-' . wp_hash( 'cheddar' ) . '.log', $file->get_basename() );
+		$this->assertEquals( 'test-Source_1-1-2023-10-23', $file->get_file_id() );
 		$this->assertEquals( 'test-Source_1-1', $file->get_source() );
 		$this->assertNull( $file->get_rotation() );
 		$this->assertEquals( strtotime( '2023-10-23' ), $file->get_created_timestamp() );
@@ -54,6 +55,7 @@ class FileTest extends WC_Unit_Test_Case {
 		$file = new File( $filename );
 
 		$this->assertEquals( 'test-Source_1-1.3-2023-10-23-' . wp_hash( 'cheddar' ) . '.log', $file->get_basename() );
+		$this->assertEquals( 'test-Source_1-1.3-2023-10-23', $file->get_file_id() );
 		$this->assertEquals( 'test-Source_1-1', $file->get_source() );
 		$this->assertEquals( 3, $file->get_rotation() );
 		$this->assertEquals( strtotime( '2023-10-23' ), $file->get_created_timestamp() );
@@ -70,6 +72,7 @@ class FileTest extends WC_Unit_Test_Case {
 		$file = new File( $filename );
 
 		$this->assertEquals( 'test-Source_1-1-' . wp_hash( 'cheddar' ) . '.log', $file->get_basename() );
+		$this->assertEquals( 'test-Source_1-1-' . wp_hash( 'cheddar' ), $file->get_file_id() );
 		$this->assertEquals( 'test-Source_1-1-' . wp_hash( 'cheddar' ), $file->get_source() );
 		$this->assertNull( $file->get_rotation() );
 		$this->assertEquals( filemtime( $filename ), $file->get_created_timestamp() );
@@ -86,6 +89,7 @@ class FileTest extends WC_Unit_Test_Case {
 		$file = new File( $filename );
 
 		$this->assertEquals( 'test-Source_1-1-' . wp_hash( 'cheddar' ) . '.5.log', $file->get_basename() );
+		$this->assertEquals( 'test-Source_1-1-' . wp_hash( 'cheddar' ) . '.5', $file->get_file_id() );
 		$this->assertEquals( 'test-Source_1-1-' . wp_hash( 'cheddar' ), $file->get_source() );
 		$this->assertEquals( 5, $file->get_rotation() );
 		$this->assertEquals( filemtime( $filename ), $file->get_created_timestamp() );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This provides a new view of a log file when you click on one in the https://github.com/woocommerce/woocommerce/pull/40662. It has several enhancements over the original log file view:

* Clickable line numbers. These provide permalinks to specific lines in the file.
* Formatting of some log entry elements. The severity level gets colorized so it's easier to see which log entries are more important, and the timestamp gets bolded so you can see where each log entry starts (since some entries are across multiple lines).
* Navigation links for switching between different "rotations" of a particular log.

This also refactors the File class a bit to use `WP_Filesystem` wherever possible instead of direct PHP filesystem calls.

Fixes #41143 

![Screen Shot 2023-11-02 at 16 08 37](https://github.com/woocommerce/woocommerce/assets/916023/c9629df7-826d-4b96-98fd-351d2d6a24b2)

### How to test the changes in this Pull Request:

#### Setup

1. In your test site's **wp-config.php** file, add this line: `define( 'WC_LOG_HANDLER', 'Automattic\\WooCommerce\\Internal\\Admin\\Logging\\LogHandlerFileV2' );`. This is what allows you to see the new log file views.
2. Install [this plugin](https://gist.github.com/coreymckrill/2968911c8b63c556e7787f2cdc65f966) on your test site for generating test log files. Probably easiest to copy the file into the mu-plugins directory.
3. Open two browser tabs: the Logs screen (WP Admin > WooCommerce > Status > Logs) and the WooCommerce Tools screen (WP Admin > WooCommerce > Status > Tools). On the Tools screen you should see the **Debug Log Generator** tool at the top of the list.

#### Tests

1. On the Logs screen, you should see a list table, which may already have some log files listed in it. Even if there are some, go ahead and generate some additional logs on the Tools screen so that we have enough different log files and sources. Generate two or three batches of test logs at once. You should then see that at least one of the logs, probably `debug-log-generator`, has more than one entry in the list table. These are "rotations" that are generated when a log file reaches a certain size.
2. Click on a log file that has one or more rotations. This should take you to the single file view, where you can see the contents of the file. There should be line numbers next to each line of the file.
3. Try clicking the line numbers. They are anchors, and the line you clicked should move to the top of the window (but not beneath the floating toolbars), assuming there are enough lines in the file that you can't see all of them at once. The line should also be highlighted in yellow.
4. Since this is a file that has rotations, you should see a label that says "File rotations" and some buttons next to it. Possible button labels are "Current" as well as any single-digit number between `0` and `9`. In this case "Current" means the file that has not hit the size threshold yet, so new log entries could be added to it. The numbered ones are files that have been rotated, with lower numbers being more recent than higher numbers. Clicking one of the buttons should take you to that file.
5. Try deleting one of the log files by clicking the "Delete permanently" button in the upper right corner. You should see a confirmation dialog popup before the file gets deleted. If you click "Cancel", the file should not be deleted!

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Add a new single file view to the Logs screen for viewing the contents of a log file.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>