### PR TITLE
Fix return type of ProductFormTemplateInterface::add_group()

### DIFF
--- a/plugins/woocommerce/changelog/update-add_group_return_type_codedoc
+++ b/plugins/woocommerce/changelog/update-add_group_return_type_codedoc
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Correct return type of ProductFormTemplateInterface::add_group() method.

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/ProductFormTemplateInterface.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/ProductFormTemplateInterface.php
@@ -14,7 +14,7 @@ interface ProductFormTemplateInterface extends BlockTemplateInterface {
 	 * Adds a new group block.
 	 *
 	 * @param array $block_config block config.
-	 * @return BlockInterface new block section.
+	 * @return GroupInterface new group block.
 	 */
 	public function add_group( array $block_config ): GroupInterface;
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR corrects the return type of `ProductFormTemplateInterface::add_group()` in the code doc.

Closes #41587.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

1. Verify that `$my_group` in the following PHP code is shown as type `GroupInterface` in VSCode editor (or whatever editor you use, if it supports PHP). And therefore that it doesn't complain about `$my_group->add_section()` not existing.

```php
<?php

use Automattic\WooCommerce\Admin\BlockTemplates\BlockInterface;
use Automattic\WooCommerce\Admin\Features\ProductBlockEditor\ProductTemplates\ProductFormTemplateInterface;

add_action(
	'woocommerce_block_template_area_product-form_after_add_block_general',
	function ( BlockInterface $general_group ) {
		$template = $general_group->get_root_template();

		/*
		 * Why is this check necessary?
		 * - Allow VSCode to provide autocomplete for the specific product form template methods
		 */
		if ( ! $template instanceof ProductFormTemplateInterface ) {
			return;
		}

		$my_group = $template->add_group(
			array(
				'id'         => 'your-prefix-example-group',
				'attributes' => array(
					'title' => __( 'My Group', 'YOUR_TEXT_DOMAIN' ),
				),
			)
		);

		$section_1 = $my_group->add_section(
			array(
				'id'         => 'your-prefix-example-section-1',
				'attributes' => array(
					'title' => __( 'My Section One', 'YOUR_TEXT_DOMAIN' ),
				),
			)
		);

		$section_1->add_block(
			array(
				'id'         => 'your-prefix-example-block-1',
				'blockName'  => 'woocommerce/product-text-field',
				'attributes' => array(
					'label'    => __( 'My Block One', 'YOUR_TEXT_DOMAIN' ),
					'property' => 'meta_data.your_prefix_example_field_1',
				),
			)
		);
	}
);

```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
