### PR TITLE
Marketplace: Add Tracks events to My Subscriptions page

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/actions/connect-button.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/actions/connect-button.tsx
@@ -30,7 +30,8 @@ export default function ConnectButton( props: ConnectProps ) {
 
 	const connect = () => {
 		recordEvent( 'marketplace_product_connect_button_clicked', {
-			product_slug: props.subscription.product_slug,
+			product_zip_slug: props.subscription.zip_slug,
+			product_id: props.subscription.product_id,
 		} );
 
 		setIsConnecting( true );

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/actions/connect-button.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/actions/connect-button.tsx
@@ -4,6 +4,7 @@
 import { Button, Icon } from '@wordpress/components';
 import { useContext, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -28,6 +29,10 @@ export default function ConnectButton( props: ConnectProps ) {
 	const { loadSubscriptions } = useContext( SubscriptionsContext );
 
 	const connect = () => {
+		recordEvent( 'marketplace_product_connect_button_clicked', {
+			product_slug: props.subscription.product_slug,
+		} );
+
 		setIsConnecting( true );
 		removeNotice( props.subscription.product_key );
 		connectProduct( props.subscription )

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/actions/install.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/actions/install.tsx
@@ -5,6 +5,7 @@ import { Button, Icon } from '@wordpress/components';
 import { dispatch, useSelect } from '@wordpress/data';
 import { useContext } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -47,6 +48,10 @@ export default function Install( props: InstallProps ) {
 	};
 
 	const install = () => {
+		recordEvent( 'marketplace_product_install_button_clicked', {
+			product_slug: props.subscription.product_slug,
+		} );
+
 		startInstall();
 		removeNotice( props.subscription.product_key );
 		installProduct( props.subscription )
@@ -65,6 +70,10 @@ export default function Install( props: InstallProps ) {
 						}
 					);
 					stopInstall();
+				} );
+
+				recordEvent( 'marketplace_product_installed', {
+					product_slug: props.subscription.product_slug,
 				} );
 			} )
 			.catch( ( error ) => {
@@ -91,6 +100,10 @@ export default function Install( props: InstallProps ) {
 						}
 					);
 					stopInstall();
+				} );
+
+				recordEvent( 'marketplace_product_install_failed', {
+					product_slug: props.subscription.product_slug,
 				} );
 			} );
 	};

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/actions/install.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/actions/install.tsx
@@ -49,7 +49,8 @@ export default function Install( props: InstallProps ) {
 
 	const install = () => {
 		recordEvent( 'marketplace_product_install_button_clicked', {
-			product_slug: props.subscription.product_slug,
+			product_zip_slug: props.subscription.zip_slug,
+			product_id: props.subscription.product_id,
 		} );
 
 		startInstall();
@@ -73,7 +74,8 @@ export default function Install( props: InstallProps ) {
 				} );
 
 				recordEvent( 'marketplace_product_installed', {
-					product_slug: props.subscription.product_slug,
+					product_zip_slug: props.subscription.zip_slug,
+					product_id: props.subscription.product_id,
 				} );
 			} )
 			.catch( ( error ) => {
@@ -103,7 +105,8 @@ export default function Install( props: InstallProps ) {
 				} );
 
 				recordEvent( 'marketplace_product_install_failed', {
-					product_slug: props.subscription.product_slug,
+					product_zip_slug: props.subscription.zip_slug,
+					product_id: props.subscription.product_id,
 				} );
 			} );
 	};

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/actions/install.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/actions/install.tsx
@@ -51,6 +51,7 @@ export default function Install( props: InstallProps ) {
 		recordEvent( 'marketplace_product_install_button_clicked', {
 			product_zip_slug: props.subscription.zip_slug,
 			product_id: props.subscription.product_id,
+			product_current_version: props.subscription.version,
 		} );
 
 		startInstall();
@@ -76,6 +77,7 @@ export default function Install( props: InstallProps ) {
 				recordEvent( 'marketplace_product_installed', {
 					product_zip_slug: props.subscription.zip_slug,
 					product_id: props.subscription.product_id,
+					product_current_version: props.subscription.version,
 				} );
 			} )
 			.catch( ( error ) => {
@@ -107,6 +109,7 @@ export default function Install( props: InstallProps ) {
 				recordEvent( 'marketplace_product_install_failed', {
 					product_zip_slug: props.subscription.zip_slug,
 					product_id: props.subscription.product_id,
+					product_current_version: props.subscription.version,
 				} );
 			} );
 	};

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/actions/renew-button.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/actions/renew-button.tsx
@@ -3,6 +3,7 @@
  */
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { queueRecordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -23,8 +24,18 @@ export default function RenewButton( props: RenewProps ) {
 		[ 'order_id', props.subscription.order_id.toString() ],
 	] );
 
