### PR TITLE
Make the `useCampaigns` hook support being used with multiple instances

### DIFF
--- a/plugins/woocommerce-admin/client/marketing/data-multichannel/reducer.ts
+++ b/plugins/woocommerce-admin/client/marketing/data-multichannel/reducer.ts
@@ -21,9 +21,7 @@ const initialState = {
 		error: undefined,
 	},
 	campaigns: {
-		perPage: undefined,
-		pages: undefined,
-		total: undefined,
+		pages: {},
 	},
 	campaignTypes: {
 		data: undefined,
@@ -66,21 +64,23 @@ export const reducer: Reducer< State, Action > = (
 			};
 
 		case TYPES.RECEIVE_CAMPAIGNS:
+			const { meta } = action;
+			const key = `${ meta.page }-${ meta.perPage }`;
+
 			return {
 				...state,
 				campaigns: {
-					perPage: action.meta.perPage,
 					pages: {
 						...state.campaigns.pages,
-						[ action.meta.page ]: action.error
+						[ key ]: action.error
 							? {
 									error: action.payload,
 							  }
 							: {
 									data: action.payload,
+									total: meta.total,
 							  },
 					},
-					total: action.meta.total,
 				},
 			};
 

--- a/plugins/woocommerce-admin/client/marketing/data-multichannel/reducer.ts
+++ b/plugins/woocommerce-admin/client/marketing/data-multichannel/reducer.ts
@@ -22,6 +22,9 @@ const initialState = {
 	},
 	campaigns: {
 		pages: {},
+		meta: {
+			total: undefined,
+		},
 	},
 	campaignTypes: {
 		data: undefined,
@@ -78,8 +81,10 @@ export const reducer: Reducer< State, Action > = (
 							  }
 							: {
 									data: action.payload,
-									total: meta.total,
 							  },
+					},
+					meta: {
+						total: meta.total,
 					},
 				},
 			};

