### PR TITLE
Downloadable Product Permissions: The text "-1" is rendered every time merchants click the "Grant access" button without entering any product

### DIFF
--- a/plugins/woocommerce/changelog/41682-issue-31678
+++ b/plugins/woocommerce/changelog/41682-issue-31678
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Provide an error message when trying to grant access without selecting a product

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-order.js
@@ -1440,7 +1440,7 @@ jQuery( function ( $ ) {
 		grant_access: function() {
 			var products = $( '#grant_access_id' ).val();
 
-			if ( ! products ) {
+			if ( ! products || 0 === products.length ) {
 				return;
 			}
 
@@ -1462,7 +1462,7 @@ jQuery( function ( $ ) {
 
 			$.post( woocommerce_admin_meta_boxes.ajax_url, data, function( response ) {
 
-				if ( response ) {
+				if ( response && -1 !== parseInt( response ) ) {
 					$( '.order_download_permissions .wc-metaboxes' ).append( response );
 				} else {
 					window.alert( woocommerce_admin_meta_boxes.i18n_download_permission_fail );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #31678  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create an order.
2. Open the order and go to the "Downloadable product permissions" section at the bottom.
3. Make sure you have not searched any product.
4. Click the "Grant access" button.
5. Error message should show.
6. Users should be notified that they need to enter a valid downloadable product so that they can grant access.
7. The "Grant access" button is disable is no product is entered.

![スクリーンショット 2023-11-25 3 40 50](https://github.com/woocommerce/woocommerce/assets/2771396/c170cc0d-6c19-4721-a516-bd77f5f3a1cd)

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Provide an error message when trying to grant access without selecting a product

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
