### PR TITLE
Fix missing or duplicated order meta after post backport when meta value is an array (WC 8.2)

### DIFF
--- a/plugins/woocommerce/changelog/41281-fix-custom-meta-backfill-post-record
+++ b/plugins/woocommerce/changelog/41281-fix-custom-meta-backfill-post-record
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Resolved an issue that would cause array order meta values to not be copied during HPOS post table backporting.

--- a/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -724,7 +724,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 				}
 
 				if ( is_array( $existing_meta_data[ $meta_data->key ] ) ) {
-					$value_index = array_search( $meta_data->value, $existing_meta_data[ $meta_data->key ], true );
+					$value_index = array_search( maybe_serialize( $meta_data->value ), $existing_meta_data[ $meta_data->key ], true );
 					if ( false !== $value_index ) {
 						unset( $existing_meta_data[ $meta_data->key ][ $value_index ] );
 						if ( 0 === count( $existing_meta_data[ $meta_data->key ] ) ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

With HPOS enabled, when order meta is an array, back porting that meta to the posts table either duplicates<sup>*</sup> it or doesn't backport it at all. 

In troubleshooting that, I discovered it's due to the `update_order_meta_from_object()` function failing to find matching meta in the post's existing meta data. This is because it uses a `in_array( $meta_value, $existing_meta_data )` check, but if that meta value is an array, it won't find a matching value because the `$existing_meta` array contains serialised versions of the meta value. 

eg: 

```php
$existing_meta_data = array (
    [_awesome_array_meta] => array
        (
            [0] => a:3:{i:0;i:1;i:1;i:2;i:2;i:3;} // != array( 1, 2 ,3 )
        )

    [_charge_id] => array
        (
            [0] => ch_3OA1vFFxxxxxxxx
        )
...
```

This PR fixes that by making sure the meta value is serialised before trying to locate it. 

Discovered testing Woo Subscriptions PR: https://github.com/Automattic/woocommerce-subscriptions-core/pull/538

> [!NOTE]  
> \* In Subscriptions we're seeing the meta being duplicated. Whereas with custom order meta, it's not being copied at all. 🤷‍♂️ It's complicated but duplication occurs when the meta has a `get_internal_data_store_key_getters` and so it isn't deleted. Failure to correctly locate the the existing meta value leads to multiple `add_post_meta()` calls and that leads to the duplicates. Even in this order meta example, there are multiple add_post_meta() calls, however something else (which I haven't been able to find), is deleting them all. 


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

```php
$order = wc_get_order( 4892 );
$order->update_meta_data( '_awesome_array_meta', array( 1, 2, 3 ) );
$order->save();
```

1. Enable HPOS. Disable syncing to the posts table. 

<p align="">
<img width="350" alt="Screenshot 2023-11-08 at 12 36 44 pm" src="https://github.com/woocommerce/woocommerce/assets/8490476/82b2ccb9-a18c-4690-b383-870f0ebcde13">
</p>

2. Purchase an order. 
3. Using the code snippet above, add custom meta that is an array.
4. Enable posts table syncing.

<p align="">
<img width="350" alt="Screenshot 2023-11-08 at 12 40 44 pm" src="https://github.com/woocommerce/woocommerce/assets/8490476/927ff695-ef69-45cc-93e5-3a6dace64903">
</p>

5. Wait or manually run the `wc_schedule_pending_batch_processes` and `wc_run_batch_process` scheduled actions.
6. Check the posts table order meta. 
7. On `trunk` the meta wouldn't have been copied over.

<p align="">
<img width="350" alt="Screenshot 2023-11-08 at 12 44 24 pm" src="https://github.com/woocommerce/woocommerce/assets/8490476/122a096a-c9c3-495c-9b9b-077ff9d9c8c1">
</p>

8. On this branch it is copied over. 

<img width="350" alt="Screenshot 2023-11-08 at 12 58 05 pm" src="https://github.com/woocommerce/woocommerce/assets/8490476/8648dc76-ae84-4529-a5fe-cb1efa3706ab">

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Resolved an issue that would cause array order meta values to not be copied during HPOS post table backporting. 

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
