### PR TITLE
Fix parse number with empty string separators

### DIFF
--- a/packages/js/number/changelog/fix-41780_parse_number
+++ b/packages/js/number/changelog/fix-41780_parse_number
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix parseNumber to allow for emptry string thousand & decimal seperators.

--- a/packages/js/number/changelog/fix-41780_parse_number
+++ b/packages/js/number/changelog/fix-41780_parse_number
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Fix parseNumber to allow for emptry string thousand & decimal seperators.
+Fix parseNumber to allow for emptry string thousand & decimal separators.

--- a/packages/js/number/src/index.ts
+++ b/packages/js/number/src/index.ts
@@ -135,10 +135,19 @@ export function parseNumber(
 		const [ , decimals ] = value.split( decimalSeparator );
 		parsedPrecision = decimals ? decimals.length : 0;
 	}
+	let parsedValue = value;
+	if ( thousandSeparator ) {
+		parsedValue = parsedValue.replace(
+			new RegExp( `\\${ thousandSeparator }`, 'g' ),
+			''
+		);
+	}
+	if ( decimalSeparator ) {
+		parsedValue = parsedValue.replace(
+			new RegExp( `\\${ decimalSeparator }`, 'g' ),
+			'.'
+		);
+	}
 
-	return Number.parseFloat(
-		value
-			.replace( new RegExp( `\\${ thousandSeparator }`, 'g' ), '' )
-			.replace( new RegExp( `\\${ decimalSeparator }`, 'g' ), '.' )
-	).toFixed( parsedPrecision );
+	return Number.parseFloat( parsedValue ).toFixed( parsedPrecision );
 }

--- a/packages/js/number/src/test/index.ts
+++ b/packages/js/number/src/test/index.ts
@@ -6,7 +6,7 @@ import { partial } from 'lodash';
 /**
  * Internal dependencies
  */
-import { numberFormat } from '../index';
+import { numberFormat, parseNumber } from '../index';
 
 const defaultNumberFormat = partial( numberFormat, {} );
 
@@ -46,5 +46,35 @@ describe( 'numberFormat', () => {
 			precision: 3,
 		};
 		expect( numberFormat( config, '12345.6789' ) ).toBe( '12.345,679' );
+	} );
+
+});
+
+describe( 'parseNumber', () => {
+	it( 'should remove thousand seperator before parsing number', () => {
+		const config = {
+			decimalSeparator: ',',
+			thousandSeparator: '.',
+			precision: 3,
+		};
+		expect( parseNumber( config, '12.345,679' ) ).toBe( '12345.679' );
+	} );
+
+	it( 'supports empty string as the thousandSeperator', () => {
+		const config = {
+			decimalSeparator: ',',
+			thousandSeparator: '',
+			precision: 3,
+		};
+		expect( parseNumber( config, '12345,679' ) ).toBe( '12345.679' );
+	} );
+
+	it( 'supports empty string as the decimalSeperator', () => {
+		const config = {
+			decimalSeparator: '',
+			thousandSeparator: ',',
+			precision: 2,
+		};
+		expect( parseNumber( config, '1,2345,679' ) ).toBe( '12345679.00' );
 	} );
 } );

--- a/packages/js/number/src/test/index.ts
+++ b/packages/js/number/src/test/index.ts
@@ -47,8 +47,7 @@ describe( 'numberFormat', () => {
 		};
 		expect( numberFormat( config, '12345.6789' ) ).toBe( '12.345,679' );
 	} );
-
-});
+} );
 
 describe( 'parseNumber', () => {
 	it( 'should remove thousand seperator before parsing number', () => {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This changes just updates the conditional logic to only use the separator replace/Regex function when there is a value.

Closes #41780  .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new WooCommerce store and set your store location to a European country ( like Portugal ) 
2. Go to **WooCommerce > settings > general**
3. Scroll to the bottom and make sure the **Thousand separator** value is blank.
4. Enable the new product editor under **WooCommerce > Settings > Advanced > Features**
5. Go to **Products > Add new**
6. Scroll down to the downloads section
7. Add a new item
8. Once added the **Manage limits** should show, click this and update the limit
9. No errors should happen
10. Navigate to the Shipping tab
11. Select the checkbox at the top and enter some values for the width, length
12. No errors should be shown and it should work correctly.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
