### PR TITLE
Fix marketing campaign link not navigating to the right page

### DIFF
--- a/plugins/woocommerce-admin/client/marketing/overview-multichannel/Campaigns/Campaigns.tsx
+++ b/plugins/woocommerce-admin/client/marketing/overview-multichannel/Campaigns/Campaigns.tsx
@@ -138,7 +138,10 @@ export const Campaigns = () => {
 									<FlexBlock>
 										<Flex direction="column" gap={ 1 }>
 											<FlexItem className="woocommerce-marketing-campaigns-card__campaign-title">
-												<Link href={ el.manageUrl }>
+												<Link
+													type="wp-admin"
+													href={ el.manageUrl }
+												>
 													{ el.title }
 												</Link>
 											</FlexItem>

--- a/plugins/woocommerce-admin/client/marketing/overview-multichannel/Campaigns/Campaigns.tsx
+++ b/plugins/woocommerce-admin/client/marketing/overview-multichannel/Campaigns/Campaigns.tsx
@@ -14,7 +14,13 @@ import {
 	FlexBlock,
 } from '@wordpress/components';
 import { Icon, megaphone, cancelCircleFilled } from '@wordpress/icons';
-import { Pagination, Table, TablePlaceholder } from '@woocommerce/components';
+import {
+	Pagination,
+	Table,
+	TablePlaceholder,
+	Link,
+} from '@woocommerce/components';
+import { isWCAdmin } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -133,9 +139,18 @@ export const Campaigns = () => {
 									<FlexBlock>
 										<Flex direction="column" gap={ 1 }>
 											<FlexItem className="woocommerce-marketing-campaigns-card__campaign-title">
-												<a href={ el.manageUrl }>
+												<Link
+													type={
+														isWCAdmin(
+															el.manageUrl
+														)
+															? 'wc-admin'
+															: 'external'
+													}
+													href={ el.manageUrl }
+												>
 													{ el.title }
-												</a>
+												</Link>
 											</FlexItem>
 											{ !! el.description && (
 												<FlexItem className="woocommerce-marketing-campaigns-card__campaign-description">

--- a/plugins/woocommerce-admin/client/marketing/overview-multichannel/Campaigns/Campaigns.tsx
+++ b/plugins/woocommerce-admin/client/marketing/overview-multichannel/Campaigns/Campaigns.tsx
@@ -14,12 +14,7 @@ import {
 	FlexBlock,
 } from '@wordpress/components';
 import { Icon, megaphone, cancelCircleFilled } from '@wordpress/icons';
-import {
-	Pagination,
-	Table,
-	TablePlaceholder,
-	Link,
-} from '@woocommerce/components';
+import { Pagination, Table, TablePlaceholder } from '@woocommerce/components';
 
 /**
  * Internal dependencies
@@ -138,12 +133,9 @@ export const Campaigns = () => {
 									<FlexBlock>
 										<Flex direction="column" gap={ 1 }>
 											<FlexItem className="woocommerce-marketing-campaigns-card__campaign-title">
-												<Link
-													type="wp-admin"
-													href={ el.manageUrl }
-												>
+												<a href={ el.manageUrl }>
 													{ el.title }
-												</Link>
+												</a>
 											</FlexItem>
 											{ !! el.description && (
 												<FlexItem className="woocommerce-marketing-campaigns-card__campaign-description">

--- a/plugins/woocommerce/changelog/41182-fix-marketing-campaign-link
+++ b/plugins/woocommerce/changelog/41182-fix-marketing-campaign-link
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix marketing campaign link not navigating to the right page.

--- a/plugins/woocommerce/changelog/41182-fix-marketing-campaign-link
+++ b/plugins/woocommerce/changelog/41182-fix-marketing-campaign-link
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fix
-
-Fix marketing campaign link not navigating to the right page.

--- a/plugins/woocommerce/changelog/fix-marketing-campaign-link
+++ b/plugins/woocommerce/changelog/fix-marketing-campaign-link
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix marketing campaign link not navigating to the right page.

--- a/plugins/woocommerce/changelog/fix-marketing-campaign-link
+++ b/plugins/woocommerce/changelog/fix-marketing-campaign-link
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fix
-
-Fix marketing campaign link not navigating to the right page.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

@triple0t tried to integrate MailPoet with the Marketing page. There is an issue with the links in the Campaigns card. The marketing campaign link is `/wp-admin/admin.php?page=mailpoet-newsletters`. Upon clicking on the link, the browser shows the correct URL, but the page is displaying WooCommerce home page. See screenshot below: 

<img width="1102" alt="image" src="https://github.com/woocommerce/woocommerce/assets/417342/195c25a3-81c1-43c1-aa30-223597a34006">

This issue happens because in the Campaigns card, we are using the `Link` component from the `@woocommerce/components` package, and it has a `type="wc-admin"` by default. For extensions that works with [WooCommerce Admin page](https://developer.woocommerce.com/extension-developer-guide/working-with-woocommerce-admin-pages/) (e.g. Google Listings and Ads), it would work fine, the navigation would happen instantaneously and give a good user experience. However, for other extensions, it would incorrectly display WooCommerce home page.

In this PR, we fix the issue by checking the `manageUrl` with the [`isWCAdmin`](https://github.com/woocommerce/woocommerce/blob/2e9c1d6e6f687449b1dddb6da40ac3026f9d52c3/packages/js/navigation/src/index.js#L309) function and set the `Link`'s `type` property to `"wc-admin"` or `"external"` accordingly.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Note: to test the changes, you may need to use some test data in some marketing channel extensions. The following is an example of how to do that using Google Listings and Ads, and with MailPoet extension installed:

1. Modify the line https://github.com/woocommerce/google-listings-and-ads/blob/72543805c6a24191c33c5cd0177d66b07537b18b/src/MultichannelMarketing/GLAChannel.php#L75 to the following:

```php
		if ( apply_filters( 'woocommerce_gla_enable_mcm', true ) === true ) {
```

2. Modify the `get_campaigns` function in https://github.com/woocommerce/google-listings-and-ads/blob/72543805c6a24191c33c5cd0177d66b07537b18b/src/MultichannelMarketing/GLAChannel.php#L178-L206, so that it returns some sample marketing campaigns from MailPoet and Google Listings and Ads:

```php
	public function get_campaigns(): array {
		return [
			new MarketingCampaign(
				'1',
				$this->campaign_types['google-ads'],
				'MailPoet campaign',
				admin_url( 'admin.php?page=mailpoet-newsletters' ),
				new Price( '100', 'USD' ),
			),
			new MarketingCampaign(
				'2',
				$this->campaign_types['google-ads'],
				'Google Listings and Ads campaign',
				admin_url( 'admin.php?page=wc-admin&path=/google/settings&subpath=/campaigns/edit' ),
				new Price( '200', 'USD' ),
			),
		];
	}
```

Test Steps:

1. Go to the WooCommerce > Marketing page: `/wp-admin/admin.php?page=wc-admin&path=%2Fmarketing`. You should see Campaigns card like below.

<img width="703" alt="image" src="https://github.com/woocommerce/woocommerce/assets/417342/0c3fd352-35a3-4e23-a1ce-2aa76574e537">

2. Click on the "MailPoet campaign" link. You should see a full page navigation to the MailPoet newsletter page.
3. Click on the "Google Listings and Ads campaign" link. You should see instant navigation to Google Listings and Ads page.
    - Note: if you have not completed the setup onboarding flow in Google Listings and Ads, you would see the settings page in Google Listings and Ads.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Fix marketing campaign link not navigating to the right page.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
