### PR TITLE
Update WooCommerce Blocks to 11.6.1

### DIFF
--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-11.6.1
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-11.6.1
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update WooCommerce Blocks to 11.6.1

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -23,7 +23,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.7.0",
-		"woocommerce/woocommerce-blocks": "11.6.0"
+		"woocommerce/woocommerce-blocks": "11.6.1"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.3.0",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d1634a3b24dd2f5c53a5d7c2d507a8ae",
+    "content-hash": "312e3278b6ae634d1c2688e34f2d4643",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1004,16 +1004,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "11.6.0",
+            "version": "11.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "2e4d7744a788af799b53ee8de128cfceac7f7930"
+                "reference": "3c6be3fbb5a3d7745864fd0ee2ea40c620c16330"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/2e4d7744a788af799b53ee8de128cfceac7f7930",
-                "reference": "2e4d7744a788af799b53ee8de128cfceac7f7930",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/3c6be3fbb5a3d7745864fd0ee2ea40c620c16330",
+                "reference": "3c6be3fbb5a3d7745864fd0ee2ea40c620c16330",
                 "shasum": ""
             },
             "require": {
@@ -1064,9 +1064,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v11.6.0"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v11.6.1"
             },
-            "time": "2023-11-22T14:44:31+00:00"
+            "time": "2023-11-23T15:22:10+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 11.6.1 and is intended to target WooCommerce 8.4 for release.
Details from all the different releases included in this pull:

## Blocks 11.6.1

* https://github.com/woocommerce/woocommerce-blocks/pull/11921
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/1161.md)
* [Release post](https://developer.woocommerce.com/2023/11/23/woocommerce-blocks-10-6-0-release-notes/)

### Changelog entry

### The following changelog entries are only those that impact existing blocks and functionality surfaced to users:

#### Bug Fixes

- Add missing woocommerce classname to Classic Cart/Checkout Blocks container so UI updates when the cart is emptied. https://github.com/woocommerce/woocommerce-blocks/pull/11919
- Fix an issue that caused the Order by select in Reviews blocks to always be disabled. https://github.com/woocommerce/woocommerce-blocks/pull/11918
- Fix All Reviews, Reviews by Product and Reviews by Category blocks not being rendered. https://github.com/woocommerce/woocommerce-blocks/pull/11913

### Changelog entry

> Dev - Update WooCommerce Blocks version to 11.6.1