### PR TITLE
Product Editor: Fix select on focus for currency and number fields

### DIFF
--- a/packages/js/product-editor/changelog/fix-currency-number-select-in-focus
+++ b/packages/js/product-editor/changelog/fix-currency-number-select-in-focus
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix selection in currency and number fields to only select if field still has focus.

--- a/packages/js/product-editor/src/hooks/use-currency-input-props.ts
+++ b/packages/js/product-editor/src/hooks/use-currency-input-props.ts
@@ -8,7 +8,7 @@ import { useContext } from '@wordpress/element';
  * Internal dependencies
  */
 import { useProductHelper } from './use-product-helper';
-import { formatCurrencyDisplayValue } from '../utils';
+import { deferSelectInFocus, formatCurrencyDisplayValue } from '../utils';
 
 export type CurrencyInputProps = {
 	prefix: string;
@@ -51,18 +51,7 @@ export const useCurrencyInputProps = ( {
 			return sanitizePrice( String( val ) );
 		},
 		onFocus( event: React.FocusEvent< HTMLInputElement > ) {
-			// In some browsers like safari .select() function inside
-			// the onFocus event doesn't work as expected because it
-			// conflicts with onClick the first time user click the
-			// input. Using setTimeout defers the text selection and
-			// avoid the unexpected behaviour.
-			setTimeout(
-				function deferSelection( element: HTMLInputElement ) {
-					element.select();
-				},
-				0,
-				event.currentTarget
-			);
+			deferSelectInFocus( event.currentTarget );
 			if ( onFocus ) {
 				onFocus( event );
 			}

--- a/packages/js/product-editor/src/hooks/use-number-input-props.ts
+++ b/packages/js/product-editor/src/hooks/use-number-input-props.ts
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { useProductHelper } from './use-product-helper';
+import { deferSelectInFocus } from '../utils';
 
 export type NumberInputProps = {
 	value: string;
@@ -28,18 +29,7 @@ export const useNumberInputProps = ( {
 	const numberInputProps: NumberInputProps = {
 		value: formatNumber( value ),
 		onFocus( event: React.FocusEvent< HTMLInputElement > ) {
-			// In some browsers like safari .select() function inside
-			// the onFocus event doesn't work as expected because it
-			// conflicts with onClick the first time user click the
-			// input. Using setTimeout defers the text selection and
-			// avoid the unexpected behaviour.
-			setTimeout(
-				function deferSelection( element: HTMLInputElement ) {
-					element.select();
-				},
-				0,
-				event.currentTarget
-			);
+			deferSelectInFocus( event.currentTarget );
 			if ( onFocus ) {
 				onFocus( event );
 			}

--- a/packages/js/product-editor/src/utils/defer-select-in-focus.ts
+++ b/packages/js/product-editor/src/utils/defer-select-in-focus.ts
@@ -1,0 +1,17 @@
+export function deferSelectInFocus( element: HTMLInputElement ) {
+	// In some browsers like safari .select() function inside
+	// the onFocus event doesn't work as expected because it
+	// conflicts with onClick the first time user click the
+	// input. Using setTimeout defers the text selection and
+	// avoid the unexpected behaviour.
+	setTimeout(
+		function deferSelection( originalElement: HTMLInputElement ) {
+			if ( element.ownerDocument.activeElement === originalElement ) {
+				// We still have focus, so select the content.
+				originalElement.select();
+			}
+		},
+		0,
+		element
+	);
+}

--- a/packages/js/product-editor/src/utils/index.ts
+++ b/packages/js/product-editor/src/utils/index.ts
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { AUTO_DRAFT_NAME } from './constants';
+import { deferSelectInFocus } from './defer-select-in-focus';
 import { formatCurrencyDisplayValue } from './format-currency-display-value';
 import { getCheckboxTracks } from './get-checkbox-tracks';
 import { getCurrencySymbolProps } from './get-currency-symbol-props';
@@ -30,6 +31,7 @@ export * from './sift';
 
 export {
 	AUTO_DRAFT_NAME,
+	deferSelectInFocus,
 	formatCurrencyDisplayValue,
 	getCheckboxTracks,
 	getCurrencySymbolProps,


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes the following issue... If you focus on a currency or number field, then focus outside of the product editor (for example, by clicking in the browser developer tools), when you try to click on another field, focus will return to the previously focused currency or number field.

https://github.com/woocommerce/woocommerce/assets/2098816/8e05c238-ebf3-44b6-b852-89995ebcc0de

It is not currently clear *why* the focus briefly returns to the previously focused block (#41174 will look into this more), but this causes an issue because of a bug in the select on focus implementation in currency and number fields.

To reproduce:

1. Focus on the list price field.
2. Focus on something outside of the product editor, such as the browser developer tools.
3. Click on a different field, such as the summary field.
4. Notice that focus goes back to the list price field.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Enable the **Product Editor** under **WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**.
3. Go to **Products** > **Add New**
4. Focus on the list price field.
5. Focus on something outside of the product editor, such as the browser developer tools.
6. Click on a different field, such as the summary field.
7. Verify that focus stays on the different field (summary field).

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
