### PR TITLE
Update WooCommerce Blocks to 11.4.3

### DIFF
--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-11.4.3
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-11.4.3
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update WooCommerce Blocks to 11.4.3

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -23,7 +23,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.6.4",
-		"woocommerce/woocommerce-blocks": "11.4.2"
+		"woocommerce/woocommerce-blocks": "11.4.3"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.3.0",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8b8f2c43765686a91b34faa824cb997d",
+    "content-hash": "6a5e201fcdc16a409789b0d63336db64",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1004,16 +1004,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "11.4.2",
+            "version": "11.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "7556d00d6ff6c013540f683c6d65f46405f41741"
+                "reference": "6a1848b9ba5277135327024262c080130641d5f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/7556d00d6ff6c013540f683c6d65f46405f41741",
-                "reference": "7556d00d6ff6c013540f683c6d65f46405f41741",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/6a1848b9ba5277135327024262c080130641d5f0",
+                "reference": "6a1848b9ba5277135327024262c080130641d5f0",
                 "shasum": ""
             },
             "require": {
@@ -1064,9 +1064,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v11.4.2"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v11.4.3"
             },
-            "time": "2023-10-26T16:18:21+00:00"
+            "time": "2023-10-31T15:11:22+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 11.4.3 and is intended to target WooCommerce 8.3 for release.

# Blocks 11.4.3
*  https://github.com/woocommerce/woocommerce-blocks/pull/11496
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/d855a1b850dcb73ef582527965ba2a1b2e3008b0/docs/internal-developers/testing/releases/1143.md)

### Changelog

```md
#### Enhancements

- Improve Hero Product Chessboard pattern. https://github.com/woocommerce/woocommerce-blocks/pull/11423
- Fix spacing on the "Minimal header" pattern. https://github.com/woocommerce/woocommerce-blocks/pull/11477
- "Product Gallery" improvements: remove product summary and update margins. https://github.com/woocommerce/woocommerce-blocks/pull/11464
- Patterns with Search Bar: improve style. https://github.com/woocommerce/woocommerce-blocks/pull/11478
- "Product Collection X Columns" patterns: align "no reviews" text with the star. https://github.com/woocommerce/woocommerce-blocks/pull/11468
- Rename the Footer with Simple Menu and Cart pattern. https://github.com/woocommerce/woocommerce-blocks/pull/11487
- Enhance the Hero Product Split pattern. https://github.com/woocommerce/woocommerce-blocks/pull/11505
- Simplify the Hero Product 3 Split pattern. https://github.com/woocommerce/woocommerce-blocks/pull/11495
- Improve the Centered Header Menu with Search pattern. https://github.com/woocommerce/woocommerce-blocks/pull/11304
- Large Header pattern: improve the layout on mobile view. https://github.com/woocommerce/woocommerce-blocks/pull/11490
- Improve the "Large footer" spacing. https://github.com/woocommerce/woocommerce-blocks/pull/11520


```

### Changelog entry

> Dev - Update WooCommerce Blocks version to 11.4.3