### PR TITLE
My Subscriptions feature flag

### DIFF
--- a/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx
+++ b/plugins/woocommerce-admin/client/marketplace/components/tabs/tabs.tsx
@@ -52,6 +52,17 @@ const tabs: Tabs = {
 	},
 };
 
+// If new My Subscriptions feature isn't enabled, go to old My Subscriptions URL
+if ( window?.wcSettings?.admin?.wccomHelper?.mySubscriptionsURL ) {
+	tabs[ 'my-subscriptions' ].href = getNewPath(
+		{
+			page: 'wc-addons',
+			section: 'helper',
+		},
+		''
+	);
+}
+
 const setUrlTabParam = ( tabKey: string ) => {
 	navigateTo( {
 		url: getNewPath(

--- a/plugins/woocommerce-admin/client/payments-welcome/index.tsx
+++ b/plugins/woocommerce-admin/client/payments-welcome/index.tsx
@@ -36,6 +36,9 @@ declare global {
 				currency?: {
 					symbol: string;
 				};
+				wccomHelper?: {
+					mySubscriptionsURL?: string;
+				}
 			};
 		};
 	}

--- a/plugins/woocommerce/includes/admin/helper/class-wc-helper-admin.php
+++ b/plugins/woocommerce/includes/admin/helper/class-wc-helper-admin.php
@@ -9,6 +9,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+
 /**
  * WC_Helper Class
  *
@@ -39,7 +41,7 @@ class WC_Helper_Admin {
 		$auth_user_data  = WC_Helper_Options::get( 'auth_user_data', array() );
 		$auth_user_email = isset( $auth_user_data['email'] ) ? $auth_user_data['email'] : '';
 
-		$settings['wccomHelper'] = array(
+		$wccom_helper_settings = array(
 			'isConnected' => WC_Helper::is_site_connected(),
 			'connectURL'  => self::get_connection_url(),
 			'userEmail'   => $auth_user_email,
@@ -47,6 +49,12 @@ class WC_Helper_Admin {
 			'storeCountry' => wc_get_base_location()['country'],
 			'inAppPurchaseURLParams' => WC_Admin_Addons::get_in_app_purchase_url_params(),
 		);
+
+		if ( ! FeaturesUtil::feature_is_enabled( 'my_subscriptions' ) ) {
+			$wccom_helper_settings['mySubscriptionsURL'] = admin_url( 'admin.php?page=wc-addons&section=helper' );
+		}
+
+		$settings['wccomHelper'] = $wccom_helper_settings;
 
 		return $settings;
 	}

--- a/plugins/woocommerce/src/Internal/Features/FeaturesController.php
+++ b/plugins/woocommerce/src/Internal/Features/FeaturesController.php
@@ -205,6 +205,16 @@ class FeaturesController {
 					'disable_ui'         => false,
 					'is_legacy'          => true,
 				),
+				'my_subscriptions' => array(
+					'name'               => __( 'My Subscriptions', 'woocommerce' ),
+					'description'        => __( 'The new way to manage your subscriptions for Woo.com extensions',
+						'woocommerce'
+					),
+					'is_experimental'    => false,
+					'enabled_by_default' => false,
+					'disable_ui'         => false,
+					'is_legacy'          => true,
+				),
 			);
 
 			foreach ( $legacy_features as $slug => $definition ) {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a `my_subscriptions` feature flag to determine whether we show the new React My Subscriptions page or the old PHP one. If the feature flag is not enabled, adds a `mySubscriptionsURL` property to `wcSettings.admin.wccomHelper`. If this property is present, `Tabs` component uses it as the URL of the My Subscriptions tab.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Check out this branch and build the project: `pnpm run build`.
2. Go to [WooCommerce > Extensions](http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fextensions).
3. Click on the `My subscriptions` tab.
4. Note that you get the old My Subscriptions UI.
5. Go to [WooCommerce > Settings > Advanced > Features](http://localhost:8888/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features).
6. Enable the setting `The new way to manage your subscriptions for Woo.com extensions`.
7. Refresh the WooCommerce > Extensions page.
8. Click on the `My subscriptions` tab.
9. Note that you get the new My Subscriptions UI.
10. Please test around this change.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

Added feature flag to determine whether we show the new My Subscriptions UI.

</details>
