### PR TITLE
Add animation for variable product tour and tweak logic

### DIFF
--- a/packages/js/product-editor/changelog/tweak-variation-tour
+++ b/packages/js/product-editor/changelog/tweak-variation-tour
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Improve Variable product editor tour

--- a/packages/js/product-editor/src/blocks/product-fields/variation-items/editor.scss
+++ b/packages/js/product-editor/src/blocks/product-fields/variation-items/editor.scss
@@ -4,13 +4,24 @@
 	}
 }
 
+@keyframes fade-in {
+	0% {
+		opacity: 0;
+	}
+	100% {
+		opacity: 1;
+	}
+}
+
 .variation-items-product-tour {
 	.tour-kit-spotlight {
 		border-radius: $gap-smaller;
 		padding: $gap-large;
+		animation: fade-in 0.6s;
 	}
 	.tour-kit-frame__container,
 	.woocommerce-tour-kit-step {
 		border-radius: $gap-smaller;
+		animation: fade-in 0.6s;
 	}
 }

--- a/packages/js/product-editor/src/blocks/product-fields/variation-items/variable-product-tour.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/variation-items/variable-product-tour.tsx
@@ -12,6 +12,7 @@ import { __ } from '@wordpress/i18n';
 import { TourKit, TourKitTypes } from '@woocommerce/components';
 import {
 	EXPERIMENTAL_PRODUCT_VARIATIONS_STORE_NAME,
+	OPTIONS_STORE_NAME,
 	useUserPreferences,
 } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
@@ -139,7 +140,19 @@ export const VariableProductTour: React.FC = () => {
 		}
 	}, [ totalCount ] );
 
-	if ( hasShownTour === 'yes' || ! isTourOpen ) {
+	const { hasShownProductEditorTour } = useSelect( ( select ) => {
+		const { getOption } = select( OPTIONS_STORE_NAME );
+		return {
+			hasShownProductEditorTour:
+				getOption( 'woocommerce_block_product_tour_shown' ) === 'yes',
+		};
+	} );
+
+	if (
+		hasShownTour === 'yes' ||
+		! isTourOpen ||
+		! hasShownProductEditorTour
+	) {
 		return null;
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This adds a CSS animation to the variable product tour and avoid showing it when the product editor tour is open.

Closes #40306 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Delete the entry with 'meta_key' === 'woocommerce_admin_variable_product_block_tour_shown' in the wp_usermeta table
2. Using WCA Test Helper, delete the option 'woocommerce_block_product_tour_shown'
3. Enable the new product editor at /wp-admin/admin.php?page=wc-settings&tab=advanced&section=features
4. Go to Products > Add
5. You should see the Product Editor Tour. Don't close it.
6. Go to Variations tab, add a variation option.
7. The variations tour should not show up, cause the product editor tour is open
8. Close the product editor tour.
9. You should see the variable product editor tour, with a fade-in animation.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
