### PR TITLE
Revert loading strategy for checkout.js to `in_footer`

### DIFF
--- a/plugins/woocommerce/changelog/fix-41556-checkout-script-defer
+++ b/plugins/woocommerce/changelog/fix-41556-checkout-script-defer
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Ensure the legacy frontend checkout script loads in the document footer

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -329,7 +329,7 @@ class WC_Frontend_Scripts {
 				'version' => Constants::get_constant( 'WC_VERSION' ),
 				'args'    => array( 'strategy' => 'defer' ),
 			);
-			$props = wp_parse_args( $props, $defaults );
+			$props    = wp_parse_args( $props, $defaults );
 
 			call_user_func_array( array( __CLASS__, 'register_script' ), $props );
 		}

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -267,7 +267,7 @@ class WC_Frontend_Scripts {
 				'src'     => self::get_asset_url( 'assets/js/frontend/checkout' . $suffix . '.js' ),
 				'deps'    => array( 'jquery', 'woocommerce', 'wc-country-select', 'wc-address-i18n' ),
 				'version' => $version,
-				'args'    => true,
+				'args'    => array( 'in_footer' => true ),
 			),
 			'wc-country-select'          => array(
 				'src'     => self::get_asset_url( 'assets/js/frontend/country-select' . $suffix . '.js' ),

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -320,7 +320,17 @@ class WC_Frontend_Scripts {
 			),
 		);
 		foreach ( $register_scripts as $name => $props ) {
-			self::register_script( $name, $props['src'], $props['deps'], $props['version'] );
+			// Ensure props are in the right order.
+			$defaults = array(
+				'name'    => $name,
+				'src'     => '',
+				'deps'    => array( 'jquery' ),
+				'version' => Constants::get_constant( 'WC_VERSION' ),
+				'args'    => array( 'strategy' => 'defer' ),
+			);
+			$props = wp_parse_args( $props, $defaults );
+
+			call_user_func_array( array( __CLASS__, 'register_script' ), $props );
 		}
 	}
 

--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -267,6 +267,7 @@ class WC_Frontend_Scripts {
 				'src'     => self::get_asset_url( 'assets/js/frontend/checkout' . $suffix . '.js' ),
 				'deps'    => array( 'jquery', 'woocommerce', 'wc-country-select', 'wc-address-i18n' ),
 				'version' => $version,
+				'args'    => true,
 			),
 			'wc-country-select'          => array(
 				'src'     => self::get_asset_url( 'assets/js/frontend/country-select' . $suffix . '.js' ),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In #40686 we changed the registration of frontend scripts to use the new loading strategy option of `defer` as the default. However, this seems to have caused an issue with some extensions, as described in #41556 and [this forum thread](https://wordpress.org/support/topic/checkout-broke-with-8-3-0/).

The change in this PR ensures that the legacy frontend checkout.js script gets loaded in the footer, rather than in the header with the `defer` loading strategy.

As a side effect, this also allows `WC_Frontend_Scripts` to have more flexibility in defining the properties of all the scripts it loads. Each script defined in the associative array in the `register_scripts` method now only needs to include properties that are not default, and can include the `args` property (formerly known as the `in_footer` property).

Fixes #41556

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Currently still trying to determine how best to replicate this issue consistently and test it. In the mean time, just looking for a review on the code changes.

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>