### PR TITLE
Update WooCommerce Blocks to 11.6.0

### DIFF
--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-11.6.0
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-11.6.0
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update WooCommerce Blocks to 11.6.0

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -23,7 +23,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.7.0",
-		"woocommerce/woocommerce-blocks": "11.5.4"
+		"woocommerce/woocommerce-blocks": "11.6.0"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.3.0",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ca936b25f519b35aaaeb886f3f9564b2",
+    "content-hash": "d1634a3b24dd2f5c53a5d7c2d507a8ae",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1004,16 +1004,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "11.5.4",
+            "version": "11.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "a701cbe4466b36a572a0daf7f7363ec23bfdff45"
+                "reference": "2e4d7744a788af799b53ee8de128cfceac7f7930"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/a701cbe4466b36a572a0daf7f7363ec23bfdff45",
-                "reference": "a701cbe4466b36a572a0daf7f7363ec23bfdff45",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/2e4d7744a788af799b53ee8de128cfceac7f7930",
+                "reference": "2e4d7744a788af799b53ee8de128cfceac7f7930",
                 "shasum": ""
             },
             "require": {
@@ -1064,9 +1064,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v11.5.4"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v11.6.0"
             },
-            "time": "2023-11-13T14:34:45+00:00"
+            "time": "2023-11-22T14:44:31+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 11.6.0. It includes changes from WooCommerce Blocks 11.5.x-11.6.0 and is intended to target WooCommerce 8.4 for release.
Details from all the different releases included in this pull:

## Blocks 11.6.0

* https://github.com/woocommerce/woocommerce-blocks/pull/11841
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/1160.md)
* [Release post WIP](https://developer.woocommerce.com/2023/11/23/woocommerce-blocks-10-6-0-release-notes/)

## Blocks 11.5.4

* https://github.com/woocommerce/woocommerce-blocks/pull/11715
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/1154.md)

## Blocks 11.5.3

* https://github.com/woocommerce/woocommerce-blocks/pull/11706
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/290a8d1bb231776637bd54f9a98483bfd1982cf4/docs/internal-developers/testing/releases/1153.md)

## Blocks 11.5.2

* https://github.com/woocommerce/woocommerce-blocks/pull/11705
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/8d0a6a7969e5c5acf48f769221b01a33e982f19b/docs/internal-developers/testing/releases/1152.md)
## Blocks 11.5.1

* https://github.com/woocommerce/woocommerce-blocks/pull/11675
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/1151.md)

## Blocks 11.5.0

