### PR TITLE
Update CYS AI loading screen

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/pages/ApiCallLoader.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/pages/ApiCallLoader.tsx
@@ -76,6 +76,7 @@ const loaderSteps = [
 	},
 ];
 
+// Loader for the API call without the last frame.
 export const ApiCallLoader = () => {
 	useEffect( () => {
 		const preload = ( src: string ) => {
@@ -91,8 +92,33 @@ export const ApiCallLoader = () => {
 
 	return (
 		<Loader>
-			<Loader.Sequence interval={ 4500 } shouldLoop={ false }>
-				{ loaderSteps.map( ( step, index ) => (
+			<Loader.Sequence
+				/*  divide all frames equally over 1m. */
+				interval={ ( 60 * 1000 ) / ( loaderSteps.length - 1 ) }
+				shouldLoop={ false }
+			>
+				{ loaderSteps.slice( 0, -1 ).map( ( step, index ) => (
+					<Loader.Layout key={ index }>
+						<Loader.Illustration>
+							{ step.image }
+						</Loader.Illustration>
+						<Loader.Title>{ step.title }</Loader.Title>
+						<Loader.ProgressBar progress={ step.progress || 0 } />
+					</Loader.Layout>
+				) ) }
+			</Loader.Sequence>
+		</Loader>
+	);
+};
+
+export const AssembleHubLoader = () => {
+	// Show the last two steps of the loader so that the last frame is the shortest time possible
+	const steps = loaderSteps.slice( -2 );
+
+	return (
+		<Loader>
+			<Loader.Sequence interval={ 3000 } shouldLoop={ false }>
+				{ steps.map( ( step, index ) => (
 					<Loader.Layout key={ index }>
 						<Loader.Illustration>
 							{ step.image }

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/state-machine.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/state-machine.tsx
@@ -19,6 +19,7 @@ import {
 	LookAndFeel,
 	ToneOfVoice,
 	ApiCallLoader,
+	AssembleHubLoader,
 } from './pages';
 import { actions } from './actions';
 import { services } from './services';
@@ -423,13 +424,17 @@ export const designWithAiStateMachineDefinition = createMachine(
 							},
 						},
 						onDone: {
-							actions: [
-								// Full redirect to the Assembler Hub to ensure the user see the new generated content.
-								'redirectToAssemblerHub',
-							],
+							target: '#designWithAi.showAssembleHub',
 						},
 					},
 				},
+			},
+			showAssembleHub: {
+				meta: {
+					component: AssembleHubLoader,
+				},
+				entry: [ 'redirectToAssemblerHub' ],
+				type: 'final',
 			},
 		},
 	},

--- a/plugins/woocommerce/changelog/update-cys-loading-frame
+++ b/plugins/woocommerce/changelog/update-cys-loading-frame
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update the CYS Design with AI loading iframes


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/41117.

Update the Design with AI loading screen so that the last frame is the shortest time possible 

Display the last two frames when we start`redirectToAssemblerHub` action. 

https://github.com/woocommerce/woocommerce/assets/4344253/c98eb845-22ad-4650-91fd-237565a74888


<!-- Begin
 testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Make sure you are testing this with a Jetpack connected instance of WooCommerce, as the AI text completion endpoint can only be called with a Jetpack connected account.**

1. Create a new WooCommerce installation with this version.
2. Make sure to enable `customize-store` feature flag
3. Go to `WooCommerce -> Home` and click `Customize Store` task
4. Click `Design with AI` button
5. Follow through the flow all the way till the loading screen shows up
6. Observe that the last frame is shown when iframe begins to show


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
