### PR TITLE
Add several WooCommerce-related commands to the Command Palette

### DIFF
--- a/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette-analytics/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette-analytics/index.js
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import { registerPlugin } from '@wordpress/plugins';
+import { __ } from '@wordpress/i18n';
+import { chartBar } from '@wordpress/icons';
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import { useCommandWithTracking } from '../command-palette/use-command-with-tracking';
+
+const useWooCommerceAnalyticsCommand = ( { label, path } ) => {
+	useCommandWithTracking( {
+		name: `woocommerce${ path }`,
+		label,
+		icon: chartBar,
+		callback: () => {
+			document.location = addQueryArgs( 'admin.php', {
+				page: 'wc-admin',
+				path,
+			} );
+		},
+	} );
+};
+
+const WooCommerceAnalyticsCommands = () => {
+	useWooCommerceAnalyticsCommand( {
+		label: __( 'Products Analytics', 'woocommerce' ),
+		path: '/analytics/products',
+	} );
+	useWooCommerceAnalyticsCommand( {
+		label: __( 'Revenue Analytics', 'woocommerce' ),
+		path: '/analytics/revenue',
+	} );
+	useWooCommerceAnalyticsCommand( {
+		label: __( 'Orders Analytics', 'woocommerce' ),
+		path: '/analytics/orders',
+	} );
+	useWooCommerceAnalyticsCommand( {
+		label: __( 'Variations Analytics', 'woocommerce' ),
+		path: '/analytics/variations',
+	} );
+	useWooCommerceAnalyticsCommand( {
+		label: __( 'Categories Analytics', 'woocommerce' ),
+		path: '/analytics/categories',
+	} );
+	useWooCommerceAnalyticsCommand( {
+		label: __( 'Coupons Analytics', 'woocommerce' ),
+		path: '/analytics/coupons',
+	} );
+	useWooCommerceAnalyticsCommand( {
+		label: __( 'Taxes Analytics', 'woocommerce' ),
+		path: '/analytics/taxes',
+	} );
+	useWooCommerceAnalyticsCommand( {
+		label: __( 'Downloads Analytics', 'woocommerce' ),
+		path: '/analytics/downloads',
+	} );
+	useWooCommerceAnalyticsCommand( {
+		label: __( 'Stock Analytics', 'woocommerce' ),
+		path: '/analytics/stock',
+	} );
+
+	return null;
+};
+
+registerPlugin( 'woocommerce-analytics-commands-registration', {
+	render: WooCommerceAnalyticsCommands,
+} );

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette-analytics/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette-analytics/index.js
@@ -5,7 +5,6 @@ import { __, sprintf } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 import { registerPlugin } from '@wordpress/plugins';
 import { addQueryArgs } from '@wordpress/url';
