### PR TITLE
Update WooCommerce Blocks package to 11.4.5

### DIFF
--- a/plugins/woocommerce/bin/composer/mozart/composer.lock
+++ b/plugins/woocommerce/bin/composer/mozart/composer.lock
@@ -1072,16 +1072,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v5.4.26",
+            "version": "v5.4.29",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "1181fe9270e373537475e826873b5867b863883c"
+                "reference": "e41bdc93def20eaf3bfc1537c4e0a2b0680a152d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/1181fe9270e373537475e826873b5867b863883c",
-                "reference": "1181fe9270e373537475e826873b5867b863883c",
+                "url": "https://api.github.com/repos/symfony/string/zipball/e41bdc93def20eaf3bfc1537c4e0a2b0680a152d",
+                "reference": "e41bdc93def20eaf3bfc1537c4e0a2b0680a152d",
                 "shasum": ""
             },
             "require": {
@@ -1138,7 +1138,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.4.26"
+                "source": "https://github.com/symfony/string/tree/v5.4.29"
             },
             "funding": [
                 {
@@ -1154,7 +1154,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-06-28T12:46:07+00:00"
+            "time": "2023-09-13T11:47:41+00:00"
         }
     ],
     "aliases": [],
@@ -1169,5 +1169,5 @@
     "platform-overrides": {
         "php": "7.3"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/plugins/woocommerce/bin/composer/phpcs/composer.lock
+++ b/plugins/woocommerce/bin/composer/phpcs/composer.lock
@@ -258,16 +258,16 @@
         },
         {
             "name": "sirbrillig/phpcs-changed",
-            "version": "v2.11.3",
+            "version": "v2.11.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sirbrillig/phpcs-changed.git",
-                "reference": "9fc94ed9adee571b7e30da4467b1d41073a9dd1c"
+                "reference": "acc946731ec65053e49cb0d3185c8ffe74895f93"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sirbrillig/phpcs-changed/zipball/9fc94ed9adee571b7e30da4467b1d41073a9dd1c",
-                "reference": "9fc94ed9adee571b7e30da4467b1d41073a9dd1c",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-changed/zipball/acc946731ec65053e49cb0d3185c8ffe74895f93",
+                "reference": "acc946731ec65053e49cb0d3185c8ffe74895f93",
                 "shasum": ""
             },
             "require": {
@@ -306,9 +306,9 @@
             "description": "Run phpcs on files, but only report warnings/errors from lines which were changed.",
             "support": {
                 "issues": "https://github.com/sirbrillig/phpcs-changed/issues",
-                "source": "https://github.com/sirbrillig/phpcs-changed/tree/v2.11.3"
+                "source": "https://github.com/sirbrillig/phpcs-changed/tree/v2.11.4"
             },
-            "time": "2023-08-24T23:27:01+00:00"
+            "time": "2023-09-29T21:27:51+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -473,5 +473,5 @@
     "platform-overrides": {
         "php": "7.2"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/plugins/woocommerce/bin/composer/phpunit/composer.lock
+++ b/plugins/woocommerce/bin/composer/phpunit/composer.lock
@@ -1711,5 +1711,5 @@
     "platform-overrides": {
         "php": "7.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/plugins/woocommerce/bin/composer/wp/composer.lock
+++ b/plugins/woocommerce/bin/composer/wp/composer.lock
@@ -492,16 +492,16 @@
         },
         {
             "name": "wp-cli/php-cli-tools",
-            "version": "v0.11.20",
+            "version": "v0.11.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/php-cli-tools.git",
-                "reference": "d788a2c79e02f2f735fbb2b9a53db94d0e1bca4f"
+                "reference": "b3457a8d60cd0b1c48cab76ad95df136d266f0b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/php-cli-tools/zipball/d788a2c79e02f2f735fbb2b9a53db94d0e1bca4f",
-                "reference": "d788a2c79e02f2f735fbb2b9a53db94d0e1bca4f",
+                "url": "https://api.github.com/repos/wp-cli/php-cli-tools/zipball/b3457a8d60cd0b1c48cab76ad95df136d266f0b6",
+                "reference": "b3457a8d60cd0b1c48cab76ad95df136d266f0b6",
                 "shasum": ""
             },
             "require": {
@@ -549,22 +549,22 @@
             ],
             "support": {
                 "issues": "https://github.com/wp-cli/php-cli-tools/issues",
-                "source": "https://github.com/wp-cli/php-cli-tools/tree/v0.11.20"
+                "source": "https://github.com/wp-cli/php-cli-tools/tree/v0.11.21"
             },
-            "time": "2023-09-01T12:21:35+00:00"
+            "time": "2023-09-29T15:28:10+00:00"
         },
         {
             "name": "wp-cli/wp-cli",
-            "version": "v2.8.1",
+            "version": "v2.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/wp-cli.git",
-                "reference": "5dd2340b9a01c3cfdbaf5e93a140759fdd190eee"
+                "reference": "8a3befba2d947fbf5cc6d1941edf2dd99da4d4b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/5dd2340b9a01c3cfdbaf5e93a140759fdd190eee",
-                "reference": "5dd2340b9a01c3cfdbaf5e93a140759fdd190eee",
+                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/8a3befba2d947fbf5cc6d1941edf2dd99da4d4b7",
+                "reference": "8a3befba2d947fbf5cc6d1941edf2dd99da4d4b7",
                 "shasum": ""
             },
             "require": {
@@ -581,7 +581,7 @@
                 "wp-cli/entity-command": "^1.2 || ^2",
                 "wp-cli/extension-command": "^1.1 || ^2",
                 "wp-cli/package-command": "^1 || ^2",
-                "wp-cli/wp-cli-tests": "^3.1.6"
+                "wp-cli/wp-cli-tests": "^4.0.1"
             },
             "suggest": {
                 "ext-readline": "Include for a better --prompt implementation",
@@ -621,7 +621,7 @@
                 "issues": "https://github.com/wp-cli/wp-cli/issues",
                 "source": "https://github.com/wp-cli/wp-cli"
             },
-            "time": "2023-06-05T06:55:55+00:00"
+            "time": "2023-10-25T09:06:37+00:00"
         }
     ],
     "aliases": [],
