### PR TITLE
Fix CYS transition screen iframe positioning

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/transitional/style.scss
+++ b/plugins/woocommerce-admin/client/customize-store/transitional/style.scss
@@ -103,7 +103,7 @@
 			overflow: hidden;
 		}
 
-		.auto-block-preview__container {
+		.auto-block-preview__container, .block-editor-block-preview__content {
 			width: 588px;
 			height: 363px;
 			position: relative;

--- a/plugins/woocommerce-admin/client/customize-store/transitional/style.scss
+++ b/plugins/woocommerce-admin/client/customize-store/transitional/style.scss
@@ -103,7 +103,8 @@
 			overflow: hidden;
 		}
 
-		.auto-block-preview__container, .block-editor-block-preview__content {
+		.auto-block-preview__container,
+		.block-editor-block-preview__content {
 			width: 588px;
 			height: 363px;
 			position: relative;

--- a/plugins/woocommerce/changelog/fix-cys-transition-screen-iframe-positioning
+++ b/plugins/woocommerce/changelog/fix-cys-transition-screen-iframe-positioning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix unintended spacing in CYS transition page's iframe


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fix a regression introduced in https://github.com/woocommerce/woocommerce/pull/41126 where the transition screen iframe has unintended spacing.

<img width="400" alt="image" src="https://github.com/woocommerce/woocommerce/assets/3747241/fbed5697-c4b6-4446-9b4c-6947932e52de">

### How to test the changes in this Pull Request:

1. Make sure to enable `customize-store` feature flag
1. Go to `WooCommerce -> Home` and click `Customize Store` task
2. Observe that no site preview is displayed
3. Go through the AI steps until it completes creating the site
4. Click on `Done`
5. Observe the iframe is positioned well

<img width="400" alt="image" src="https://github.com/woocommerce/woocommerce/assets/3747241/dde83066-0b94-4b38-ba57-242abd4f8027">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
