### PR TITLE
Modify notice for legacy local attributes

### DIFF
--- a/packages/js/data/changelog/add-40348_notice_when_product_has_local_attributes
+++ b/packages/js/data/changelog/add-40348_notice_when_product_has_local_attributes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Modify notice for legacy local attributes #41646

--- a/packages/js/data/src/user/types.ts
+++ b/packages/js/data/src/user/types.ts
@@ -28,14 +28,14 @@ export type UserPreferences = {
 	variable_product_tour_shown?: string;
 	variable_product_block_tour_shown?: string;
 	variations_report_columns?: string;
-	variable_options_dismissed_notices_ids?: number[];
+	local_attributes_notice_dismissed_ids?: number[];
 	variable_items_without_price_notice_dismissed?: Record< number, string >;
 };
 
 export type WoocommerceMeta = UserPreferences & {
 	task_list_tracked_started_tasks?: string;
 	variable_items_without_price_notice_dismissed?: string;
-	variable_options_dismissed_notices_ids?: string;
+	local_attributes_notice_dismissed_ids?: string;
 };
 
 export type WCUser<

--- a/packages/js/data/src/user/types.ts
+++ b/packages/js/data/src/user/types.ts
@@ -28,13 +28,14 @@ export type UserPreferences = {
 	variable_product_tour_shown?: string;
 	variable_product_block_tour_shown?: string;
 	variations_report_columns?: string;
-	product_block_variable_options_dismissed_notices_ids?: number[];
+	variable_options_dismissed_notices_ids?: number[];
 	variable_items_without_price_notice_dismissed?: Record< number, string >;
 };
 
 export type WoocommerceMeta = UserPreferences & {
 	task_list_tracked_started_tasks?: string;
 	variable_items_without_price_notice_dismissed?: string;
+	variable_options_dismissed_notices_ids?: string;
 };
 
 export type WCUser<

--- a/packages/js/data/src/user/types.ts
+++ b/packages/js/data/src/user/types.ts
@@ -28,7 +28,7 @@ export type UserPreferences = {
 	variable_product_tour_shown?: string;
 	variable_product_block_tour_shown?: string;
 	variations_report_columns?: string;
-	product_block_variable_options_notice_dismissed?: string;
+	product_block_variable_options_dismissed_notices_ids?: number[];
 	variable_items_without_price_notice_dismissed?: Record< number, string >;
 };
 

--- a/packages/js/product-editor/changelog/add-40348_notice_when_product_has_local_attributes
+++ b/packages/js/product-editor/changelog/add-40348_notice_when_product_has_local_attributes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Modify notice for legacy local attributes #41646

--- a/packages/js/product-editor/src/blocks/product-fields/variation-options/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/variation-options/edit.tsx
@@ -16,6 +16,7 @@ import {
 } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
 import { Link } from '@woocommerce/components';
+import { getAdminLink } from '@woocommerce/settings';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore No types for this exist yet.
 // eslint-disable-next-line @woocommerce/dependency-group
