### PR TITLE
[CYS] Fix `getCompletion` API hanging and color choices parsing error

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/prompts/colorChoices.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/prompts/colorChoices.ts
@@ -242,7 +242,7 @@ export const defaultColorPalette = {
 		return `
             You are a WordPress theme expert designing a WooCommerce site. Analyse the following store description, merchant's chosen look and tone, and determine the most appropriate color scheme, along with 8 best alternatives.
 			Do not use any palette names that are not part of the color choices provided below.
-			Respond in the form: "{ default: "palette name", bestColors: [ "palette name 1", "palette name 2", "palette name 3", "palette name 4", "palette name 5", "palette name 6", "palette name 7", "palette name 8" ] }"
+			Respond in the JSON form: "{ "default": "palette name", "bestColors": [ "palette name 1", "palette name 2", "palette name 3", "palette name 4", "palette name 5", "palette name 6", "palette name 7", "palette name 8" ] }"
 			
             Chosen look and tone: ${ look } look, ${ tone } tone.
             Business description: ${ businessDescription }

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/services.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/services.ts
@@ -46,12 +46,14 @@ export const getCompletion = async < ValidResponseObject >( {
 	version,
 	responseValidation,
 	retryCount,
+	abortSignal = AbortSignal.timeout( 10000 ),
 }: {
 	queryId: string;
 	prompt: string;
 	version: string;
 	responseValidation: ( arg0: string ) => ValidResponseObject;
 	retryCount: number;
+	abortSignal?: AbortSignal;
 } ) => {
 	const { token } = await requestJetpackToken();
 	let data: {
@@ -73,6 +75,7 @@ export const getCompletion = async < ValidResponseObject >( {
 				prompt,
 				_fields: 'completion',
 			},
+			signal: abortSignal,
 		} );
 	} catch ( error ) {
 		recordEvent( 'customize_your_store_ai_completion_api_error', {
@@ -128,6 +131,8 @@ export const getLookAndTone = async (
 			context.businessInfoDescription.descriptionText
 		),
 		retryCount: 0,
+		// If the request takes longer than 5 seconds, abort it. We don't want to wait too long for the AI to respond. We will use default values instead.
+		abortSignal: AbortSignal.timeout( 5000 ),
 	} );
 };
 

--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/tests/services.test.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/tests/services.test.ts
@@ -26,6 +26,11 @@ jest.mock(
 	} )
 );
 
+// @ts-expect-error Mock AbortSignal.
+global.AbortSignal = {
+	timeout: jest.fn(),
+};
+
 describe( 'getCompletion', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();

--- a/plugins/woocommerce/changelog/fix-cys-ai-api
+++ b/plugins/woocommerce/changelog/fix-cys-ai-api
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix cys ai api hanging and validation error


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes two bugs:

1. It might get stuck right at the beginning of the AI wizard, never leaving the “Tell us a bit more about your business” page because `get Completion` endpoint hangs.

2.  JSON parse error because AI returns an invalid JSON for color choices:

```js
# Invalid
{ 
  default: "Ancient Bronze", 
  bestColors: [ "Crimson Tide", "Raspberry Chocolate", "Gumtree Sunset", "Cinder", "Blue Lagoon", "Evergreen Twilight", "Charcoal", "Slate" ] 
}

# Valid
{ 
 "default": "Ancient Bronze", 
  "bestColors": [ "Crimson Tide", "Raspberry Chocolate", "Gumtree Sunset", "Cinder", "Blue Lagoon", "Evergreen Twilight", "Charcoal", "Slate" ] 
}
```

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new WooCommerce installation with this version.
2. Make sure to enable `customize-store` feature flag
3. Open DevTools > network tab
4. Search `text-completion` 
5. Go to `WooCommerce -> Home` and click `Customize Store` task
6. Click `Design with AI` button
7. Fill out business description and click on "Continue"
8. Confirm it goes to the `How would you like your store to look?` step.
9. Go back to `Tell us a bit more about your business` step and repeat steps 6-7 a few times to confirm it doesn't stuck when an API request takes too long.
 
![Screenshot 2023-11-14 at 16 33 58](https://github.com/woocommerce/woocommerce/assets/4344253/b9236280-8202-48e8-98de-376d3cdc4c9d)

10. Follow through the flow all the way till the loading screen shows up 
11. Observe that `text-completion` endpoint returns a valid JSON response.

![Screenshot 2023-11-14 at 16 37 04](https://github.com/woocommerce/woocommerce/assets/4344253/8ede2c43-9440-40e7-a347-01189cc0ff91)

Note that please ignore WC pattern API errors during the loading screen.


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
