### PR TITLE
Update WooCommerce Blocks version to 11.4.5

### DIFF
--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-11.4.5
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-11.4.5
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+WordPress 6.4: fixed a bug which would break sites using the Classic Template block for the Single Product template.

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -23,7 +23,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.6.4",
-		"woocommerce/woocommerce-blocks": "11.4.3"
+		"woocommerce/woocommerce-blocks": "11.4.5"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.3.0",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6a5e201fcdc16a409789b0d63336db64",
+    "content-hash": "65629a97776aa986e20f4128be901e36",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1004,16 +1004,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "11.4.3",
+            "version": "11.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "6a1848b9ba5277135327024262c080130641d5f0"
+                "reference": "4657618d8b9762744db5b1dee963c9e0592c8550"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/6a1848b9ba5277135327024262c080130641d5f0",
-                "reference": "6a1848b9ba5277135327024262c080130641d5f0",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/4657618d8b9762744db5b1dee963c9e0592c8550",
+                "reference": "4657618d8b9762744db5b1dee963c9e0592c8550",
                 "shasum": ""
             },
             "require": {
@@ -1064,9 +1064,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v11.4.3"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v11.4.5"
             },
-            "time": "2023-10-31T15:11:22+00:00"
+            "time": "2023-11-08T09:01:16+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This pull updates the WooCommerce Blocks plugin to 11.4.5

#### Blocks 11.4.5

- Release PR: https://github.com/woocommerce/woocommerce-blocks/pull/11672
- Release post: n/a
- Testing instructions: https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/1145.md

The following changelog entries are only those that impact existing blocks and functionality surfaced to users:

#### Bug fixes

- WordPress 6.4: fixed a bug which would break sites using the Classic Template block for the Single Product template. https://github.com/woocommerce/woocommerce-blocks/pull/11455

### Changelog entry

> Dev - Update WooCommerce Blocks version to 11.4.5