### PR TITLE
Tree Select Control: Allow parents to be searchable

### DIFF
--- a/packages/js/components/changelog/41559-try-tree-select-control-search-parents-trunk
+++ b/packages/js/components/changelog/41559-try-tree-select-control-search-parents-trunk
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update Tree Select Control to allow for searching parent values when `individuallySelectParent` is turned on.

--- a/packages/js/components/changelog/41559-try-tree-select-control-search-parents-trunk
+++ b/packages/js/components/changelog/41559-try-tree-select-control-search-parents-trunk
@@ -1,4 +1,4 @@
 Significance: minor
 Type: update
 
-Update Tree Select Control to allow for searching parent values.
+Update Tree Select Control to allow for searching parent values when `individuallySelectParent` is turned on.

--- a/packages/js/components/changelog/41559-try-tree-select-control-search-parents-trunk
+++ b/packages/js/components/changelog/41559-try-tree-select-control-search-parents-trunk
@@ -1,4 +1,4 @@
 Significance: minor
 Type: update
 
-Update Tree Select Control to allow for searching parent values when `individuallySelectParent` is turned on.
+Update Tree Select Control to allow for searching parent values.

--- a/packages/js/components/src/tree-select-control/index.js
+++ b/packages/js/components/src/tree-select-control/index.js
@@ -266,16 +266,22 @@ const TreeSelectControl = ( {
 					);
 				},
 			},
