### PR TITLE
Hide virtual & downloadable sections when the product type is 'variable'

### DIFF
--- a/plugins/woocommerce/changelog/add-40806
+++ b/plugins/woocommerce/changelog/add-40806
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Show virtual and downloadable features in simple product and variations only

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/ProductVariationTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/ProductVariationTemplate.php
@@ -479,22 +479,22 @@ class ProductVariationTemplate extends AbstractProductFormTemplate implements Pr
 		// Virtual section.
 		if ( Features::is_enabled( 'product-virtual-downloadable' ) ) {
 			$shipping_group->add_section(
-				[
+				array(
 					'id'    => 'product-variation-virtual-section',
 					'order' => 20,
-				]
+				)
 			)->add_block(
-				[
+				array(
 					'id'         => 'product-variation-virtual',
 					'blockName'  => 'woocommerce/product-toggle-field',
 					'order'      => 10,
-					'attributes' => [
+					'attributes' => array(
 						'property'       => 'virtual',
 						'checkedValue'   => false,
 						'uncheckedValue' => true,
 						'label'          => __( 'This variation requires shipping or pickup', 'woocommerce' ),
-					],
-				]
+					),
+				)
 			);
 		}
 		// Product Shipping Section.

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/ProductVariationTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/ProductVariationTemplate.php
@@ -477,24 +477,26 @@ class ProductVariationTemplate extends AbstractProductFormTemplate implements Pr
 			)
 		);
 		// Virtual section.
-		$shipping_group->add_section(
-			array(
-				'id'    => 'product-variation-virtual-section',
-				'order' => 20,
-			)
-		)->add_block(
-			array(
-				'id'         => 'product-variation-virtual',
-				'blockName'  => 'woocommerce/product-toggle-field',
-				'order'      => 10,
-				'attributes' => array(
-					'property'       => 'virtual',
-					'checkedValue'   => false,
-					'uncheckedValue' => true,
-					'label'          => __( 'This variation requires shipping or pickup', 'woocommerce' ),
-				),
-			)
-		);
+		if ( Features::is_enabled( 'product-virtual-downloadable' ) ) {
+			$shipping_group->add_section(
+				[
+					'id'    => 'product-variation-virtual-section',
+					'order' => 20,
+				]
+			)->add_block(
+				[
+					'id'         => 'product-variation-virtual',
+					'blockName'  => 'woocommerce/product-toggle-field',
+					'order'      => 10,
+					'attributes' => [
+						'property'       => 'virtual',
+						'checkedValue'   => false,
+						'uncheckedValue' => true,
+						'label'          => __( 'This variation requires shipping or pickup', 'woocommerce' ),
+					],
+				]
+			);
+		}
 		// Product Shipping Section.
 		$product_fee_and_dimensions_section = $shipping_group->add_section(
 			array(

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -263,6 +263,11 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 						'title'       => __( 'Downloads', 'woocommerce' ),
 						'description' => __( "Add any files you'd like to make available for the customer to download after purchasing, such as instructions or warranty info.", 'woocommerce' ),
 					),
+					'hideConditions' => [
+						[
+							'expression' => 'editedProduct.type !== "simple"',
+						],
+					],
 				)
 			)->add_block(
 				array(
@@ -766,24 +771,31 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 			)
 		);
 		// Virtual section.
-		$shipping_group->add_section(
-			array(
-				'id'    => 'product-virtual-section',
-				'order' => 10,
-			)
-		)->add_block(
-			array(
-				'id'         => 'product-virtual',
-				'blockName'  => 'woocommerce/product-toggle-field',
-				'order'      => 10,
-				'attributes' => array(
-					'property'       => 'virtual',
-					'checkedValue'   => false,
-					'uncheckedValue' => true,
-					'label'          => __( 'This product requires shipping or pickup', 'woocommerce' ),
-				),
-			)
-		);
+		if ( Features::is_enabled( 'product-virtual-downloadable' ) ) {
+			$shipping_group->add_section(
+				[
+					'id'             => 'product-virtual-section',
+					'order'          => 10,
+					'hideConditions' => [
+						[
+							'expression' => 'editedProduct.type !== "simple"',
+						],
+					],
+				]
+			)->add_block(
+				[
+					'id'         => 'product-virtual',
+					'blockName'  => 'woocommerce/product-toggle-field',
+					'order'      => 10,
+					'attributes' => [
+						'property'       => 'virtual',
+						'checkedValue'   => false,
+						'uncheckedValue' => true,
+						'label'          => __( 'This product requires shipping or pickup', 'woocommerce' ),
+					],
+				]
+			);
+		}
 		// Product Shipping Section.
 		$product_fee_and_dimensions_section = $shipping_group->add_section(
 			array(

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -257,17 +257,17 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 		if ( Features::is_enabled( 'product-virtual-downloadable' ) ) {
 			$general_group->add_section(
 				array(
-					'id'         => 'product-downloads-section',
-					'order'      => 40,
-					'attributes' => array(
+					'id'             => 'product-downloads-section',
+					'order'          => 40,
+					'attributes'     => array(
 						'title'       => __( 'Downloads', 'woocommerce' ),
 						'description' => __( "Add any files you'd like to make available for the customer to download after purchasing, such as instructions or warranty info.", 'woocommerce' ),
 					),
-					'hideConditions' => [
-						[
+					'hideConditions' => array(
+						array(
 							'expression' => 'editedProduct.type !== "simple"',
-						],
-					],
+						),
+					),
 				)
 			)->add_block(
 				array(
@@ -773,27 +773,27 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 		// Virtual section.
 		if ( Features::is_enabled( 'product-virtual-downloadable' ) ) {
 			$shipping_group->add_section(
-				[
+				array(
 					'id'             => 'product-virtual-section',
 					'order'          => 10,
-					'hideConditions' => [
-						[
+					'hideConditions' => array(
+						array(
 							'expression' => 'editedProduct.type !== "simple"',
-						],
-					],
-				]
+						),
+					),
+				)
 			)->add_block(
-				[
+				array(
 					'id'         => 'product-virtual',
 					'blockName'  => 'woocommerce/product-toggle-field',
 					'order'      => 10,
-					'attributes' => [
+					'attributes' => array(
 						'property'       => 'virtual',
 						'checkedValue'   => false,
 						'uncheckedValue' => true,
 						'label'          => __( 'This product requires shipping or pickup', 'woocommerce' ),
-					],
-				]
+					),
+				)
 			);
 		}
 		// Product Shipping Section.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #40806

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure feature `product-virtual-downloadable` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper` (WooCommerce Beta Tester plugin) is required
3. Go to `/wp-admin/admin.php?page=wc-admin&path=/add-product`
4. Under `General` tab and the bottom of the page a new `Downloads` section should be shown.
5. If you add some variations from the `Variations` tab the product changes from `simple` to `variable` so you will no longer see the `Downloads` section form the `General` tab.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
