### PR TITLE
Clear payment suggestion cache when base country gets updated

### DIFF
--- a/plugins/woocommerce/changelog/41344-fix-clear-payment-suggestion-on-base-country-update
+++ b/plugins/woocommerce/changelog/41344-fix-clear-payment-suggestion-on-base-country-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Clear payment suggestion spec when the base country gets updated.

--- a/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/PaymentGatewaySuggestions/Init.php
@@ -25,6 +25,7 @@ class Init {
 	 */
 	public function __construct() {
 		PaymentGatewaysController::init();
+		add_action( 'update_option_woocommerce_default_country', array( $this, 'delete_specs_transient' ) );
 	}
 
 	/**


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #41343  

This PR clears payment suggestion transient when the base country gets updated during the onboarding.

Cause: We run [do_wc_admin_daily](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Internal/Admin/Events.php#L142) for a new store. In the function, we also execute [possibly_refresh_data_source_pollers()](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Internal/Admin/Events.php#L267), which refreshes payment suggestion spec with the country code. There are two problems with this call.

1. Users haven't completed the onboarding yet and the base country is set to the U.S by default.
2. Payment suggestion list is cached for 7 days.

Users who select a non-U.S. country during the onboarding wizard will still see the payment suggestion list for the U.S. because the list is cached





<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new site with the latest WooCommerce
4. Choose Brazil as country during the OBW
5. Go to `WooCommerce -> Home` and click on `Set up payments`
6. Confirm Mercado Pago is rendered before PayPal Payments


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Clear payment suggestion spec when the base country gets updated.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
