### PR TITLE
Change To be able to download order data from all products removed

### DIFF
--- a/plugins/woocommerce/changelog/add-show-downloads-hook
+++ b/plugins/woocommerce/changelog/add-show-downloads-hook
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Adds new hook `woocommerce_order_downloads_table_show_downloads` to control rendering of the downloads table (classic templates only).

--- a/plugins/woocommerce/includes/class-wc-order.php
+++ b/plugins/woocommerce/includes/class-wc-order.php
@@ -1654,16 +1654,18 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return bool
 	 */
 	public function has_downloadable_item() {
+		$has_downloadable_item = false;
 		foreach ( $this->get_items() as $item ) {
 			if ( $item->is_type( 'line_item' ) ) {
 				$product = $item->get_product();
 
 				if ( $product && $product->has_file() ) {
-					return true;
+					$has_downloadable_item = true;
+					break;
 				}
 			}
 		}
-		return false;
+		return apply_filters( 'woocommerce_order_has_downloadable_item', $has_downloadable_item, $this );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/class-wc-order.php
+++ b/plugins/woocommerce/includes/class-wc-order.php
@@ -1654,18 +1654,16 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return bool
 	 */
 	public function has_downloadable_item() {
-		$has_downloadable_item = false;
 		foreach ( $this->get_items() as $item ) {
 			if ( $item->is_type( 'line_item' ) ) {
 				$product = $item->get_product();
 
 				if ( $product && $product->has_file() ) {
-					$has_downloadable_item = true;
-					break;
+					return true;
 				}
 			}
 		}
-		return apply_filters( 'woocommerce_order_has_downloadable_item', $has_downloadable_item, $this );
+		return false;
 	}
 
 	/**

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -2733,6 +2733,19 @@ if ( ! function_exists( 'woocommerce_order_details_table' ) ) {
 			'order/order-details.php',
 			array(
 				'order_id'       => $order_id,
+				/**
+				 * Determines if the order downloads table should be shown (in the context of the order details
+				 * template).
+				 *
+				 * By default, this is true if the order has at least one dowloadable items and download is permitted
+				 * (which is partly determined by the order status). For special cases, though, this can be overridden
+				 * and the downloads table can be forced to render (or forced not to render).
+				 *
+				 * @since 8.4.0
+				 *
+				 * @param bool     $show_downloads If the downloads table should be shown.
+				 * @param WC_Order $order          The related order.
+				 */
 				'show_downloads' => apply_filters( 'woocommerce_order_downloads_table_show_downloads', ( $order->has_downloadable_item() && $order->is_download_permitted() ), $order ),
 			)
 		);

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -2723,10 +2723,17 @@ if ( ! function_exists( 'woocommerce_order_details_table' ) ) {
 			return;
 		}
 
+		$order = wc_get_order( $order_id );
+
+		if ( ! $order ) {
+			return;
+		}
+
 		wc_get_template(
 			'order/order-details.php',
 			array(
-				'order_id' => $order_id,
+				'order_id'       => $order_id,
+				'show_downloads' => apply_filters( 'woocommerce_order_downloads_table_show_downloads', ( $order->has_downloadable_item() && $order->is_download_permitted() ), $order ),
 			)
 		);
 	}

