### PR TITLE
Fix CYS pattern thumbnail size

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/auto-block-preview.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/auto-block-preview.tsx
@@ -6,7 +6,7 @@
  * External dependencies
  */
 import { useResizeObserver, pure, useRefEffect } from '@wordpress/compose';
-import { useContext } from '@wordpress/element';
+import { useContext, useMemo, useState } from '@wordpress/element';
 import { Disabled } from '@wordpress/components';
 import {
 	__unstableEditorStyles as EditorStyles,
@@ -36,6 +36,7 @@ const { Provider: DisabledProvider } = Disabled.Context;
 let MemoizedBlockList: typeof BlockList | undefined;
 
 const { useGlobalSetting } = unlock( blockEditorPrivateApis );
+const MAX_HEIGHT = 2000;
 
 export type ScaledBlockPreviewProps = {
 	viewportWidth?: number;
@@ -49,6 +50,8 @@ export type ScaledBlockPreviewProps = {
 	onClickNavigationItem: ( event: MouseEvent ) => void;
 	isNavigable?: boolean;
 	isScrollable?: boolean;
+	autoScale?: boolean;
+	setLogoBlockContext?: boolean;
 };
 
 function ScaledBlockPreview( {
@@ -59,12 +62,16 @@ function ScaledBlockPreview( {
 	onClickNavigationItem,
 	isNavigable = false,
 	isScrollable = true,
+	autoScale = true,
+	setLogoBlockContext = false,
 }: ScaledBlockPreviewProps ) {
+	const [ contentHeight, setContentHeight ] = useState< number | null >(
+		null
+	);
 	const { setLogoBlockIds } = useContext( LogoBlockContext );
 	const [ fontFamilies ] = useGlobalSetting(
 		'typography.fontFamilies.theme'
 	) as [ FontFamily[] ];
-
 	const externalFontFamilies = fontFamilies.filter(
 		( { slug } ) => slug !== SYSTEM_FONT_SLUG
 	);
@@ -73,163 +80,213 @@ function ScaledBlockPreview( {
 		viewportWidth = containerWidth;
 	}
 
+	// Avoid scrollbars for pattern previews.
+	const editorStyles = useMemo( () => {
+		if ( ! isScrollable && settings.styles ) {
+			return [
+				...settings.styles,
+				{
+					css: 'body{height:auto;overflow:hidden;border:none;padding:0;}',
+					__unstableType: 'presets',
+				},
+			];
+		}
+
+		return settings.styles;
+	}, [ settings.styles, isScrollable ] );
+
+	const scale = containerWidth / viewportWidth;
+	const aspectRatio = contentHeight
+		? containerWidth / ( contentHeight * scale )
+		: 0;
 	// Initialize on render instead of module top level, to avoid circular dependency issues.
 	MemoizedBlockList = MemoizedBlockList || pure( BlockList );
 
+	const updateIframeContent = ( bodyElement: HTMLBodyElement ) => {
+		let navigationContainers: NodeListOf< HTMLDivElement >;
+		let siteTitles: NodeListOf< HTMLAnchorElement >;
+
+		const onMouseMove = ( event: MouseEvent ) => {
+			event.stopImmediatePropagation();
+		};
+
+		const onClickNavigation = ( event: MouseEvent ) => {
+			event.preventDefault();
+			onClickNavigationItem( event );
+		};
+
+		const possiblyRemoveAllListeners = () => {
+			bodyElement.removeEventListener( 'mousemove', onMouseMove, false );
+			if ( navigationContainers ) {
+				navigationContainers.forEach( ( element ) => {
+					element.removeEventListener( 'click', onClickNavigation );
+				} );
+			}
+
+			if ( siteTitles ) {
+				siteTitles.forEach( ( element ) => {
+					element.removeEventListener( 'click', onClickNavigation );
+				} );
+			}
+		};
+
+		const enableNavigation = () => {
+			// Remove contenteditable and inert attributes from editable elements so that users can click on navigation links.
+			bodyElement
+				.querySelectorAll(
+					'.block-editor-rich-text__editable[contenteditable="true"]'
+				)
+				.forEach( ( element ) => {
+					element.removeAttribute( 'contenteditable' );
+				} );
+
+			bodyElement
+				.querySelectorAll( '*[inert="true"]' )
+				.forEach( ( element ) => {
+					element.removeAttribute( 'inert' );
+				} );
+
+			possiblyRemoveAllListeners();
+			navigationContainers = bodyElement.querySelectorAll(
+				'.wp-block-navigation__container'
+			);
+			navigationContainers.forEach( ( element ) => {
+				element.addEventListener( 'click', onClickNavigation, true );
+			} );
+
+			siteTitles = bodyElement.querySelectorAll(
+				'.wp-block-site-title a'
+			);
+			siteTitles.forEach( ( element ) => {
+				element.addEventListener( 'click', onClickNavigation, true );
+			} );
+		};
+
+		const findAndSetLogoBlock = () => {
+			// Get the current logo block client ID from DOM and set it in the logo block context. This is used for the logo settings. See: ./sidebar/sidebar-navigation-screen-logo.tsx
+			// Ideally, we should be able to get the logo block client ID from the block editor store but it is not available.
+			// We should update this code once the there is a selector in the block editor store that can be used to get the logo block client ID.
+			const siteLogos = bodyElement.querySelectorAll(
+				'.wp-block-site-logo'
+			);
+
+			const logoBlockIds = Array.from( siteLogos )
+				.map( ( siteLogo ) => {
+					return siteLogo.getAttribute( 'data-block' );
+				} )
+				.filter( Boolean ) as string[];
+			setLogoBlockIds( logoBlockIds );
+		};
+
+		const onChange = () => {
+			if ( autoScale ) {
+				const rootContainer =
+					bodyElement.querySelector( '.is-root-container' );
+
+				setContentHeight(
+					rootContainer ? rootContainer.clientHeight : null
+				);
+			}
+
+			if ( isNavigable ) {
+				enableNavigation();
+			}
+
+			if ( setLogoBlockContext ) {
+				findAndSetLogoBlock();
+			}
+		};
+
+		// Stop mousemove event listener to disable block tool insertion feature.
+		bodyElement.addEventListener( 'mousemove', onMouseMove, true );
+
+		const observer = new window.MutationObserver( onChange );
+		observer.observe( bodyElement, {
+			attributes: true,
+			characterData: false,
+			subtree: true,
+			childList: true,
+		} );
+
+		return () => {
+			observer.disconnect();
+			possiblyRemoveAllListeners();
+
+			if ( setLogoBlockContext ) {
+				setLogoBlockIds( [] );
+			}
+		};
+	};
+
 	return (
 		<DisabledProvider value={ true }>
-			<Iframe
-				aria-hidden
-				scrolling={ isScrollable ? 'yes' : 'no' }
-				tabIndex={ -1 }
-				readonly={ ! isNavigable }
-				contentRef={ useRefEffect(
-					( bodyElement: HTMLBodyElement ) => {
-						const {
-							ownerDocument: { documentElement },
-						} = bodyElement;
-
-						documentElement.classList.add(
-							'block-editor-block-preview__content-iframe'
-						);
-						documentElement.style.position = 'absolute';
-						documentElement.style.width = '100%';
-
-						// Necessary for contentResizeListener to work.
-						bodyElement.style.boxSizing = 'border-box';
-						bodyElement.style.position = 'absolute';
-						bodyElement.style.width = '100%';
-
-						let navigationContainers: NodeListOf< HTMLDivElement >;
-						let siteTitles: NodeListOf< HTMLAnchorElement >;
-						const onClickNavigation = ( event: MouseEvent ) => {
-							event.preventDefault();
-							onClickNavigationItem( event );
-						};
-
-						const onMouseMove = ( event: MouseEvent ) => {
-							event.stopImmediatePropagation();
-						};
-
-						const possiblyRemoveAllListeners = () => {
-							bodyElement.removeEventListener(
-								'mousemove',
-								onMouseMove,
-								false
-							);
-							if ( navigationContainers ) {
-								navigationContainers.forEach( ( element ) => {
-									element.removeEventListener(
-										'click',
-										onClickNavigation
-									);
-								} );
-							}
-
-							if ( siteTitles ) {
-								siteTitles.forEach( ( element ) => {
-									element.removeEventListener(
-										'click',
-										onClickNavigation
-									);
-								} );
-							}
-						};
-
-						const enableNavigation = () => {
-							// Remove contenteditable and inert attributes from editable elements so that users can click on navigation links.
-							bodyElement
-								.querySelectorAll(
-									'.block-editor-rich-text__editable[contenteditable="true"]'
-								)
-								.forEach( ( element ) => {
-									element.removeAttribute(
-										'contenteditable'
-									);
-								} );
-
-							bodyElement
-								.querySelectorAll( '*[inert="true"]' )
-								.forEach( ( element ) => {
-									element.removeAttribute( 'inert' );
-								} );
-
-							possiblyRemoveAllListeners();
-							navigationContainers = bodyElement.querySelectorAll(
-								'.wp-block-navigation__container'
-							);
-							navigationContainers.forEach( ( element ) => {
-								element.addEventListener(
-									'click',
-									onClickNavigation,
-									true
-								);
-							} );
-
-							siteTitles = bodyElement.querySelectorAll(
-								'.wp-block-site-title a'
-							);
-							siteTitles.forEach( ( element ) => {
-								element.addEventListener(
-									'click',
-									onClickNavigation,
-									true
-								);
-							} );
-						};
-
-						const onChange = () => {
-							// Get the current logo block client ID from DOM and set it in the logo block context. This is used for the logo settings. See: ./sidebar/sidebar-navigation-screen-logo.tsx
-							// Ideally, we should be able to get the logo block client ID from the block editor store but it is not available.
-							// We should update this code once the there is a selector in the block editor store that can be used to get the logo block client ID.
-							const siteLogos = bodyElement.querySelectorAll(
-								'.wp-block-site-logo'
-							);
-
-							const logoBlockIds = Array.from( siteLogos )
-								.map( ( siteLogo ) => {
-									return siteLogo.getAttribute(
-										'data-block'
-									);
-								} )
-								.filter( Boolean ) as string[];
-							setLogoBlockIds( logoBlockIds );
-
-							if ( isNavigable ) {
-								enableNavigation();
-							}
-						};
-
-						// Stop mousemove event listener to disable block tool insertion feature.
-						bodyElement.addEventListener(
-							'mousemove',
-							onMouseMove,
-							true
-						);
-
-						const observer = new window.MutationObserver(
-							onChange
-						);
-
-						observer.observe( bodyElement, {
-							attributes: true,
-							characterData: false,
-							subtree: true,
-							childList: true,
-						} );
-
-						return () => {
-							observer.disconnect();
-							possiblyRemoveAllListeners();
-							setLogoBlockIds( [] );
-						};
-					},
-					[ isNavigable ]
-				) }
+			<div
+				className="block-editor-block-preview__content"
+				style={
+					autoScale
+						? {
+								transform: `scale(${ scale })`,
+								// Using width + aspect-ratio instead of height here triggers browsers' native
+								// handling of scrollbar's visibility. It prevents the flickering issue seen
+								// in https://github.com/WordPress/gutenberg/issues/52027.
+								// See https://github.com/WordPress/gutenberg/pull/52921 for more info.
+								aspectRatio,
+								maxHeight:
+									contentHeight !== null &&
+									contentHeight > MAX_HEIGHT
+										? MAX_HEIGHT * scale
+										: undefined,
+						  }
+						: {}
+				}
 			>
-				<EditorStyles styles={ settings.styles } />
-				<style>
-					{ `
+				<Iframe
+					aria-hidden
+					scrolling={ isScrollable ? 'yes' : 'no' }
+					tabIndex={ -1 }
+					readonly={ ! isNavigable }
+					style={
+						autoScale
+							? {
+									position: 'absolute',
+									width: viewportWidth,
+									height: contentHeight,
+									pointerEvents: 'none',
+									// This is a catch-all max-height for patterns.
+									// See: https://github.com/WordPress/gutenberg/pull/38175.
+									maxHeight: MAX_HEIGHT,
+							  }
+							: {}
+					}
+					contentRef={ useRefEffect(
+						( bodyElement: HTMLBodyElement ) => {
+							const {
+								ownerDocument: { documentElement },
+							} = bodyElement;
+
+							documentElement.classList.add(
+								'block-editor-block-preview__content-iframe'
+							);
+							documentElement.style.position = 'absolute';
+							documentElement.style.width = '100%';
+
+							// Necessary for contentResizeListener to work.
+							bodyElement.style.boxSizing = 'border-box';
+							bodyElement.style.position = 'absolute';
+							bodyElement.style.width = '100%';
+
+							const cleanup = updateIframeContent( bodyElement );
+							return () => {
+								cleanup();
+								setContentHeight( null );
+							};
+						},
+						[ isNavigable ]
+					) }
+				>
+					<EditorStyles styles={ editorStyles } />
+					<style>
+						{ `
 						.block-editor-block-list__block::before,
 						.is-selected::after,
 						.is-hovered::after,
@@ -257,13 +314,14 @@ function ScaledBlockPreview( {
 
 						${ additionalStyles }
 					` }
-				</style>
-				<MemoizedBlockList renderAppender={ false } />
-				<FontFamiliesLoader
-					fontFamilies={ externalFontFamilies }
-					onLoad={ noop }
-				/>
-			</Iframe>
+					</style>
+					<MemoizedBlockList renderAppender={ false } />
+					<FontFamiliesLoader
+						fontFamilies={ externalFontFamilies }
+						onLoad={ noop }
+					/>
+				</Iframe>
+			</div>
 		</DisabledProvider>
 	);
 }

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/block-editor.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/block-editor.tsx
@@ -66,7 +66,7 @@ const MAX_PAGE_COUNT = 100;
 export const BlockEditor = ( {} ) => {
 	const history = useHistory();
 	const settings = useSiteEditorSettings();
-	const [ blocks ] = useEditorBlocks();
+	const [ blocks, onChange ] = useEditorBlocks();
 	const urlParams = useQuery();
 	const { currentState } = useContext( CustomizeStoreContext );
 
@@ -119,8 +119,6 @@ export const BlockEditor = ( {} ) => {
 		[ history, urlParams, pages ]
 	);
 
-	const [ , , onChange ] = useEditorBlocks();
-
 	const { highlightedBlockIndex } = useContext( HighlightedBlockContext );
 	const isHighlighting = highlightedBlockIndex !== -1;
 	const additionalStyles = isHighlighting
@@ -163,7 +161,8 @@ export const BlockEditor = ( {} ) => {
 					onClickNavigationItem={ onClickNavigationItem }
 					// Don't use sub registry so that we can get the logo block from the main registry on the logo sidebar navigation screen component.
 					useSubRegistry={ false }
-					previewOpacity={ previewOpacity }
+					autoScale={ false }
+					setLogoBlockContext={ true }
 				/>
 			</div>
 		</div>

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/block-pattern-list.jsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/block-pattern-list.jsx
@@ -1,3 +1,4 @@
+// Reference: https://github.com/WordPress/gutenberg/blob/94ff2ba55379d9ad7f6bed743b20b85ff26cf56d/packages/block-editor/src/components/block-patterns-list/index.js#L1
 /* eslint-disable @woocommerce/dependency-group */
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 /**

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/block-pattern-list.jsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/block-pattern-list.jsx
@@ -1,0 +1,138 @@
+/* eslint-disable @woocommerce/dependency-group */
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+/**
+ * External dependencies
+ */
+import {
+	VisuallyHidden,
+	__unstableComposite as Composite,
+	__unstableUseCompositeState as useCompositeState,
+	__unstableCompositeItem as CompositeItem,
+	Tooltip,
+} from '@wordpress/components';
+import { useInstanceId } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import BlockPreview from './block-preview';
+
+const WithToolTip = ( { showTooltip, title, children } ) => {
+	if ( showTooltip ) {
+		return <Tooltip text={ title }>{ children }</Tooltip>;
+	}
+	return <>{ children }</>;
+};
+
+function BlockPattern( { pattern, onClick, onHover, composite, showTooltip } ) {
+	const { blocks, viewportWidth } = pattern;
+	const instanceId = useInstanceId( BlockPattern );
+	const descriptionId = `block-editor-block-patterns-list__item-description-${ instanceId }`;
+	const originalSettings = useSelect(
+		( select ) => select( blockEditorStore ).getSettings(),
+		[]
+	);
+	const settings = useMemo(
+		() => ( { ...originalSettings, __unstableIsPreviewMode: true } ),
+		[ originalSettings ]
+	);
+	return (
+		<div>
+			<div className="block-editor-block-patterns-list__list-item">
+				<WithToolTip
+					showTooltip={ showTooltip }
+					title={ pattern.title }
+				>
+					<CompositeItem
+						role="option"
+						as="div"
+						{ ...composite }
+						className="block-editor-block-patterns-list__item"
+						onClick={ () => {
+							onClick( pattern, blocks );
+							onHover?.( null );
+						} }
+						onMouseEnter={ () => {
+							onHover?.( pattern );
+						} }
+						onMouseLeave={ () => onHover?.( null ) }
+						aria-label={ pattern.title }
+						aria-describedby={
+							pattern.description ? descriptionId : undefined
+						}
+					>
+						<BlockPreview
+							blocks={ blocks }
+							viewportWidth={ viewportWidth || 1200 }
+							additionalStyles=""
+							useSubRegistry={ true }
+							settings={ settings }
+							isScrollable={ false }
+							autoScale={ true }
+						/>
+						{ ! showTooltip && (
+							<div className="block-editor-block-patterns-list__item-title">
+								{ pattern.title }
+							</div>
+						) }
+						{ !! pattern.description && (
+							<VisuallyHidden id={ descriptionId }>
+								{ pattern.description }
+							</VisuallyHidden>
+						) }
+					</CompositeItem>
+				</WithToolTip>
+			</div>
+		</div>
+	);
+}
+
+function BlockPatternPlaceholder() {
+	return (
+		<div className="block-editor-block-patterns-list__item is-placeholder" />
+	);
+}
+
+function BlockPatternList( {
+	isDraggable,
+	blockPatterns,
+	shownPatterns,
+	onHover,
+	onClickPattern,
+	orientation,
+	label = __( 'Block Patterns', 'woocommerce' ),
+	showTitlesAsTooltip,
+} ) {
+	const composite = useCompositeState( { orientation } );
+	return (
+		<Composite
+			{ ...composite }
+			role="listbox"
+			className="block-editor-block-patterns-list"
+			aria-label={ label }
+		>
+			{ blockPatterns.map( ( pattern ) => {
+				const isShown = shownPatterns.includes( pattern );
+				return isShown ? (
+					<BlockPattern
+						key={ pattern.name }
+						pattern={ pattern }
+						onClick={ onClickPattern }
+						onHover={ onHover }
+						isDraggable={ isDraggable }
+						composite={ composite }
+						showTooltip={ showTitlesAsTooltip }
+					/>
+				) : (
+					<BlockPatternPlaceholder key={ pattern.name } />
+				);
+			} ) }
+		</Composite>
+	);
+}
+
+export default BlockPatternList;

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/block-preview.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/block-preview.tsx
@@ -22,7 +22,6 @@ export const BlockPreview = ( {
 	blocks,
 	settings,
 	useSubRegistry = true,
-	additionalStyles,
 	onChange,
 	...props
 }: {
@@ -30,7 +29,6 @@ export const BlockPreview = ( {
 	settings: Record< string, unknown >;
 	onChange?: ChangeHandler | undefined;
 	useSubRegistry?: boolean;
-	previewOpacity?: number;
 } & Omit< ScaledBlockPreviewProps, 'containerWidth' > ) => {
 	const renderedBlocks = useMemo( () => {
 		const _blocks = Array.isArray( blocks ) ? blocks : [ blocks ];
@@ -45,11 +43,7 @@ export const BlockPreview = ( {
 			onChange={ onChange }
 			useSubRegistry={ useSubRegistry }
 		>
-			<AutoHeightBlockPreview
-				settings={ settings }
-				additionalStyles={ additionalStyles }
-				{ ...props }
-			/>
+			<AutoHeightBlockPreview settings={ settings } { ...props } />
 		</BlockEditorProvider>
 	);
 };

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-footer.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-footer.tsx
@@ -14,8 +14,6 @@ import {
 import { Link } from '@woocommerce/components';
 import { recordEvent } from '@woocommerce/tracks';
 import { Spinner } from '@wordpress/components';
-// @ts-expect-error Missing type in core-data.
-import { __experimentalBlockPatternsList as BlockPatternList } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -28,6 +26,7 @@ import { HighlightedBlockContext } from '../context/highlighted-block-context';
 import { useEditorScroll } from '../hooks/use-editor-scroll';
 import { useSelectedPattern } from '../hooks/use-selected-pattern';
 import { findPatternByBlock } from './utils';
+import BlockPatternList from '../block-pattern-list';
 
 const SUPPORTED_FOOTER_PATTERNS = [
 	'woocommerce-blocks/footer-simple-menu-and-cart',
@@ -140,8 +139,8 @@ export const SidebarNavigationScreenFooter = () => {
 								onClickPattern={ onClickFooterPattern }
 								label={ 'Footers' }
 								orientation="vertical"
-								category={ 'footer' }
 								isDraggable={ false }
+								onHover={ () => {} }
 								showTitlesAsTooltip={ true }
 							/>
 						) }

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-header.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-header.tsx
@@ -14,8 +14,6 @@ import {
 import { Link } from '@woocommerce/components';
 import { recordEvent } from '@woocommerce/tracks';
 import { Spinner } from '@wordpress/components';
-// @ts-ignore No types for this exist yet.
-// import { __experimentalBlockPatternsList as BlockPatternList } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-header.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-header.tsx
@@ -15,7 +15,7 @@ import { Link } from '@woocommerce/components';
 import { recordEvent } from '@woocommerce/tracks';
 import { Spinner } from '@wordpress/components';
 // @ts-ignore No types for this exist yet.
-import { __experimentalBlockPatternsList as BlockPatternList } from '@wordpress/block-editor';
+// import { __experimentalBlockPatternsList as BlockPatternList } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -28,6 +28,7 @@ import { useEditorBlocks } from '../hooks/use-editor-blocks';
 import { HighlightedBlockContext } from '../context/highlighted-block-context';
 import { useEditorScroll } from '../hooks/use-editor-scroll';
 import { findPatternByBlock } from './utils';
+import BlockPatternList from '../block-pattern-list';
 
 const SUPPORTED_HEADER_PATTERNS = [
 	'woocommerce-blocks/header-essential',
@@ -138,8 +139,8 @@ export const SidebarNavigationScreenHeader = () => {
 								onClickPattern={ onClickHeaderPattern }
 								label={ 'Headers' }
 								orientation="vertical"
-								category={ 'header' }
 								isDraggable={ false }
+								onHover={ () => {} }
 								showTitlesAsTooltip={ true }
 							/>
 						) }

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
@@ -469,23 +469,44 @@
 
 	/* Layout sidebar */
 	.block-editor-block-patterns-list__item {
-		.block-editor-block-preview__container {
+		.auto-block-preview__container {
 			border-radius: 4px;
 			border: 1.5px solid transparent;
+			align-items: center;
+			display: flex;
+			overflow: hidden;
 		}
 
 		&.is-selected,
 		&:hover,
 		&:focus {
-			.block-editor-block-preview__container {
+			.auto-block-preview__container {
 				box-shadow: none;
 				border-color: var(--wp-admin-theme-color);
 			}
 		}
 	}
 
-	.edit-site-sidebar-navigation-screen__content .block-editor-block-patterns-list {
-		width: 324px;
+	.block-editor-block-preview__content {
+		height: 100%;
+		width: 100%;
+	}
+
+	.edit-site-sidebar-navigation-screen__content {
+		.block-editor-block-preview__content {
+			left: 0;
+			margin: 0;
+			min-height: auto;
+			overflow: visible;
+			text-align: initial;
+			top: 0;
+			transform-origin: top left;
+			position: relative;
+		}
+
+		.block-editor-block-patterns-list {
+			width: 324px;
+		}
 	}
 
 	.woocommerce-customize-store__sidebar-homepage-content {

--- a/plugins/woocommerce/changelog/fix-thumbnail-size
+++ b/plugins/woocommerce/changelog/fix-thumbnail-size
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix cys pattern thumbnail size


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/41121.

This PR fixes the extra spacing in the header thumbnails issue. It seems that the `useResizeObserver` in the Gutenberg component doesn't work as expected when the cache is enabled. I suspect that somehow listening event is not triggered after the content is loaded.

I forked the `block-pattern-list` component and [set the contentHeight](https://github.com/woocommerce/woocommerce/pull/41126/files#diff-530c34e8e7e5073c1689976ba5acc30a98d8452dbd7ab47ec949c0a6a8413ab0R182-R189
) in the auto-block-preview component instead to fix the issue.  We should report the issue to Gutenberg when we contribute back upstream.

Before:
![Screenshot 2023-10-31 at 16 49 46](https://github.com/woocommerce/woocommerce/assets/4344253/bb39dfe7-7c04-42b1-8e92-1765578571f3)

After:
![Screenshot 2023-10-31 at 16 50 06](https://github.com/woocommerce/woocommerce/assets/4344253/38c9ed13-2e83-4243-8d7a-64ddcaf166de)

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


1. Create a new WooCommerce installation with this version.
2. Make sure to enable `customize-store` feature flag
3. Go to `/wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store%2Fassembler-hub``
4. Click on `Change your header`
5. Observe that thumbnails do not have extra spacing at the bottom. 
6. Go back to the parent menu
7. Repeat 4-5 steps again 


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>