### PR TITLE
Fix imported variations count on batched import.

### DIFF
--- a/plugins/woocommerce/changelog/41187-fix-41186
+++ b/plugins/woocommerce/changelog/41187-fix-41186
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Import variations count fails when importing more than 30 products

--- a/plugins/woocommerce/includes/admin/class-wc-admin-importers.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-importers.php
@@ -303,12 +303,13 @@ class WC_Admin_Importers {
 		} else {
 			wp_send_json_success(
 				array(
-					'position'   => $importer->get_file_position(),
-					'percentage' => $percent_complete,
-					'imported'   => count( $results['imported'] ),
-					'failed'     => count( $results['failed'] ),
-					'updated'    => count( $results['updated'] ),
-					'skipped'    => count( $results['skipped'] ),
+					'position'            => $importer->get_file_position(),
+					'percentage'          => $percent_complete,
+					'imported'            => count( $results['imported'] ),
+					'imported_variations' => count( $results['imported_variations'] ),
+					'failed'              => count( $results['failed'] ),
+					'updated'             => count( $results['updated'] ),
+					'skipped'             => count( $results['skipped'] ),
 				)
 			);
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Includes the count of imported variations in all related AJAX responses, not just the final one.

This also prevents the count of imported variations from becoming a `NaN` after trying to add a non-existing value to the existing count.

Closes #41186.

### How to test the changes in this Pull Request:

1. Create a shop A and fill it with at most 29 products, including at least a couple of variations for a variable product.
2. Export the products from the shop A.
3. Create a new empty shop B and import your 29 products. Your import success message should correctly count your imported products (without the variation ones) plus your variations.
4. Add a couple of new products to your original shop A so you have at least 31 products including some variations.
5. Export the products from the shop A again.
6. Create an empty shop C and import your 31 products from the updated shop A. Your import success message should correctly count your products (without the variation ones), and also the right count for imported variations.

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message Import variations count fails when importing more than 30 products

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