--- a/plugins/woocommerce/includes/wc-template-functions.php
+++ b/plugins/woocommerce/includes/wc-template-functions.php
@@ -2741,7 +2741,7 @@ if ( ! function_exists( 'woocommerce_order_details_table' ) ) {
 				 * (which is partly determined by the order status). For special cases, though, this can be overridden
 				 * and the downloads table can be forced to render (or forced not to render).
 				 *
-				 * @since 8.4.0
+				 * @since 8.5.0
 				 *
 				 * @param bool     $show_downloads If the downloads table should be shown.
 				 * @param WC_Order $order          The related order.

--- a/plugins/woocommerce/templates/order/order-details.php
+++ b/plugins/woocommerce/templates/order/order-details.php
@@ -12,7 +12,7 @@
  *
  * @see     https://woo.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 8.4.0
+ * @version 8.5.0
  *
  * @var bool $show_downloads Controls whether the downloads table should be rendered.
  */

--- a/plugins/woocommerce/templates/order/order-details.php
+++ b/plugins/woocommerce/templates/order/order-details.php
@@ -12,7 +12,9 @@
  *
  * @see     https://woo.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.8.0
+ * @version 8.4.0
+ *
+ * @var bool $show_downloads Controls whether the downloads table should be rendered.
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -28,7 +30,7 @@ $show_purchase_note    = $order->has_status( apply_filters( 'woocommerce_purchas
 $show_customer_details = is_user_logged_in() && $order->get_user_id() === get_current_user_id();
 $downloads             = $order->get_downloadable_items();
 
-if ( $show_downloads ) { // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+if ( $show_downloads ) {
 	wc_get_template(
 		'order/order-downloads.php',
 		array(

--- a/plugins/woocommerce/templates/order/order-details.php
+++ b/plugins/woocommerce/templates/order/order-details.php
@@ -27,9 +27,8 @@ $order_items           = $order->get_items( apply_filters( 'woocommerce_purchase
 $show_purchase_note    = $order->has_status( apply_filters( 'woocommerce_purchase_note_order_statuses', array( 'completed', 'processing' ) ) );
 $show_customer_details = is_user_logged_in() && $order->get_user_id() === get_current_user_id();
 $downloads             = $order->get_downloadable_items();
-$show_downloads        = $order->has_downloadable_item() && $order->is_download_permitted();
 
-if ( $show_downloads ) {
+if ( $show_downloads ) { // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 	wc_get_template(
 		'order/order-downloads.php',
 		array(


### PR DESCRIPTION
### Scenario

- We have a store handling a large number of downloadable products. It has rules for removing products that are out of stock.
- Currently, if all products purchased by a customer are deleted, the download button will no longer be displayed on the order details page.
- This is a reasonable default, but it would be useful if downloadable assets could be programmatically 'injected' so that downloads can remain available to customers, even after the corresponding product has been deleted *(if* this is what the merchant/developer wishes to do).

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions.

1. This PR only applies to the 'classic' (non-Block driven) experience. Therefore, to test, please ensure your environment is configured appropriately (activating a theme like Storefront can help).
2. Functionally, this should not alter the default experience: it simply adds hooks that *allow* 3PDs to modify that experience, if they wish.

**Test that the conventional experience is unchanged**

1. Login as a customer, and purchase a downloadable product.
2. Once you get to the *order-received* page, freeze! You will not see the download table if the order status is not complete so, as an admin user, go ahead and complete the order (but keep the original tab open).
3. Refresh the *order-received* page, and you should be able to see the downloads table:

<div align="center"><img width="700" alt="Downloads table (classic 'order received' page)" src="https://github.com/woocommerce/woocommerce/assets/3594411/acc1b55e-438f-45dc-a30a-a8f9eb481f9b"></div>

4. Visit the My Accounts page, open the order you just placed. You should again see the Downloads table here.

**Test the newly added hook**

Add the following snippet to a suitable location, such as `wp-content/mu-plugins/test-pr-41449.php`:

```php
<?php

add_filter( 'woocommerce_order_downloads_table_show_downloads', '__return_false' );
```

Repeat the previous testing steps. However, this time, the downloads table should not render.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>

### Notes

The testing instructions above are only intended to demonstrate that the default experience (when purchasing downloadable products) is unchanged, and that the new filter can be used to modify the experience.  To simulate the described scenario we'd need something a little more involved. Simplified example, mostly adding in case handy for future reference:

```php
$inserted_downloads = function ( $downloads, $order = null ) {
	return [ [
		'download_url'        => 'https://example.com/download/123.pdf',
		'download_id'         => 'ab12cd34ef56gh78',
		'product_id'          => 123,
		'product_name'        => 'Injected product',
		'product_url'         => false,
		'download_name'       => 'Injected download',
		'order_id'            => $order ? $order->get_id() : 123,
		'order_key'           => $order ? $order->get_order_key() : 456,
		'downloads_remaining' => 100,
		'access_expires'      => time() + YEAR_IN_SECONDS,
		'file'                => [
			'name' => 'Injected file',
			'file' => 'abcdef12345',
		],
	] ];
};

add_filter( 'woocommerce_order_get_downloadable_items', $inserted_downloads, 10, 2 );
add_filter( 'woocommerce_customer_get_downloadable_products', $inserted_downloads, 10, 2 );
add_filter( 'woocommerce_order_downloads_table_show_downloads', '__return_true' );
```