@@ -31,13 +32,14 @@ import { ProductEditorBlockEditProps } from '../../../types';
 
 export function Edit( {
 	attributes: blockAttributes,
+	context,
 }: ProductEditorBlockEditProps< BlockAttributes > ) {
 	const blockProps = useWooBlockProps( blockAttributes );
 	const { generateProductVariations } = useProductVariationsHelper();
 	const {
 		updateUserPreferences,
-		product_block_variable_options_notice_dismissed:
-			hasDismissedVariableOptionsNotice,
+		product_block_variable_options_dismissed_notices_ids:
+			dismissedNoticesIds = [],
 	} = useUserPreferences();
 
 	const [ entityAttributes, setEntityAttributes ] = useEntityProp<
@@ -50,6 +52,9 @@ export function Edit( {
 			'product',
 			'default_attributes'
 		);
+
+	const { postType } = context;
+	const productId = useEntityId( 'postType', postType );
 
 	const { attributes, handleChange } = useProductAttributes( {
 		allAttributes: entityAttributes,
@@ -68,7 +73,7 @@ export function Edit( {
 	let notice: string | React.ReactElement = '';
 	if (
 		localAttributeNames.length > 0 &&
-		hasDismissedVariableOptionsNotice !== 'yes'
+		! dismissedNoticesIds?.includes( productId )
 	) {
 		notice = createInterpolateElement(
 			__(
@@ -87,7 +92,9 @@ export function Edit( {
 				),
 				globalAttributeLink: (
 					<Link
-						href="https://woo.com/document/variable-product/#add-attributes-to-use-for-variations"
+						href={ getAdminLink(
+							'edit.php?post_type=product&page=product_attributes'
+						) }
 						type="external"
 						target="_blank"
 					/>
@@ -122,7 +129,10 @@ export function Edit( {
 				useRemoveConfirmationModal={ true }
 				onNoticeDismiss={ () =>
 					updateUserPreferences( {
-						product_block_variable_options_notice_dismissed: 'yes',
+						product_block_variable_options_dismissed_notices_ids: [
+							...dismissedNoticesIds,
+							productId,
+						],
 					} )
 				}
 				onAddAnother={ () => {

--- a/packages/js/product-editor/src/blocks/product-fields/variation-options/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/variation-options/edit.tsx
@@ -38,7 +38,7 @@ export function Edit( {
 	const { generateProductVariations } = useProductVariationsHelper();
 	const {
 		updateUserPreferences,
-		product_block_variable_options_dismissed_notices_ids:
+		variable_options_dismissed_notices_ids:
 			dismissedNoticesIds = [],
 	} = useUserPreferences();
 
@@ -129,7 +129,7 @@ export function Edit( {
 				useRemoveConfirmationModal={ true }
 				onNoticeDismiss={ () =>
 					updateUserPreferences( {
-						product_block_variable_options_dismissed_notices_ids: [
+						variable_options_dismissed_notices_ids: [
 							...dismissedNoticesIds,
 							productId,
 						],

--- a/packages/js/product-editor/src/blocks/product-fields/variation-options/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/variation-options/edit.tsx
@@ -38,8 +38,7 @@ export function Edit( {
 	const { generateProductVariations } = useProductVariationsHelper();
 	const {
 		updateUserPreferences,
-		variable_options_dismissed_notices_ids:
-			dismissedNoticesIds = [],
+		local_attributes_notice_dismissed_ids: dismissedNoticesIds = [],
 	} = useUserPreferences();
 
 	const [ entityAttributes, setEntityAttributes ] = useEntityProp<
@@ -129,7 +128,7 @@ export function Edit( {
 				useRemoveConfirmationModal={ true }
 				onNoticeDismiss={ () =>
 					updateUserPreferences( {
-						variable_options_dismissed_notices_ids: [
+						local_attributes_notice_dismissed_ids: [
 							...dismissedNoticesIds,
 							productId,
 						],

--- a/plugins/woocommerce/changelog/add-40348_notice_when_product_has_local_attributes
+++ b/plugins/woocommerce/changelog/add-40348_notice_when_product_has_local_attributes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Modify notice for legacy local attributes #41646

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -175,7 +175,7 @@ class Init {
 			$user_data_fields,
 			array(
 				'variable_product_block_tour_shown',
-				'product_block_variable_options_dismissed_notices_ids',
+				'variable_options_dismissed_notices_ids',
 				'variable_items_without_price_notice_dismissed',
 			)
 		);

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -175,7 +175,7 @@ class Init {
 			$user_data_fields,
 			array(
 				'variable_product_block_tour_shown',
-				'variable_options_dismissed_notices_ids',
+				'local_attributes_notice_dismissed_ids',
 				'variable_items_without_price_notice_dismissed',
 			)
 		);

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -175,7 +175,7 @@ class Init {
 			$user_data_fields,
 			array(
 				'variable_product_block_tour_shown',
-				'product_block_variable_options_notice_dismissed',
+				'product_block_variable_options_dismissed_notices_ids',
 				'variable_items_without_price_notice_dismissed',
 			)
 		);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR modifies the message shown when the product has local attributes created in the legacy editor.

**Design**
AkVNGImLgSqCObTQ3idVn7-fi-1642_218064

**Acceptance criteria**

- [ ] When the user opens a product with variation options created using at least 1 local attribute, we display a notice.
- [ ] The link in the notice links to `Products > Attributes`.
- [ ] If dismissed, the notice will not show up again for this product. It may show up again for other products meeting the criteria.

Closes #40348.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a WooCommerce store with this branch.
2. Be sure that the new product editor is  **disabled**.
3. Go to **Products > Add New** and create a `Variable` product.
4. Add at least one local attribute and create the variations.
5. Publish the product.
6. Create and publish another product with local attributes and variations.
7. Now **enable** the product editor using **WooCommerce > Settings > Advanced > Features**
8. Go to **Products > All Products** and select the product you published in step 5
9. Go to the `Variations` tab and confirm the notice is visible

![Screenshot 2023-11-22 at 18 25 00](https://github.com/woocommerce/woocommerce/assets/1314156/6182647d-4e67-495b-891f-345d12cdb021)

11. Try the `global attributes` link. It should point to **Products > Attributes**
7. Press the `X` and close the notice
8. It should dismiss the notice for that product but it should be shown for every product with local attributes
9. Go to **Products > All Products** and select the second product you published in step 5
12. Verify the notice is shown for that product

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