-			hasChildSearchValue: {
+			hasSearchedDescendent: {
+				/**
+				 * Returns whether this option is being searched for or any of its
+				 * descendents is also a being searched for.
+				 *
+				 * @return {boolean} True if has a searched descendent, false otherwise.
+				 */
 				get() {
-					// Since we are doing recursion, exit true if a child is search result.
+					// Since we are doing recursion, exit true if a child is searched result.
 					if ( this.isSearchResult ) {
 						return true;
 					}
 
 					if ( this.hasChildren ) {
 						return this.children.some(
-							( opt ) => opt.hasChildSearchValue
+							( opt ) => opt.hasSearchedDescendent
 						);
 					}
 
@@ -283,16 +289,28 @@ const TreeSelectControl = ( {
 				},
 			},
 			isVisible: {
+				/**
+				 * Returns whether this option should be visible.
+				 * All options are visible when not searching. Otherwise, true if this option is
+				 * a search result or it has a descendent that is being searched for.
+				 *
+				 * @return {boolean} True if option should be visible, false otherwise.
+				 */
 				get() {
 					// everything is visible when not searching.
 					if ( ! isSearching ) {
 						return true;
 					}
-					// Otherwise visible if searched or has child search
-					return this.isSearchResult || this.hasChildSearchValue;
+					// Otherwise visible if searched or has child being searched.
+					return this.isSearchResult || this.hasSearchedDescendent;
 				},
 			},
 			isSearchResult: {
+				/**
+				 * Returns whether this option is a searched result.
+				 *
+				 * @return {boolean} True if option is being searched, false otherwise.
+				 */
 				get() {
 					if ( ! isSearching ) {
 						return false;
@@ -309,7 +327,7 @@ const TreeSelectControl = ( {
 				 */
 				get() {
 					return (
-						( isSearching && this.hasChildSearchValue ) ||
+						( isSearching && this.hasSearchedDescendent ) ||
 						this.value === ROOT_VALUE ||
 						cache.expandedValues.includes( this.value )
 					);

--- a/packages/js/components/src/tree-select-control/index.js
+++ b/packages/js/components/src/tree-select-control/index.js
@@ -266,31 +266,9 @@ const TreeSelectControl = ( {
 					);
 				},
 			},
-			hasSearchedDescendent: {
-				/**
-				 * Returns whether this option is being searched for or any of its
-				 * descendents is also a being searched for.
-				 *
-				 * @return {boolean} True if has a searched descendent, false otherwise.
-				 */
-				get() {
-					// Since we are doing recursion, exit true if a child is searched result.
-					if ( this.isSearchResult ) {
-						return true;
-					}
-
-					if ( this.hasChildren ) {
-						return this.children.some(
-							( opt ) => opt.hasSearchedDescendent
-						);
-					}
-
-					return this.leaves.some( ( opt ) => opt.isSearchResult );
-				},
-			},
 			isVisible: {
 				/**
-				 * Returns whether this option should be visible.
+				 * Returns whether this option should be visible based on search.
 				 * All options are visible when not searching. Otherwise, true if this option is
 				 * a search result or it has a descendent that is being searched for.
 				 *
@@ -301,8 +279,18 @@ const TreeSelectControl = ( {
 					if ( ! isSearching ) {
 						return true;
 					}
-					// Otherwise visible if searched or has child being searched.
-					return this.isSearchResult || this.hasSearchedDescendent;
+
+					// Exit true if this is searched result.
+					if ( this.isSearchResult ) {
+						return true;
+					}
+
+					// If any children are search results, remain visible.
+					if ( this.hasChildren ) {
+						return this.children.some( ( opt ) => opt.isVisible );
+					}
+
+					return this.leaves.some( ( opt ) => opt.isSearchResult );
 				},
 			},
 			isSearchResult: {
@@ -327,7 +315,7 @@ const TreeSelectControl = ( {
 				 */
 				get() {
 					return (
-						( isSearching && this.hasSearchedDescendent ) ||
+						( isSearching && this.isVisible ) ||
 						this.value === ROOT_VALUE ||
 						cache.expandedValues.includes( this.value )
 					);

--- a/packages/js/components/src/tree-select-control/options.js
+++ b/packages/js/components/src/tree-select-control/options.js
@@ -58,6 +58,7 @@ const Options = ( {
 		const { hasChildren, checked, partialChecked, expanded } = option;
 
 		if ( ! option?.value ) return null;
+		if ( ! isRoot && ! option?.isVisible ) return null;
 
 		return (
 			<div

--- a/packages/js/components/src/tree-select-control/stories/index.js
+++ b/packages/js/components/src/tree-select-control/stories/index.js
@@ -29,7 +29,7 @@ const treeSelectControlOptions = [
 				children: [
 					{
 						value: 'TO',
-						label: 'Tokio',
+						label: 'Tokyo',
 						children: [
 							{ value: 'SI', label: 'Shibuya' },
 							{ value: 'GI', label: 'Ginza' },
@@ -98,6 +98,7 @@ Base.args = {
 	includeParent: false,
 	alwaysShowPlaceholder: false,
 	individuallySelectParent: false,
+	clearOnSelect: true,
 };
 
 Base.argTypes = {

--- a/packages/js/components/src/tree-select-control/test/index.test.js
+++ b/packages/js/components/src/tree-select-control/test/index.test.js
@@ -168,6 +168,22 @@ describe( 'TreeSelectControl Component', () => {
 		expect( queryByLabelText( 'Asia' ) ).toBeFalsy(); // doesn't match pain
 	} );
 
+	it( 'Filters Option categories on Search', () => {
+		const { queryByLabelText, queryByRole } = render(
+			<TreeSelectControl options={ options } />
+		);
+
+		const control = queryByRole( 'combobox' );
+		fireEvent.click( control );
+		expect( queryByLabelText( 'Europe' ) ).toBeTruthy();
+		expect( queryByLabelText( 'Asia' ) ).toBeTruthy();
+
+		fireEvent.change( control, { target: { value: 'eur' } } );
+
+		expect( queryByLabelText( 'Europe' ) ).toBeTruthy(); // match 'eur'
+		expect( queryByLabelText( 'Asia' ) ).toBeFalsy(); // doesn't match 'eur'
+	} );
+
 	it( 'should call onInputChange when input field changed', () => {
 		const onInputChangeMock = jest.fn();
 		const { queryByRole } = render(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/41418

The Tree Select Component does not allow searching for parent options, ie options with children. This PR changes the display recursion such that all elements of the tree remain in the tree and an `isVisible` attribute added to each option based on search matches for itself and any of its children.

There was also a change made to partial selections which were broken when using `individuallySelectParent`. It will now work for even deeply nested options.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. `cd tools/storybook && pnpm storybook`
2. Head to `http://localhost:6007/?path=/story/woocommerce-admin-components-treeselectcontrol--base`
3. Try search for any option, parent or otherwise, at any level of nestedness. The results should be as expected. Setting `clearOnSelect` to `false` is helpful here.
4. When searching, try selecting/unselecting any of the results. When `individuallySelectParent` is `false` all children will be selected. When `individuallySelectParent` is `true`, only the parent gets selected.
5. Observe the "partial" selection behaviour. When selecting a deeply nested option, ensure partial selection is correctly noted going up the tree. Try this using `individuallySelectParent` on and off.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Update Tree Select Control to allow for searching parent values when `individuallySelectParent` is turned on.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
