### PR TITLE
[CYS] Add track events

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/actions.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/actions.ts
@@ -286,7 +286,9 @@ const recordTracksStepCompleted = (
 	} );
 };
 
-const redirectToAssemblerHub = async ( context ) => {
+const redirectToAssemblerHub = async (
+	context: designWithAiStateMachineContext
+) => {
 	const assemblerUrl = getNewPath( {}, '/customize-store/assembler-hub', {} );
 	const iframe = document.createElement( 'iframe' );
 	iframe.classList.add( 'cys-fullscreen-iframe' );

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/actions.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/actions.ts
@@ -31,6 +31,13 @@ import {
 } from './pages';
 import { attachIframeListeners, onIframeLoad } from '../utils';
 
+const assignStartLoadingTime = assign<
+	designWithAiStateMachineContext,
+	designWithAiStateMachineEvents
+>( {
+	startLoadingTime: () => performance.now(),
+} );
+
 const assignBusinessInfoDescription = assign<
 	designWithAiStateMachineContext,
 	designWithAiStateMachineEvents
@@ -210,6 +217,8 @@ const assignAPICallLoaderError = assign<
 	designWithAiStateMachineEvents
 >( {
 	apiCallLoader: () => {
+		recordEvent( 'customize_your_store_ai_wizard_error' );
+
 		return {
 			hasErrors: true,
 		};
@@ -277,20 +286,34 @@ const recordTracksStepCompleted = (
 	} );
 };
 
-const redirectToAssemblerHub = async () => {
+const redirectToAssemblerHub = async ( context ) => {
 	const assemblerUrl = getNewPath( {}, '/customize-store/assembler-hub', {} );
 	const iframe = document.createElement( 'iframe' );
 	iframe.classList.add( 'cys-fullscreen-iframe' );
 	iframe.src = assemblerUrl;
 
 	const showIframe = () => {
+		if ( iframe.style.opacity === '1' ) {
+			// iframe is already visible
+			return;
+		}
+
 		const loader = document.getElementsByClassName(
 			'woocommerce-onboarding-loader'
 		);
 		if ( loader[ 0 ] ) {
 			( loader[ 0 ] as HTMLElement ).style.display = 'none';
 		}
+
 		iframe.style.opacity = '1';
+
+		if ( context.startLoadingTime ) {
+			const endLoadingTime = performance.now();
+			const timeToLoad = endLoadingTime - context.startLoadingTime;
+			recordEvent( 'customize_your_store_ai_wizard_loading_time', {
+				time_in_s: ( timeToLoad / 1000 ).toFixed( 2 ),
+			} );
+		}
 	};
 
 	iframe.onload = () => {
@@ -307,6 +330,7 @@ const redirectToAssemblerHub = async () => {
 };
 
 export const actions = {
+	assignStartLoadingTime,
 	assignBusinessInfoDescription,
 	assignLookAndFeel,
 	assignToneOfVoice,

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/state-machine.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/state-machine.tsx
@@ -62,6 +62,7 @@ export const designWithAiStateMachineDefinition = createMachine(
 			},
 		},
 		context: {
+			startLoadingTime: null,
 			businessInfoDescription: {
 				descriptionText: '',
 			},
@@ -269,6 +270,7 @@ export const designWithAiStateMachineDefinition = createMachine(
 				initial: 'preApiCallLoader',
 				states: {
 					preApiCallLoader: {
+						entry: [ 'assignStartLoadingTime' ],
 						always: {
 							target: 'apiCallLoader',
 						},

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/state-machine.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/state-machine.tsx
@@ -270,7 +270,6 @@ export const designWithAiStateMachineDefinition = createMachine(
 				initial: 'preApiCallLoader',
 				states: {
 					preApiCallLoader: {
-						entry: [ 'assignStartLoadingTime' ],
 						always: {
 							target: 'apiCallLoader',
 						},
@@ -284,6 +283,7 @@ export const designWithAiStateMachineDefinition = createMachine(
 								type: 'updateQueryStep',
 								step: 'api-call-loader',
 							},
+							'assignStartLoadingTime',
 						],
 						type: 'parallel',
 						states: {

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/types.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/types.ts
@@ -16,6 +16,7 @@ import {
 } from './prompts';
 
 export type designWithAiStateMachineContext = {
+	startLoadingTime: number | null;
 	businessInfoDescription: {
 		descriptionText: string;
 	};

--- a/plugins/woocommerce-admin/client/customize-store/intro/actions.ts
+++ b/plugins/woocommerce-admin/client/customize-store/intro/actions.ts
@@ -44,7 +44,7 @@ export const recordTracksThemeSelected = (
 		{ type: 'SELECTED_ACTIVE_THEME' | 'SELECTED_NEW_THEME' }
 	>
 ) => {
-	recordEvent( 'wcadmin_customize_your_store_intro_theme_select', {
+	recordEvent( 'customize_your_store_intro_theme_select', {
 		theme: event.payload.theme,
 		is_active: event.type === 'SELECTED_ACTIVE_THEME' ? 'yes' : 'no',
 	} );

--- a/plugins/woocommerce-admin/client/customize-store/intro/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/intro/index.tsx
@@ -188,6 +188,19 @@ export const Intro: CustomizeStoreComponent = ( { sendEvent, context } ) => {
 								total_palettes={ theme.total_palettes }
 								link_url={ theme?.link_url }
 								is_active={ theme.is_active }
+								onClick={ () => {
+									if ( theme.is_active ) {
+										sendEvent( {
+											type: 'SELECTED_ACTIVE_THEME',
+											payload: { theme: theme.slug },
+										} );
+									} else {
+										sendEvent( {
+											type: 'SELECTED_NEW_THEME',
+											payload: { theme: theme.slug },
+										} );
+									}
+								} }
 							/>
 						) ) }
 					</div>

--- a/plugins/woocommerce-admin/client/customize-store/intro/intro-banners.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/intro/intro-banners.tsx
@@ -194,9 +194,6 @@ export const ExistingAiThemeBanner = ( {
 			className=""
 			onClick={ () => {
 				setOpenDesignChangeWarningModal( true );
-				recordEvent(
-					'customize_your_store_intro_create_a_new_one_click'
-				);
 			} }
 			variant={ 'secondary' }
 		>

--- a/plugins/woocommerce-admin/client/customize-store/intro/intro-banners.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/intro/intro-banners.tsx
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import classNames from 'classnames';
 import { Button } from '@wordpress/components';
 import { getNewPath } from '@woocommerce/navigation';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -13,7 +14,6 @@ import { Intro } from '.';
 import { IntroSiteIframe } from './intro-site-iframe';
 import { getAdminSetting } from '~/utils/admin-settings';
 import { navigateOrParent } from '../utils';
-import { recordEvent } from '@woocommerce/tracks';
 
 export const BaseIntroBanner = ( {
 	bannerTitle,

--- a/plugins/woocommerce-admin/client/customize-store/intro/intro-banners.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/intro/intro-banners.tsx
@@ -13,6 +13,7 @@ import { Intro } from '.';
 import { IntroSiteIframe } from './intro-site-iframe';
 import { getAdminSetting } from '~/utils/admin-settings';
 import { navigateOrParent } from '../utils';
+import { recordEvent } from '@woocommerce/tracks';
 
 export const BaseIntroBanner = ( {
 	bannerTitle,
@@ -193,6 +194,9 @@ export const ExistingAiThemeBanner = ( {
 			className=""
 			onClick={ () => {
 				setOpenDesignChangeWarningModal( true );
+				recordEvent(
+					'customize_your_store_intro_create_a_new_one_click'
+				);
 			} }
 			variant={ 'secondary' }
 		>
@@ -211,6 +215,7 @@ export const ExistingAiThemeBanner = ( {
 			bannerClass="existing-ai-theme-banner"
 			buttonIsLink={ false }
 			bannerButtonOnClick={ () => {
+				recordEvent( 'customize_your_store_intro_customize_click' );
 				navigateOrParent(
 					window,
 					getNewPath( {}, '/customize-store/assembler-hub', {} )

--- a/plugins/woocommerce-admin/client/customize-store/intro/theme-card.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/intro/theme-card.tsx
@@ -19,12 +19,15 @@ export const ThemeCard = ( {
 	total_palettes = 0,
 	link_url = '',
 	is_active = false,
-}: TypeThemeCard ) => {
+	onClick,
+}: TypeThemeCard & {
+	onClick: () => void;
+} ) => {
 	return (
 		<div className="theme-card" key={ slug }>
 			<div>
 				{ link_url ? (
-					<Link href={ link_url }>
+					<Link href={ link_url } onClick={ onClick }>
 						<img src={ thumbnail_url } alt={ description } />
 					</Link>
 				) : (

--- a/plugins/woocommerce-admin/client/customize-store/intro/warning-modals.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/intro/warning-modals.tsx
@@ -6,6 +6,7 @@ import { Sender } from 'xstate';
 import { __ } from '@wordpress/i18n';
 import { Link } from '@woocommerce/components';
 import { createInterpolateElement } from '@wordpress/element';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -180,7 +181,12 @@ export const StartOverWarningModal = ( {
 					{ __( 'Cancel', 'woocommerce' ) }
 				</Button>
 				<Button
-					onClick={ () => sendEvent( { type: 'DESIGN_WITH_AI' } ) }
+					onClick={ () => {
+						sendEvent( { type: 'DESIGN_WITH_AI' } );
+						recordEvent(
+							'customize_your_store_intro_start_again_click'
+						);
+					} }
 					variant="primary"
 				>
 					{ __( 'Start again', 'woocommerce' ) }

--- a/plugins/woocommerce/changelog/add-cys-tracks
+++ b/plugins/woocommerce/changelog/add-cys-tracks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add tracks for cys


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Add missing high-priority tracking events: pdnLyh-4d9-p2

- % of users that proceed with Tsubaki, Tazza, Zaino, or Amulet.
- AI wizard failure rate.
- Average loading time

(Secondary flow: My Home, task completed)

- % of users that click on “Customize”
- % of users that click on “Create a new store”



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


1. Create a new WooCommerce installation with this version.
2. Make sure to enable `customize-store` feature flag
3. Install but NOT activate [WooCommerce Blocks nightly build](https://github.com/woocommerce/woocommerce-blocks/releases/tag/nightly) 
4. Go to `WooCommerce -> Home` and click `Customize Store` task
5. Enable logging `window.localStorage.setItem( 'debug', 'wc-admin:*')`
6. Enable "preserve log" in dev console
7. Click on a theme such as `Tsubaki`
8. Observe that `wcadmin_wcadmin_customize_your_store_intro_theme_select` event is recorded
9. Go to AI wizard
10. Follow through the flow all the way
11. Confirm AI wizard fails
12. Observe that `wcadmin_customize_your_store_ai_wizard_error` event is recorded
13. Activate WooCommerce Blocks 
14. Complete AI wizard
15. Observe that `customize_your_store_ai_wizard_loading_time` event is recorded.
16. Click on "Done" button
17. Go to  Customize Store` task intro screen
18. Click on "Create a new one" button
19. Click on "Start again" button
20. Observe that `customize_your_store_intro_start_again_click` event is recorded.
21. Go back to intro screen.
22. Click on "Customize" button
23. Observe that customize_your_store_intro_customize_click event is recorded.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>