### PR TITLE
Switch assembler theme to TT4

### DIFF
--- a/plugins/woocommerce-admin/client/customize-store/design-with-ai/services.ts
+++ b/plugins/woocommerce-admin/client/customize-store/design-with-ai/services.ts
@@ -440,7 +440,7 @@ export const assembleSite = async (
 };
 
 const installAndActivateTheme = async () => {
-	const themeSlug = 'twentytwentythree';
+	const themeSlug = 'twentytwentyfour';
 
 	try {
 		await apiFetch( {

--- a/plugins/woocommerce/changelog/41736-41697-switch-to-tt4
+++ b/plugins/woocommerce/changelog/41736-41697-switch-to-tt4
@@ -1,4 +1,0 @@
-Significance: minor
-Type: update
-
-Switch the default assembler theme to "Twenty-twenty four"

--- a/plugins/woocommerce/changelog/41736-41697-switch-to-tt4
+++ b/plugins/woocommerce/changelog/41736-41697-switch-to-tt4
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Switch the default assembler theme to "Twenty-twenty four"

--- a/plugins/woocommerce/changelog/41736-switch-assembler-theme-to-tt4
+++ b/plugins/woocommerce/changelog/41736-switch-assembler-theme-to-tt4
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Switch the default assembler theme to "Twenty-twenty four"


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR updates the default assembler theme to Twenty Twenty Four.
<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/41697

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Please test the feature on a WooExpress install instead of Jurassic Ninja, as the latter can be very limited in terms of server resources and unstable, as other installs can interfere with your own.

- If you already have a pre-configured install, remove the pre-existing WooCommerce and upload the one from this branch.
- Alternatively, create a new WooExpress install from scratch, remove the pre-existing WooCommerce plugin via SSH and upload the one from this branch.
- Install and activate WooCommerce Beta Tester (the plugin is available [within the monorepo](https://github.com/woocommerce/woocommerce/tree/trunk/plugins))
- Head over to `/wp-admin/tools.php?page=woocommerce-admin-test-helper` and enable `customize-store` feature flag:

<img width="1233" alt="Screenshot 2023-10-22 at 10 32 24" src="https://github.com/woocommerce/woocommerce-blocks/assets/15730971/816867c6-34e5-40a1-a87d-f4a7cda46429">

### Test the CYS experience

0. Make sure you don't have any products in your store.
1. Head over to Home > Customize your Store:
 
<img width="1232" alt="Screenshot 2023-10-22 at 09 29 08" src="https://github.com/woocommerce/woocommerce-blocks/assets/15730971/b5d34131-3edc-47ed-a8e4-8e2775ca1bbd">

2. Click on design with AI.
3. Type a description for your business and finish the process.
4. **Make sure the theme selected after the process is Twenty Twenty Four**.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message
Switch the default assembler theme to "Twenty-twenty four"

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
