### PR TITLE
[CYS] Show warning modal when clicking this back arrow in assembler hub

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/go-back-warning-modal.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/go-back-warning-modal.tsx
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import { Button, Modal } from '@wordpress/components';
+import { Sender } from 'xstate';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { customizeStoreStateMachineEvents } from '../..';
+
+export const GoBackWarningModal = ( {
+	setOpenWarningModal,
+	sendEvent,
+	classname = 'woocommerce-customize-store__design-change-warning-modal',
+}: {
+	setOpenWarningModal: ( arg0: boolean ) => void;
+	sendEvent: Sender< customizeStoreStateMachineEvents >;
+	classname?: string;
+} ) => {
+	return (
+		<Modal
+			className={ classname }
+			title={ __( 'Are you sure you want to exit?', 'woocommerce' ) }
+			onRequestClose={ () => setOpenWarningModal( false ) }
+			shouldCloseOnClickOutside={ false }
+		>
+			<p>
+				{ __(
+					"You'll lose any changes you've made to your store's design and will start the process again.",
+					'woocommerce'
+				) }
+			</p>
+			<div className="woocommerce-customize-store__design-change-warning-modal-footer">
+				<Button
+					onClick={ () => sendEvent( 'GO_BACK_TO_DESIGN_WITH_AI' ) }
+					variant="link"
+				>
+					{ __( 'Exit and lose changes', 'woocommerce' ) }
+				</Button>
+				<Button
+					onClick={ () => setOpenWarningModal( false ) }
+					variant="primary"
+				>
+					{ __( 'Continue designing', 'woocommerce' ) }
+				</Button>
+			</div>
+		</Modal>
+	);
+};

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen.tsx
@@ -25,6 +25,7 @@ import { unlock } from '@wordpress/edit-site/build-module/lock-unlock';
 // @ts-ignore No types for this exist yet.
 import SidebarButton from '@wordpress/edit-site/build-module/components/sidebar-button';
 import { GoBackWarningModal } from './go-back-warning-modal';
+
 /**
  * Internal dependencies
  */

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/sidebar/sidebar-navigation-screen.tsx
@@ -5,7 +5,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { useContext } from '@wordpress/element';
+import { useContext, useState } from '@wordpress/element';
 import {
 	// @ts-ignore No types for this exist yet.
 	__experimentalHStack as HStack,
@@ -24,7 +24,7 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { unlock } from '@wordpress/edit-site/build-module/lock-unlock';
 // @ts-ignore No types for this exist yet.
 import SidebarButton from '@wordpress/edit-site/build-module/components/sidebar-button';
-
+import { GoBackWarningModal } from './go-back-warning-modal';
 /**
  * Internal dependencies
  */
@@ -53,6 +53,8 @@ export const SidebarNavigationScreen = ( {
 	onNavigateBackClick?: () => void;
 } ) => {
 	const { sendEvent } = useContext( CustomizeStoreContext );
+	const [ openWarningModal, setOpenWarningModal ] =
+		useState< boolean >( false );
 	const location = useLocation();
 	const navigator = useNavigator();
 	const icon = isRTL() ? chevronRight : chevronLeft;
@@ -96,8 +98,7 @@ export const SidebarNavigationScreen = ( {
 					{ isRoot && (
 						<SidebarButton
 							onClick={ () => {
-								onNavigateBackClick?.();
-								sendEvent( 'GO_BACK_TO_DESIGN_WITH_AI' );
+								setOpenWarningModal( true );
 							} }
 							icon={ icon }
 							label={ __( 'Back', 'woocommerce' ) }
@@ -139,6 +140,12 @@ export const SidebarNavigationScreen = ( {
 				<footer className="edit-site-sidebar-navigation-screen__footer">
 					{ footer }
 				</footer>
+			) }
+			{ openWarningModal && (
+				<GoBackWarningModal
+					setOpenWarningModal={ setOpenWarningModal }
+					sendEvent={ sendEvent }
+				/>
 			) }
 		</>
 	);

--- a/plugins/woocommerce/changelog/add-cys-go-back-warning-modal
+++ b/plugins/woocommerce/changelog/add-cys-go-back-warning-modal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Show notice when clicking this back arrow in CYS assembler-hub


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #41227.

Show a warning modal when clicking this back arrow in assembler hub

![Screenshot 2023-11-07 at 10 48 54](https://github.com/woocommerce/woocommerce/assets/4344253/132d8b20-7eaf-47f0-8b0a-653a1374151b)


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


1. Create a new WooCommerce installation with this version.
2. Make sure to enable `customize-store` feature flag
3. Go to `/wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store%2Fassembler-hub`
4. Click on "back arrow"
5. Observe that a warming modal should be displayed
6. Click on `Continue designing`
7. The modal should be closed.
8. Click on "back arrow" and click on `Exit and lose changes`
9. Should be redirected to the first AI step.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
