### PR TITLE
The variations table should match the height of number of rows selected

### DIFF
--- a/packages/js/product-editor/changelog/add-40211
+++ b/packages/js/product-editor/changelog/add-40211
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+The variations table should match the height of number of rows selected

--- a/packages/js/product-editor/src/components/variations-table/styles.scss
+++ b/packages/js/product-editor/src/components/variations-table/styles.scss
@@ -3,6 +3,7 @@
 @import "./pagination/styles.scss";
 @import "./table-empty-state/styles.scss";
 @import "./variations-filter/styles.scss";
+@import "./table-row-skeleton/styles.scss";
 
 $table-row-height: calc($grid-unit * 9);
 
@@ -37,11 +38,6 @@ $table-row-height: calc($grid-unit * 9);
 				margin-left: 0px;
 			}
 		}
-	}
-
-	&__table {
-		height: $table-row-height * 5;
-		overflow: auto;
 	}
 
 	&__selection {

--- a/packages/js/product-editor/src/components/variations-table/table-row-skeleton/index.ts
+++ b/packages/js/product-editor/src/components/variations-table/table-row-skeleton/index.ts
@@ -1,0 +1,1 @@
+export * from './table-row-skeleton';

--- a/packages/js/product-editor/src/components/variations-table/table-row-skeleton/styles.scss
+++ b/packages/js/product-editor/src/components/variations-table/table-row-skeleton/styles.scss
@@ -1,0 +1,51 @@
+.woocommerce-table-row-skeleton {
+	@mixin skeleton {
+		@include placeholder();
+		background-color: $gray-200;
+		border-radius: $grid-unit-05;
+		width: $grid-unit-30;
+		min-height: $grid-unit-30;
+	}
+
+	display: grid;
+	grid-template-columns: 44px auto 25% 25% 88px;
+	padding: 0;
+	min-height: 9 * $grid-unit;
+	border: none;
+	align-items: center;
+
+	&__checkbox {
+		@include skeleton();
+	}
+
+	&__attribute-option {
+		@include skeleton();
+		width: 9 * $grid-unit;
+	}
+
+	&__regular-price,
+	&__quantity {
+		@include skeleton();
+		width: $grid-unit-80;
+		display: inline-block;
+	}
+
+	&__visibility-icon {
+		@include skeleton();
+		flex-shrink: 0;
+	}
+
+	&__edit-link {
+		@include skeleton();
+		width: $grid-unit-70;
+		height: $grid-unit-40 + $grid-unit-05;
+		flex-shrink: 0;
+	}
+
+	&__menu-toggle {
+		@include skeleton();
+		width: $grid-unit-40 + $grid-unit-05;
+		height: $grid-unit-40 + $grid-unit-05;
+		flex-shrink: 0;
+	}
+}

--- a/packages/js/product-editor/src/components/variations-table/table-row-skeleton/table-row-skeleton.tsx
+++ b/packages/js/product-editor/src/components/variations-table/table-row-skeleton/table-row-skeleton.tsx
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import { createElement } from '@wordpress/element';
+
+export function TableRowSkeleton() {
+	return (
+		<div className="woocommerce-sortable__item" aria-hidden="true">
+			<div className="woocommerce-list-item woocommerce-table-row-skeleton">
+				<div className="woocommerce-sortable__handle" />
+
+				<div className="woocommerce-product-variations__selection">
+					<div className="woocommerce-table-row-skeleton__checkbox" />
+				</div>
+
+				<div className="woocommerce-product-variations__attributes">
+					{ Array( 3 )
+						.fill( 0 )
+						.map( ( _, index ) => (
+							<div
+								key={ index }
+								className="woocommerce-tag woocommerce-product-variations__attribute"
+							>
+								<div className="woocommerce-table-row-skeleton__attribute-option" />
+							</div>
+						) ) }
+				</div>
+
+				<div className="woocommerce-product-variations__price">
+					<div className="woocommerce-table-row-skeleton__regular-price" />
+				</div>
+
+				<div className="woocommerce-product-variations__quantity">
+					<div className="woocommerce-table-row-skeleton__quantity" />
+				</div>
+
+				<div className="woocommerce-product-variations__actions">
+					<div className="woocommerce-table-row-skeleton__visibility-icon" />
+
+					<div className="woocommerce-table-row-skeleton__edit-link" />
+
+					<div className="woocommerce-table-row-skeleton__menu-toggle" />
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/packages/js/product-editor/src/components/variations-table/variations-table.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variations-table.tsx
@@ -405,11 +405,11 @@ export const VariationsTable = forwardRef<
 							: __( 'Loading variations…', 'woocommerce' )
 					}
 				>
-					{ Array( 5 )
-						.fill( 0 )
-						.map( ( _, index ) => (
+					{ Array.from( { length: variations.length || 5 } ).map(
+						( _, index ) => (
 							<TableRowSkeleton key={ index } />
-						) ) }
+						)
+					) }
 				</div>
 			) : (
 				<Sortable className="woocommerce-product-variations__table">

--- a/packages/js/product-editor/src/components/variations-table/variations-table.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variations-table.tsx
@@ -41,6 +41,7 @@ import { Pagination } from './pagination';
 import { EmptyTableState } from './table-empty-state';
 import { VariationsFilter } from './variations-filter';
 import { useVariations } from './use-variations';
+import { TableRowSkeleton } from './table-row-skeleton';
 
 const NOT_VISIBLE_TEXT = __( 'Not visible to customers', 'woocommerce' );
 
@@ -302,16 +303,6 @@ export const VariationsTable = forwardRef<
 
 	return (
 		<div className="woocommerce-product-variations" ref={ ref }>
-			{ ( isLoading || isGenerating ) && (
-				<div className="woocommerce-product-variations__loading">
-					<Spinner />
-					{ isGenerating && (
-						<span>
-							{ __( 'Generating variations…', 'woocommerce' ) }
-						</span>
-					) }
-				</div>
-			) }
 			{ noticeText && (
 				<Notice
 					status={ noticeStatus }
@@ -405,148 +396,170 @@ export const VariationsTable = forwardRef<
 				</div>
 			) }
 
-			<Sortable className="woocommerce-product-variations__table">
-				{ variations.map( ( variation ) => (
-					<ListItem key={ `${ variation.id }` }>
-						<div className="woocommerce-product-variations__selection">
-							{ isUpdating[ variation.id ] ? (
-								<Spinner />
-							) : (
-								<CheckboxControl
-									value={ variation.id }
-									checked={ isSelected( variation ) }
-									onChange={ onSelect( variation ) }
-									disabled={ isSelectingAll }
-								/>
-							) }
-						</div>
-						<div className="woocommerce-product-variations__attributes">
-							{ variation.attributes.map( ( attribute ) => {
-								const tag = (
-									/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
-									/* @ts-ignore Additional props are not required. */
-									<Tag
-										id={ attribute.id }
-										className="woocommerce-product-variations__attribute"
-										key={ attribute.id }
-										label={ truncate( attribute.option, {
-											length: PRODUCT_VARIATION_TITLE_LIMIT,
-										} ) }
-										screenReaderLabel={ attribute.option }
-									/>
-								);
-
-								return attribute.option.length <=
-									PRODUCT_VARIATION_TITLE_LIMIT ? (
-									tag
+			{ isLoading || isGenerating ? (
+				<div
+					className="woocommerce-product-variations__table"
+					aria-label={
+						isGenerating
+							? __( 'Generating variations…', 'woocommerce' )
+							: __( 'Loading variations…', 'woocommerce' )
+					}
+				>
+					{ Array( 5 )
+						.fill( 0 )
+						.map( ( _, index ) => (
+							<TableRowSkeleton key={ index } />
+						) ) }
+				</div>
+			) : (
+				<Sortable className="woocommerce-product-variations__table">
+					{ variations.map( ( variation ) => (
+						<ListItem key={ `${ variation.id }` }>
+							<div className="woocommerce-product-variations__selection">
+								{ isUpdating[ variation.id ] ? (
+									<Spinner />
 								) : (
-									<Tooltip
-										key={ attribute.id }
-										text={ attribute.option }
-										position="top center"
-									>
-										<span>{ tag }</span>
-									</Tooltip>
-								);
-							} ) }
-						</div>
-						<div
-							className={ classnames(
-								'woocommerce-product-variations__price',
-								{
-									'woocommerce-product-variations__price--fade':
-										variation.status === 'private',
-								}
-							) }
-						>
-							{ variation.on_sale && (
-								<span className="woocommerce-product-variations__sale-price">
-									{ formatAmount( variation.sale_price ) }
-								</span>
-							) }
-							<span
+									<CheckboxControl
+										value={ variation.id }
+										checked={ isSelected( variation ) }
+										onChange={ onSelect( variation ) }
+										disabled={ isSelectingAll }
+									/>
+								) }
+							</div>
+							<div className="woocommerce-product-variations__attributes">
+								{ variation.attributes.map( ( attribute ) => {
+									const tag = (
+										/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
+										/* @ts-ignore Additional props are not required. */
+										<Tag
+											id={ attribute.id }
+											className="woocommerce-product-variations__attribute"
+											key={ attribute.id }
+											label={ truncate(
+												attribute.option,
+												{
+													length: PRODUCT_VARIATION_TITLE_LIMIT,
+												}
+											) }
+											screenReaderLabel={
+												attribute.option
+											}
+										/>
+									);
+
+									return attribute.option.length <=
+										PRODUCT_VARIATION_TITLE_LIMIT ? (
+										tag
+									) : (
+										<Tooltip
+											key={ attribute.id }
+											text={ attribute.option }
+											position="top center"
+										>
+											<span>{ tag }</span>
+										</Tooltip>
+									);
+								} ) }
+							</div>
+							<div
 								className={ classnames(
-									'woocommerce-product-variations__regular-price',
+									'woocommerce-product-variations__price',
 									{
-										'woocommerce-product-variations__regular-price--on-sale':
-											variation.on_sale,
+										'woocommerce-product-variations__price--fade':
+											variation.status === 'private',
 									}
 								) }
 							>
-								{ formatAmount( variation.regular_price ) }
-							</span>
-						</div>
-						<div
-							className={ classnames(
-								'woocommerce-product-variations__quantity',
-								{
-									'woocommerce-product-variations__quantity--fade':
-										variation.status === 'private',
-								}
-							) }
-						>
-							{ variation.regular_price && (
-								<>
-									<span
-										className={ classnames(
-											'woocommerce-product-variations__status-dot',
-											getProductStockStatusClass(
-												variation
-											)
-										) }
-									>
-										●
+								{ variation.on_sale && (
+									<span className="woocommerce-product-variations__sale-price">
+										{ formatAmount( variation.sale_price ) }
 									</span>
-									{ getProductStockStatus( variation ) }
-								</>
-							) }
-						</div>
-						<div className="woocommerce-product-variations__actions">
-							{ ( variation.status === 'private' ||
-								! variation.regular_price ) && (
-								<Tooltip
-									// @ts-expect-error className is missing in TS, should remove this when it is included.
-									className="woocommerce-attribute-list-item__actions-tooltip"
-									position="top center"
-									text={ NOT_VISIBLE_TEXT }
+								) }
+								<span
+									className={ classnames(
+										'woocommerce-product-variations__regular-price',
+										{
+											'woocommerce-product-variations__regular-price--on-sale':
+												variation.on_sale,
+										}
+									) }
 								>
-									<div className="woocommerce-attribute-list-item__actions-icon-wrapper">
-										<HiddenIcon className="woocommerce-attribute-list-item__actions-icon-wrapper-icon" />
-									</div>
-								</Tooltip>
-							) }
-
-							{ ! areSomeSelected && (
-								<>
-									<Button
-										href={ getEditVariationLink(
-											variation
-										) }
-										onClick={ editVariationClickHandler(
-											variation
-										) }
+									{ formatAmount( variation.regular_price ) }
+								</span>
+							</div>
+							<div
+								className={ classnames(
+									'woocommerce-product-variations__quantity',
+									{
+										'woocommerce-product-variations__quantity--fade':
+											variation.status === 'private',
+									}
+								) }
+							>
+								{ variation.regular_price && (
+									<>
+										<span
+											className={ classnames(
+												'woocommerce-product-variations__status-dot',
+												getProductStockStatusClass(
+													variation
+												)
+											) }
+										>
+											●
+										</span>
+										{ getProductStockStatus( variation ) }
+									</>
+								) }
+							</div>
+							<div className="woocommerce-product-variations__actions">
+								{ ( variation.status === 'private' ||
+									! variation.regular_price ) && (
+									<Tooltip
+										// @ts-expect-error className is missing in TS, should remove this when it is included.
+										className="woocommerce-attribute-list-item__actions-tooltip"
+										position="top center"
+										text={ NOT_VISIBLE_TEXT }
 									>
-										{ __( 'Edit', 'woocommerce' ) }
-									</Button>
+										<div className="woocommerce-attribute-list-item__actions-icon-wrapper">
+											<HiddenIcon className="woocommerce-attribute-list-item__actions-icon-wrapper-icon" />
+										</div>
+									</Tooltip>
+								) }
 
-									<VariationActionsMenu
-										selection={ variation }
-										onChange={ ( value ) =>
-											handleVariationChange( {
-												id: variation.id,
-												...value,
-											} )
-										}
-										onDelete={ ( { id } ) =>
-											handleDeleteVariationClick( id )
-										}
-									/>
-								</>
-							) }
-						</div>
-					</ListItem>
-				) ) }
-			</Sortable>
+								{ ! areSomeSelected && (
+									<>
+										<Button
+											href={ getEditVariationLink(
+												variation
+											) }
+											onClick={ editVariationClickHandler(
+												variation
+											) }
+										>
+											{ __( 'Edit', 'woocommerce' ) }
+										</Button>
+
+										<VariationActionsMenu
+											selection={ variation }
+											onChange={ ( value ) =>
+												handleVariationChange( {
+													id: variation.id,
+													...value,
+												} )
+											}
+											onDelete={ ( { id } ) =>
+												handleDeleteVariationClick( id )
+											}
+										/>
+									</>
+								) }
+							</div>
+						</ListItem>
+					) ) }
+				</Sortable>
+			) }
 
 			{ totalCount > 5 && (
 				<Pagination


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #40211

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure feature `product-variation-management` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper` (WooCommerce Beta Tester plugin) is required
3. Go to `/wp-admin/admin.php?page=wc-admin&path=/add-product&tab=variations` and add some attributes to generate variations. Make sure that the total generated variations are more than 25
4. Wait until variations get generated
5. After picking the 5/10/25 from the items per page select at the bottom of the table, the table should adjust its height to the amount of rows within it

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
