### PR TITLE
Add SlotFill for custom buttons on Transitional Page

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/index.tsx
@@ -16,7 +16,7 @@ import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 import { dispatch, resolveSelect } from '@wordpress/data';
 import { Spinner } from '@woocommerce/components';
 import { getAdminLink } from '@woocommerce/settings';
-
+import { PluginArea } from '@wordpress/plugins';
 /**
  * Internal dependencies
  */
@@ -394,6 +394,8 @@ export const CustomizeStoreController = ( {
 					</div>
 				) }
 			</div>
+			{ /* @ts-expect-error 'scope' does exist. @types/wordpress__plugins is outdated. */ }
+			<PluginArea scope="woocommerce-customize-store" />
 		</>
 	);
 };

--- a/plugins/woocommerce-admin/client/customize-store/transitional/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/transitional/index.tsx
@@ -15,7 +15,6 @@ import {
 } from '@wordpress/components';
 // @ts-ignore No types for this exist yet.
 import { useIsSiteEditorLoading } from '@wordpress/edit-site/build-module/components/layout/hooks';
-
 /**
  * Internal dependencies
  */
@@ -24,6 +23,7 @@ import { ADMIN_URL } from '~/utils/admin-settings';
 
 import './style.scss';
 import { navigateOrParent } from '../utils';
+import { WooCYSSecondaryButtonSlot } from './secondary-button-slot';
 
 export type events = { type: 'GO_BACK_TO_HOME' };
 
@@ -58,18 +58,23 @@ export const Transitional = ( {
 						'woocommerce'
 					) }
 				</h2>
