### PR TITLE
[External products] Product details

### DIFF
--- a/packages/js/product-editor/changelog/add-35148
+++ b/packages/js/product-editor/changelog/add-35148
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add support for custom validation message to the generic text block

--- a/packages/js/product-editor/src/blocks/generic/text/README.md
+++ b/packages/js/product-editor/src/blocks/generic/text/README.md
@@ -8,46 +8,125 @@ A reusable text field for the product editor.
 
 ### label
 
-- **Type:** `String`
-- **Required:** `Yes`
+-   **Type:** `String`
+-   **Required:** `Yes`
 
 Label that appears on top of the field.
 
 ### property
 
-- **Type:** `String`
-- **Required:** `Yes`
+-   **Type:** `String`
+-   **Required:** `Yes`
 
 Property in which the value is stored.
 
-
 ### help
 
-- **Type:** `String`
-- **Required:** `No`
+-   **Type:** `String`
+-   **Required:** `No`
 
 Help text that appears below the field.
 
 ### required
 
-- **Type:** `Boolean`
-- **Required:** `No`
+-   **Type:** `Boolean`|`String`
+-   **Required:** `No`
 
 Indicates and enforces that the field is required.
+If the value is string it will be used as the custom error message.
 
 ### tooltip
 
-- **Type:** `String`
-- **Required:** `No`
+-   **Type:** `String`
+-   **Required:** `No`
 
 If provided, shows a tooltip next to the label with additional information.
 
 ### placeholder
 
-- **Type:** `String`
-- **Required:** `No`
+-   **Type:** `String`
+-   **Required:** `No`
 
 Placeholder text that appears in the field when it's empty.
