### PR TITLE
HPOS verification tool should not report missing `_completed_date` meta as error

### DIFF
--- a/plugins/woocommerce/changelog/fix-41264
+++ b/plugins/woocommerce/changelog/fix-41264
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ignore '_completed_date' in HPOS verification tool.

--- a/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
+++ b/plugins/woocommerce/src/Database/Migrations/CustomOrderTable/CLIRunner.php
@@ -582,7 +582,8 @@ class CLIRunner {
 	 */
 	private function verify_meta_data( array $order_ids, array $failed_ids ) : array {
 		$meta_keys_to_ignore = array(
-			'_paid_date', // This is set by the CPT datastore but no longer used anywhere.
+			'_paid_date', // This has been deprecated and replaced by '_date_paid' in the CPT datastore.
+			'_completed_date', // This has been deprecated and replaced by '_date_completed' in the CPT datastore.
 			'_edit_lock',
 		);
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Property `_completed_date` is deprecated in the CPT datastore and has been replaced by `_date_completed`. HPOS' sync process stores this date in the correct column in the HPOS tables, but doesn't add the metadata to the `wc_orders_meta` table as that's no longer needed.

Still, the verification tool might complain that this piece of deprecated meta wasn't migrated, even though it is irrelevant.

This PR silences errors related to this key in the CLI verification tool.

Closes #41264.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure HPOS and sync are enabled in WC > Settings > Advanced > Features.
2. Go to WC > Orders and create an order with status "Completed". Take note of this order's ID.
3. Run `wp wc cot verify_cot_data --start-from=ORDER_ID` (replace `ORDER_ID` by the order ID from step 2).
4. Confirm that no error is reported. Optionally contrast this with `trunk` where an error about `_completed_date` will get reported.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
