### PR TITLE
In-App Marketplace: record page views at the end of the `useEffect` hook

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/content/content.tsx
@@ -33,17 +33,6 @@ export default function Content(): JSX.Element {
 	// Get the content for this screen
 	useEffect( () => {
 		const abortController = new AbortController();
-		// we are recording both the new and legacy events here for now
-		// they're separate methods to make it easier to remove the legacy one later
-		const marketplaceViewProps = {
-			view: query?.tab,
-			search_term: query?.term,
-			product_type: query?.section,
-			category: query?.category,
-		};
-
-		recordMarketplaceView( marketplaceViewProps );
-		recordLegacyTabView( marketplaceViewProps );
 
 		if ( query.tab && [ '', 'discover' ].includes( query.tab ) ) {
 			return;
@@ -82,6 +71,17 @@ export default function Content(): JSX.Element {
 				setProducts( [] );
 			} )
 			.finally( () => {
+				// we are recording both the new and legacy events here for now
+				// they're separate methods to make it easier to remove the legacy one later
+				const marketplaceViewProps = {
+					view: query?.tab,
+					search_term: query?.term,
+					product_type: query?.section,
+					category: query?.category,
+				};
+
+				recordMarketplaceView( marketplaceViewProps );
+				recordLegacyTabView( marketplaceViewProps );
 				setIsLoading( false );
 			} );
 		return () => {

--- a/plugins/woocommerce/changelog/41604-update-marketplace-tracking-views
+++ b/plugins/woocommerce/changelog/41604-update-marketplace-tracking-views
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Fixes duplication of page view Tracks events in the In-App Marketplace.
+


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Moves calls to `recordMarketplaceView` and `recordLegacyTabView` to the `finally` of the `useEffect` hook in the Content component. Calling them at the top of the hook records a view for the default screen as well as the selected screen when you navigate directly to the URL for a marketplace tab like `wp-admin/admin.php?page=wc-admin&tab=themes&path=%2Fextensions`.

Related: https://github.com/woocommerce/woocommerce/pull/40951

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check out this branch and build the project.
2. Visit any WC Admin page such as `/wp-admin/admin.php?page=wc-admin` ([wp-env link](http://localhost:8888/wp-admin/admin.php?page=wc-admin)).
3. Open the browser console, the paste and run the following: `localStorage.setItem( 'debug', 'wc-admin:*' );` to allow tracks events from React to show in the console.
4. Visit the marketplace pages and see the page view events `wcadmin_marketplace_view` and `wcadmin_extensions_view` are recording correctly to the console. There should be one of each for each view of a tab in the Marketplace. Try refreshing the page when on one of the marketplace screens. Again there should be one of each view event. (See https://github.com/woocommerce/woocommerce/pull/40951 for more details about the events.) Please disgregard the `wcadmin_page_view` event, which is the standard WooCommerce Admin page view.
6. Please test around this issue

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

Fixes duplication of page view Tracks events in the In-App Marketplace.

</details>

#### Screenshots

Before, when visiting the [themes tab](http://localhost:8888/wp-admin/admin.php?page=wc-admin&tab=themes&path=%2Fextensions) directly:

<img width="500" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1647564/ab513bc5-52c3-429c-ab7f-90ddfcc198fa">

After:

<img width="500" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1647564/42d0a0af-50d2-4a9f-aaf0-da570a6570c2">


