### PR TITLE
Add filter to remove some of the `order-received` page protections

### DIFF
--- a/plugins/woocommerce/changelog/39598-add-order-received-validation-filter
+++ b/plugins/woocommerce/changelog/39598-add-order-received-validation-filter
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Create the filter woocommerce_order_received_verification_required to allow guest users to see the page order-received
+Adds filter `woocommerce_order_received_verify_known_shoppers` to allow known shoppers to access the order received page without being logged in.

--- a/plugins/woocommerce/changelog/39598-add-order-received-validation-filter
+++ b/plugins/woocommerce/changelog/39598-add-order-received-validation-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Create the filter woocommerce_order_received_verification_required to allow guest users to see the page order-received

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -307,7 +307,7 @@ class WC_Shortcode_Checkout {
 		 */
 		$verify_known_shoppers = apply_filters( 'woocommerce_order_received_verify_known_shoppers', true );
 		$order_customer_id = $order->get_customer_id();
-	
+
 		// For non-guest orders, require the user to be logged in before showing this page.
 		if ( $verify_known_shoppers && $order_customer_id && get_current_user_id() !== $order_customer_id ) {
 			wc_get_template( 'checkout/order-received.php', array( 'order' => false ) );

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -306,7 +306,7 @@ class WC_Shortcode_Checkout {
 		 * @since 8.4.0
 		 */
 		$verify_known_shoppers = apply_filters( 'woocommerce_order_received_verify_known_shoppers', true );
-		$order_customer_id = $order->get_customer_id();
+		$order_customer_id     = $order->get_customer_id();
 
 		// For non-guest orders, require the user to be logged in before showing this page.
 		if ( $verify_known_shoppers && $order_customer_id && get_current_user_id() !== $order_customer_id ) {

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -297,14 +297,25 @@ class WC_Shortcode_Checkout {
 			return;
 		}
 
-		$order_customer_id = $order->get_customer_id();
+		/**
+		 * Allow to guest users see the page order-received
+		 *
+		 * @param bool $order_received_verification_required If order-received verification is required.
+		 *
+		 * @since 8.4.0
+		 */
+		$order_received_verification_required = apply_filters( 'woocommerce_order_received_verification_required', true );
 
-		// For non-guest orders, require the user to be logged in before showing this page.
-		if ( $order_customer_id && get_current_user_id() !== $order_customer_id ) {
-			wc_get_template( 'checkout/order-received.php', array( 'order' => false ) );
-			wc_print_notice( esc_html__( 'Please log in to your account to view this order.', 'woocommerce' ), 'notice' );
-			woocommerce_login_form( array( 'redirect' => $order->get_checkout_order_received_url() ) );
-			return;
+		if($order_received_verification_required) {
+			$order_customer_id = $order->get_customer_id();
+	
+			// For non-guest orders, require the user to be logged in before showing this page.
+			if ( $order_customer_id && get_current_user_id() !== $order_customer_id ) {
+				wc_get_template( 'checkout/order-received.php', array( 'order' => false ) );
+				wc_print_notice( esc_html__( 'Please log in to your account to view this order.', 'woocommerce' ), 'notice' );
+				woocommerce_login_form( array( 'redirect' => $order->get_checkout_order_received_url() ) );
+				return;
+			}
 		}
 
 		// For guest orders, request they verify their email address (unless we can identify them via the active user session).

--- a/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -298,24 +298,22 @@ class WC_Shortcode_Checkout {
 		}
 
 		/**
-		 * Allow to guest users see the page order-received
+		 * Indicates if known (non-guest) shoppers need to be logged in before we let
+		 * them access the order received page.
 		 *
-		 * @param bool $order_received_verification_required If order-received verification is required.
+		 * @param bool $verify_known_shoppers If verification is required.
 		 *
 		 * @since 8.4.0
 		 */
-		$order_received_verification_required = apply_filters( 'woocommerce_order_received_verification_required', true );
-
-		if($order_received_verification_required) {
-			$order_customer_id = $order->get_customer_id();
+		$verify_known_shoppers = apply_filters( 'woocommerce_order_received_verify_known_shoppers', true );
+		$order_customer_id = $order->get_customer_id();
 	
-			// For non-guest orders, require the user to be logged in before showing this page.
-			if ( $order_customer_id && get_current_user_id() !== $order_customer_id ) {
-				wc_get_template( 'checkout/order-received.php', array( 'order' => false ) );
-				wc_print_notice( esc_html__( 'Please log in to your account to view this order.', 'woocommerce' ), 'notice' );
-				woocommerce_login_form( array( 'redirect' => $order->get_checkout_order_received_url() ) );
-				return;
-			}
+		// For non-guest orders, require the user to be logged in before showing this page.
+		if ( $verify_known_shoppers && $order_customer_id && get_current_user_id() !== $order_customer_id ) {
+			wc_get_template( 'checkout/order-received.php', array( 'order' => false ) );
+			wc_print_notice( esc_html__( 'Please log in to your account to view this order.', 'woocommerce' ), 'notice' );
+			woocommerce_login_form( array( 'redirect' => $order->get_checkout_order_received_url() ) );
+			return;
 		}
 
 		// For guest orders, request they verify their email address (unless we can identify them via the active user session).


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

When an authenticated shopper successfully places an order, they will be taken to a summary on the *order received* page. However, the same URL is not accessible to other users: if they somehow discover the URL and attempt to access it, they will be asked to log in first of all.

This is a sensible default protection, but it is not always desirable and can conflict with customized checkout flows (see examples in the linked issue). To that end, this PR introduces a new hook that makes it possible (/easier) to programmatically remove this extra protection. 

Unless the hook is used, however, there will be no change to the default shopper experience.

Closes #39598.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Login as a customer, and place a new order. 
2. You should be taken to the *order received* page. Copy the URL.
4. Logout, or else open an incognito/private-mode browsing session, and try to re-use the URL you copied: instead of seeing the same information as previously, you will be asked to login.  ***Note: just to clarify, this matches the existing/expected behavior.***
5. Let's now create a filter for `woocommerce_order_received_verify_known_shoppers` which should return false. You cna do that with a snippet like this one, which could be added to `wp-content/mu-plugins/test-41347.php`:

```php
<?php

add_filter( 'woocommerce_order_received_verify_known_shoppers', '__return_false' );
```

6. Refresh the page: you should now be able to see the full *order received* page. ***Note: this is the change enabled by this PR.***
7. Log back in as a customer, and you should again be able to see the full *order received* page details, regardless of what the above filter is set to.

<!-- End testing instructions -->

#### Comment
This is my first PR to Woocommerce so let me know if anything is wrong or misunderstood.

</details>
