### PR TITLE
[Product Block Editor]: fix Input control issue in Manage download limit form

### DIFF
--- a/packages/js/product-editor/changelog/fix-download-input-number-jumps-twice
+++ b/packages/js/product-editor/changelog/fix-download-input-number-jumps-twice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+[Product Block Editor]: fix Input control issue in Manage download limit form

--- a/packages/js/product-editor/src/components/manage-download-limits-modal/manage-download-limits-modal.tsx
+++ b/packages/js/product-editor/src/components/manage-download-limits-modal/manage-download-limits-modal.tsx
@@ -122,11 +122,14 @@ export function ManageDownloadLimitsModal( {
 		return true;
 	}
 
+	const downloadLimitInputProps = useNumberInputProps( {
+		value: downloadLimit,
+		onChange: setDownloadLimit,
+	} );
+
 	const downloadLimitProps = {
-		...useNumberInputProps( {
-			value: downloadLimit,
-			onChange: setDownloadLimit,
-		} ),
+		value: downloadLimitInputProps.value,
+		onChange: downloadLimitInputProps.onChange,
 		id: useInstanceId(
 			BaseControl,
 			'product_download_limit_field'
@@ -154,11 +157,14 @@ export function ManageDownloadLimitsModal( {
 		},
 	};
 
+	const downloadExpiryInputProps = useNumberInputProps( {
+		value: downloadExpiry,
+		onChange: setDownloadExpiry,
+	} );
+
 	const downloadExpiryProps = {
-		...useNumberInputProps( {
-			value: downloadExpiry,
-			onChange: setDownloadExpiry,
-		} ),
+		value: downloadExpiryInputProps.value,
+		onChange: downloadExpiryInputProps.onChange,
 		id: useInstanceId(
 			BaseControl,
 			'product_download_expiry_field'


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes an issue that happens when the user increases/decreases the input value of the Manage download limit form  by pressing the key up/down:

https://github.com/woocommerce/woocommerce/assets/77539/ed81a48f-72f6-403d-9425-91462feb831c

In the video above, the value of the input changes twice when the key is pressed down.

Follow up of https://github.com/woocommerce/woocommerce/pull/41792


Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to the Product editor
2. Open the Manage Download Limit modal
3. Focus on of the the input element
4. Press keyup/keydown 
5. **Before**: confirm that the input changes its value by two units
6. **After**: It works as expected

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
