### PR TITLE
Update WooCommerce Blocks to 11.4.9

### DIFF
--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-11.4.9
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-11.4.9
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Update WooCommerce Blocks to 11.4.9

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -23,7 +23,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.6.4",
-		"woocommerce/woocommerce-blocks": "11.4.8"
+		"woocommerce/woocommerce-blocks": "11.4.9"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.3.0",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b66f0c116f87680df45402a303db6f40",
+    "content-hash": "2d4db689c5af5edbed15ffb53d752898",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1004,16 +1004,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "11.4.8",
+            "version": "11.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "ab8ddb68949ef2189f3ac608947e8c66b3cda9a1"
+                "reference": "183f091a74c626a528c79f109672eea22dca31b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/ab8ddb68949ef2189f3ac608947e8c66b3cda9a1",
-                "reference": "ab8ddb68949ef2189f3ac608947e8c66b3cda9a1",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/183f091a74c626a528c79f109672eea22dca31b2",
+                "reference": "183f091a74c626a528c79f109672eea22dca31b2",
                 "shasum": ""
             },
             "require": {
@@ -1064,9 +1064,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v11.4.8"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v11.4.9"
             },
-            "time": "2023-11-13T07:21:06+00:00"
+            "time": "2023-11-21T16:45:25+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This pull updates the WooCommerce Blocks plugin to 11.4.9

#### Blocks 11.4.9

- Release PR: https://github.com/woocommerce/woocommerce-blocks/pull/11863
- Release post: n/a
- Testing instructions: https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/1149.md

The following changelog entry is only that impact existing blocks and functionality surfaced to users:

#### Bug fixes

- Fixed params passed to woocommerce_before_thankyou for block checkout. This should be an order ID, not an order object. (https://github.com/woocommerce/woocommerce-blocks/pull/11862)
- Enhance validation for limited use coupons and guest users. (https://github.com/woocommerce/woocommerce-blocks/pull/11860)

### Changelog entry

> Dev - Update WooCommerce Blocks version to 11.4.9