### PR TITLE
Fix intro page button styles

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/intro/intro.scss
+++ b/plugins/woocommerce-admin/client/customize-store/intro/intro.scss
@@ -127,9 +127,13 @@
 		margin-left: 50px;
 
 		button.is-link {
-			color: #3858e9;
+			color: var(--wp-admin-theme-color, #3858e9);
 			text-decoration: none;
 			font-weight: 500;
+		}
+
+		button.components-button {
+			padding: 8px 16px;
 		}
 
 		button.components-button + button.components-button { // add left margin for all buttons with another button to its left
@@ -246,9 +250,9 @@
 
 	button {
 		background-color: #fff;
-		border: 1px solid #3858e9;
+		border: 1px solid var(--wp-admin-theme-color, #3858e9);
 		border-radius: 2px;
-		color: #3858e9;
+		color: var(--wp-admin-theme-color, #3858e9);
 		display: inline-block;
 		font-size: 0.8125rem;
 		margin: 3.75rem 0;
@@ -259,22 +263,31 @@
 .woocommerce-customize-store__design-change-warning-modal {
 	width: 480px;
 	max-width: 480px;
+
 	.components-modal__header {
 		padding-top: 32px;
 	}
+
 	p {
 		padding: 16px 0 16px 0;
 		margin: 0;
 	}
+
 	a,
 	button {
 		text-decoration: none !important;
 	}
+
+	.components-button {
+		padding: 8px 16px;
+	}
+
 	h1 {
 		line-height: 28px;
 		font-size: 20px;
 		color: #1e1e1e;
 	}
+
 	.woocommerce-customize-store__design-change-warning-modal-footer {
 		display: flex;
 		gap: 12px;

--- a/plugins/woocommerce/changelog/fix-intro-modal-button
+++ b/plugins/woocommerce/changelog/fix-intro-modal-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix cys intro page button styles


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/41019#issuecomment-1786395461.

This PR updates the CYS button styles on the intro page.

- Add padding
- Use theme color

![Screenshot 2023-10-31 at 12 32 16](https://github.com/woocommerce/woocommerce/assets/4344253/5d8ac15b-5858-4fbb-99d4-d02415ba4b86)


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


1. Create a new WooCommerce installation with this version.
2. Make sure to enable `customize-store` feature flag
3. Go to WP > theme page
4. Install and activate a block theme.
5. Change the color theme Users > All Users > edit
6. Go to `WooCommerce -> Home` and click `Customize Store` task
7. Click on `Create a new one` button
8. Observe that the modal buttons match the design.
9. See button colors adjust to theme

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
