### PR TITLE
Fix TypeError in WC_Discounts->apply_coupons() when being called a second time [redux]

### DIFF
--- a/changelog/pr-39234
+++ b/changelog/pr-39234
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixes a `TypeError` when recalculating order coupons.

--- a/changelog/pr-39234
+++ b/changelog/pr-39234
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fixes a `TypeError` when recalculating order coupons.

--- a/plugins/woocommerce/changelog/pr-39234
+++ b/plugins/woocommerce/changelog/pr-39234
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix `TypeError` in `WC_Discounts->apply_coupons()` when being called a second time.

--- a/plugins/woocommerce/includes/class-wc-discounts.php
+++ b/plugins/woocommerce/includes/class-wc-discounts.php
@@ -7,7 +7,6 @@
  */
 
 use Automattic\WooCommerce\Utilities\NumberUtil;
-use Automattic\WooCommerce\Utilities\ArrayUtil;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/plugins/woocommerce/includes/class-wc-discounts.php
+++ b/plugins/woocommerce/includes/class-wc-discounts.php
@@ -7,7 +7,7 @@
  */
 
 use Automattic\WooCommerce\Utilities\NumberUtil;
-use Automattic\WooCommerce\Utilities\StringUtil;
+use Automattic\WooCommerce\Utilities\ArrayUtil;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -257,7 +257,7 @@ class WC_Discounts {
 		}
 
 		$coupon_code = $coupon->get_code();
-		if ( StringUtil::is_null_or_whitespace( $this->discounts[ $coupon_code ] ?? null ) ) {
+		if ( ! isset( $this->discounts[ $coupon_code ] ) || ! is_array( $this->discounts[ $coupon_code ] ) ) {
 			$this->discounts[ $coupon_code ] = array_fill_keys( array_keys( $this->items ), 0 );
 		}
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

(This is the same as #39234, which didn't pass CI for no apparent reason despite numerous attempts)

From #39234:

> This fixes an issue where a WC_Discounts class with existing discounts will fail with the following error:
> 
> ```
> Exception has occurred.
> TypeError: Automattic\WooCommerce\Utilities\StringUtil::is_null_or_empty(): Argument #1 ($value) must be of type ?string, array given, called in wp-content/plugins/woocommerce/includes/class-wc-discounts.php on line 260
> ```
> 
> This issue occurs when a `fixed_cart` discount is applied twice to an order. This isn't technically possible in the Woo interface, but this is how a project I'm working on works. It receives dynamic discounts when creating an order via an API for a user to pay for.
> 
> Upon adding a second instance of the discount with the same coupon code and calling `$order->recalculate_coupons()`, a TypeError is raised. I understand that this is a workaround, however there is still a bug in the code that should be checking for an array but is instead checking for a string.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

Run the following snippet within `wp shell` or as a mu-plugin, which should not produce any errors.

```php
// Create a test product.
$product = new \WC_Product_Simple();
$product->set_name( 'Test Product' );
$product->set_regular_price( '20.00' );
$product->save();

// Create a test coupon.
$coupon = new \WC_Coupon();
$coupon->set_code( 'test_coupon' );
$coupon->set_amount( 5.0 );
$coupon->save();

// Create a test order under the super admin user.
$order = new \WC_Order();
$order->set_customer_id( 1 );
$order->add_product( $product, 1 );

$coupon_order_item_1 = new \WC_Order_item_Coupon();
$coupon_order_item_1->set_code( 'test_coupon' );
$coupon_order_item_1->set_discount( '5.00' );

$coupon_order_item_2 = new \WC_Order_item_Coupon();
$coupon_order_item_2->set_code( 'test_coupon' );
$coupon_order_item_2->set_discount( '5.00' );

// Add two coupon line items with the same coupon code.
$order->add_item( $coupon_order_item_1 );
$order->add_item( $coupon_order_item_2 );
$order->save();

// Recalculate totals and taxes.
// ERR:
// Argument 1 passed to Automattic\WooCommerce\Utilities\StringUtil::is_null_or_whitespace() must be of the type string or null, array given,
// called in /var/www/html/wp-content/plugins/woocommerce/includes/class-wc-discounts.php on line 260
// and defined in /var/www/html/wp-content/plugins/woocommerce/src/Utilities/StringUtil.php:104
$order->recalculate_coupons();
```

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
