### PR TITLE
[CYS] Add more Tracks

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/actions.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/actions.ts
@@ -54,8 +54,9 @@ const assignLookAndFeel = assign<
 	designWithAiStateMachineContext,
 	designWithAiStateMachineEvents
 >( {
-	lookAndFeel: ( _context, event: unknown ) => {
+	lookAndFeel: ( context, event: unknown ) => {
 		return {
+			...context.lookAndFeel,
 			choice: ( event as lookAndFeelCompleteEvent ).payload,
 		};
 	},
@@ -65,8 +66,9 @@ const assignToneOfVoice = assign<
 	designWithAiStateMachineContext,
 	designWithAiStateMachineEvents
 >( {
-	toneOfVoice: ( _context, event: unknown ) => {
+	toneOfVoice: ( context, event: unknown ) => {
 		return {
+			...context.toneOfVoice,
 			choice: ( event as toneOfVoiceCompleteEvent ).payload,
 		};
 	},
@@ -80,12 +82,16 @@ const assignLookAndTone = assign<
 		return {
 			choice: ( event as { data: LookAndToneCompletionResponse } ).data
 				.look,
+			aiRecommended: ( event as { data: LookAndToneCompletionResponse } )
+				.data.look,
 		};
 	},
 	toneOfVoice: ( _context, event: unknown ) => {
 		return {
 			choice: ( event as { data: LookAndToneCompletionResponse } ).data
 				.tone,
+			aiRecommended: ( event as { data: LookAndToneCompletionResponse } )
+				.data.tone,
 		};
 	},
 } );

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/pages/LookAndFeel.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/pages/LookAndFeel.tsx
@@ -60,6 +60,7 @@ export const LookAndFeel = ( {
 			? choices[ 0 ].key
 			: context.lookAndFeel.choice
 	);
+
 	return (
 		<div>
 			<ProgressBar
@@ -69,20 +70,6 @@ export const LookAndFeel = ( {
 			/>
 			<CloseButton
 				onClick={ () => {
-					if (
-						context.lookAndFeel.choice !== '' &&
-						context.lookAndFeel.choice !== look
-					) {
-						recordEvent(
-							'customize_your_store_ai_wizard_changed_ai_option',
-							{
-								step: 'look-and-feel',
-								ai_option: context.lookAndFeel.choice,
-								user_choice: look,
-							}
-						);
-					}
-
 					sendEvent( {
 						type: 'AI_WIZARD_CLOSED_BEFORE_COMPLETION',
 						payload: { step: 'look-and-feel' },
@@ -118,6 +105,21 @@ export const LookAndFeel = ( {
 					<Button
 						variant="primary"
 						onClick={ () => {
+							if (
+								context.lookAndFeel.aiRecommended &&
+								context.lookAndFeel.aiRecommended !== look
+							) {
+								recordEvent(
+									'customize_your_store_ai_wizard_changed_ai_option',
+									{
+										step: 'look-and-feel',
+										ai_recommended:
+											context.lookAndFeel.aiRecommended,
+										user_choice: look,
+									}
+								);
+							}
+
 							sendEvent( {
 								type: 'LOOK_AND_FEEL_COMPLETE',
 								payload: look,

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/pages/LookAndFeel.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/pages/LookAndFeel.tsx
@@ -5,6 +5,7 @@ import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { ProgressBar } from '@woocommerce/components';
 import { useState } from '@wordpress/element';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -68,6 +69,20 @@ export const LookAndFeel = ( {
 			/>
 			<CloseButton
 				onClick={ () => {
+					if (
+						context.lookAndFeel.choice !== '' &&
+						context.lookAndFeel.choice !== look
+					) {
+						recordEvent(
+							'customize_your_store_ai_wizard_changed_ai_option',
+							{
+								step: 'look-and-feel',
+								ai_option: context.lookAndFeel.choice,
+								user_choice: look,
+							}
+						);
+					}
+
 					sendEvent( {
 						type: 'AI_WIZARD_CLOSED_BEFORE_COMPLETION',
 						payload: { step: 'look-and-feel' },

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/pages/ToneOfVoice.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/pages/ToneOfVoice.tsx
@@ -5,6 +5,7 @@ import { Button, Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { ProgressBar } from '@woocommerce/components';
 import { useState, createInterpolateElement } from '@wordpress/element';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -76,6 +77,20 @@ export const ToneOfVoice = ( {
 			/>
 			<CloseButton
 				onClick={ () => {
+					if (
+						context.toneOfVoice.choice !== '' &&
+						context.toneOfVoice.choice !== sound
+					) {
+						recordEvent(
+							'customize_your_store_ai_wizard_changed_ai_option',
+							{
+								step: 'tone-of-voice',
+								ai_option: context.toneOfVoice.choice,
+								user_choice: sound,
+							}
+						);
+					}
+
 					sendEvent( {
 						type: 'AI_WIZARD_CLOSED_BEFORE_COMPLETION',
 						payload: { step: 'tone-of-voice' },

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/pages/ToneOfVoice.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/pages/ToneOfVoice.tsx
@@ -62,6 +62,17 @@ export const ToneOfVoice = ( {
 	);
 
 	const onContinue = () => {
+		if (
+			context.toneOfVoice.aiRecommended &&
+			context.toneOfVoice.aiRecommended !== sound
+		) {
+			recordEvent( 'customize_your_store_ai_wizard_changed_ai_option', {
+				step: 'tone-of-voice',
+				ai_recommended: context.toneOfVoice.aiRecommended,
+				user_choice: sound,
+			} );
+		}
+
 		sendEvent( {
 			type: 'TONE_OF_VOICE_COMPLETE',
 			payload: sound,
@@ -77,20 +88,6 @@ export const ToneOfVoice = ( {
 			/>
 			<CloseButton
 				onClick={ () => {
-					if (
-						context.toneOfVoice.choice !== '' &&
-						context.toneOfVoice.choice !== sound
-					) {
-						recordEvent(
-							'customize_your_store_ai_wizard_changed_ai_option',
-							{
-								step: 'tone-of-voice',
-								ai_option: context.toneOfVoice.choice,
-								user_choice: sound,
-							}
-						);
-					}
-
 					sendEvent( {
 						type: 'AI_WIZARD_CLOSED_BEFORE_COMPLETION',
 						payload: { step: 'tone-of-voice' },

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/types.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/types.ts
@@ -21,9 +21,11 @@ export type designWithAiStateMachineContext = {
 		descriptionText: string;
 	};
 	lookAndFeel: {
+		aiRecommended?: Look;
 		choice: Look | '';
 	};
 	toneOfVoice: {
+		aiRecommended?: Tone;
 		choice: Tone | '';
 	};
 	aiSuggestions: {

--- a/plugins/woocommerce-admin/client/customize-store/intro/intro-banners.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/intro/intro-banners.tsx
@@ -193,6 +193,9 @@ export const ExistingAiThemeBanner = ( {
 		<Button
 			className=""
 			onClick={ () => {
+				recordEvent(
+					'customize_your_store_intro_create_a_new_one_click'
+				);
 				setOpenDesignChangeWarningModal( true );
 			} }
 			variant={ 'secondary' }

--- a/plugins/woocommerce/changelog/add-more-cys-tracks
+++ b/plugins/woocommerce/changelog/add-more-cys-tracks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add more track events for cys


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We track users when they confirm to create a new one in https://github.com/woocommerce/woocommerce/pull/41284#pullrequestreview-1720093727. 

In that PR we replaced `customize_your_store_intro_create_a_new_one_click` event with `customize_your_store_intro_start_again_click`

But I just found that it's a high priority to also track "% of users that click on `Create a new store`.  (pdnLyh-4d9-p2).

This PR adds `customize_your_store_intro_create_a_new_one_click` track and also adds a new event `customize_your_store_ai_wizard_changed_ai_option` to track "% of users that change the AI recommended option.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:


1. Create a new WooCommerce installation with this version.
2. Make sure to enable `customize-store` feature flag
3. Install but NOT activate [WooCommerce Blocks nightly build](https://github.com/woocommerce/woocommerce-blocks/releases/tag/nightly) 
4. Go to `WooCommerce -> Home` and click `Customize Store` task
5. Enable logging `window.localStorage.setItem( 'debug', 'wc-admin:*')`
6. Go to AI wizard
7. Fill the business description
8. Click on "Continue"
9. Change the default AI recommended option
10. Observe that `wcadmin_customize_your_store_ai_wizard_changed_ai_option` event is recorded
11. Go back but reset to AI recommended option
12. Click on "Continue"
13. Observe that `wcadmin_customize_your_store_ai_wizard_changed_ai_option` event is NOT recorded
14. Click on "Continue"
15. Observe that `wcadmin_customize_your_store_ai_wizard_changed_ai_option` event is recorded
16. Complete AI wizard
13. Click on "Done" button
17. Go to  Customize Store` task intro screen
18. Click on "Create a new one" button
19. Observe that `customize_your_store_intro_create_a_new_one_click` event is recorded.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>