### PR TITLE
Style <mark> tag on order detail page

### DIFF
--- a/plugins/woocommerce/changelog/41323-fix-41268-mark-tag-on-order-page
+++ b/plugins/woocommerce/changelog/41323-fix-41268-mark-tag-on-order-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+- Enhancement: Style `<mark>` tag on order detail page

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-three.scss
@@ -538,13 +538,6 @@
 			}
 		}
 	}
-
-	// Highlights for specific info, e.g. on the My Account > Orders > Order X: Order ___ was placed on ____
-	mark {
-		font-weight: bold;
-		background-color: transparent;
-	}
-
 }
 
 // Description/Additional info/Reviews tabs.

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-two.scss
@@ -546,11 +546,6 @@ $tt2-gray: #f7f7f7;
 			padding: 0.7rem 2rem;
 		}
 	}
-
-	mark {
-		background: var(--wp--preset--color--secondary);
-		color: initial;
-	}
 }
 
 // Description/Additional info/Reviews tabs.

--- a/plugins/woocommerce/client/legacy/css/woocommerce-layout.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce-layout.scss
@@ -477,6 +477,12 @@
 	.woocommerce-MyAccount-content {
 		float: right;
 		width: 68%;
+
+		mark {
+			background-color: transparent;
+			color: inherit;
+			font-weight: 700;
+		}
 	}
 }
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

On the order detail page, the order ID, the order date and the order status are wrapped in a `<mark>` tag. For the Twenty Twenty-Two and the Twenty Twenty-Three theme, we applied custom styles. WordPress 6.4, which was released on November 7, 2023, contains a new core theme, the Twenty Twenty-Four theme. Instead of adding custom styles to target this theme, I decided to implement a generic solution. This generic solution should work for all themes, both classic and block themes. 

Closes #41268.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install and activate the Twenty Twenty-Four theme.
2. Go to the frontend and create a test order.
3. Go to `/my-account/view-order/` and view the test order.
4. Verify that the order ID, the order date and the order status are displayed in bold.
5. Repeat the previous step with the following themes:
  - Twenty Twenty-Three → testing against regressions, as `twenty-twenty-three.scss` had been modified
  - Twenty Twenty-Two → testing against regressions (see note below), as `twenty-twenty-two.scss` had been modified
  - Twenty Twenty-One → testing against a block theme
  - Storefront → testing against a classic theme

> **Important**
> The testing instructions above say _"Twenty Twenty-Two → testing against regressions, as `twenty-twenty-two.scss` had been modified"_. Technically, the PR introduces a regression, as the new styling looks different than the existing one. That said, this PR streamlines the styles for all themes, ensuring consistent styling.

### Screenshots

<details>
<summary>Twenty Twenty-Four</summary>
<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="1279" alt="Screenshot 2023-11-09 at 16 34 17" src="https://github.com/woocommerce/woocommerce/assets/3323310/6f68403f-e7f9-4314-8b26-942c07b358d5">
</td>
<td valign="top">After:
<br><br>
<img width="1278" alt="Screenshot 2023-11-09 at 16 07 56" src="https://github.com/woocommerce/woocommerce/assets/3323310/2e285039-d2ab-4975-9dbb-2d8ebb420ad1">
</td>
</tr>
</table>
</details>

<details>
<summary>Twenty Twenty-Three</summary>
<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="1278" alt="Screenshot 2023-11-09 at 16 34 43" src="https://github.com/woocommerce/woocommerce/assets/3323310/1d82a88a-ab4f-4c5f-b80b-126168974062">
</td>
<td valign="top">After:
<br><br>
<img width="1278" alt="Screenshot 2023-11-09 at 16 11 39" src="https://github.com/woocommerce/woocommerce/assets/3323310/530d9971-50f5-4a0d-9842-d5a8afe7acd7">
</td>
</tr>
</table>
</details>

<details>
<summary>Twenty Twenty-Two</summary>
<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="1278" alt="Screenshot 2023-11-09 at 16 35 17" src="https://github.com/woocommerce/woocommerce/assets/3323310/94fcb1b5-c944-442d-9b55-c3c9652af2f6">
</td>
<td valign="top">After:
<br><br>
<img width="1278" alt="Screenshot 2023-11-09 at 16 08 43" src="https://github.com/woocommerce/woocommerce/assets/3323310/0b6f6e03-3a3a-4714-8914-5833d34fcd65">
</td>
</tr>
</table>
</details>

<details>
<summary>Twenty Twenty-One</summary>
<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="1278" alt="Screenshot 2023-11-09 at 16 35 42" src="https://github.com/woocommerce/woocommerce/assets/3323310/67e84eb4-daaf-447e-a01e-ebe08c48d7d3">
</td>
<td valign="top">After:
<br><br>
<img width="1276" alt="Screenshot 2023-11-09 at 16 10 39" src="https://github.com/woocommerce/woocommerce/assets/3323310/8429b373-7213-4881-8d0f-9c287308c0c9">
</td>
</tr>
</table>
</details>

<details>
<summary>Storefront</summary>
<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="1280" alt="Screenshot 2023-11-09 at 16 36 06" src="https://github.com/woocommerce/woocommerce/assets/3323310/a4668970-ec46-4ef7-ab14-d41bc86bb287">
</td>
<td valign="top">After:
<br><br>
<img width="1278" alt="Screenshot 2023-11-09 at 16 09 29" src="https://github.com/woocommerce/woocommerce/assets/3323310/8ba15e8f-b710-444d-b497-869d71230cfa">
</td>
</tr>
</table>
</details>

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

- Enhancement: Style `<mark>` tag on order detail page

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
