### PR TITLE
Remove Subscriptions from the Add Product task list

### DIFF
--- a/plugins/woocommerce-admin/client/task-lists/fills/import-products/index.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/fills/import-products/index.tsx
@@ -52,9 +52,7 @@ export const Products = () => {
 		} );
 
 	const { productTypes: productTypeListItems } = useProductTypeListItems(
-		getProductTypes( {
-			exclude: [ 'subscription' ],
-		} ),
+		getProductTypes(),
 		[],
 		{
 			onClick: recordCompletionTime,

--- a/plugins/woocommerce-admin/client/task-lists/fills/products/constants.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/fills/products/constants.tsx
@@ -89,4 +89,4 @@ export const onboardingProductTypesToSurfaced: Readonly<
 export const defaultSurfacedProductTypes =
 	onboardingProductTypesToSurfaced.physical;
 
-export const supportedOnboardingProductTypes = [ 'physical','downloads' ];
+export const supportedOnboardingProductTypes = [ 'physical', 'downloads' ];

--- a/plugins/woocommerce-admin/client/task-lists/fills/products/constants.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/fills/products/constants.tsx
@@ -47,16 +47,6 @@ export const productTypes = Object.freeze( [
 		after: <Icon icon={ chevronRight } />,
 	},
 	{
-		key: 'subscription' as const,
-		title: __( 'Subscription product', 'woocommerce' ),
-		content: __(
-			'Item that customers receive on a regular basis.',
-			'woocommerce'
-		),
-		before: <CalendarIcon />,
-		after: <Icon icon={ chevronRight } />,
-	},
-	{
 		key: 'grouped' as const,
 		title: __( 'Grouped product', 'woocommerce' ),
 		content: __( 'A collection of related products.', 'woocommerce' ),
@@ -93,23 +83,14 @@ export const onboardingProductTypesToSurfaced: Readonly<
 	Record< string, ProductTypeKey[] >
 > = Object.freeze( {
 	physical: [ 'physical', 'variable', 'grouped' ],
-	subscriptions: [ 'subscription' ],
 	downloads: [ 'digital' ],
 	// key in alphabetical and ascending order for mapping
-	'physical,subscriptions': [ 'physical', 'subscription' ],
 	'downloads,physical': [ 'physical', 'digital' ],
-	'downloads,subscriptions': [ 'digital', 'subscription' ],
-	'downloads,physical,subscriptions': [
-		'physical',
-		'digital',
-		'subscription',
-	],
 } );
 export const defaultSurfacedProductTypes =
 	onboardingProductTypesToSurfaced.physical;
 
 export const supportedOnboardingProductTypes = [
 	'physical',
-	'subscriptions',
 	'downloads',
 ];

--- a/plugins/woocommerce-admin/client/task-lists/fills/products/constants.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/fills/products/constants.tsx
@@ -5,7 +5,6 @@ import { __ } from '@wordpress/i18n';
 import ProductIcon from 'gridicons/dist/product';
 import CloudOutlineIcon from 'gridicons/dist/cloud-outline';
 import TypesIcon from 'gridicons/dist/types';
-import CalendarIcon from 'gridicons/dist/calendar';
 import { Icon, chevronRight } from '@wordpress/icons';
 
 /**
@@ -90,7 +89,4 @@ export const onboardingProductTypesToSurfaced: Readonly<
 export const defaultSurfacedProductTypes =
 	onboardingProductTypesToSurfaced.physical;
 
-export const supportedOnboardingProductTypes = [
-	'physical',
-	'downloads',
-];
+export const supportedOnboardingProductTypes = [ 'physical','downloads' ];

--- a/plugins/woocommerce-admin/client/task-lists/fills/products/index.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/fills/products/index.tsx
@@ -10,8 +10,6 @@ import { Button } from '@wordpress/components';
 import { getAdminLink } from '@woocommerce/settings';
 import { Icon, chevronDown, chevronUp } from '@wordpress/icons';
 import { recordEvent } from '@woocommerce/tracks';
-import { SETTINGS_STORE_NAME } from '@woocommerce/data';
-import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -26,7 +24,6 @@ import LoadSampleProductModal from '../components/load-sample-product-modal';
 import useLoadSampleProducts from '../components/use-load-sample-products';
 import LoadSampleProductConfirmModal from '../components/load-sample-product-confirm-modal';
 import useRecordCompletionTime from '../use-record-completion-time';
-import { getCountryCode } from '~/dashboard/utils';
 
 const getOnboardingProductType = (): string[] => {
 	const onboardingData = getAdminSetting( 'onboarding' );
@@ -59,29 +56,12 @@ export const Products = () => {
 		setIsConfirmingLoadSampleProducts,
 	] = useState( false );
 
-	const { isStoreInUS } = useSelect( ( select ) => {
-		const { getSettings } = select( SETTINGS_STORE_NAME );
-		const { general: settings = {} } = getSettings( 'general' );
-
-		const country =
-			typeof settings.woocommerce_default_country === 'string'
-				? settings.woocommerce_default_country
-				: '';
-
-		return {
-			isStoreInUS: getCountryCode( country ) === 'US',
-		};
-	} );
-
 	const surfacedProductTypeKeys = getSurfacedProductTypeKeys(
 		getOnboardingProductType()
 	);
 
 	const { productTypes, isRequesting } = useProductTypeListItems(
-		// Subscriptions only in the US
-		getProductTypes( {
-			exclude: isStoreInUS ? [] : [ 'subscription' ],
-		} ),
+		getProductTypes(),
 		surfacedProductTypeKeys
 	);
 	const { recordCompletionTime } = useRecordCompletionTime( 'products' );

--- a/plugins/woocommerce-admin/client/task-lists/fills/products/test/index.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/fills/products/test/index.tsx
@@ -4,7 +4,6 @@
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { recordEvent } from '@woocommerce/tracks';
-import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies

--- a/plugins/woocommerce-admin/client/task-lists/fills/products/test/index.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/fills/products/test/index.tsx
@@ -43,7 +43,6 @@ const confirmModalText =
 describe( 'Products', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
-		);
 	} );
 
 	it( 'should render default products types when onboardingData.profile.productType is null', () => {

--- a/plugins/woocommerce-admin/client/task-lists/fills/products/test/index.tsx
+++ b/plugins/woocommerce-admin/client/task-lists/fills/products/test/index.tsx
@@ -43,14 +43,6 @@ const confirmModalText =
 describe( 'Products', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
-		( useSelect as jest.Mock ).mockImplementation( ( fn ) =>
-			fn( () => ( {
-				getSettings: () => ( {
-					general: {
-						woocommerce_default_country: 'US',
-					},
-				} ),
-			} ) )
 		);
 	} );
 
@@ -80,66 +72,6 @@ describe( 'Products', () => {
 		expect( queryByText( 'Digital product' ) ).toBeInTheDocument();
 		expect( queryByRole( 'menu' )?.childElementCount ).toBe( 1 );
 		expect( queryByText( 'View more product types' ) ).toBeInTheDocument();
-	} );
-
-	it( 'should not render subscriptions products type when store is not in the US', () => {
-		( getAdminSetting as jest.Mock ).mockImplementation( () => ( {
-			profile: {
-				product_types: [ 'subscriptions' ],
-			},
-		} ) );
-		( useSelect as jest.Mock ).mockImplementation( ( fn ) =>
-			fn( () => ( {
-				getSettings: () => ( {
-					general: {
-						woocommerce_default_country: 'GB',
-					},
-				} ),
-			} ) )
-		);
-		const { queryByText } = render( <Products /> );
-
-		expect( queryByText( 'Subscription product' ) ).not.toBeInTheDocument();
-	} );
-
-	it( 'should not render subscriptions products type when store country is unknown', () => {
-		( getAdminSetting as jest.Mock ).mockImplementation( () => ( {
-			profile: {
-				product_types: [ 'subscriptions' ],
-			},
-		} ) );
-		( useSelect as jest.Mock ).mockImplementation( ( fn ) =>
-			fn( () => ( {
-				getSettings: () => ( {
-					general: {
-						woocommerce_default_country: undefined,
-					},
-				} ),
-			} ) )
-		);
-		const { queryByText } = render( <Products /> );
-
-		expect( queryByText( 'Subscription product' ) ).not.toBeInTheDocument();
-	} );
-
-	it( 'should render subscriptions products type when store is in the US', () => {
-		( getAdminSetting as jest.Mock ).mockImplementation( () => ( {
-			profile: {
-				product_types: [ 'subscriptions' ],
-			},
-		} ) );
-		( useSelect as jest.Mock ).mockImplementation( ( fn ) =>
-			fn( () => ( {
-				getSettings: () => ( {
-					general: {
-						woocommerce_default_country: 'US',
-					},
-				} ),
-			} ) )
-		);
-		const { queryByText } = render( <Products /> );
-
-		expect( queryByText( 'Subscription product' ) ).toBeInTheDocument();
 	} );
 
 	it( 'clicking on suggested product should fire event tasklist_add_product with method: product_template, tasklist_product_template_selection with is_suggested:true and task_completion_time', () => {

--- a/plugins/woocommerce-admin/client/task-lists/fills/products/test/utils.ts
+++ b/plugins/woocommerce-admin/client/task-lists/fills/products/test/utils.ts
@@ -14,7 +14,7 @@ describe( 'getProductTypes', () => {
 			getProductTypes( { exclude: [ 'external', 'digital' ] } ).map(
 				( p ) => p.key
 			)
-		).toEqual( [ 'physical', 'variable', 'subscription', 'grouped' ] );
+		).toEqual( [ 'physical', 'variable', 'grouped' ] );
 	} );
 } );
 

--- a/plugins/woocommerce-admin/client/task-lists/fills/products/use-create-product-by-type.ts
+++ b/plugins/woocommerce-admin/client/task-lists/fills/products/use-create-product-by-type.ts
@@ -25,7 +25,6 @@ export const useCreateProductByType = () => {
 		window.wcAdminFeatures[ 'new-product-management-experience' ];
 
 	const createProductByType = async ( type: ProductTypeKey ) => {
-
 		setIsRequesting( true );
 
 		if (

--- a/plugins/woocommerce-admin/client/task-lists/fills/products/use-create-product-by-type.ts
+++ b/plugins/woocommerce-admin/client/task-lists/fills/products/use-create-product-by-type.ts
@@ -25,12 +25,6 @@ export const useCreateProductByType = () => {
 		window.wcAdminFeatures[ 'new-product-management-experience' ];
 
 	const createProductByType = async ( type: ProductTypeKey ) => {
-		if ( type === 'subscription' ) {
-			window.location.href = getAdminLink(
-				'post-new.php?post_type=product&subscription_pointers=true'
-			);
-			return;
-		}
 
 		setIsRequesting( true );
 

--- a/plugins/woocommerce/changelog/41778-issue-41606
+++ b/plugins/woocommerce/changelog/41778-issue-41606
@@ -1,0 +1,4 @@
+Significance: patch
+Type: update
+
+Removed the Subscription product type from the 'Add Product' onboarding task list.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR removes the Subscription product type from the "Add Product" onboarding tasklist. Subscriptions used to be offered for free via Woo Payments, but this is no longer the case. 

Before: 

![pReiyQ.png](https://github.com/woocommerce/woocommerce/assets/25955483/0fc601ea-f2c1-442f-a39c-26dc49af1cc0)

After:

![90TCEY.png](https://github.com/woocommerce/woocommerce/assets/25955483/517cab2d-46a4-4889-b8f4-24606ee145cf)

Closes #41606 

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Navigate to `wp-admin/admin.php?page=wc-admin&task=products`.
2. View the available product types -- Subscriptions should be there.
3. Apply the patch. 
4. Refresh the page -- Subscriptions should not be offered.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->
Removed the Subscription product type from the 'Add Product' onboarding task list.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>