--- a/plugins/woocommerce-admin/client/marketing/data-multichannel/selectors.ts
+++ b/plugins/woocommerce-admin/client/marketing/data-multichannel/selectors.ts
@@ -13,9 +13,14 @@ export const getRecommendedChannels = ( state: State ) => {
 
 /**
  * Get campaigns from state.
+ *
+ * @param state   State passed in from the data store.
+ * @param page    Page number. First page is `1`.
+ * @param perPage Page size, i.e. number of records in one page.
  */
-export const getCampaigns = ( state: State ) => {
-	return state.campaigns;
+export const getCampaigns = ( state: State, page: number, perPage: number ) => {
+	const key = `${ page }-${ perPage }`;
+	return state.campaigns.pages[ key ] || null;
 };
 
 export const getCampaignTypes = ( state: State ) => {

--- a/plugins/woocommerce-admin/client/marketing/data-multichannel/selectors.ts
+++ b/plugins/woocommerce-admin/client/marketing/data-multichannel/selectors.ts
@@ -20,16 +20,10 @@ export const getRecommendedChannels = ( state: State ) => {
  */
 export const getCampaigns = ( state: State, page: number, perPage: number ) => {
 	const key = `${ page }-${ perPage }`;
-	return state.campaigns.pages[ key ] || null;
-};
-
-/**
- * Get the meta of campaigns from state.
- *
- * @param state State passed in from the data store.
- */
-export const getCampaignsMeta = ( state: State ) => {
-	return state.campaigns.meta;
+	return {
+		campaignsPage: state.campaigns.pages[ key ] || null,
+		meta: state.campaigns.meta,
+	};
 };
 
 export const getCampaignTypes = ( state: State ) => {

--- a/plugins/woocommerce-admin/client/marketing/data-multichannel/selectors.ts
+++ b/plugins/woocommerce-admin/client/marketing/data-multichannel/selectors.ts
@@ -23,6 +23,15 @@ export const getCampaigns = ( state: State, page: number, perPage: number ) => {
 	return state.campaigns.pages[ key ] || null;
 };
 
+/**
+ * Get the meta of campaigns from state.
+ *
+ * @param state State passed in from the data store.
+ */
+export const getCampaignsMeta = ( state: State ) => {
+	return state.campaigns.meta;
+};
+
 export const getCampaignTypes = ( state: State ) => {
 	return state.campaignTypes;
 };

--- a/plugins/woocommerce-admin/client/marketing/data-multichannel/types.ts
+++ b/plugins/woocommerce-admin/client/marketing/data-multichannel/types.ts
@@ -63,13 +63,12 @@ export type Campaign = {
 
 export type CampaignsPage = {
 	data?: Array< Campaign >;
+	total?: number;
 	error?: ApiFetchError;
 };
 
 export type CampaignsState = {
-	perPage?: number;
-	pages?: Record< number, CampaignsPage >;
-	total?: number;
+	pages: Record< string, CampaignsPage >;
 };
 
 export type CampaignType = {

--- a/plugins/woocommerce-admin/client/marketing/data-multichannel/types.ts
+++ b/plugins/woocommerce-admin/client/marketing/data-multichannel/types.ts
@@ -75,6 +75,11 @@ export type CampaignsState = {
 	meta: CampaignsMeta;
 };
 
+export type CampaignsPagination = {
+	campaignsPage: CampaignsPage | null;
+	meta: CampaignsMeta;
+};
+
 export type CampaignType = {
 	id: string;
 	name: string;

--- a/plugins/woocommerce-admin/client/marketing/data-multichannel/types.ts
+++ b/plugins/woocommerce-admin/client/marketing/data-multichannel/types.ts
@@ -63,12 +63,16 @@ export type Campaign = {
 
 export type CampaignsPage = {
 	data?: Array< Campaign >;
-	total?: number;
 	error?: ApiFetchError;
+};
+
+export type CampaignsMeta = {
+	total?: number;
 };
 
 export type CampaignsState = {
 	pages: Record< string, CampaignsPage >;
+	meta: CampaignsMeta;
 };
 
 export type CampaignType = {

--- a/plugins/woocommerce-admin/client/marketing/hooks/test/useCampaigns.test.ts
+++ b/plugins/woocommerce-admin/client/marketing/hooks/test/useCampaigns.test.ts
@@ -1,0 +1,230 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react-hooks/dom';
+import { waitFor } from '@testing-library/react';
+import { dispatch } from '@wordpress/data';
+import 'whatwg-fetch'; /* eslint-disable-line import/no-unresolved */ /* To make sure Response is available */
+
+/**
+ * Internal dependencies
+ */
+import { useCampaigns } from '../useCampaigns';
+import { useRegisteredChannels } from '../useRegisteredChannels';
+import { STORE_KEY } from '../../data-multichannel/constants';
+import { RegisteredChannel } from '../../types';
+import { Campaign as APICampaign } from '../../data-multichannel/types';
+import '../../data-multichannel'; // To ensure the store is registered
+
+type Channel = Pick< RegisteredChannel, 'slug' | 'title' | 'icon' >;
+
+jest.mock( '@wordpress/api-fetch', () =>
+	jest.fn( ( { path } ) => {
+		const total = 9;
+
+		const params = new URLSearchParams( path.replace( /^[^?]*/, '' ) );
+		const page = Number( params.get( 'page' ) );
+		const perPage = Number( params.get( 'per_page' ) );
+
+		if ( ! Number.isInteger( page ) || ! Number.isInteger( perPage ) ) {
+			return Promise.reject(
+				new Response( '{"message": "invalid query"}', { status: 400 } )
+			);
+		}
+
+		const length = Math.min( perPage, total - ( page - 1 ) * perPage );
+
+		const campaigns: Array< APICampaign > = Array.from( { length } ).map(
+			( _, index ) => {
+				const id = `${ page }_${ index + 1 }`;
+				return {
+					id,
+					channel: 'extension-foo',
+					title: `Campaign ${ id }`,
+					manage_url: `https://test/extension-foo?path=setup&id=${ id }`,
+					cost: {
+						value: ( ( page * perPage + index ) * 0.25 ).toString(),
+						currency: 'USD',
+					},
+				};
+			}
+		);
+
+		// For testing fallbacks when data fields are not available
+		if ( campaigns[ 2 ] ) {
+			campaigns[ 2 ].channel = 'intentional-mismatch-channel';
+			campaigns[ 2 ].cost = null;
+		}
+
+		return Promise.resolve(
+			new Response( JSON.stringify( campaigns ), {
+				headers: new Headers( { 'x-wp-total': total.toString() } ),
+			} )
+		);
+	} )
+);
+
+jest.mock( '../useRegisteredChannels', () => ( {
+	useRegisteredChannels: jest.fn(),
+} ) );
+
+function mockRegisteredChannels( ...channels: Array< Channel > ) {
+	(
+		useRegisteredChannels as jest.MockedFunction<
+			typeof useRegisteredChannels
+		>
+	 ).mockReturnValue( {
+		loading: false,
+		data: channels.map( ( channel ) => ( {
+			...channel,
+			// The following is not relevant to this test scope
+			description: '',
+			isSetupCompleted: true,
+			setupUrl: '',
+			manageUrl: '',
+			syncStatus: 'synced',
+			issueType: 'none',
+			issueText: '',
+		} ) ),
+		refetch: () => {},
+	} );
+}
+
+describe( 'useCampaigns', () => {
+	beforeEach( () => {
+		dispatch( STORE_KEY ).invalidateResolutionForStoreSelector(
+			'getCampaigns'
+		);
+
+		mockRegisteredChannels( {
+			slug: 'extension-foo',
+			title: 'Extension Foo',
+			icon: 'https://test/foo.png',
+		} );
+	} );
+
+	it( 'should return correct data', async () => {
+		const { result } = renderHook( () => useCampaigns() );
+
+		await waitFor( () => expect( result.current.loading ).toBe( false ) );
+		expect( result.current.error ).toBeUndefined();
+
+		// Campaign matched with a channel
+		expect( result.current.data?.[ 0 ] ).toEqual( {
+			id: 'extension-foo|1_1',
+			title: 'Campaign 1_1',
+			description: '',
+			cost: 'USD 1.25',
+			manageUrl: 'https://test/extension-foo?path=setup&id=1_1',
+			icon: 'https://test/foo.png',
+			channelName: 'Extension Foo',
+			channelSlug: 'extension-foo',
+		} );
+
+		// Campaign didn't match any channel
+		expect( result.current.data?.[ 2 ] ).toEqual( {
+			id: 'intentional-mismatch-channel|1_3',
+			title: 'Campaign 1_3',
+			description: '',
+			cost: '',
+			manageUrl: 'https://test/extension-foo?path=setup&id=1_3',
+			icon: '',
+			channelName: '',
+			channelSlug: 'intentional-mismatch-channel',
+		} );
+	} );
+
+	it( 'should handle error', async () => {
+		const { result } = renderHook( () => useCampaigns( 1.5 ) );
+
+		await waitFor( () => expect( result.current.loading ).toBe( false ) );
+		expect( result.current.data ).toBeUndefined();
+		expect( result.current.error ).toEqual( { message: 'invalid query' } );
+	} );
+
+	it( 'should handle pagination according to the page and perPage arguments', async () => {
+		// Initial page
+		const { result, rerender } = renderHook<
+			{ page: number; perPage: number },
+			ReturnType< typeof useCampaigns >
+		>( ( { page, perPage } ) => useCampaigns( page, perPage ), {
+			initialProps: { page: 1, perPage: 5 },
+		} );
+
+		await waitFor( () => expect( result.current.loading ).toBe( false ) );
+		expect( result.current.meta ).toEqual( { total: 9 } );
+		expect( result.current.data ).toHaveLength( 5 );
+		expect( result.current.data?.[ 0 ].id ).toEqual( 'extension-foo|1_1' );
+		expect( result.current.data?.[ 4 ].id ).toEqual( 'extension-foo|1_5' );
+
+		// Change page
+		rerender( { page: 2, perPage: 5 } );
+
+		await waitFor( () => expect( result.current.loading ).toBe( false ) );
+		expect( result.current.data ).toHaveLength( 4 );
+		expect( result.current.data?.[ 0 ].id ).toEqual( 'extension-foo|2_1' );
+		expect( result.current.data?.[ 1 ].id ).toEqual( 'extension-foo|2_2' );
+
+		// Change page to a page that doesn't exist
+		rerender( { page: 3, perPage: 5 } );
+
+		await waitFor( () => expect( result.current.loading ).toBe( false ) );
+		expect( result.current.data ).toEqual( [] );
+
+		// Change perPage
+		rerender( { page: 3, perPage: 4 } );
+
+		await waitFor( () => expect( result.current.loading ).toBe( false ) );
+		expect( result.current.meta ).toEqual( { total: 9 } );
+		expect( result.current.data ).toHaveLength( 1 );
+		expect( result.current.data?.[ 0 ].id ).toEqual( 'extension-foo|3_1' );
+	} );
+
+	it( 'should update data accordingly once the registered channels are updated', async () => {
+		const { result, rerender } = renderHook( () => useCampaigns() );
+
+		await waitFor( () => expect( result.current.loading ).toBe( false ) );
+		expect( result.current.data?.[ 0 ] ).toMatchObject( {
+			id: 'extension-foo|1_1',
+			channelName: 'Extension Foo',
+			icon: 'https://test/foo.png',
+		} );
+
+		// Update registered channels
+		mockRegisteredChannels( {
+			slug: 'extension-foo',
+			title: 'Extension Bar',
+			icon: 'https://test/bar.png',
+		} );
+
+		rerender();
+
+		expect( result.current.data?.[ 0 ] ).toMatchObject( {
+			id: 'extension-foo|1_1',
+			channelName: 'Extension Bar',
+			icon: 'https://test/bar.png',
+		} );
+	} );
+
+	it( 'should be able to use different arguments for different instances at the same time', async () => {
+		const { result: resultA } = renderHook( () => useCampaigns( 1, 2 ) );
+		const { result: resultB } = renderHook( () => useCampaigns( 2, 2 ) );
+		const { result: resultC } = renderHook( () => useCampaigns( 2, 4 ) );
+
+		await waitFor( () => expect( resultA.current.loading ).toBe( false ) );
+		await waitFor( () => expect( resultB.current.loading ).toBe( false ) );
+		await waitFor( () => expect( resultC.current.loading ).toBe( false ) );
+
+		expect( resultA.current.data ).toHaveLength( 2 );
+		expect( resultA.current.data?.[ 0 ].id ).toEqual( 'extension-foo|1_1' );
+		expect( resultA.current.data?.[ 1 ].id ).toEqual( 'extension-foo|1_2' );
+
+		expect( resultB.current.data ).toHaveLength( 2 );
+		expect( resultB.current.data?.[ 0 ].id ).toEqual( 'extension-foo|2_1' );
+		expect( resultB.current.data?.[ 1 ].id ).toEqual( 'extension-foo|2_2' );
+
+		expect( resultC.current.data ).toHaveLength( 4 );
+		expect( resultC.current.data?.[ 0 ].id ).toEqual( 'extension-foo|2_1' );
+		expect( resultC.current.data?.[ 3 ].id ).toEqual( 'extension-foo|2_4' );
+	} );
+} );

--- a/plugins/woocommerce-admin/client/marketing/hooks/useCampaigns.ts
+++ b/plugins/woocommerce-admin/client/marketing/hooks/useCampaigns.ts
@@ -81,6 +81,6 @@ export const useCampaigns = ( page = 1, perPage = 5 ): UseCampaignsType => {
 				},
 			};
 		},
-		[ page, perPage ]
+		[ page, perPage, channels ]
 	);
 };

--- a/plugins/woocommerce-admin/client/marketing/hooks/useCampaigns.ts
+++ b/plugins/woocommerce-admin/client/marketing/hooks/useCampaigns.ts
@@ -9,7 +9,7 @@ import { useSelect } from '@wordpress/data';
 import { Campaign } from '~/marketing/types';
 import { STORE_KEY } from '~/marketing/data-multichannel/constants';
 import {
-	CampaignsState,
+	CampaignsPage,
 	Campaign as APICampaign,
 	ApiFetchError,
 } from '~/marketing/data-multichannel/types';
@@ -36,7 +36,7 @@ export const useCampaigns = ( page = 1, perPage = 5 ): UseCampaignsType => {
 	return useSelect(
 		( select ) => {
 			const { hasFinishedResolution, getCampaigns } = select( STORE_KEY );
-			const campaignsState = getCampaigns< CampaignsState >(
+			const campaignsPage = getCampaigns< CampaignsPage | null >(
 				page,
 				perPage
 			);
@@ -62,22 +62,15 @@ export const useCampaigns = ( page = 1, perPage = 5 ): UseCampaignsType => {
 				};
 			};
 
-			const error =
-				campaignsState.pages && campaignsState.pages[ page ]?.error;
-
-			const data =
-				campaignsState.pages &&
-				campaignsState.pages[ page ]?.data?.map( convert );
-
 			return {
 				loading: ! hasFinishedResolution( 'getCampaigns', [
 					page,
 					perPage,
 				] ),
-				data,
-				error,
+				data: campaignsPage?.data?.map( convert ),
+				error: campaignsPage?.error,
 				meta: {
-					total: campaignsState.total,
+					total: campaignsPage?.total,
 				},
 			};
 		},

--- a/plugins/woocommerce-admin/client/marketing/hooks/useCampaigns.ts
+++ b/plugins/woocommerce-admin/client/marketing/hooks/useCampaigns.ts
@@ -9,8 +9,7 @@ import { useSelect } from '@wordpress/data';
 import { Campaign } from '~/marketing/types';
 import { STORE_KEY } from '~/marketing/data-multichannel/constants';
 import {
-	CampaignsPage,
-	CampaignsMeta,
+	CampaignsPagination,
 	Campaign as APICampaign,
 	ApiFetchError,
 } from '~/marketing/data-multichannel/types';
@@ -36,10 +35,8 @@ export const useCampaigns = ( page = 1, perPage = 5 ): UseCampaignsType => {
 
 	return useSelect(
 		( select ) => {
-			const { hasFinishedResolution, getCampaigns, getCampaignsMeta } =
-				select( STORE_KEY );
-			const meta = getCampaignsMeta< CampaignsMeta >();
-			const campaignsPage = getCampaigns< CampaignsPage | null >(
+			const { hasFinishedResolution, getCampaigns } = select( STORE_KEY );
+			const { campaignsPage, meta } = getCampaigns< CampaignsPagination >(
 				page,
 				perPage
 			);
@@ -65,8 +62,6 @@ export const useCampaigns = ( page = 1, perPage = 5 ): UseCampaignsType => {
 				};
 			};
 
-			// The `loading` value only considers 'getCampaigns' as the data of 'getCampaignsMeta'
-			// is resolved along with 'getCampaigns' within the data store.
 			return {
 				loading: ! hasFinishedResolution( 'getCampaigns', [
 					page,

--- a/plugins/woocommerce-admin/client/marketing/hooks/useCampaigns.ts
+++ b/plugins/woocommerce-admin/client/marketing/hooks/useCampaigns.ts
@@ -10,6 +10,7 @@ import { Campaign } from '~/marketing/types';
 import { STORE_KEY } from '~/marketing/data-multichannel/constants';
 import {
 	CampaignsPage,
+	CampaignsMeta,
 	Campaign as APICampaign,
 	ApiFetchError,
 } from '~/marketing/data-multichannel/types';
@@ -35,7 +36,9 @@ export const useCampaigns = ( page = 1, perPage = 5 ): UseCampaignsType => {
 
 	return useSelect(
 		( select ) => {
-			const { hasFinishedResolution, getCampaigns } = select( STORE_KEY );
+			const { hasFinishedResolution, getCampaigns, getCampaignsMeta } =
+				select( STORE_KEY );
+			const meta = getCampaignsMeta< CampaignsMeta >();
 			const campaignsPage = getCampaigns< CampaignsPage | null >(
 				page,
 				perPage
@@ -62,6 +65,8 @@ export const useCampaigns = ( page = 1, perPage = 5 ): UseCampaignsType => {
 				};
 			};
 
+			// The `loading` value only considers 'getCampaigns' as the data of 'getCampaignsMeta'
+			// is resolved along with 'getCampaigns' within the data store.
 			return {
 				loading: ! hasFinishedResolution( 'getCampaigns', [
 					page,
@@ -69,9 +74,7 @@ export const useCampaigns = ( page = 1, perPage = 5 ): UseCampaignsType => {
 				] ),
 				data: campaignsPage?.data?.map( convert ),
 				error: campaignsPage?.error,
-				meta: {
-					total: campaignsPage?.total,
-				},
+				meta,
 			};
 		},
 		[ page, perPage, channels ]

--- a/plugins/woocommerce/changelog/tweak-37177-use-campaigns-hook-multiple-instances
+++ b/plugins/woocommerce/changelog/tweak-37177-use-campaigns-hook-multiple-instances
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Make the `useCampaigns` hook support being used with multiple instances.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #37177 

 This PR makes the `useCampaigns` hook support being used with multiple instances.

- Include the `perPage` in the page key of campaigns in the multichannel's data store.
- Move the processing of querying the campaigns paging to the selector of the multichannel's data store.
- ~Move `total` in each campaign's paging of the multichannel's data store.~ Move the `total` from `campaigns.pages[*]` to `campaigns.meta`.
- Remove unused properties and their types: `state.campaigns.perPage` and `state.campaigns.total`

💡 Currently, the `useCampaigns` hook has only one use instance, so the problems in issue #37177 don't exist. Therefore, the **Campaigns** card on the Marketing > Overview page should work as well as before.

💡 This PR is based on #41180 to include the relevant code changes.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

#### 📌 By test cases

1. View the `useCampaigns.test.ts` file to determine if it fulfills the test purpose
2. Run `cd plugins/woocommerce-admin`
3. Run `git checkout b1b8539a6b78ad4353a03ab9a6092161034ec824` and `npm run turbo:test -- useCampaigns`
   - Check if the added tests can catch the two problems in [#37177](https://github.com/woocommerce/woocommerce/issues/37177)
   - These last two should be failed:
      ![image](https://github.com/woocommerce/woocommerce/assets/17420811/38e2eb28-cff9-4fde-89ce-ec3a7cdedd61)
4. Run `git checkout e2651bf3b921995bd08caa3297eb9642c9a94fbf` and `npm run turbo:test -- useCampaigns`
   - Check if the "**should update data accordingly once the registered channels are updated**" case is turned to pass
   - The last one should be still failed
5. Run `git checkout tweak/37177-use-campaigns-hook-multiple-instances` and `npm run turbo:test -- useCampaigns`
   - Check if the "**should be able to use different arguments for different instances at the same time**" case is turned to pass
   - All test cases should pass as well
      ![image](https://github.com/woocommerce/woocommerce/assets/17420811/b7949fd3-566d-49a9-88dd-0af58ff0e61d)

#### 📌 By web page

1. Install [Google Listings & Ads](https://github.com/woocommerce/google-listings-and-ads) and finish the extension onboarding and ads onboarding
2. Modify the line of [GLAChannel.php#L75](https://github.com/woocommerce/google-listings-and-ads/blob/72543805c6a24191c33c5cd0177d66b07537b18b/src/MultichannelMarketing/GLAChannel.php#L75) to the following:
   ```php
   if ( apply_filters( 'woocommerce_gla_enable_mcm', true ) === true ) {
   ```
3. If the number of campaigns is less than 6, modify the `get_campaigns` function in [GLAChannel.php#L178-L206](https://github.com/woocommerce/google-listings-and-ads/blob/72543805c6a24191c33c5cd0177d66b07537b18b/src/MultichannelMarketing/GLAChannel.php#L178-L206), so that it returns some sample marketing campaigns:
   ```php
   public function get_campaigns(): array {
   	return [
   		new MarketingCampaign(
   			'1',
   			$this->campaign_types['google-ads'],
   			'Campaign 1',
   			admin_url( 'admin.php?page=wc-admin&path=/google/settings&subpath=/campaigns/edit' ),
   			new Price( '19.99', 'USD' ),
   		),
   		new MarketingCampaign(
   			'2',
   			$this->campaign_types['google-ads'],
   			'Campaign 2',
   			admin_url( 'admin.php?page=wc-admin&path=/google/settings&subpath=/campaigns/edit' ),
   			new Price( '20', 'USD' ),
   		),
   		new MarketingCampaign(
   			'3',
   			$this->campaign_types['google-ads'],
   			'Campaign 3',
   			admin_url( 'admin.php?page=wc-admin&path=/google/settings&subpath=/campaigns/edit' ),
   			new Price( '30', 'USD' ),
   		),
   		new MarketingCampaign(
   			'4',
   			$this->campaign_types['google-ads'],
   			'Campaign 4',
   			admin_url( 'admin.php?page=wc-admin&path=/google/settings&subpath=/campaigns/edit' ),
   			new Price( '400', 'USD' ),
   		),
   		new MarketingCampaign(
   			'5',
   			$this->campaign_types['google-ads'],
   			'Campaign 5',
   			admin_url( 'admin.php?page=wc-admin&path=/google/settings&subpath=/campaigns/edit' ),
   			new Price( '5,000', 'USD' ),
   		),
   		new MarketingCampaign(
   			'6',
   			$this->campaign_types['google-ads'],
   			'Campaign 6',
   			admin_url( 'admin.php?page=wc-admin&path=/google/settings&subpath=/campaigns/edit' ),
   			new Price( '6,888.5', 'USD' ),
   		),
   	];
   }
   ```
4. Go to the Marketing > Overview admin page
5. View if the **Campaigns** card works as well as before

https://github.com/woocommerce/woocommerce/assets/17420811/0ce7b90e-3b3a-4190-ae9c-63af6533bbff

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
