### PR TITLE
[CYS] Fix navigation disappears after choosing a homepage template

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/block-editor.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/block-editor.tsx
@@ -153,7 +153,13 @@ export const BlockEditor = ( {} ) => {
 			<div className={ 'woocommerce-block-preview-container' }>
 				<BlockPreview
 					blocks={ renderedBlocks }
-					onChange={ isHighlighting ? undefined : onChange }
+					onChange={
+						// We only need to pass onChange for the logo screen so that logo block can be updated when we change the logo attributes in logo sidebar navigation screen component.
+						// For other screens, we don't need to pass onChange. Otherwise, we'll get a race condition issue where the block editor will be updated twice: once from the onChange in the sidebar component, and once from the onChange in the block editor component.
+						urlParams.path === '/customize-store/assembler-hub/logo'
+							? onChange
+							: undefined
+					}
 					settings={ settings }
 					additionalStyles={ additionalStyles }
 					isNavigable={ false }

--- a/plugins/woocommerce/changelog/fix-cys-navigation-disappear
+++ b/plugins/woocommerce/changelog/fix-cys-navigation-disappear
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix navigation disappears after choosing a homepage template


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/41263

Fix navigation disappears after choosing a homepage template. There seems to be a race condition issue when we replace the home template.


Before:
![pasted-image-20231101194553](https://github.com/woocommerce/woocommerce/assets/4344253/099632b7-fb58-4b1e-9784-92f7e1591e84)

After:

https://github.com/woocommerce/woocommerce/assets/4344253/3cc8317c-64ce-4075-8ff4-dc6fe9afeca5


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


1. Create a new WooCommerce installation with this version.
2. Make sure to enable `customize-store` feature flag
3. Go to `/wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store%2Fassembler-hub`
4. Go to `Change your homepage`
5. Select a homepage template
6. Confirm navigation still exists 



<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>