### PR TITLE
add: remove email marketing experiment

### DIFF
--- a/plugins/woocommerce-admin/client/core-profiler/actions/tracks.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/actions/tracks.tsx
@@ -99,7 +99,7 @@ const recordTracksIsEmailChanged = (
 		opt_in: event.payload.isOptInMarketing,
 		email_field_prefilled_source: emailSource,
 		email_field_modified: isEmailChanged,
-	});
+	} );
 };
 
 const recordTracksBusinessInfoCompleted = (

--- a/plugins/woocommerce-admin/client/core-profiler/actions/tracks.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/actions/tracks.tsx
@@ -76,48 +76,30 @@ const recordTracksSkipBusinessLocationCompleted = () => {
 	} );
 };
 
-// Temporarily expand the step viewed track for BusinessInfo so that we can include the experiment assignment
-// Remove this and change the action back to recordTracksStepViewed when the experiment is over
-const recordTracksStepViewedBusinessInfo = (
-	context: CoreProfilerStateMachineContext,
-	_event: unknown,
-	{ action }: { action: unknown }
-) => {
-	const { step } = action as { step: string };
-	recordEvent( 'coreprofiler_step_view', {
-		step,
-		email_marketing_experiment_assignment:
-			context.emailMarketingExperimentAssignment,
-		wc_version: getSetting( 'wcVersion' ),
-	} );
-};
-
 const recordTracksIsEmailChanged = (
 	context: CoreProfilerStateMachineContext,
 	event: BusinessInfoEvent
 ) => {
-	if ( context.emailMarketingExperimentAssignment === 'treatment' ) {
-		let emailSource, isEmailChanged;
-		if ( context.onboardingProfile.store_email ) {
-			emailSource = 'onboarding_profile_store_email'; // from previous entry
-			isEmailChanged =
-				event.payload.storeEmailAddress !==
-				context.onboardingProfile.store_email;
-		} else if ( context.currentUserEmail ) {
-			emailSource = 'current_user_email'; // from currentUser
-			isEmailChanged =
-				event.payload.storeEmailAddress !== context.currentUserEmail;
-		} else {
-			emailSource = 'was_empty';
-			isEmailChanged = event.payload.storeEmailAddress?.length > 0;
-		}
-
-		recordEvent( 'coreprofiler_email_marketing', {
-			opt_in: event.payload.isOptInMarketing,
-			email_field_prefilled_source: emailSource,
-			email_field_modified: isEmailChanged,
-		} );
+	let emailSource, isEmailChanged;
+	if ( context.onboardingProfile.store_email ) {
+		emailSource = 'onboarding_profile_store_email'; // from previous entry
+		isEmailChanged =
+			event.payload.storeEmailAddress !==
+			context.onboardingProfile.store_email;
+	} else if ( context.currentUserEmail ) {
+		emailSource = 'current_user_email'; // from currentUser
+		isEmailChanged =
+			event.payload.storeEmailAddress !== context.currentUserEmail;
+	} else {
+		emailSource = 'was_empty';
+		isEmailChanged = event.payload.storeEmailAddress?.length > 0;
 	}
+
+	recordEvent( 'coreprofiler_email_marketing', {
+		opt_in: event.payload.isOptInMarketing,
+		email_field_prefilled_source: emailSource,
+		email_field_modified: isEmailChanged,
+	});
 };
 
 const recordTracksBusinessInfoCompleted = (
@@ -126,8 +108,6 @@ const recordTracksBusinessInfoCompleted = (
 ) => {
 	recordEvent( 'coreprofiler_step_complete', {
 		step: 'business_info',
-		email_marketing_experiment_assignment:
-			context.emailMarketingExperimentAssignment,
 		wc_version: getSetting( 'wcVersion' ),
 	} );
 
@@ -227,5 +207,4 @@ export default {
 	recordSuccessfulPluginInstallation,
 	recordTracksPluginsInstallationRequest,
 	recordTracksIsEmailChanged,
-	recordTracksStepViewedBusinessInfo,
 };

--- a/plugins/woocommerce-admin/client/core-profiler/pages/BusinessInfo.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/pages/BusinessInfo.tsx
@@ -98,12 +98,7 @@ export type BusinessInfoContextProps = Pick<
 		| 'is_agree_marketing'
 		| 'store_email'
 	>;
-} & Partial<
-		Pick<
-			CoreProfilerStateMachineContext,
-			'emailMarketingExperimentAssignment' | 'currentUserEmail'
-		>
-	>;
+} & Partial< Pick< CoreProfilerStateMachineContext, 'currentUserEmail' > >;
 
 export const BusinessInfo = ( {
 	context,
@@ -126,7 +121,6 @@ export const BusinessInfo = ( {
 			is_agree_marketing: isOptInMarketingFromOnboardingProfile,
 			store_email: storeEmailAddressFromOnboardingProfile,
 		},
-		emailMarketingExperimentAssignment,
 		currentUserEmail,
 	} = context;
 
@@ -390,7 +384,7 @@ export const BusinessInfo = ( {
 							</ul>
 						</Notice>
 					) }
-					{ emailMarketingExperimentAssignment === 'treatment' && (
+					{
 						<>
 							<TextControl
 								className={ classNames(
@@ -447,18 +441,13 @@ export const BusinessInfo = ( {
 								} }
 							/>
 						</>
-					) }
+					}
 				</form>
 				<div className="woocommerce-profiler-button-container">
 					<Button
 						className="woocommerce-profiler-button"
 						variant="primary"
-						disabled={
-							! storeCountry.key ||
-							( emailMarketingExperimentAssignment ===
-								'treatment' &&
-								isEmailInvalid )
-						}
+						disabled={ ! storeCountry.key || isEmailInvalid }
 						onClick={ () => {
 							sendEvent( {
 								type: 'BUSINESS_INFO_COMPLETED',

--- a/plugins/woocommerce-admin/client/core-profiler/pages/tests/business-info.test.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/pages/tests/business-info.test.tsx
@@ -317,7 +317,6 @@ describe( 'BusinessInfo', () => {
 	} );
 
 	describe( 'business info page, email marketing opt-in', () => {
-
 		it( 'should not disable the continue field when opt in checkbox is not checked and email field is empty', () => {
 			props.context.businessInfo.location = 'AW';
 			props.context.onboardingProfile.is_store_country_set = true;

--- a/plugins/woocommerce-admin/client/core-profiler/pages/tests/business-info.test.tsx
+++ b/plugins/woocommerce-admin/client/core-profiler/pages/tests/business-info.test.tsx
@@ -65,6 +65,8 @@ describe( 'BusinessInfo', () => {
 			screen.getByText( /Where is your store located?/i )
 		).toBeInTheDocument();
 
+		expect( screen.getByText( /Your email address/i ) ).toBeInTheDocument();
+
 		expect(
 			screen.getByRole( 'button', {
 				name: /Continue/i,
@@ -314,19 +316,9 @@ describe( 'BusinessInfo', () => {
 		} );
 	} );
 
-	describe( 'business info page, email marketing variant', () => {
-		beforeEach( () => {
-			props.context.emailMarketingExperimentAssignment = 'treatment';
-		} );
+	describe( 'business info page, email marketing opt-in', () => {
 
-		it( 'should correctly render the experiment variant with the email field', () => {
-			render( <BusinessInfo { ...props } /> );
-			expect(
-				screen.getByText( /Your email address/i )
-			).toBeInTheDocument();
-		} );
-
-		it( 'should not disable the continue field when experiment variant is shown, opt in checkbox is not checked and email field is empty', () => {
+		it( 'should not disable the continue field when opt in checkbox is not checked and email field is empty', () => {
 			props.context.businessInfo.location = 'AW';
 			props.context.onboardingProfile.is_store_country_set = true;
 			render( <BusinessInfo { ...props } /> );
@@ -336,7 +328,7 @@ describe( 'BusinessInfo', () => {
 			expect( continueButton ).not.toBeDisabled();
 		} );
 
-		it( 'should disable the continue field when experiment variant is shown, opt in checkbox is checked and email field is empty', () => {
+		it( 'should disable the continue field when opt in checkbox is checked and email field is empty', () => {
 			props.context.businessInfo.location = 'AW';
 			props.context.onboardingProfile.is_store_country_set = true;
 			render( <BusinessInfo { ...props } /> );
@@ -350,7 +342,7 @@ describe( 'BusinessInfo', () => {
 			expect( continueButton ).toBeDisabled();
 		} );
 
-		it( 'should correctly send event with opt-in true when experiment variant is shown, opt in checkbox is checked and email field is filled', () => {
+		it( 'should correctly send event with opt-in true when opt in checkbox is checked and email field is filled', () => {
 			props.context.businessInfo.location = 'AW';
 			props.context.onboardingProfile.is_store_country_set = true;
 			render( <BusinessInfo { ...props } /> );

--- a/plugins/woocommerce/changelog/add-remove-email-marketing-experiment
+++ b/plugins/woocommerce/changelog/add-remove-email-marketing-experiment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Removed experimental code for email marketing opt in


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

Remove all code related to experimental assignment for the email marketing opt in feature as it's to be launched in WC 8.4.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Since none of the internal logic is modified, testing that the email marketing shows up on the Core Profiler Business Info page should provide sufficient confidence that there are no issues. However for a more in-depth testing, could refer to the testing instructions in https://github.com/woocommerce/woocommerce/pull/40869 and follow the 'treatment' path. The page itself is also comprehensively unit tested.

1. Set up a WooCommerce installation or use the live branch JN instance
1. Visit the core profiler 'Tell us a bit about your store' page and observe that you see the correct design in the Business Info step of the core profiler, with email field and opt-in checkbox.


![image](https://github.com/woocommerce/woocommerce/assets/27843274/7b3b086d-5b62-47ae-8394-7c4ee93c0293)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
