### PR TITLE
Fix product variation sale_price_dates_to not being set to 23:59:59 when it's set via the variation bulk actions

### DIFF
--- a/plugins/woocommerce/changelog/fix-sale-date-end-variation-bulk-action
+++ b/plugins/woocommerce/changelog/fix-sale-date-end-variation-bulk-action
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix product variation sale_price_dates_to not being set to 23:59:59 when it's set via the variation bulk actions

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -2714,12 +2714,13 @@ class WC_AJAX {
 			$variation = wc_get_product( $variation_id );
 
 			if ( 'false' !== $data['date_from'] ) {
-				$variation->set_date_on_sale_from( wc_clean( $data['date_from'] ) );
+				$date_on_sale_from = date( 'Y-m-d 00:00:00', strtotime( wc_clean( $data['date_from'] ) ) ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
+				$variation->set_date_on_sale_from( $date_on_sale_from );
 			}
 
 			if ( 'false' !== $data['date_to'] ) {
-				$date_on_sale_to = date( 'Y-m-d 23:59:59', strtotime( wc_clean( $data['date_to'] ) ) );
-				$variation->set_date_on_sale_to( $date_on_sale_to );
+				$date_on_sale_to = date( 'Y-m-d 23:59:59', strtotime( wc_clean( $data['date_to'] ) ) ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
+				$variation->set_date_on_sale_to( $date_on_sale_to );	
 			}
 
 			$variation->save();

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -2720,7 +2720,7 @@ class WC_AJAX {
 
 			if ( 'false' !== $data['date_to'] ) {
 				$date_on_sale_to = date( 'Y-m-d 23:59:59', strtotime( wc_clean( $data['date_to'] ) ) ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
-				$variation->set_date_on_sale_to( $date_on_sale_to );	
+				$variation->set_date_on_sale_to( $date_on_sale_to );
 			}
 
 			$variation->save();

--- a/plugins/woocommerce/includes/class-wc-ajax.php
+++ b/plugins/woocommerce/includes/class-wc-ajax.php
@@ -2718,7 +2718,8 @@ class WC_AJAX {
 			}
 
 			if ( 'false' !== $data['date_to'] ) {
-				$variation->set_date_on_sale_to( wc_clean( $data['date_to'] ) );
+				$date_on_sale_to = date( 'Y-m-d 23:59:59', strtotime( wc_clean( $data['date_to'] ) ) );
+				$variation->set_date_on_sale_to( $date_on_sale_to );
 			}
 
 			$variation->save();


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Since WooCommerce sets the sale end date hour to 23:59:59 for a given date on the Metabox UI for simple and variable products this should also happen when it's set via the bulk action editor for variations.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to the product editor on the Product data part
2. Create a variable product, set attributes and create variations.
3. In the Bulk Actions select "Set scheduled sale dates". Set for example the starting date to "2023-11-01" and the end date to "2023-11-30".
<img width="397" alt="Screenshot 2023-11-19 at 02 49 24" src="https://github.com/woocommerce/woocommerce/assets/43281889/9a0f4f95-c374-42cb-b871-b717ad481964">
<img width="448" alt="Screenshot 2023-11-19 at 02 49 54" src="https://github.com/woocommerce/woocommerce/assets/43281889/342f25a2-2e28-436e-b587-73d0062b5e3d">
<img width="451" alt="Screenshot 2023-11-19 at 02 50 29" src="https://github.com/woocommerce/woocommerce/assets/43281889/33dc8a0c-bdcb-41b4-b515-4c9f56cfca72">

4. In the post_meta table the meta_key `_sale_price_dates_to` should be set to `1701388799` indicating the end of the sale is set to `Thu Nov 30 2023 23:59:59`. If the fix in this commit is not applied the meta_key `_sale_price_dates_to` will be set to `1701302400` indicating the end of the sale is `Thu Nov 30 2023 00:00:00` which is incorrect and incoherent to the rest of the WooCommerce behaviours.
 
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message
Fix product variation sale_price_dates_to not being set to 23:59:59 when it's set via the variation bulk actions

</details>
