### PR TITLE
Logging: Add missing script exit after redirect

### DIFF
--- a/plugins/woocommerce/changelog/41201-fix-41197-log-file-bulk-fatal
+++ b/plugins/woocommerce/changelog/41201-fix-41197-log-file-bulk-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent a fatal error that could occur if you submitted the bulk edit form on the Logs list table without selecting any log files first.

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -287,6 +287,7 @@ class PageController {
 
 			if ( ! is_array( $files ) || count( $files ) < 1 ) {
 				wp_safe_redirect( $sendback );
+				exit;
 			}
 
 			switch ( $action ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Prevents a fatal error that could occur if you submitted the bulk edit form on the Logs list table without selecting any log files first.

Fixes #41197

### How to test the changes in this Pull Request:

#### Setup

1. In your test site's wp-config.php file, add this line: `define( 'WC_LOG_HANDLER', 'Automattic\\WooCommerce\\Internal\\Admin\\Logging\\LogHandlerFileV2' );`. This is what allows you to see the new log file views.
2. Install [this plugin](https://gist.github.com/coreymckrill/2968911c8b63c556e7787f2cdc65f966) on your test site for generating test log files. Probably easiest to copy the file into the mu-plugins directory.

#### Test

1. Perform the action shown in the screencast on #41197. With this branch, clicking "Apply" should just refresh the screen without taking any action, and no fatal errors should happen.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message

Prevent a fatal error that could occur if you submitted the bulk edit form on the Logs list table without selecting any log files first.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
