### PR TITLE
Use a transient when computing orders in the last 90 days

### DIFF
--- a/plugins/woocommerce/changelog/fix-40889-remove-orders-query-on-all-admin-pages
+++ b/plugins/woocommerce/changelog/fix-40889-remove-orders-query-on-all-admin-pages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Avoid expensive DB orders queries in WP admin pages when evaluating incentives eligibility.

--- a/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
+++ b/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
@@ -2,9 +2,9 @@
 
 namespace Automattic\WooCommerce\Internal\Admin;
 
-use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\WooCommercePayments;
 use Automattic\WooCommerce\Admin\WCAdminHelper;
 use Automattic\WooCommerce\Admin\PageController;
+use WC_Abstract_Order;
 
 /**
  * Class WCPayWelcomePage
@@ -12,8 +12,9 @@ use Automattic\WooCommerce\Admin\PageController;
  * @package Automattic\WooCommerce\Admin\Features
  */
 class WcPayWelcomePage {
-	const CACHE_TRANSIENT_NAME  = 'wcpay_welcome_page_incentive';
-	const HAD_WCPAY_OPTION_NAME = 'wcpay_was_in_use';
+	const CACHE_TRANSIENT_NAME      = 'wcpay_welcome_page_incentive';
+	const HAS_ORDERS_TRANSIENT_NAME = 'wcpay_incentive_store_has_orders';
+	const HAD_WCPAY_OPTION_NAME     = 'wcpay_was_in_use';
 
 	/**
 	 * Plugin instance.
@@ -276,6 +277,57 @@ class WcPayWelcomePage {
 	}
 
 	/**
+	 * Check if the store has any paid orders.
+	 *
+	 * Currently, we look at the past 90 days and only consider orders with status `wc-completed` or `wc-processing`.
+	 *
+	 * @return boolean Whether the store has any paid orders.
+	 */
+	private function has_orders(): bool {
+		// First, get the stored value, if it exists.
+		// This way we avoid costly DB queries and API calls.
+		$has_orders = get_transient( self::HAS_ORDERS_TRANSIENT_NAME );
+		if ( false !== $has_orders ) {
+			return 'yes' === $has_orders;
+		}
+
+		// We need to determine the value.
+		// Start with the assumption that the store doesn't have orders in the timeframe we look at.
+		$has_orders = false;
+		// By default, we will check for new orders every 6 hours.
+		$expiration = 6 * HOUR_IN_SECONDS;
+
+		// Get the latest completed, processing, or refunded order.
+		$latest_order = wc_get_orders(
+			array(
+				'status'  => array( 'wc-completed', 'wc-processing', 'wc-refunded' ),
+				'limit'   => 1,
+				'orderby' => 'date',
+				'order'   => 'DESC',
+			)
+		);
+		if ( ! empty( $latest_order ) ) {
+			$latest_order = reset( $latest_order );
+			// If the latest order is within the timeframe we look at, we consider the store to have orders.
+			// Otherwise, it clearly doesn't have orders.
+			if ( $latest_order instanceof WC_Abstract_Order
+				&& strtotime( $latest_order->get_date_created() ) >= strtotime( '-90 days' ) ) {
+
+				$has_orders = true;
+
+				// For ultimate efficiency, we will check again after 90 days from the latest order
+				// because in all that time we will consider the store to have orders regardless of new orders.
+				$expiration = strtotime( $latest_order->get_date_created() ) + 90 * DAY_IN_SECONDS - time();
+			}
+		}
+
+		// Store the value for future use.
+		set_transient( self::HAS_ORDERS_TRANSIENT_NAME, $has_orders ? 'yes' : 'no', $expiration );
+
+		return $has_orders;
+	}
+
+	/**
 	 * Check if the current incentive has been manually dismissed.
 	 *
 	 * @return boolean
@@ -331,19 +383,9 @@ class WcPayWelcomePage {
 			'country'      => WC()->countries->get_base_country(),
 			// Store locale, e.g. `en_US`.
 			'locale'       => get_locale(),
-			// WooCommerce active for duration in seconds.
+			// WooCommerce store active for duration in seconds.
 			'active_for'   => WCAdminHelper::get_wcadmin_active_for_in_seconds(),
-			// Whether the store has paid orders in the last 90 days.
-			'has_orders'   => ! empty(
-				wc_get_orders(
-					[
-						'status'       => [ 'wc-completed', 'wc-processing' ],
-						'date_created' => '>=' . strtotime( '-90 days' ),
-						'return'       => 'ids',
-						'limit'        => 1,
-					]
-				)
-			),
+			'has_orders'   => $this->has_orders(),
 			// Whether the store has at least one payment gateway enabled.
 			'has_payments' => ! empty( WC()->payment_gateways()->get_available_payment_gateways() ),
 			'has_wcpay'    => $this->has_wcpay(),

--- a/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
+++ b/plugins/woocommerce/src/Internal/Admin/WcPayWelcomePage.php
@@ -279,7 +279,8 @@ class WcPayWelcomePage {
 	/**
 	 * Check if the store has any paid orders.
 	 *
-	 * Currently, we look at the past 90 days and only consider orders with status `wc-completed` or `wc-processing`.
+	 * Currently, we look at the past 90 days and only consider orders
+	 * with status `wc-completed`, `wc-processing`, or `wc-refunded`.
 	 *
 	 * @return boolean Whether the store has any paid orders.
 	 */


### PR DESCRIPTION
Fixes #40889  

### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Due to the fact that for stores with a large number of orders, the query to determine if there are orders in the past 90 days can be quite slow. Even more, we don't need to run it so often as we can employ opportunistic caching:
- store in a transient whether the store has orders in the last 90 days and compute only every 6 hours, by default (only when there are no orders found)
- use opportunistic caching to use a 90-days from the latest order transient expiration period.

I also added `wc-refunded` orders to our target statuses to avoid ignoring orders that have been completed but refunded in the meantime.

### How to test the changes in this Pull Request:

>[!Note]
>We need to check the existence of an SQL query. You can use [Query Monitor](https://wordpress.org/plugins/query-monitor/) or any other similar option.
>We need to play with DB options. You can use the WooCommerce Admin Test Helper, [Options View](https://wordpress.org/plugins/options-view/), or any other way to inspect and delete DB options.

#### Only one order query by payment method, ever
- Create a new JN site with WC from this PR branch.
- **Payments (1)** menu should be visible.
- Remove the `_transient_wcpay_incentive_store_has_orders` option if there is one in the DB. Refresh the WP admin page.
- The below SQL query **should be** in the logs, probably next to the INSERT like so:
![Screenshot 2023-11-23 at 17 13 50](https://github.com/woocommerce/woocommerce/assets/8830539/82da3b58-65b7-4949-b178-25d6944964be)
- Search for an INSERT SQL query about setting the transient (search for `_transient_wcpay_incentive_store_has_orders ` with the Query Monitor panel opened - see above screenshot)
- Refresh the page as many times as you want and confirm that the below SQL query **has not been** executed. You can also navigate to other WP admin pages.
- Bonus: Check that the `wcpay_was_in_use` option is present in the DB with a `no` value since WooPayments hasn't been activated or used on the store.
- Remove the `_transient_wcpay_incentive_store_has_orders` DB option, refresh the page, and the below SQL query **should be** in the logs.
- Continue to refresh, and it shouldn't be in the logs again.

#### Incentive applied as expected
- Go to **Payments (1)** and finish the onboarding process by following [test onboarding instructions](https://woocommerce.com/document/woopayments/testing-and-troubleshooting/dev-mode/).
- Confirm that the incentive fee is applied by checking **Active discounts** under **Payments > Overview**.

**SQL query:**
Searching for `wc-refunded` with the Query Monitor panel opened should be enough to find it in the Database queries tab. This is the full SQL query we are after:

```sql
SELECT wp_posts.ID
FROM wp_posts
WHERE 1=1
AND wp_posts.post_type IN ('shop_order', 'shop_order_refund')
AND ((wp_posts.post_status = 'wc-processing'
OR wp_posts.post_status = 'wc-completed'
OR wp_posts.post_status = 'wc-refunded'))
ORDER BY wp_posts.post_date DESC
LIMIT 0, 1
```

Related to: https://github.com/woocommerce/woocommerce/issues/39668 https://github.com/woocommerce/woocommerce/issues/39742