### PR TITLE
Invalidate coupon cache after hold/usage data is modified in datastore via SQL

### DIFF
--- a/plugins/woocommerce/changelog/fix-41506
+++ b/plugins/woocommerce/changelog/fix-41506
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixes an issue where coupon usage is not correctly recorded when HPOS is active.

--- a/plugins/woocommerce/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/plugins/woocommerce/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -377,10 +377,9 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 			if ( $meta_id ) {
 				delete_metadata_by_mid( 'post', $meta_id );
 				$coupon->set_used_by( (array) get_post_meta( $coupon->get_id(), '_used_by' ) );
+				$this->refresh_coupon_data( $coupon );
 			}
 		}
-
-		$this->refresh_coupon_data( $coupon );
 
 		do_action( 'woocommerce_decrease_coupon_usage_count', $coupon, $new_count, $used_by );
 

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -3222,7 +3222,7 @@ class OrdersTableDataStoreTests extends HposTestCase {
 		$order_id = WC()->checkout->create_order(
 			array(
 				'billing_email'  => 'user@woo.test',
-				'payment_method' => 'dummy'
+				'payment_method' => 'dummy',
 			)
 		);
 

--- a/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
+++ b/plugins/woocommerce/tests/php/src/Internal/DataStores/Orders/OrdersTableDataStoreTests.php
@@ -3198,4 +3198,45 @@ class OrdersTableDataStoreTests extends HposTestCase {
 		remove_all_actions( 'woocommerce_webhook_process_delivery' );
 		remove_all_actions( 'woocommerce_webhook_should_deliver' );
 	}
+
+	/**
+	 * @testDox Check that functions in the datastore correctly hold and release coupons from the order.
+	 */
+	public function test_datastore_coupon_methods() {
+		$this->toggle_cot_authoritative( true );
+
+		$coupon = new \WC_Coupon();
+		$coupon->set_code( '10off' );
+		$coupon->set_discount_type( 'percent' );
+		$coupon->set_amount( 10.0 );
+		$coupon->set_usage_limit_per_user( 2 );
+		$coupon->save();
+
+		$product = WC_Helper_Product::create_simple_product( true );
+
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+		WC()->cart->add_discount( $coupon->get_code() );
+
+		$this->assertEquals( 0, $coupon->get_data_store()->get_usage_by_email( $coupon, 'user@woo.test' ) );
+
+		$order_id = WC()->checkout->create_order(
+			array(
+				'billing_email'  => 'user@woo.test',
+				'payment_method' => 'dummy'
+			)
+		);
+
+		$this->assertEquals( 1, $coupon->get_data_store()->get_tentative_usages_for_user( $coupon->get_id(), array( 'user@woo.test' ) ) );
+		$this->assertEquals( 1, $coupon->get_data_store()->get_usage_by_email( $coupon, 'user@woo.test' ) );
+
+		wc_get_order( $order_id )->payment_complete();
+
+		$this->assertEquals( 0, $coupon->get_data_store()->get_tentative_usages_for_user( $coupon->get_id(), array( 'user@woo.test' ) ) );
+		$this->assertEquals( 1, $coupon->get_data_store()->get_usage_by_email( $coupon, 'user@woo.test' ) );
+
+		// Load a fresh copy of the coupon and make sure things look ok.
+		$coupon = new \WC_Coupon( $coupon->get_id() );
+		$this->assertContains( 'user@woo.test', $coupon->get_used_by( 'edit' ) );
+	}
+
 }


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
The coupons datastore uses a mix of calls to post meta functions and also direct SQL queries to performantly record usage of coupons as well as coupons held during checkout, etc. While this works for performance, it does mean that instantiating a given coupon at a later stage might not reflect the correct information in the database, because either the internal `WC_Data` cache does not pick up changes made outside of CRUD, or WP's postmeta those made via SQL queries.

Some of the methods in the datastore did attempt to do some cache clearing, but that was insufficient.

This PR makes sure we're a bit more aggressive when invalidating coupon-related cache, at least until the time comes that we properly implement these methods as CRUD methods.

<details><summary>Why did this result in coupon usage not being recorded with HPOS?</summary>
<p>

A curious one you are, young Padawan.

When coupon usage is updated (like [here](https://github.com/woocommerce/woocommerce/blob/c768ca0dc680cf64c596c76738251e39fb7f6c91/plugins/woocommerce/includes/data-stores/class-wc-coupon-data-store-cpt.php#L334C1-L342)) we some times use a direct query. In this case, the query actually _renames_ the meta key of a row of metadata to `_used_by`, but given caches were not cleared, our CRUD layer didn't pick up this change.

Instead, instances of said `WC_Coupon` would still think that row used the prior `meta_key` name. That's not a problem most of the time, except the HPOS datastore, contrary to the CPT one, [uses CRUD methods to release coupons held during checkout](https://github.com/woocommerce/woocommerce/blob/c768ca0dc680cf64c596c76738251e39fb7f6c91/plugins/woocommerce/src/Internal/DataStores/Orders/OrdersTableDataStore.php#L2651-L2669).
Metadata in `WC_Data` is deleted [by referencing the `meta_id`](https://github.com/woocommerce/woocommerce/blob/c768ca0dc680cf64c596c76738251e39fb7f6c91/plugins/woocommerce/includes/abstracts/abstract-wc-data.php#L685C4-L686) value of any given piece of metadata, and since the SQL query doesn't change this, HPOS was effectively removing the data that was no longer temporary and we actually wanted to keep.

In this case, the record of the coupon being used.
</p>
</details> 


Closes #41506.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

0. Make sure HPOS is active in WC > Settings > Advanced > Features.
1. Go to Marketing > Coupons and create a coupon with any details you like. Make sure it's limited to 1 use per user.
2. In an incognito window, order something as a guest and with the coupon applied.
3. Repeat step 2 and confirm that the order doesn't go through this time.
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
