### PR TITLE
Prevent possible activation notice due to early initialization of feature settings

### DIFF
--- a/plugins/woocommerce/changelog/fix-41363
+++ b/plugins/woocommerce/changelog/fix-41363
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent possible notice during plugin activation.

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -7,8 +7,6 @@ namespace Automattic\WooCommerce\Internal\Features;
 
 use Automattic\WooCommerce\Internal\Admin\Analytics;
 use Automattic\WooCommerce\Admin\Features\Navigation\Init;
-use Automattic\WooCommerce\Admin\Features\NewProductManagementExperience;
-use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
 use Automattic\WooCommerce\Internal\Traits\AccessiblePrivateMethods;
 use Automattic\WooCommerce\Proxies\LegacyProxy;
 use Automattic\WooCommerce\Utilities\ArrayUtil;
@@ -688,19 +686,21 @@ class FeaturesController {
 			'id'   => empty( $experimental_feature_ids ) ? 'features_options' : 'experimental_features_options',
 		);
 
-		// Allow feature setting properties to be determined dynamically just before being rendered.
-		$feature_settings = array_map(
-			function( $feature_setting ) {
-				foreach ( $feature_setting as $prop => $value ) {
-					if ( is_callable( $value ) ) {
-						$feature_setting[ $prop ] = call_user_func( $value );
+		if ( $this->verify_did_woocommerce_init() ) {
+			// Allow feature setting properties to be determined dynamically just before being rendered.
+			$feature_settings = array_map(
+				function( $feature_setting ) {
+					foreach ( $feature_setting as $prop => $value ) {
+						if ( is_callable( $value ) ) {
+							$feature_setting[ $prop ] = call_user_func( $value );
+						}
 					}
-				}
 
-				return $feature_setting;
-			},
-			$feature_settings
-		);
+					return $feature_setting;
+				},
+				$feature_settings
+			);
+		}
 
 		return $feature_settings;
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR addresses a possible "doing it wrong" notice that can appear during activation if callbacks associated to features in `FeaturesController` end up calling functions (from `FeaturesController` itself) that are not available until after the `woocommerce_init` hook.

This can happen, for example, when `WC_Install::create_options()` attempts [to load settings pages](https://github.com/woocommerce/woocommerce/blob/55766ac140f6c234d548e53099c642d3590a63e3/plugins/woocommerce/includes/class-wc-install.php#L886-L894) (and thus, settings), including those [handled](https://github.com/woocommerce/woocommerce/blob/55766ac140f6c234d548e53099c642d3590a63e3/plugins/woocommerce/src/Internal/Features/FeaturesController.php#L88) by `FeaturesController`. This would only happen when it is executed as an [activation hook](https://github.com/woocommerce/woocommerce/blob/55766ac140f6c234d548e53099c642d3590a63e3/plugins/woocommerce/includes/class-woocommerce.php#L230). When it is triggered by a version change (or in any other form) this wouldn't be a problem since it'd occur during `init` and after `woocommerce_init` has run.

(See p1699891043650119-slack-C0E1AV8T0).

Closes #41363.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Manually deactivate WooCommerce (if active) and re-activate. Alternatively, use WP-CLI:
   ```
   wp plugin deactivate woocommerce && wp plugin activate woocommerce
   ```
2. Make sure no notices are logged. In particular, the following one should not occur:
   > PHP Notice:  Function FeaturesController::get_compatible_plugins_for_feature was called incorrectly. FeaturesController::get_compatible_plugins_for_feature should not be called before the woocommerce_init action.
3. Try the above on a new site (for instance using JN) and confirm that after activation, HPOS is the default order datastore. Confirm this in WC > Settings > Advanced > Features.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>