### PR TITLE
We won’t append a unique string to the filename if the settings are configured to do so

### DIFF
--- a/packages/js/product-editor/changelog/add-41510
+++ b/packages/js/product-editor/changelog/add-41510
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+append a unique string to the filename if the settings are configured to do so

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/downloads-menu/downloads-menu.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/downloads-menu/downloads-menu.tsx
@@ -10,13 +10,11 @@ import { chevronDown, chevronUp } from '@wordpress/icons';
  * Internal dependencies
  */
 import { DownloadsMenuProps } from './types';
-import { UploadFilesMenuItem } from '../upload-files-menu-item';
 import { MediaLibraryMenuItem } from '../media-library-menu-item';
 import { InsertUrlMenuItem } from '../insert-url-menu-item';
 
 export function DownloadsMenu( {
 	allowedTypes,
-	maxUploadFileSize,
 	onUploadSuccess,
 	onUploadError,
 }: DownloadsMenuProps ) {
@@ -38,16 +36,6 @@ export function DownloadsMenu( {
 			renderContent={ ( { onClose } ) => (
 				<div className="components-dropdown-menu__menu">
 					<MenuGroup>
-						<UploadFilesMenuItem
-							allowedTypes={ allowedTypes }
-							maxUploadFileSize={ maxUploadFileSize }
-							onUploadSuccess={ ( files ) => {
-								onUploadSuccess( files );
-								onClose();
-							} }
-							onUploadError={ onUploadError }
-						/>
-
 						<MediaLibraryMenuItem
 							allowedTypes={ allowedTypes }
 							onUploadSuccess={ ( files ) => {

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/edit-downloads-modal/edit-downloads-modal.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/edit-downloads-modal/edit-downloads-modal.tsx
@@ -1,17 +1,14 @@
 /**
  * External dependencies
  */
-import { ChangeEvent } from 'react';
 import { __, sprintf } from '@wordpress/i18n';
 import { createElement, useState } from '@wordpress/element';
 import { trash } from '@wordpress/icons';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { ImageGallery, ImageGalleryItem } from '@woocommerce/components';
-import { uploadMedia } from '@wordpress/media-utils';
 import {
 	Button,
-	FormFileUpload,
 	Modal,
 	BaseControl,
 	// @ts-expect-error `__experimentalInputControl` does exist.
@@ -34,28 +31,14 @@ export interface Image {
 
 export const EditDownloadsModal: React.FC< EditDownloadsModalProps > = ( {
 	downloableItem,
-	maxUploadFileSize = 10000000,
 	onCancel,
 	onChange,
 	onRemove,
 	onSave,
-	onUploadSuccess,
-	onUploadError,
 } ) => {
 	const { createNotice } = useDispatch( 'core/notices' );
 	const [ isCopingToClipboard, setIsCopingToClipboard ] =
 		useState< boolean >( false );
-	const [ isFileUploading, setIsFileUploading ] =
-		useState< boolean >( false );
-
-	const { allowedMimeTypes } = useSelect( ( select ) => {
-		const { getEditorSettings } = select( 'core/editor' );
-		return getEditorSettings();
-	} );
-
-	const allowedTypes = allowedMimeTypes
-		? Object.values( allowedMimeTypes )
-		: [];
 
 	const { id = 0, file = '', name = '' } = downloableItem;
 
@@ -96,21 +79,6 @@ export const EditDownloadsModal: React.FC< EditDownloadsModalProps > = ( {
 		setIsCopingToClipboard( false );
 	}
 
-	async function handleFormFileUploadChange(
-		event: ChangeEvent< HTMLInputElement >
-	) {
-		setIsFileUploading( true );
-		const filesList = event.currentTarget.files as FileList;
-		await uploadMedia( {
-			allowedTypes,
-			filesList,
-			maxUploadFileSize,
-			onFileChange: onUploadSuccess,
-			onError: onUploadError,
-		} );
-		setIsFileUploading( false );
-	}
-
 	return (
 		<Modal
 			title={ sprintf(
@@ -145,21 +113,10 @@ export const EditDownloadsModal: React.FC< EditDownloadsModalProps > = ( {
 						<DownloadsCustomImage />
 					) }
 				</ImageGallery>
-				<FormFileUpload
-					onChange={ handleFormFileUploadChange }
-					render={ ( { openFileDialog } ) => (
-						<div>
-							<p>{ name }</p>
-							<Button
-								onClick={ openFileDialog }
-								isBusy={ isFileUploading }
-								disabled={ isFileUploading }
-							>
-								{ __( 'Replace', 'woocommerce' ) }
-							</Button>
-						</div>
-					) }
-				/>
+
+				<div className="components-form-file-upload">
+					<p>{ name }</p>
+				</div>
 			</div>
 			<BaseControl
 				id={ 'file-name-help' }

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/edit.tsx
@@ -13,7 +13,7 @@ import {
 import { closeSmall } from '@wordpress/icons';
 import { MediaItem } from '@wordpress/media-utils';
 import { useWooBlockProps } from '@woocommerce/block-templates';
-import { ListItem, MediaUploader, Sortable } from '@woocommerce/components';
+import { ListItem, Sortable } from '@woocommerce/components';
 import { Product, ProductDownload } from '@woocommerce/data';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore No types for this exist yet.
@@ -24,7 +24,6 @@ import { useEntityProp } from '@wordpress/core-data';
  * Internal dependencies
  */
 import { UploadsBlockAttributes } from './types';
-import { UploadImage } from './upload-image';
 import { DownloadsMenu } from './downloads-menu';
 import { ProductEditorBlockEditProps } from '../../../types';
 import {
@@ -250,50 +249,36 @@ export function Edit( {
 			</div>
 
 			<div className="wp-block-woocommerce-product-downloads-field__body">
-				<MediaUploader
-					label={
-						! Boolean( downloads.length ) ? (
-							<div className="wp-block-woocommerce-product-downloads-field__drop-zone-content">
-								<UploadImage />
-								<p className="wp-block-woocommerce-product-downloads-field__drop-zone-label">
-									{ createInterpolateElement(
-										__(
-											'Supported file types: <Types /> and more. <link>View all</link>',
-											'woocommerce'
-										),
-										{
-											Types: (
-												<Fragment>
-													PNG, JPG, PDF, PPT, DOC,
-													MP3, MP4
-												</Fragment>
-											),
-											link: (
-												// eslint-disable-next-line jsx-a11y/anchor-has-content
-												<a
-													href="https://codex.wordpress.org/Uploading_Files"
-													target="_blank"
-													rel="noreferrer"
-													onClick={ ( event ) =>
-														event.stopPropagation()
-													}
-												/>
-											),
-										}
-									) }
-								</p>
-							</div>
-						) : (
-							''
-						)
-					}
-					buttonText=""
-					allowedMediaTypes={ allowedTypes }
-					multipleSelect={ 'add' }
-					onUpload={ handleFileUpload }
-					onFileUploadChange={ handleFileUpload }
-					onError={ handleUploadError }
-				/>
+				{ ! Boolean( downloads.length ) && (
+					<div className="wp-block-woocommerce-product-downloads-field__drop-zone-content">
+						<p className="wp-block-woocommerce-product-downloads-field__drop-zone-label">
+							{ createInterpolateElement(
+								__(
+									'Supported file types: <Types /> and more. <link>View all</link>',
+									'woocommerce'
+								),
+								{
+									Types: (
+										<Fragment>
+											PNG, JPG, PDF, PPT, DOC, MP3, MP4
+										</Fragment>
+									),
+									link: (
+										// eslint-disable-next-line jsx-a11y/anchor-has-content
+										<a
+											href="https://codex.wordpress.org/Uploading_Files"
+											target="_blank"
+											rel="noreferrer"
+											onClick={ ( event ) =>
+												event.stopPropagation()
+											}
+										/>
+									),
+								}
+							) }
+						</p>
+					</div>
+				) }
 
 				{ Boolean( downloads.length ) && (
 					<Sortable className="wp-block-woocommerce-product-downloads-field__table">

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/media-library-menu-item/media-library-menu-item.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/media-library-menu-item/media-library-menu-item.tsx
@@ -1,17 +1,17 @@
 /**
  * External dependencies
  */
-
 import { MenuItem } from '@wordpress/components';
 import { createElement, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { media } from '@wordpress/icons';
-import { MediaItem, MediaUpload } from '@wordpress/media-utils';
+import { MediaItem } from '@wordpress/media-utils';
 
 /**
  * Internal dependencies
  */
 import { MediaLibraryMenuItemProps } from './types';
+import { MediaLibrary } from '../media-library';
 
 const MODAL_CLASS_NAME =
 	'woocommerce-media-library-menu-item__upload_files_modal';
@@ -39,8 +39,8 @@ export function MediaLibraryMenuItem( {
 		[ uploadFilesModalOpen ]
 	);
 
-	function handleMediaUploadSelect( value: unknown ) {
-		onUploadSuccess( value as MediaItem[] );
+	function handleMediaUploadSelect( value: MediaItem[] ) {
+		onUploadSuccess( value );
 	}
 
 	function uploadFilesClickHandler( openMediaUploadModal: () => void ) {
@@ -51,13 +51,16 @@ export function MediaLibraryMenuItem( {
 	}
 
 	return (
-		<MediaUpload
-			modalClass={ MODAL_CLASS_NAME }
-			onSelect={ handleMediaUploadSelect }
+		<MediaLibrary
+			className={ MODAL_CLASS_NAME }
 			allowedTypes={ allowedTypes }
-			// @ts-expect-error - TODO multiple also accepts string.
-			multiple={ 'add' }
-			render={ ( { open } ) => (
+			multiple="add"
+			uploaderParams={ {
+				type: 'downloadable_product',
+			} }
+			onSelect={ handleMediaUploadSelect }
+		>
+			{ ( { open } ) => (
 				<MenuItem
 					icon={ media }
 					iconPosition="left"
@@ -67,6 +70,6 @@ export function MediaLibraryMenuItem( {
 					{ __( 'Media Library', 'woocommerce' ) }
 				</MenuItem>
 			) }
-		/>
+		</MediaLibrary>
 	);
 }

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/media-library/index.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/media-library/index.ts
@@ -1,0 +1,2 @@
+export * from './media-library';
+export * from './types';

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/media-library/media-library.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/media-library/media-library.tsx
@@ -1,0 +1,94 @@
+/**
+ * External dependencies
+ */
+import { useEffect, useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { MediaLibraryProps } from './types';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+declare const wp: any;
+
+export function MediaLibrary( {
+	allowedTypes,
+	modalTitle,
+	modalButtonText,
+	multiple,
+	className,
+	uploaderParams,
+	children,
+	onSelect,
+}: MediaLibraryProps ) {
+	const mediaLibraryModal = useMemo(
+		function createMediaLibraryModal() {
+			const media = wp.media( {
+				title: modalTitle,
+				library: {
+					type: allowedTypes,
+				},
+				button: {
+					text: modalButtonText,
+				},
+				multiple,
+				states: [
+					new wp.media.controller.Library( {
+						title: modalTitle,
+						library: wp.media.query(),
+						multiple,
+						priority: 20,
+						filterable: 'all',
+					} ),
+				],
+			} );
+
+			return media;
+		},
+		[ allowedTypes, modalTitle, modalButtonText, multiple ]
+	);
+
+	useEffect(
+		function initializeEvents() {
+			function handleSelect() {
+				const mediaItems = mediaLibraryModal
+					.state()
+					.get( 'selection' )
+					.toJSON();
+
+				onSelect( mediaItems );
+			}
+
+			function handleReady() {
+				mediaLibraryModal.uploader.options.uploader.params =
+					uploaderParams;
+			}
+
+			mediaLibraryModal.on( 'select', handleSelect );
+			mediaLibraryModal.on( 'ready', handleReady );
+
+			return function unmountMediaLibraryModal() {
+				mediaLibraryModal.off( 'select', handleSelect );
+				mediaLibraryModal.off( 'ready', handleReady );
+			};
+		},
+		[ mediaLibraryModal, uploaderParams, onSelect ]
+	);
+
+	useEffect(
+		() =>
+			function unmountMediaLibraryModal() {
+				mediaLibraryModal.remove();
+			},
+		[ mediaLibraryModal ]
+	);
+
+	function openMediaLibraryModal() {
+		mediaLibraryModal.$el.addClass( className );
+		mediaLibraryModal.open();
+	}
+
+	return children( {
+		open: openMediaLibraryModal,
+	} );
+}

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/media-library/types.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/media-library/types.ts
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import { MediaItem } from '@wordpress/media-utils';
+
+export type ChildrenProps = {
+	open(): void;
+};
+
+export type MediaLibraryProps = {
+	allowedTypes?: string[];
+	modalTitle?: string;
+	modalButtonText?: string;
+	multiple?: boolean | 'add';
+	className?: string;
+	uploaderParams?: Record< string, string >;
+	children( props: ChildrenProps ): JSX.Element;
+	onSelect( selection: MediaItem[] ): void;
+};


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #41510

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
2. Make sure feature `product-virtual-downloadable` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper` (WooCommerce Beta Tester plugin) is required
3. Go to `/wp-admin/admin.php?page=wc-admin&path=/add-product`
4. Under `General` tab and the bottom of the page a new `Downloads` section should be shown.
5. From now you cannot upload image by clicking the empty state box or dragging/dropping images there
<img width="677" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/8a39eb1e-1594-40da-9a9c-6765fac13ea4">

6. From the `Add new` menu only two options are now available `Media Library` and `Insert from URL` 
<img width="673" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/9b7f6eca-2a66-4d5b-9b43-144fc89829b7">

7. And when editing a file from the `Edit ...` modal, not is not possible to change the file already uploaded 
<img width="582" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/3d4c7ea2-8841-4853-a262-dc2400b685b4">

8. When enabling `Append a unique string to filename for security` checkbox under `/wp-admin/admin.php?page=wc-settings&tab=products&section=downloadable` any new file uploaded from this moment must has a 6 random characters string as a suffix of the file name and also stored under the `/woocommerce_uploads` folder in the server. 
<img width="685" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/7fa5d04f-40ac-4a9f-ad1d-8643c2e457e0">
<img width="544" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/b92a1252-9a9a-4dc4-b68f-425e1f03e52a">


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
