### PR TITLE
Render customers filter on HPOS list table on hook `woocommerce_order_list_table_restrict_manage_orders`

### DIFF
--- a/plugins/woocommerce/changelog/fix-39271
+++ b/plugins/woocommerce/changelog/fix-39271
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Render customer filter on HPOS orders on hook execution for backwards compat.

--- a/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Orders/ListTable.php
@@ -103,6 +103,7 @@ class ListTable extends WP_List_Table {
 		add_filter( 'set_screen_option_edit_' . $this->order_type . '_per_page', array( $this, 'set_items_per_page' ), 10, 3 );
 		add_filter( 'default_hidden_columns', array( $this, 'default_hidden_columns' ), 10, 2 );
 		add_action( 'admin_footer', array( $this, 'enqueue_scripts' ) );
+		add_action( 'woocommerce_order_list_table_restrict_manage_orders', array( $this, 'customers_filter' ) );
 
 		$this->items_per_page();
 		set_screen_options();
@@ -673,7 +674,6 @@ class ListTable extends WP_List_Table {
 			ob_start();
 
 			$this->months_filter();
-			$this->customers_filter();
 
 			/**
 			 * Fires before the "Filter" button on the list table for orders and other order types.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
For backwards compatibility, we should render our own customers filter on the orders list table on hook `woocommerce_order_list_table_restrict_manage_orders`.
This allows 3rd parties to add filters that come before or after our own filter by manipulating their callback's hook priority.

Closes #39271.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Drop the following snippet in `wp-content/mu-plugins/` as a `.php` file. This will simulate an orders filter being added to the list table.
   ```php
   foreach ( [ 'restrict_manage_posts', 'woocommerce_order_list_table_restrict_manage_orders' ] as $hook ) {
	   add_action(
		   $hook,
		   function() { echo "<select><option>I wish I were a real filter</option></select>"; }
	   );
   }
   ```
2. Make sure HPOS is disabled in WC > Settings > Advanced > Features.
3. Go to WC > Orders.
4. Confirm that the top of the list table looks as in the screenshot, with "I wish I were a real filter" _in the middle_ of the dates dropdown and the customers dropdown.
   <img width="990" alt="Screenshot 2023-11-09 at 13 18 47" src="https://github.com/woocommerce/woocommerce/assets/184724/4da8bb43-40a0-49e0-852a-67b53292310d">
5. Go to WC > Settings > Advanced > Features and **enable** HPOS.
6. Repeat steps 3-4. Output should be identical.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
