### PR TITLE
Update WooCommerce Blocks package to 11.5.4

### DIFF
--- a/plugins/woocommerce/bin/composer/mozart/composer.lock
+++ b/plugins/woocommerce/bin/composer/mozart/composer.lock
@@ -268,16 +268,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.4.28",
+            "version": "v5.4.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "f4f71842f24c2023b91237c72a365306f3c58827"
+                "reference": "11ac5f154e0e5c4c77af83ad11ead9165280b92a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/f4f71842f24c2023b91237c72a365306f3c58827",
-                "reference": "f4f71842f24c2023b91237c72a365306f3c58827",
+                "url": "https://api.github.com/repos/symfony/console/zipball/11ac5f154e0e5c4c77af83ad11ead9165280b92a",
+                "reference": "11ac5f154e0e5c4c77af83ad11ead9165280b92a",
                 "shasum": ""
             },
             "require": {
@@ -347,7 +347,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.28"
+                "source": "https://github.com/symfony/console/tree/v5.4.31"
             },
             "funding": [
                 {
@@ -363,7 +363,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-07T06:12:30+00:00"
+            "time": "2023-10-31T07:58:33+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -1072,16 +1072,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v5.4.29",
+            "version": "v5.4.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "e41bdc93def20eaf3bfc1537c4e0a2b0680a152d"
+                "reference": "2765096c03f39ddf54f6af532166e42aaa05b24b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/e41bdc93def20eaf3bfc1537c4e0a2b0680a152d",
-                "reference": "e41bdc93def20eaf3bfc1537c4e0a2b0680a152d",
+                "url": "https://api.github.com/repos/symfony/string/zipball/2765096c03f39ddf54f6af532166e42aaa05b24b",
+                "reference": "2765096c03f39ddf54f6af532166e42aaa05b24b",
                 "shasum": ""
             },
             "require": {
@@ -1138,7 +1138,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.4.29"
+                "source": "https://github.com/symfony/string/tree/v5.4.31"
             },
             "funding": [
                 {
@@ -1154,7 +1154,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-09-13T11:47:41+00:00"
+            "time": "2023-11-09T08:19:44+00:00"
         }
     ],
     "aliases": [],

--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-11.5.4
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-11.5.4
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update WooCommerce Blocks to 11.5.4

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -23,7 +23,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.6.4",
-		"woocommerce/woocommerce-blocks": "11.5.3"
+		"woocommerce/woocommerce-blocks": "11.5.4"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.3.0",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "80d3e18e8cb8badab9416cc82d074b37",
+    "content-hash": "27393699927a70878b830621857eea8c",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1004,16 +1004,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "11.5.3",
+            "version": "11.5.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "21e398e5e53d38e7a8bb464192160d3b103b2004"
+                "reference": "a701cbe4466b36a572a0daf7f7363ec23bfdff45"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/21e398e5e53d38e7a8bb464192160d3b103b2004",
-                "reference": "21e398e5e53d38e7a8bb464192160d3b103b2004",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/a701cbe4466b36a572a0daf7f7363ec23bfdff45",
+                "reference": "a701cbe4466b36a572a0daf7f7363ec23bfdff45",
                 "shasum": ""
             },
             "require": {
@@ -1056,7 +1056,7 @@
                 "GPL-3.0-or-later"
             ],
             "description": "WooCommerce blocks for the Gutenberg editor.",
-            "homepage": "https://woo.com/",
+            "homepage": "https://woocommerce.com/",
             "keywords": [
                 "blocks",
                 "gutenberg",
@@ -1064,9 +1064,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v11.5.3"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v11.5.4"
             },
-            "time": "2023-11-08T21:48:50+00:00"
+            "time": "2023-11-13T14:34:45+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This pull updates the WooCommerce Blocks plugin to 11.5.4.

#### Blocks 11.5.4

- Release PR: https://github.com/woocommerce/woocommerce-blocks/pull/11715
- Testing instructions: https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/1154.md

#### Bug Fixes

- Prevent PHP warnings when using Jetpack WooCommerce Analytics module. https://github.com/woocommerce/woocommerce-blocks/pull/11707
- Fixed address components in Firefox, and editing of address form in the editor. https://github.com/woocommerce/woocommerce-blocks/pull/11714
- Fix Classic Cart/Checkout styling on non-cart and checkout pages. https://github.com/woocommerce/woocommerce-blocks/pull/11694
- Fix double border in cart and notes field width on mobile. https://github.com/woocommerce/woocommerce-blocks/pull/11742
- Ensure that incompatible notices are displayed in Safari. https://github.com/woocommerce/woocommerce-blocks/pull/11736
- Enabled the new blockified Order Confirmation by default for block-based themes. https://github.com/woocommerce/woocommerce-blocks/pull/11615

### Changelog entry

> Dev - Update WooCommerce Blocks version to 11.5.4