### PR TITLE
Add filter to change the number of terms returned on metabox attribute term search

### DIFF
--- a/plugins/woocommerce/changelog/add-filter-for-attribute-term-list-limit
+++ b/plugins/woocommerce/changelog/add-filter-for-attribute-term-list-limit
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Adds filter to change the number of terms returned when searching for terms of a product attribute in the metabox

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute-inner.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-product-attribute-inner.php
@@ -40,7 +40,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 					?>
 					<select multiple="multiple"
 							data-minimum_input_length="0"
-							data-limit="50" data-return_id="id"
+							data-limit="<?php echo absint( apply_filters( 'woocommerce_admin_meta_boxes_attribute_term_limit', 50 ) ); ?>"
+							data-return_id="id"
 							data-placeholder="<?php esc_attr_e( 'Select values', 'woocommerce' ); ?>"
 							data-orderby="<?php echo esc_attr( $attribute_orderby ); ?>"
 							class="multiselect attribute_values wc-taxonomy-term-search"


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add a filter called `woocommerce_admin_meta_boxes_attribute_term_limit` so developers can change the number of terms that are returned when searching on the attribute metabox in the product admin editor.

For example, if someone has an attribute called "Size" and within it they have multiple terms like "L", "XL", "XXL", "L | 36", "L|XXL", etc and the number of terms passes the limit in the HTML attribute `data-limit` currently (which is 50) it can get hard to find terms with the name "L" for example. This pull request creates a filter that developers can use to overcome this issue if needed since this is not a very common issue but it has happened on multiple stores I run WooCommerce on.

### How to test the changes in this Pull Request:

1. Go to the product editor on the Product data part and select "Attributes"
2. Select an existing attribute that has more than 50 terms inside it.
3. Run a search for query term that will return more than 50 terms (the example i mentioned earlier is a good test case)
4. Should return 50 if the filter is not used anywhere else. If the filter is called somewhere else in the code and returns a valid value, should return the number of terms on the filter. For example, the following code should make it so it returns at max 100 term results:

```
add_filter( 'woocommerce_admin_meta_boxes_attribute_term_limit', 'custom_woocommerce_admin_meta_boxes_attribute_term_limit' );
function custom_woocommerce_admin_meta_boxes_attribute_term_limit( $limit ) {
	return 100;
}
```

Before the change:

<img width="1512" alt="Screenshot 2023-11-23 at 21 50 35" src="https://github.com/woocommerce/woocommerce/assets/43281889/a83f721a-0502-45e1-8b38-e64c5a8f8a15">

After the change:

<img width="1512" alt="Screenshot 2023-11-23 at 21 49 17" src="https://github.com/woocommerce/woocommerce/assets/43281889/c8d80d1c-cd7f-4b77-8726-82e045fcb6d9">

### Changelog entry

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Adds a filter to change the number of terms returned when searching for terms of a product attribute in the metabox

</details>
