### PR TITLE
Prevent double escaping of special chars in HPOS search query

### DIFF
--- a/plugins/woocommerce/changelog/fix-41359
+++ b/plugins/woocommerce/changelog/fix-41359
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Address a problem with searches involving underscore characters in the HPOS.

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
@@ -32,9 +32,8 @@ class OrdersTableSearchQuery {
 	 * @param OrdersTableQuery $query The order query object.
 	 */
 	public function __construct( OrdersTableQuery $query ) {
-		global $wpdb;
 		$this->query         = $query;
-		$this->search_term   = esc_sql( '%' . $wpdb->esc_like( urldecode( $query->get( 's' ) ) ) . '%' );
+		$this->search_term   = urldecode( $query->get( 's' ) );
 	}
 
 	/**
@@ -81,7 +80,7 @@ class OrdersTableSearchQuery {
 	private function generate_where(): string {
 		global $wpdb;
 		$where             = '';
-		$possible_order_id = (string) absint( $this->query->get( 's' ) );
+		$possible_order_id = (string) absint( $this->search_term );
 		$order_table       = $this->query->get_table_name( 'orders' );
 
 		// Support the passing of an order ID as the search term.
@@ -96,7 +95,7 @@ class OrdersTableSearchQuery {
 			search_query_items.order_item_name LIKE %s
 			OR `$order_table`.id IN ( $meta_sub_query )
 			",
-			$this->search_term
+			'%' . $wpdb->esc_like( $this->search_term ) . '%'
 		);
 
 		return " ( $where ) ";
@@ -123,7 +122,7 @@ WHERE search_query_meta.meta_key IN ( $meta_fields )
 AND search_query_meta.meta_value LIKE %s
 GROUP BY search_query_meta.order_id
 ",
-			$this->search_term
+			'%' . $wpdb->esc_like( $this->search_term ) . '%'
 		);
 	}
 

--- a/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
+++ b/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableSearchQuery.php
@@ -32,8 +32,8 @@ class OrdersTableSearchQuery {
 	 * @param OrdersTableQuery $query The order query object.
 	 */
 	public function __construct( OrdersTableQuery $query ) {
-		$this->query         = $query;
-		$this->search_term   = urldecode( $query->get( 's' ) );
+		$this->query       = $query;
+		$this->search_term = urldecode( $query->get( 's' ) );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
@@ -402,4 +402,48 @@ class OrdersTableQueryTests extends WC_Unit_Test_Case {
 
 		remove_all_filters( 'woocommerce_hpos_pre_query' );
 	}
+
+	/**
+	 * @testdox Orders will be correctly returned by inexact queries using the 's' search argument.
+	 */
+	public function test_query_s_argument() {
+		$order1 = new \WC_Order();
+		$order1->set_billing_first_name( '%ir Woo' );
+		$order1->set_billing_email( 'test_user@woo.test' );
+		$order1->save();
+
+		$order2 = new \WC_Order();
+		$order2->set_billing_email( 'other_user@woo.test' );
+		$order2->save();
+
+		$query_args = array(
+			's'      => '',
+			'return' => 'ids',
+		);
+
+		$query_args['s'] = '%';
+		$query = new OrdersTableQuery( $query_args );
+		$this->assertEqualsCanonicalizing( array( $order1->get_id() ), $query->orders );
+
+		$query_args['s'] = '%ir';
+		$query = new OrdersTableQuery( $query_args );
+		$this->assertEqualsCanonicalizing( array( $order1->get_id() ), $query->orders );
+
+		$query_args['s'] = 'test_user';
+		$query = new OrdersTableQuery( $query_args );
+		$this->assertEqualsCanonicalizing( array( $order1->get_id() ), $query->orders );
+
+		$query_args['s'] = 'woo.test';
+		$query = new OrdersTableQuery( $query_args );
+		$this->assertEqualsCanonicalizing( array( $order1->get_id(), $order2->get_id() ), $query->orders );
+
+		$query_args['s'] = '_user';
+		$query = new OrdersTableQuery( $query_args );
+		$this->assertEqualsCanonicalizing( array( $order1->get_id(), $order2->get_id() ), $query->orders );
+
+		$query_args['s'] = 'nowhere_to_be_found';
+		$query = new OrdersTableQuery( $query_args );
+		$this->assertCount( 0, $query->orders );
+	}
+
 }

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableQueryTests.php
@@ -422,27 +422,27 @@ class OrdersTableQueryTests extends WC_Unit_Test_Case {
 		);
 
 		$query_args['s'] = '%';
-		$query = new OrdersTableQuery( $query_args );
+		$query           = new OrdersTableQuery( $query_args );
 		$this->assertEqualsCanonicalizing( array( $order1->get_id() ), $query->orders );
 
 		$query_args['s'] = '%ir';
-		$query = new OrdersTableQuery( $query_args );
+		$query           = new OrdersTableQuery( $query_args );
 		$this->assertEqualsCanonicalizing( array( $order1->get_id() ), $query->orders );
 
 		$query_args['s'] = 'test_user';
-		$query = new OrdersTableQuery( $query_args );
+		$query           = new OrdersTableQuery( $query_args );
 		$this->assertEqualsCanonicalizing( array( $order1->get_id() ), $query->orders );
 
 		$query_args['s'] = 'woo.test';
-		$query = new OrdersTableQuery( $query_args );
+		$query           = new OrdersTableQuery( $query_args );
 		$this->assertEqualsCanonicalizing( array( $order1->get_id(), $order2->get_id() ), $query->orders );
 
 		$query_args['s'] = '_user';
-		$query = new OrdersTableQuery( $query_args );
+		$query           = new OrdersTableQuery( $query_args );
 		$this->assertEqualsCanonicalizing( array( $order1->get_id(), $order2->get_id() ), $query->orders );
 
 		$query_args['s'] = 'nowhere_to_be_found';
-		$query = new OrdersTableQuery( $query_args );
+		$query           = new OrdersTableQuery( $query_args );
 		$this->assertCount( 0, $query->orders );
 	}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Currently, `OrdersTableSearchQuery` is invoked when performing an inexact order search in HPOS (i.e. when the `s` argument is used). When the search term involves characters `%` or `_`, the search query ends up being double escaped, which effectively returns no results.
This can be seen by performing a search on the admin that uses any of those characters.

In particular, we were passing the search term through both `esc_sql()` and `$wpdb->esc_like()`, which then combined with `$wpdb->prepare()` results in things being escaped twice. This can be confirmed in WP CLI (`wp shell`):

```
> global $wpdb;
> $wpdb->prepare( 'LIKE %s', esc_sql( $wpdb->esc_like( 'test_string' ) ) );
=> string(22) "LIKE 'test\\\\_string'"
```

Closes #41359.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure HPOS is enabled in WC > Settings > Advanced > Features.
2. Go to WC > Orders.
3. Click **Add Order** and create an order with any items and details. Make sure that customer's e-mail address contains an underscore (example: `test_user@store.test`).
4. Go back to WC > Orders.
5. Enter `test_user` in the search box. You can also try just `test_` or `_user` or other combinations as matching is inexact.
6. Click **Search orders**.
7. Make sure the order was returned.
8. Edit the order you just created by changing the customer e-mail address to `test%user@store.test`.
9. Repeat steps 4-7 with `test%user` as search term (and some variations).

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
