### PR TITLE
Logging: Enable downloading log files singularly and in bulk

### DIFF
--- a/plugins/woocommerce/changelog/fix-40645-log-export
+++ b/plugins/woocommerce/changelog/fix-40645-log-export
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add functionality and UI for downloading log files directly from WC Admin

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -4116,7 +4116,7 @@ table.wc_shipping {
 
 	.wc-backbone-modal-main article {
 		padding: 0 32px 32px 32px;
-		
+
 	}
 
 	.wc-backbone-modal-main header{
@@ -4125,7 +4125,7 @@ table.wc_shipping {
 
 	.wc-backbone-modal-main footer {
 		padding: 20px 32px 12px 32px;
-		
+
 	}
 
 	.wc-backbone-modal-main .wc-backbone-modal-header h1 {
@@ -4169,7 +4169,7 @@ table.wc_shipping {
 				display: none;
 			}
 		}
-		
+
 	}
 
 	.wc-shipping-method-add-class-costs {
@@ -4187,7 +4187,7 @@ table.wc_shipping {
 			height: 1px;
 			overflow: hidden;
 			position: absolute;
-			white-space: nowrap; 
+			white-space: nowrap;
 			width: 1px;
 
 			&:checked + label {
@@ -4238,7 +4238,7 @@ table.wc_shipping {
 			font-size: 24px;
 		}
 	}
-	
+
 	.wc-shipping-zone-method-fields {
 
 		& > label {
@@ -4259,7 +4259,7 @@ table.wc_shipping {
 			margin-bottom: 24px;
 			position: relative;
 
-			input, 
+			input,
 			select {
 				margin: 6px 0;
 				padding: 12px;
@@ -4363,7 +4363,7 @@ table {
 	.edit {
 		margin: 5px 0;
 	}
-	
+
 	.edit > input,
 	.edit > select {
 		width: 100%;
@@ -4391,7 +4391,7 @@ table {
 	}
 }
 
-.wc-shipping-class-hide-sibling-view + .view { 
+.wc-shipping-class-hide-sibling-view + .view {
 	display: none;
 }
 
@@ -4403,7 +4403,7 @@ table {
 		display: inline-block;
 		margin: 0 12px;
 	}
-} 
+}
 
 .wc-shipping-zone-heading-help-text {
 	max-width: 800px;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1348,7 +1348,8 @@ table.wc_status_table--tools {
 	}
 }
 
-.wc-logs-single-file-actions {
+.wc-logs-single-file-actions,
+.wc-logs-search {
 	margin-left: auto;
 	display: flex;
 	flex-flow: row wrap;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1474,6 +1474,10 @@ table.wc_status_table--tools {
 		width: 8%;
 	}
 
+	.column-line {
+		font-family: Consolas, Monaco, monospace;
+	}
+
 	.search-match {
 		background: #fff8c5;
 		padding: 0.46em 0;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1474,10 +1474,6 @@ table.wc_status_table--tools {
 		width: 8%;
 	}
 
-	.column-line {
-		font-family: Consolas, Monaco, monospace;
-	}
-
 	.search-match {
 		background: #fff8c5;
 		padding: 0.46em 0;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1348,8 +1348,7 @@ table.wc_status_table--tools {
 	}
 }
 
-.wc-logs-single-file-actions,
-.wc-logs-search {
+.wc-logs-single-file-actions {
 	margin-left: auto;
 	display: flex;
 	flex-flow: row wrap;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1477,18 +1477,9 @@ table.wc_status_table--tools {
 
 	.search-match {
 		background: #fff8c5;
-<<<<<<< HEAD
 		padding: 0.46em 0;
 		border: 1px dashed #c3c4c7;
 		line-height: 2.3;
-=======
-		padding: 0.52em 0;
-	}
-
-	.no-match {
-		display: block;
-		padding: 1em;
->>>>>>> a59774c798 (Fix various search string edge cases)
 	}
 }
 

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1477,9 +1477,18 @@ table.wc_status_table--tools {
 
 	.search-match {
 		background: #fff8c5;
+<<<<<<< HEAD
 		padding: 0.46em 0;
 		border: 1px dashed #c3c4c7;
 		line-height: 2.3;
+=======
+		padding: 0.52em 0;
+	}
+
+	.no-match {
+		display: block;
+		padding: 1em;
+>>>>>>> a59774c798 (Fix various search string edge cases)
 	}
 }
 

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
@@ -180,6 +180,15 @@ class File {
 	}
 
 	/**
+	 * Get the full absolute path of the file.
+	 *
+	 * @return string
+	 */
+	public function get_path(): string {
+		return $this->path;
+	}
+
+	/**
 	 * Get the name of the file, with extension, but without full path.
 	 *
 	 * @return string

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
@@ -63,13 +63,6 @@ class FileController {
 	private const SEARCH_CACHE_KEY = 'logs_previous_search';
 
 	/**
-	 * A cache key for storing and retrieving the results of the last logs search.
-	 *
-	 * @const string
-	 */
-	private const SEARCH_CACHE_KEY = 'logs_previous_search';
-
-	/**
 	 * The absolute path to the log directory.
 	 *
 	 * @var string

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
@@ -63,6 +63,13 @@ class FileController {
 	private const SEARCH_CACHE_KEY = 'logs_previous_search';
 
 	/**
+	 * A cache key for storing and retrieving the results of the last logs search.
+	 *
+	 * @const string
+	 */
+	private const SEARCH_CACHE_KEY = 'logs_previous_search';
+
+	/**
 	 * The absolute path to the log directory.
 	 *
 	 * @var string

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
@@ -371,7 +371,7 @@ class FileController {
 	 *
 	 * @param array $file_ids An array of file IDs (file basename without the hash).
 	 *
-	 * @return WP_Error|null
+	 * @return WP_Error|void Only returns something if there is an error.
 	 */
 	public function export_multiple_files( array $file_ids ) {
 		$files = $this->get_files_by_id( $file_ids );
@@ -383,16 +383,18 @@ class FileController {
 			);
 		}
 
-		if ( ! get_temp_dir() ) {
+		$temp_dir = get_temp_dir();
+
+		if ( ! is_dir( $temp_dir ) || ! wp_is_writable( $temp_dir ) ) {
 			return new WP_Error(
 				'wc_logs_invalid_directory',
-				__( 'Could not write to the temp directory.', 'woocommerce' )
+				__( 'Could not write to the temp directory. Try downloading files one at a time instead.', 'woocommerce' )
 			);
 		}
 
 		require_once ABSPATH . 'wp-admin/includes/class-pclzip.php';
 
-		$path       = trailingslashit( get_temp_dir() ) . 'woocommerce_logs_' . gmdate( 'Y-m-d_H-i-s' ) . '.zip';
+		$path       = trailingslashit( $temp_dir ) . 'woocommerce_logs_' . gmdate( 'Y-m-d_H-i-s' ) . '.zip';
 		$file_paths = array_map(
 			fn( $file ) => $file->get_path(),
 			$files

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileExporter.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileExporter.php
@@ -51,11 +51,9 @@ class FileExporter {
 	/**
 	 * Configure PHP and stream the file to the browser.
 	 *
-	 * Modeled on WC_CSV_Exporter::send_headers().
-	 *
 	 * @return WP_Error|void Only returns something if there is an error.
 	 */
-	public function emit_file(  ) {
+	public function emit_file() {
 		global $wp_filesystem;
 		if ( ! $wp_filesystem->is_file( $this->path ) || ! $wp_filesystem->is_readable( $this->path ) ) {
 			return new WP_Error(
@@ -64,20 +62,21 @@ class FileExporter {
 			);
 		}
 
+		// These configuration tweaks are copied from WC_CSV_Exporter::send_headers().
+		// phpcs:disable WordPress.PHP.NoSilencedErrors.Discouraged
 		if ( function_exists( 'gc_enable' ) ) {
 			gc_enable(); // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions.gc_enableFound
 		}
-
 		if ( function_exists( 'apache_setenv' ) ) {
-			@apache_setenv( 'no-gzip', '1' );
+			@apache_setenv( 'no-gzip', '1' ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_apache_setenv
 		}
-
-		@ini_set( 'zlib.output_compression', 'Off' );
-		@ini_set( 'output_buffering', 'Off' );
-		@ini_set( 'output_handler', '' );
+		@ini_set( 'zlib.output_compression', 'Off' ); // phpcs:ignore WordPress.PHP.IniSet.Risky
+		@ini_set( 'output_buffering', 'Off' ); // phpcs:ignore WordPress.PHP.IniSet.Risky
+		@ini_set( 'output_handler', '' ); // phpcs:ignore WordPress.PHP.IniSet.Risky
 		ignore_user_abort( true );
 		wc_set_time_limit();
 		wc_nocache_headers();
+		// phpcs:enable WordPress.PHP.NoSilencedErrors.Discouraged
 
 		$this->send_headers();
 		$this->send_contents();
@@ -109,9 +108,11 @@ class FileExporter {
 		$stream = fopen( $this->path, 'rb' );
 
 		while ( is_resource( $stream ) && ! feof( $stream ) ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fread -- No suitable alternative.
 			$chunk = fread( $stream, self::CHUNK_SIZE );
 
 			if ( is_string( $chunk ) ) {
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Outputting to file.
 				echo $chunk;
 			}
 		}

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileExporter.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileExporter.php
@@ -1,0 +1,135 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Internal\Admin\Logging\FileV2;
+
+use WP_Error;
+use WP_Filesystem_Direct;
+
+/**
+ * FileExport class.
+ */
+class FileExporter {
+	/**
+	 * The number of bytes per read while streaming the file.
+	 *
+	 * @const int
+	 */
+	private const CHUNK_SIZE = 4 * KB_IN_BYTES;
+
+	/**
+	 * The absolute path of the file.
+	 *
+	 * @var string
+	 */
+	private $path;
+
+	/**
+	 * A name of the file to send to the browser rather than the filename part of the path.
+	 *
+	 * @var string
+	 */
+	private $alternate_filename;
+
+	/**
+	 * Class FileExporter.
+	 *
+	 * @param string $path               The absolute path of the file.
+	 * @param string $alternate_filename Optional. The name of the file to send to the browser rather than the filename
+	 *                                   part of the path.
+	 */
+	public function __construct( string $path, string $alternate_filename = '' ) {
+		global $wp_filesystem;
+		if ( ! $wp_filesystem instanceof WP_Filesystem_Direct ) {
+			WP_Filesystem();
+		}
+
+		$this->path               = $path;
+		$this->alternate_filename = $alternate_filename;
+	}
+
+	/**
+	 * Configure PHP and stream the file to the browser.
+	 *
+	 * Modeled on WC_CSV_Exporter::send_headers().
+	 *
+	 * @return WP_Error|void Only returns something if there is an error.
+	 */
+	public function emit_file(  ) {
+		global $wp_filesystem;
+		if ( ! $wp_filesystem->is_file( $this->path ) || ! $wp_filesystem->is_readable( $this->path ) ) {
+			return new WP_Error(
+				'wc_logs_invalid_file',
+				__( 'Could not access file.', 'woocommerce' )
+			);
+		}
+
+		if ( function_exists( 'gc_enable' ) ) {
+			gc_enable(); // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions.gc_enableFound
+		}
+
+		if ( function_exists( 'apache_setenv' ) ) {
+			@apache_setenv( 'no-gzip', '1' );
+		}
+
+		@ini_set( 'zlib.output_compression', 'Off' );
+		@ini_set( 'output_buffering', 'Off' );
+		@ini_set( 'output_handler', '' );
+		ignore_user_abort( true );
+		wc_set_time_limit();
+		wc_nocache_headers();
+
+		$this->send_headers();
+		$this->send_contents();
+
+		die;
+	}
+
+	/**
+	 * Send HTTP headers at the beginning of a file.
+	 *
+	 * Modeled on WC_CSV_Exporter::send_headers().
+	 *
+	 * @return void
+	 */
+	private function send_headers(): void {
+		header( 'Content-Type: text/plain; charset=utf-8' );
+		header( 'Content-Disposition: attachment; filename=' . $this->get_filename() );
+		header( 'Pragma: no-cache' );
+		header( 'Expires: 0' );
+	}
+
+	/**
+	 * Send the contents of the file.
+	 *
+	 * @return void
+	 */
+	private function send_contents(): void {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fopen -- No suitable alternative.
+		$stream = fopen( $this->path, 'rb' );
+
+		while ( is_resource( $stream ) && ! feof( $stream ) ) {
+			$chunk = fread( $stream, self::CHUNK_SIZE );
+
+			if ( is_string( $chunk ) ) {
+				echo $chunk;
+			}
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fclose -- No suitable alternative.
+		fclose( $stream );
+	}
+
+	/**
+	 * Get the name of the file that will be sent to the browser.
+	 *
+	 * @return string
+	 */
+	private function get_filename(): string {
+		if ( $this->alternate_filename ) {
+			return $this->alternate_filename;
+		}
+
+		return basename( $this->path );
+	}
+}

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileListTable.php
@@ -67,6 +67,7 @@ class FileListTable extends WP_List_Table {
 	 */
 	protected function get_bulk_actions(): array {
 		return array(
+			'export' => esc_html__( 'Download', 'woocommerce' ),
 			'delete' => esc_html__( 'Delete permanently', 'woocommerce' ),
 		);
 	}

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -567,69 +567,6 @@ class PageController {
 	}
 
 	/**
-	 * Format a search results line.
-	 *
-	 * @param string $file_id     The file ID that contains the matched line.
-	 * @param int    $line_number The line number of the matched line.
-	 * @param string $line        The matched line, with matched substrings highlighted.
-	 *
-	 * @return string
-	 */
-	private function format_match( string $file_id, int $line_number, string $line ): string {
-		$params = $this->get_query_params( array( 'search' ) );
-
-		// Add a word break after the rotation number, if it exists.
-		$file_id = preg_replace( '/\.([0-9])+\-/', '.\1<wbr>-', $file_id );
-
-		$match_url = add_query_arg(
-			array(
-				'view'    => 'single_file',
-				'file_id' => $file_id,
-			),
-			$this->get_logs_tab_url() . '#L' . absint( $line_number )
-		);
-
-		// Highlight matches within the line.
-		$pattern = preg_quote( $params['search'], '/' );
-		preg_match_all( "/$pattern/i", $line, $matches, PREG_OFFSET_CAPTURE );
-		if ( is_array( $matches[0] ) && count( $matches[0] ) >= 1 ) {
-			$length_change = 0;
-
-			foreach ( $matches[0] as $match ) {
-				$replace        = '<span class="search-match">' . $match[0] . '</span>';
-				$offset         = $match[1] + $length_change;
-				$orig_length    = strlen( $match[0] );
-				$replace_length = strlen( $replace );
-
-				$line = substr_replace( $line, $replace, $offset, $orig_length );
-
-				$length_change += $replace_length - $orig_length;
-			}
-		}
-
-		return sprintf(
-			'<span class="match">%1$s%2$s%3$s</span>',
-			sprintf(
-				'<span class="match-file">%s</span>',
-				wp_kses( $file_id, array( 'wbr' => array() ) )
-			),
-			sprintf(
-				'<a href="%1$s" class="match-anchor">%2$s</a>',
-				esc_url( $match_url ),
-				sprintf(
-					// translators: %s is a line number in a file.
-					esc_html__( 'Line %s', 'woocommerce' ),
-					number_format_i18n( absint( $line_number ) )
-				)
-			),
-			sprintf(
-				'<span class="match-content">%s</span>',
-				wp_kses_post( $line )
-			)
-		);
-	}
-
-	/**
 	 * Render a form for searching within log files.
 	 *
 	 * @return void

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -569,6 +569,43 @@ class PageController {
 	}
 
 	/**
+	 * Format a search results line.
+	 *
+	 * @param string $file_id     The file ID that contains the matched line.
+	 * @param int    $line_number The line number of the matched line.
+	 * @param string $line        The matched line, with matched substrings highlighted.
+	 *
+	 * @return string
+	 */
+	private function format_match( string $file_id, int $line_number, string $line ): string {
+		$match_url = add_query_arg(
+			array(
+				'view'    => 'single_file',
+				'file_id' => $file_id,
+			),
+			$this->get_logs_tab_url() . '#L' . absint( $line_number )
+		);
+
+		return sprintf(
+			'<span class="match">%1$s%2$s</span>',
+			sprintf(
+				'<a href="%1$s" class="match-anchor">%2$s<br />%3$s</a>',
+				esc_url( $match_url ),
+				esc_html( $file_id ),
+				sprintf(
+					// translators: %d is a line number in a file.
+					esc_html__( 'Line %d', 'woocommerce' ),
+					absint( $line_number )
+				)
+			),
+			sprintf(
+				'<span class="match-content">%s</span>',
+				wp_kses_post( $line )
+			)
+		);
+	}
+
+	/**
 	 * Render a form for searching within log files.
 	 *
 	 * @return void

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -580,6 +580,9 @@ class PageController {
 	private function format_match( string $file_id, int $line_number, string $line ): string {
 		$params = $this->get_query_params( array( 'search' ) );
 
+		// Add a word break after the rotation number, if it exists.
+		$file_id = preg_replace( '/\.([0-9])+\-/', '.\1<wbr>-', $file_id );
+
 		$match_url = add_query_arg(
 			array(
 				'view'    => 'single_file',
@@ -607,15 +610,18 @@ class PageController {
 		}
 
 		return sprintf(
-			'<span class="match">%1$s%2$s</span>',
+			'<span class="match">%1$s%2$s%3$s</span>',
 			sprintf(
-				'<a href="%1$s" class="match-anchor">%2$s<br />%3$s</a>',
+				'<span class="match-file">%s</span>',
+				wp_kses( $file_id, array( 'wbr' => array() ) )
+			),
+			sprintf(
+				'<a href="%1$s" class="match-anchor">%2$s</a>',
 				esc_url( $match_url ),
-				esc_html( $file_id ),
 				sprintf(
-					// translators: %d is a line number in a file.
-					esc_html__( 'Line %d', 'woocommerce' ),
-					absint( $line_number )
+					// translators: %s is a line number in a file.
+					esc_html__( 'Line %s', 'woocommerce' ),
+					number_format_i18n( absint( $line_number ) )
 				)
 			),
 			sprintf(

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -143,8 +143,6 @@ class PageController {
 
 		$list_table->prepare_items();
 
-		$this->get_list_table()->prepare_items();
-
 		?>
 		<header id="logs-header" class="wc-logs-header">
 			<h2>

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -143,6 +143,8 @@ class PageController {
 
 		$list_table->prepare_items();
 
+		$this->get_list_table()->prepare_items();
+
 		?>
 		<header id="logs-header" class="wc-logs-header">
 			<h2>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds functionality and UI for downloading log files directly from WC Admin.

Fixes #40645

![Screen Shot 2023-11-29 at 16 40 38](https://github.com/woocommerce/woocommerce/assets/916023/11c270c4-fdbd-4d12-98db-3d5803704054)

### How to test the changes in this Pull Request:

#### Setup

1. After checking out this branch, you may need to update the autoloader. From the **plugins/woocommerce** directory, run `composer dump-autoload`. You also will probably need to rebuild the stylesheet for the Logs screen. For this, run `pnpm --filter=woocommerce/client/legacy run build`.
1. In your test site's **wp-config.php** file, add this line: `define( 'WC_LOG_HANDLER', 'Automattic\\WooCommerce\\Internal\\Admin\\Logging\\LogHandlerFileV2' );`. This is what allows you to see the new log file functionality.
2. Install [this plugin](https://gist.github.com/coreymckrill/2968911c8b63c556e7787f2cdc65f966) on your test site for generating test log files. Probably easiest to copy the file into the mu-plugins directory.
3. Open two browser tabs: the Logs screen (WP Admin > WooCommerce > Status > Logs) and the WooCommerce Tools screen (WP Admin > WooCommerce > Status > Tools). On the Tools screen you should see the **Debug Log Generator** tool at the top of the list.

#### Tests

1. On the Logs screen, you should see a list table, which may already have some log files listed in it. Even if there are some, go ahead and generate some additional logs on the Tools screen so that we have enough different log files and sources.
2. Click on one of the log files to view its contents. In this single file view, you should see a "Download" button in the upper right corner, next to the "Delete" button. Clicking the button should present you with your browser's save dialog modal, allowing you to save the file to your local computer. The filename should be something like `debug-log-generator-2023-11-08.log`, noticeably _without_ a long hash string at the end.
3. Back on the main Logs screen with the list of log files, check the boxes next to two or more log files. Then choose "Download" from the "Bulk Actions" dropdown and click "Apply". You should once again be presented with your browser's save dialog. This time the file saved to your computer should be named something like `woocommerce_logs_2023-11-30_00-36-03.zip` where the numbers represent the current date and time in UTC. Within this zip file should be each of the files you selected from the list table. These files will be named similarly to if you downloaded an individual file, except they will have a long hash string at the end. This is because of a limitation in the PclZip library that ships with WordPress Core that makes it hard to change the names of the files you're adding to a zip archive.
4. Try the bulk download again, but only select one file. This time you should get the same result as in Step 2.