+	function recordTracksEvent() {
+		queueRecordEvent( 'marketplace_renew_button_clicked', {
+			product_slug: props.subscription.product_slug,
+		} );
+	}
+
 	return (
-		<Button href={ renewUrl } variant={ props.variant ?? 'secondary' }>
+		<Button
+			href={ renewUrl }
+			variant={ props.variant ?? 'secondary' }
+			onClick={ recordTracksEvent }
+		>
 			{ __( 'Renew', 'woocommerce' ) }
 		</Button>
 	);

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/actions/renew-button.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/actions/renew-button.tsx
@@ -26,7 +26,8 @@ export default function RenewButton( props: RenewProps ) {
 
 	function recordTracksEvent() {
 		queueRecordEvent( 'marketplace_renew_button_clicked', {
-			product_slug: props.subscription.product_slug,
+			product_zip_slug: props.subscription.zip_slug,
+			product_id: props.subscription.product_id,
 		} );
 	}
 

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/actions/subscribe-button.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/actions/subscribe-button.tsx
@@ -24,7 +24,8 @@ export default function SubscribeButton( props: SubscribeProps ) {
 
 	function recordTracksEvent() {
 		queueRecordEvent( 'marketplace_subscribe_button_clicked', {
-			product_slug: props.subscription.product_slug,
+			product_zip_slug: props.subscription.zip_slug,
+			product_id: props.subscription.product_id,
 		} );
 	}
 

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/actions/subscribe-button.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/actions/subscribe-button.tsx
@@ -3,6 +3,7 @@
  */
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { queueRecordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -20,8 +21,19 @@ export default function SubscribeButton( props: SubscribeProps ) {
 	const subscribeUrl = appendURLParams( MARKETPLACE_CART_PATH, [
 		[ 'add-to-cart', props.subscription.product_id.toString() ],
 	] );
+
+	function recordTracksEvent() {
+		queueRecordEvent( 'marketplace_subscribe_button_clicked', {
+			product_slug: props.subscription.product_slug,
+		} );
+	}
+
 	return (
-		<Button href={ subscribeUrl } variant={ props.variant ?? 'secondary' }>
+		<Button
+			href={ subscribeUrl }
+			variant={ props.variant ?? 'secondary' }
+			onClick={ recordTracksEvent }
+		>
 			{ __( 'Subscribe', 'woocommerce' ) }
 		</Button>
 	);

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/actions/update.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/actions/update.tsx
@@ -38,7 +38,8 @@ export default function Update( props: UpdateProps ) {
 
 	function update() {
 		recordEvent( 'marketplace_product_update_button_clicked', {
-			product_slug: props.subscription.product_slug,
+			product_zip_slug: props.subscription.zip_slug,
+			product_id: props.subscription.product_id,
 		} );
 
 		if ( ! canUpdate ) {
@@ -93,7 +94,8 @@ export default function Update( props: UpdateProps ) {
 				} );
 
 				recordEvent( 'marketplace_product_updated', {
-					product_slug: props.subscription.product_slug,
+					product_zip_slug: props.subscription.zip_slug,
+					product_id: props.subscription.product_id,
 				} );
 			} )
 			.catch( () => {
@@ -117,7 +119,8 @@ export default function Update( props: UpdateProps ) {
 				setIsUpdating( false );
 
 				recordEvent( 'marketplace_product_update_failed', {
-					product_slug: props.subscription.product_slug,
+					product_zip_slug: props.subscription.zip_slug,
+					product_id: props.subscription.product_id,
 				} );
 			} );
 	}

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/actions/update.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/actions/update.tsx
@@ -4,6 +4,7 @@
 import { Button, Icon } from '@wordpress/components';
 import { useContext, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -36,6 +37,10 @@ export default function Update( props: UpdateProps ) {
 		props.subscription.local.path;
 
 	function update() {
+		recordEvent( 'marketplace_product_update_button_clicked', {
+			product_slug: props.subscription.product_slug,
+		} );
+
 		if ( ! canUpdate ) {
 			setShowModal( true );
 			return;
@@ -86,6 +91,10 @@ export default function Update( props: UpdateProps ) {
 					);
 					setIsUpdating( false );
 				} );
+
+				recordEvent( 'marketplace_product_updated', {
+					product_slug: props.subscription.product_slug,
+				} );
 			} )
 			.catch( () => {
 				addNotice(
@@ -106,6 +115,10 @@ export default function Update( props: UpdateProps ) {
 					}
 				);
 				setIsUpdating( false );
+
+				recordEvent( 'marketplace_product_update_failed', {
+					product_slug: props.subscription.product_slug,
+				} );
 			} );
 	}
 

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/actions/update.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/actions/update.tsx
@@ -40,6 +40,8 @@ export default function Update( props: UpdateProps ) {
 		recordEvent( 'marketplace_product_update_button_clicked', {
 			product_zip_slug: props.subscription.zip_slug,
 			product_id: props.subscription.product_id,
+			product_installed_version: props.subscription.local.installed,
+			product_current_version: props.subscription.version,
 		} );
 
 		if ( ! canUpdate ) {
@@ -96,6 +98,9 @@ export default function Update( props: UpdateProps ) {
 				recordEvent( 'marketplace_product_updated', {
 					product_zip_slug: props.subscription.zip_slug,
 					product_id: props.subscription.product_id,
+					product_installed_version:
+						props.subscription.local.installed,
+					product_current_version: props.subscription.version,
 				} );
 			} )
 			.catch( () => {
@@ -121,6 +126,9 @@ export default function Update( props: UpdateProps ) {
 				recordEvent( 'marketplace_product_update_failed', {
 					product_zip_slug: props.subscription.zip_slug,
 					product_id: props.subscription.product_id,
+					product_installed_version:
+						props.subscription.local.installed,
+					product_current_version: props.subscription.version,
 				} );
 			} );
 	}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:
Adds Tracks events for actions taken in the My Subscription page. 
- marketplace_product_install_button_clicked
- marketplace_product_installed
- marketplace_product_install_failed
- marketplace_renew_button_clicked
- marketplace_subscribe_button_clicked
- marketplace_product_update_button_clicked
- marketplace_product_updated
- marketplace_product_update_failed
- marketplace_product_connect_button_clicked

### How to test the changes in this Pull Request:

- Checkout this branch and build assets
- Connect to the `customerwoocommercedotcom` Woo.com account
- Go to WooCommerce > Settings > Advanced > WooCommerce.com and make sure Allow usage of WooCommerce to be tracked option is checked
-  Open JS console and run localStorage.setItem( 'debug', 'wc-admin:*' );. This makes tracks logs show up in console. While in development, tracks events are not sent up to the server.
- Click **Install** on any one of the products
    - Once clicked you should get `marketplace_product_install_button_clicked`
    - Once install finishes you should get `marketplace_product_installed`
    - The props are `product_zip_slug`, `product_id` and `product_current_version`.
-  Find **Google Product Feed** and click **Renew**
    - When clicked we're actually closing this page to go to a new one, the queue system will take place and in the console it'll say _Processing items in queue_ and it'll go to WooCommerce.com.
    - From WooCommerce.com, go back to the in app my subscriptions page. The console will say Processing item in queue. You can look at the arguments for this and see the event name.
- Manually install and outdated plugin by uploading a zip. 
    - Once clicked you should get `marketplace_product_update_button_clicked`
    - Once install finishes you should get `marketplace_product_updated`
- When updated, click the **Connect** button. 
    - Once clicked you should get the `marketplace_product_connect_button_clicked`
- Make the subscribe button show up. You can use this snippet below achieve that. 
    - When clicked, we're actually closing this page to go to a new one, the queue system will take place and in the console it'll say _Processing items in queue_ and it'll go to WooCommerce.com.
    - From WooCommerce.com, go back to the in app my subscriptions page. The console will say Processing item in queue. 

**Snippet to make Subscribe button show up**. Add this to the bottom of the `WC_Helper::get_subscription_list_data` method
```php
// Remove product key. Shows subscribe button.
$subscriptions_to_remove_licence = [
	'W00-61a2c077-4dfc-8a1c-5b52bfc47cf0', // Woo Subscriptions
];

foreach ($subscriptions as &$subscription) {
        if ( in_array( $subscription['product_key'], $subscriptions_to_remove_licence, true ) ) {
		$subscription['product_key'] = '';
	}
}
```