+
+### type
+
+-   **Type:** `Object`
+    -   `value`
+        -   **Type:** `String`
+        -   **Required:** `No`
+        -   **Default:** `'text'`
+    -   `message`
+        -   **Type:** `String`
+        -   **Required:** `No`
+-   **Required:** `No`
+
+Reffers to the type of the input. The `value` can be [any valid input type](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#input_types). The message is used as a custom error `message` for the [typeMismatch](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState/typeMismatch) validity.
+
+### pattern
+
+-   **Type:** `Object`
+    -   `value`
+        -   **Type:** `String`
+        -   **Required:** `Yes`
+    -   `message`
+        -   **Type:** `String`
+        -   **Required:** `No`
+-   **Required:** `No`
+
+Reffers to the validation pattern of the input. The `value` can be [any valid regular expression](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/pattern). The `message` is used as a custom error message for the [patternMismatch](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState/patternMismatch) validity.
+
+### minLength
+
+-   **Type:** `Object`
+    -   `value`
+        -   **Type:** `Number`
+        -   **Required:** `Yes`
+    -   `message`
+        -   **Type:** `String`
+        -   **Required:** `No`
+-   **Required:** `No`
+
+Reffers to the minimum string length constraint of the input. The `value` can be [any positive integer](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/minLength). The `message` is used as a custom error message for the [tooShort](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState/tooShort) validity.
+
+### maxLength
+
+-   **Type:** `Object`
+    -   `value`
+        -   **Type:** `Number`
+        -   **Required:** `Yes`
+    -   `message`
+        -   **Type:** `String`
+        -   **Required:** `No`
+-   **Required:** `No`
+
+Reffers to the maximum string length constraint of the input. The `value` can be [any positive integer](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/maxLength). The `message` is used as a custom error message for the [tooLong](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState/tooLong) validity.
+
+### min
+
+-   **Type:** `Object`
+    -   `value`
+        -   **Type:** `Number`
+        -   **Required:** `Yes`
+    -   `message`
+        -   **Type:** `String`
+        -   **Required:** `No`
+-   **Required:** `No`
+
+Reffers to the [minimum](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/min) value that is acceptable and valid for the input containing the attribute. The `value` must be less than or equal to the value of the `max` attribute. The `message` is used as a custom error message for the [rangeUnderflow](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState/rangeUnderflow) validity.
+
+### max
+
+-   **Type:** `Object`
+    -   `value`
+        -   **Type:** `Number`
+        -   **Required:** `Yes`
+    -   `message`
+        -   **Type:** `String`
+        -   **Required:** `No`
+-   **Required:** `No`
+
+Reffers to the [maximum](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/max) value that is acceptable and valid for the input containing the attribute. The `value` must be greater than or equal to the value of the `min` attribute. The `message` is used as a custom error message for the [rangeOverflow](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState/rangeOverflow) validity.
 
 ## Usage
 
@@ -55,19 +134,45 @@ Here's a snippet that adds a field similar to the previous screenshot:
 
 ```php
 $section->add_block(
-  [
-      'id'         => 'example-text-meta',
-      'blockName'  => 'woocommerce/product-text-field',
-      'order'      => 13,
-      'attributes' => [
-        'label' => 'Text',
-        'property' => 'meta_data.text',
-        'placeholder' => 'Placeholder',
-        'required' => true,
-        'help' => 'Add additional information here',
-        'tooltip' => 'My tooltip'
-      ],
-    ]
+  array(
+    'id'         => 'example-text-meta',
+    'blockName'  => 'woocommerce/product-text-field',
+    'order'      => 13,
+    'attributes' => array(
+      'label'       => 'Text',
+      'property'    => 'meta_data.text',
+      'placeholder' => 'Placeholder',
+      'required'    => true,
+      'help'        => 'Add additional information here',
+      'tooltip'     => 'My tooltip',
+    ),
+  )
 );
 ```
 
+Here's a snippet that adds fields validations:
+
+```php
+$section->add_block(
+  array(
+    'id'         => 'product-external-url',
+    'blockName'  => 'woocommerce/product-text-field',
+    'order'      => 10,
+    'attributes' => array(
+      'property'    => 'external_url',
+      'label'       => __( 'Link to the external product', 'woocommerce' ),
+      'placeholder' => __( 'Enter the external URL to the product', 'woocommerce' ),
+      'suffix'      => true,
+      'type'        => array(
+        'value'   => 'url',
+        'message' => __( 'Link to the external product is an invalid URL.', 'woocommerce' ),
+      ),
+      'minLength'   => array(
+        'value'   => 8,
+        'message' => __( 'The link must be longer than %d.', 'woocommerce' ),
+      ),
+      'required'    => __( 'Link to the external product is required.', 'woocommerce' ),
+    ),
+  )
+);
+```

--- a/packages/js/product-editor/src/blocks/generic/text/block.json
+++ b/packages/js/product-editor/src/blocks/generic/text/block.json
@@ -31,7 +31,7 @@
 			"type": "object"
 		},
 		"required": {
-			"type": "boolean",
+			"type": "object",
 			"default": false
 		},
 		"validationRegex": {

--- a/packages/js/product-editor/src/blocks/generic/text/block.json
+++ b/packages/js/product-editor/src/blocks/generic/text/block.json
@@ -24,27 +24,29 @@
 		"tooltip": {
 			"type": "string"
 		},
-		"type": {
-			"type": "string"
-		},
 		"suffix": {
 			"type": "object"
 		},
+		"type": {
+			"type": "object"
+		},
 		"required": {
-			"type": "object",
-			"default": false
+			"type": "object"
 		},
-		"validationRegex": {
-			"type": "string"
-		},
-		"validationErrorMessage": {
-			"type": "string"
+		"pattern": {
+			"type": "object"
 		},
 		"minLength": {
-			"type": "number"
+			"type": "object"
 		},
 		"maxLength": {
-			"type": "number"
+			"type": "object"
+		},
+		"min": {
+			"type": "object"
+		},
+		"max": {
+			"type": "object"
 		}
 	},
 	"supports": {

--- a/packages/js/product-editor/src/blocks/generic/text/block.json
+++ b/packages/js/product-editor/src/blocks/generic/text/block.json
@@ -5,10 +5,7 @@
 	"title": "Product text field",
 	"category": "woocommerce",
 	"description": "A text field for use in the product editor.",
-	"keywords": [
-		"products",
-		"text"
-	],
+	"keywords": [ "products", "text" ],
 	"textdomain": "default",
 	"attributes": {
 		"label": {
@@ -26,6 +23,12 @@
 		},
 		"tooltip": {
 			"type": "string"
+		},
+		"type": {
+			"type": "string"
+		},
+		"suffix": {
+			"type": "object"
 		},
 		"required": {
 			"type": "boolean",

--- a/packages/js/product-editor/src/blocks/generic/text/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/text/edit.tsx
@@ -53,6 +53,9 @@ export function Edit( {
 				);
 			}
 			if ( required && ! value ) {
+				if ( typeof required === 'string' ) {
+					return required;
+				}
 				return __( 'This field is required.', 'woocommerce' );
 			}
 			if ( validationRegex ) {
@@ -85,7 +88,7 @@ export function Edit( {
 				);
 			}
 		},
-		[ value ]
+		[ value, required ]
 	);
 
 	function getSuffix() {
@@ -122,9 +125,9 @@ export function Edit( {
 				error={ error }
 				help={ help }
 				placeholder={ placeholder }
-				required={ required }
 				tooltip={ tooltip }
 				suffix={ getSuffix() }
+				required={ Boolean( required ) }
 			/>
 		</div>
 	);

--- a/packages/js/product-editor/src/blocks/generic/text/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/text/edit.tsx
@@ -76,6 +76,7 @@ export function Edit( {
 					__( 'Invalid value for the field.', 'woocommerce' );
 			}
 			if ( input.validity.tooShort ) {
+				// eslint-disable-next-line @wordpress/valid-sprintf
 				customErrorMessage = sprintf(
 					minLength?.message ??
 						/* translators: %d: minimum length */
@@ -87,6 +88,7 @@ export function Edit( {
 				);
 			}
 			if ( input.validity.tooLong ) {
+				// eslint-disable-next-line @wordpress/valid-sprintf
 				customErrorMessage = sprintf(
 					maxLength?.message ??
 						/* translators: %d: maximum length */
@@ -98,6 +100,7 @@ export function Edit( {
 				);
 			}
 			if ( input.validity.rangeUnderflow ) {
+				// eslint-disable-next-line @wordpress/valid-sprintf
 				customErrorMessage = sprintf(
 					min?.message ??
 						/* translators: %d: minimum length */
@@ -109,6 +112,7 @@ export function Edit( {
 				);
 			}
 			if ( input.validity.rangeOverflow ) {
+				// eslint-disable-next-line @wordpress/valid-sprintf
 				customErrorMessage = sprintf(
 					max?.message ??
 						/* translators: %d: maximum length */

--- a/packages/js/product-editor/src/blocks/generic/text/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/text/edit.tsx
@@ -1,20 +1,22 @@
 /**
  * External dependencies
  */
+import { useWooBlockProps } from '@woocommerce/block-templates';
+import { Link } from '@woocommerce/components';
+import { Product } from '@woocommerce/data';
 import { createElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { Product } from '@woocommerce/data';
-import { useWooBlockProps } from '@woocommerce/block-templates';
+import { Icon, external } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
-import { useValidation } from '../../../contexts/validation-context';
-import useProductEntityProp from '../../../hooks/use-product-entity-prop';
-import { TextBlockAttributes } from './types';
-import { ProductEditorBlockEditProps } from '../../../types';
 import { TextControl } from '../../../components/text-control';
+import { useValidation } from '../../../contexts/validation-context';
 import { useProductEdits } from '../../../hooks/use-product-edits';
+import useProductEntityProp from '../../../hooks/use-product-entity-prop';
+import { ProductEditorBlockEditProps } from '../../../types';
+import { TextBlockAttributes } from './types';
 
 export function Edit( {
 	attributes,
@@ -33,6 +35,8 @@ export function Edit( {
 		help,
 		tooltip,
 		disabled,
+		type,
+		suffix,
 	} = attributes;
 	const [ value, setValue ] = useProductEntityProp< string >( property, {
 		postType,
@@ -84,9 +88,27 @@ export function Edit( {
 		[ value ]
 	);
 
+	function getSuffix() {
+		if ( suffix && type === 'url' && value && ! error ) {
+			return (
+				<Link
+					href={ value }
+					target="_blank"
+					rel="noreferrer"
+					className="wp-block-woocommerce-product-text-field__suffix-link"
+				>
+					<Icon icon={ external } size={ 20 } />
+				</Link>
+			);
+		}
+
+		return typeof suffix === 'string' ? suffix : undefined;
+	}
+
 	return (
 		<div { ...blockProps }>
 			<TextControl
+				type={ type }
 				value={ value }
 				disabled={ disabled }
 				label={ label }
@@ -101,6 +123,7 @@ export function Edit( {
 				placeholder={ placeholder }
 				required={ required }
 				tooltip={ tooltip }
+				suffix={ getSuffix() }
 			/>
 		</div>
 	);

--- a/packages/js/product-editor/src/blocks/generic/text/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/text/edit.tsx
@@ -92,6 +92,7 @@ export function Edit( {
 		if ( suffix && type === 'url' && value && ! error ) {
 			return (
 				<Link
+					type="external"
 					href={ value }
 					target="_blank"
 					rel="noreferrer"

--- a/packages/js/product-editor/src/blocks/generic/text/editor.scss
+++ b/packages/js/product-editor/src/blocks/generic/text/editor.scss
@@ -1,0 +1,10 @@
+.wp-block-woocommerce-product-text-field {
+	&__suffix-link {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: $grid-unit-30;
+		height: $grid-unit-30;
+		fill: $gray-700;
+	}
+}

--- a/packages/js/product-editor/src/blocks/generic/text/types.ts
+++ b/packages/js/product-editor/src/blocks/generic/text/types.ts
@@ -12,7 +12,7 @@ export interface TextBlockAttributes extends BlockAttributes {
 	placeholder?: string;
 	type?: HTMLInputTypeAttribute;
 	suffix?: boolean | string;
-	required?: boolean;
+	required?: boolean | string;
 	validationRegex?: string;
 	validationErrorMessage?: string;
 	minLength?: number;

--- a/packages/js/product-editor/src/blocks/generic/text/types.ts
+++ b/packages/js/product-editor/src/blocks/generic/text/types.ts
@@ -10,11 +10,12 @@ export interface TextBlockAttributes extends BlockAttributes {
 	help?: string;
 	tooltip?: string;
 	placeholder?: string;
-	type?: HTMLInputTypeAttribute;
 	suffix?: boolean | string;
 	required?: boolean | string;
-	validationRegex?: string;
-	validationErrorMessage?: string;
-	minLength?: number;
-	maxLength?: number;
+	type?: { value?: HTMLInputTypeAttribute; message?: string };
+	pattern?: { value: string; message?: string };
+	minLength?: { value: number; message?: string };
+	maxLength?: { value: number; message?: string };
+	min?: { value: number; message?: string };
+	max?: { value: number; message?: string };
 }

--- a/packages/js/product-editor/src/blocks/generic/text/types.ts
+++ b/packages/js/product-editor/src/blocks/generic/text/types.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import type { HTMLInputTypeAttribute } from 'react';
 import type { BlockAttributes } from '@wordpress/blocks';
 
 export interface TextBlockAttributes extends BlockAttributes {
@@ -9,6 +10,8 @@ export interface TextBlockAttributes extends BlockAttributes {
 	help?: string;
 	tooltip?: string;
 	placeholder?: string;
+	type?: HTMLInputTypeAttribute;
+	suffix?: boolean | string;
 	required?: boolean;
 	validationRegex?: string;
 	validationErrorMessage?: string;

--- a/packages/js/product-editor/src/components/block-editor/style.scss
+++ b/packages/js/product-editor/src/components/block-editor/style.scss
@@ -42,13 +42,19 @@
 		max-width: unset;
 	}
 
-	.components-base-control.has-error {
-		.components-input-control__backdrop {
-			border-color: $studio-red-50;
+	.components-base-control {
+		&.has-error {
+			.components-input-control__backdrop {
+				border-color: $studio-red-50;
+			}
+
+			.components-base-control__help {
+				color: $studio-red-50;
+			}
 		}
 
-		.components-base-control__help {
-			color: $studio-red-50;
+		.components-input-control__container .components-input-control__input {
+			min-height: $grid-unit-40 + $grid-unit-05;
 		}
 	}
 

--- a/packages/js/product-editor/src/components/block-editor/style.scss
+++ b/packages/js/product-editor/src/components/block-editor/style.scss
@@ -42,6 +42,19 @@
 		max-width: unset;
 	}
 
+	.components-base-control.has-error {
+		.components-input-control__backdrop {
+			border-color: $studio-red-50;
+		}
+
+		.components-base-control__help {
+			color: $studio-red-50;
+		}
+	}
+
+	// This is wrong for @wordpress/components/InputControl since it is
+	// wrapped within the BaseControl by default. So it does not need
+	// to be wrapped again.
 	.has-error {
 		.components-base-control {
 			margin-bottom: 0;

--- a/packages/js/product-editor/src/components/index.ts
+++ b/packages/js/product-editor/src/components/index.ts
@@ -46,3 +46,8 @@ export { NumberControl as __experimentalNumberControl } from './number-control';
 export * from './product-page-skeleton';
 
 export * from './modal-editor-welcome-guide';
+
+export {
+	TextControl as __experimentalTextControl,
+	TextControlProps,
+} from './text-control';

--- a/packages/js/product-editor/src/components/text-control/index.ts
+++ b/packages/js/product-editor/src/components/text-control/index.ts
@@ -1,1 +1,2 @@
 export * from './text-control';
+export * from './types';

--- a/packages/js/product-editor/src/components/text-control/text-control.tsx
+++ b/packages/js/product-editor/src/components/text-control/text-control.tsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { createElement } from '@wordpress/element';
+import { Ref } from 'react';
+import { createElement, forwardRef } from '@wordpress/element';
 import classNames from 'classnames';
 import {
 	// @ts-expect-error `__experimentalInputControl` does exist.
@@ -14,20 +15,24 @@ import {
 import { Label } from '../label/label';
 import { TextControlProps } from './types';
 
-export function TextControl( {
-	label,
-	help,
-	error,
-	tooltip,
-	className,
-	required,
-	onChange,
-	onBlur,
-	...props
-}: TextControlProps ) {
+export const TextControl = forwardRef( function ForwardedTextControl(
+	{
+		label,
+		help,
+		error,
+		tooltip,
+		className,
+		required,
+		onChange,
+		onBlur,
+		...props
+	}: TextControlProps,
+	ref: Ref< HTMLInputElement >
+) {
 	return (
 		<InputControl
 			{ ...props }
+			ref={ ref }
 			className={ classNames( className, {
 				'has-error': error,
 			} ) }
@@ -44,4 +49,4 @@ export function TextControl( {
 			onBlur={ onBlur }
 		/>
 	);
-}
+} );

--- a/packages/js/product-editor/src/components/text-control/text-control.tsx
+++ b/packages/js/product-editor/src/components/text-control/text-control.tsx
@@ -2,51 +2,35 @@
  * External dependencies
  */
 import { createElement } from '@wordpress/element';
-import { useInstanceId } from '@wordpress/compose';
 import classNames from 'classnames';
 import {
-	BaseControl,
 	// @ts-expect-error `__experimentalInputControl` does exist.
 	__experimentalInputControl as InputControl,
 } from '@wordpress/components';
+
 /**
  * Internal dependencies
  */
 import { Label } from '../label/label';
+import { TextControlProps } from './types';
 
-export type TextProps = {
-	value?: string;
-	onChange: ( selected: string ) => void;
-	label: string;
-	suffix?: string;
-	help?: string;
-	error?: string;
-	placeholder?: string;
-	required?: boolean;
-	onBlur?: () => void;
-	tooltip?: string;
-	disabled?: boolean;
-};
-
-export const TextControl: React.FC< TextProps > = ( {
-	value,
-	onChange,
+export function TextControl( {
 	label,
 	help,
 	error,
-	onBlur,
-	placeholder,
-	required,
 	tooltip,
-	disabled,
-}: TextProps ) => {
-	const textControlId = useInstanceId(
-		BaseControl,
-		'text-control'
-	) as string;
+	className,
+	required,
+	onChange,
+	onBlur,
+	...props
+}: TextControlProps ) {
 	return (
-		<BaseControl
-			id={ textControlId }
+		<InputControl
+			{ ...props }
+			className={ classNames( className, {
+				'has-error': error,
+			} ) }
 			label={
 				<Label
 					label={ label }
@@ -54,19 +38,10 @@ export const TextControl: React.FC< TextProps > = ( {
 					tooltip={ tooltip }
 				/>
 			}
-			className={ classNames( {
-				'has-error': error,
-			} ) }
+			required={ required }
 			help={ error || help }
-		>
-			<InputControl
-				id={ textControlId }
-				disabled={ disabled }
-				placeholder={ placeholder }
-				value={ value }
-				onChange={ onChange }
-				onBlur={ onBlur }
-			></InputControl>
-		</BaseControl>
+			onChange={ onChange }
+			onBlur={ onBlur }
+		/>
 	);
-};
+}

--- a/packages/js/product-editor/src/components/text-control/types.ts
+++ b/packages/js/product-editor/src/components/text-control/types.ts
@@ -1,0 +1,19 @@
+/**
+ * This must inherit the InputControlProp from @wordpress/components
+ * but it has not been exported yet
+ */
+export type TextControlProps = Omit<
+	React.DetailedHTMLProps<
+		React.InputHTMLAttributes< HTMLInputElement >,
+		HTMLInputElement
+	>,
+	'onChange'
+> & {
+	label: string;
+	help?: string;
+	error?: string;
+	tooltip?: string;
+	prefix?: React.ReactNode;
+	suffix?: React.ReactNode;
+	onChange?( value: string ): void;
+};

--- a/packages/js/product-editor/src/components/variations-table/variations-table-row/variations-table-row.tsx
+++ b/packages/js/product-editor/src/components/variations-table/variations-table-row/variations-table-row.tsx
@@ -205,7 +205,6 @@ export function VariationsTableRow( {
 				{ ( variation.status === 'private' ||
 					! variation.regular_price ) && (
 					<Tooltip
-						// @ts-expect-error className is missing in TS, should remove this when it is included.
 						className="woocommerce-attribute-list-item__actions-tooltip"
 						position="top center"
 						text={ NOT_VISIBLE_TEXT }

--- a/plugins/woocommerce/changelog/add-35148
+++ b/plugins/woocommerce/changelog/add-35148
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add support for external/affiliate products

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -45,6 +45,10 @@ class Init {
 			array_push( $this->supported_post_types, 'variable' );
 		}
 
+		if ( Features::is_enabled( 'product-external-affiliate' ) ) {
+			array_push( $this->supported_post_types, 'external' );
+		}
+
 		$this->redirection_controller = new RedirectionController( $this->supported_post_types );
 
 		if ( \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'product_block_editor' ) ) {

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -237,7 +237,7 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 						'title'       => __( 'Buy button', 'woocommerce' ),
 						'description' => __( 'Add a link and choose a label for the button linked to a product sold elsewhere.', 'woocommerce' ),
 					),
-          'hideConditions' => array(
+					'hideConditions' => array(
 						array(
 							'expression' => 'editedProduct.type !== "external"',
 						),
@@ -256,23 +256,23 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 						'placeholder' => __( 'Enter the external URL to the product', 'woocommerce' ),
 						'suffix'      => true,
 						'type'        => array(
-              'value'   => 'url',
-              'message' => __( 'Link to the external product is an invalid URL.', 'woocommerce' ),
-            ),
+							'value'   => 'url',
+							'message' => __( 'Link to the external product is an invalid URL.', 'woocommerce' ),
+						),
 						'required'    => __( 'Link to the external product is required.', 'woocommerce' ),
 					),
 				)
 			);
 
-      $button_text_columns = $buy_button_section->add_block(
+			$button_text_columns = $buy_button_section->add_block(
 				array(
 					'id'        => 'product-button-text-columns',
 					'blockName' => 'core/columns',
 					'order'     => 20,
 				)
-      );
-      
-      $button_text_columns->add_block(
+			);
+
+			$button_text_columns->add_block(
 				array(
 					'id'        => 'product-button-text-column1',
 					'blockName' => 'core/column',
@@ -290,13 +290,13 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 				)
 			);
 
-      $button_text_columns->add_block(
+			$button_text_columns->add_block(
 				array(
 					'id'        => 'product-button-text-column2',
 					'blockName' => 'core/column',
 					'order'     => 20,
 				)
-      );
+			);
 		}
 
 		// Images section.

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -256,7 +256,7 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 						'placeholder' => __( 'Enter the external URL to the product', 'woocommerce' ),
 						'type'        => 'url',
 						'suffix'      => true,
-						'required'    => true,
+						'required'    => __( 'Link to the external product is required.', 'woocommerce' ),
 					),
 				)
 			);

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -253,6 +253,8 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 					'attributes' => array(
 						'property' => 'external_url',
 						'label'    => __( 'Link to the external product', 'woocommerce' ),
+						'type'     => 'url',
+						'suffix'   => true,
 						'required' => true,
 					),
 				)

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -226,11 +226,74 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 				'order'     => 10,
 			)
 		);
+
+		// External/Affiliate section.
+		if ( Features::is_enabled( 'product-external-affiliate' ) ) {
+			$buy_button_section = $general_group->add_section(
+				array(
+					'id'         => 'product-buy-button-section',
+					'order'      => 30,
+					'attributes' => array(
+						'title'       => __( 'Buy button', 'woocommerce' ),
+						'description' => __( 'Add a link and choose a label for the button linked to a product sold elsewhere.', 'woocommerce' ),
+					),
+				)
+			);
+
+			$buy_button_section->add_block(
+				array(
+					'id'         => 'product-external-url',
+					'blockName'  => 'woocommerce/product-text-field',
+					'order'      => 10,
+					'attributes' => array(
+						'property' => 'external_url',
+						'label'    => __( 'Link to the external product', 'woocommerce' ),
+						'required' => true,
+					),
+				)
+			);
+
+      $button_text_columns = $buy_button_section->add_block(
+				array(
+					'id'         => 'product-button-text-columns',
+					'blockName'  => 'core/columns',
+					'order'      => 20,
+				)
+      );
+      
+      $button_text_columns->add_block(
+				array(
+					'id'         => 'product-button-text-column1',
+					'blockName'  => 'core/column',
+					'order'      => 10,
+				)
+			)->add_block(
+				array(
+					'id'         => 'product-button-text',
+					'blockName'  => 'woocommerce/product-text-field',
+					'order'      => 10,
+					'attributes' => array(
+						'property' => 'button_text',
+						'label'    => __( 'Buy button text', 'woocommerce' ),
+						'required' => true,
+					),
+				)
+			);
+
+      $button_text_columns->add_block(
+				array(
+					'id'         => 'product-button-text-column2',
+					'blockName'  => 'core/column',
+					'order'      => 20,
+				)
+      );
+		}
+
 		// Images section.
 		$images_section = $general_group->add_section(
 			array(
 				'id'         => 'product-images-section',
-				'order'      => 30,
+				'order'      => 40,
 				'attributes' => array(
 					'title'       => __( 'Images', 'woocommerce' ),
 					'description' => sprintf(
@@ -258,7 +321,7 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 			$general_group->add_section(
 				array(
 					'id'             => 'product-downloads-section',
-					'order'          => 40,
+					'order'          => 50,
 					'attributes'     => array(
 						'title'       => __( 'Downloads', 'woocommerce' ),
 						'description' => __( "Add any files you'd like to make available for the customer to download after purchasing, such as instructions or warranty info.", 'woocommerce' ),

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -254,8 +254,11 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 						'property'    => 'external_url',
 						'label'       => __( 'Link to the external product', 'woocommerce' ),
 						'placeholder' => __( 'Enter the external URL to the product', 'woocommerce' ),
-						'type'        => 'url',
 						'suffix'      => true,
+						'type'        => array(
+              'value'   => 'url',
+              'message' => __( 'Link to the external product is an invalid URL.', 'woocommerce' ),
+            ),
 						'required'    => __( 'Link to the external product is required.', 'woocommerce' ),
 					),
 				)

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -231,11 +231,16 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 		if ( Features::is_enabled( 'product-external-affiliate' ) ) {
 			$buy_button_section = $general_group->add_section(
 				array(
-					'id'         => 'product-buy-button-section',
-					'order'      => 30,
-					'attributes' => array(
+					'id'             => 'product-buy-button-section',
+					'order'          => 30,
+					'attributes'     => array(
 						'title'       => __( 'Buy button', 'woocommerce' ),
 						'description' => __( 'Add a link and choose a label for the button linked to a product sold elsewhere.', 'woocommerce' ),
+					),
+          'hideConditions' => array(
+						array(
+							'expression' => 'editedProduct.type !== "external"',
+						),
 					),
 				)
 			);
@@ -255,17 +260,17 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 
       $button_text_columns = $buy_button_section->add_block(
 				array(
-					'id'         => 'product-button-text-columns',
-					'blockName'  => 'core/columns',
-					'order'      => 20,
+					'id'        => 'product-button-text-columns',
+					'blockName' => 'core/columns',
+					'order'     => 20,
 				)
       );
       
       $button_text_columns->add_block(
 				array(
-					'id'         => 'product-button-text-column1',
-					'blockName'  => 'core/column',
-					'order'      => 10,
+					'id'        => 'product-button-text-column1',
+					'blockName' => 'core/column',
+					'order'     => 10,
 				)
 			)->add_block(
 				array(
@@ -282,9 +287,9 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 
       $button_text_columns->add_block(
 				array(
-					'id'         => 'product-button-text-column2',
-					'blockName'  => 'core/column',
-					'order'      => 20,
+					'id'        => 'product-button-text-column2',
+					'blockName' => 'core/column',
+					'order'     => 20,
 				)
       );
 		}

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -251,11 +251,12 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 					'blockName'  => 'woocommerce/product-text-field',
 					'order'      => 10,
 					'attributes' => array(
-						'property' => 'external_url',
-						'label'    => __( 'Link to the external product', 'woocommerce' ),
-						'type'     => 'url',
-						'suffix'   => true,
-						'required' => true,
+						'property'    => 'external_url',
+						'label'       => __( 'Link to the external product', 'woocommerce' ),
+						'placeholder' => __( 'Enter the external URL to the product', 'woocommerce' ),
+						'type'        => 'url',
+						'suffix'      => true,
+						'required'    => true,
 					),
 				)
 			);
@@ -282,7 +283,6 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 					'attributes' => array(
 						'property' => 'button_text',
 						'label'    => __( 'Buy button text', 'woocommerce' ),
-						'required' => true,
 					),
 				)
 			);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #35148

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is **enabled** under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure feature `product-external-affiliate` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper` (WooCommerce Beta Tester plugin) is required
3. Go to `/wp-admin/admin.php?page=wc-admin&task=products` 
<img width="585" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/81bd4c8e-0d7e-4bfb-bfe3-76f67d2378b7">

4. Then click on `View more product types` 
<img width="575" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/478e1721-2023-49f7-8012-7e159d40af5f">

5. Then click on the `External product` item
6. You should be redirected to the new product editor experience
7. Under the `General` section a new `Buy button` section should be shown 
<img width="656" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/45fe1517-9ece-4f71-aed6-8a3e2cf3dd84">

8. The link field is required. When the user attempts to publish a product without filling it out, we show an error message that reads: `Link to the external product is required`
9. When the user adds a link, we display an icon on the right side of the field. Clicking it will open the product link in a new tab. If the field is empty, the icon is hidden.
10. By default, the Button text field says `Buy product`. The label should match the store’s language and locale (just like the regular buy button). 
<img width="1026" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/f81223d4-b9a9-4543-b31e-c83a6b2266c7">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
