### PR TITLE
Add extra protections against wrong filter values in the Command Palette logic

### DIFF
--- a/plugins/woocommerce/changelog/41773-add-command-palette-extra-protections
+++ b/plugins/woocommerce/changelog/41773-add-command-palette-extra-protections
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Prevent Command Palette logic showing PHP errors if buggy extensions add incorrect settings tabs or analytics reports.
+

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -593,6 +593,9 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 				$analytics_reports = Analytics::get_report_pages();
 				if ( is_array( $analytics_reports ) && count( $analytics_reports ) > 0 ) {
 					$formatted_analytics_reports = array_map( function( $report ) {
+						if ( ! is_array( $report ) ) {
+							return null;
+						}
 						$title = array_key_exists( 'title', $report ) ? $report['title'] : '';
 						$path = array_key_exists( 'path', $report ) ? $report['path'] : '';
 						if (

--- a/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-assets.php
@@ -567,10 +567,15 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 			if ( is_array( $settings_tabs ) && count( $settings_tabs ) > 0  ) {
 				$formatted_settings_tabs = array();
 				foreach ($settings_tabs as $key => $label) {
-					$formatted_settings_tabs[] = array(
-						'key'   => is_string( $key ) ? $key : '',
-						'label' => is_string( $label ) ? $label : '',
-					);
+					if (
+						is_string( $key ) && $key !== "" &&
+						is_string( $label ) && $label !== ""
+					) {
+						$formatted_settings_tabs[] = array(
+							'key'   => $key,
+							'label' => $label,
+						);
+					}
 				}
 
 				WCAdminAssets::register_script( 'wp-admin-scripts', 'command-palette' );
@@ -588,11 +593,20 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 				$analytics_reports = Analytics::get_report_pages();
 				if ( is_array( $analytics_reports ) && count( $analytics_reports ) > 0 ) {
 					$formatted_analytics_reports = array_map( function( $report ) {
-						return array(
-							'title' => is_string( $report['title'] ) ? $report['title']: '' ,
-							'path' => is_string( $report['path'] ) ? $report['path']: '',
-						);
+						$title = array_key_exists( 'title', $report ) ? $report['title'] : '';
+						$path = array_key_exists( 'path', $report ) ? $report['path'] : '';
+						if (
+							is_string( $title ) && $title !== "" &&
+							is_string( $path ) && $path !== ""
+						) {
+							return array(
+								'title' => $title,
+								'path' => $path,
+							);
+						}
+						return null;
 					}, $analytics_reports );
+					$formatted_analytics_reports = array_filter( $formatted_analytics_reports, 'is_array' );
 
 					WCAdminAssets::register_script( 'wp-admin-scripts', 'command-palette-analytics' );
 					wp_localize_script(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

### Changes proposed in this Pull Request:

Follow-up of https://github.com/woocommerce/woocommerce/pull/41605.

This PR adds some extra protections around the PHP code used by the Command Palette logic, so in case an extension, theme or custom code returns incorrect data for certain filters, we silently omit those errors.

### How to test the changes in this Pull Request:

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Install [Code Snippets](https://wordpress.org/plugins/code-snippets/), that will allow us to insert some PHP code into our store.
2. Go to Snippets > Add New. Here we will add some buggy code, simulating a buggy extension. So set the code snippet title to `Buggy extension` and add this PHP code:

```PHP
add_filter( 'woocommerce_analytics_report_menu_items', function($reports ) {
	return array_merge( $reports, array(
		array(
			'path'     => '/analytics/report-with-no-title',
		),
		array(),
		null,
	) );
});
add_filter( 'woocommerce_settings_tabs_array', function( $tabs ) {
	return array_merge( $tabs, array(
		'settings-no-label' => array(
			'key'     => 'settings-no-label',
		),
		array(),
		null,
	) );
});
```

3. You can leave the other options as they are. To save, press _Save Changes and Activate_.
4. Now, go to Posts > Add New Post.
5. Verify no errors are shown while the editor is loaded.
6. Open the Command Palette (<kbd>Ctrl</kbd>+<kbd>K</kbd>) and search for _settings_. Verify there are no entries with no empty title.
7. Do the same searching for _analytics_.

Before | After
--- | ---
![imatge](https://github.com/woocommerce/woocommerce/assets/3616980/5d3932e4-93b6-4bda-9d56-7256124bb1b7) | ![imatge](https://github.com/woocommerce/woocommerce/assets/3616980/09eb9a0d-961f-4394-9261-614833a4e7e9)
![imatge](https://github.com/woocommerce/woocommerce/assets/3616980/163d0c6e-1225-471c-b80a-b3320c7567e6) | ![imatge](https://github.com/woocommerce/woocommerce/assets/3616980/95eaf579-baa6-4239-ae29-8bc6c5ca64a4)


<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment

Prevent Command Palette logic showing PHP errors if buggy extensions add incorrect settings tabs or analytics reports.

</details>
