### PR TITLE
[CYS] The “Preview" on the transitional screen doesn’t represent our custom color palette

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/index.tsx
@@ -4,8 +4,8 @@
 /**
  * External dependencies
  */
-import { useEffect, createContext } from '@wordpress/element';
-import { dispatch, useDispatch } from '@wordpress/data';
+import { createContext, useRef } from '@wordpress/element';
+import { dispatch } from '@wordpress/data';
 import {
 	__experimentalFetchLinkSuggestions as fetchLinkSuggestions,
 	__experimentalFetchUrlData as fetchUrlData,
@@ -70,80 +70,82 @@ export type events =
 	| { type: 'FINISH_CUSTOMIZATION' }
 	| { type: 'GO_BACK_TO_DESIGN_WITH_AI' };
 
-export const AssemblerHub: CustomizeStoreComponent = ( props ) => {
-	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
-	useEffect( () => {
-		if ( ! window.wcBlockSettings ) {
-			// eslint-disable-next-line no-console
-			console.warn(
-				'window.blockSettings not found. Skipping initialization.'
-			);
-			return;
+const initializeAssembleHub = () => {
+	if ( ! window.wcBlockSettings ) {
+		// eslint-disable-next-line no-console
+		console.warn(
+			'window.blockSettings not found. Skipping initialization.'
+		);
+		return;
+	}
+
+	// Set up the block editor settings.
+	const settings = window.wcBlockSettings;
+	settings.__experimentalFetchLinkSuggestions = (
+		search: string,
+		searchOptions: {
+			isInitialSuggestions: boolean;
+			type: 'attachment' | 'post' | 'term' | 'post-format';
+			subtype: string;
+			page: number;
+			perPage: number;
 		}
+	) => fetchLinkSuggestions( search, searchOptions, settings );
+	settings.__experimentalFetchRichUrlData = fetchUrlData;
 
-		// Set up the block editor settings.
-		const settings = window.wcBlockSettings;
-		settings.__experimentalFetchLinkSuggestions = (
-			search: string,
-			searchOptions: {
-				isInitialSuggestions: boolean;
-				type: 'attachment' | 'post' | 'term' | 'post-format';
-				subtype: string;
-				page: number;
-				perPage: number;
-			}
-		) => fetchLinkSuggestions( search, searchOptions, settings );
-		settings.__experimentalFetchRichUrlData = fetchUrlData;
-
-		const reapplyBlockTypeFilters =
-			// @ts-ignore No types for this exist yet.
-			dispatch( blocksStore ).__experimentalReapplyBlockTypeFilters || // GB < 16.6
-			// @ts-ignore No types for this exist yet.
-			dispatch( blocksStore ).reapplyBlockTypeFilters; // GB >= 16.6
-		reapplyBlockTypeFilters();
-
-		const coreBlocks = __experimentalGetCoreBlocks().filter(
-			( { name }: { name: string } ) =>
-				name !== 'core/freeform' && ! getBlockType( name )
-		);
-		registerCoreBlocks( coreBlocks );
-
+	const reapplyBlockTypeFilters =
 		// @ts-ignore No types for this exist yet.
-		dispatch( blocksStore ).setFreeformFallbackBlockName( 'core/html' );
-
+		dispatch( blocksStore ).__experimentalReapplyBlockTypeFilters || // GB < 16.6
 		// @ts-ignore No types for this exist yet.
-		dispatch( preferencesStore ).setDefaults( 'core/edit-site', {
-			editorMode: 'visual',
-			fixedToolbar: false,
-			focusMode: false,
-			distractionFree: false,
-			keepCaretInsideBlock: false,
-			welcomeGuide: false,
-			welcomeGuideStyles: false,
-			welcomeGuidePage: false,
-			welcomeGuideTemplate: false,
-			showListViewByDefault: false,
-			showBlockBreadcrumbs: true,
-		} );
-		// @ts-ignore No types for this exist yet.
-		dispatch( editSiteStore ).updateSettings( settings );
+		dispatch( blocksStore ).reapplyBlockTypeFilters; // GB >= 16.6
+	reapplyBlockTypeFilters();
 
-		// @ts-ignore No types for this exist yet.
-		dispatch( editorStore ).updateEditorSettings( {
-			defaultTemplateTypes: settings.defaultTemplateTypes,
-			defaultTemplatePartAreas: settings.defaultTemplatePartAreas,
-		} );
+	const coreBlocks = __experimentalGetCoreBlocks().filter(
+		( { name }: { name: string } ) =>
+			name !== 'core/freeform' && ! getBlockType( name )
+	);
+	registerCoreBlocks( coreBlocks );
 
-		// Prevent the default browser action for files dropped outside of dropzones.
-		window.addEventListener(
-			'dragover',
-			( e ) => e.preventDefault(),
-			false
-		);
-		window.addEventListener( 'drop', ( e ) => e.preventDefault(), false );
+	// @ts-ignore No types for this exist yet.
+	dispatch( blocksStore ).setFreeformFallbackBlockName( 'core/html' );
 
-		setCanvasMode( 'view' );
-	}, [ setCanvasMode ] );
+	// @ts-ignore No types for this exist yet.
+	dispatch( preferencesStore ).setDefaults( 'core/edit-site', {
+		editorMode: 'visual',
+		fixedToolbar: false,
+		focusMode: false,
+		distractionFree: false,
+		keepCaretInsideBlock: false,
+		welcomeGuide: false,
+		welcomeGuideStyles: false,
+		welcomeGuidePage: false,
+		welcomeGuideTemplate: false,
+		showListViewByDefault: false,
+		showBlockBreadcrumbs: true,
+	} );
+	// @ts-ignore No types for this exist yet.
+	dispatch( editSiteStore ).updateSettings( settings );
+
+	// @ts-ignore No types for this exist yet.
+	dispatch( editorStore ).updateEditorSettings( {
+		defaultTemplateTypes: settings.defaultTemplateTypes,
+		defaultTemplatePartAreas: settings.defaultTemplatePartAreas,
+	} );
+
+	// Prevent the default browser action for files dropped outside of dropzones.
+	window.addEventListener( 'dragover', ( e ) => e.preventDefault(), false );
+	window.addEventListener( 'drop', ( e ) => e.preventDefault(), false );
+
+	unlock( dispatch( editorStore ) ).setCanvasMode( 'view' );
+};
+
+export const AssemblerHub: CustomizeStoreComponent = ( props ) => {
+	const isInitializedRef = useRef( false );
+
+	if ( ! isInitializedRef.current ) {
+		initializeAssembleHub();
+		isInitializedRef.current = true;
+	}
 
 	return (
 		<CustomizeStoreContext.Provider value={ props }>

--- a/plugins/woocommerce-admin/client/customize-store/assembler-hub/index.tsx
+++ b/plugins/woocommerce-admin/client/customize-store/assembler-hub/index.tsx
@@ -136,7 +136,7 @@ const initializeAssembleHub = () => {
 	window.addEventListener( 'dragover', ( e ) => e.preventDefault(), false );
 	window.addEventListener( 'drop', ( e ) => e.preventDefault(), false );
 
-	unlock( dispatch( editorStore ) ).setCanvasMode( 'view' );
+	unlock( dispatch( editSiteStore ) ).setCanvasMode( 'view' );
 };
 
 export const AssemblerHub: CustomizeStoreComponent = ( props ) => {

--- a/plugins/woocommerce/changelog/fix-cys-transnational-screen-preview
+++ b/plugins/woocommerce/changelog/fix-cys-transnational-screen-preview
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix the “Preview” on the transnational screen doesn’t represent our custom color palette


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/41493.

The preview on the transnational screen differs from the assembler because it's overwritten by the initial settings when re-rendering. Use `useRef` to ensure it only runs once.



<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

**Make sure you are testing this with a Jetpack connected instance of WooCommerce, as the AI text completion endpoint can only be called with a Jetpack connected account.**

1. Create a new WooCommerce installation with this version.
2. Make sure to enable `customize-store` feature flag
3. Go to `WooCommerce -> Home` and click `Customize Store` task
4. Click `Design with AI` button
5. Follow through the flow all the way till the assembler hub shows up
6. Click on "change the color palette"
7. Change color and click on "Save"
8. Click on "Done" button
9. Observe that the preview shown on the transnational screen is the same one shown on assembler hub.


https://github.com/woocommerce/woocommerce/assets/4344253/c4ff891e-5691-4fea-aded-90b49fff7662


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
