### PR TITLE
Fix the slides overlapping on the Marketing > Coupon page

### DIFF
--- a/plugins/woocommerce-admin/client/marketing/coupons/slider/style.scss
+++ b/plugins/woocommerce-admin/client/marketing/coupons/slider/style.scss
@@ -1,3 +1,20 @@
+@mixin animate-slider($vector, $duration: 300ms, $timing-function: ease-in) {
+	.slide-enter {
+		transform: translateX($vector * 100%);
+	}
+	.slide-enter-active {
+		transform: translateX(0%);
+		transition: transform $duration $timing-function;
+	}
+	.slide-exit {
+		transform: translateX(0%);
+	}
+	.slide-exit-active {
+		transform: translateX($vector * -100%);
+		transition: transform $duration $timing-function;
+	}
+}
+
 .woocommerce-marketing-slider {
 	display: block;
 	width: 100%;
@@ -17,7 +34,6 @@
 		top: 0;
 		left: 0;
 		width: 100%;
-		transition: transform 300ms ease-in;
 		position: relative;
 	}
 
@@ -27,33 +43,13 @@
 	}
 
 	&.animate-right {
-		.slide-enter {
-			transform: translateX(-100%);
-		}
-		.slide-enter-active {
-			transform: translateX(0%);
-		}
-		.slide-exit {
-			transform: translateX(0%);
-		}
-		.slide-exit-active {
-			transform: translateX(100%);
-		}
+		// $vector = -1 for sliding from left to right
+		@include animate-slider(-1);
 	}
 
 	&.animate-left {
-		.slide-enter {
-			transform: translateX(100%);
-		}
-		.slide-enter-active {
-			transform: translateX(0%);
-		}
-		.slide-exit {
-			transform: translateX(0%);
-		}
-		.slide-exit-active {
-			transform: translateX(-100%);
-		}
+		// $vector = 1 for sliding from right to left
+		@include animate-slider(1);
 	}
 
 	@media screen and (prefers-reduced-motion: reduce) {

--- a/plugins/woocommerce/changelog/fix-34602-marketing-coupon-page-slides-overlap
+++ b/plugins/woocommerce/changelog/fix-34602-marketing-coupon-page-slides-overlap
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the slides overlapping on the Marketing > Coupon page.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #34602 

Fix the issue of slides overlapping with each other on the Marketing > Coupon page.

The https://github.com/woocommerce/woocommerce/issues/34602#issuecomment-1788607865 has detailed context.

https://github.com/woocommerce/woocommerce/assets/17420811/ddba74c9-114b-4b8d-8a46-08d44446b65e

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

All steps are operated within WooCommerce Admin pages.

1. Go to WooCommerce > Marketing > Coupon page
2. Click on the next and previous buttons within the **WooCommerce knowledge base** Card
3. Check if the slide transition works well
4. During the slide transition, observe if the issue of slides overlapping with each other is addressed

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
