### PR TITLE
Merge Marketplace subscriptions changelogs

### DIFF
--- a/plugins/woocommerce/changelog/41288-fix-subscriptions-edge-cases
+++ b/plugins/woocommerce/changelog/41288-fix-subscriptions-edge-cases
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-Comment: Fix subscription grouping to ensure one installed subscription is available in the installed section.
-

--- a/plugins/woocommerce/changelog/41397-add-refres-button-busy
+++ b/plugins/woocommerce/changelog/41397-add-refres-button-busy
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-Comment: Subscriptions refresh button uses the API instead of redirect.
-

--- a/plugins/woocommerce/changelog/41398-fix-connect-deny-redirect
+++ b/plugins/woocommerce/changelog/41398-fix-connect-deny-redirect
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-Comment: Fix marketplace connection deny redirects.
-

--- a/plugins/woocommerce/changelog/add-marketplace-helper-endpoints
+++ b/plugins/woocommerce/changelog/add-marketplace-helper-endpoints
@@ -1,4 +1,0 @@
-Significance: patch
-Type: add
-Comment: Add refresh, activate, and deactivate endpoints to the Marketplace API.
-

--- a/plugins/woocommerce/changelog/add-marketplace-helper-subscriptions-api
+++ b/plugins/woocommerce/changelog/add-marketplace-helper-subscriptions-api
@@ -1,4 +1,0 @@
-Significance: minor
-Type: add
-
-Add marketplace/subscriptions API.

--- a/plugins/woocommerce/changelog/add-marketplace-subscriptions-api-license-error-responses
+++ b/plugins/woocommerce/changelog/add-marketplace-subscriptions-api-license-error-responses
@@ -1,4 +1,0 @@
-Significance: patch
-Type: add
-Comment: Add Marketplace subscriptions API license error responses.
-

--- a/plugins/woocommerce/changelog/add-my-subscription-product-update
+++ b/plugins/woocommerce/changelog/add-my-subscription-product-update
@@ -1,4 +1,0 @@
-Significance: patch
-Type: add
-
-Add update support to the My subscriptions page.

--- a/plugins/woocommerce/changelog/add-my-subscriptions-action-modals
+++ b/plugins/woocommerce/changelog/add-my-subscriptions-action-modals
@@ -1,4 +1,0 @@
-Significance: patch
-Type: add
-Comment: Add my subscription action buttons and modals.
-

--- a/plugins/woocommerce/changelog/add-my-subscriptions-notices
+++ b/plugins/woocommerce/changelog/add-my-subscriptions-notices
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-Comment: Add My subscriptions error notices and move existing notices to helper functions.
-

--- a/plugins/woocommerce/changelog/add-org-support-to-subscriptions
+++ b/plugins/woocommerce/changelog/add-org-support-to-subscriptions
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-Comment: Correctly show .org products as installed and active in My Subscriptions.
-

--- a/plugins/woocommerce/changelog/add-subscriptions-empty-state
+++ b/plugins/woocommerce/changelog/add-subscriptions-empty-state
@@ -1,4 +1,0 @@
-Significance: patch
-Type: add
-Comment: Add disconnected state to My Subscriptions.
-

--- a/plugins/woocommerce/changelog/feature-marketplace-subscriptions
+++ b/plugins/woocommerce/changelog/feature-marketplace-subscriptions
@@ -1,4 +1,4 @@
 Significance: major
 Type: update
 
-The WooCommerce > Extensions section now includes a rebuilt "My Subscriptions" section with improvements to how subscriptions can be managed and installed.
+The WooCommerce > Extensions section now includes a rebuilt "My Subscriptions" page with improvements to how subscriptions can be managed and installed.

--- a/plugins/woocommerce/changelog/feature-marketplace-subscriptions
+++ b/plugins/woocommerce/changelog/feature-marketplace-subscriptions
@@ -1,0 +1,4 @@
+Significance: major
+Type: update
+
+The WooCommerce > Extensions section now includes a rebuilt "My Subscriptions" section with improvements to how subscriptions can be managed and installed.

--- a/plugins/woocommerce/changelog/feature-marketplace-subscriptions-skeleton
+++ b/plugins/woocommerce/changelog/feature-marketplace-subscriptions-skeleton
@@ -1,5 +1,0 @@
-Significance: patch
-Type: add
-Comment: Add WooCommerce > Extensions > My subscriptions page skeleton to the feature branch.
-
-

--- a/plugins/woocommerce/changelog/update-connect-redirect-to-new-subscriptions
+++ b/plugins/woocommerce/changelog/update-connect-redirect-to-new-subscriptions
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-Comment: Redirect old subscriptions page to new page when action requests are made from the new page.
-

--- a/plugins/woocommerce/changelog/update-my-subscriptions-wp-installer
+++ b/plugins/woocommerce/changelog/update-my-subscriptions-wp-installer
@@ -1,4 +1,0 @@
-Significance: patch
-Type: update
-Comment: Use WP installer for my subscriptions instead of the Woo installer API.
-


### PR DESCRIPTION
### Changes proposed in this Pull Request:

We have been creating changelogs for each individual branch merged into the feature branch. When we merge the project, we should have a single changelog entry that covers all the work. This PR merges all the changelogs into a single one.

Closes https://github.com/Automattic/woocommerce.com/issues/18473

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. There is no local dev setup required - this is only a file change
2. Check the `plugins/woocommerce/changelogs` folder changes
3. There should be only a single file and all others we introduced should be removed.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
