### PR TITLE
Logging: Implement "search within log files"

### DIFF
--- a/plugins/woocommerce/changelog/try-log-search
+++ b/plugins/woocommerce/changelog/try-log-search
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Adds a search field to the log files list table screen that will do a partial match string search on the contents of all the files currently shown in the list table

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1348,9 +1348,11 @@ table.wc_status_table--tools {
 	}
 }
 
-.wc-logs-single-file-actions {
+.wc-logs-single-file-actions,
+.wc-logs-search {
 	margin-left: auto;
 	display: flex;
+	flex-flow: row wrap;
 	gap: 0.5em;
 }
 

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1420,6 +1420,52 @@ table.wc_status_table--tools {
 	}
 }
 
+.wc-logs-search-results {
+	border: 1px solid #c3c4c7;
+	background: #ffffff;
+	font-family: Consolas, Monaco, monospace;
+	word-wrap: break-word;
+	line-height: 2.3;
+
+	.match {
+		display: flex;
+		align-items: center;
+		width: 100%;
+		background: #ffffff;
+		border-top: 1px solid #c3c4c7;
+
+		&:first-child {
+			border-top: 0;
+		}
+
+		&:nth-child( 2n + 1 ) {
+			background: #f6f7f7;
+		}
+	}
+
+	.match-anchor {
+		flex: 1;
+		padding: 0 1em;
+		font-size: 0.9em;
+	}
+
+	.match-content {
+		flex: 6;
+		overflow: hidden;
+		padding: 0 1em;
+	}
+
+	.search-match {
+		display: inline-block;
+		background: #fff8c5;
+	}
+
+	.no-match {
+		display: block;
+		padding: 1em;
+	}
+}
+
 /**
  * Log severity level colors.
  *

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1443,21 +1443,27 @@ table.wc_status_table--tools {
 		}
 	}
 
+	.match-file {
+		width: 16%;
+		padding: 0.3em 0.5em 0.3em 1em;
+		line-height: 2;
+	}
+
 	.match-anchor {
-		flex: 1;
-		padding: 0 1em;
-		font-size: 0.9em;
+		width: 8%;
+		padding: 0 0.5em;
 	}
 
 	.match-content {
-		flex: 6;
+		flex: 1;
 		overflow: hidden;
-		padding: 0 1em;
+		padding: 0 1em 0 0.5em;
 	}
 
 	.search-match {
 		background: #fff8c5;
-		padding: 0.52em 0;
+		padding: 0.46em 0;
+		border: 1px dashed #c3c4c7;
 	}
 
 	.no-match {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1456,8 +1456,8 @@ table.wc_status_table--tools {
 	}
 
 	.search-match {
-		display: inline-block;
 		background: #fff8c5;
+		padding: 0.52em 0;
 	}
 
 	.no-match {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1421,54 +1421,37 @@ table.wc_status_table--tools {
 }
 
 .wc-logs-search-results {
-	border: 1px solid #c3c4c7;
-	background: #ffffff;
-	font-family: Consolas, Monaco, monospace;
-	word-wrap: break-word;
-	line-height: 2.3;
+	tbody {
+		font-family: Consolas, Monaco, monospace;
+		word-wrap: break-word;
 
-	.match {
-		display: flex;
-		align-items: center;
-		width: 100%;
-		background: #ffffff;
-		border-top: 1px solid #c3c4c7;
-
-		&:first-child {
-			border-top: 0;
+		.column-file_id {
+			line-height: 2;
 		}
 
-		&:nth-child( 2n + 1 ) {
-			background: #f6f7f7;
+		.column-line_number,
+		.column-line {
+			line-height: 2.3;
 		}
 	}
 
-	.match-file {
+	td {
+		vertical-align: middle;
+	}
+
+	.column-file_id {
 		width: 16%;
-		padding: 0.3em 0.5em 0.3em 1em;
-		line-height: 2;
 	}
 
-	.match-anchor {
+	.column-line_number {
 		width: 8%;
-		padding: 0 0.5em;
-	}
-
-	.match-content {
-		flex: 1;
-		overflow: hidden;
-		padding: 0 1em 0 0.5em;
 	}
 
 	.search-match {
 		background: #fff8c5;
 		padding: 0.46em 0;
 		border: 1px dashed #c3c4c7;
-	}
-
-	.no-match {
-		display: block;
-		padding: 1em;
+		line-height: 2.3;
 	}
 }
 

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1348,13 +1348,47 @@ table.wc_status_table--tools {
 	}
 }
 
-.wc-logs-single-file-actions,
-.wc-logs-search {
+.wc-logs-single-file-actions {
 	margin-left: auto;
 	display: flex;
 	flex-flow: row wrap;
 	gap: 0.5em;
 }
+
+.wc-logs-search {
+	margin-left: auto;
+	display: flex;
+	flex-flow: column;
+}
+
+.wc-logs-search-fieldset {
+	display: flex;
+	gap: 0.5em;
+	justify-content: flex-end;
+}
+
+.wc-logs-search-notice {
+	font-size: 0.9em;
+	line-height: 2;
+	text-align: right;
+	visibility: hidden;
+	height: 0;
+
+	.wc-logs-search:focus-within & {
+		visibility: visible;
+		height: auto;
+	}
+}
+
+//.wc-logs-search {
+//	.wc-logs-search-notice {
+//		display: none;
+//	}
+//
+//	&:focus-within .wc-logs-search-notice {
+//		display: block;
+//	}
+//}
 
 .wc-logs-entries {
 	background: #f6f7f7;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1456,6 +1456,10 @@ table.wc_status_table--tools {
 		.column-line {
 			line-height: 2.3;
 		}
+
+		.column-line {
+			font-family: Consolas, Monaco, monospace;
+		}
 	}
 
 	td {
@@ -1468,10 +1472,6 @@ table.wc_status_table--tools {
 
 	.column-line_number {
 		width: 8%;
-	}
-
-	.column-line {
-		font-family: Consolas, Monaco, monospace;
 	}
 
 	.search-match {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1380,16 +1380,6 @@ table.wc_status_table--tools {
 	}
 }
 
-//.wc-logs-search {
-//	.wc-logs-search-notice {
-//		display: none;
-//	}
-//
-//	&:focus-within .wc-logs-search-notice {
-//		display: block;
-//	}
-//}
-
 .wc-logs-entries {
 	background: #f6f7f7;
 	border: 1px solid #c3c4c7;
@@ -1456,7 +1446,6 @@ table.wc_status_table--tools {
 
 .wc-logs-search-results {
 	tbody {
-		font-family: Consolas, Monaco, monospace;
 		word-wrap: break-word;
 
 		.column-file_id {
@@ -1479,6 +1468,10 @@ table.wc_status_table--tools {
 
 	.column-line_number {
 		width: 8%;
+	}
+
+	.column-line {
+		font-family: Consolas, Monaco, monospace;
 	}
 
 	.search-match {

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -12,7 +12,7 @@ use Automattic\WooCommerce\Internal\Admin\Marketplace;
 use Automattic\WooCommerce\Internal\Admin\Orders\COTRedirectionController;
 use Automattic\WooCommerce\Internal\Admin\Orders\PageController as Custom_Orders_PageController;
 use Automattic\WooCommerce\Internal\Admin\Logging\PageController as LoggingPageController;
-use Automattic\WooCommerce\Internal\Admin\Logging\FileV2\ListTable as LoggingListTable;
+use Automattic\WooCommerce\Internal\Admin\Logging\FileV2\{ FileListTable, SearchListTable };
 use Automattic\WooCommerce\Internal\Admin\WCAdminAssets;
 use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
 use Automattic\WooCommerce\Utilities\FeaturesUtil;
@@ -324,7 +324,8 @@ class WC_Admin_Menus {
 		$screen_options = array(
 			'woocommerce_keys_per_page',
 			'woocommerce_webhooks_per_page',
-			LoggingListTable::PER_PAGE_USER_OPTION_KEY,
+			FileListTable::PER_PAGE_USER_OPTION_KEY,
+			SearchListTable::PER_PAGE_USER_OPTION_KEY,
 		);
 
 		if ( in_array( $option, $screen_options, true ) ) {

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
@@ -153,7 +153,7 @@ class File {
 	}
 
 	/**
-	 * Open a read-only stream file this file.
+	 * Open a read-only stream for this file.
 	 *
 	 * @return resource|false
 	 */
