### PR TITLE
revert stalebot to v8 and single run

### DIFF
--- a/.github/workflows/stalebot.yml
+++ b/.github/workflows/stalebot.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Scan issues
-        uses: actions/stale@b69b346013879cedbf50c69f572cd85439a41936
+        uses: actions/stale@v8
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: "As a part of this repository's maintenance, this issue is being marked as stale due to inactivity. Please feel free to comment on it in case we missed something.\n\n###### After 7 days with no activity this issue will be automatically be closed."

--- a/.github/workflows/stalebot.yml
+++ b/.github/workflows/stalebot.yml
@@ -1,7 +1,7 @@
 name: 'Process stale needs-feedback issues'
 on:
   schedule:
-    - cron: '21 * * * *'
+    - cron: '21 0 * * *'
 
 permissions: {}
 
@@ -19,6 +19,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: "As a part of this repository's maintenance, this issue is being marked as stale due to inactivity. Please feel free to comment on it in case we missed something.\n\n###### After 7 days with no activity this issue will be automatically be closed."
           close-issue-message: 'This issue was closed because it has been 14 days with no activity.'
+          operations-per-run: 140
           days-before-stale: -1
           days-before-close: -1
           days-before-issue-stale: 7

--- a/plugins/woocommerce/changelog/stalebot-use-v8
+++ b/plugins/woocommerce/changelog/stalebot-use-v8
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+revert stalebot to v8 and single run


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR reverts stalebot to v8 and a single run per day. The `operations-per-run` parameter is set to 140 per calculation on #42523.

Closes #41523 .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. YAML review.
2.
3.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
