### PR TITLE
Fix possible warning when edit lock is released mid page load

### DIFF
--- a/plugins/woocommerce/changelog/fix-39824
+++ b/plugins/woocommerce/changelog/fix-39824
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent PHP warning when order lock is released during page load.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php
@@ -237,6 +237,10 @@ class Edit {
 		// Order updated message.
 		$this->message = 1;
 
+		// Claim lock.
+		$edit_lock = wc_get_container()->get( EditLock::class );
+		$edit_lock->lock( $this->order );
+
 		$this->redirect_order( $this->order );
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/Orders/EditLock.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/EditLock.php
@@ -166,9 +166,9 @@ class EditLock {
 	 * @return void
 	 */
 	public function render_dialog( $order ) {
-		$locked = $this->is_locked_by_another_user( $order );
 		$lock   = $this->get_lock( $order );
-		$user   = get_user_by( 'id', $lock['user_id'] );
+		$user   = $lock ? get_user_by( 'id', $lock['user_id'] ) : false;
+		$locked = $user && ( get_current_user_id() !== $user->ID );
 
 		$edit_url = wc_get_container()->get( \Automattic\WooCommerce\Internal\Admin\Orders\PageController::class )->get_edit_url( $order->get_id() );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
We currently render the order lock dialog (which allows users to take over an order or indicates that someone else has taken over) on `admin_footer`, close to the end of the request. This makes it possible for the lock to have expired between initial page load and the time we use it while rendering the dialog.

This is highly unlikely to happen as loading the edit page claims the lock (if not already locked) and it's also constantly refreshed through the WP heartbeat, but better safe than sorry.

This PR slightly changes the logic in the order lock to make sure we don't try to access properties that don't exist. It also forces a lock as soon as the order is updated, so that "last edit" wins, which is the same strategy WP uses for posts.

Closes #39824.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure HPOS is the authoritative datastore in WC > Settings > Advanced > Features.
2. If there are no orders on your site, manually create an order in WC > Orders and take note of its ID.
3. Given it is difficult to get into a situation where the lock expires in the middle of the page load, we simulate that using the following snippet, which could be dropped in `wp-content/mu-plugins/`:
   ```php
   add_action(
	   'admin_footer',
	   function() {
		   global $theorder;
		   if ( ! empty( $theorder ) ) {
			   // Fake lock being released just now.
			   $theorder->update_meta_data( '_edit_lock', '0:0' );
		   }
	   },
	   0
   );
   ```
4. Go to WC > Orders and open any order. Take note of the ID.
5. No warnings should be logged in the log file.
6. Run the following CLI command to confirm that the lock has been set for your current user:
   ```
   wp db query "SELECT meta_value FROM $(wp db prefix)wc_orders_meta WHERE meta_key = '_edit_lock' AND order_id=<ORDER_ID>"
   ```
   Adjust `<ORDER_ID>` accordingly. Output should be in the format `<timestamp>:<user_id>`.
7. Click "Update" on the order.
8. Run the command from 6 again and confirm that the timestamp has been updated.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