-				<Button
-					className="woocommerce-customize-store__transitional-preview-button"
-					variant="primary"
-					onClick={ () => {
-						recordEvent(
-							'customize_your_store_transitional_preview_store_click'
-						);
-						window.open( homeUrl, '_blank' );
-					} }
-				>
-					{ __( 'Preview store', 'woocommerce' ) }
-				</Button>
+
+				<div className="woocommerce-customize-store__transitional-main-actions">
+					<WooCYSSecondaryButtonSlot />
+
+					<Button
+						className="woocommerce-customize-store__transitional-preview-button"
+						variant="primary"
+						onClick={ () => {
+							recordEvent(
+								'customize_your_store_transitional_preview_store_click'
+							);
+							window.open( homeUrl, '_blank' );
+						} }
+					>
+						{ __( 'Preview store', 'woocommerce' ) }
+					</Button>
+				</div>
 
 				<div
 					className={ classNames(

--- a/plugins/woocommerce-admin/client/customize-store/transitional/secondary-button-slot/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/transitional/secondary-button-slot/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { useSlot } from '@woocommerce/experimental';
-export * from './example-fill'; // just so that the example script is run in the package
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce-admin/client/customize-store/transitional/secondary-button-slot/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/transitional/secondary-button-slot/index.tsx
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import { useSlot } from '@woocommerce/experimental';
+export * from './example-fill'; // just so that the example script is run in the package
+
+/**
+ * Internal dependencies
+ */
+import {
+	EXPERIMENTAL_WC_CYS_TRANSITIONAL_PAGE_SECONDARY_BUTTON_SLOT_NAME,
+	WooCYSSecondaryButton,
+} from './utils';
+
+export const WooCYSSecondaryButtonSlot = () => {
+	const slot = useSlot(
+		EXPERIMENTAL_WC_CYS_TRANSITIONAL_PAGE_SECONDARY_BUTTON_SLOT_NAME
+	);
+
+	const hasFills = Boolean( slot?.fills?.length );
+	if ( ! hasFills ) {
+		return null;
+	}
+
+	return <WooCYSSecondaryButton.Slot />;
+};

--- a/plugins/woocommerce-admin/client/customize-store/transitional/secondary-button-slot/utils.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/transitional/secondary-button-slot/utils.tsx
@@ -1,0 +1,63 @@
+/**
+ * External dependencies
+ */
+import { Slot, Fill } from '@wordpress/components';
+import {
+	sortFillsByOrder,
+	createOrderedChildren,
+} from '@woocommerce/components';
+
+export const EXPERIMENTAL_WC_CYS_TRANSITIONAL_PAGE_SECONDARY_BUTTON_SLOT_NAME =
+	'customize_your_store_transitional_page_secondary_button';
+
+/**
+ * Create a Fill for extensions to add a secondary button to the transitional page.
+ *
+ * @slotFill WooCYSSecondaryButton
+ * @scope woocommerce-admin
+ * @example
+ * const MyButton = () => (
+ * 	<Fill name="__experimental_customize_your_store_transitional_page_secondary_button">
+ * 		<Button className="woocommerce-experiments-button-slotfill">
+ * 				Slotfill goes in here!
+ *    </Button>
+ * 	</Fill>
+ * );
+ *
+ * registerPlugin( 'my-extension', {
+ * 	render: MyButton,
+ * 	scope: 'woocommerce-admin',
+ * } );
+ * @param {Object} param0
+ * @param {Array}  param0.children - Node children.
+ * @param {Array}  param0.order    - Node order.
+ */
+export const WooCYSSecondaryButton: React.FC< {
+	children?: React.ReactNode;
+	order?: number;
+} > & {
+	Slot: React.FC< Slot.Props >;
+} = ( { children, order = 1 } ) => {
+	return (
+		<Fill
+			name={
+				EXPERIMENTAL_WC_CYS_TRANSITIONAL_PAGE_SECONDARY_BUTTON_SLOT_NAME
+			}
+		>
+			{ ( fillProps: Fill.Props ) => {
+				return createOrderedChildren( children, order, fillProps );
+			} }
+		</Fill>
+	);
+};
+
+WooCYSSecondaryButton.Slot = ( { fillProps } ) => (
+	<Slot
+		name={
+			EXPERIMENTAL_WC_CYS_TRANSITIONAL_PAGE_SECONDARY_BUTTON_SLOT_NAME
+		}
+		fillProps={ fillProps }
+	>
+		{ sortFillsByOrder }
+	</Slot>
+);

--- a/plugins/woocommerce-admin/client/customize-store/transitional/style.scss
+++ b/plugins/woocommerce-admin/client/customize-store/transitional/style.scss
@@ -61,10 +61,16 @@
 		width: 560px;
 	}
 
-	.woocommerce-customize-store__transitional-preview-button {
-		padding: 8px 16px;
-		height: 40px;
+	.woocommerce-customize-store__transitional-main-actions {
 		margin: 20px 0 0;
+		display: flex;
+		gap: 20px;
+		flex-direction: row;
+
+		.components-button {
+			padding: 8px 16px;
+			height: 40px;
+		}
 	}
 
 	.woocommerce-customize-store__transitional-site-preview-container {

--- a/plugins/woocommerce/changelog/add-cys-slotfill-transitional-button
+++ b/plugins/woocommerce/changelog/add-cys-slotfill-transitional-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add slotfill for cys transitiona page secondary button

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/CustomizeStore.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/CustomizeStore.php
@@ -97,6 +97,7 @@ class CustomizeStore extends Task {
 	 * Possibly add site editor scripts.
 	 */
 	public function possibly_add_site_editor_scripts() {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		$is_wc_admin_page = (
 			isset( $_GET['page'] ) &&
 			'wc-admin' === $_GET['page'] &&
@@ -105,6 +106,7 @@ class CustomizeStore extends Task {
 
 		$is_assembler_hub     = $is_wc_admin_page && str_starts_with( wc_clean( wp_unslash( $_GET['path'] ) ), '/customize-store/assembler-hub' );
 		$is_transitional_page = $is_wc_admin_page && str_starts_with( wc_clean( wp_unslash( $_GET['path'] ) ), '/customize-store/transitional' );
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		if ( ! ( $is_assembler_hub || $is_transitional_page ) ) {
 			return;

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/CustomizeStore.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/CustomizeStore.php
@@ -97,13 +97,16 @@ class CustomizeStore extends Task {
 	 * Possibly add site editor scripts.
 	 */
 	public function possibly_add_site_editor_scripts() {
-		$is_assembler_hub = (
+		$is_wc_admin_page = (
 			isset( $_GET['page'] ) &&
 			'wc-admin' === $_GET['page'] &&
-			isset( $_GET['path'] ) &&
-			str_starts_with( wc_clean( wp_unslash( $_GET['path'] ) ), '/customize-store/assembler-hub' )
+			isset( $_GET['path'] )
 		);
-		if ( ! $is_assembler_hub ) {
+
+		$is_assembler_hub     = $is_wc_admin_page && str_starts_with( wc_clean( wp_unslash( $_GET['path'] ) ), '/customize-store/assembler-hub' );
+		$is_transitional_page = $is_wc_admin_page && str_starts_with( wc_clean( wp_unslash( $_GET['path'] ) ), '/customize-store/transitional' );
+
+		if ( ! ( $is_assembler_hub || $is_transitional_page ) ) {
 			return;
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #41147.

```
  Scenario: Transitional Page is displayed
    When the transitional page is displayed
    Then a SlotFill slot should be provided named __experimental_customize_your_store_transitional_page_secondary_button
    And it should be positioned to the left of the Preview Store button
```

![Screenshot 2023-11-01 at 15 26 13](https://github.com/woocommerce/woocommerce/assets/4344253/c98f6501-53f6-490e-afc4-b02b3378868d)


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new WooCommerce installation with this version.
2. Make sure to enable `customize-store` feature flag
3. Checkout the demo branch `demo/cys-slotfill-transitional-button` or [commit](https://github.com/woocommerce/woocommerce/commit/bff59789a97843d520b7bcde36d5e0e1f8754d6f)
4. Go to `/wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store%2Ftransitional`
5. Confirm a button is positioned to the left of the Preview Store button

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
