### PR TITLE
Unconnected subscription improvements

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.scss
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.scss
@@ -72,7 +72,8 @@ a.woocommerce-marketplace__refresh-subscriptions {
 }
 
 .woocommerce-marketplace__my-subscriptions__product-statuses {
-	display: flex;
+	display: flex;  flex-direction: column;
+	gap: $grid-unit-10;
 }
 
 .woocommerce-marketplace__my-subscriptions__product-status {

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.scss
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.scss
@@ -71,11 +71,6 @@ a.woocommerce-marketplace__refresh-subscriptions {
 	}
 }
 
-.woocommerce-marketplace__my-subscriptions__product-statuses {
-	display: flex;  flex-direction: column;
-	gap: $grid-unit-10;
-}
-
 .woocommerce-marketplace__my-subscriptions__product-status {
 	display: flex;
 	align-items: center;

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.tsx
@@ -59,11 +59,12 @@ export default function MySubscriptions(): JSX.Element {
 		}
 	);
 
-	const subscriptionsInstalled: Array< Subscription > = subscriptions.filter(
+	let subscriptionsInstalled: Array< Subscription > = subscriptions.filter(
 		( subscription: Subscription ) => subscription.subscription_installed
 	);
 
-	const subscriptionsAvailable: Array< Subscription > = subscriptions.filter(
+	const subscriptionsAvailable: Array< Subscription > = [];
+	subscriptions.filter(
 		( subscription: Subscription ) => ! subscription.subscription_installed
 	);
 
@@ -87,46 +88,44 @@ export default function MySubscriptions(): JSX.Element {
 		);
 	}
 
+	subscriptionsInstalled = [];
 	return (
 		<div className="woocommerce-marketplace__my-subscriptions">
-			{ subscriptionsInstalled.length > 0 && (
-				<section className="woocommerce-marketplace__my-subscriptions__installed">
-					<header className="woocommerce-marketplace__my-subscriptions__header">
-						<div>
-							<h2 className="woocommerce-marketplace__my-subscriptions__heading">
-								{ __(
-									'Installed on this store',
+			<section className="woocommerce-marketplace__my-subscriptions__installed">
+				<header className="woocommerce-marketplace__my-subscriptions__header">
+					<div>
+						<h2 className="woocommerce-marketplace__my-subscriptions__heading">
+							{ __( 'Installed on this store', 'woocommerce' ) }
+						</h2>
+						<span className="woocommerce-marketplace__my-subscriptions__table-description">
+							{ installedTableDescription }
+						</span>
+					</div>
+					<div>
+						<Button
+							href={ updateConnectionUrl }
+							className="woocommerce-marketplace__refresh-subscriptions"
+						>
+							<img
+								src={ RefreshIcon }
+								alt={ __(
+									'Refresh subscriptions',
 									'woocommerce'
 								) }
-							</h2>
-							<span className="woocommerce-marketplace__my-subscriptions__table-description">
-								{ installedTableDescription }
-							</span>
-						</div>
-						<div>
-							<Button
-								href={ updateConnectionUrl }
-								className="woocommerce-marketplace__refresh-subscriptions"
-							>
-								<img
-									src={ RefreshIcon }
-									alt={ __(
-										'Refresh subscriptions',
-										'woocommerce'
-									) }
-								/>
-								{ __( 'Refresh', 'woocommerce' ) }
-							</Button>
-						</div>
-					</header>
+							/>
+							{ __( 'Refresh', 'woocommerce' ) }
+						</Button>
+					</div>
+				</header>
+				{ subscriptionsInstalled.length > 0 && (
 					<InstalledSubscriptionsTable
 						isLoading={ isLoading }
 						rows={ subscriptionsInstalled.map( ( item ) => {
 							return installedSubscriptionRow( item );
 						} ) }
 					/>
-				</section>
-			) }
+				) }
+			</section>
 
 			{ subscriptionsAvailable.length > 0 && (
 				<section className="woocommerce-marketplace__my-subscriptions__available">

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.tsx
@@ -89,57 +89,64 @@ export default function MySubscriptions(): JSX.Element {
 
 	return (
 		<div className="woocommerce-marketplace__my-subscriptions">
-			<section className="woocommerce-marketplace__my-subscriptions__installed">
-				<header className="woocommerce-marketplace__my-subscriptions__header">
-					<div>
-						<h2 className="woocommerce-marketplace__my-subscriptions__heading">
-							{ __( 'Installed on this store', 'woocommerce' ) }
-						</h2>
-						<span className="woocommerce-marketplace__my-subscriptions__table-description">
-							{ installedTableDescription }
-						</span>
-					</div>
-					<div>
-						<Button
-							href={ updateConnectionUrl }
-							className="woocommerce-marketplace__refresh-subscriptions"
-						>
-							<img
-								src={ RefreshIcon }
-								alt={ __(
-									'Refresh subscriptions',
+			{ subscriptionsInstalled.length > 0 && (
+				<section className="woocommerce-marketplace__my-subscriptions__installed">
+					<header className="woocommerce-marketplace__my-subscriptions__header">
+						<div>
+							<h2 className="woocommerce-marketplace__my-subscriptions__heading">
+								{ __(
+									'Installed on this store',
 									'woocommerce'
 								) }
-							/>
-							{ __( 'Refresh', 'woocommerce' ) }
-						</Button>
-					</div>
-				</header>
-				<InstalledSubscriptionsTable
-					isLoading={ isLoading }
-					rows={ subscriptionsInstalled.map( ( item ) => {
-						return installedSubscriptionRow( item );
-					} ) }
-				/>
-			</section>
+							</h2>
+							<span className="woocommerce-marketplace__my-subscriptions__table-description">
+								{ installedTableDescription }
+							</span>
+						</div>
+						<div>
+							<Button
+								href={ updateConnectionUrl }
+								className="woocommerce-marketplace__refresh-subscriptions"
+							>
+								<img
+									src={ RefreshIcon }
+									alt={ __(
+										'Refresh subscriptions',
+										'woocommerce'
+									) }
+								/>
+								{ __( 'Refresh', 'woocommerce' ) }
+							</Button>
+						</div>
+					</header>
+					<InstalledSubscriptionsTable
+						isLoading={ isLoading }
+						rows={ subscriptionsInstalled.map( ( item ) => {
+							return installedSubscriptionRow( item );
+						} ) }
+					/>
+				</section>
+			) }
 
-			<section className="woocommerce-marketplace__my-subscriptions__available">
-				<h2 className="woocommerce-marketplace__my-subscriptions__heading">
-					{ __( 'Available to use', 'woocommerce' ) }
-				</h2>
-				<p className="woocommerce-marketplace__my-subscriptions__table-description">
-					{ __(
-						"Woo.com subscriptions you haven't used yet.",
-						'woocommerce'
-					) }
-				</p>
-				<AvailableSubscriptionsTable
-					isLoading={ isLoading }
-					rows={ subscriptionsAvailable.map( ( item ) => {
-						return availableSubscriptionRow( item );
-					} ) }
-				/>
-			</section>
+			{ subscriptionsAvailable.length > 0 && (
+				<section className="woocommerce-marketplace__my-subscriptions__available">
+					<h2 className="woocommerce-marketplace__my-subscriptions__heading">
+						{ __( 'Available to use', 'woocommerce' ) }
+					</h2>
+					<p className="woocommerce-marketplace__my-subscriptions__table-description">
+						{ __(
+							"Woo.com subscriptions you haven't used yet.",
+							'woocommerce'
+						) }
+					</p>
+					<AvailableSubscriptionsTable
+						isLoading={ isLoading }
+						rows={ subscriptionsAvailable.map( ( item ) => {
+							return availableSubscriptionRow( item );
+						} ) }
+					/>
+				</section>
+			) }
 		</div>
 	);
 }

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.tsx
@@ -59,12 +59,11 @@ export default function MySubscriptions(): JSX.Element {
 		}
 	);
 
-	let subscriptionsInstalled: Array< Subscription > = subscriptions.filter(
+	const subscriptionsInstalled: Array< Subscription > = subscriptions.filter(
 		( subscription: Subscription ) => subscription.subscription_installed
 	);
 
-	const subscriptionsAvailable: Array< Subscription > = [];
-	subscriptions.filter(
+	const subscriptionsAvailable: Array< Subscription > = subscriptions.filter(
 		( subscription: Subscription ) => ! subscription.subscription_installed
 	);
 
@@ -88,7 +87,6 @@ export default function MySubscriptions(): JSX.Element {
 		);
 	}
 
-	subscriptionsInstalled = [];
 	return (
 		<div className="woocommerce-marketplace__my-subscriptions">
 			<section className="woocommerce-marketplace__my-subscriptions__installed">

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.tsx
@@ -115,14 +115,12 @@ export default function MySubscriptions(): JSX.Element {
 						</Button>
 					</div>
 				</header>
-				{ subscriptionsInstalled.length > 0 && (
-					<InstalledSubscriptionsTable
-						isLoading={ isLoading }
-						rows={ subscriptionsInstalled.map( ( item ) => {
-							return installedSubscriptionRow( item );
-						} ) }
-					/>
-				) }
+				<InstalledSubscriptionsTable
+					isLoading={ isLoading }
+					rows={ subscriptionsInstalled.map( ( item ) => {
+						return installedSubscriptionRow( item );
+					} ) }
+				/>
 			</section>
 
 			{ subscriptionsAvailable.length > 0 && (

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/rows/functions.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/rows/functions.tsx
@@ -38,7 +38,8 @@ function getStatusBadge( subscription: Subscription ): StatusBadge | false {
 				'woocommerce'
 			),
 		};
-	} else if ( subscription.local.installed && ! subscription.active ) {
+	}
+	if ( subscription.local.installed && ! subscription.active ) {
 		return {
 			text: __( 'Not connected', 'woocommerce' ),
 			level: StatusLevel.Warning,
@@ -47,7 +48,8 @@ function getStatusBadge( subscription: Subscription ): StatusBadge | false {
 				'woocommerce'
 			),
 		};
-	} else if ( subscription.expired ) {
+	}
+	if ( subscription.expired ) {
 		return {
 			text: __( 'Expired', 'woocommerce' ),
 			level: StatusLevel.Error,

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/rows/functions.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/rows/functions.tsx
@@ -25,48 +25,39 @@ type StatusBadge = {
 	explanation?: string;
 };
 
-function getStatusBadges( subscription: Subscription ): StatusBadge[] {
-	const badges: StatusBadge[] = [];
-
-	if ( subscription.local.installed && ! subscription.active ) {
-		badges.push( {
-			text: __( 'Not connected', 'woocommerce' ),
-			level: StatusLevel.Warning,
-			explanation: __(
-				'To receive updates and support, please connect your subscription to this store.',
-				'woocommerce'
-			),
-		} );
-	}
-
+function getStatusBadge( subscription: Subscription ): StatusBadge | false {
 	if ( subscription.product_key === '' ) {
-		badges.push( {
+		/**
+		 * If there is no subscription, we don't need to check for the expiry.
+		 */
+		return {
 			text: __( 'No subscription', 'woocommerce' ),
 			level: StatusLevel.Error,
 			explanation: __(
 				'To get updates and support for this extension, you need to purchase a new subscription, or else share or transfer a subscription for this extension from another account.',
 				'woocommerce'
 			),
-		} );
-
-		/**
-		 * If there is no subscription, we don't need to check for the expiry.
-		 */
-		return badges;
-	}
-
-	if ( subscription.expired ) {
-		badges.push( {
+		};
+	} else if ( subscription.local.installed && ! subscription.active ) {
+		return {
+			text: __( 'Not connected', 'woocommerce' ),
+			level: StatusLevel.Warning,
+			explanation: __(
+				'To receive updates and support, please connect your subscription to this store.',
+				'woocommerce'
+			),
+		};
+	} else if ( subscription.expired ) {
+		return {
 			text: __( 'Expired', 'woocommerce' ),
 			level: StatusLevel.Error,
 			explanation: __(
 				'To receive updates and support, please renew your subscription.',
 				'woocommerce'
 			),
-		} );
+		};
 	}
-
-	return badges;
+	return false;
 }
 
 function getVersion( subscription: Subscription ): string | JSX.Element {
@@ -107,18 +98,7 @@ export function nameAndStatus( subscription: Subscription ): TableRow {
 		);
 	}
 
-	const statusBadges = getStatusBadges( subscription );
-
-	const statusElement = statusBadges.map( ( badge, index ) => {
-		return (
-			<StatusPopover
-				key={ index }
-				text={ badge.text }
-				level={ badge.level }
-				explanation={ badge.explanation ?? '' }
-			/>
-		);
-	} );
+	const statusBadge = getStatusBadge( subscription );
 
 	const displayElement = (
 		<div className="woocommerce-marketplace__my-subscriptions__product">
@@ -129,7 +109,13 @@ export function nameAndStatus( subscription: Subscription ): TableRow {
 				{ subscription.product_name }
 			</span>
 			<span className="woocommerce-marketplace__my-subscriptions__product-statuses">
-				{ statusElement }
+				{ statusBadge && (
+					<StatusPopover
+						text={ statusBadge.text }
+						level={ statusBadge.level }
+						explanation={ statusBadge.explanation ?? '' }
+					/>
+				) }
 			</span>
 		</div>
 	);

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/rows/functions.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/rows/functions.tsx
@@ -143,6 +143,16 @@ export function nameAndStatus( subscription: Subscription ): TableRow {
 export function expiry( subscription: Subscription ): TableRow {
 	const expiryDate = subscription.expires;
 
+	if (
+		subscription.local.installed === true &&
+		subscription.product_key === ''
+	) {
+		return {
+			display: '',
+			value: '',
+		};
+	}
+
 	let expiryDateElement = __( 'Never expires', 'woocommerce' );
 
 	if ( expiryDate ) {

--- a/plugins/woocommerce/changelog/41468-update-18630-subscription-feedback
+++ b/plugins/woocommerce/changelog/41468-update-18630-subscription-feedback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+Comment: Unconnected subscriptions screen improvements.
+


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR contains a few improvements for the subscriptions screen when the product isn't connected, but is installed.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Open the [new subscriptions page](http://localhost:8086/wp-admin/admin.php?page=wc-admin&tab=my-subscriptions&path=%2Fextensions) (links are to the tests site, so that you won't mess up your standard local site)
2. Delete all products from your local site
3. Confirm that the Installed_ list is hidden (there is no data so we are removing the list)
4. Manually install a paid Woo.com product like Bookings if you don't have one already
5. Confirm that your installed paid Woo.com product doesn't have an expiry date (it's not applicable, so we are leaving it empty)
6. Confirm that there is only one status badge (_No subscription_)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

Unconnected subscriptions screen improvements.

</details>

![Screenshot 2023-11-16 at 09 58 01](https://github.com/woocommerce/woocommerce/assets/1199991/5bf18597-f2a4-499c-ae87-14de4f84fb93)


