### PR TITLE
Update/new editor downloads section view file

### DIFF
--- a/packages/js/product-editor/src/blocks/product-fields/downloads/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/edit.tsx
@@ -10,7 +10,7 @@ import {
 	createInterpolateElement,
 	useState,
 } from '@wordpress/element';
-import { closeSmall } from '@wordpress/icons';
+import { closeSmall, external } from '@wordpress/icons';
 import { MediaItem } from '@wordpress/media-utils';
 import { useWooBlockProps } from '@woocommerce/block-templates';
 import { ListItem, Sortable } from '@woocommerce/components';
@@ -319,6 +319,16 @@ export function Edit( {
 											>
 												{ __( 'Edit', 'woocommerce' ) }
 											</Button>
+										) }
+										{ ! isUploading && (
+											<Button
+												className='has-external-icon'
+												href={ download.file }
+												icon={ external }
+												label={ __( 'View file', 'woocommerce' ) }
+												variant='link'
+												target='_blank'
+											/>
 										) }
 										<Button
 											icon={ closeSmall }

--- a/packages/js/product-editor/src/blocks/product-fields/downloads/editor.scss
+++ b/packages/js/product-editor/src/blocks/product-fields/downloads/editor.scss
@@ -62,7 +62,15 @@ $fixed-section-height: 224px;
 			width: $grid-unit-30;
 			height: $grid-unit-30;
 			min-width: inherit;
-			padding: 0;
+			
+			&:not(.has-external-icon) {
+				padding: 0;
+			}
+
+			&.has-external-icon {
+				// Give button little bit more padding to make icon smaller thus making the size more inline with the other icon(s)
+				padding: 2px;
+			}
 		}
 	}
 

--- a/plugins/woocommerce/changelog/update-new-editor-downloads-section-view-file
+++ b/plugins/woocommerce/changelog/update-new-editor-downloads-section-view-file
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Added View file link to downloads section


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #41467 .

This PR adds "View file" link to new product editors downloads section. See linked issue for visuals

I went bit rogue with the acceptance criteria here. Last two bullets points

> if the file is an image, PDF, or any other type that can be opened in the browser, clicking the button will open it in a new tab.
If the file can't be opened in the browser, clicking the button will download the file.

There is no need for this kind logic in our end since browsers will automatically download file if it is unable to show it (or please correct me if I am wrong here 😅 )


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Open "downloadable" product in the new product editor
2. Navigate to downloads section and observe "View file" link in the list. Link uses WordPress external icon
3. Click link and you get new tab showing file in browser. Or if browser don't know what to do it then it downloads it for you

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
