### PR TITLE
Show global attribute slug without 'pa_' prefix

### DIFF
--- a/packages/js/product-editor/changelog/fix-global_attributes_display
+++ b/packages/js/product-editor/changelog/fix-global_attributes_display
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+Comment: Show global attribute slug without 'pa_' prefix
+
+

--- a/packages/js/product-editor/src/components/attribute-input-field/attribute-input-field.tsx
+++ b/packages/js/product-editor/src/components/attribute-input-field/attribute-input-field.tsx
@@ -52,6 +52,10 @@ function isNewAttributeListItem( attribute: NarrowedQueryAttribute ): boolean {
 	return attribute.id === -99;
 }
 
+function sanitizeSlugName( slug: string | undefined ): string {
+	return slug ? slug.replace( /pa_/g, '' ) : '';
+}
+
 export const AttributeInputField: React.FC< AttributeInputFieldProps > = ( {
 	value = null,
 	onChange,
@@ -211,7 +215,7 @@ export const AttributeInputField: React.FC< AttributeInputFieldProps > = ( {
 									tooltipText={
 										item.isDisabled
 											? disabledAttributeMessage
-											: item.slug
+											: sanitizeSlugName( item.slug )
 									}
 								>
 									{ isNewAttributeListItem( item ) ? (

--- a/packages/js/product-editor/src/components/attribute-input-field/attribute-input-field.tsx
+++ b/packages/js/product-editor/src/components/attribute-input-field/attribute-input-field.tsx
@@ -53,7 +53,7 @@ function isNewAttributeListItem( attribute: NarrowedQueryAttribute ): boolean {
 }
 
 function sanitizeSlugName( slug: string | undefined ): string {
-	return slug ? slug.replace( /pa_/g, '' ) : '';
+	return slug && slug.startsWith( 'pa_' ) ? slug.substring( 3 ) : '';
 }
 
 export const AttributeInputField: React.FC< AttributeInputFieldProps > = ( {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

I decided to display the attributes slug without the 'pa_' prefix, since that is the current behavior at the global attributes view (/wp-admin/edit.php?post_type=product&page=product_attributes)

Closes #40204 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Enable the new product editor at /wp-admin/admin.php?page=wc-settings&tab=advanced&section=features
2. Go to Products > Add new
3. Go to Organization tab
4. Press 'Add new' in Attributes section
5. Create a new global attribute if you don't have any
6. Hover over the list of attributes in the modal and see if the slug appears without the 'pa_' prefix.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
