### PR TITLE
[CYS] Hide feedback button when survey has already been completed

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/layout.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/layout.tsx
@@ -71,11 +71,16 @@ export const Layout = () => {
 	const { record: template } = useEditedEntityRecord();
 	const { id: templateId, type: templateType } = template;
 
-	const { sendEvent, currentState } = useContext( CustomizeStoreContext );
+	const { sendEvent, currentState, context } = useContext(
+		CustomizeStoreContext
+	);
 	const [ isSurveyOpen, setSurveyOpen ] = useState( false );
 	const editor = <Editor isLoading={ isEditorLoading } />;
 
-	if ( currentState === 'transitionalScreen' ) {
+	if (
+		typeof currentState === 'object' &&
+		currentState.transitionalScreen === 'transitional'
+	) {
 		return (
 			<EntityProvider kind="root" type="site">
 				<EntityProvider
@@ -88,6 +93,9 @@ export const Layout = () => {
 						editor={ editor }
 						isSurveyOpen={ isSurveyOpen }
 						setSurveyOpen={ setSurveyOpen }
+						hasCompleteSurvey={
+							!! context?.transitionalScreen?.hasCompleteSurvey
+						}
 					/>
 				</EntityProvider>
 			</EntityProvider>

--- a/plugins/woocommerce-admin/client/customize-store/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/index.tsx
@@ -29,7 +29,11 @@ import {
 } from './intro';
 import { DesignWithAi, events as designWithAiEvents } from './design-with-ai';
 import { AssemblerHub, events as assemblerHubEvents } from './assembler-hub';
-import { events as transitionalEvents } from './transitional';
+import {
+	events as transitionalEvents,
+	services as transitionalServices,
+	actions as transitionalActions,
+} from './transitional';
 import { findComponentMeta } from '~/utils/xstate/find-component';
 import {
 	CustomizeStoreComponentMeta,
@@ -101,6 +105,12 @@ const browserPopstateHandler =
 		};
 	};
 
+const CYSSpinner = () => (
+	<div className="woocommerce-customize-store__loading">
+		<Spinner />
+	</div>
+);
+
 export const machineActions = {
 	updateQueryStep,
 	redirectToWooHome,
@@ -109,11 +119,13 @@ export const machineActions = {
 
 export const customizeStoreStateMachineActions = {
 	...introActions,
+	...transitionalActions,
 	...machineActions,
 };
 
 export const customizeStoreStateMachineServices = {
 	...introServices,
+	...transitionalServices,
 	browserPopstateHandler,
 	markTaskComplete,
 };
@@ -144,6 +156,9 @@ export const customizeStoreStateMachineDefinition = createMachine( {
 			activeThemeHasMods: false,
 			customizeStoreTaskCompleted: false,
 			currentThemeIsAiGenerated: false,
+		},
+		transitionalScreen: {
+			hasCompleteSurvey: false,
 		},
 	} as customizeStoreStateMachineContext,
 	invoke: {
@@ -281,12 +296,19 @@ export const customizeStoreStateMachineDefinition = createMachine( {
 					},
 				},
 				postAssemblerHub: {
-					invoke: {
-						src: 'markTaskComplete',
-						onDone: {
-							target: '#customizeStore.transitionalScreen',
+					invoke: [
+						{
+							src: 'markTaskComplete',
+							// eslint-disable-next-line xstate/no-ondone-outside-compound-state
+							onDone: {
+								target: '#customizeStore.transitionalScreen',
+							},
 						},
-					},
+						{
+							// Pre-fetch survey completed option so we can show the screen immediately.
+							src: 'fetchSurveyCompletedOption',
+						},
+					],
 				},
 			},
 			on: {
@@ -299,13 +321,38 @@ export const customizeStoreStateMachineDefinition = createMachine( {
 			},
 		},
 		transitionalScreen: {
-			entry: [ { type: 'updateQueryStep', step: 'transitional' } ],
-			meta: {
-				component: AssemblerHub,
-			},
-			on: {
-				GO_BACK_TO_HOME: {
-					actions: 'redirectToWooHome',
+			initial: 'preTransitional',
+			states: {
+				preTransitional: {
+					meta: {
+						component: CYSSpinner,
+					},
+					invoke: {
+						src: 'fetchSurveyCompletedOption',
+						onError: {
+							target: 'transitional', // leave it as initialised default on error
+						},
+						onDone: {
+							target: 'transitional',
+							actions: [ 'assignHasCompleteSurvey' ],
+						},
+					},
+				},
+				transitional: {
+					entry: [
+						{ type: 'updateQueryStep', step: 'transitional' },
+					],
+					meta: {
+						component: AssemblerHub,
+					},
+					on: {
+						GO_BACK_TO_HOME: {
+							actions: 'redirectToWooHome',
+						},
+						COMPLETE_SURVEY: {
+							actions: 'completeSurvey',
+						},
+					},
 				},
 			},
 		},
@@ -389,9 +436,7 @@ export const CustomizeStoreController = ( {
 						currentState={ state.value }
 					/>
 				) : (
-					<div className="woocommerce-customize-store__loading">
-						<Spinner />
-					</div>
+					<CYSSpinner />
 				) }
 			</div>
 			{ /* @ts-expect-error 'scope' does exist. @types/wordpress__plugins is outdated. */ }

--- a/plugins/woocommerce-admin/client/customize-store/intro/tests/intro-banner.test.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/intro/tests/intro-banner.test.tsx
@@ -41,6 +41,9 @@ describe( 'Intro Banners', () => {
 						currentThemeIsAiGenerated: false,
 					},
 					themeConfiguration: {},
+					transitionalScreen: {
+						hasCompleteSurvey: false,
+					},
 				} }
 				currentState={ 'intro' }
 				parentMachine={ null as unknown as AnyInterpreter }
@@ -75,6 +78,9 @@ describe( 'Intro Banners', () => {
 						currentThemeIsAiGenerated: false,
 					},
 					themeConfiguration: {},
+					transitionalScreen: {
+						hasCompleteSurvey: false,
+					},
 				} }
 				currentState={ 'intro' }
 				parentMachine={ null as unknown as AnyInterpreter }
@@ -115,6 +121,9 @@ describe( 'Intro Banners', () => {
 						currentThemeIsAiGenerated: true,
 					},
 					themeConfiguration: {},
+					transitionalScreen: {
+						hasCompleteSurvey: false,
+					},
 				} }
 				currentState={ 'intro' }
 				parentMachine={ null as unknown as AnyInterpreter }

--- a/plugins/woocommerce-admin/client/customize-store/intro/tests/intro-modal.test.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/intro/tests/intro-modal.test.tsx
@@ -39,6 +39,9 @@ describe( 'Intro Modals', () => {
 						currentThemeIsAiGenerated: false,
 					},
 					themeConfiguration: {},
+					transitionalScreen: {
+						hasCompleteSurvey: false,
+					},
 				} }
 				currentState={ 'intro' }
 				parentMachine={ null as unknown as AnyInterpreter }
@@ -90,6 +93,9 @@ describe( 'Intro Modals', () => {
 						currentThemeIsAiGenerated: true,
 					},
 					themeConfiguration: {},
+					transitionalScreen: {
+						hasCompleteSurvey: false,
+					},
 				} }
 				currentState={ 'intro' }
 				parentMachine={ null as unknown as AnyInterpreter }
@@ -139,6 +145,9 @@ describe( 'Intro Modals', () => {
 						currentThemeIsAiGenerated: false,
 					},
 					themeConfiguration: {},
+					transitionalScreen: {
+						hasCompleteSurvey: false,
+					},
 				} }
 				currentState={ 'intro' }
 				parentMachine={ null as unknown as AnyInterpreter }

--- a/plugins/woocommerce-admin/client/customize-store/transitional/actions.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/transitional/actions.tsx
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import { assign, DoneInvokeEvent } from 'xstate';
+import { dispatch } from '@wordpress/data';
+import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+
+/**
+ * Internal dependencies
+ */
+import { customizeStoreStateMachineContext } from '../types';
+import { customizeStoreStateMachineEvents } from '..';
+
+export const assignHasCompleteSurvey = assign<
+	customizeStoreStateMachineContext,
+	customizeStoreStateMachineEvents
+>( {
+	transitionalScreen: (
+		context: customizeStoreStateMachineContext,
+		event
+	) => {
+		return {
+			...context.transitionalScreen,
+			hasCompleteSurvey:
+				( event as DoneInvokeEvent< string | undefined > ).data ===
+				'yes',
+		};
+	},
+} );
+
+export const completeSurvey = assign<
+	customizeStoreStateMachineContext,
+	customizeStoreStateMachineEvents
+>( {
+	transitionalScreen: ( context: customizeStoreStateMachineContext ) => {
+		dispatch( OPTIONS_STORE_NAME ).updateOptions( {
+			woocommerce_admin_customize_store_survey_completed: 'yes',
+		} );
+
+		return {
+			...context.transitionalScreen,
+			hasCompleteSurvey: true,
+		};
+	},
+} );

--- a/plugins/woocommerce-admin/client/customize-store/transitional/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/transitional/index.tsx
@@ -28,22 +28,26 @@ import { navigateOrParent } from '../utils';
 import { WooCYSSecondaryButtonSlot } from './secondary-button-slot';
 import { SurveyForm } from './survey-form';
 
-export type events = { type: 'GO_BACK_TO_HOME' };
+export * as actions from './actions';
+export * as services from './services';
+
+export type events = { type: 'GO_BACK_TO_HOME' } | { type: 'COMPLETE_SURVEY' };
 
 export const Transitional = ( {
 	editor,
 	sendEvent,
+	hasCompleteSurvey,
 	isSurveyOpen,
 	setSurveyOpen,
 }: {
 	editor: React.ReactNode;
 	sendEvent: ( event: events ) => void;
+	hasCompleteSurvey: boolean;
 	isSurveyOpen: boolean;
 	setSurveyOpen: ( isOpen: boolean ) => void;
 } ) => {
 	const homeUrl: string = getSetting( 'homeUrl', '' );
 	const isEditorLoading = useIsSiteEditorLoading();
-
 	const closeSurvey = () => {
 		setSurveyOpen( false );
 	};
@@ -57,7 +61,15 @@ export const Transitional = ( {
 					shouldCloseOnClickOutside={ false }
 					className="woocommerce-ai-survey-modal"
 				>
-					<SurveyForm closeFunction={ closeSurvey } />
+					<SurveyForm
+						onSend={ () => {
+							sendEvent( {
+								type: 'COMPLETE_SURVEY',
+							} );
+							closeSurvey();
+						} }
+						closeFunction={ closeSurvey }
+					/>
 				</Modal>
 			) }
 			<SiteHub
@@ -83,18 +95,20 @@ export const Transitional = ( {
 				<div className="woocommerce-customize-store__transitional-main-actions">
 					<WooCYSSecondaryButtonSlot />
 
-					<Button
-						className="woocommerce-customize-store__transitional-preview-button"
-						variant="secondary"
-						onClick={ () => {
-							recordEvent(
-								'customize_your_store_transitional_survey_click'
-							);
-							setSurveyOpen( true );
-						} }
-					>
-						{ __( 'Share feedback', 'woocommerce' ) }
-					</Button>
+					{ ! hasCompleteSurvey && (
+						<Button
+							className="woocommerce-customize-store__transitional-preview-button"
+							variant="secondary"
+							onClick={ () => {
+								recordEvent(
+									'customize_your_store_transitional_survey_click'
+								);
+								setSurveyOpen( true );
+							} }
+						>
+							{ __( 'Share feedback', 'woocommerce' ) }
+						</Button>
+					) }
 
 					<Button
 						className="woocommerce-customize-store__transitional-preview-button"

--- a/plugins/woocommerce-admin/client/customize-store/transitional/services.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/transitional/services.tsx
@@ -1,0 +1,10 @@
+/**
+ * External dependencies
+ */
+import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { resolveSelect } from '@wordpress/data';
+
+export const fetchSurveyCompletedOption = async () =>
+	resolveSelect( OPTIONS_STORE_NAME ).getOption(
+		'woocommerce_admin_customize_store_survey_completed'
+	);

--- a/plugins/woocommerce-admin/client/customize-store/transitional/survey-form/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/transitional/survey-form/index.tsx
@@ -60,8 +60,10 @@ const StarRating = ( {
 };
 
 export const SurveyForm = ( {
+	onSend,
 	closeFunction,
 }: {
+	onSend: () => void;
 	closeFunction: CloseSurveyFunction;
 } ): JSX.Element => {
 	const [ isStreamlineChecked, setStreamlineChecked ] = useState( false );
@@ -83,7 +85,8 @@ export const SurveyForm = ( {
 			feedback: feedbackText,
 			spill_beans: spillBeansText,
 		} );
-		closeFunction();
+
+		onSend();
 		createSuccessNotice(
 			__(
 				"Thanks for the feedback. We'll put it to good use!",

--- a/plugins/woocommerce-admin/client/customize-store/types.ts
+++ b/plugins/woocommerce-admin/client/customize-store/types.ts
@@ -39,4 +39,7 @@ export type customizeStoreStateMachineContext = {
 		customizeStoreTaskCompleted: boolean;
 		currentThemeIsAiGenerated: boolean;
 	};
+	transitionalScreen: {
+		hasCompleteSurvey: boolean;
+	};
 };

--- a/plugins/woocommerce/changelog/fix-feedback-button-appear-after-survey-completed
+++ b/plugins/woocommerce/changelog/fix-feedback-button-appear-after-survey-completed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Hide CYS feedback button when survey has already been completed

--- a/plugins/woocommerce/src/Admin/API/Options.php
+++ b/plugins/woocommerce/src/Admin/API/Options.php
@@ -218,6 +218,7 @@ class Options extends \WC_REST_Data_Controller {
 			'woocommerce_customize_store_ai_suggestions',
 			'woocommerce_admin_customize_store_completed',
 			'woocommerce_admin_customize_store_completed_theme_id',
+			'woocommerce_admin_customize_store_survey_completed',
 			// WC Test helper options.
 			'wc-admin-test-helper-rest-api-filters',
 			'wc_admin_helper_feature_values',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/41319

![Image](https://github.com/woocommerce/woocommerce/assets/4344253/71cac7ae-ceb0-4fad-ba58-683c5396342d)


![Image](https://github.com/woocommerce/woocommerce/assets/4344253/fdbbd6e7-f99a-4212-9f81-4f93663d71ba)


Feedback button should not appear if survey has already been completed

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new WooCommerce installation with this version.
3. Make sure to enable customize-store feature flag
4. Go to /wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store%2Ftransitional
5. Click "Share Feedback" 
6. Answer survey questions
7. Press "Send"
8. See that the survey modal is closed
9. See that the "Share Feedback" button disappears.
10. Reload the page
11. Observe that the "Share Feedback" button is not displayed.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>