-import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -40,7 +39,7 @@ const WooCommerceAnalyticsCommands = () => {
 
 		analyticsReports.forEach( ( analyticsReport ) => {
 			registerWooCommerceAnalyticsCommand( {
-				label: decodeEntities( analyticsReport.title ),
+				label: analyticsReport.title,
 				path: analyticsReport.path,
 			} );
 		} );

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette-analytics/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette-analytics/index.js
@@ -5,6 +5,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 import { registerPlugin } from '@wordpress/plugins';
 import { addQueryArgs } from '@wordpress/url';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -39,7 +40,7 @@ const WooCommerceAnalyticsCommands = () => {
 
 		analyticsReports.forEach( ( analyticsReport ) => {
 			registerWooCommerceAnalyticsCommand( {
-				label: analyticsReport.title,
+				label: decodeEntities( analyticsReport.title ),
 				path: analyticsReport.path,
 			} );
 		} );

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette-analytics/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette-analytics/index.js
@@ -1,20 +1,24 @@
 /**
  * External dependencies
  */
-import { registerPlugin } from '@wordpress/plugins';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
+import { registerPlugin } from '@wordpress/plugins';
 import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
  */
-import { useCommandWithTracking } from '../command-palette/use-command-with-tracking';
+import { registerCommandWithTracking } from '../command-palette/register-command-with-tracking';
 
-const useWooCommerceAnalyticsCommand = ( { label, path } ) => {
-	useCommandWithTracking( {
+const registerWooCommerceAnalyticsCommand = ( { label, path } ) => {
+	registerCommandWithTracking( {
 		name: `woocommerce${ path }`,
-		label,
+		label: sprintf(
+			// translators: %s is the title of the Analytics Page. This is used as a command in the Command Palette.
+			__( 'WooCommerce Analytics: %s', 'woocommerce' ),
+			label
+		),
 		icon: chartBar,
 		callback: () => {
 			document.location = addQueryArgs( 'admin.php', {
@@ -26,42 +30,20 @@ const useWooCommerceAnalyticsCommand = ( { label, path } ) => {
 };
 
 const WooCommerceAnalyticsCommands = () => {
-	useWooCommerceAnalyticsCommand( {
-		label: __( 'Products Analytics', 'woocommerce' ),
-		path: '/analytics/products',
-	} );
-	useWooCommerceAnalyticsCommand( {
-		label: __( 'Revenue Analytics', 'woocommerce' ),
-		path: '/analytics/revenue',
-	} );
-	useWooCommerceAnalyticsCommand( {
-		label: __( 'Orders Analytics', 'woocommerce' ),
-		path: '/analytics/orders',
-	} );
-	useWooCommerceAnalyticsCommand( {
-		label: __( 'Variations Analytics', 'woocommerce' ),
-		path: '/analytics/variations',
-	} );
-	useWooCommerceAnalyticsCommand( {
-		label: __( 'Categories Analytics', 'woocommerce' ),
-		path: '/analytics/categories',
-	} );
-	useWooCommerceAnalyticsCommand( {
-		label: __( 'Coupons Analytics', 'woocommerce' ),
-		path: '/analytics/coupons',
-	} );
-	useWooCommerceAnalyticsCommand( {
-		label: __( 'Taxes Analytics', 'woocommerce' ),
-		path: '/analytics/taxes',
-	} );
-	useWooCommerceAnalyticsCommand( {
-		label: __( 'Downloads Analytics', 'woocommerce' ),
-		path: '/analytics/downloads',
-	} );
-	useWooCommerceAnalyticsCommand( {
-		label: __( 'Stock Analytics', 'woocommerce' ),
-		path: '/analytics/stock',
-	} );
+	if (
+		window.hasOwnProperty( 'wcCommandPaletteAnalytics' ) &&
+		window.wcCommandPaletteAnalytics.hasOwnProperty( 'reports' ) &&
+		Array.isArray( window.wcCommandPaletteAnalytics.reports )
+	) {
+		const analyticsReports = window.wcCommandPaletteAnalytics.reports;
+
+		analyticsReports.forEach( ( analyticsReport ) => {
+			registerWooCommerceAnalyticsCommand( {
+				label: analyticsReport.title,
+				path: analyticsReport.path,
+			} );
+		} );
+	}
 
 	return null;
 };

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette/index.js
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import { useCommand } from '@wordpress/commands';
+import { registerPlugin } from '@wordpress/plugins';
+import { __ } from '@wordpress/i18n';
+import { box } from '@wordpress/icons';
+
+const WooCommerceCommands = () => {
+	useCommand( {
+		name: 'woocommere-commands-view-products',
+		label: __( 'View Products', 'woocommerce' ),
+		searchLabel: __( 'View Products', 'woocommerce' ),
+		icon: box,
+		callback: () => {
+			window.location.href = '/wp-admin/edit.php?post_type=product';
+		},
+	} );
+	return null;
+};
+
+registerPlugin( 'woocommerce-commands-registration', {
+	render: WooCommerceCommands,
+} );

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette/index.js
@@ -135,29 +135,24 @@ const WooCommerceCommands = () => {
 		name: 'woocommerce/product',
 		hook: useProductCommandLoader,
 	} );
-
 	useWooCommerceSettingsCommand( {
 		label: __( 'Products Settings', 'woocommerce' ),
 		tab: 'products',
 	} );
-
 	useWooCommerceSettingsCommand( {
 		label: __( 'Shipping Settings', 'woocommerce' ),
 		tab: 'shipping',
 	} );
-
 	useWooCommerceSettingsCommand( {
 		label: __( 'Payments Settings', 'woocommerce' ),
 		tab: 'checkout',
 	} );
-
 	useWooCommerceSettingsCommand( {
 		label: __( 'Accounts & Privacy Settings', 'woocommerce' ),
 		tab: 'account',
 	} );
-
 	useWooCommerceSettingsCommand( {
-		label: __( 'WooCommerce Email Settings', 'woocommerce' ),
+		label: __( 'WooCommerce Emails Settings', 'woocommerce' ),
 		tab: 'email',
 	} );
 

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette/index.js
@@ -1,21 +1,166 @@
 /**
  * External dependencies
  */
-import { useCommand } from '@wordpress/commands';
+import { useCommandLoader } from '@wordpress/commands';
 import { registerPlugin } from '@wordpress/plugins';
 import { __ } from '@wordpress/i18n';
-import { box } from '@wordpress/icons';
+import { box, plus, settings } from '@wordpress/icons';
+import { useMemo } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { addQueryArgs } from '@wordpress/url';
+import { queueRecordEvent } from '@woocommerce/tracks';
 
-const WooCommerceCommands = () => {
-	useCommand( {
-		name: 'woocommere-commands-view-products',
-		label: __( 'View Products', 'woocommerce' ),
-		searchLabel: __( 'View Products', 'woocommerce' ),
-		icon: box,
+/**
+ * Internal dependencies
+ */
+import { useCommandWithTracking } from './use-command-with-tracking';
+
+const useWooCommerceSettingsCommand = ( { label, tab } ) => {
+	useCommandWithTracking( {
+		name: `woocommerce/settings-${ tab }`,
+		label,
+		icon: settings,
 		callback: () => {
-			window.location.href = '/wp-admin/edit.php?post_type=product';
+			document.location = addQueryArgs( 'admin.php', {
+				page: 'wc-settings',
+				tab,
+			} );
 		},
 	} );
+};
+
+// Code adapted from the equivalent in Gutenberg:
+// https://github.com/WordPress/gutenberg/blob/8863b49b7e686f555e8b8adf70cc588c4feebfbf/packages/core-commands/src/site-editor-navigation-commands.js#L36C7-L36C44
+function useProductCommandLoader( { search } ) {
+	const postType = 'product';
+	const { records, isLoading } = useSelect(
+		( select ) => {
+			const { getEntityRecords } = select( coreStore );
+			const query = {
+				search: !! search ? search : undefined,
+				per_page: 10,
+				orderby: search ? 'relevance' : 'date',
+				status: [ 'publish', 'future', 'draft', 'pending', 'private' ],
+			};
+			return {
+				records: getEntityRecords( 'postType', postType, query ),
+				isLoading: ! select( coreStore ).hasFinishedResolution(
+					'getEntityRecords',
+					[ 'postType', postType, query ]
+				),
+			};
+		},
+		[ search ]
+	);
+
+	const commands = useMemo( () => {
+		return ( records ?? [] ).map( ( record ) => {
+			const command = {
+				name: postType + '-' + record.id,
+				searchLabel: record.title?.rendered + ' ' + record.id,
+				label: record.title?.rendered
+					? record.title?.rendered
+					: __( '(no title)', 'woocommerce' ),
+				icon: box,
+			};
+			return {
+				...command,
+				callback: ( { close } ) => {
+					queueRecordEvent( 'woocommerce_command_palette_submit', {
+						name: 'woocommerce/product',
+					} );
+
+					const args = {
+						post: record.id,
+						action: 'edit',
+					};
+					const targetUrl = addQueryArgs( 'post.php', args );
+					document.location = targetUrl;
+					close();
+				},
+			};
+		} );
+	}, [ records ] );
+
+	return {
+		commands,
+		isLoading,
+	};
+}
+
+const WooCommerceCommands = () => {
+	useCommandWithTracking( {
+		name: 'woocommerce/add-new-product',
+		label: __( 'Add new product', 'woocommerce' ),
+		icon: plus,
+		callback: () => {
+			document.location = addQueryArgs( 'post-new.php', {
+				post_type: 'product',
+			} );
+		},
+	} );
+	useCommandWithTracking( {
+		name: 'woocommerce/add-new-order',
+		label: __( 'Add new order', 'woocommerce' ),
+		icon: plus,
+		callback: () => {
+			document.location = addQueryArgs( 'admin.php', {
+				page: 'wc-orders',
+				action: 'new',
+			} );
+		},
+	} );
+	useCommandWithTracking( {
+		name: 'woocommerce/view-products',
+		label: __( 'Products', 'woocommerce' ),
+		icon: box,
+		callback: () => {
+			document.location = addQueryArgs( 'edit.php', {
+				post_type: 'product',
+			} );
+		},
+	} );
+	useCommandWithTracking( {
+		name: 'woocommerce/view-orders',
+		label: __( 'Orders', 'woocommerce' ),
+		icon: box,
+		callback: () => {
+			document.location = addQueryArgs( 'admin.php', {
+				page: 'wc-orders',
+			} );
+		},
+	} );
+	useCommandLoader( {
+		name: 'woocommerce/product',
+		hook: useProductCommandLoader,
+	} );
+
+	useWooCommerceSettingsCommand( {
+		label: __( 'Products Settings', 'woocommerce' ),
+		tab: 'products',
+	} );
+
+	useWooCommerceSettingsCommand( {
+		label: __( 'Shipping Settings', 'woocommerce' ),
+		tab: 'shipping',
+	} );
+
+	useWooCommerceSettingsCommand( {
+		label: __( 'Payments Settings', 'woocommerce' ),
+		tab: 'checkout',
+	} );
+
+	useWooCommerceSettingsCommand( {
+		label: __( 'Accounts & Privacy Settings', 'woocommerce' ),
+		tab: 'account',
+	} );
+
+	useWooCommerceSettingsCommand( {
+		label: __( 'WooCommerce Email Settings', 'woocommerce' ),
+		tab: 'email',
+	} );
+
 	return null;
 };
 

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette/index.js
@@ -10,6 +10,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { addQueryArgs } from '@wordpress/url';
 import { queueRecordEvent } from '@woocommerce/tracks';
 import { store as commandsStore } from '@wordpress/commands';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -149,7 +150,7 @@ const WooCommerceCommands = () => {
 
 		settingsCommands.forEach( ( settingsCommand ) => {
 			registerWooCommerceSettingsCommand( {
-				label: settingsCommand.label,
+				label: decodeEntities( settingsCommand.label ),
 				tab: settingsCommand.key,
 			} );
 		} );

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette/index.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette/index.js
@@ -65,7 +65,7 @@ function useProductCommandLoader( { search } ) {
 				name: postType + '-' + record.id,
 				searchLabel: record.title?.rendered + ' ' + record.id,
 				label: record.title?.rendered
-					? record.title?.rendered
+					? decodeEntities( record.title?.rendered )
 					: __( '(no title)', 'woocommerce' ),
 				icon: box,
 			};
@@ -150,7 +150,7 @@ const WooCommerceCommands = () => {
 
 		settingsCommands.forEach( ( settingsCommand ) => {
 			registerWooCommerceSettingsCommand( {
-				label: decodeEntities( settingsCommand.label ),
+				label: settingsCommand.label,
 				tab: settingsCommand.key,
 			} );
 		} );

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette/register-command-with-tracking.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette/register-command-with-tracking.js
@@ -1,11 +1,17 @@
 /**
  * External dependencies
  */
-import { useCommand } from '@wordpress/commands';
+import { store as commandsStore } from '@wordpress/commands';
+import { dispatch } from '@wordpress/data';
 import { queueRecordEvent } from '@woocommerce/tracks';
 
-export const useCommandWithTracking = ( { name, label, icon, callback } ) => {
-	useCommand( {
+export const registerCommandWithTracking = ( {
+	name,
+	label,
+	icon,
+	callback,
+} ) => {
+	dispatch( commandsStore ).registerCommand( {
 		name,
 		label,
 		icon,

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette/register-command-with-tracking.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette/register-command-with-tracking.js
@@ -4,6 +4,7 @@
 import { store as commandsStore } from '@wordpress/commands';
 import { dispatch } from '@wordpress/data';
 import { queueRecordEvent } from '@woocommerce/tracks';
+import { decodeEntities } from '@wordpress/html-entities';
 
 export const registerCommandWithTracking = ( {
 	name,
@@ -13,7 +14,7 @@ export const registerCommandWithTracking = ( {
 } ) => {
 	dispatch( commandsStore ).registerCommand( {
 		name,
-		label,
+		label: decodeEntities( label ),
 		icon,
 		callback: ( ...args ) => {
 			queueRecordEvent( 'woocommerce_command_palette_submit', {

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette/use-command-with-tracking.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/command-palette/use-command-with-tracking.js
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import { useCommand } from '@wordpress/commands';
+import { queueRecordEvent } from '@woocommerce/tracks';
+
+export const useCommandWithTracking = ( { name, label, icon, callback } ) => {
+	useCommand( {
+		name,
+		label,
+		icon,
+		callback: ( ...args ) => {
+			queueRecordEvent( 'woocommerce_command_palette_submit', {
+				name,
+			} );
+
+			callback( ...args );
+		},
+	} );
+};

--- a/plugins/woocommerce-admin/webpack.config.js
+++ b/plugins/woocommerce-admin/webpack.config.js
@@ -71,6 +71,7 @@ const wpAdminScripts = [
 	'variable-product-tour',
 	'product-category-metabox',
 	'shipping-settings-region-picker',
+	'command-palette',
 ];
 const getEntryPoints = () => {
 	const entryPoints = {

--- a/plugins/woocommerce-admin/webpack.config.js
+++ b/plugins/woocommerce-admin/webpack.config.js
@@ -72,6 +72,7 @@ const wpAdminScripts = [
 	'product-category-metabox',
 	'shipping-settings-region-picker',
 	'command-palette',
+	'command-palette-analytics',
 ];
 const getEntryPoints = () => {
 	const entryPoints = {

--- a/plugins/woocommerce/changelog/41605-add-command-palette-commands
+++ b/plugins/woocommerce/changelog/41605-add-command-palette-commands
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add several WooCommerce-related commands to the Command Palette

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -8,6 +8,7 @@
 
 use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Admin\Features\Features;
+use Automattic\WooCommerce\Internal\Admin\Analytics;
 use Automattic\WooCommerce\Internal\Admin\WCAdminAssets;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -561,10 +562,47 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 		 * @return void
 		 */
 		public function enqueue_block_editor_assets() {
-			WCAdminAssets::register_script( 'wp-admin-scripts', 'command-palette' );
+			$settings_tabs = apply_filters('woocommerce_settings_tabs_array', []);
+
+			if ( is_array( $settings_tabs ) && count( $settings_tabs ) > 0  ) {
+				$formatted_settings_tabs = array();
+				foreach ($settings_tabs as $key => $label) {
+					$formatted_settings_tabs[] = array(
+						'key'   => is_string( $key ) ? $key : '',
+						'label' => is_string( $label ) ? $label : '',
+					);
+				}
+
+				WCAdminAssets::register_script( 'wp-admin-scripts', 'command-palette' );
+				wp_localize_script(
+					'wc-admin-command-palette',
+					'wcCommandPaletteSettings',
+					array(
+						'settingsTabs'    => $formatted_settings_tabs,
+					)
+				);
+			}
+
 			$admin_features_disabled = apply_filters( 'woocommerce_admin_disabled', false );
 			if ( ! $admin_features_disabled ) {
-				WCAdminAssets::register_script( 'wp-admin-scripts', 'command-palette-analytics' );
+				$analytics_reports = Analytics::get_report_pages();
+				if ( is_array( $analytics_reports ) && count( $analytics_reports ) > 0 ) {
+					$formatted_analytics_reports = array_map( function( $report ) {
+						return array(
+							'title' => is_string( $report['title'] ) ? $report['title']: '' ,
+							'path' => is_string( $report['path'] ) ? $report['path']: '',
+						);
+					}, $analytics_reports );
+
+					WCAdminAssets::register_script( 'wp-admin-scripts', 'command-palette-analytics' );
+					wp_localize_script(
+						'wc-admin-command-palette-analytics',
+						'wcCommandPaletteAnalytics',
+						array(
+							'reports'    => $formatted_analytics_reports,
+						)
+					);
+				}
 			}
 		}
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -27,6 +27,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 		public function __construct() {
 			add_action( 'admin_enqueue_scripts', array( $this, 'admin_styles' ) );
 			add_action( 'admin_enqueue_scripts', array( $this, 'admin_scripts' ) );
+			add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ) );
 		}
 
 		/**
@@ -552,6 +553,15 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 				);
 				wp_enqueue_script( 'marketplace-suggestions' );
 			}
+		}
+
+		/**
+		 * Enqueue block editor assets.
+		 *
+		 * @return void
+		 */
+		public function enqueue_block_editor_assets() {
+			WCAdminAssets::register_script( 'wp-admin-scripts', 'command-palette' );
 		}
 
 		/**

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -562,6 +562,10 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 		 */
 		public function enqueue_block_editor_assets() {
 			WCAdminAssets::register_script( 'wp-admin-scripts', 'command-palette' );
+			$admin_features_disabled = apply_filters( 'woocommerce_admin_disabled', false );
+			if ( ! $admin_features_disabled ) {
+				WCAdminAssets::register_script( 'wp-admin-scripts', 'command-palette-analytics' );
+			}
 		}
 
 		/**

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/command-palette.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/command-palette.spec.js
@@ -84,7 +84,6 @@ test.describe( 'Use Command Palette commands', () => {
 			page,
 			optionName: 'Add new product',
 		} );
-		await page.waitForLoadState( 'networkidle' );
 
 		// Verify that the page has loaded.
 		await expect(
@@ -99,7 +98,6 @@ test.describe( 'Use Command Palette commands', () => {
 			page,
 			optionName: 'Add new order',
 		} );
-		await page.waitForLoadState( 'networkidle' );
 
 		// Verify that the page has loaded.
 		await expect(
@@ -114,7 +112,6 @@ test.describe( 'Use Command Palette commands', () => {
 			page,
 			optionName: 'Products',
 		} );
-		await page.waitForLoadState( 'networkidle' );
 
 		// Verify that the page has loaded.
 		await expect(
@@ -129,7 +126,6 @@ test.describe( 'Use Command Palette commands', () => {
 			page,
 			optionName: 'Orders',
 		} );
-		await page.waitForLoadState( 'networkidle' );
 
 		// Verify that the page has loaded.
 		await expect(
@@ -144,7 +140,6 @@ test.describe( 'Use Command Palette commands', () => {
 			page,
 			optionName: 'Product to search',
 		} );
-		await page.waitForLoadState( 'networkidle' );
 
 		// Verify that the page has loaded.
 		await expect( page.getByLabel( 'Product name' ) ).toHaveValue(
@@ -159,7 +154,6 @@ test.describe( 'Use Command Palette commands', () => {
 			page,
 			optionName: 'Products Settings',
 		} );
-		await page.waitForLoadState( 'networkidle' );
 
 		// Verify that the page has loaded.
 		await expect( page.getByText( 'Shop pages' ) ).toBeVisible();
@@ -172,9 +166,11 @@ test.describe( 'Use Command Palette commands', () => {
 			page,
 			optionName: 'Products Analytics',
 		} );
-		await page.waitForLoadState( 'networkidle' );
 
 		// Verify that the page has loaded.
+		await expect(
+			page.locator( 'h1' ).filter( { hasText: 'Products' } )
+		).toBeVisible();
 		const pageTitle = await page.title();
 		expect( pageTitle.includes( 'Products ‹ Analytics' ) ).toBeTruthy();
 	} );

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/command-palette.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/command-palette.spec.js
@@ -27,7 +27,6 @@ const goToPostEditor = async ( { page } ) => {
 	}
 };
 
-// Locate input field with label "Command palette".
 const clickOnCommandPaletteOption = async ( { page, optionName } ) => {
 	// Press `Ctrl` + `K` to open the command palette.
 	await page.keyboard.press( 'Control+K' );
@@ -81,7 +80,6 @@ test.describe( 'Use Command Palette commands', () => {
 	test( 'can use the "Add new product" command', async ( { page } ) => {
 		await goToPostEditor( { page } );
 
-		// Click on command palette option.
 		await clickOnCommandPaletteOption( {
 			page,
 			optionName: 'Add new product',
@@ -97,7 +95,6 @@ test.describe( 'Use Command Palette commands', () => {
 	test( 'can use the "Add new order" command', async ( { page } ) => {
 		await goToPostEditor( { page } );
 
-		// Click on command palette option.
 		await clickOnCommandPaletteOption( {
 			page,
 			optionName: 'Add new order',
@@ -113,7 +110,6 @@ test.describe( 'Use Command Palette commands', () => {
 	test( 'can use the "Products" command', async ( { page } ) => {
 		await goToPostEditor( { page } );
 
-		// Click on command palette option.
 		await clickOnCommandPaletteOption( {
 			page,
 			optionName: 'Products',
@@ -129,7 +125,6 @@ test.describe( 'Use Command Palette commands', () => {
 	test( 'can use the "Orders" command', async ( { page } ) => {
 		await goToPostEditor( { page } );
 
-		// Click on command palette option.
 		await clickOnCommandPaletteOption( {
 			page,
 			optionName: 'Orders',
@@ -145,7 +140,6 @@ test.describe( 'Use Command Palette commands', () => {
 	test( 'can use the product search command', async ( { page } ) => {
 		await goToPostEditor( { page } );
 
-		// Click on command palette option.
 		await clickOnCommandPaletteOption( {
 			page,
 			optionName: 'Product to search',
@@ -161,7 +155,6 @@ test.describe( 'Use Command Palette commands', () => {
 	test( 'can use a settings command', async ( { page } ) => {
 		await goToPostEditor( { page } );
 
-		// Click on command palette option.
 		await clickOnCommandPaletteOption( {
 			page,
 			optionName: 'Products Settings',
@@ -175,7 +168,6 @@ test.describe( 'Use Command Palette commands', () => {
 	test( 'can use an analytics command', async ( { page } ) => {
 		await goToPostEditor( { page } );
 
-		// Click on command palette option.
 		await clickOnCommandPaletteOption( {
 			page,
 			optionName: 'Products Analytics',

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/command-palette.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/command-palette.spec.js
@@ -152,7 +152,7 @@ test.describe( 'Use Command Palette commands', () => {
 
 		await clickOnCommandPaletteOption( {
 			page,
-			optionName: 'Products Settings',
+			optionName: 'WooCommerce Settings: Products',
 		} );
 
 		// Verify that the page has loaded.
@@ -164,7 +164,7 @@ test.describe( 'Use Command Palette commands', () => {
 
 		await clickOnCommandPaletteOption( {
 			page,
-			optionName: 'Products Analytics',
+			optionName: 'WooCommerce Analytics: Products',
 		} );
 
 		// Verify that the page has loaded.

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/command-palette.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/command-palette.spec.js
@@ -1,0 +1,189 @@
+const { test, expect } = require( '@playwright/test' );
+const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
+
+const goToPostEditor = async ( { page } ) => {
+	await page.goto( 'wp-admin/post-new.php' );
+
+	const welcomeModalVisible =
+		await test.step( 'Check if the Welcome modal appeared', async () => {
+			return await page
+				.getByRole( 'heading', {
+					name: 'Welcome to the block editor',
+				} )
+				.isVisible();
+		} );
+
+	if ( welcomeModalVisible ) {
+		await test.step( 'Welcome modal appeared. Close it.', async () => {
+			await page
+				.getByRole( 'document' )
+				.getByRole( 'button', { name: 'Close' } )
+				.click();
+		} );
+	} else {
+		await test.step( 'Welcome modal did not appear.', async () => {
+			// do nothing.
+		} );
+	}
+};
+
+// Locate input field with label "Command palette".
+const clickOnCommandPaletteOption = async ( { page, optionName } ) => {
+	// Press `Ctrl` + `K` to open the command palette.
+	await page.keyboard.press( 'Control+K' );
+
+	await page.getByLabel( 'Command palette' ).fill( optionName );
+
+	// Click on the relevant option.
+	const option = page.getByRole( 'option', {
+		name: optionName,
+		exact: true,
+	} );
+	await expect( option ).toBeVisible();
+	option.click();
+};
+
+test.describe( 'Use Command Palette commands', () => {
+	test.use( { storageState: process.env.ADMINSTATE } );
+
+	let productId;
+
+	test.beforeAll( async ( { baseURL } ) => {
+		const api = new wcApi( {
+			url: baseURL,
+			consumerKey: process.env.CONSUMER_KEY,
+			consumerSecret: process.env.CONSUMER_SECRET,
+			version: 'wc/v3',
+		} );
+		await api
+			.post( 'products', {
+				name: 'Product to search',
+				type: 'simple',
+				regular_price: '12.99',
+			} )
+			.then( ( response ) => {
+				productId = response.data.id;
+			} );
+	} );
+
+	test.afterAll( async ( { baseURL } ) => {
+		const api = new wcApi( {
+			url: baseURL,
+			consumerKey: process.env.CONSUMER_KEY,
+			consumerSecret: process.env.CONSUMER_SECRET,
+			version: 'wc/v3',
+		} );
+		await api.delete( `products/${ productId }`, {
+			force: true,
+		} );
+	} );
+
+	test( 'can use the "Add new product" command', async ( { page } ) => {
+		await goToPostEditor( { page } );
+
+		// Click on command palette option.
+		await clickOnCommandPaletteOption( {
+			page,
+			optionName: 'Add new product',
+		} );
+		await page.waitForLoadState( 'networkidle' );
+
+		// Verify that the page has loaded.
+		await expect(
+			page.getByRole( 'heading', { name: 'Add new product' } )
+		).toBeVisible();
+	} );
+
+	test( 'can use the "Add new order" command', async ( { page } ) => {
+		await goToPostEditor( { page } );
+
+		// Click on command palette option.
+		await clickOnCommandPaletteOption( {
+			page,
+			optionName: 'Add new order',
+		} );
+		await page.waitForLoadState( 'networkidle' );
+
+		// Verify that the page has loaded.
+		await expect(
+			page.getByRole( 'heading', { name: 'Add new order' } )
+		).toBeVisible();
+	} );
+
+	test( 'can use the "Products" command', async ( { page } ) => {
+		await goToPostEditor( { page } );
+
+		// Click on command palette option.
+		await clickOnCommandPaletteOption( {
+			page,
+			optionName: 'Products',
+		} );
+		await page.waitForLoadState( 'networkidle' );
+
+		// Verify that the page has loaded.
+		await expect(
+			page.locator( 'h1' ).filter( { hasText: 'Products' } ).first()
+		).toBeVisible();
+	} );
+
+	test( 'can use the "Orders" command', async ( { page } ) => {
+		await goToPostEditor( { page } );
+
+		// Click on command palette option.
+		await clickOnCommandPaletteOption( {
+			page,
+			optionName: 'Orders',
+		} );
+		await page.waitForLoadState( 'networkidle' );
+
+		// Verify that the page has loaded.
+		await expect(
+			page.locator( 'h1' ).filter( { hasText: 'Orders' } ).first()
+		).toBeVisible();
+	} );
+
+	test( 'can use the product search command', async ( { page } ) => {
+		await goToPostEditor( { page } );
+
+		// Click on command palette option.
+		await clickOnCommandPaletteOption( {
+			page,
+			optionName: 'Product to search',
+		} );
+		await page.waitForLoadState( 'networkidle' );
+
+		// Verify that the page has loaded.
+		await expect( page.getByLabel( 'Product name' ) ).toHaveValue(
+			'Product to search'
+		);
+	} );
+
+	test( 'can use a settings command', async ( { page } ) => {
+		await goToPostEditor( { page } );
+
+		// Click on command palette option.
+		await clickOnCommandPaletteOption( {
+			page,
+			optionName: 'Products Settings',
+		} );
+		await page.waitForLoadState( 'networkidle' );
+
+		// Verify that the page has loaded.
+		await expect( page.getByText( 'Shop pages' ) ).toBeVisible();
+	} );
+
+	test( 'can use an analytics command', async ( { page } ) => {
+		await goToPostEditor( { page } );
+
+		// Click on command palette option.
+		await clickOnCommandPaletteOption( {
+			page,
+			optionName: 'Products Analytics',
+		} );
+		await page.waitForLoadState( 'networkidle' );
+
+		// Verify that the page has loaded.
+		const pageTitle = await page.title();
+		expect( pageTitle.includes( 'Products ‹ Analytics' ) ).toBeTruthy();
+	} );
+} );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Based on https://github.com/woocommerce/woocommerce/pull/39268.

This PR adds several WooCommmerce-related commands to the Command Palette. See https://github.com/woocommerce/woocommerce/discussions/41472 for the discussion about which commands to add.

<img src="https://github.com/woocommerce/woocommerce/assets/3616980/2db0718c-b18c-4629-b7b3-f0dd09fcd745" alt="Command Palette showing WooCommerce-related options after searching with the keyword 'products'" width="520" />

Closes https://github.com/woocommerce/woocommerce-blocks/issues/11521.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

0. To test tracking, open the browser console (<kbd>F12</kbd>) and run `localStorage.setItem( 'debug', 'wc-admin:*' );`.
1. Go to the post editor (Posts > Add New).
2. Press <kbd>Ctrl</kbd>+<kbd>K</kbd> to open the Command Palette.
3. For each of the commands listed below, write the command in the Command Palette input field and click on the command option that appears below.
4. Make sure there is at least one result for each command and, when clicking on it, it redirects to the correct page. Test also that tracking works: in the browser console (<kbd>F12</kbd>) you will see an entre like `wc-admin:tracks recordevent wcadmin_woocommerce_command_palette_submit ...`.

Command | Expected redirect
--- | ---
Add new product | `/wp-admin/post-new.php?post_type=product`
Add new order | `/wp-admin/admin.php?page=wc-orders&action=new`
Products | `/wp-admin/edit.php?post_type=product`
Orders | `/wp-admin/admin.php?page=wc-orders`
<product_name> (ie: `Hoodie`) | <product_edit_url> (ie: `/wp-admin/post.php?post=15&action=edit`)
WooCommerce Settings: Products | `/wp-admin/admin.php?page=wc-settings&tab=products`
WooCommerce Settings: Shipping | `/wp-admin/admin.php?page=wc-settings&tab=shipping`
WooCommerce Settings: Payments | `/wp-admin/admin.php?page=wc-settings&tab=checkout`
WooCommerce Settings: Accounts & Privacy | `/wp-admin/admin.php?page=wc-settings&tab=account`
WooCommerce Settings: WooCommerce Emails | `/wp-admin/admin.php?page=wc-settings&tab=email`
WooCommerce Analytics: Products | `/wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Fproducts`
WooCommerce Analytics: Revenue | `/wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Frevenue`
WooCommerce Analytics: Orders | `/wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Forders`
WooCommerce Analytics: Variations | `/wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Fvariations`
WooCommerce Analytics: Categories | `/wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Fcategories`
WooCommerce Analytics: Coupons | `/wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Fcoupons`
WooCommerce Analytics: Taxes | `/wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Ftaxes`
WooCommerce Analytics: Downloads | `/wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Fdownloads`
WooCommerce Analytics: Stock | `/wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Fstock`


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Add several WooCommerce-related commands to the Command Palette

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
