### PR TITLE
Fix typographic quotes used in HTML attributes

### DIFF
--- a/plugins/woocommerce/changelog/pr-41320
+++ b/plugins/woocommerce/changelog/pr-41320
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Fix typographic quotes mistakenly added to HTML attributes

--- a/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-notices.php
@@ -147,7 +147,7 @@ class WC_Admin_Notices {
 					),
 					sprintf(
 					// translators: Placeholders are URLs.
-						wpautop( wp_kses_data( __( 'The WooCommerce Legacy REST API, <a href="%1$s">currently enabled in this site</a>, will be removed in WooCommerce 9.0. A separate WooCommerce extension will be available to keep it enabled. <b><a target=”_blank” href="%2$s">Learn more about this change.</a></b>', 'woocommerce' ) ) ),
+						wpautop( wp_kses_data( __( 'The WooCommerce Legacy REST API, <a href="%1$s">currently enabled in this site</a>, will be removed in WooCommerce 9.0. A separate WooCommerce extension will be available to keep it enabled. <b><a target="_blank" href="%2$s">Learn more about this change.</a></b>', 'woocommerce' ) ) ),
 						admin_url( 'admin.php?page=wc-settings&tab=advanced&section=legacy_api' ),
 						'https://developer.woocommerce.com/2023/10/03/the-legacy-rest-api-will-move-to-a-dedicated-extension-in-woocommerce-9-0/'
 					)
@@ -166,7 +166,7 @@ class WC_Admin_Notices {
 					),
 					sprintf(
 					// translators: Placeholders are URLs.
-						wpautop( wp_kses_data( __( 'The WooCommerce Legacy REST API will be removed in WooCommerce 9.0, and this will cause <a href="%1$s">webhooks on this site that are configured to use the Legacy REST API</a> to stop working. A separate WooCommerce extension will be available to allow these webhooks to keep using the Legacy REST API without interruption. You can also edit these webhooks to use the current REST API version to generate the payload instead. <b><a target=”_blank” href="%2$s">Learn more about this change.</a></b>', 'woocommerce' ) ) ),
+						wpautop( wp_kses_data( __( 'The WooCommerce Legacy REST API will be removed in WooCommerce 9.0, and this will cause <a href="%1$s">webhooks on this site that are configured to use the Legacy REST API</a> to stop working. A separate WooCommerce extension will be available to allow these webhooks to keep using the Legacy REST API without interruption. You can also edit these webhooks to use the current REST API version to generate the payload instead. <b><a target="_blank" href="%2$s">Learn more about this change.</a></b>', 'woocommerce' ) ) ),
 						admin_url( 'admin.php?page=wc-settings&tab=advanced&section=webhooks&legacy=true' ),
 						'https://developer.woocommerce.com/2023/10/03/the-legacy-rest-api-will-move-to-a-dedicated-extension-in-woocommerce-9-0/'
 					)

--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-advanced.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-advanced.php
@@ -395,7 +395,7 @@ class WC_Settings_Advanced extends WC_Settings_Page {
 			$enable_legacy_api_setting['desc_tip'] = sprintf(
 			// translators: Placeholder is a URL.
 				__(
-					'⚠️ <b>️The Legacy REST API will be removed in WooCommerce 9.0.</b> A separate WooCommerce extension will soon be available to keep it enabled. <b><a target=”_blank” href="%s">Learn more about this change.</a></b>',
+					'⚠️ <b>️The Legacy REST API will be removed in WooCommerce 9.0.</b> A separate WooCommerce extension will soon be available to keep it enabled. <b><a target="_blank" href="%s">Learn more about this change.</a></b>',
 					'woocommerce'
 				),
 				'https://developer.woocommerce.com/2023/10/03/the-legacy-rest-api-will-move-to-a-dedicated-extension-in-woocommerce-9-0/'


### PR DESCRIPTION
### Changes proposed in this Pull Request:

https://github.com/woocommerce/woocommerce/pull/40535 and https://github.com/woocommerce/woocommerce/pull/40866 accidentally introduced HTML attributes delimited with typographic quotes. This doesn't seem to be an issue for browsers (tested in Chrome, Edge, Firefox and Brave) but is something to be fixed anyway, and that's what this pull request does.

Closes #41179.

### How to test the changes in this Pull Request:

No testing is really needed, but if you want to test you can follow the testing instructions of the pull requests mentioned above.


### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
