### PR TITLE
Fix CYS UI bugs - Nov 3

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/layout.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/layout.tsx
@@ -145,35 +145,15 @@ export const Layout = () => {
 								</NavigableRegion>
 
 								{ ! isMobileViewport && (
-									<div
-										className={ classnames(
-											'edit-site-layout__canvas-container'
-										) }
-									>
+									<div className="edit-site-layout__canvas-container">
 										{ canvasResizer }
 										{ !! canvasSize.width && (
 											<motion.div
-												whileHover={ {
-													scale: 1.005,
-													transition: {
-														duration: disableMotion
-															? 0
-															: 0.5,
-														ease: 'easeOut',
-													},
-												} }
 												initial={ false }
 												layout="position"
 												className={ classnames(
 													'edit-site-layout__canvas'
 												) }
-												transition={ {
-													type: 'tween',
-													duration: disableMotion
-														? 0
-														: ANIMATION_DURATION,
-													ease: 'easeOut',
-												} }
 											>
 												<ErrorBoundary>
 													<ResizableFrame

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/onboarding-tour/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/onboarding-tour/index.tsx
@@ -158,7 +158,7 @@ export const OnboardingTour = ( {
 									[ key: string ]: unknown;
 								} ) => {
 									if ( placement === 'left' ) {
-										return [ 0, 25 ];
+										return [ 0, 20 ];
 									}
 									return [ 52, 16 ];
 								},

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/onboarding-tour/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/onboarding-tour/index.tsx
@@ -158,7 +158,7 @@ export const OnboardingTour = ( {
 									[ key: string ]: unknown;
 								} ) => {
 									if ( placement === 'left' ) {
-										return [ -15, 35 ];
+										return [ 0, 25 ];
 									}
 									return [ 52, 16 ];
 								},

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/resizable-frame.jsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/resizable-frame.jsx
@@ -244,6 +244,13 @@ function ResizableFrame( {
 				if ( definition === 'fullWidth' )
 					setFrameSize( { width: '100%', height: '100%' } );
 			} }
+			whileHover={ {
+				scale: 1.005,
+				transition: {
+					duration: 0.5,
+					ease: 'easeOut',
+				},
+			} }
 			transition={ frameTransition }
 			size={ frameSize }
 			enable={ {

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/resizable-frame.jsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/resizable-frame.jsx
@@ -189,12 +189,10 @@ function ResizableFrame( {
 		},
 	};
 	const currentResizeHandleVariant = ( () => {
-		if ( isResizing ) {
+		if ( isResizing || isHandleVisibleByDefault ) {
 			return 'active';
 		}
-		return shouldShowHandle || isHandleVisibleByDefault
-			? 'visible'
-			: 'hidden';
+		return shouldShowHandle ? 'visible' : 'hidden';
 	} )();
 
 	const resizeHandler = (

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/color-palette-variations/constants.ts
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/color-palette-variations/constants.ts
@@ -1187,6 +1187,13 @@ export const COLOR_PALETTES = [
 							text: 'var(--wp--preset--color--background)',
 						},
 					},
+					':visited': {
+						color: {
+							text: color.styles.elements?.button
+								? color.styles.elements.button.color
+								: 'var(--wp--preset--color--background)',
+						},
+					},
 					color: {
 						background: 'var(--wp--preset--color--primary)',
 						text: 'var(--wp--preset--color--background)',

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/color-panel.jsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/global-styles/color-panel.jsx
@@ -26,8 +26,17 @@ export const ColorPanel = () => {
 	const [ rawSettings ] = useGlobalSetting( '' );
 	const settings = useSettingsForBlockElement( rawSettings );
 
-	const onChange = ( ...props ) => {
-		setStyle( ...props );
+	const onChange = ( _style ) => {
+		setStyle( {
+			..._style,
+			blocks: {
+				..._style.blocks,
+				// Reset the "core/button" color that may have been set via predefined color palette to ensure it uses the custom button color.
+				'core/button': {
+					color: {},
+				},
+			},
+		} );
 		setUserConfig( ( currentConfig ) => ( {
 			...currentConfig,
 			settings: mergeBaseAndUserConfigs( currentConfig.settings, {

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-color-palette.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen-color-palette.tsx
@@ -4,10 +4,14 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { createInterpolateElement } from '@wordpress/element';
+import { createInterpolateElement, useContext } from '@wordpress/element';
 import { Link } from '@woocommerce/components';
 import { PanelBody } from '@wordpress/components';
 import { recordEvent } from '@woocommerce/tracks';
+// @ts-ignore No types for this exist yet.
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+// @ts-ignore No types for this exist yet.
+import { unlock } from '@wordpress/edit-site/build-module/lock-unlock';
 
 /**
  * Internal dependencies
@@ -16,7 +20,14 @@ import { SidebarNavigationScreen } from './sidebar-navigation-screen';
 import { ADMIN_URL } from '~/utils/admin-settings';
 import { ColorPalette, ColorPanel } from './global-styles';
 
+const { GlobalStylesContext } = unlock( blockEditorPrivateApis );
+
 const SidebarNavigationScreenColorPaletteContent = () => {
+	// @ts-ignore No types for this exist yet.
+	const { user } = useContext( GlobalStylesContext );
+	const hasCreatedOwnColors = !! (
+		user.settings.color && user.settings.color.palette.hasCreatedOwnColors
+	);
 	// Wrap in a BlockEditorProvider to ensure that the Iframe's dependencies are
 	// loaded. This is necessary because the Iframe component waits until
 	// the block editor store's `__internalIsInitialized` is true before
@@ -34,7 +45,7 @@ const SidebarNavigationScreenColorPaletteContent = () => {
 			<PanelBody
 				className="woocommerce-customize-store__color-panel-container"
 				title={ __( 'or create your own', 'woocommerce' ) }
-				initialOpen={ false }
+				initialOpen={ hasCreatedOwnColors }
 			>
 				<ColorPanel />
 			</PanelBody>

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/style.scss
@@ -415,6 +415,11 @@
 				color: $gray-900;
 			}
 		}
+
+		.color-block-support-panel {
+			border-top: 0;
+			padding: 0;
+		}
 	}
 
 	.woocommerce-customize-store_color-palette-container {

--- a/plugins/woocommerce/changelog/fix-cys-ui-nov-3
+++ b/plugins/woocommerce/changelog/fix-cys-ui-nov-3
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix cys ui issues


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes the following CYS UI bugs reported from the Internal Call for Testing.

1. Some zooming in/out while moving mouse over to the left sidebar p6q8Tx-3Je-p2#comment-8368
2. Button’s background doesn't change p6q8Tx-3Je-p2#comment-8370
3. Fix the resizer handler bar style and position Mrk6SERPZ4KrFHSjM0a8TK-fi-7334%3A132539
4. https://github.com/woocommerce/woocommerce/issues/41207

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


1. Create a new WooCommerce installation with this version.
2. Make sure to enable `customize-store` feature flag
3. Go to `/wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store%2Fassembler-hub`
5. Take the onboarding tour
6. Confirm the handler doesn't have transparency applied and the tour step card is close to it. (see figma: Mrk6SERPZ4KrFHSjM0a8TK-fi-7334%3A132564)
7. Close tour
8.  Move the mouse over to the left sidebar
9. Confirm the preview frame is not zooming in/out
10. Select a homepage pattern if you haven't.
11. Go to `Change the color palette`
12. Select a color palette
13. Click on `OR CREATE YOUR OWN`
14. Change the button background color
15. Button background color in preview frame should be changed accordingly
16. Reload the page
17. Observe that "create your own" color panel is expanded by default

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>