@@ -634,5 +634,5 @@
     "platform-overrides": {
         "php": "7.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-11.4.4
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-11.4.4
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-
-Update WooCommerce Blocks to 11.4.4

--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-11.4.4
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-11.4.4
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update WooCommerce Blocks to 11.4.4

--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-11.4.5
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-11.4.5
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update WooCommerce Blocks to 11.4.5

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -23,7 +23,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.6.4",
-		"woocommerce/woocommerce-blocks": "11.4.4"
+		"woocommerce/woocommerce-blocks": "11.4.5"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.3.0",

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -23,7 +23,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.6.4",
-		"woocommerce/woocommerce-blocks": "11.4.2"
+		"woocommerce/woocommerce-blocks": "11.4.4"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.3.0",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ac1803cdbaa1544f5c6bf421703853c8",
+    "content-hash": "65629a97776aa986e20f4128be901e36",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1004,16 +1004,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "11.4.4",
+            "version": "11.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "9a4832de0213ca4e1450d6c3ce4114eacbfed2b3"
+                "reference": "4657618d8b9762744db5b1dee963c9e0592c8550"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/9a4832de0213ca4e1450d6c3ce4114eacbfed2b3",
-                "reference": "9a4832de0213ca4e1450d6c3ce4114eacbfed2b3",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/4657618d8b9762744db5b1dee963c9e0592c8550",
+                "reference": "4657618d8b9762744db5b1dee963c9e0592c8550",
                 "shasum": ""
             },
             "require": {
@@ -1064,9 +1064,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v11.4.4"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v11.4.5"
             },
-            "time": "2023-11-07T15:21:00+00:00"
+            "time": "2023-11-08T09:01:16+00:00"
         }
     ],
     "packages-dev": [

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8b8f2c43765686a91b34faa824cb997d",
+    "content-hash": "ac1803cdbaa1544f5c6bf421703853c8",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1004,16 +1004,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "11.4.2",
+            "version": "11.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "7556d00d6ff6c013540f683c6d65f46405f41741"
+                "reference": "9a4832de0213ca4e1450d6c3ce4114eacbfed2b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/7556d00d6ff6c013540f683c6d65f46405f41741",
-                "reference": "7556d00d6ff6c013540f683c6d65f46405f41741",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/9a4832de0213ca4e1450d6c3ce4114eacbfed2b3",
+                "reference": "9a4832de0213ca4e1450d6c3ce4114eacbfed2b3",
                 "shasum": ""
             },
             "require": {
@@ -1064,9 +1064,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v11.4.2"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v11.4.4"
             },
-            "time": "2023-10-26T16:18:21+00:00"
+            "time": "2023-11-07T15:21:00+00:00"
         }
     ],
     "packages-dev": [
@@ -3949,5 +3949,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This pull updates the WooCommerce Blocks plugin to 11.4.5

#### Blocks 11.4.5

- Release PR: https://github.com/woocommerce/woocommerce-blocks/pull/11672
- Release post: n/a
- Testing instructions: https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/1145.md

#### Blocks 11.4.4

- Release PR: https://github.com/woocommerce/woocommerce-blocks/pull/11624
- Release post: n/a
- Testing instructions: https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/1144.md

#### Blocks 11.4.3

- Release PR: https://github.com/woocommerce/woocommerce-blocks/pull/11496
- Release post: n/a
- Testing instructions: https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/1143.md

The following changelog entries are only those that impact existing blocks and functionality surfaced to users:

#### Enhancements

- Enabled the new blockified Order Confirmation by default for block-based themes. https://github.com/woocommerce/woocommerce-blocks/pull/11615
- Improve Hero Product Chessboard pattern. https://github.com/woocommerce/woocommerce-blocks/pull/11423
- Fix spacing on the "Minimal header" pattern. https://github.com/woocommerce/woocommerce-blocks/pull/11477
- "Product Gallery" improvements: remove product summary and update margins. https://github.com/woocommerce/woocommerce-blocks/pull/11464
- Patterns with Search Bar: improve style. https://github.com/woocommerce/woocommerce-blocks/pull/11478
- "Product Collection X Columns" patterns: align "no reviews" text with the star. https://github.com/woocommerce/woocommerce-blocks/pull/11468
- Rename the Footer with Simple Menu and Cart pattern. https://github.com/woocommerce/woocommerce-blocks/pull/11487
- Enhance the Hero Product Split pattern. https://github.com/woocommerce/woocommerce-blocks/pull/11505
- Simplify the Hero Product 3 Split pattern. https://github.com/woocommerce/woocommerce-blocks/pull/11495
- Improve the Centered Header Menu with Search pattern. https://github.com/woocommerce/woocommerce-blocks/pull/11304
- Large Header pattern: improve the layout on mobile view. https://github.com/woocommerce/woocommerce-blocks/pull/11490
- Improve the "Large footer" spacing. https://github.com/woocommerce/woocommerce-blocks/pull/11520

#### Bug Fixes

- WordPress 6.4: fixed a bug which would break sites using the Classic Template block for the Single Product template. https://github.com/woocommerce/woocommerce-blocks/pull/11455

### Changelog entry

> Dev - Update WooCommerce Blocks version to 11.4.5