### PR TITLE
Fix cys remove scrollbar iframe in intro screen

### DIFF
--- a/plugins/woocommerce/changelog/fix-41149-cys-remove-scrollbar-iframe
+++ b/plugins/woocommerce/changelog/fix-41149-cys-remove-scrollbar-iframe
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Remove iframe scrollbar when viewing CYS intro iframe

--- a/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/CustomizeStore.php
+++ b/plugins/woocommerce/src/Admin/Features/OnboardingTasks/Tasks/CustomizeStore.php
@@ -27,6 +27,9 @@ class CustomizeStore extends Task {
 		if ( ! $theme_switch_via_cys_ai_loader ) {
 				add_action( 'switch_theme', array( $this, 'mark_task_as_complete' ) );
 		}
+
+		// Hook to remove unwanted UI elements when users are viewing with ?cys-hide-admin-bar=true.
+		add_action( 'wp_head', array( $this, 'possibly_remove_unwanted_ui_elements' ) );
 	}
 
 	/**
@@ -227,5 +230,20 @@ class CustomizeStore extends Task {
 			return false;
 		}
 		return $show;
+	}
+
+	/**
+	 * Runs script and add styles to remove unwanted elements and hide scrollbar
+	 * when users are viewing with ?cys-hide-admin-bar=true.
+	 *
+	 * @return void
+	 */
+	public function possibly_remove_unwanted_ui_elements() {
+		if ( isset( $_GET['cys-hide-admin-bar'] ) ) { // @phpcs:ignore
+			echo '
+			<style type="text/css">
+				body { overflow: hidden; }
+			</style>';
+		}
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #41149 

Removes the scrollbar in CYS iframe preview in its intro screen.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure to enable `customize-store` feature flag
1. Go to `WooCommerce -> Home` and click `Customize Store` task
2. Observe that no site preview is displayed
3. Go through the AI steps until it completes creating the site
4. Click on `Save` to ensure CYS task is marked as complete
1. Go back to `WooCommerce -> Home` and click `Customize Store` task
1. Observe that the iframe preview is displayed
1. Observe that the following are not displayed in the iframe preview:
    - Scrollbar

<img width="1012" alt="image" src="https://github.com/woocommerce/woocommerce/assets/3747241/a13713db-3f1e-47fd-874d-ba8f58675164">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
