### PR TITLE
Product Editor: Select product name block initially if set to autofocus

### DIFF
--- a/packages/js/product-editor/changelog/fix-select-product-name-block-initially
+++ b/packages/js/product-editor/changelog/fix-select-product-name-block-initially
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Select the product name block initially if set to autofocus.

--- a/packages/js/product-editor/src/blocks/product-fields/name/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/name/edit.tsx
@@ -2,7 +2,12 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { createElement, Fragment, useState } from '@wordpress/element';
+import {
+	createElement,
+	Fragment,
+	useEffect,
+	useState,
+} from '@wordpress/element';
 
 import { useInstanceId } from '@wordpress/compose';
 import { cleanForSlug } from '@wordpress/url';
@@ -38,6 +43,7 @@ import { Label } from '../../../components/label/label';
 
 export function Edit( {
 	attributes,
+	clientId,
 }: ProductEditorBlockEditProps< NameBlockAttributes > ) {
 	const blockProps = useWooBlockProps( attributes );
 
@@ -138,6 +144,15 @@ export function Edit( {
 		BaseControl,
 		'product_name'
 	) as string;
+
+	// Select the block initially if it is set to autofocus.
+	// (this does not get done automatically by focusing the input)
+	const { selectBlock } = useDispatch( 'core/block-editor' );
+	useEffect( () => {
+		if ( attributes.autoFocus ) {
+			selectBlock( clientId );
+		}
+	}, [] );
 
 	return (
 		<>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR selected the product name block initially if it is set to autofocus. This fixes a bug where the block was not selected even though the input control in it was focused.



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Add the following to a `mu-plugin`:

```php
<?php

function YOUR_PREFIX_enqueue_footer_script() {
    wp_enqueue_script(
        'your-prefix-footer',
        plugin_dir_url( __FILE__ ) . 'your-prefix-footer.js',
        [],
        filemtime( dirname( __FILE__ ) . '/your-prefix-footer.js' ),
        true,
    );
}

add_action( 'admin_enqueue_scripts', 'YOUR_PREFIX_enqueue_footer_script' );

```

Add the following to a file in the same folder as the `mu-plugin`:

```js
wp.plugins.registerPlugin( 'your-prefix-footer', {
    scope: 'woocommerce-product-block-editor',
    render: function() {
        const postType = wp.element.useContext( wc.productEditor.PostTypeContext );

        const [ id ] = wp.coreData.useEntityProp( 'postType', postType, 'id' );

        const selectedBlock = wp.data.useSelect( (select) => 
            select( 'core/block-editor' ).getSelectedBlock()
        );

        return wp.element.createElement(
            wp.element.Fragment,
            {},
            wp.element.createElement(
                wc.adminLayout.WooFooterItem,
                {
                    order: 1000,
                },
                wp.element.createElement(
                    'div',
                    {
                        style: {
                            padding: '32px',
                            textAlign: 'center',
                            backgroundColor: 'black',
                            color: 'white',
                        }
                    },
                    wp.element.createElement(
                        'p',
                        {},
                        `Post type: ${ postType }`, 
                    ),
                    wp.element.createElement(
                        'p',
                        {},
                        `Post id: ${ id }`, 
                    ),
                    wp.element.createElement(
                        'p',
                        {},
                        `Selected block: ${ selectedBlock?.name }`, 
                    ),
                )
            ),
        );
    }
} );
```

1. Enable the **Product Editor** under **WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**.
2. Go to **Products** > **Add New**
3. Verify the custom footer says `product` for the post type, shows the post id, and shows the product name block name:

<img width="1095" alt="Screenshot 2023-11-02 at 08 24 41" src="https://github.com/woocommerce/woocommerce/assets/2098816/d996c61b-3852-4f67-a668-31e1ae028c76">

<!-- End testing instructions -->


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
