### PR TITLE
Show feedback bar only once

### DIFF
--- a/packages/js/product-editor/changelog/dev-39167_show_feedback_prompt_only_once
+++ b/packages/js/product-editor/changelog/dev-39167_show_feedback_prompt_only_once
@@ -1,0 +1,4 @@
+Significance: minor
+Type: dev
+
+Show feedback bar only once #41787

--- a/packages/js/product-editor/src/components/feedback-bar/feedback-bar.tsx
+++ b/packages/js/product-editor/src/components/feedback-bar/feedback-bar.tsx
@@ -12,6 +12,7 @@ import {
 	createElement,
 	createInterpolateElement,
 	Fragment,
+	useState,
 } from '@wordpress/element';
 import { closeSmall } from '@wordpress/icons';
 import { Pill } from '@woocommerce/components';
@@ -30,9 +31,10 @@ export type FeedbackBarProps = {
 };
 
 export function FeedbackBar( { productType }: FeedbackBarProps ) {
-	const { hideFeedbackBar, shouldShowFeedbackBar } = useFeedbackBar();
+	const { shouldShowFeedbackBar } = useFeedbackBar();
 	const { showCesModal, showProductMVPFeedbackModal } =
 		useCustomerEffortScoreModal();
+	const [ isFeedbackBarHidden, setIsFeedbackBarHidden ] = useState( false );
 
 	const getProductTracksProps = () => {
 		const tracksProps = {
@@ -175,6 +177,7 @@ export function FeedbackBar( { productType }: FeedbackBarProps ) {
 				type: 'snackbar',
 			}
 		);
+		setIsFeedbackBarHidden( true );
 	};
 
 	const onTurnOffEditorClick = () => {
@@ -182,7 +185,7 @@ export function FeedbackBar( { productType }: FeedbackBarProps ) {
 			...getProductTracksProps(),
 		} );
 
-		hideFeedbackBar();
+		setIsFeedbackBarHidden( true );
 
 		showProductMVPFeedbackModal();
 	};
@@ -192,12 +195,12 @@ export function FeedbackBar( { productType }: FeedbackBarProps ) {
 			...getProductTracksProps(),
 		} );
 
-		hideFeedbackBar();
+		setIsFeedbackBarHidden( true );
 	};
 
 	return (
 		<>
-			{ shouldShowFeedbackBar && (
+			{ shouldShowFeedbackBar && ! isFeedbackBarHidden && (
 				<div className="woocommerce-product-mvp-ces-footer">
 					<Pill>Beta</Pill>
 					<div className="woocommerce-product-mvp-ces-footer__message">

--- a/packages/js/product-editor/src/hooks/use-feedback-bar/use-feedback-bar.ts
+++ b/packages/js/product-editor/src/hooks/use-feedback-bar/use-feedback-bar.ts
@@ -68,6 +68,5 @@ export const useFeedbackBar = () => {
 	return {
 		shouldShowFeedbackBar,
 		maybeShowFeedbackBar,
-		hideFeedbackBar,
 	};
 };

--- a/packages/js/product-editor/src/hooks/use-feedback-bar/use-feedback-bar.ts
+++ b/packages/js/product-editor/src/hooks/use-feedback-bar/use-feedback-bar.ts
@@ -41,10 +41,11 @@ export const useFeedbackBar = () => {
 		}
 	};
 
-	const hideFeedbackBar = () => {
+	const showFeedbackBarOnce = () => {
 		updateOptions( {
 			[ PRODUCT_EDITOR_SHOW_FEEDBACK_BAR_OPTION_NAME ]: 'no',
 		} );
+		setShouldShowFeedbackBar( true );
 	};
 
 	const fetchShowFeedbackBarOption = useCallback( () => {
@@ -55,8 +56,7 @@ export const useFeedbackBar = () => {
 					window.wcTracks?.isEnabled &&
 					showFeedbackBarOption === 'yes'
 				) {
-					setShouldShowFeedbackBar( true );
-					hideFeedbackBar();
+					showFeedbackBarOnce();
 				}
 			} );
 	}, [] );


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds the code to show the feedback bar only once.

Closes #39167.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a WooCommerce store with this branch and enable the product editor using **WooCommerce > Settings > Advanced > Features**.
2. Under **WooCommerce > Settings > Advanced > Woo.com** verify that the `Enable tracking` option is `enabled`.  
3. Go to **Products > Add New**.
4. Add a product name and press `Save draft`.
5. Refresh the page.
6. Verify that the feedback bar is visible (it will appear after a few seconds).
7. Refresh the page and verify that the feedback bar is not visible anymore.

![Screen Capture on 2023-11-29 at 15-43-16](https://github.com/woocommerce/woocommerce/assets/1314156/4939a3af-fcea-4f42-a738-f0fdf0811423)

8. Go to **Tools > WCA Test Helper** and modify the option `woocommerce_product_editor_show_feedback_bar` as `yes`.
9. Now go to **Products > Add New**, the feedback bar should be visible again.
10. Verify that the buttons `Share feedback`, `turn it off` and the `x` hide the feedback bar.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
