### PR TITLE
Add payment-gateway-suggestions cache unit test

### DIFF
--- a/plugins/woocommerce/changelog/41412-update-41378-write-unit-test-for-payment-suggestion-cache
+++ b/plugins/woocommerce/changelog/41412-update-41378-write-unit-test-for-payment-suggestion-cache
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add a unit test to ensure that the payment gateway suggestion cache is refreshed when the base country is updated

--- a/plugins/woocommerce/tests/php/src/Admin/API/PaymentGatewaySuggestionsTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/API/PaymentGatewaySuggestionsTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Automattic\WooCommerce\Tests\Admin\API;
+
+use Automattic\WooCommerce\Admin\Features\PaymentGatewaySuggestions\Init;
+use Automattic\WooCommerce\Admin\Marketing\MarketingCampaign;
+use Automattic\WooCommerce\Admin\Marketing\MarketingCampaignType;
+use Automattic\WooCommerce\Admin\Marketing\MarketingChannelInterface;
+use Automattic\WooCommerce\Admin\Marketing\MarketingChannels as MarketingChannelsService;
+use WC_REST_Unit_Test_Case;
+use WP_REST_Request;
+
+/**
+ * PaymentGatewaySuggestionsTest API controller test.
+ *
+ * @class PaymentGatewaySuggestionsTest.
+ */
+class PaymentGatewaySuggestionsTest extends WC_REST_Unit_Test_Case {
+	/**
+	 * Endpoint.
+	 *
+	 * @var string
+	 */
+	const ENDPOINT = '/wc-admin/payment-gateway-suggestions';
+
+	/**
+	 * Set up.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// Register an administrator user and log in.
+		$this->user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+		wp_set_current_user( $this->user );
+
+	}
+
+	public function test_it_clears_cache_when_the_base_country_gets_updated()
+	{
+		// Clear any exisiting cache first
+		Init::delete_specs_transient();
+
+		$response_mock_ref = function( $preempt, $parsed_args, $url ) {
+			if ( str_contains( $url, 'https://woocommerce.com/wp-json/wccom/payment-gateway-suggestions/1.0/suggestions.json' ) ) {
+				return array(
+					'success' => true,
+					'body' => json_encode(array(
+						array(
+							'id' => wc_get_base_location()['country']
+						)
+					))
+				);
+			}
+
+			return $preempt;
+		};
+		// Make a new request -- this should populate the cache with the base country
+		add_filter( 'pre_http_request', $response_mock_ref , 10, 3 );
+		$request = new WP_REST_Request( 'GET', self::ENDPOINT );
+		$response = rest_get_server()->dispatch( $request )->get_data();
+
+		// Confirm the current data returns id = US
+		$this->assertEquals('US', $response[0]->id);
+
+		// Remove filter just in case and a new request still returns the cached data
+		remove_filter( 'pre_http_request', $response_mock_ref );
+		$response = rest_get_server()->dispatch( $request )->get_data();
+		$this->assertEquals('US', $response[0]->id);
+
+		add_filter( 'pre_http_request', $response_mock_ref , 10, 3 );
+
+		// Update the base country to CA
+		update_option( 'woocommerce_default_country', 'CA:ON' );
+
+		// Make a new request -- this should populate the cache with the updated country
+		$response = rest_get_server()->dispatch( $request )->get_data();
+		$this->assertEquals('CA', $response[0]->id);
+
+		// Clean up
+		remove_filter( 'pre_http_request', $response_mock_ref );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Admin/API/PaymentGatewaySuggestionsTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/API/PaymentGatewaySuggestionsTest.php
@@ -51,7 +51,7 @@ class PaymentGatewaySuggestionsTest extends WC_REST_Unit_Test_Case {
 					'success' => true,
 					'body' => json_encode(array(
 						array(
-							'id' => $current_base_country
+							'id' => wc_get_base_location()['country']
 						)
 					))
 				);

--- a/plugins/woocommerce/tests/php/src/Admin/API/PaymentGatewaySuggestionsTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/API/PaymentGatewaySuggestionsTest.php
@@ -39,50 +39,55 @@ class PaymentGatewaySuggestionsTest extends WC_REST_Unit_Test_Case {
 
 	}
 
-	public function test_it_clears_cache_when_the_base_country_gets_updated()
-	{
-		// Clear any exisiting cache first
+	/**
+	 * Test it clears cache when the base country gets updated.
+	 *
+	 * @return void
+	 */
+	public function test_it_clears_cache_when_the_base_country_gets_updated() {
+		// Clear any exisiting cache first.
 		Init::delete_specs_transient();
 
 		$current_base_country = wc_get_base_location()['country'];
-		$response_mock_ref = function( $preempt, $parsed_args, $url ) use ( $current_base_country ) {
+		$response_mock_ref    = function( $preempt, $parsed_args, $url ) use ( $current_base_country ) {
 			if ( str_contains( $url, 'https://woocommerce.com/wp-json/wccom/payment-gateway-suggestions/1.0/suggestions.json' ) ) {
 				return array(
 					'success' => true,
-					'body' => json_encode(array(
+					'body'    => wp_json_encode(
 						array(
-							'id' => wc_get_base_location()['country']
+							array(
+								'id' => wc_get_base_location()['country'],
+							),
 						)
-					))
+					),
 				);
 			}
 
 			return $preempt;
 		};
-		// Make a new request -- this should populate the cache with the base country
-		add_filter( 'pre_http_request', $response_mock_ref , 10, 3 );
-		$request = new WP_REST_Request( 'GET', self::ENDPOINT );
+		// Make a new request -- this should populate the cache with the base country.
+		add_filter( 'pre_http_request', $response_mock_ref, 10, 3 );
+		$request  = new WP_REST_Request( 'GET', self::ENDPOINT );
 		$response = rest_get_server()->dispatch( $request )->get_data();
 
-		// Confirm the current data returns id = US
-		$this->assertEquals( $current_base_country , $response[0]->id);
+		// Confirm the current data returns id = US.
+		$this->assertEquals( $current_base_country, $response[0]->id );
 
-		// Remove filter just in case and a new request still returns the cached data
+		// Remove filter just in case and a new request still returns the cached data.
 		remove_filter( 'pre_http_request', $response_mock_ref );
 		$response = rest_get_server()->dispatch( $request )->get_data();
-		$this->assertEquals( $current_base_country , $response[0]->id);
+		$this->assertEquals( $current_base_country, $response[0]->id );
 
-		add_filter( 'pre_http_request', $response_mock_ref , 10, 3 );
+		add_filter( 'pre_http_request', $response_mock_ref, 10, 3 );
 
-		// Update the base country to CA
+		// Update the base country to CA.
 		update_option( 'woocommerce_default_country', 'CA:ON' );
 
-		// Make a new request -- this should populate the cache with the updated country
+		// Make a new request -- this should populate the cache with the updated country.
 		$response = rest_get_server()->dispatch( $request )->get_data();
-		$this->assertEquals('CA', $response[0]->id);
+		$this->assertEquals( 'CA', $response[0]->id );
 
-		// Clean up
+		// Clean up.
 		remove_filter( 'pre_http_request', $response_mock_ref );
-
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Admin/API/PaymentGatewaySuggestionsTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/API/PaymentGatewaySuggestionsTest.php
@@ -70,7 +70,7 @@ class PaymentGatewaySuggestionsTest extends WC_REST_Unit_Test_Case {
 		// Remove filter just in case and a new request still returns the cached data
 		remove_filter( 'pre_http_request', $response_mock_ref );
 		$response = rest_get_server()->dispatch( $request )->get_data();
-		$this->assertEquals('US', $response[0]->id);
+		$this->assertEquals( $current_base_country , $response[0]->id);
 
 		add_filter( 'pre_http_request', $response_mock_ref , 10, 3 );
 

--- a/plugins/woocommerce/tests/php/src/Admin/API/PaymentGatewaySuggestionsTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/API/PaymentGatewaySuggestionsTest.php
@@ -52,14 +52,14 @@ class PaymentGatewaySuggestionsTest extends WC_REST_Unit_Test_Case {
 		// update the base country to the U.S for testing purposes.
 		update_option( 'woocommerce_default_country', 'US:CA' );
 
-		$response_mock_ref    = function( $preempt, $parsed_args, $url ) {
+		$response_mock_ref = function( $preempt, $parsed_args, $url ) {
 			if ( str_contains( $url, 'https://woocommerce.com/wp-json/wccom/payment-gateway-suggestions/1.0/suggestions.json' ) ) {
 				return array(
 					'success' => true,
 					'body'    => wp_json_encode(
 						array(
 							array(
-								'id' => wc_get_base_location()['country']
+								'id' => wc_get_base_location()['country'],
 							),
 						)
 					),
@@ -94,7 +94,7 @@ class PaymentGatewaySuggestionsTest extends WC_REST_Unit_Test_Case {
 		// Clean up.
 		remove_filter( 'pre_http_request', $response_mock_ref );
 
-		// restore the base country
+		// restore the base country.
 		update_option( 'woocommerce_default_country', $existing_base_country['country'] . ':' . $existing_base_country['state'] );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Admin/API/PaymentGatewaySuggestionsTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/API/PaymentGatewaySuggestionsTest.php
@@ -44,13 +44,14 @@ class PaymentGatewaySuggestionsTest extends WC_REST_Unit_Test_Case {
 		// Clear any exisiting cache first
 		Init::delete_specs_transient();
 
-		$response_mock_ref = function( $preempt, $parsed_args, $url ) {
+		$current_base_country = wc_get_base_location()['country'];
+		$response_mock_ref = function( $preempt, $parsed_args, $url ) use ( $current_base_country ) {
 			if ( str_contains( $url, 'https://woocommerce.com/wp-json/wccom/payment-gateway-suggestions/1.0/suggestions.json' ) ) {
 				return array(
 					'success' => true,
 					'body' => json_encode(array(
 						array(
-							'id' => wc_get_base_location()['country']
+							'id' => $current_base_country
 						)
 					))
 				);
@@ -64,7 +65,7 @@ class PaymentGatewaySuggestionsTest extends WC_REST_Unit_Test_Case {
 		$response = rest_get_server()->dispatch( $request )->get_data();
 
 		// Confirm the current data returns id = US
-		$this->assertEquals('US', $response[0]->id);
+		$this->assertEquals( $current_base_country , $response[0]->id);
 
 		// Remove filter just in case and a new request still returns the cached data
 		remove_filter( 'pre_http_request', $response_mock_ref );
@@ -82,5 +83,6 @@ class PaymentGatewaySuggestionsTest extends WC_REST_Unit_Test_Case {
 
 		// Clean up
 		remove_filter( 'pre_http_request', $response_mock_ref );
+
 	}
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #41378 

This pull request adds a unit test to ensure that the payment gateway suggestion cache is refreshed when the base country is updated.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

No visual test required.

1. Confirm the test makes sense.
2. Run the test locally and confirm it passes.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add a unit test to ensure that the payment gateway suggestion cache is refreshed when the base country is updated

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
