### PR TITLE
Exclude async-upload.php from admin access protection

### DIFF
--- a/plugins/woocommerce/changelog/41431-fix-async-upload-access
+++ b/plugins/woocommerce/changelog/41431-fix-async-upload-access
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Exclude async-upload.php from admin access protection to fix error when using the WordPress Media Library Upload popup in the front-end.

--- a/plugins/woocommerce/includes/admin/class-wc-admin.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin.php
@@ -151,7 +151,7 @@ class WC_Admin {
 		$prevent_access = false;
 
 		// Do not interfere with admin-post or admin-ajax requests.
-		$exempted_paths = array( 'admin-post.php', 'admin-ajax.php' );
+		$exempted_paths = array( 'admin-post.php', 'admin-ajax.php', 'async-upload.php' );
 
 		if (
 			/**


### PR DESCRIPTION
Without this fix, WooCommerce blocks Media Library popup when used on the front-end

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #41430

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Load the WordPress Media Library popup on the front-end, follow the [example](https://derekspringer.wordpress.com/2015/05/07/using-the-wordpress-media-loader-in-the-front-end/).
2. Try to upload a file while WooCommerce >= 7.8 is active

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Exclude async-upload.php from admin access protection to fix error when using the WordPress Media Library Upload popup in the front-end.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
