### PR TITLE
[CYS] Fix frame overlap sidebar

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/resizable-frame.jsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/resizable-frame.jsx
@@ -271,7 +271,7 @@ function ResizableFrame( {
 				right: HANDLE_STYLES_OVERRIDE,
 			} }
 			minWidth={ FRAME_MIN_WIDTH }
-			maxWidth={ isFullWidth ? '100%' : '150%' }
+			maxWidth={ '100%' }
 			maxHeight={ '100%' }
 			onFocus={ () => setShouldShowHandle( true ) }
 			onBlur={ () => setShouldShowHandle( false ) }

--- a/plugins/woocommerce/changelog/fix-cys-frame-overlay-sidebar
+++ b/plugins/woocommerce/changelog/fix-cys-frame-overlay-sidebar
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Fix cys frame overlay the sidebar
+Fix cys frame overlap the sidebar

--- a/plugins/woocommerce/changelog/fix-cys-frame-overlay-sidebar
+++ b/plugins/woocommerce/changelog/fix-cys-frame-overlay-sidebar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix cys frame overlay the sidebar


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #41206.


https://github.com/woocommerce/woocommerce/assets/4344253/ab137347-aeb9-4f1e-9f17-1d766c45fa35

Set resizable-frame max-width to `100%` to fix frame overlap sidebar

<!-- Begin te

sting instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new WooCommerce installation with this version.
2. Make sure to enable `customize-store` feature flag
3. Go to `/wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store%2Fassembler-hub`
4. Drag the resize handler and confirm you can't pull it to overlap the sidebar.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
