### PR TITLE
Fix CYS initial pattern population bug

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/services.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/services.ts
@@ -260,6 +260,12 @@ const updateGlobalStyles = async ( {
 		( pairing ) => pairing.title === fontPairingName
 	);
 
+	// @ts-ignore No types for this exist yet.
+	const { invalidateResolutionForStoreSelector } = dispatch( coreStore );
+	invalidateResolutionForStoreSelector(
+		'__experimentalGetCurrentGlobalStylesId'
+	);
+
 	const globalStylesId = await resolveSelect(
 		coreStore
 		// @ts-ignore No types for this exist yet.
@@ -299,6 +305,7 @@ const updateTemplate = async ( {
 
 	// Ensure that the patterns are up to date because we populate images and content in previous step.
 	invalidateResolutionForStoreSelector( 'getBlockPatterns' );
+	invalidateResolutionForStoreSelector( '__experimentalGetTemplateForLink' );
 
 	const patterns = ( await resolveSelect(
 		coreStore
@@ -349,7 +356,6 @@ export const assembleSite = async (
 		} );
 		recordEvent( 'customize_your_store_ai_update_global_styles_success' );
 	} catch ( error ) {
-		// TODO handle error
 		// eslint-disable-next-line no-console
 		console.error( error );
 		recordEvent(
@@ -358,6 +364,7 @@ export const assembleSite = async (
 				error: error instanceof Error ? error.message : 'unknown',
 			}
 		);
+		throw error;
 	}
 
 	try {
@@ -368,12 +375,12 @@ export const assembleSite = async (
 		} );
 		recordEvent( 'customize_your_store_ai_update_template_success' );
 	} catch ( error ) {
-		// TODO handle error
 		// eslint-disable-next-line no-console
 		console.error( error );
 		recordEvent( 'customize_your_store_ai_update_template_response_error', {
 			error: error instanceof Error ? error.message : 'unknown',
 		} );
+		throw error;
 	}
 };
 

--- a/plugins/woocommerce/changelog/fix-cys-initial-pattern-population
+++ b/plugins/woocommerce/changelog/fix-cys-initial-pattern-population
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix CYS initial pattern population bug


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #41229.

The bug is due to that we used some selectors on the intro page but we didn't invalidate them after the theme switch from Tsubaki to TT3 during the loading screen. This PR fixes the bug by calling `invalidateResolutionForStoreSelector` and also makes a change to throw the error which will bring the user back to the previous step so that we can notice the error earlier.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Creating a Woo Express Site for Testing CYS - pdibGW-2pG-p2
2. Switch to this branch p1698814143748519/1698803237.183139-slack-C01SFMVEYAK
3. Make sure you're using the default theme (`Tsubaki`) if you use an old Woo X site.
4. Go to `WooCommerce -> Home` and click `Customize Store` task
5. Open dev tool > network tab
6. Click `Design with AI` button
7. Follow through the flow all the way till the loading screen shows up
8. Confirm the preview frame shows the home template correctly (NOT default TT3 page).
9. Repeat steps 4-6 but block the `/wp-json/wp/v2/templates/` request using a browser tool
10. Confirm You're redirected to the `Which writing style do you prefer?` screen. 

![Screenshot 2023-11-06 at 14 38 48](https://github.com/woocommerce/woocommerce/assets/4344253/24b3baff-08ed-46a0-8cfe-6f893bc31363)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>