### PR TITLE
Show one help text when user clicks help button

### DIFF
--- a/packages/js/components/changelog/fix-40205_show_one_help_text_when_user_clicks_button
+++ b/packages/js/components/changelog/fix-40205_show_one_help_text_when_user_clicks_button
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Add className prop to Tooltip component #41435

--- a/packages/js/components/src/tooltip/tooltip.tsx
+++ b/packages/js/components/src/tooltip/tooltip.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
 import { Button, Popover } from '@wordpress/components';
 import { createElement, Fragment, useState } from '@wordpress/element';
 import { FocusEvent, KeyboardEvent } from 'react';
@@ -23,10 +24,12 @@ type TooltipProps = {
 	helperText?: string;
 	position?: Position;
 	text: JSX.Element | string;
+	className?: string;
 };
 
 export const Tooltip: React.FC< TooltipProps > = ( {
 	children = <Icon icon={ help } />,
+	className = '',
 	helperText = __( 'Help', 'woocommerce' ),
 	position = 'top center',
 	text,
@@ -37,7 +40,10 @@ export const Tooltip: React.FC< TooltipProps > = ( {
 		<>
 			<div className="woocommerce-tooltip">
 				<Button
-					className="woocommerce-tooltip__button"
+					className={ classnames(
+						'woocommerce-tooltip__button',
+						className
+					) }
 					onKeyDown={ (
 						event: KeyboardEvent< HTMLButtonElement >
 					) => {
@@ -60,7 +66,7 @@ export const Tooltip: React.FC< TooltipProps > = ( {
 						onFocusOutside={ ( event: FocusEvent ) => {
 							if (
 								event.relatedTarget?.classList.contains(
-									'woocommerce-tooltip__button'
+									className
 								)
 							) {
 								return;

--- a/packages/js/product-editor/changelog/fix-40205_show_one_help_text_when_user_clicks_button
+++ b/packages/js/product-editor/changelog/fix-40205_show_one_help_text_when_user_clicks_button
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Show one help text when user clicks tooltip button #41435

--- a/packages/js/product-editor/src/blocks/generic/section/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/section/edit.tsx
@@ -20,6 +20,7 @@ import { ProductEditorBlockEditProps } from '../../../types';
 
 export function Edit( {
 	attributes,
+	clientId,
 }: ProductEditorBlockEditProps< SectionBlockAttributes > ) {
 	const { description, title, blockGap } = attributes;
 	const blockProps = useWooBlockProps( attributes );
@@ -34,6 +35,7 @@ export function Edit( {
 	);
 	const SectionTagName = title ? 'fieldset' : 'div';
 	const HeadingTagName = SectionTagName === 'fieldset' ? 'legend' : 'div';
+	const tooltipClassName = `wp-block-woocommerce-product-section__heading-tooltip-${ clientId }`;
 
 	return (
 		<SectionTagName { ...blockProps }>
@@ -43,6 +45,7 @@ export function Edit( {
 						{ title }
 						{ description && (
 							<Tooltip
+								className={ tooltipClassName }
 								text={
 									<p
 										className="wp-block-woocommerce-product-section__heading-description"

--- a/packages/js/product-editor/src/components/attribute-control/edit-attribute-modal.scss
+++ b/packages/js/product-editor/src/components/attribute-control/edit-attribute-modal.scss
@@ -32,7 +32,7 @@
 		flex-direction: row;
 		align-items: center;
 
-		.components-checkbox-control .components-base-control__field {
+		.components-base-control, .components-base-control__field {
 			margin-bottom: 0;
 		}
 	}

--- a/packages/js/product-editor/src/components/attribute-control/edit-attribute-modal.tsx
+++ b/packages/js/product-editor/src/components/attribute-control/edit-attribute-modal.tsx
@@ -232,7 +232,10 @@ export const EditAttributeModal: React.FC< EditAttributeModalProps > = ( {
 									checked={ editableAttribute?.isDefault }
 									label={ isDefaultLabel }
 								/>
-								<Tooltip text={ isDefaultTooltip } />
+								<Tooltip
+									className="woocommerce-edit-attribute-modal__tooltip-set-default-value"
+									text={ isDefaultTooltip }
+								/>
 							</div>
 						) }
 
@@ -247,7 +250,10 @@ export const EditAttributeModal: React.FC< EditAttributeModalProps > = ( {
 								checked={ editableAttribute?.visible }
 								label={ visibleLabel }
 							/>
-							<Tooltip text={ visibleTooltip } />
+							<Tooltip
+								className="woocommerce-edit-attribute-modal__tooltip-show-in-product-details"
+								text={ visibleTooltip }
+							/>
 						</div>
 						{ attribute.id !== 0 && (
 							/* Only supported for global attributes, and disabled for now as the 'Filter by Attributes' block does not support this yet. */
@@ -260,7 +266,10 @@ export const EditAttributeModal: React.FC< EditAttributeModalProps > = ( {
 									checked={ true }
 									label={ useAsFilterLabel }
 								/>
-								<Tooltip text={ useAsFilterTooltip } />
+								<Tooltip
+									className="woocommerce-edit-attribute-modal__tooltip-use-as-filter"
+									text={ useAsFilterTooltip }
+								/>
 							</div>
 						) }
 					</div>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds a fix to show only one help popover at a time. It also fixes a small visual problem.

Previously, we showed the help popover for every [ ? ] button the user clicks, leading to a chaotic and confusing experience. 

Before
<img width="690" alt="image" src="https://github.com/woocommerce/woocommerce/assets/79307566/3cf14d8f-d448-4fe8-9e88-145332a7e354">

After

![Screen Capture on 2023-11-14 at 14-23-45](https://github.com/woocommerce/woocommerce/assets/1314156/4ec571f1-d8f9-470f-bb78-53d7992c4f31)

**Acceptance criteria**

- [ ] Users can only view one help popover at a time.

Closes #40205.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a WooCommerce store with this branch and enable the product editor using **WooCommerce > Settings > Advanced > Features**
2. Go to **Products > Add New > Organization**
3. Press the `Add new` button in the `Attributes` section
4. Add an attribute with values
5. You'll see a new file in the table below. Press the `Edit` button
6. Press the help [ ? ] button next to the checkbox `Show in product details` and then press the help [ ? ] button next to the `Use as filter` checkbox
7. Observe that only one popover is visible at any time
8. Confirm that clicking the help [ ? ] button again toggles the visibility of the popover
9. Create a few variations and verify that the popovers in the attribute editor modal work well.
10. In the `Variations` tab, verify that the help buttons next to the section titles work as expected.

![Screen Capture on 2023-11-14 at 16-16-25](https://github.com/woocommerce/woocommerce/assets/1314156/ed3efe8d-ef63-4361-b4e7-b5cff071ed51)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
