### PR TITLE
WooCommerce Beta Tester - CYS: implement removing patterns_ai_data post type

### DIFF
--- a/plugins/woocommerce-beta-tester/api/tools/reset-cys.php
+++ b/plugins/woocommerce-beta-tester/api/tools/reset-cys.php
@@ -44,5 +44,15 @@ function tools_reset_cys() {
 		array( '%s', '%s' )
 	);
 
+	// Reset the patterns AI data.
+	$wpdb->delete(
+		$wpdb->prefix . 'posts',
+		array(
+			'post_type'  => 'patterns_ai_data',
+			'post_title' => 'Patterns AI Data',
+		),
+		array( '%s', '%s' )
+	);
+
 	return true;
 }

--- a/plugins/woocommerce-beta-tester/changelog/fix-remove_patterns_ai_data_post_reset_cys
+++ b/plugins/woocommerce-beta-tester/changelog/fix-remove_patterns_ai_data_post_reset_cys
@@ -1,4 +1,4 @@
 Significance: minor
 Type: update
 
-WooCommerce Beta Tester - CSY: implement removing patterns_ai_data post type
+WooCommerce Beta Tester - CYS: implement removing patterns_ai_data post type

--- a/plugins/woocommerce-beta-tester/changelog/fix-remove_patterns_ai_data_post_reset_cys
+++ b/plugins/woocommerce-beta-tester/changelog/fix-remove_patterns_ai_data_post_reset_cys
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+WooCommerce Beta Tester - CSY: implement removing patterns_ai_data post type

--- a/plugins/woocommerce-beta-tester/src/tools/data/actions.js
+++ b/plugins/woocommerce-beta-tester/src/tools/data/actions.js
@@ -217,7 +217,6 @@ export function* resetCustomizeYourStore() {
 			'woocommerce_customize_store_onboarding_tour_hidden',
 			'woocommerce_admin_customize_store_completed',
 			'woocommerce_admin_customize_store_completed_theme_id',
-			'wc_blocks_patterns_content',
 		];
 		yield apiFetch( {
 			method: 'DELETE',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

With https://github.com/woocommerce/woocommerce-blocks/pull/11659, we migrate from wp_option table to use a dedicated post type to store pattern data generated by the AI. 

For this, it is necessary to update the tool for Resets Customize Your Store changes.



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Follow the testing instructions of https://github.com/woocommerce/woocommerce-blocks/pull/11659
2. Connect to the database and find the only one post that has the post_type: `patterns_ai_data`.
3. Install the build of WooCommerce Beta tester that included this patch: 
[woocommerce-beta-tester.zip](https://github.com/woocommerce/woocommerce/files/13295241/woocommerce-beta-tester.zip).
4. Go on `wp-admin/tools.php?page=woocommerce-admin-test-helper`.
5. Click on `Tools`.
6. Click run on the row about the Reset Customize Your Store setting.
7. Connect to the database and ensure that doesn't exist any post with the post_type: `patterns_ai_data`.

![image](https://github.com/woocommerce/woocommerce/assets/4463174/8036d3a7-98f3-412d-b315-d090f4f0295f)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
