### PR TITLE
Remove hardcoded colors when using a block theme

### DIFF
--- a/plugins/woocommerce/changelog/fix-41358-hardcoded-colors
+++ b/plugins/woocommerce/changelog/fix-41358-hardcoded-colors
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Removed hardcoded colors from the base stylesheet when a block theme is used

--- a/plugins/woocommerce/client/legacy/css/woocommerce.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce.scss
@@ -582,7 +582,6 @@ p.demo_store,
 		}
 
 		.price {
-			color: $highlight;
 			display: block;
 			font-weight: normal;
 			margin-bottom: 0.5em;
@@ -1750,6 +1749,10 @@ p.demo_store,
 		.out-of-stock {
 			color: red;
 		}
+	}
+
+	ul.products li.product .price {
+		color: $highlight;
 	}
 
 	#reviews #comments ol.commentlist li .meta {

--- a/plugins/woocommerce/client/legacy/css/woocommerce.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce.scss
@@ -100,19 +100,6 @@ p.demo_store,
 		margin-top: 10px;
 	}
 
-	.woocommerce-breadcrumb {
-
-		@include clearfix();
-		margin: 0 0 1em;
-		padding: 0;
-		font-size: 0.92em;
-		color: $subtext;
-
-		a {
-			color: $subtext;
-		}
-	}
-
 	.quantity .qty {
 		width: 3.631em;
 		text-align: center;
@@ -133,8 +120,6 @@ p.demo_store,
 
 		span.price,
 		p.price {
-			color: $highlight;
-			font-size: 1.25em;
 
 			ins {
 				background: inherit;
@@ -150,14 +135,6 @@ p.demo_store,
 
 		p.stock {
 			font-size: 0.92em;
-		}
-
-		.stock {
-			color: $highlight;
-		}
-
-		.out-of-stock {
-			color: red;
 		}
 
 		.woocommerce-product-rating {
@@ -754,11 +731,6 @@ p.demo_store,
 					position: relative;
 					background: 0;
 					border: 0;
-
-					.meta {
-						color: $subtext;
-						font-size: 0.75em;
-					}
 
 					img.avatar {
 						float: left;
@@ -1745,6 +1717,47 @@ p.demo_store,
 		}
 	}
 }
+
+/**
+ * WooCommerce specific styles for legacy themes.
+ */
+.woocommerce:where(body:not(.woocommerce-uses-block-theme)) {
+
+	.woocommerce-breadcrumb {
+
+		@include clearfix();
+		margin: 0 0 1em;
+		padding: 0;
+		font-size: 0.92em;
+		color: $subtext;
+
+		a {
+			color: $subtext;
+		}
+	}
+
+	div.product {
+		span.price,
+		p.price {
+			color: $highlight;
+			font-size: 1.25em;
+		}
+
+		.stock {
+			color: $highlight;
+		}
+
+		.out-of-stock {
+			color: red;
+		}
+	}
+
+	#reviews #comments ol.commentlist li .meta {
+		color: $subtext;
+		font-size: 0.75em;
+	}
+}
+
 
 .woocommerce-no-js {
 

--- a/plugins/woocommerce/client/legacy/css/woocommerce.scss
+++ b/plugins/woocommerce/client/legacy/css/woocommerce.scss
@@ -100,6 +100,13 @@ p.demo_store,
 		margin-top: 10px;
 	}
 
+	.woocommerce-breadcrumb {
+
+		@include clearfix();
+		margin: 0 0 1em;
+		padding: 0;
+	}
+
 	.quantity .qty {
 		width: 3.631em;
 		text-align: center;
@@ -1724,9 +1731,6 @@ p.demo_store,
 
 	.woocommerce-breadcrumb {
 
-		@include clearfix();
-		margin: 0 0 1em;
-		padding: 0;
 		font-size: 0.92em;
 		color: $subtext;
 

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -340,9 +340,9 @@ function wc_body_class( $classes ) {
 	}
 
 	if ( wc_current_theme_is_fse_theme() ) {
-		
+
 		$classes[] = 'woocommerce-uses-block-theme';
-		
+
 	}
 
 	if ( wc_block_theme_has_styles_for_element( 'button' ) ) {

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -339,6 +339,12 @@ function wc_body_class( $classes ) {
 		}
 	}
 
+	if ( wc_current_theme_is_fse_theme() ) {
+		
+		$classes[] = 'woocommerce-uses-block-theme';
+		
+	}
+
 	if ( wc_block_theme_has_styles_for_element( 'button' ) ) {
 
 		$classes[] = 'woocommerce-block-theme-has-button-styles';


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR aims to remove hardcoded colors from the base `woocommerce.css` file to enhance the Woo experience further using a block theme.

Modified Elements:
- Breadcrumbs.
- Product Prices on the single-product page.
- Stock Information Messages on the single-product page.
- Comment's meta.

### Specification

The goal of this PR is to:
- Introduce a new body class named `woocommerce-uses-block-theme` when the store uses a block theme and;
- Remove all hardcoded colors by using the `:where(body:not(.woocommerce-uses-block-theme))` rule so that it won't affect the specificity of CSS selectors.

Related work: https://github.com/woocommerce/woocommerce/pull/36225

Closes #41358

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

#### Breadcrumb

1. Visit a store with a block theme (e.g., TT4)
2. Switch to a dark background style like _Maelstorm_
3. Navigate to a single-product page
4. Notice the breadcrumbs appearing grey.
5. Apply this patch.
6. Ensure that by default, breadcrumbs are getting the foreground color.
7. Make some styling adjustments in the Site Editor and ensure they work as expected.

##### Screenshot
|Before|After|
|---|---|
|![Q3MAzb.png](https://github.com/woocommerce/woocommerce/assets/1105590/d1409d99-2585-4820-8d53-248054264559)|![6hQ7OC.png](https://github.com/woocommerce/woocommerce/assets/1105590/1b407f28-f9d3-4a41-bf4c-45e08cad1263)|

#### Product Prices

1. Visit a store with a block theme (e.g., TT4)
2. Switch to a dark background style like _Maelstorm_
3. Navigate to a variable-product page (ensure that at least two variations exist with different prices.)
4. Select a variation.
8. Notice the price element appearing yellow-ish.
9. Now add a few up-sells to the same product (Linked Products.)
10. Visit the single product page again.
11. Notice the same coloring in the Up-Sells product grid.
12. Apply this patch and ensure that all prices work as expected.

##### Screenshot

###### Before
|Variation|Legacy Product Grid|Extensions|
|---|---|---|
| ![XtOq6n.png](https://github.com/woocommerce/woocommerce/assets/1105590/851a24dc-dc7a-4b46-9bc6-2967cf4b8cce)| ![OIopPv.png](https://github.com/woocommerce/woocommerce/assets/1105590/37fe477f-7fbf-45e8-a2b4-a92f396ddc0f)|![YnXU7T.png](https://github.com/woocommerce/woocommerce/assets/1105590/887725ee-0ccf-41d9-a64e-cb5852e780f0)|

###### After

|Variation|Legacy Product Grid|Extensions|
|---|---|---|
|![IT5sjw.png](https://github.com/woocommerce/woocommerce/assets/1105590/11fcd7e4-2220-4934-982f-31c25cdbd9a3)|![Pra1Rc.png](https://github.com/woocommerce/woocommerce/assets/1105590/33ecc6a8-cc3a-4273-b51a-59a445f0caf2)|![BaTTiD.png](https://github.com/woocommerce/woocommerce/assets/1105590/b1066728-f3d8-4e72-b652-888bff503b05)|

##### Testing Extensions
- Install the Product Bundles extension.
- Add some bundle sells to a product under Product Data > Linked Products.
- Visit the product template.

#### Comments Meta

1. Visit a store with a block theme (e.g., TT4)
2. Switch to a dark background style like _Maelstorm_
3. Navigate to a single-product page
4. Ensure the product has at least one review; if not, add one.
13. Notice the comment meta/author appearing grey.

##### Screenshot
|Before|After|
|---|---|
|![s8TbiS.png](https://github.com/woocommerce/woocommerce/assets/1105590/4bf1f26e-7602-45d1-85d9-38e059d31262)|![X8VG8E.png](https://github.com/woocommerce/woocommerce/assets/1105590/6dc73dc0-b5f6-4416-9b40-b12406918422)|

#### Out of Stock Message

1. Visit a store with a block theme (e.g., TT4)
2. Switch to a dark background style like _Maelstorm_
3. Navigate to an out-of-stock single-product page
4. Notice the out-of-stock message being red.

##### Screenshot
|Before|After|
|---|---|
|![1O36Ls.png](https://github.com/woocommerce/woocommerce/assets/1105590/1ef7e80e-4589-4027-85d0-afed9c5c0515)|![zSLVfa.png](https://github.com/woocommerce/woocommerce/assets/1105590/d4969cb0-223d-467b-bbcf-1fc4a9b4bb78)|

#### Low Stock Message

1. Visit a store with a block theme (e.g., TT4)
2. Switch to a dark background style like _Maelstorm_
3. Navigate to a low-stock single-product page
4. Notice the low-stock message being yellow-ish.

##### Screenshot
|Before|After|
|---|---|
|![VcjCYY.png](https://github.com/woocommerce/woocommerce/assets/1105590/ad38f6b9-3179-4826-8246-0dc45aad5ce2)|![JWCKEx.png](https://github.com/woocommerce/woocommerce/assets/1105590/7f202482-a9fb-4e6f-9806-7409ff929e7f)|

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message
Remove hardcoded colors in the 'woocommerce.css' when using a block theme

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>