### PR TITLE
Update variations message to include missing downloads section

### DIFF
--- a/plugins/woocommerce/changelog/dev-41521_update_variations_message
+++ b/plugins/woocommerce/changelog/dev-41521_update_variations_message
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Update variations message to include missing downloads section #41581

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -125,6 +125,18 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 	 */
 	private function add_general_group_blocks() {
 		$general_group = $this->get_group_by_id( $this::GROUP_IDS['GENERAL'] );
+		$general_group->add_block(
+			array(
+				'id'         => 'product_variation_notice_general_tab',
+				'blockName'  => 'woocommerce/product-has-variations-notice',
+				'order'      => 10,
+				'attributes' => array(
+					'content'    => __( 'This product has options, such as size or color. You can manage each variation\'s images, downloads, and other details individually.', 'woocommerce' ),
+					'buttonText' => __( 'Go to Variations', 'woocommerce' ),
+					'type'       => 'info',
+				),
+			)
+		);
 		// Basic Details Section.
 		$basic_details = $general_group->add_section(
 			array(
@@ -623,7 +635,7 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 				'blockName'  => 'woocommerce/product-has-variations-notice',
 				'order'      => 10,
 				'attributes' => array(
-					'content'    => __( 'This product has options, such as size or color. You can now manage each variation\'s price and other details individually.', 'woocommerce' ),
+					'content'    => __( 'This product has options, such as size or color. You can now manage each variation\'s inventory and other details individually.', 'woocommerce' ),
 					'buttonText' => __( 'Go to Variations', 'woocommerce' ),
 					'type'       => 'info',
 				),
@@ -837,7 +849,7 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 				'blockName'  => 'woocommerce/product-has-variations-notice',
 				'order'      => 10,
 				'attributes' => array(
-					'content'    => __( 'This product has options, such as size or color. You can now manage each variation\'s price and other details individually.', 'woocommerce' ),
+					'content'    => __( 'This product has options, such as size or color. You can now manage each variation\'s shipping settings and other details individually.', 'woocommerce' ),
 					'buttonText' => __( 'Go to Variations', 'woocommerce' ),
 					'type'       => 'info',
 				),


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds a notice at the top of the general tab when a product becomes a variable product.

It also updates the copy of the other variation notices for the tabs.

Design:
![image-6](https://github.com/woocommerce/woocommerce/assets/2240960/2a53b3b1-0887-46be-bc39-db7e31174521)


**Acceptance criteria**

- [ ] Blue notice should be shown at the top of the general tab when the product type is variable.
- [ ] Update the copy of the other notices in the general, pricing, inventory, and shipping tabs.

Closes #41521.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a WooCommerce store with this branch and enable the product editor using **WooCommerce > Settings > Advanced > Features**
2. Go to **Products > Add New > Variations**
3. Create a few variations.
4. Go to the `General` tab. A notice should be visible with the following text:
```
This product has options, such as size or color. You can manage each variation's images, downloads, and other details individually.
```
5. Go to the `Pricing` tab. A notice should be visible with the following text:
```
This product has options, such as size or color. You can now manage each variation's price and other details individually.
```
6. Go to the `Inventory` tab. A notice should be visible with the following text:
```
This product has options, such as size or color. You can now manage each variation's inventory and other details individually.
```
7. Go to the `Shipping` tab. A notice should be visible with the following text:
```
This product has options, such as size or color. You can now manage each variation's shipping settings and other details individually.
```
8. Now delete the variations you created in step 3 and verify the notices are not there anymore in any tab

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