* https://github.com/woocommerce/woocommerce-blocks/pull/11617
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/1150.md)
* [Release post](https://developer.woocommerce.com/2023/06/21/woocommerce-blocks-10-5-0-release-notes/)


### Changelog entry

### The following changelog entries are only those that impact existing blocks and functionality surfaced to users:

#### Enhancements

##### 11.6.0

- Product Collection - New 'No Results' block with default UI. https://github.com/woocommerce/woocommerce-blocks/pull/11783
- We have moved the TotalsItem, TotalsFees, Subtotal, Banner, StoreNotice, StoreNotices, Panel, TextInput, ValidatedTextInput and ValidationInputError components to the @woocommerce/blocks-components package. Previously these were available in @woocommerce/blocks-checkout . Your code will continue to work as we have added aliases to the new location. Despite this, it is recommended that you change your code to import this component from @woocommerce/blocks-components as the import from the checkout package will be deprecated in the future. https://github.com/woocommerce/woocommerce-blocks/pull/11766 https://github.com/woocommerce/woocommerce-blocks/pull/11698 https://github.com/woocommerce/woocommerce-blocks/pull/11654 https://github.com/woocommerce/woocommerce-blocks/pull/11773
- Improve performance in patterns registration. https://github.com/woocommerce/woocommerce-blocks/pull/11733
- Patterns: remove unused author, sticky, and parents attributes from the Product Collection block in patterns. https://github.com/woocommerce/woocommerce-blocks/pull/11673
- Semantic enhancement to the position of a phone field in Checkout. https://github.com/woocommerce/woocommerce-blocks/pull/11651
- Migrate the Product Button to the new store() API of the Interactivity API.. https://github.com/woocommerce/woocommerce-blocks/pull/11558
- Product Collection: Add support for filtering products by featured status. https://github.com/woocommerce/woocommerce-blocks/pull/11522

##### 11.5.0

- Add margin bottom to the Hero Product 3 Split pattern. (https://github.com/woocommerce/woocommerce-blocks/pull/11573)
- Set explicit margins in the search bar group on the Large Header pattern. (https://github.com/woocommerce/woocommerce-blocks/pull/11571)
- Add aspect ratio to the Featured Products 5 Columns pattern. (https://github.com/woocommerce/woocommerce-blocks/pull/11570)
- [CYS] Fix Product Collection 4 Columns pattern button height. (https://github.com/woocommerce/woocommerce-blocks/pull/11553)
- Change the "chessboard" pattern structure to improve mobile view. (https://github.com/woocommerce/woocommerce-blocks/pull/11545)
- Footer with 3 menus pattern: Update the spacing in the columns to improve the mobile view. (https://github.com/woocommerce/woocommerce-blocks/pull/11544)
- Add checkout-header template to the correct area in site editor. (https://github.com/woocommerce/woocommerce-blocks/pull/11528)
- Product gallery/add crop images. (https://github.com/woocommerce/woocommerce-blocks/pull/11482)
- Remove authors filter from Product Collection block. (https://github.com/woocommerce/woocommerce-blocks/pull/11427)
- Move SortSelect to components package. (https://github.com/woocommerce/woocommerce-blocks/pull/11411)
- Move Textarea to components package. (https://github.com/woocommerce/woocommerce-blocks/pull/11384)
- Move Title to components package. (https://github.com/woocommerce/woocommerce-blocks/pull/11383)
- Use the element for the checkout header. (https://github.com/woocommerce/woocommerce-blocks/pull/11222)
- Product Gallery Thumbnails: Add View all overlay. (https://github.com/woocommerce/woocommerce-blocks/pull/11087)

#### Bug Fixes

##### 11.6.0

- Make "Use same address for billing" visible by default. https://github.com/woocommerce/woocommerce-blocks/pull/11804
- Fix the order endpoint tax line items format. https://github.com/woocommerce/woocommerce-blocks/pull/11796
- Store API/Blocks Extensibility: Fix recursive extension schema validation. https://github.com/woocommerce/woocommerce-blocks/pull/11792
- Fix: Left align local pickup address. https://github.com/woocommerce/woocommerce-blocks/pull/11772
- Fix typo in classic checkout modal. https://github.com/woocommerce/woocommerce-blocks/pull/11771
- Fix hardcoded shop link in "Hero Product 3 Split" pattern. https://github.com/woocommerce/woocommerce-blocks/pull/11767
- Fix billing address condensed address state in the editor and in Firefox. https://github.com/woocommerce/woocommerce-blocks/pull/11765
- Related Products: Make the heading translated when in blockified Single Product template. https://github.com/woocommerce/woocommerce-blocks/pull/11693
- Add to Cart with Options block: fix inconsistency between editor and frontend styles. https://github.com/woocommerce/woocommerce-blocks/pull/11614
- Product Button: Improve the width and padding. https://github.com/woocommerce/woocommerce-blocks/pull/11537
- Fix the Layout for Shipping and Billing Address Forms in the Checkout Block https://github.com/woocommerce/woocommerce-blocks/pull/11486
- Minor fixes for PHP 8. https://github.com/woocommerce/woocommerce-blocks/pull/11473
- Product Button: always enqueue the store. https://github.com/woocommerce/woocommerce-blocks/pull/11858
- Fixed params passed to woocommerce_before_thankyou for block checkout. This should be an order ID, not an order object. https://github.com/woocommerce/woocommerce-blocks/pull/11862
- Enhanced validation for limited use coupons and guest users. https://github.com/woocommerce/woocommerce-blocks/pull/11860

##### 11.5.4

- Prevent PHP warnings when using Jetpack WooCommerce Analytics module. https://github.com/woocommerce/woocommerce-blocks/pull/11707
- Fixed address components in Firefox, and editing of address form in the editor. https://github.com/woocommerce/woocommerce-blocks/pull/11714
- Fix Classic Cart/Checkout styling on non-cart and checkout pages. https://github.com/woocommerce/woocommerce-blocks/pull/11694
- Fix double border in cart and notes field width on mobile. https://github.com/woocommerce/woocommerce-blocks/pull/11742
- Ensure that incompatible notices are displayed in Safari. https://github.com/woocommerce/woocommerce-blocks/pull/11736
- Enabled the new blockified Order Confirmation by default for block-based themes. https://github.com/woocommerce/woocommerce-blocks/pull/11615

##### 11.5.3

- Use wp_json_file_decode instead of json_decode https://github.com/woocommerce/woocommerce-blocks/pull/11681

##### 11.5.2

- Rename the Centered Header Menu with Search to Centered Header Menu. https://github.com/woocommerce/woocommerce-blocks/pull/11637
- Fix decoding issue and pattern. https://github.com/woocommerce/woocommerce-blocks/pull/11681

##### 11.5.1

- WordPress 6.4: fixed a bug which would break sites using the Classic Template block for the Single Product template. https://github.com/woocommerce/woocommerce-blocks/pull/11455
- Fix an error that might appear when pre_get_block_template filter was called with wrong params. https://github.com/woocommerce/woocommerce-blocks/pull/11690

##### 11.5.0

- Fix Hero Product 3 Split pattern text content. (https://github.com/woocommerce/woocommerce-blocks/pull/11612)
- Prevent theme button border appearing in opinionated patterns. (https://github.com/woocommerce/woocommerce-blocks/pull/11564)
- Prevent Sale badge overflowing the Product Image in some product grid blocks. (https://github.com/woocommerce/woocommerce-blocks/pull/11556)
- Block Checkout: Add back missing render-checkout-form hook. (https://github.com/woocommerce/woocommerce-blocks/pull/11554)
- Ensure that the "Remove Item" link on Cart block has a hover state. (https://github.com/woocommerce/woocommerce-blocks/pull/11526)
- All Products: Add cursor pointer when hovering over pagination items. (https://github.com/woocommerce/woocommerce-blocks/pull/11502)
- Product Collection: Fix the PHP Warning after migrating from Products (Beta). (https://github.com/woocommerce/woocommerce-blocks/pull/11494)
- Footer with 2 Menus Dark pattern: Fix the Site Title color contrast in TT4. (https://github.com/woocommerce/woocommerce-blocks/pull/11484)
- Essential Header Dark pattern: Fix color contrast issues in TT4. (https://github.com/woocommerce/woocommerce-blocks/pull/11480)
- Display shipping calculator link for guests shopper. (https://github.com/woocommerce/woocommerce-blocks/pull/11442)
- Comboboxes should match against values before looking at labels. (https://github.com/woocommerce/woocommerce-blocks/pull/11410)
- Fix products incorrectly marked as discounted. (https://github.com/woocommerce/woocommerce-blocks/pull/11386)
- Ensure input is validated when autofilled in Firefox. (https://github.com/woocommerce/woocommerce-blocks/pull/11062)

#### Documentation

##### 11.6.0

- Updated documentation for the onProcessingSetup observer. https://github.com/woocommerce/woocommerce-blocks/pull/11751

### Changelog entry

> Dev - Update WooCommerce Blocks version to 11.6.0