### PR TITLE
Allow null in multichannel campaign.

### DIFF
--- a/plugins/woocommerce-admin/client/marketing/data-multichannel/types.ts
+++ b/plugins/woocommerce-admin/client/marketing/data-multichannel/types.ts
@@ -58,7 +58,7 @@ export type Campaign = {
 	cost: {
 		value: string;
 		currency: string;
-	};
+	} | null;
 };
 
 export type CampaignsPage = {

--- a/plugins/woocommerce-admin/client/marketing/hooks/useCampaigns.ts
+++ b/plugins/woocommerce-admin/client/marketing/hooks/useCampaigns.ts
@@ -46,14 +46,15 @@ export const useCampaigns = ( page = 1, perPage = 5 ): UseCampaignsType => {
 					( el ) => el.slug === campaign.channel
 				);
 
-				const currency = campaign?.cost.currency || '';
-				const value = campaign?.cost.value || '';
+				const cost = campaign.cost
+					? `${ campaign.cost.currency } ${ campaign.cost.value }`
+					: '';
 
 				return {
 					id: `${ campaign.channel }|${ campaign.id }`,
 					title: campaign.title,
 					description: '',
-					cost: `${ currency } ${ value }`,
+					cost,
 					manageUrl: campaign.manage_url,
 					icon: channel?.icon || '',
 					channelName: channel?.title || '',

--- a/plugins/woocommerce-admin/client/marketing/hooks/useCampaigns.ts
+++ b/plugins/woocommerce-admin/client/marketing/hooks/useCampaigns.ts
@@ -46,11 +46,14 @@ export const useCampaigns = ( page = 1, perPage = 5 ): UseCampaignsType => {
 					( el ) => el.slug === campaign.channel
 				);
 
+				const currency = campaign?.cost.currency || '';
+				const value = campaign?.cost.value || '';
+
 				return {
 					id: `${ campaign.channel }|${ campaign.id }`,
 					title: campaign.title,
 					description: '',
-					cost: `${ campaign.cost.currency } ${ campaign.cost.value }`,
+					cost: `${ currency } ${ value }`,
 					manageUrl: campaign.manage_url,
 					icon: channel?.icon || '',
 					channelName: channel?.title || '',

--- a/plugins/woocommerce/changelog/fix-null-allowed-in-multichannel-campaign
+++ b/plugins/woocommerce/changelog/fix-null-allowed-in-multichannel-campaign
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Allow null value in cost field for multichannel campaign.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The code was not properly handling null values if they had been used for the campaign costs in the multichannel campaign. It causes an error in the browser console that says "TypeError: Cannot read properties of undefined (reading 'currency')".

![image](https://github.com/woocommerce/woocommerce/assets/17271089/42180be8-db63-402e-937e-7850a4143246)

As per this line: 

https://github.com/woocommerce/woocommerce/blob/408d6b7aee9e83bf98afcd0058ece068095882bc/plugins/woocommerce/src/Admin/Marketing/MarketingCampaign.php#L58

Campaign cost is allowed to be null.

In this PR, we fix the code to handle `campaign.cost` with `null` value.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Note: to test the changes, you may need to use some test data in some marketing channel extensions. The following is an example of how to do that using Google Listings and Ads, and with MailPoet extension installed:

1. Modify the line https://github.com/woocommerce/google-listings-and-ads/blob/72543805c6a24191c33c5cd0177d66b07537b18b/src/MultichannelMarketing/GLAChannel.php#L75 to the following:

```php
		if ( apply_filters( 'woocommerce_gla_enable_mcm', true ) === true ) {
```

2. Modify the `get_campaigns` function in https://github.com/woocommerce/google-listings-and-ads/blob/72543805c6a24191c33c5cd0177d66b07537b18b/src/MultichannelMarketing/GLAChannel.php#L178-L206, so that it returns some sample marketing campaigns from MailPoet and Google Listings and Ads. Note that the cost for the "MailPoet campaign" is `null` here:

```php
	public function get_campaigns(): array {
		return [
			new MarketingCampaign(
				'1',
				$this->campaign_types['google-ads'],
				'MailPoet campaign',
				admin_url( 'admin.php?page=mailpoet-newsletters' ),
				null,
			),
			new MarketingCampaign(
				'2',
				$this->campaign_types['google-ads'],
				'Google Listings and Ads campaign',
				admin_url( 'admin.php?page=wc-admin&path=/google/settings&subpath=/campaigns/edit' ),
				new Price( '200', 'USD' ),
			),
		];
	}
```

Test Steps:

1. Go to the WooCommerce > Marketing page: `/wp-admin/admin.php?page=wc-admin&path=%2Fmarketing`. You should see Campaigns card like below.

![image](https://github.com/woocommerce/woocommerce/assets/417342/cdd772ed-212f-4a74-bf2e-e22cd40f6e57)

2. The following error should not be present in the browser console:

![image](https://github.com/woocommerce/woocommerce/assets/17271089/42180be8-db63-402e-937e-7850a4143246)

<!-- End testing instructions -->

### Changelog entry

Fix - Allow null value for Multichannel Campaign cost.

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