@@ -164,6 +164,18 @@ class File {
 		}
 
 		return $this->stream;
+	}
+
+	/**
+	 * Close the stream for this file.
+	 *
+	 * The stream will also close automatically when the class instance destructs, but this can be useful for
+	 * avoiding having a large number of streams open simultaneously.
+	 *
+	 * @return bool
+	 */
+	public function close_stream(): bool {
+		return fclose( $this->stream );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
@@ -175,6 +175,7 @@ class File {
 	 * @return bool
 	 */
 	public function close_stream(): bool {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fclose -- No suitable alternative.
 		return fclose( $this->stream );
 	}
 

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
@@ -339,44 +339,25 @@ class FileController {
 		foreach ( $files as $file ) {
 			$stream      = $file->get_stream();
 			$line_number = 1;
+
 			while ( ! feof( $stream ) ) {
 				$line = fgets( $stream );
-				if ( is_string( $line ) ) {
-					$line = esc_html( trim( $line ) );
-					if ( empty( $line ) ) {
-						continue;
-					}
+				if ( ! is_string( $line ) ) {
+					continue;
 				}
 
-				if ( is_string( $line ) ) {
-					if ( false !== stripos( $line, $search ) ) {
-						$pattern = preg_quote( $search, '/' );
-						preg_match_all( "/$pattern/i", $line, $matches, PREG_OFFSET_CAPTURE );
-
-						if ( is_array( $matches[0] ) && count( $matches[0] ) >= 1 ) {
-							$length_change = 0;
-
-							foreach ( $matches[0] as $match ) {
-								$replace        = '<span class="search-match">' . $match[0] . '</span>';
-								$offset         = $match[1] + $length_change;
-								$orig_length    = strlen( $match[0] );
-								$replace_length = strlen( $replace );
-
-								$line = substr_replace( $line, $replace, $offset, $orig_length );
-
-								$length_change += $replace_length - $orig_length;
-							}
-						}
-
-						$matched_lines[] = array(
-							'file_id'     => $file->get_file_id(),
-							'line_number' => $line_number,
-							'line'        => $line,
-						);
-					}
+				$line = esc_html( trim( $line ) );
+				if ( false !== stripos( $line, $search ) ) {
+					$matched_lines[] = array(
+						'file_id'     => $file->get_file_id(),
+						'line_number' => $line_number,
+						'line'        => $line,
+					);
 				}
+
 				$line_number ++;
 			}
+
 			$file->close_stream();
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
@@ -341,14 +341,20 @@ class FileController {
 				if ( is_string( $line ) ) {
 					if ( false !== stripos( $line, $search ) ) {
 						$pattern = addcslashes( $search, '/' );
-						preg_match_all( "/$pattern/i", $line, $matches );
+						preg_match_all( "/$pattern/i", $line, $matches, PREG_OFFSET_CAPTURE );
+
 						if ( is_array( $matches[0] ) && count( $matches[0] ) >= 1 ) {
+							$length_change = 0;
+
 							foreach ( $matches[0] as $match ) {
-								$line = str_replace(
-									$match,
-									'<span class="search-match">' . $match . '</span>',
-									$line
-								);
+								$replace        = '<span class="search-match">' . $match[0] . '</span>';
+								$offset         = $match[1] + $length_change;
+								$orig_length    = strlen( $match[0] );
+								$replace_length = strlen( $replace );
+
+								$line = substr_replace( $line, $replace, $offset, $orig_length );
+
+								$length_change += $replace_length - $orig_length;
 							}
 						}
 
@@ -361,6 +367,7 @@ class FileController {
 				}
 				$line_number ++;
 			}
+			$file->close_stream();
 		}
 
 		return $matched_lines;

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
@@ -315,6 +315,12 @@ class FileController {
 	 *                        line number, and the matched string with HTML markup around the matched parts.
 	 */
 	public function search_within_files( string $search, array $file_args = array() ) {
+		if ( '' === $search ) {
+			return array();
+		}
+
+		$search = esc_html( $search );
+
 		$file_args = array_merge(
 			$file_args,
 			array(
@@ -323,24 +329,28 @@ class FileController {
 			)
 		);
 
-		if ( '' === $search ) {
-			return array();
-		}
-
 		$files = $this->get_files( $file_args );
 		if ( is_wp_error( $files ) ) {
 			return $files;
 		}
 
 		$matched_lines = array();
+
 		foreach ( $files as $file ) {
 			$stream      = $file->get_stream();
 			$line_number = 1;
 			while ( ! feof( $stream ) ) {
 				$line = fgets( $stream );
 				if ( is_string( $line ) ) {
+					$line = esc_html( trim( $line ) );
+					if ( empty( $line ) ) {
+						continue;
+					}
+				}
+
+				if ( is_string( $line ) ) {
 					if ( false !== stripos( $line, $search ) ) {
-						$pattern = addcslashes( $search, '/' );
+						$pattern = preg_quote( $search, '/' );
 						preg_match_all( "/$pattern/i", $line, $matches, PREG_OFFSET_CAPTURE );
 
 						if ( is_array( $matches[0] ) && count( $matches[0] ) >= 1 ) {

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
@@ -380,7 +380,7 @@ class FileController {
 					);
 				}
 
-				if ( count( $matched_lines ) >= self::SEARCH_MAX_RESULTS ) {
+				if ( count( $matched_lines ) > self::SEARCH_MAX_RESULTS ) {
 					break 2;
 				}
 

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
@@ -411,6 +411,7 @@ class FileController {
 					}
 
 					if ( count( $matched_lines ) > self::SEARCH_MAX_RESULTS ) {
+						$file->close_stream();
 						break 2;
 					}
 

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
@@ -410,7 +410,7 @@ class FileController {
 						);
 					}
 
-					if ( count( $matched_lines ) > self::SEARCH_MAX_RESULTS ) {
+					if ( count( $matched_lines ) >= self::SEARCH_MAX_RESULTS ) {
 						$file->close_stream();
 						break 2;
 					}

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileListTable.php
@@ -150,7 +150,7 @@ class FileListTable extends WP_List_Table {
 	public function prepare_items(): void {
 		$per_page = $this->get_items_per_page(
 			self::PER_PAGE_USER_OPTION_KEY,
-			$this->file_controller::DEFAULTS_GET_FILES['per_page']
+			$this->get_per_page_default()
 		);
 
 		$defaults  = array(
@@ -320,5 +320,14 @@ class FileListTable extends WP_List_Table {
 		$size = $item->get_file_size();
 
 		return size_format( $size );
+	}
+
+	/**
+	 * Helper to get the default value for the per_page arg.
+	 *
+	 * @return int
+	 */
+	public function get_per_page_default(): int {
+		return $this->file_controller::DEFAULTS_GET_FILES['per_page'];
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileListTable.php
@@ -8,9 +8,9 @@ use Automattic\WooCommerce\Internal\Admin\Logging\PageController;
 use WP_List_Table;
 
 /**
- * ListTable class.
+ * FileListTable class.
  */
-class ListTable extends WP_List_Table {
+class FileListTable extends WP_List_Table {
 	/**
 	 * The user option key for saving the preferred number of files displayed per page.
 	 *
@@ -33,7 +33,7 @@ class ListTable extends WP_List_Table {
 	private $page_controller;
 
 	/**
-	 * ListTable class.
+	 * FileListTable class.
 	 *
 	 * @param FileController $file_controller Instance of FileController.
 	 * @param PageController $page_controller Instance of PageController.

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/ListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/ListTable.php
@@ -157,7 +157,10 @@ class ListTable extends WP_List_Table {
 			'per_page' => $per_page,
 			'offset'   => ( $this->get_pagenum() - 1 ) * $per_page,
 		);
-		$file_args = wp_parse_args( $this->page_controller->get_query_params(), $defaults );
+		$file_args = wp_parse_args(
+			$this->page_controller->get_query_params( array( 'order', 'orderby', 'source' ) ),
+			$defaults
+		);
 
 		$total_items = $this->file_controller->get_files( $file_args, true );
 		if ( is_wp_error( $total_items ) ) {

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/SearchListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/SearchListTable.php
@@ -104,6 +104,17 @@ class SearchListTable extends WP_List_Table {
 			return;
 		}
 
+		if ( $total_items > get_class( $this->file_controller )::SEARCH_MAX_RESULTS ) {
+			printf(
+				'<div class="notice notice-info"><p>%s</p></div>',
+				sprintf(
+					// translators: %s is a number.
+					esc_html__( 'The number of search results has exceeded the limit of %s. Try narrowing your search.', 'woocommerce' ),
+					number_format_i18n( get_class( $this->file_controller )::SEARCH_MAX_RESULTS )
+				)
+			);
+		}
+
 		$total_pages = ceil( $total_items / $per_page );
 		$results     = $this->file_controller->search_within_files( $search, $args, $file_args );
 		$this->items = $results;

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/SearchListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/SearchListTable.php
@@ -1,0 +1,216 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Internal\Admin\Logging\FileV2;
+
+use Automattic\WooCommerce\Internal\Admin\Logging\PageController;
+
+use WP_List_Table;
+
+/**
+ * SearchListTable class.
+ */
+class SearchListTable extends WP_List_Table {
+	/**
+	 * The user option key for saving the preferred number of search results displayed per page.
+	 *
+	 * @const string
+	 */
+	public const PER_PAGE_USER_OPTION_KEY = 'woocommerce_logging_search_results_per_page';
+
+	/**
+	 * Instance of FileController.
+	 *
+	 * @var FileController
+	 */
+	private $file_controller;
+
+	/**
+	 * Instance of PageController.
+	 *
+	 * @var PageController
+	 */
+	private $page_controller;
+
+	/**
+	 * SearchListTable class.
+	 *
+	 * @param FileController $file_controller Instance of FileController.
+	 * @param PageController $page_controller Instance of PageController.
+	 */
+	public function __construct( FileController $file_controller, PageController $page_controller ) {
+		$this->file_controller = $file_controller;
+		$this->page_controller = $page_controller;
+
+		parent::__construct(
+			array(
+				'singular' => 'wc-logs-search-result',
+				'plural'   => 'wc-logs-search-results',
+				'ajax'     => false,
+			)
+		);
+	}
+
+	/**
+	 * Render message when there are no items.
+	 *
+	 * @return void
+	 */
+	public function no_items(): void {
+		esc_html_e( 'No search results.', 'woocommerce' );
+	}
+
+	/**
+	 * Set up the column header info.
+	 *
+	 * @return void
+	 */
+	public function prepare_column_headers(): void {
+		$this->_column_headers = array(
+			$this->get_columns(),
+			array(),
+			array(),
+			$this->get_primary_column(),
+		);
+	}
+
+	/**
+	 * Prepares the list of items for displaying.
+	 *
+	 * @return void
+	 */
+	public function prepare_items(): void {
+		$per_page = $this->get_items_per_page(
+			self::PER_PAGE_USER_OPTION_KEY,
+			$this->get_per_page_default()
+		);
+
+		$args = array(
+			'per_page' => $per_page,
+			'offset'   => ( $this->get_pagenum() - 1 ) * $per_page,
+		);
+
+		$file_args = $this->page_controller->get_query_params( array( 'order', 'orderby', 'search', 'source' ) );
+		$search    = $file_args['search'];
+		unset( $file_args['search'] );
+
+		$total_items = $this->file_controller->search_within_files( $search, $args, $file_args, true );
+		if ( is_wp_error( $total_items ) ) {
+			printf(
+				'<div class="notice notice-warning"><p>%s</p></div>',
+				esc_html( $total_items->get_error_message() )
+			);
+
+			return;
+		}
+
+		$total_pages = ceil( $total_items / $per_page );
+		$results     = $this->file_controller->search_within_files( $search, $args, $file_args );
+		$this->items = $results;
+
+		$this->set_pagination_args(
+			array(
+				'per_page'    => $per_page,
+				'total_items' => $total_items,
+				'total_pages' => $total_pages,
+			)
+		);
+	}
+
+	/**
+	 * Gets a list of columns.
+	 *
+	 * @return array
+	 */
+	public function get_columns(): array {
+		$columns = array(
+			'file_id'     => esc_html__( 'File', 'woocommerce' ),
+			'line_number' => esc_html__( 'Line #', 'woocommerce' ),
+			'line'        => esc_html__( 'Matched Line', 'woocommerce' ),
+		);
+
+		return $columns;
+	}
+
+	/**
+	 * Render the file_id column.
+	 *
+	 * @param array $item The current search result being rendered.
+	 *
+	 * @return string
+	 */
+	public function column_file_id( array $item ): string {
+		// Add a word break after the rotation number, if it exists.
+		$file_id = preg_replace( '/\.([0-9])+\-/', '.\1<wbr>-', $item['file_id'] );
+
+		return wp_kses( $file_id, array( 'wbr' => array() ) );
+	}
+
+	/**
+	 * Render the line_number column.
+	 *
+	 * @param array $item The current search result being rendered.
+	 *
+	 * @return string
+	 */
+	public function column_line_number( array $item ): string {
+		$match_url = add_query_arg(
+			array(
+				'view'    => 'single_file',
+				'file_id' => $item['file_id'],
+			),
+			$this->page_controller->get_logs_tab_url() . '#L' . absint( $item['line_number'] )
+		);
+
+		return sprintf(
+			'<a href="%1$s">%2$s</a>',
+			esc_url( $match_url ),
+			sprintf(
+				// translators: %s is a line number in a file.
+				esc_html__( 'Line %s', 'woocommerce' ),
+				number_format_i18n( absint( $item['line_number'] ) )
+			)
+		);
+	}
+
+	/**
+	 * Render the line column.
+	 *
+	 * @param array $item The current search result being rendered.
+	 *
+	 * @return string
+	 */
+	public function column_line( array $item ): string {
+		$params = $this->page_controller->get_query_params( array( 'search' ) );
+		$line   = $item['line'];
+
+		// Highlight matches within the line.
+		$pattern = preg_quote( $params['search'], '/' );
+		preg_match_all( "/$pattern/i", $line, $matches, PREG_OFFSET_CAPTURE );
+		if ( is_array( $matches[0] ) && count( $matches[0] ) >= 1 ) {
+			$length_change = 0;
+
+			foreach ( $matches[0] as $match ) {
+				$replace        = '<span class="search-match">' . $match[0] . '</span>';
+				$offset         = $match[1] + $length_change;
+				$orig_length    = strlen( $match[0] );
+				$replace_length = strlen( $replace );
+
+				$line = substr_replace( $line, $replace, $offset, $orig_length );
+
+				$length_change += $replace_length - $orig_length;
+			}
+		}
+
+		return wp_kses_post( $line );
+	}
+
+	/**
+	 * Helper to get the default value for the per_page arg.
+	 *
+	 * @return int
+	 */
+	public function get_per_page_default(): int {
+		return $this->file_controller::DEFAULTS_SEARCH_WITHIN_FILES['per_page'];
+	}
+}

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/SearchListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/SearchListTable.php
@@ -104,12 +104,12 @@ class SearchListTable extends WP_List_Table {
 			return;
 		}
 
-		if ( $total_items > $this->file_controller::SEARCH_MAX_RESULTS ) {
+		if ( $total_items >= $this->file_controller::SEARCH_MAX_RESULTS ) {
 			printf(
 				'<div class="notice notice-info"><p>%s</p></div>',
 				sprintf(
 					// translators: %s is a number.
-					esc_html__( 'The number of search results has exceeded the limit of %s. Try narrowing your search.', 'woocommerce' ),
+					esc_html__( 'The number of search results has reached the limit of %s. Try refining your search.', 'woocommerce' ),
 					esc_html( number_format_i18n( $this->file_controller::SEARCH_MAX_RESULTS ) )
 				)
 			);

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/SearchListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/SearchListTable.php
@@ -110,7 +110,7 @@ class SearchListTable extends WP_List_Table {
 				sprintf(
 					// translators: %s is a number.
 					esc_html__( 'The number of search results has exceeded the limit of %s. Try narrowing your search.', 'woocommerce' ),
-					number_format_i18n( get_class( $this->file_controller )::SEARCH_MAX_RESULTS )
+					esc_html( number_format_i18n( get_class( $this->file_controller )::SEARCH_MAX_RESULTS ) )
 				)
 			);
 		}

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/SearchListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/SearchListTable.php
@@ -104,13 +104,13 @@ class SearchListTable extends WP_List_Table {
 			return;
 		}
 
-		if ( $total_items > get_class( $this->file_controller )::SEARCH_MAX_RESULTS ) {
+		if ( $total_items > $this->file_controller::SEARCH_MAX_RESULTS ) {
 			printf(
 				'<div class="notice notice-info"><p>%s</p></div>',
 				sprintf(
 					// translators: %s is a number.
 					esc_html__( 'The number of search results has exceeded the limit of %s. Try narrowing your search.', 'woocommerce' ),
-					esc_html( number_format_i18n( get_class( $this->file_controller )::SEARCH_MAX_RESULTS ) )
+					esc_html( number_format_i18n( $this->file_controller::SEARCH_MAX_RESULTS ) )
 				)
 			);
 		}

--- a/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
@@ -2,9 +2,36 @@
 
 namespace Automattic\WooCommerce\Internal\Admin\Logging;
 
+use Automattic\WooCommerce\Internal\Admin\Logging\FileV2\FileController;
 use WC_Log_Handler_File;
 
 /**
  * LogHandlerFileV2 class.
  */
-class LogHandlerFileV2 extends WC_Log_Handler_File {}
+class LogHandlerFileV2 extends WC_Log_Handler_File {
+	/**
+	 * Handle a log entry.
+	 *
+	 * @param int    $timestamp Log timestamp.
+	 * @param string $level emergency|alert|critical|error|warning|notice|info|debug.
+	 * @param string $message Log message.
+	 * @param array  $context {
+	 *      Additional information for log handlers.
+	 *
+	 *     @type string $source Optional. Determines log file to write to. Default 'log'.
+	 *     @type bool $_legacy Optional. Default false. True to use outdated log format
+	 *         originally used in deprecated WC_Logger::add calls.
+	 * }
+	 *
+	 * @return bool False if value was not handled and true if value was handled.
+	 */
+	public function handle( $timestamp, $level, $message, $context ) {
+		$written = parent::handle( $timestamp, $level, $message, $context );
+
+		if ( $written ) {
+			wc_get_container()->get( FileController::class )->invalidate_cache();
+		}
+
+		return $written;
+	}
+}

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -148,9 +148,7 @@ class PageController {
 			<h2>
 				<?php esc_html_e( 'Browse log files', 'woocommerce' ); ?>
 			</h2>
-			<?php if ( $list_table->has_items() ) : ?>
-				<?php $this->render_search_field(); ?>
-			<?php endif; ?>
+			<?php $this->render_search_field(); ?>
 		</header>
 		<form id="logs-list-table-form" method="get">
 			<input type="hidden" name="page" value="wc-status" />
@@ -640,37 +638,54 @@ class PageController {
 		$params        = $this->get_query_params( array( 'search', 'source' ) );
 		$defaults      = $this->get_query_param_defaults();
 		$search_action = add_query_arg( 'view', 'search_results', $this->get_logs_tab_url() );
-		?>
+		$file_count    = $this->file_controller->get_files( $params, true );
+
+		if ( $file_count > 0 ) :?>
 		<form
 			id="logs-search"
 			class="wc-logs-search"
 			method="get"
 			action="<?php echo esc_url( $search_action ); ?>"
 		>
-			<input type="hidden" name="page" value="wc-status" />
-			<input type="hidden" name="tab" value="logs" />
-			<input type="hidden" name="view" value="search_results" />
-			<?php foreach ( $params as $key => $value ) : ?>
-				<?php if ( $value !== $defaults[ $key ] ) : ?>
+			<fieldset class="wc-logs-search-fieldset">
+				<input type="hidden" name="page" value="wc-status" />
+				<input type="hidden" name="tab" value="logs" />
+				<input type="hidden" name="view" value="search_results" />
+				<?php foreach ( $params as $key => $value ) : ?>
+					<?php if ( $value !== $defaults[ $key ] ) : ?>
+						<input
+							type="hidden"
+							name="<?php echo esc_attr( $key ); ?>"
+							value="<?php echo esc_attr( $value ); ?>"
+						/>
+					<?php endif; ?>
+				<?php endforeach; ?>
+				<label for="logs-search-field">
+					<?php esc_html_e( 'Search within these files', 'woocommerce' ); ?>
 					<input
-						type="hidden"
-						name="<?php echo esc_attr( $key ); ?>"
-						value="<?php echo esc_attr( $value ); ?>"
+						id="logs-search-field"
+						class="wc-logs-search-field"
+						type="text"
+						name="search"
+						value="<?php echo esc_attr( $params['search'] ); ?>"
 					/>
-				<?php endif; ?>
-			<?php endforeach; ?>
-			<label for="logs-search-field">
-				<?php esc_html_e( 'Search within these files', 'woocommerce' ); ?>
-				<input
-					id="logs-search-field"
-					class="wc-logs-search-field"
-					type="text"
-					name="search"
-					value="<?php echo esc_attr( $params['search'] ); ?>"
-				/>
-			</label>
-			<?php submit_button( __( 'Search', 'woocommerce' ), 'secondary', 'submit', false ); ?>
+				</label>
+				<?php submit_button( __( 'Search', 'woocommerce' ), 'secondary', null, false ); ?>
+			</fieldset>
+			<?php if ( $file_count >= get_class( $this->file_controller )::SEARCH_MAX_FILES ) : ?>
+				<div class="wc-logs-search-notice">
+					<?php
+					printf(
+						esc_html__(
+							'⚠️ Only %s files can be searched at one time. Try filtering the file list before searching.',
+							'woocommerce'
+						),
+						number_format_i18n( get_class( $this->file_controller )::SEARCH_MAX_FILES )
+					);
+					?>
+				</div>
+			<?php endif; ?>
 		</form>
-		<?php
+		<?php endif;
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -4,7 +4,7 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Internal\Admin\Logging;
 
 use Automattic\Jetpack\Constants;
-use Automattic\WooCommerce\Internal\Admin\Logging\FileV2\{ FileController, ListTable };
+use Automattic\WooCommerce\Internal\Admin\Logging\FileV2\{ FileController, FileListTable };
 use Automattic\WooCommerce\Internal\Traits\AccessiblePrivateMethods;
 use WC_Admin_Status;
 use WC_Log_Levels;
@@ -24,11 +24,11 @@ class PageController {
 	private $file_controller;
 
 	/**
-	 * Instance of ListTable.
+	 * Instance of FileListTable.
 	 *
-	 * @var ListTable
+	 * @var FileListTable
 	 */
-	private $list_table;
+	private $file_list_table;
 
 	/**
 	 * Initialize dependencies.
@@ -139,14 +139,14 @@ class PageController {
 		$params   = $this->get_query_params( array( 'order', 'orderby', 'source', 'view' ) );
 		$defaults = $this->get_query_param_defaults();
 
-		$this->get_list_table()->prepare_items();
+		$this->get_file_list_table()->prepare_items();
 
 		?>
 		<header id="logs-header" class="wc-logs-header">
 			<h2>
 				<?php esc_html_e( 'Browse log files', 'woocommerce' ); ?>
 			</h2>
-			<?php if ( $this->get_list_table()->has_items() ) : ?>
+			<?php if ( $this->get_file_list_table()->has_items() ) : ?>
 				<?php $this->render_search_field(); ?>
 			<?php endif; ?>
 		</header>
@@ -162,7 +162,7 @@ class PageController {
 					/>
 				<?php endif; ?>
 			<?php endforeach; ?>
-			<?php $this->get_list_table()->display(); ?>
+			<?php $this->get_file_list_table()->display(); ?>
 		</form>
 		<?php
 	}
@@ -406,16 +406,16 @@ class PageController {
 	/**
 	 * Get and cache an instance of the list table.
 	 *
-	 * @return ListTable
+	 * @return FileListTable
 	 */
-	private function get_list_table(): ListTable {
-		if ( $this->list_table instanceof ListTable ) {
-			return $this->list_table;
+	private function get_file_list_table(): FileListTable {
+		if ( $this->file_list_table instanceof FileListTable ) {
+			return $this->file_list_table;
 		}
 
-		$this->list_table = new ListTable( $this->file_controller, $this );
+		$this->file_list_table = new FileListTable( $this->file_controller, $this );
 
-		return $this->list_table;
+		return $this->file_list_table;
 	}
 
 	/**
@@ -428,13 +428,13 @@ class PageController {
 
 		if ( 'list_files' === $params['view'] ) {
 			// Ensure list table columns are initialized early enough to enable column hiding.
-			$this->get_list_table()->prepare_column_headers();
+			$this->get_file_list_table()->prepare_column_headers();
 
 			add_screen_option(
 				'per_page',
 				array(
 					'default' => 20,
-					'option'  => ListTable::PER_PAGE_USER_OPTION_KEY,
+					'option'  => FileListTable::PER_PAGE_USER_OPTION_KEY,
 				)
 			);
 		}
@@ -453,7 +453,7 @@ class PageController {
 			return;
 		}
 
-		$action = $this->get_list_table()->current_action();
+		$action = $this->get_file_list_table()->current_action();
 
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : $this->get_logs_tab_url();

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -567,69 +567,6 @@ class PageController {
 	}
 
 	/**
-	 * Format a search results line.
-	 *
-	 * @param string $file_id     The file ID that contains the matched line.
-	 * @param int    $line_number The line number of the matched line.
-	 * @param string $line        The matched line, with matched substrings highlighted.
-	 *
-	 * @return string
-	 */
-	private function format_match( string $file_id, int $line_number, string $line ): string {
-		$params = $this->get_query_params( array( 'search' ) );
-
-		// Add a word break after the rotation number, if it exists.
-		$file_id = preg_replace( '/\.([0-9])+\-/', '.\1<wbr>-', $file_id );
-
-		$match_url = add_query_arg(
-			array(
-				'view'    => 'single_file',
-				'file_id' => $file_id,
-			),
-			$this->get_logs_tab_url() . '#L' . absint( $line_number )
-		);
-
-		// Highlight matches within the line.
-		$pattern = preg_quote( $params['search'], '/' );
-		preg_match_all( "/$pattern/i", $line, $matches, PREG_OFFSET_CAPTURE );
-		if ( is_array( $matches[0] ) && count( $matches[0] ) >= 1 ) {
-			$length_change = 0;
-
-			foreach ( $matches[0] as $match ) {
-				$replace        = '<span class="search-match">' . $match[0] . '</span>';
-				$offset         = $match[1] + $length_change;
-				$orig_length    = strlen( $match[0] );
-				$replace_length = strlen( $replace );
-
-				$line = substr_replace( $line, $replace, $offset, $orig_length );
-
-				$length_change += $replace_length - $orig_length;
-			}
-		}
-
-		return sprintf(
-			'<span class="match">%1$s%2$s%3$s</span>',
-			sprintf(
-				'<span class="match-file">%s</span>',
-				wp_kses( $file_id, array( 'wbr' => array() ) )
-			),
-			sprintf(
-				'<a href="%1$s" class="match-anchor">%2$s</a>',
-				esc_url( $match_url ),
-				sprintf(
-					// translators: %s is a line number in a file.
-					esc_html__( 'Line %s', 'woocommerce' ),
-					number_format_i18n( absint( $line_number ) )
-				)
-			),
-			sprintf(
-				'<span class="match-content">%s</span>',
-				wp_kses_post( $line )
-			)
-		);
-	}
-
-	/**
 	 * Render a form for searching within log files.
 	 *
 	 * @return void

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -590,6 +590,9 @@ class PageController {
 	private function format_match( string $file_id, int $line_number, string $line ): string {
 		$params = $this->get_query_params( array( 'search' ) );
 
+		// Add a word break after the rotation number, if it exists.
+		$file_id = preg_replace( '/\.([0-9])+\-/', '.\1<wbr>-', $file_id );
+
 		$match_url = add_query_arg(
 			array(
 				'view'    => 'single_file',
@@ -617,15 +620,18 @@ class PageController {
 		}
 
 		return sprintf(
-			'<span class="match">%1$s%2$s</span>',
+			'<span class="match">%1$s%2$s%3$s</span>',
 			sprintf(
-				'<a href="%1$s" class="match-anchor">%2$s<br />%3$s</a>',
+				'<span class="match-file">%s</span>',
+				wp_kses( $file_id, array( 'wbr' => array() ) )
+			),
+			sprintf(
+				'<a href="%1$s" class="match-anchor">%2$s</a>',
 				esc_url( $match_url ),
-				esc_html( $file_id ),
 				sprintf(
-					// translators: %d is a line number in a file.
-					esc_html__( 'Line %d', 'woocommerce' ),
-					absint( $line_number )
+					// translators: %s is a line number in a file.
+					esc_html__( 'Line %s', 'woocommerce' ),
+					number_format_i18n( absint( $line_number ) )
 				)
 			),
 			sprintf(

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -375,7 +375,7 @@ class PageController {
 				'search'  => array(
 					'filter'  => FILTER_CALLBACK,
 					'options' => function( $search ) {
-						return sanitize_text_field( wp_unslash( $search ) );
+						return esc_html( wp_unslash( $search ) );
 					},
 				),
 				'source'  => array(

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -122,10 +122,10 @@ class PageController {
 		switch ( $view ) {
 			case 'list_files':
 			default:
-				$this->render_file_list_page( $params );
+				$this->render_list_files_view( $params );
 				break;
 			case 'single_file':
-				$this->render_single_file_page( $params );
+				$this->render_single_file_view( $params );
 				break;
 		}
 	}
@@ -137,7 +137,7 @@ class PageController {
 	 *
 	 * @return void
 	 */
-	private function render_file_list_page( array $params = array() ): void {
+	private function render_list_files_view( array $params = array() ): void {
 		$defaults = $this->get_query_param_defaults();
 
 		?>
@@ -171,7 +171,7 @@ class PageController {
 	 *
 	 * @return void
 	 */
-	private function render_single_file_page( array $params ): void {
+	private function render_single_file_view( array $params ): void {
 		$file = $this->file_controller->get_file_by_id( $params['file_id'] );
 
 		if ( is_wp_error( $file ) ) {

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -351,7 +351,7 @@ class PageController {
 				'search'  => array(
 					'filter'  => FILTER_CALLBACK,
 					'options' => function( $search ) {
-						return sanitize_text_field( $search );
+						return sanitize_text_field( wp_unslash( $search ) );
 					},
 				),
 				'source'  => array(

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -422,7 +422,7 @@ class PageController {
 				'per_page',
 				array(
 					'default' => $list_table->get_per_page_default(),
-					'option'  => get_class( $list_table )::PER_PAGE_USER_OPTION_KEY,
+					'option'  => $list_table::PER_PAGE_USER_OPTION_KEY,
 				)
 			);
 		}
@@ -604,7 +604,7 @@ class PageController {
 					</label>
 					<?php submit_button( __( 'Search', 'woocommerce' ), 'secondary', null, false ); ?>
 				</fieldset>
-				<?php if ( $file_count >= get_class( $this->file_controller )::SEARCH_MAX_FILES ) : ?>
+				<?php if ( $file_count >= $this->file_controller::SEARCH_MAX_FILES ) : ?>
 					<div class="wc-logs-search-notice">
 						<?php
 						printf(
@@ -613,7 +613,7 @@ class PageController {
 								'⚠️ Only %s files can be searched at one time. Try filtering the file list before searching.',
 								'woocommerce'
 							),
-							esc_html( number_format_i18n( get_class( $this->file_controller )::SEARCH_MAX_FILES ) )
+							esc_html( number_format_i18n( $this->file_controller::SEARCH_MAX_FILES ) )
 						);
 						?>
 					</div>

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -572,19 +572,13 @@ class PageController {
 	 * @return void
 	 */
 	private function render_search_field(): void {
-		$params        = $this->get_query_params( array( 'search', 'source' ) );
-		$defaults      = $this->get_query_param_defaults();
-		$search_action = add_query_arg( 'view', 'search_results', $this->get_logs_tab_url() );
-		$file_count    = $this->file_controller->get_files( $params, true );
+		$params     = $this->get_query_params( array( 'search', 'source' ) );
+		$defaults   = $this->get_query_param_defaults();
+		$file_count = $this->file_controller->get_files( $params, true );
 
 		if ( $file_count > 0 ) {
 			?>
-			<form
-				id="logs-search"
-				class="wc-logs-search"
-				method="get"
-				action="<?php echo esc_url( $search_action ); ?>"
-			>
+			<form id="logs-search" class="wc-logs-search" method="get">
 				<fieldset class="wc-logs-search-fieldset">
 					<input type="hidden" name="page" value="wc-status" />
 					<input type="hidden" name="tab" value="logs" />

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -412,7 +412,7 @@ class PageController {
 	private function setup_screen_options(): void {
 		$params = $this->get_query_params( array( 'view' ) );
 
-		if ( in_array( $params['view'], array( 'list_files', 'search_results' ) ) ) {
+		if ( in_array( $params['view'], array( 'list_files', 'search_results' ), true ) ) {
 			$list_table = $this->get_list_table( $params['view'] );
 
 			// Ensure list table columns are initialized early enough to enable column hiding, if available.
@@ -577,52 +577,55 @@ class PageController {
 		$search_action = add_query_arg( 'view', 'search_results', $this->get_logs_tab_url() );
 		$file_count    = $this->file_controller->get_files( $params, true );
 
-		if ( $file_count > 0 ) :?>
-		<form
-			id="logs-search"
-			class="wc-logs-search"
-			method="get"
-			action="<?php echo esc_url( $search_action ); ?>"
-		>
-			<fieldset class="wc-logs-search-fieldset">
-				<input type="hidden" name="page" value="wc-status" />
-				<input type="hidden" name="tab" value="logs" />
-				<input type="hidden" name="view" value="search_results" />
-				<?php foreach ( $params as $key => $value ) : ?>
-					<?php if ( $value !== $defaults[ $key ] ) : ?>
+		if ( $file_count > 0 ) {
+			?>
+			<form
+				id="logs-search"
+				class="wc-logs-search"
+				method="get"
+				action="<?php echo esc_url( $search_action ); ?>"
+			>
+				<fieldset class="wc-logs-search-fieldset">
+					<input type="hidden" name="page" value="wc-status" />
+					<input type="hidden" name="tab" value="logs" />
+					<input type="hidden" name="view" value="search_results" />
+					<?php foreach ( $params as $key => $value ) : ?>
+						<?php if ( $value !== $defaults[ $key ] ) : ?>
+							<input
+								type="hidden"
+								name="<?php echo esc_attr( $key ); ?>"
+								value="<?php echo esc_attr( $value ); ?>"
+							/>
+						<?php endif; ?>
+					<?php endforeach; ?>
+					<label for="logs-search-field">
+						<?php esc_html_e( 'Search within these files', 'woocommerce' ); ?>
 						<input
-							type="hidden"
-							name="<?php echo esc_attr( $key ); ?>"
-							value="<?php echo esc_attr( $value ); ?>"
+							id="logs-search-field"
+							class="wc-logs-search-field"
+							type="text"
+							name="search"
+							value="<?php echo esc_attr( $params['search'] ); ?>"
 						/>
-					<?php endif; ?>
-				<?php endforeach; ?>
-				<label for="logs-search-field">
-					<?php esc_html_e( 'Search within these files', 'woocommerce' ); ?>
-					<input
-						id="logs-search-field"
-						class="wc-logs-search-field"
-						type="text"
-						name="search"
-						value="<?php echo esc_attr( $params['search'] ); ?>"
-					/>
-				</label>
-				<?php submit_button( __( 'Search', 'woocommerce' ), 'secondary', null, false ); ?>
-			</fieldset>
-			<?php if ( $file_count >= get_class( $this->file_controller )::SEARCH_MAX_FILES ) : ?>
-				<div class="wc-logs-search-notice">
-					<?php
-					printf(
-						esc_html__(
-							'⚠️ Only %s files can be searched at one time. Try filtering the file list before searching.',
-							'woocommerce'
-						),
-						number_format_i18n( get_class( $this->file_controller )::SEARCH_MAX_FILES )
-					);
-					?>
-				</div>
-			<?php endif; ?>
-		</form>
-		<?php endif;
+					</label>
+					<?php submit_button( __( 'Search', 'woocommerce' ), 'secondary', null, false ); ?>
+				</fieldset>
+				<?php if ( $file_count >= get_class( $this->file_controller )::SEARCH_MAX_FILES ) : ?>
+					<div class="wc-logs-search-notice">
+						<?php
+						printf(
+							// translators: %s is a number.
+							esc_html__(
+								'⚠️ Only %s files can be searched at one time. Try filtering the file list before searching.',
+								'woocommerce'
+							),
+							esc_html( number_format_i18n( get_class( $this->file_controller )::SEARCH_MAX_FILES ) )
+						);
+						?>
+					</div>
+				<?php endif; ?>
+			</form>
+			<?php
+		}
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileControllerTest.php
@@ -233,4 +233,43 @@ class FileControllerTest extends WC_Unit_Test_Case {
 		$this->assertEquals( 2, $deleted );
 		$this->assertEquals( 0, $this->sut->get_files( array(), true ) );
 	}
+
+	/**
+	 * @testdox The search_within_files method should return an associative array of case-insensitive search results.
+	 */
+	public function test_search_within_files(): void {
+		$log_time = time();
+
+		$this->handler->handle( $log_time, 'debug', 'Foo', array( 'source' => 'unit-testing1' ) );
+		$this->handler->handle( $log_time, 'debug', 'Bar', array( 'source' => 'unit-testing1' ) );
+		$this->handler->handle( $log_time, 'debug', 'foobar', array( 'source' => 'unit-testing1' ) );
+		$this->handler->handle( $log_time, 'debug', 'A trip to the food bar', array( 'source' => 'unit-testing2' ) );
+		$this->handler->handle( $log_time, 'debug', 'Hello world', array( 'source' => 'unit-testing2' ) );
+
+		$this->assertEquals( 2, $this->sut->get_files( array(), true ) );
+
+		$file_args = array(
+			'order'   => 'asc',
+			'orderby' => 'source',
+		);
+
+		$results   = $this->sut->search_within_files( 'foo', array(), $file_args );
+		$this->assertCount( 3, $results );
+
+		$match = array_shift( $results );
+		$this->assertArrayHasKey( 'file_id', $match );
+		$this->assertArrayHasKey( 'line_number', $match );
+		$this->assertArrayHasKey( 'line', $match );
+		$this->assertEquals( 'unit-testing1-' . gmdate( 'Y-m-d', $log_time ), $match['file_id'] );
+		$this->assertEquals( 1, $match['line_number'] );
+		$this->assertStringContainsString( 'Foo', $match['line'] );
+
+		$match = array_shift( $results );
+		$this->assertEquals( 3, $match['line_number'] );
+		$this->assertStringContainsString( 'foobar', $match['line'] );
+
+		$match = array_shift( $results );
+		$this->assertEquals( 1, $match['line_number'] );
+		$this->assertStringContainsString( 'A trip to the food bar', $match['line'] );
+	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileControllerTest.php
@@ -253,7 +253,7 @@ class FileControllerTest extends WC_Unit_Test_Case {
 			'orderby' => 'source',
 		);
 
-		$results   = $this->sut->search_within_files( 'foo', array(), $file_args );
+		$results = $this->sut->search_within_files( 'foo', array(), $file_args );
 		$this->assertCount( 3, $results );
 
 		$match = array_shift( $results );

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileTest.php
@@ -145,7 +145,7 @@ class FileTest extends WC_Unit_Test_Case {
 	 */
 	public function test_delete() {
 		$filename = Constants::get_constant( 'WC_LOG_DIR' ) . 'test-Source_1-1-' . wp_hash( 'cheddar' ) . '.5.log';
-		$resource = fopen( $filename, 'a' ); // phpcs:ignore WordPress.PHP.NoSilencedErrors
+		$resource = fopen( $filename, 'a' );
 		fclose( $resource );
 		$file = new File( $filename );
 

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileTest.php
@@ -125,7 +125,7 @@ class FileTest extends WC_Unit_Test_Case {
 	/**
 	 * @testdox Check that get_stream returns a PHP resource representation of the file.
 	 */
-	public function test_get_stream() {
+	public function test_get_and_close_stream() {
 		$filename = Constants::get_constant( 'WC_LOG_DIR' ) . 'test-Source_1-1-2023-10-23-' . wp_hash( 'cheddar' ) . '.log';
 		$resource = fopen( $filename, 'a' );
 		fclose( $resource );
@@ -134,6 +134,10 @@ class FileTest extends WC_Unit_Test_Case {
 		$stream = $file->get_stream();
 
 		$this->assertTrue( is_resource( $stream ) );
+
+		$file->close_stream();
+
+		$this->assertFalse( is_resource( $stream ) );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds a search field to the log files list table screen that will do a partial match string search on the contents of all the files currently shown in the list table (and subsequent pages, if there is pagination). Introduces a new Search Results view that shows a list table of the matches resulting from a search. Each match shows the entire line from a log file that contains the match, and the matched string itself is highlighted. Each match also includes a link that goes to that particular line in situ in the corresponding log file.

Fixes #41257

![Screen Shot 2023-11-16 at 16 39 26](https://github.com/woocommerce/woocommerce/assets/916023/1dcc0c91-bdf9-4c18-9c82-e300895ddd7b)

### How to test the changes in this Pull Request:

#### Setup

1. After checking out this branch, you may need to update the autoloader. From the **plugins/woocommerce** directory, run `composer dump-autoload`. You also will probably need to rebuild the stylesheet for the Logs screen. For this, run `pnpm --filter=woocommerce/client/legacy run build`.
1. In your test site's **wp-config.php** file, add this line: `define( 'WC_LOG_HANDLER', 'Automattic\\WooCommerce\\Internal\\Admin\\Logging\\LogHandlerFileV2' );`. This is what allows you to see the new log file views.
2. Install [this plugin](https://gist.github.com/coreymckrill/2968911c8b63c556e7787f2cdc65f966) on your test site for generating test log files. Probably easiest to copy the file into the mu-plugins directory.
3. Open two browser tabs: the Logs screen (WP Admin > WooCommerce > Status > Logs) and the WooCommerce Tools screen (WP Admin > WooCommerce > Status > Tools). On the Tools screen you should see the **Debug Log Generator** tool at the top of the list.

#### Tests

1. On the Logs screen, you should see a list table, which may already have some log files listed in it. Even if there are some, go ahead and generate some additional logs on the Tools screen so that we have enough different log files and sources.
2. On the Logs screen, type something in the field labeled "Search within these files". E.g. try `debug`. Then click Search.
3. This should take you to a "Search results" view. You should have a few results since the test plugin for generating log files adds some entries with "DEBUG" level severity. Note that the string match is not case sensitive, and the "DEBUG" substring in each search result is highlighted in yellow.
4. Click on the linked line number for one of the results. This should take you to the single file view for the corresponding log file, and the line with the matched substring should be highlighted.
5. While viewing this single file, click "Delete permanently" to delete the log file. After confirming, this should take you back to the list table of all the available log files. Now try searching for exactly the same string again.
6. On the search results screen, the matches that were in the file that you just deleted should no longer appear.
7. While still on the search results screen, click the Screen Options tab at the top and change the number of items per page to something low, like `2`, so you can test the pagination of search results.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
