### PR TITLE
[CYS] Fix Spotlight Tour caret is not centered vertically

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/onboarding-tour/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/onboarding-tour/index.tsx
@@ -144,7 +144,7 @@ export const OnboardingTour = ( {
 							requires: [ 'computeStyles' ],
 							fn: ( { state } ) => {
 								state.styles.arrow.transform =
-									'translate3d(0px, 114.4px, 0)';
+									'translate3d(0px, 96px, 0)';
 							},
 						},
 						{

--- a/plugins/woocommerce/changelog/fix-spotlight-caret
+++ b/plugins/woocommerce/changelog/fix-spotlight-caret
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix CYS Spotlight Tour caret is not centered vertically


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/41119

After:

![Screenshot 2023-11-01 at 15 58 07](https://github.com/woocommerce/woocommerce/assets/4344253/7dd1f1b2-9554-4342-9364-11aa2b4a6d45)

![Screenshot 2023-11-01 at 15 58 12](https://github.com/woocommerce/woocommerce/assets/4344253/f29fec83-6fd9-4371-b9f9-8ef3a9d3c076)


Confirmed it's placed exactly in the center. 

![Screenshot 2023-11-01 at 16 03 36](https://github.com/woocommerce/woocommerce/assets/4344253/ff3f0b22-9abd-46c3-a38f-b1b55c5c8be9)


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new WooCommerce installation with this version.
2. Make sure to enable `customize-store` feature flag
3. Go to `/wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store%2Fassembler-hub`
4. Take the onboarding tour
5. Confirm the caret is centered.
 
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>