### PR TITLE
Template API: Only generate templates on WCA routes

### DIFF
--- a/packages/js/product-editor/changelog/update-template-api-limit-generation
+++ b/packages/js/product-editor/changelog/update-template-api-limit-generation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: tweak
+Comment: Just removed an unused attribute from a type.
+
+

--- a/packages/js/product-editor/src/components/block-editor/block-editor.tsx
+++ b/packages/js/product-editor/src/components/block-editor/block-editor.tsx
@@ -41,7 +41,6 @@ type BlockEditorProps = {
 	productId: number;
 	settings:
 		| ( Partial< EditorSettings & EditorBlockListSettings > & {
-				template?: Template[];
 				templates: Record< string, Template[] >;
 		  } )
 		| undefined;

--- a/packages/js/product-editor/src/components/block-editor/block-editor.tsx
+++ b/packages/js/product-editor/src/components/block-editor/block-editor.tsx
@@ -35,15 +35,17 @@ import { useConfirmUnsavedProductChanges } from '../../hooks/use-confirm-unsaved
 import { ProductEditorContext } from '../../types';
 import { PostTypeContext } from '../../contexts/post-type-context';
 
+type BlockEditorSettings = Partial<
+	EditorSettings & EditorBlockListSettings
+> & {
+	templates?: Record< string, Template[] >;
+};
+
 type BlockEditorProps = {
 	context: Partial< ProductEditorContext >;
 	productType: string;
 	productId: number;
-	settings:
-		| ( Partial< EditorSettings & EditorBlockListSettings > & {
-				templates: Record< string, Template[] >;
-		  } )
-		| undefined;
+	settings: BlockEditorSettings | undefined;
 };
 
 export function BlockEditor( {
@@ -59,27 +61,31 @@ export function BlockEditor( {
 		return canUser( 'create', 'media', '' ) !== false;
 	}, [] );
 
-	const settings = useMemo( () => {
-		if ( ! canUserCreateMedia ) {
-			return _settings;
-		}
+	const settings: BlockEditorSettings = useMemo( () => {
+		const mediaSettings = canUserCreateMedia
+			? {
+					mediaUpload( {
+						onError,
+						...rest
+					}: {
+						onError: ( message: string ) => void;
+					} ) {
+						// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+						// @ts-ignore No types for this exist yet.
+						uploadMedia( {
+							wpAllowedMimeTypes:
+								_settings?.allowedMimeTypes || undefined,
+							onError: ( { message } ) => onError( message ),
+							...rest,
+						} );
+					},
+			  }
+			: {};
+
 		return {
 			..._settings,
-			mediaUpload( {
-				onError,
-				...rest
-			}: {
-				onError: ( message: string ) => void;
-			} ) {
-				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-				// @ts-ignore No types for this exist yet.
-				uploadMedia( {
-					wpAllowedMimeTypes:
-						_settings?.allowedMimeTypes || undefined,
-					onError: ( { message } ) => onError( message ),
-					...rest,
-				} );
-			},
+			...mediaSettings,
+			templateLock: 'all',
 		};
 	}, [ canUserCreateMedia, _settings ] );
 
@@ -92,12 +98,17 @@ export function BlockEditor( {
 	const { updateEditorSettings } = useDispatch( 'core/editor' );
 
 	useLayoutEffect( () => {
-		const template = _settings?.templates[ productType ];
+		const template = settings?.templates?.[ productType ];
+
+		if ( ! template ) {
+			return;
+		}
+
 		const blockInstances = synchronizeBlocksWithTemplate( [], template );
 
 		onChange( blockInstances, {} );
 
-		updateEditorSettings( _settings ?? {} );
+		updateEditorSettings( settings ?? {} );
 	}, [ productType, productId ] );
 
 	if ( ! blocks ) {

--- a/plugins/woocommerce/changelog/update-template-api-limit-generation
+++ b/plugins/woocommerce/changelog/update-template-api-limit-generation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Only generate product editor templates on WCA routes.

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -75,18 +75,7 @@ class Init {
 			return;
 		}
 
-		$template_registry = wc_get_container()->get( BlockTemplateRegistry::class );
-
-		$editor_settings = array();
-
-		$editor_settings['template']  = $template_registry->get_registered( 'simple-product' )->get_formatted_template();
-		$editor_settings['templates'] = array(
-			'product'           => $template_registry->get_registered( 'simple-product' )->get_formatted_template(),
-			'product_variation' => $template_registry->get_registered( 'product-variation' )->get_formatted_template(),
-		);
-
-		$block_editor_context = new WP_Block_Editor_Context( array( 'name' => self::EDITOR_CONTEXT_NAME ) );
-		$editor_settings      = get_block_editor_settings( $editor_settings, $block_editor_context );
+		$editor_settings = $this->get_product_editor_settings();
 
 		$script_handle = 'wc-admin-edit-product';
 		wp_register_script( $script_handle, '', array(), '0.1.0', true );
@@ -203,6 +192,25 @@ class Init {
 				'wp.blocks && wp.blocks.unstable__bootstrapServerSideBlockDefinitions && wp.blocks.unstable__bootstrapServerSideBlockDefinitions(' . wp_json_encode( get_block_editor_server_block_settings() ) . ');'
 			);
 		}
+	}
+
+	/**
+	 * Get the product editor settings.
+	 */
+	private function get_product_editor_settings() {
+		$editor_settings = array();
+
+		$template_registry = wc_get_container()->get( BlockTemplateRegistry::class );
+
+		$editor_settings['template']  = $template_registry->get_registered( 'simple-product' )->get_formatted_template();
+		$editor_settings['templates'] = array(
+			'product'           => $template_registry->get_registered( 'simple-product' )->get_formatted_template(),
+			'product_variation' => $template_registry->get_registered( 'product-variation' )->get_formatted_template(),
+		);
+
+		$block_editor_context = new WP_Block_Editor_Context( array( 'name' => self::EDITOR_CONTEXT_NAME ) );
+
+		return get_block_editor_settings( $editor_settings, $block_editor_context );
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -202,7 +202,6 @@ class Init {
 
 		$template_registry = wc_get_container()->get( BlockTemplateRegistry::class );
 
-		$editor_settings['template']  = $template_registry->get_registered( 'simple-product' )->get_formatted_template();
 		$editor_settings['templates'] = array(
 			'product'           => $template_registry->get_registered( 'simple-product' )->get_formatted_template(),
 			'product_variation' => $template_registry->get_registered( 'product-variation' )->get_formatted_template(),

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -46,8 +46,6 @@ class Init {
 		$this->redirection_controller = new RedirectionController( $this->supported_post_types );
 
 		if ( \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_block_editor' ) ) {
-			$this->register_product_editor_templates();
-
 			if ( ! Features::is_enabled( 'new-product-management-experience' ) ) {
 				add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_styles' ) );
 				add_action( 'admin_enqueue_scripts', array( $this, 'dequeue_conflicting_styles' ), 100 );
@@ -75,6 +73,7 @@ class Init {
 			return;
 		}
 
+		$this->register_product_editor_templates();
 		$editor_settings = $this->get_product_editor_settings();
 
 		$script_handle = 'wc-admin-edit-product';

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -46,10 +46,7 @@ class Init {
 		$this->redirection_controller = new RedirectionController( $this->supported_post_types );
 
 		if ( \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_block_editor' ) ) {
-			// Register the product block template.
-			$template_registry = wc_get_container()->get( BlockTemplateRegistry::class );
-			$template_registry->register( new SimpleProductTemplate() );
-			$template_registry->register( new ProductVariationTemplate() );
+			$this->register_product_editor_templates();
 
 			if ( ! Features::is_enabled( 'new-product-management-experience' ) ) {
 				add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_styles' ) );
@@ -58,7 +55,6 @@ class Init {
 			}
 			add_filter( 'woocommerce_admin_get_user_data_fields', array( $this, 'add_user_data_fields' ) );
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
-			add_filter( 'woocommerce_register_post_type_product', array( $this, 'add_product_template' ) );
 			add_filter( 'woocommerce_register_post_type_product_variation', array( $this, 'enable_rest_api_for_product_variation' ) );
 
 			add_action( 'current_screen', array( $this, 'set_current_screen_to_block_editor_if_wc_admin' ) );
@@ -78,21 +74,19 @@ class Init {
 		if ( ! PageController::is_admin_or_embed_page() ) {
 			return;
 		}
-		$post_type_object     = get_post_type_object( 'product' );
-		$block_editor_context = new WP_Block_Editor_Context( array( 'name' => self::EDITOR_CONTEXT_NAME ) );
-		$template_registry    = wc_get_container()->get( BlockTemplateRegistry::class );
+
+		$template_registry = wc_get_container()->get( BlockTemplateRegistry::class );
 
 		$editor_settings = array();
-		if ( ! empty( $post_type_object->template ) ) {
-			$editor_settings['template']     = $post_type_object->template;
-			$editor_settings['templateLock'] = ! empty( $post_type_object->template_lock ) ? $post_type_object->template_lock : false;
-			$editor_settings['templates']    = array(
-				'product'           => $post_type_object->template,
-				'product_variation' => $template_registry->get_registered( 'product-variation' )->get_formatted_template(),
-			);
-		}
 
-		$editor_settings = get_block_editor_settings( $editor_settings, $block_editor_context );
+		$editor_settings['template']  = $template_registry->get_registered( 'simple-product' )->get_formatted_template();
+		$editor_settings['templates'] = array(
+			'product'           => $template_registry->get_registered( 'simple-product' )->get_formatted_template(),
+			'product_variation' => $template_registry->get_registered( 'product-variation' )->get_formatted_template(),
+		);
+
+		$block_editor_context = new WP_Block_Editor_Context( array( 'name' => self::EDITOR_CONTEXT_NAME ) );
+		$editor_settings      = get_block_editor_settings( $editor_settings, $block_editor_context );
 
 		$script_handle = 'wc-admin-edit-product';
 		wp_register_script( $script_handle, '', array(), '0.1.0', true );
@@ -162,26 +156,6 @@ class Init {
 	}
 
 	/**
-	 * Enqueue styles needed for the rich text editor.
-	 *
-	 * @param array $args Array of post type arguments.
-	 * @return array Array of post type arguments.
-	 */
-	public function add_product_template( $args ) {
-		if ( ! isset( $args['template'] ) ) {
-			// Get the template from the registry.
-			$template_registry = wc_get_container()->get( BlockTemplateRegistry::class );
-			$template          = $template_registry->get_registered( 'simple-product' );
-
-			if ( isset( $template ) ) {
-				$args['template_lock'] = 'all';
-				$args['template']      = $template->get_formatted_template();
-			}
-		}
-		return $args;
-	}
-
-	/**
 	 * Enables variation post type in REST API.
 	 *
 	 * @param array $args Array of post type arguments.
@@ -229,5 +203,15 @@ class Init {
 				'wp.blocks && wp.blocks.unstable__bootstrapServerSideBlockDefinitions && wp.blocks.unstable__bootstrapServerSideBlockDefinitions(' . wp_json_encode( get_block_editor_server_block_settings() ) . ');'
 			);
 		}
+	}
+
+	/**
+	 * Register product editor templates.
+	 */
+	private function register_product_editor_templates() {
+		$template_registry = wc_get_container()->get( BlockTemplateRegistry::class );
+
+		$template_registry->register( new SimpleProductTemplate() );
+		$template_registry->register( new ProductVariationTemplate() );
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In the review of #41316 we discovered that we were generating the product editor templates on every page request, including the front end and non-WCA admin pages.

This is wasteful (consuming CPU cycles for nothing) and also had the side-effect of quickly filling up the log file needlessly.

This PR addresses this by only generating the templates for WCA route requests.

#41316 will further improve matters by only logging template events when the template has actually changed.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Add the following template modifications to a `mu-plugin`:

```php
use Automattic\WooCommerce\Admin\BlockTemplates\BlockInterface;
use Automattic\WooCommerce\Admin\Features\ProductBlockEditor\ProductTemplates\SectionInterface;

if ( ! function_exists( 'example_hook_up_block_template_modifications' ) ) {
	/**
	 * Hook up the block template after hooks.
	 */
	function example_hook_up_block_template_modifications() {
		/*
		 * Events that will be logged:
		 * - Block removed from template - INFO
		 */
		add_action(
			'woocommerce_block_template_area_product-form_after_add_block_product-summary',
			function ( BlockInterface $product_summary_field ) {
				$product_summary_field->remove();
			}
		);

	}
}

add_action( 'init', 'example_hook_up_block_template_modifications', 0 );
```

1. Enable the **Product Editor** under **WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**.
2. Go to **Products** > **Add New**
3. Verify the default logging threshold (`warning`) -- there should be 1 events
    - Look at the log (**WooCommerce** > **Status** > **Logs** > `block_template` files (multiple template generations will be in a single file, so look closely at the timestamps)
4. Reload the **Add New** page... there should be another log entry.
5. Reload the admin dashboard page (`/wp-admin/index.php`)... there should not be another log entry.
6. Reload other WCA pages, like the WooCommerce Home page (`/wp-admin/admin.php?page=wc-admin`)... there should be a new log entry for every reload. Note: if just navigating between WCA pages in the client, there will be no additional log entries, as the routing is done client-side.
7. Reload front-end pages. There should be no new log entries.

Regression testing:

8. Verify saving a new product in the editor works.
9. Verify creating a variable product with variations in the editor works.
10. Disable the product editor.
11. Verify the classic experience works (simple saving of a new product should suffice).

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
