### PR TITLE
use consistent capitalization in docs titles

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# WooCommerce Developer Documentation
+# WooCommerce developer documentation
 
 > ⚠️ **Notice:** This documentation is currently a **work in progress**. While it's open to the public for transparency and collaboration, please be aware that some sections might be incomplete or subject to change. We appreciate your patience and welcome any contributions!
 

--- a/docs/code-snippets/change-a-currency-symbol.md
+++ b/docs/code-snippets/change-a-currency-symbol.md
@@ -1,4 +1,4 @@
-# Rename a country
+# Change a currency symbol
 
 See the [currency list](https://woocommerce.github.io/code-reference/files/woocommerce-includes-wc-core-functions.html#source-view.475) for reference on currency codes.
 

--- a/docs/code-snippets/useful-functions.md
+++ b/docs/code-snippets/useful-functions.md
@@ -1,4 +1,4 @@
-# Useful Core Functions
+# Useful core functions
 
 WooCommerce core functions are available on both front-end and admin. They can be found in `includes/wc-core-functions.php` and can be used by themes in plugins.
 

--- a/docs/contributing/CSS-SASS-coding-guidelines-and-naming-conventions.md
+++ b/docs/contributing/CSS-SASS-coding-guidelines-and-naming-conventions.md
@@ -1,4 +1,4 @@
-# CSS SASS coding guidelines and naming convetions
+# CSS SASS coding guidelines and naming conventions
 
 Our guidelines are based on those used in [Calypso](https://github.com/Automattic/wp-calypso) which itself follows the BEM methodology. Refer to [this doc](https://wpcalypso.wordpress.com/devdocs/docs/coding-guidelines/css.md?term=css) for full details. There are a few differences in WooCommerce however which are outlined below;
 

--- a/docs/contributing/api-critical-flows.md
+++ b/docs/contributing/api-critical-flows.md
@@ -1,4 +1,4 @@
-# API Critical Flows
+# API critical flows
 
 In our documentation, we've pinpointed the essential user flows within the WooCommerce Core API. These flows serve as
 the compass for our testing initiatives, aiding us in concentrating our efforts where they matter most. They also

--- a/docs/contributing/deciding-pr-high-impact.md
+++ b/docs/contributing/deciding-pr-high-impact.md
@@ -1,4 +1,4 @@
-# How to decide if a Pull Request is High-Impact
+# How to decide if a pull request is high impact
 
 Deciding if a Pull Request should be declared High-Impact is a complex task. To achieve it, we need to assess and estimate the impact that the changes introduced in the Pull Request have in WooCommerce, which is usually a subjective task and sometimes inaccurate, due to the huge knowledge it demands of the WooCommerce product details, technical details and even customers issues history.
 

--- a/docs/contributing/deprecation-in-core.md
+++ b/docs/contributing/deprecation-in-core.md
@@ -1,4 +1,4 @@
-# Deprecation in Core
+# Deprecation in core
 
 Deprecation is a method of discouraging usage of a feature or practice in favour of something else without breaking backwards compatibility or totally prohibiting its usage. To quote the Wikipedia article on Deprecation:
 

--- a/docs/contributing/naming-conventions.md
+++ b/docs/contributing/naming-conventions.md
@@ -1,4 +1,4 @@
-# Naming Conventions
+# Naming conventions
 
 ## PHP
 

--- a/docs/contributing/woocommerce-git-flow.md
+++ b/docs/contributing/woocommerce-git-flow.md
@@ -1,4 +1,4 @@
-# WooCommerce Git Flow
+# WooCommerce Git flow
 
 For core development, we use the following structure and flow.
 

--- a/docs/data-management/data-stores.md
+++ b/docs/data-management/data-stores.md
@@ -1,4 +1,4 @@
-# Data Stores
+# Data stores
 
 ## Introduction
 

--- a/docs/extension-development/adding-a-section-to-a-settings-tab.md
+++ b/docs/extension-development/adding-a-section-to-a-settings-tab.md
@@ -1,5 +1,5 @@
 
-# Adding a Section to a Settings Tab
+# Adding a section to a settings tab
 
 When you’re adding building an extension for WooCommerce that requires settings of some kind, it’s important to ask yourself:  **Where do they belong?**  If your extension just has a couple of simple settings, do you really need to create a new tab specifically for it? Most likely the answer is no.
 

--- a/docs/extension-development/extension-developer-handbook.md
+++ b/docs/extension-development/extension-developer-handbook.md
@@ -1,4 +1,4 @@
-# WooCommerce Extension Developer Handbook
+# WooCommerce extension developer handbook
 
 Want to create a plugin to extend WooCommerce? WooCommerce extensions are the same as regular WordPress plugins. For more information, visit [Writing a plugin](https://developer.wordpress.org/plugins/).
 

--- a/docs/extension-development/implementing-settings.md
+++ b/docs/extension-development/implementing-settings.md
@@ -1,4 +1,4 @@
-# Implementing Settings for Extensions
+# Implementing settings for extensions
 
 If you’re customizing WooCommerce or adding your own functionality to it you’ll probably need a settings page of some sort. One of the easiest ways to create a settings page is by taking advantage of the [`WC_Integration` class](https://woocommerce.github.io/code-reference/classes/WC-Integration.html 'WC_Integration Class'). Using the Integration class will automatically create a new settings page under **WooCommerce > Settings > Integrations** and it will automatically save, and sanitize your data for you. We’ve created this tutorial so you can see how to create a new integration.
 

--- a/docs/extension-development/readme.md
+++ b/docs/extension-development/readme.md
@@ -1,4 +1,4 @@
-# Extension Development
+# Extension development
 
 > ⚠️ **Notice:** This documentation is currently a **work in progress**. While it's open to the public for transparency and collaboration, please be aware that some sections might be incomplete or subject to change. We appreciate your patience and welcome any contributions!
 

--- a/docs/getting-started/developer-resources.md
+++ b/docs/getting-started/developer-resources.md
@@ -1,4 +1,4 @@
-# WooCommerce Developer Resources
+# WooCommerce developer resources
 
 This guide is a great starting point for WooCommerce development. From setting up your first online store to diving deep into advanced features, you'll find what you need here. New to WooCommerce? Start with the basics. Experienced and looking for specific documentation or community discussions? We've got that covered too. Navigate through the sections below to find the resources tailored for you.
 

--- a/docs/getting-started/developer-tools.md
+++ b/docs/getting-started/developer-tools.md
@@ -1,4 +1,4 @@
-# WooCommerce Developer Tools
+# WooCommerce developer tools
 
 This guide provides an overview of essential tools and libraries for WooCommerce development. It's intended for developers looking to enhance their WooCommerce projects efficiently.
 

--- a/docs/getting-started/readme.md
+++ b/docs/getting-started/readme.md
@@ -1,4 +1,4 @@
-# Getting-started
+# Getting started
 
 > ⚠️ **Notice:** This documentation is currently a **work in progress**. While it's open to the public for transparency and collaboration, please be aware that some sections might be incomplete or subject to change. We appreciate your patience and welcome any contributions!
 

--- a/docs/payments/payment-gateway-api.md
+++ b/docs/payments/payment-gateway-api.md
@@ -1,4 +1,4 @@
-# Payment Gateway API
+# Payment gateway API
 
 Payment gateways in WooCommerce are class based and can be added through traditional plugins. This guide provides an intro to gateway development.
 

--- a/docs/payments/payment-token-api.md
+++ b/docs/payments/payment-token-api.md
@@ -1,4 +1,4 @@
-# Payment Token API
+# Payment token API
 
 WooCommerce 2.6 introduced an API for storing and managing payment tokens for gateways. Users can also manage these tokens from their account settings and choose from saved payment tokens on checkout.
 

--- a/docs/product-editor-development/product-editor-extensibility-guidelines.md
+++ b/docs/product-editor-development/product-editor-extensibility-guidelines.md
@@ -1,4 +1,4 @@
-# Product Editor Extensibility Guidelines
+# Product editor extensibility guidelines
 
 > ⚠️ **Notice:** These guidelines are currently a **work in progress**. Please be aware that some details might be incomplete or subject to change. We appreciate your patience and welcome any contributions!
 

--- a/docs/quality-and-best-practices/css-sass-naming-conventions.md
+++ b/docs/quality-and-best-practices/css-sass-naming-conventions.md
@@ -1,4 +1,4 @@
-# CSS/Sass Naming Conventions
+# CSS/Sass naming conventions
 
 Table of Contents:
 

--- a/docs/quality-and-best-practices/naming-conventions.md
+++ b/docs/quality-and-best-practices/naming-conventions.md
@@ -1,4 +1,4 @@
-# Naming Conventions
+# Naming conventions
 
 Table of Contents:
 

--- a/docs/quality-and-best-practices/readme.md
+++ b/docs/quality-and-best-practices/readme.md
@@ -1,4 +1,4 @@
-# Quality and Best Practices
+# Quality and best practices
 
 > ⚠️ **Notice:** This documentation is currently a **work in progress**. While it's open to the public for transparency and collaboration, please be aware that some sections might be incomplete or subject to change. We appreciate your patience and welcome any contributions!
 

--- a/docs/reference-code/readme.md
+++ b/docs/reference-code/readme.md
@@ -1,4 +1,4 @@
-# Reference Code
+# Reference code
 
 > ⚠️ **Notice:** This documentation is currently a **work in progress**. While it's open to the public for transparency and collaboration, please be aware that some sections might be incomplete or subject to change. We appreciate your patience and welcome any contributions!
 

--- a/docs/reporting/extending-woocommerce-admin-reports.md
+++ b/docs/reporting/extending-woocommerce-admin-reports.md
@@ -1,4 +1,4 @@
-# Extending WC-Admin reports
+# Extending WooCommerce Analytics reports
 
 ## Introduction
 

--- a/docs/shipping/shipping-method-api.md
+++ b/docs/shipping/shipping-method-api.md
@@ -1,4 +1,4 @@
-# Shipping Method API
+# Shipping method API
 
 WooCommerce has a shipping method API which plugins can use to add their own rates. This article will take you through the steps to creating a new shipping method and interacting with the API.
 

--- a/docs/theme-development/fixing-outdated-woocommerce-templates.md
+++ b/docs/theme-development/fixing-outdated-woocommerce-templates.md
@@ -1,4 +1,4 @@
-# Fixing Outdated WooCommerce Templates
+# Fixing outdated WooCommerce templates
 
 ## Template Updates and Changes
 

--- a/docs/theme-development/theme-design-ux-guidelines.md
+++ b/docs/theme-development/theme-design-ux-guidelines.md
@@ -1,4 +1,4 @@
-# Theme Design and User Experience Guidelines
+# Theme design and user experience guidelines
 
 This guide covers general guidelines and best practices to follow in order to ensure your theme experience aligns with ecommerce industry standards and WooCommerce for providing a great online shopping experience, maximizing sales, ensuring ease of use, seamless integration, and strong UX adoption.
 

--- a/docs/user-experience/accessibility.md
+++ b/docs/user-experience/accessibility.md
@@ -1,4 +1,4 @@
-# User Experience Guidelines: Accessibility 
+# User experience guidelines: accessibility
 
 ## Accessibility
 

--- a/docs/user-experience/best-practices.md
+++ b/docs/user-experience/best-practices.md
@@ -1,4 +1,4 @@
-# User Experience Guidelines: Best Practices
+# User experience guidelines: best practices
 
 ## Best practices
 

--- a/docs/user-experience/colors.md
+++ b/docs/user-experience/colors.md
@@ -1,4 +1,4 @@
-# User Experience Guidelines: Colors
+# User experience guidelines: colors
 
 ## Colors
 

--- a/docs/user-experience/notices.md
+++ b/docs/user-experience/notices.md
@@ -1,4 +1,4 @@
-# User Experience Guidelines: Notices
+# User experience guidelines: notices
 
 ## Notices
 

--- a/docs/user-experience/onboarding.md
+++ b/docs/user-experience/onboarding.md
@@ -1,4 +1,4 @@
-# User Experience Guidelines: Onboarding 
+# User experience guidelines: onboarding
 
 ## Onboarding
 

--- a/docs/user-experience/task-list-and-inbox.md
+++ b/docs/user-experience/task-list-and-inbox.md
@@ -1,4 +1,4 @@
-# User Experience Guidelines: Task list and Inbox 
+# User experience guidelines: task list and inbox
 
 ## Task List & Inbox
 

--- a/docs/user-experience/user-experience-guidelines.md
+++ b/docs/user-experience/user-experience-guidelines.md
@@ -1,4 +1,4 @@
-# User Experience Guidelines
+# User experience guidelines
 
 This guide covers general guidelines, and best practices to follow in order to ensure your product experience aligns with WooCommerce for ease of use, seamless integration, and strong adoption.
 

--- a/docs/wc-cli/commands.md
+++ b/docs/wc-cli/commands.md
@@ -1,4 +1,4 @@
-# WC CLI: Commands
+# WC CLI: commands
 
 ## wc shop_coupon
 

--- a/docs/wc-cli/overview.md
+++ b/docs/wc-cli/overview.md
@@ -1,4 +1,4 @@
-# WC CLI: Overview
+# WC CLI: overview
 
 WooCommerce CLI (WC-CLI) offers the ability to manage WooCommerce (WC) via the command-line, using WP CLI. The documentation here covers the version of WC CLI that started shipping in WC 3.0.0 and later.
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR update some of the opening H1 headers in `.md`files in the docs folder to use consistent lowercase titles except the first word and proper names. It also fixes few typo / grammar issues in some of the titles.

Note: I noticed these while working on changes to the docs manifest generator.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. Markdown review
2.
3.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
