### PR TITLE
My Subscriptions: link product icon and product name to Woo.com product page

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.scss
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/my-subscriptions.scss
@@ -129,12 +129,13 @@
 
 	display: flex;
 	align-items: center;
-	color: $gray-900;
 
 	&-name {
 		margin-left: $grid-unit-15;
 		line-height: 18px;
 		font-weight: 600;
+		color: $gray-900;
+		text-decoration: none;
 	}
 
 	&-icon img {
@@ -145,6 +146,7 @@
 	&-icon {
 		width: $product-icon-size;
 		height: $product-icon-size;
+
 		svg {
 			border-radius: 4px;
 			padding: $grid-unit-10;
@@ -152,6 +154,16 @@
 			background-color: $gray-200;
 			width: $product-icon-size;
 			height: $product-icon-size;
+		}
+	}
+}
+
+.woocommerce-table__item {
+	.woocommerce-marketplace__my-subscriptions__product-name {
+		&:active,
+		&:hover,
+		&:visited {
+			color: $gray-900;
 		}
 	}
 }

--- a/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/rows/functions.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/my-subscriptions/table/rows/functions.tsx
@@ -19,7 +19,11 @@ import Update from '../actions/update';
 import StatusPopover from './status-popover';
 import ActionsDropdownMenu from './actions-dropdown-menu';
 import Version from './version';
-import { renewUrl, subscribeUrl } from '../../../../utils/functions';
+import {
+	appendURLParams,
+	renewUrl,
+	subscribeUrl,
+} from '../../../../utils/functions';
 import { MARKETPLACE_COLLABORATION_PATH } from '../../../constants';
 
 type StatusBadge = {
@@ -141,6 +145,15 @@ function getVersion( subscription: Subscription ): string | JSX.Element {
 	return '';
 }
 
+function appendUTMParams( url: string ) {
+	return appendURLParams( url, [
+		[ 'utm_source', 'subscriptionsscreen' ],
+		[ 'utm_medium', 'product' ],
+		[ 'utm_campaign', 'wcaddons' ],
+		[ 'utm_content', 'product-name' ],
+	] );
+}
+
 export function nameAndStatus( subscription: Subscription ): TableRow {
 	// This is the fallback icon element with products without
 	let iconElement = <Icon icon={ plugins } size={ 40 } />;
@@ -163,12 +176,23 @@ export function nameAndStatus( subscription: Subscription ): TableRow {
 
 	const displayElement = (
 		<div className="woocommerce-marketplace__my-subscriptions__product">
-			<span className="woocommerce-marketplace__my-subscriptions__product-icon">
-				{ iconElement }
-			</span>
-			<span className="woocommerce-marketplace__my-subscriptions__product-name">
+			<a
+				href={ appendUTMParams( subscription.product_url ) }
+				target="_blank"
+				rel="noreferrer"
+			>
+				<span className="woocommerce-marketplace__my-subscriptions__product-icon">
+					{ iconElement }
+				</span>
+			</a>
+			<a
+				href={ appendUTMParams( subscription.product_url ) }
+				className="woocommerce-marketplace__my-subscriptions__product-name"
+				target="_blank"
+				rel="noreferrer"
+			>
 				{ subscription.product_name }
-			</span>
+			</a>
 			<span className="woocommerce-marketplace__my-subscriptions__product-statuses">
 				{ statusBadge && (
 					<StatusPopover


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Links the product icon and product name in each row of the My Subscriptions table to the corresponding Woo.com product page. Link opens in new tab. This reproduces the behaviour of the current My Subscriptions page.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check out this branch and build the project.
2. Go to the [My Subscriptions](http://localhost:8888/wp-admin/admin.php?page=wc-admin&tab=my-subscriptions&path=%2Fextensions) page. 
3. If you are not connected to your Woo.com account, connect it using the user icon at top right. You should have some subscriptions to Woo products.
4. Manually install a Woo product you don't have a subscription for in the plugins admin page. For example [WooCommerce Bookings](https://woocommerce.com/products/woocommerce-bookings/).
5. Check that clicking on a product icon or product name in the list opens the Woo.com product page for that extension in a new tab.
6. Check that the same thing is true for the extension you don't have a current subscription for.
7. Note that these UTM parameters are present on the link URLs: `utm_source=subscriptionsscreen&utm_medium=product&utm_campaign=wcaddons&utm_content=product-name`.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
