### PR TITLE
Logging: Improve functionality in new LogHandlerFileV2 handler class

### DIFF
--- a/plugins/woocommerce/changelog/try-new-log-file-handler
+++ b/plugins/woocommerce/changelog/try-new-log-file-handler
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Add improved functionality to the log file handler

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1416,6 +1416,17 @@ table.wc_status_table--tools {
 				color: #fff8c5;
 			}
 		}
+
+		&.has-context {
+			summary {
+				cursor: pointer;
+			}
+
+			pre {
+				margin-top: 0;
+				white-space: pre-wrap;
+			}
+		}
 	}
 
 	.line-anchor {

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1348,7 +1348,8 @@ table.wc_status_table--tools {
 	}
 }
 
-.wc-logs-single-file-actions {
+.wc-logs-single-file-actions,
+.wc-logs-search {
 	margin-left: auto;
 	display: flex;
 	flex-flow: row wrap;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1474,6 +1474,10 @@ table.wc_status_table--tools {
 		width: 8%;
 	}
 
+	.column-line {
+		font-family: Consolas, Monaco, monospace;
+	}
+
 	.search-match {
 		background: #fff8c5;
 		padding: 0.46em 0;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1474,10 +1474,6 @@ table.wc_status_table--tools {
 		width: 8%;
 	}
 
-	.column-line {
-		font-family: Consolas, Monaco, monospace;
-	}
-
 	.search-match {
 		background: #fff8c5;
 		padding: 0.46em 0;

--- a/plugins/woocommerce/client/legacy/css/admin.scss
+++ b/plugins/woocommerce/client/legacy/css/admin.scss
@@ -1348,8 +1348,7 @@ table.wc_status_table--tools {
 	}
 }
 
-.wc-logs-single-file-actions,
-.wc-logs-search {
+.wc-logs-single-file-actions {
 	margin-left: auto;
 	display: flex;
 	flex-flow: row wrap;

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-log-handler.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-log-handler.php
@@ -25,7 +25,7 @@ abstract class WC_Log_Handler implements WC_Log_Handler_Interface {
 	 * @return string Formatted time for use in log entry.
 	 */
 	protected static function format_time( $timestamp ) {
-		return date( 'c', $timestamp );
+		return gmdate( 'c', $timestamp );
 	}
 
 	/**

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-log-handler.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-log-handler.php
@@ -43,6 +43,14 @@ abstract class WC_Log_Handler implements WC_Log_Handler_Interface {
 		$level_string = strtoupper( $level );
 		$entry        = "{$time_string} {$level_string} {$message}";
 
+		/**
+		 * Filter the formatted log entry before it is written.
+		 *
+		 * @since 3.0.0
+		 *
+		 * @param string $entry The formatted entry.
+		 * @param array  $args  The raw data that gets assembled into a log entry.
+		 */
 		return apply_filters(
 			'woocommerce_format_log_entry',
 			$entry,

--- a/plugins/woocommerce/includes/class-wc-logger.php
+++ b/plugins/woocommerce/includes/class-wc-logger.php
@@ -303,6 +303,11 @@ class WC_Logger implements WC_Logger_Interface {
 	 * @since 3.4.0
 	 */
 	public function clear_expired_logs() {
+		/**
+		 * Filter the retention period of log entries.
+		 *
+		 * @param int $days The number of days to retain log entries.
+		 */
 		$days      = absint( apply_filters( 'woocommerce_logger_days_to_retain_logs', 30 ) );
 		$timestamp = strtotime( "-{$days} days" );
 

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
@@ -330,7 +330,7 @@ class File {
 
 		// Ensure content ends with a line ending.
 		$eol_pos = strrpos( $text, PHP_EOL );
-		if ( false === $eol_pos || $eol_pos + 1 !== strlen( $text ) ) {
+		if ( false === $eol_pos || strlen( $text ) !== $eol_pos + 1 ) {
 			$text .= PHP_EOL;
 		}
 
@@ -384,8 +384,7 @@ class File {
 		$new_filename = str_replace( $search, $replace, $old_filename );
 		$new_path     = str_replace( $old_filename, $new_filename, $this->path );
 
-		$moved    = $wp_filesystem->move( $this->path, $new_path, true );
-
+		$moved = $wp_filesystem->move( $this->path, $new_path, true );
 		if ( ! $moved ) {
 			return false;
 		}

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
@@ -150,7 +150,7 @@ class File {
 			$parsed['source'] = substr( $parsed['source'], 0, $rotation_marker );
 		}
 
-		$parsed['file_id'] = self::generate_file_id(
+		$parsed['file_id'] = static::generate_file_id(
 			$parsed['source'],
 			$parsed['rotation'],
 			$parsed['created']
@@ -173,7 +173,7 @@ class File {
 	 * @return string
 	 */
 	public static function generate_file_id( string $source, ?int $rotation = null, int $created = 0 ): string {
-		$file_id = self::sanitize_source( $source );
+		$file_id = static::sanitize_source( $source );
 
 		if ( ! is_null( $rotation ) ) {
 			$file_id .= '.' . $rotation;
@@ -216,7 +216,7 @@ class File {
 	 * @return void
 	 */
 	protected function ingest_path(): void {
-		$parsed_path    = self::parse_path( $this->path );
+		$parsed_path    = static::parse_path( $this->path );
 		$this->source   = $parsed_path['source'];
 		$this->rotation = $parsed_path['rotation'];
 		$this->created  = $parsed_path['created'];
@@ -347,7 +347,7 @@ class File {
 			$created = $this->get_created_timestamp();
 		}
 
-		$file_id = self::generate_file_id(
+		$file_id = static::generate_file_id(
 			$this->get_source(),
 			$this->get_rotation(),
 			$created
@@ -476,13 +476,13 @@ class File {
 			$new_rotation = $this->get_rotation() + 1;
 		}
 
-		$new_file_id = self::generate_file_id( $this->get_source(), $new_rotation, $created );
+		$new_file_id = static::generate_file_id( $this->get_source(), $new_rotation, $created );
 
 		$search  = array( $this->get_file_id() );
 		$replace = array( $new_file_id );
 		if ( $this->has_standard_filename() ) {
 			$search[]  = $this->get_hash();
-			$replace[] = self::generate_hash( $new_file_id );
+			$replace[] = static::generate_hash( $new_file_id );
 		}
 
 		$old_filename = $this->get_basename();

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
@@ -343,7 +343,11 @@ class File {
 		return true;
 	}
 
-
+	/**
+	 * Rename this file with an incremented rotation number.
+	 *
+	 * @return bool True if the file was successfully rotated.
+	 */
 	public function rotate(): bool {
 		global $wp_filesystem;
 

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
@@ -231,7 +231,7 @@ class File {
 	 * @return bool
 	 */
 	public function has_standard_filename(): bool {
-		return !! $this->get_hash();
+		return ! ! $this->get_hash();
 	}
 
 	/**
@@ -481,8 +481,8 @@ class File {
 		$search  = array( $this->get_file_id() );
 		$replace = array( $new_file_id );
 		if ( $this->has_standard_filename() ) {
-			$search[]    = $this->get_hash();
-			$replace[]   = self::generate_hash( $new_file_id );
+			$search[]  = $this->get_hash();
+			$replace[] = self::generate_hash( $new_file_id );
 		}
 
 		$old_filename = $this->get_basename();

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
@@ -124,8 +124,7 @@ class File {
 			$this->created = strtotime( implode( '-', array_slice( $segments, -4, 3 ) ) );
 			$this->hash    = array_slice( $segments, -1 )[0];
 		} else {
-			$this->source  = implode( '-', $segments );
-			$this->created = filectime( $this->path );
+			$this->source = implode( '-', $segments );
 		}
 
 		$rotation_marker = strrpos( $this->source, '.', -1 );
@@ -171,6 +170,10 @@ class File {
 	 * @return resource|false
 	 */
 	public function get_stream() {
+		if ( ! $this->is_readable() ) {
+			return false;
+		}
+
 		if ( ! is_resource( $this->stream ) ) {
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fopen -- No suitable alternative.
 			$this->stream = fopen( $this->path, 'rb' );
@@ -265,6 +268,10 @@ class File {
 	 * @return int|false
 	 */
 	public function get_created_timestamp() {
+		if ( ! $this->created && $this->is_readable() ) {
+			$this->created = filectime( $this->path );
+		}
+
 		return $this->created;
 	}
 
@@ -323,7 +330,7 @@ class File {
 		if ( ! $this->is_writable() ) {
 			$created = $this->create();
 
-			if ( ! $created ) {
+			if ( ! $created || ! $this->is_writable() ) {
 				return false;
 			}
 		}

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/File.php
@@ -139,6 +139,17 @@ class File {
 	}
 
 	/**
+	 * Check if the filename structure is in the expected format.
+	 *
+	 * @see parse_filename().
+	 *
+	 * @return bool
+	 */
+	public function has_standard_filename(): bool {
+		return !! $this->get_hash();
+	}
+
+	/**
 	 * Check if the file represented by the class instance is a file and is readable.
 	 *
 	 * @global WP_Filesystem_Direct $wp_filesystem
@@ -255,7 +266,7 @@ class File {
 			$file_id .= '.' . $this->get_rotation();
 		}
 
-		if ( $this->get_hash() ) {
+		if ( $this->has_standard_filename() ) {
 			$file_id .= '-' . gmdate( 'Y-m-d', $this->get_created_timestamp() );
 		}
 

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
@@ -64,6 +64,13 @@ class FileController {
 	private const SEARCH_CACHE_KEY = 'logs_previous_search';
 
 	/**
+	 * A cache key for storing and retrieving the results of the last logs search.
+	 *
+	 * @const string
+	 */
+	private const SEARCH_CACHE_KEY = 'logs_previous_search';
+
+	/**
 	 * The absolute path to the log directory.
 	 *
 	 * @var string

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
@@ -98,6 +98,8 @@ class FileController {
 		/**
 		 * Filter the maximum size of a log file before it will get rotated.
 		 *
+		 * @since 8.5.0
+		 *
 		 * @param int $max_file_size The file size in bytes.
 		 */
 		$this->max_file_size = apply_filters( 'woocommerce_log_file_size_limit', 5 * MB_IN_BYTES );
@@ -151,7 +153,7 @@ class FileController {
 	/**
 	 * Get all the rotations of a file and increment them, so that they overwrite the previous file with that rotation.
 	 *
-	 * @param string $file_id
+	 * @param string $file_id A file ID (file basename without the hash).
 	 *
 	 * @return bool True if the file and all its rotations were successfully rotated.
 	 */

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
@@ -64,13 +64,6 @@ class FileController {
 	private const SEARCH_CACHE_KEY = 'logs_previous_search';
 
 	/**
-	 * A cache key for storing and retrieving the results of the last logs search.
-	 *
-	 * @const string
-	 */
-	private const SEARCH_CACHE_KEY = 'logs_previous_search';
-
-	/**
 	 * The absolute path to the log directory.
 	 *
 	 * @var string

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
@@ -83,26 +83,34 @@ class FileController {
 	private $log_directory;
 
 	/**
-	 * The maximum size of a file before it will get rotated.
-	 *
-	 * @var int
-	 */
-	private $max_file_size;
-
-	/**
 	 * Class FileController
 	 */
 	public function __construct() {
 		$this->log_directory = trailingslashit( realpath( Constants::get_constant( 'WC_LOG_DIR' ) ) );
+	}
+
+	/**
+	 * Get the file size limit that determines when to rotate a file.
+	 *
+	 * @return int
+	 */
+	private function get_file_size_limit(): int {
+		$default = 5 * MB_IN_BYTES;
 
 		/**
-		 * Filter the maximum size of a log file before it will get rotated.
+		 * Filter the threshold size of a log file at which point it will get rotated.
 		 *
 		 * @since 3.4.0
 		 *
-		 * @param int $max_file_size The file size in bytes.
+		 * @param int $file_size_limit The file size limit in bytes.
 		 */
-		$this->max_file_size = apply_filters( 'woocommerce_log_file_size_limit', 5 * MB_IN_BYTES );
+		$file_size_limit = apply_filters( 'woocommerce_log_file_size_limit', $default );
+
+		if ( ! is_int( $file_size_limit ) || $file_size_limit < 1 ) {
+			return $default;
+		}
+
+		return $file_size_limit;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
@@ -98,7 +98,7 @@ class FileController {
 		/**
 		 * Filter the maximum size of a log file before it will get rotated.
 		 *
-		 * @since 8.5.0
+		 * @since 3.4.0
 		 *
 		 * @param int $max_file_size The file size in bytes.
 		 */

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileListTable.php
@@ -99,7 +99,7 @@ class FileListTable extends WP_List_Table {
 		$all_sources = $this->get_sources_list();
 
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended
-		$current_source = $this->file_controller->sanitize_source( wp_unslash( $_GET['source'] ?? '' ) );
+		$current_source = File::sanitize_source( wp_unslash( $_GET['source'] ?? '' ) );
 
 		?>
 		<div class="alignleft actions">

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileListTable.php
@@ -236,7 +236,7 @@ class FileListTable extends WP_List_Table {
 			name="file_id[]"
 			value="<?php echo esc_attr( $item->get_file_id() ); ?>"
 		/>
-		<label for="cb-select-<?php echo esc_attr( $item->get_hash() ); ?>">
+		<label for="cb-select-<?php echo esc_attr( $item->get_file_id() ); ?>">
 			<span class="screen-reader-text">
 				<?php
 				printf(

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/SearchListTable.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/SearchListTable.php
@@ -90,7 +90,9 @@ class SearchListTable extends WP_List_Table {
 			'offset'   => ( $this->get_pagenum() - 1 ) * $per_page,
 		);
 
-		$file_args = $this->page_controller->get_query_params( array( 'order', 'orderby', 'search', 'source' ) );
+		$file_args = $this->page_controller->get_query_params(
+			array( 'date_end', 'date_filter', 'date_start', 'order', 'orderby', 'search', 'source' )
+		);
 		$search    = $file_args['search'];
 		unset( $file_args['search'] );
 

--- a/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
@@ -2,36 +2,116 @@
 
 namespace Automattic\WooCommerce\Internal\Admin\Logging;
 
+use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Internal\Admin\Logging\FileV2\FileController;
-use WC_Log_Handler_File;
+use WC_Log_Handler;
 
 /**
  * LogHandlerFileV2 class.
  */
-class LogHandlerFileV2 extends WC_Log_Handler_File {
+class LogHandlerFileV2 extends WC_Log_Handler {
+	/**
+	 * Instance of the FileController class.
+	 *
+	 * @var FileController
+	 */
+	private $file_controller;
+
+	/**
+	 * LogHandlerFileV2 class.
+	 */
+	public function __construct() {
+		$this->file_controller = wc_get_container()->get( FileController::class );
+	}
+
 	/**
 	 * Handle a log entry.
 	 *
 	 * @param int    $timestamp Log timestamp.
-	 * @param string $level emergency|alert|critical|error|warning|notice|info|debug.
-	 * @param string $message Log message.
-	 * @param array  $context {
-	 *      Additional information for log handlers.
+	 * @param string $level     emergency|alert|critical|error|warning|notice|info|debug.
+	 * @param string $message   Log message.
+	 * @param array  $context   {
+	 *     Optional. Additional information for log handlers.
 	 *
-	 *     @type string $source Optional. Determines log file to write to. Default 'log'.
-	 *     @type bool $_legacy Optional. Default false. True to use outdated log format
-	 *         originally used in deprecated WC_Logger::add calls.
+	 *     @type string $source Optional. Determines which log file to write to.
 	 * }
 	 *
 	 * @return bool False if value was not handled and true if value was handled.
 	 */
 	public function handle( $timestamp, $level, $message, $context ) {
-		$written = parent::handle( $timestamp, $level, $message, $context );
+		if ( isset( $context['source'] ) && is_string( $context['source'] ) && strlen( $context['source'] ) >= 3 ) {
+			$source = sanitize_title( trim( $context['source'] ) );
+		} else {
+			$source = $this->determine_source();
+		}
+
+		$entry = self::format_entry( $timestamp, $level, $message, $context );
+
+		$written = $this->file_controller->write_to_file( $source, $entry );
 
 		if ( $written ) {
-			wc_get_container()->get( FileController::class )->invalidate_cache();
+			$this->file_controller->invalidate_cache();
 		}
 
 		return $written;
+	}
+
+	/**
+	 * Figures out a source string to use for a log entry based on where the log method was called from.
+	 *
+	 * @return string
+	 * @throws \ReflectionException
+	 */
+	protected function determine_source(): string {
+		// Get the filename of the current logger class.
+		$reflector    = new \ReflectionClass( wc_get_logger() );
+		$logger_file  = $reflector->getFileName();
+		$ignore_files = array( __FILE__, $logger_file );
+
+		$source_roots = array(
+			'mu-plugin' => trailingslashit( Constants::get_constant( 'WPMU_PLUGIN_DIR' ) ),
+			'plugin'    => trailingslashit( Constants::get_constant( 'WP_PLUGIN_DIR' ) ),
+			'theme'     => trailingslashit( get_theme_root() ),
+		);
+		$source       = '';
+
+		$backtrace = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
+
+		foreach ( $backtrace as $frame ) {
+			if ( ! isset( $frame['file'] ) || in_array( $frame['file'], $ignore_files, true ) ) {
+				continue;
+			}
+
+			foreach ( $source_roots as $type => $path ) {
+				if ( 0 === strpos( $frame['file'], $path ) ) {
+					$relative_path = trim( substr( $frame['file'], strlen( $path ) ), DIRECTORY_SEPARATOR );
+
+					if ( 'mu-plugin' === $type ) {
+						$info = pathinfo( $relative_path );
+
+						if ( '.' === $info['dirname'] ) {
+							$source = "$type-" . $info['filename'];
+						} else {
+							$source = "$type-" . $info['dirname'];
+						}
+
+						break 2;
+					}
+
+					$segments = explode( DIRECTORY_SEPARATOR, $relative_path );
+					if ( is_array( $segments ) ) {
+						$source = "$type-" . reset( $segments );
+					}
+
+					break 2;
+				}
+			}
+		}
+
+		if ( ! $source ) {
+			$source = 'log';
+		}
+
+		return sanitize_title( $source );
 	}
 }

--- a/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
@@ -60,28 +60,18 @@ class LogHandlerFileV2 extends WC_Log_Handler {
 	 * Figures out a source string to use for a log entry based on where the log method was called from.
 	 *
 	 * @return string
-	 * @throws \ReflectionException
 	 */
 	protected function determine_source(): string {
-		// Get the filename of the current logger class.
-		$reflector    = new \ReflectionClass( wc_get_logger() );
-		$logger_file  = $reflector->getFileName();
-		$ignore_files = array( __FILE__, $logger_file );
-
 		$source_roots = array(
 			'mu-plugin' => trailingslashit( Constants::get_constant( 'WPMU_PLUGIN_DIR' ) ),
 			'plugin'    => trailingslashit( Constants::get_constant( 'WP_PLUGIN_DIR' ) ),
 			'theme'     => trailingslashit( get_theme_root() ),
 		);
-		$source       = '';
 
-		$backtrace = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
+		$source    = '';
+		$backtrace = self::get_backtrace();
 
 		foreach ( $backtrace as $frame ) {
-			if ( ! isset( $frame['file'] ) || in_array( $frame['file'], $ignore_files, true ) ) {
-				continue;
-			}
-
 			foreach ( $source_roots as $type => $path ) {
 				if ( 0 === strpos( $frame['file'], $path ) ) {
 					$relative_path = trim( substr( $frame['file'], strlen( $path ) ), DIRECTORY_SEPARATOR );

--- a/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
@@ -208,7 +208,7 @@ class LogHandlerFileV2 extends WC_Log_Handler {
 					),
 					sprintf(
 						esc_html(
-						// translators: %s is a number of days.
+							// translators: %s is a number of days.
 							_n(
 								'The retention period for log files is %s day.',
 								'The retention period for log files is %s days.',

--- a/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
@@ -49,7 +49,7 @@ class LogHandlerFileV2 extends WC_Log_Handler {
 
 		$entry = self::format_entry( $timestamp, $level, $message, $context );
 
-		$written = $this->file_controller->write_to_file( $source, $entry );
+		$written = $this->file_controller->write_to_file( $source, $entry, $timestamp );
 
 		if ( $written ) {
 			$this->file_controller->invalidate_cache();

--- a/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
@@ -183,40 +183,42 @@ class LogHandlerFileV2 extends WC_Log_Handler {
 		/** This filter is documented in includes/class-wc-logger.php. */
 		$retention_days = absint( apply_filters( 'woocommerce_logger_days_to_retain_logs', 30 ) );
 
-		$this->handle(
-			time(),
-			'info',
-			sprintf(
-				'%s %s',
+		if ( $deleted > 0 ) {
+			$this->handle(
+				time(),
+				'info',
 				sprintf(
-					esc_html(
+					'%s %s',
+					sprintf(
+						esc_html(
 						// translators: %s is a number of log files.
-						_n(
-							'%s expired log file was deleted.',
-							'%s expired log files were deleted.',
-							$deleted,
-							'woocommerce'
-						)
+							_n(
+								'%s expired log file was deleted.',
+								'%s expired log files were deleted.',
+								$deleted,
+								'woocommerce'
+							)
+						),
+						number_format_i18n( $deleted )
 					),
-					number_format_i18n( $deleted )
-				),
-				sprintf(
-					esc_html(
+					sprintf(
+						esc_html(
 						// translators: %s is a number of days.
-						_n(
-							'The retention period for log files is %s day.',
-							'The retention period for log files is %s days.',
-							$retention_days,
-							'woocommerce'
-						)
-					),
-					number_format_i18n( $retention_days )
+							_n(
+								'The retention period for log files is %s day.',
+								'The retention period for log files is %s days.',
+								$retention_days,
+								'woocommerce'
+							)
+						),
+						number_format_i18n( $retention_days )
+					)
+				),
+				array(
+					'source' => 'wc_logger',
 				)
-			),
-			array(
-				'source' => 'wc_logger',
-			)
-		);
+			);
+		}
 
 		return $deleted;
 	}

--- a/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
@@ -127,11 +127,13 @@ class LogHandlerFileV2 extends WC_Log_Handler {
 			return 0;
 		}
 
-		$files = $this->file_controller->get_files( array(
-			'date_filter' => 'created',
-			'date_start'  => 1,
-			'date_end'    => $timestamp,
-		) );
+		$files = $this->file_controller->get_files(
+			array(
+				'date_filter' => 'created',
+				'date_start'  => 1,
+				'date_end'    => $timestamp,
+			)
+		);
 
 		if ( is_wp_error( $files ) ) {
 			return 0;
@@ -178,7 +180,7 @@ class LogHandlerFileV2 extends WC_Log_Handler {
 				)
 			),
 			array(
-				'source' => 'wc_logger'
+				'source' => 'wc_logger',
 			)
 		);
 

--- a/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
@@ -4,6 +4,7 @@ namespace Automattic\WooCommerce\Internal\Admin\Logging;
 
 use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Internal\Admin\Logging\FileV2\FileController;
+use Automattic\WooCommerce\Proxies\LegacyProxy;
 use WC_Log_Handler;
 
 /**
@@ -47,7 +48,7 @@ class LogHandlerFileV2 extends WC_Log_Handler {
 			$source = $this->determine_source();
 		}
 
-		$entry = self::format_entry( $timestamp, $level, $message, $context );
+		$entry = static::format_entry( $timestamp, $level, $message, $context );
 
 		$written = $this->file_controller->write_to_file( $source, $entry, $timestamp );
 
@@ -69,7 +70,7 @@ class LogHandlerFileV2 extends WC_Log_Handler {
 	 * @return string Formatted log entry.
 	 */
 	protected static function format_entry( $timestamp, $level, $message, $context ) {
-		$time_string  = self::format_time( $timestamp );
+		$time_string  = static::format_time( $timestamp );
 		$level_string = strtoupper( $level );
 
 		// Remove line breaks so the whole entry is on one line in the file.
@@ -78,7 +79,7 @@ class LogHandlerFileV2 extends WC_Log_Handler {
 		unset( $context['source'] );
 		if ( ! empty( $context ) ) {
 			if ( isset( $context['backtrace'] ) && true === filter_var( $context['backtrace'], FILTER_VALIDATE_BOOLEAN ) ) {
-				$context['backtrace'] = self::get_backtrace();
+				$context['backtrace'] = static::get_backtrace();
 			}
 
 			$formatted_context  = wp_json_encode( $context );
@@ -115,7 +116,7 @@ class LogHandlerFileV2 extends WC_Log_Handler {
 		);
 
 		$source    = '';
-		$backtrace = self::get_backtrace();
+		$backtrace = static::get_backtrace();
 
 		foreach ( $backtrace as $frame ) {
 			foreach ( $source_roots as $type => $path ) {

--- a/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/LogHandlerFileV2.php
@@ -32,7 +32,7 @@ class LogHandlerFileV2 extends WC_Log_Handler {
 	 * @param string $message   Log message.
 	 * @param array  $context   {
 	 *     Optional. Additional information for log handlers. Any data can be added here, but there are some array
-	 *     keys that have special behavior:
+	 *     keys that have special behavior.
 	 *
 	 *     @type string $source    Determines which log file to write to. Must be at least 3 characters in length.
 	 *     @type bool   $backtrace True to include a backtrace that shows where the logging function got called.
@@ -81,12 +81,13 @@ class LogHandlerFileV2 extends WC_Log_Handler {
 				$context['backtrace'] = self::get_backtrace();
 			}
 
-			$formatted_context = wp_json_encode( $context );
+			$formatted_context  = wp_json_encode( $context );
 			$formatted_message .= " CONTEXT: $formatted_context";
 		}
 
 		$entry = "$time_string $level_string $formatted_message";
 
+		// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingSinceComment
 		/** This filter is documented in includes/abstracts/abstract-wc-log-handler.php */
 		return apply_filters(
 			'woocommerce_format_log_entry',
@@ -98,6 +99,7 @@ class LogHandlerFileV2 extends WC_Log_Handler {
 				'context'   => $context,
 			)
 		);
+		// phpcs:enable WooCommerce.Commenting.CommentHooks.MissingSinceComment
 	}
 
 	/**
@@ -180,8 +182,10 @@ class LogHandlerFileV2 extends WC_Log_Handler {
 
 		$deleted = $this->file_controller->delete_files( $file_ids );
 
+		// phpcs:disable WooCommerce.Commenting.CommentHooks.MissingSinceComment
 		/** This filter is documented in includes/class-wc-logger.php. */
 		$retention_days = absint( apply_filters( 'woocommerce_logger_days_to_retain_logs', 30 ) );
+		// phpcs:enable WooCommerce.Commenting.CommentHooks.MissingSinceComment
 
 		if ( $deleted > 0 ) {
 			$this->handle(
@@ -191,7 +195,7 @@ class LogHandlerFileV2 extends WC_Log_Handler {
 					'%s %s',
 					sprintf(
 						esc_html(
-						// translators: %s is a number of log files.
+							// translators: %s is a number of log files.
 							_n(
 								'%s expired log file was deleted.',
 								'%s expired log files were deleted.',

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -145,6 +145,8 @@ class PageController {
 
 		$list_table->prepare_items();
 
+		$this->get_list_table()->prepare_items();
+
 		?>
 		<header id="logs-header" class="wc-logs-header">
 			<h2>

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -623,6 +623,9 @@ class PageController {
 	private function format_match( string $file_id, int $line_number, string $line ): string {
 		$params = $this->get_query_params( array( 'search' ) );
 
+		// Add a word break after the rotation number, if it exists.
+		$file_id = preg_replace( '/\.([0-9])+\-/', '.\1<wbr>-', $file_id );
+
 		$match_url = add_query_arg(
 			array(
 				'view'    => 'single_file',
@@ -650,15 +653,18 @@ class PageController {
 		}
 
 		return sprintf(
-			'<span class="match">%1$s%2$s</span>',
+			'<span class="match">%1$s%2$s%3$s</span>',
 			sprintf(
-				'<a href="%1$s" class="match-anchor">%2$s<br />%3$s</a>',
+				'<span class="match-file">%s</span>',
+				wp_kses( $file_id, array( 'wbr' => array() ) )
+			),
+			sprintf(
+				'<a href="%1$s" class="match-anchor">%2$s</a>',
 				esc_url( $match_url ),
-				esc_html( $file_id ),
 				sprintf(
-					// translators: %d is a line number in a file.
-					esc_html__( 'Line %d', 'woocommerce' ),
-					absint( $line_number )
+					// translators: %s is a line number in a file.
+					esc_html__( 'Line %s', 'woocommerce' ),
+					number_format_i18n( absint( $line_number ) )
 				)
 			),
 			sprintf(

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -640,7 +640,7 @@ class PageController {
 	 * @return void
 	 */
 	private function render_search_field(): void {
-		$params     = $this->get_query_params( array( 'search', 'source' ) );
+		$params     = $this->get_query_params( array( 'date_end', 'date_filter', 'date_start', 'search', 'source' ) );
 		$defaults   = $this->get_query_param_defaults();
 		$file_count = $this->file_controller->get_files( $params, true );
 

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -621,6 +621,8 @@ class PageController {
 	 * @return string
 	 */
 	private function format_match( string $file_id, int $line_number, string $line ): string {
+		$params = $this->get_query_params( array( 'search' ) );
+
 		$match_url = add_query_arg(
 			array(
 				'view'    => 'single_file',
@@ -628,6 +630,24 @@ class PageController {
 			),
 			$this->get_logs_tab_url() . '#L' . absint( $line_number )
 		);
+
+		// Highlight matches within the line.
+		$pattern = preg_quote( $params['search'], '/' );
+		preg_match_all( "/$pattern/i", $line, $matches, PREG_OFFSET_CAPTURE );
+		if ( is_array( $matches[0] ) && count( $matches[0] ) >= 1 ) {
+			$length_change = 0;
+
+			foreach ( $matches[0] as $match ) {
+				$replace        = '<span class="search-match">' . $match[0] . '</span>';
+				$offset         = $match[1] + $length_change;
+				$orig_length    = strlen( $match[0] );
+				$replace_length = strlen( $replace );
+
+				$line = substr_replace( $line, $replace, $offset, $orig_length );
+
+				$length_change += $replace_length - $orig_length;
+			}
+		}
 
 		return sprintf(
 			'<span class="match">%1$s%2$s</span>',

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -607,7 +607,7 @@ class PageController {
 
 					$segments[2] = implode( ' ', $message_chunks );
 					$classes[]   = 'has-context';
-				} catch ( \JsonException $exception ) {
+				} catch ( \JsonException $exception ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 					// It's not valid JSON so don't do anything with it.
 				}
 			}

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -610,69 +610,6 @@ class PageController {
 	}
 
 	/**
-	 * Format a search results line.
-	 *
-	 * @param string $file_id     The file ID that contains the matched line.
-	 * @param int    $line_number The line number of the matched line.
-	 * @param string $line        The matched line, with matched substrings highlighted.
-	 *
-	 * @return string
-	 */
-	private function format_match( string $file_id, int $line_number, string $line ): string {
-		$params = $this->get_query_params( array( 'search' ) );
-
-		// Add a word break after the rotation number, if it exists.
-		$file_id = preg_replace( '/\.([0-9])+\-/', '.\1<wbr>-', $file_id );
-
-		$match_url = add_query_arg(
-			array(
-				'view'    => 'single_file',
-				'file_id' => $file_id,
-			),
-			$this->get_logs_tab_url() . '#L' . absint( $line_number )
-		);
-
-		// Highlight matches within the line.
-		$pattern = preg_quote( $params['search'], '/' );
-		preg_match_all( "/$pattern/i", $line, $matches, PREG_OFFSET_CAPTURE );
-		if ( is_array( $matches[0] ) && count( $matches[0] ) >= 1 ) {
-			$length_change = 0;
-
-			foreach ( $matches[0] as $match ) {
-				$replace        = '<span class="search-match">' . $match[0] . '</span>';
-				$offset         = $match[1] + $length_change;
-				$orig_length    = strlen( $match[0] );
-				$replace_length = strlen( $replace );
-
-				$line = substr_replace( $line, $replace, $offset, $orig_length );
-
-				$length_change += $replace_length - $orig_length;
-			}
-		}
-
-		return sprintf(
-			'<span class="match">%1$s%2$s%3$s</span>',
-			sprintf(
-				'<span class="match-file">%s</span>',
-				wp_kses( $file_id, array( 'wbr' => array() ) )
-			),
-			sprintf(
-				'<a href="%1$s" class="match-anchor">%2$s</a>',
-				esc_url( $match_url ),
-				sprintf(
-					// translators: %s is a line number in a file.
-					esc_html__( 'Line %s', 'woocommerce' ),
-					number_format_i18n( absint( $line_number ) )
-				)
-			),
-			sprintf(
-				'<span class="match-content">%s</span>',
-				wp_kses_post( $line )
-			)
-		);
-	}
-
-	/**
 	 * Render a form for searching within log files.
 	 *
 	 * @return void

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -5,7 +5,7 @@ namespace Automattic\WooCommerce\Internal\Admin\Logging;
 
 use Automattic\Jetpack\Constants;
 use Automattic\WooCommerce\Internal\Admin\Logging\LogHandlerFileV2;
-use Automattic\WooCommerce\Internal\Admin\Logging\FileV2\{ FileController, FileListTable, SearchListTable };
+use Automattic\WooCommerce\Internal\Admin\Logging\FileV2\{ File, FileController, FileListTable, SearchListTable };
 use Automattic\WooCommerce\Internal\Traits\AccessiblePrivateMethods;
 use WC_Admin_Status;
 use WC_Log_Handler_File, WC_Log_Handler_DB;
@@ -374,7 +374,7 @@ class PageController {
 				'source'  => array(
 					'filter'  => FILTER_CALLBACK,
 					'options' => function( $source ) {
-						return $this->file_controller->sanitize_source( wp_unslash( $source ) );
+						return File::sanitize_source( wp_unslash( $source ) );
 					},
 				),
 				'view'    => array(

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -612,6 +612,43 @@ class PageController {
 	}
 
 	/**
+	 * Format a search results line.
+	 *
+	 * @param string $file_id     The file ID that contains the matched line.
+	 * @param int    $line_number The line number of the matched line.
+	 * @param string $line        The matched line, with matched substrings highlighted.
+	 *
+	 * @return string
+	 */
+	private function format_match( string $file_id, int $line_number, string $line ): string {
+		$match_url = add_query_arg(
+			array(
+				'view'    => 'single_file',
+				'file_id' => $file_id,
+			),
+			$this->get_logs_tab_url() . '#L' . absint( $line_number )
+		);
+
+		return sprintf(
+			'<span class="match">%1$s%2$s</span>',
+			sprintf(
+				'<a href="%1$s" class="match-anchor">%2$s<br />%3$s</a>',
+				esc_url( $match_url ),
+				esc_html( $file_id ),
+				sprintf(
+					// translators: %d is a line number in a file.
+					esc_html__( 'Line %d', 'woocommerce' ),
+					absint( $line_number )
+				)
+			),
+			sprintf(
+				'<span class="match-content">%s</span>',
+				wp_kses_post( $line )
+			)
+		);
+	}
+
+	/**
 	 * Render a form for searching within log files.
 	 *
 	 * @return void

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -145,8 +145,6 @@ class PageController {
 
 		$list_table->prepare_items();
 
-		$this->get_list_table()->prepare_items();
-
 		?>
 		<header id="logs-header" class="wc-logs-header">
 			<h2>

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileControllerTest.php
@@ -154,14 +154,15 @@ class FileControllerTest extends WC_Unit_Test_Case {
 		$source      = 'unit-testing';
 		$new_content = 'test';
 
-		$result  = $this->sut->write_to_file( $source, $new_content, $time );
+		$result = $this->sut->write_to_file( $source, $new_content, $time );
 		$this->assertTrue( $result );
 
 		$paths = glob( trailingslashit( realpath( Constants::get_constant( 'WC_LOG_DIR' ) ) ) . '*.log' );
 		$this->assertCount( 2, $paths );
 
 		foreach ( $paths as $path ) {
-			$file           = new File( $path );
+			$file = new File( $path );
+
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 			$actual_content = file_get_contents( $file->get_path() );
 
@@ -218,7 +219,7 @@ class FileControllerTest extends WC_Unit_Test_Case {
 		$first_file = array_shift( $files );
 		$this->assertEquals( 'unit-testing', $first_file->get_source() );
 
-		$files      = $this->sut->get_files(
+		$files = $this->sut->get_files(
 			array(
 				'date_filter' => 'created',
 				'date_start'  => strtotime( '-6 days' ),

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileControllerTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileControllerTest.php
@@ -4,9 +4,11 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Tests\Internal\Admin\Logging\FileV2;
 
 use Automattic\Jetpack\Constants;
-use Automattic\WooCommerce\Internal\Admin\Logging\FileV2\FileController;
-use WC_Log_Handler_File;
+use Automattic\WooCommerce\Internal\Admin\Logging\LogHandlerFileV2;
+use Automattic\WooCommerce\Internal\Admin\Logging\FileV2\{ File, FileController };
 use WC_Unit_Test_Case;
+
+// phpcs:disable WordPress.WP.AlternativeFunctions.file_system_read_fopen, WordPress.WP.AlternativeFunctions.file_system_read_fclose
 
 /**
  * FileControllerTest class.
@@ -15,7 +17,7 @@ class FileControllerTest extends WC_Unit_Test_Case {
 	/**
 	 * Instance of the logging class.
 	 *
-	 * @var WC_Log_Handler_File|null
+	 * @var LogHandlerFileV2|null
 	 */
 	private $handler;
 
@@ -44,7 +46,7 @@ class FileControllerTest extends WC_Unit_Test_Case {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->handler = new WC_Log_Handler_File();
+		$this->handler = new LogHandlerFileV2();
 		$this->sut     = new FileController();
 	}
 
@@ -71,13 +73,122 @@ class FileControllerTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox The write_to_file method should create a new file with the proper filename when it doesn't exist yet.
+	 */
+	public function test_write_to_file_new() {
+		$source  = 'unit-testing';
+		$content = 'test';
+
+		$result = $this->sut->write_to_file( $source, $content );
+		$this->assertTrue( $result );
+
+		$paths = glob( trailingslashit( realpath( Constants::get_constant( 'WC_LOG_DIR' ) ) ) . '*.log' );
+		$this->assertCount( 1, $paths );
+
+		$path = reset( $paths );
+		$file = new File( $path );
+
+		$this->assertStringStartsWith( $source, $file->get_basename() );
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$actual_content = file_get_contents( $path );
+		$this->assertEquals( $content . "\n", $actual_content );
+	}
+
+	/**
+	 * @testdox The write_to_file method should append content to an existing file of the correct source that isn't rotated.
+	 */
+	public function test_write_to_file_existing() {
+		$time = time();
+		$hash = wp_hash( 'cheddar' );
+
+		$existing_files = array(
+			'target' => 'unit-testing-' . gmdate( 'Y-m-d', $time ) . '-' . $hash . '.log',
+			'other1' => 'unit-testing.0-' . gmdate( 'Y-m-d', $time ) . '-' . $hash . '.log',
+			'other2' => 'unit-testing-' . gmdate( 'Y-m-d', strtotime( '-2 days' ) ) . '-' . $hash . '.log',
+		);
+		foreach ( $existing_files as $filename ) {
+			$path     = Constants::get_constant( 'WC_LOG_DIR' ) . $filename;
+			$resource = fopen( $path, 'a' );
+			fclose( $resource );
+		}
+
+		$paths = glob( trailingslashit( realpath( Constants::get_constant( 'WC_LOG_DIR' ) ) ) . '*.log' );
+		$this->assertCount( 3, $paths );
+
+		$source  = 'unit-testing';
+		$content = 'test';
+
+		$result = $this->sut->write_to_file( $source, $content, $time );
+		$this->assertTrue( $result );
+
+		$paths = glob( trailingslashit( realpath( Constants::get_constant( 'WC_LOG_DIR' ) ) ) . '*.log' );
+		$this->assertCount( 3, $paths );
+
+		$target_path = Constants::get_constant( 'WC_LOG_DIR' ) . $existing_files['target'];
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$actual_content = file_get_contents( $target_path );
+		$this->assertEquals( $content . "\n", $actual_content );
+	}
+
+	/**
+	 * @testdox The write_to_file method should rotate a file that has reached the size limit and then write the content to a fresh file.
+	 */
+	public function test_write_to_file_needs_rotation() {
+		$time = time();
+		$path = Constants::get_constant( 'WC_LOG_DIR' ) . 'unit-testing-' . gmdate( 'Y-m-d', $time ) . '-' . wp_hash( 'cheddar' ) . '.log';
+
+		$resource         = fopen( $path, 'a' );
+		$existing_content = random_bytes( 200 ) . "\n";
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fwrite
+		fwrite( $resource, $existing_content );
+		fclose( $resource );
+
+		$paths = glob( trailingslashit( realpath( Constants::get_constant( 'WC_LOG_DIR' ) ) ) . '*.log' );
+		$this->assertCount( 1, $paths );
+
+		// Set the file size low to induce log rotation.
+		$filter_callback = fn() => 100;
+		add_filter( 'woocommerce_log_file_size_limit', $filter_callback );
+
+		$source      = 'unit-testing';
+		$new_content = 'test';
+
+		$result  = $this->sut->write_to_file( $source, $new_content, $time );
+		$this->assertTrue( $result );
+
+		$paths = glob( trailingslashit( realpath( Constants::get_constant( 'WC_LOG_DIR' ) ) ) . '*.log' );
+		$this->assertCount( 2, $paths );
+
+		foreach ( $paths as $path ) {
+			$file           = new File( $path );
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			$actual_content = file_get_contents( $file->get_path() );
+
+			switch ( true ) {
+				case is_null( $file->get_rotation() ):
+					$this->assertEquals( $new_content . "\n", $actual_content );
+					break;
+				case 0 === $file->get_rotation():
+					$this->assertEquals( $existing_content, $actual_content );
+					break;
+				default:
+					$this->fail();
+					break;
+			}
+		}
+
+		remove_filter( 'woocommerce_log_file_size_limit', $filter_callback );
+	}
+
+	/**
 	 * @testdox The get_files method should retrieve log files as File instances, in a specified order.
 	 */
 	public function test_get_files_with_files(): void {
-		$this->handler->handle( time(), 'debug', '1', array() ); // No source defaults to "log" as source.
+		$this->handler->handle( strtotime( '-5 days' ), 'debug', '1', array() ); // No source defaults to "plugin-woocommerce" as source.
 		$this->handler->handle( time(), 'debug', '2', array( 'source' => 'unit-testing' ) );
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_wp_debug_backtrace_summary -- Unit test.
-		$this->handler->handle( time(), 'debug', wp_debug_backtrace_summary(), array( 'source' => 'unit-testing' ) ); // Increase file size.
+		$this->handler->handle( time(), 'debug', random_bytes( 100 ), array( 'source' => 'unit-testing' ) ); // Increase file size.
 
 		$files = $this->sut->get_files();
 		$this->assertCount( 2, $files );
@@ -94,7 +205,7 @@ class FileControllerTest extends WC_Unit_Test_Case {
 			)
 		);
 		$first_file = array_shift( $files );
-		$this->assertEquals( 'log', $first_file->get_source() );
+		$this->assertEquals( 'plugin-woocommerce', $first_file->get_source() );
 		$second_file = array_shift( $files );
 		$this->assertEquals( 'unit-testing', $second_file->get_source() );
 
@@ -106,6 +217,17 @@ class FileControllerTest extends WC_Unit_Test_Case {
 		);
 		$first_file = array_shift( $files );
 		$this->assertEquals( 'unit-testing', $first_file->get_source() );
+
+		$files      = $this->sut->get_files(
+			array(
+				'date_filter' => 'created',
+				'date_start'  => strtotime( '-6 days' ),
+				'date_end'    => strtotime( '-4 days' ),
+			)
+		);
+		$this->assertCount( 1, $files );
+		$first_file = array_shift( $files );
+		$this->assertEquals( 'plugin-woocommerce', $first_file->get_source() );
 	}
 
 	/**
@@ -123,13 +245,21 @@ class FileControllerTest extends WC_Unit_Test_Case {
 	 * @testdox The get_files_by_id method should return an array of File instances given an array of valid file IDs.
 	 */
 	public function test_get_files_by_id() {
+		// Create a log file with an accompanying rotation.
 		$this->handler->handle( time(), 'debug', '1', array( 'source' => 'unit-testing1' ) );
+		$file1_path = glob( Constants::get_constant( 'WC_LOG_DIR' ) . '*.log' );
+		$file1      = new File( reset( $file1_path ) );
+		$file1->rotate();
+		$this->handler->handle( time(), 'debug', '1', array( 'source' => 'unit-testing1' ) );
+
 		$this->handler->handle( time(), 'debug', '2', array( 'source' => 'unit-testing2' ) );
 		$this->handler->handle( time(), 'debug', '3', array( 'source' => 'unit-testing3' ) );
+
 		$file_id_1 = 'unit-testing1-' . gmdate( 'Y-m-d', time() );
 		$file_id_2 = 'unit-testing2-' . gmdate( 'Y-m-d', time() );
+		$files     = $this->sut->get_files_by_id( array( $file_id_1, $file_id_2 ) );
 
-		$files = $this->sut->get_files_by_id( array( $file_id_1, $file_id_2 ) );
+		// The retrieved files should not include the rotation.
 		$this->assertCount( 2, $files );
 
 		$sources = array_map(
@@ -166,47 +296,53 @@ class FileControllerTest extends WC_Unit_Test_Case {
 	 * @testdox The get_file_rotations method should return an associative array of File instances.
 	 */
 	public function test_get_file_rotations() {
-		$this->handler->handle( time(), 'debug', '1', array( 'source' => 'unit-testing1' ) );
-		$this->handler->handle( time(), 'debug', '2', array( 'source' => 'unit-testing2' ) );
-		$file_id = 'unit-testing1-' . gmdate( 'Y-m-d', time() );
+		$target_file_path = Constants::get_constant( 'WC_LOG_DIR' ) . 'test-file.log';
+		$other_file_path  = Constants::get_constant( 'WC_LOG_DIR' ) . 'other-test-file.log';
 
-		$reflection = new \ReflectionClass( get_class( $this->handler ) );
-		$method     = $reflection->getMethod( 'log_rotate' );
-		$method->setAccessible( true );
+		$oldest_file = new File( $target_file_path );
+		$oldest_file->write( 'test' );
+		$oldest_file->rotate();
+		$oldest_file->rotate();
 
-		// Handler has to be reset after rotating a log file because it caches handles.
-		$method->invoke( $this->handler, 'unit-testing1' );
-		$this->handler = new WC_Log_Handler_File();
-		$this->handler->handle( time(), 'debug', '1', array( 'source' => 'unit-testing1' ) );
-		$method->invoke( $this->handler, 'unit-testing1' );
-		$this->handler = new WC_Log_Handler_File();
-		$this->handler->handle( time(), 'debug', '1', array( 'source' => 'unit-testing1' ) );
+		$middle_file = new File( $target_file_path );
+		$middle_file->write( 'test' );
+		$middle_file->rotate();
 
+		$newest_file = new File( $target_file_path );
+		$newest_file->write( 'test' );
+
+		$other_file = new File( $other_file_path );
+		$other_file->write( 'test' );
+
+		$paths = glob( trailingslashit( realpath( Constants::get_constant( 'WC_LOG_DIR' ) ) ) . '*.log' );
+		$this->assertCount( 4, $paths );
+
+		$file_id   = 'test-file';
 		$rotations = $this->sut->get_file_rotations( $file_id );
 
 		$this->assertCount( 3, $rotations );
 		$this->assertArrayHasKey( 'current', $rotations );
 		$this->assertNull( $rotations['current']->get_rotation() );
-		$this->assertEquals( 'unit-testing1', $rotations['current']->get_source() );
+		$this->assertEquals( 'test-file', $rotations['current']->get_source() );
 		$this->assertArrayHasKey( 0, $rotations );
 		$this->assertEquals( 0, $rotations[0]->get_rotation() );
-		$this->assertEquals( 'unit-testing1', $rotations[0]->get_source() );
+		$this->assertEquals( 'test-file', $rotations[0]->get_source() );
 		$this->assertArrayHasKey( 1, $rotations );
 		$this->assertEquals( 1, $rotations[1]->get_rotation() );
-		$this->assertEquals( 'unit-testing1', $rotations[1]->get_source() );
+		$this->assertEquals( 'test-file', $rotations[1]->get_source() );
 	}
 
 	/**
 	 * @testdox The get_file_sources method should return a unique array of sources.
 	 */
 	public function test_get_file_sources(): void {
-		$this->handler->handle( time(), 'debug', '1', array() ); // No source defaults to "log" as source.
+		$this->handler->handle( time(), 'debug', '1', array() ); // No source defaults to "plugin-woocommerce" as source.
 		$this->handler->handle( time(), 'debug', '2', array( 'source' => 'unit-testing' ) );
 		$this->handler->handle( time(), 'debug', '3', array( 'source' => 'unit-testing' ) );
 
 		$sources = $this->sut->get_file_sources();
 		$this->assertCount( 2, $sources );
-		$this->assertContains( 'log', $sources );
+		$this->assertContains( 'plugin-woocommerce', $sources );
 		$this->assertContains( 'unit-testing', $sources );
 	}
 
@@ -220,7 +356,7 @@ class FileControllerTest extends WC_Unit_Test_Case {
 
 		$this->assertEquals( 3, $this->sut->get_files( array(), true ) );
 
-		$files   = $this->sut->get_files( array( 'source' => 'log' ) );
+		$files   = $this->sut->get_files( array( 'source' => 'plugin-woocommerce' ) );
 		$file_id = $files[0]->get_file_id();
 		$deleted = $this->sut->delete_files( array( $file_id ) );
 		$this->assertEquals( 1, $deleted );
@@ -273,3 +409,5 @@ class FileControllerTest extends WC_Unit_Test_Case {
 		$this->assertStringContainsString( 'A trip to the food bar', $match['line'] );
 	}
 }
+
+// phpcs:enable WordPress.WP.AlternativeFunctions.file_system_read_fopen, WordPress.WP.AlternativeFunctions.file_system_read_fclose

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileTest.php
@@ -33,13 +33,79 @@ class FileTest extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Check that all properties are populated correctly when a File instance receives a filename in the standard format.
+	 * @testdox Check that the readable and writable methods correctly detect whether the file exists in the filesystem,
+	 *          and whether the file is readable and writable.
 	 */
-	public function test_initialize_file_standard() {
-		$filename = Constants::get_constant( 'WC_LOG_DIR' ) . 'test-Source_1-1-2023-10-23-' . wp_hash( 'cheddar' ) . '.log';
+	public function test_file_readable_writable() {
+		$filename = Constants::get_constant( 'WC_LOG_DIR' ) . 'test-file.log';
+		$file     = new File( $filename );
+
+		$this->assertFalse( $file->is_readable() );
+		$this->assertFalse( $file->is_writable() );
+
 		$resource = fopen( $filename, 'a' );
 		fclose( $resource );
+
+		$this->assertTrue( $file->is_readable() );
+		$this->assertTrue( $file->is_writable() );
+	}
+
+	/**
+	 * @testdox Check that writing to a file that doesn't exist yet creates that file.
+	 */
+	public function test_write_new_file() {
+		$filename = Constants::get_constant( 'WC_LOG_DIR' ) . 'test-file.log';
+		$content  = "You can't take the sky from me";
+		$file     = new File( $filename );
+
+		$this->assertFalse( $file->is_writable() );
+
+		$result = $file->write( $content );
+
+		$this->assertTrue( $result );
+		$this->assertTrue( $file->is_writable() );
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$actual_content = file_get_contents( $filename );
+
+		$this->assertEquals( $content . "\n", $actual_content );
+	}
+
+	/**
+	 * @testdox Check that writing to a file that already exists appends the new content to the existing content.
+	 */
+	public function test_write_existing_file() {
+		$filename = Constants::get_constant( 'WC_LOG_DIR' ) . 'test-file.log';
+		$content1 = 'Shiny';
+		$content2 = 'Scratch';
+
+		$resource = fopen( $filename, 'a' );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fwrite
+		fwrite( $resource, $content1 . "\n" );
+		fclose( $resource );
 		$file = new File( $filename );
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$actual_content = file_get_contents( $filename );
+
+		$this->assertEquals( $content1 . "\n", $actual_content );
+
+		$result = $file->write( $content2 );
+
+		$this->assertTrue( $result );
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$actual_content = file_get_contents( $filename );
+
+		$this->assertEquals( $content1 . "\n" . $content2 . "\n", $actual_content );
+	}
+
+	/**
+	 * @testdox Check that all properties are populated correctly when a File instance receives a filename in the standard format.
+	 */
+	public function test_initialize_existing_file_standard() {
+		$filename = Constants::get_constant( 'WC_LOG_DIR' ) . 'test-Source_1-1-2023-10-23-' . wp_hash( 'cheddar' ) . '.log';
+		$file     = new File( $filename );
 
 		$this->assertEquals( 'test-Source_1-1-2023-10-23-' . wp_hash( 'cheddar' ) . '.log', $file->get_basename() );
 		$this->assertEquals( 'test-Source_1-1-2023-10-23', $file->get_file_id() );
@@ -52,11 +118,9 @@ class FileTest extends WC_Unit_Test_Case {
 	/**
 	 * @testdox Check that all properties are populated correctly when a File instance receives a rotated filename in the standard format.
 	 */
-	public function test_initialize_file_standard_rotated() {
+	public function test_initialize_existing_file_standard_rotated() {
 		$filename = Constants::get_constant( 'WC_LOG_DIR' ) . 'test-Source_1-1.3-2023-10-23-' . wp_hash( 'cheddar' ) . '.log';
-		$resource = fopen( $filename, 'a' );
-		fclose( $resource );
-		$file = new File( $filename );
+		$file     = new File( $filename );
 
 		$this->assertEquals( 'test-Source_1-1.3-2023-10-23-' . wp_hash( 'cheddar' ) . '.log', $file->get_basename() );
 		$this->assertEquals( 'test-Source_1-1.3-2023-10-23', $file->get_file_id() );
@@ -69,17 +133,18 @@ class FileTest extends WC_Unit_Test_Case {
 	/**
 	 * @testdox Check that all properties are populated correctly when a File instance receives a filename in a non-standard format.
 	 */
-	public function test_initialize_file_non_standard() {
+	public function test_initialize_existing_file_non_standard() {
 		$filename = Constants::get_constant( 'WC_LOG_DIR' ) . 'test-Source_1-1-' . wp_hash( 'cheddar' ) . '.log';
-		$resource = fopen( $filename, 'a' );
-		fclose( $resource );
-		$file = new File( $filename );
+		$file     = new File( $filename );
+
+		// For non-standard files, file must exist to get the created timestamp.
+		$file->write( 'test' );
 
 		$this->assertEquals( 'test-Source_1-1-' . wp_hash( 'cheddar' ) . '.log', $file->get_basename() );
 		$this->assertEquals( 'test-Source_1-1-' . wp_hash( 'cheddar' ), $file->get_file_id() );
 		$this->assertEquals( 'test-Source_1-1-' . wp_hash( 'cheddar' ), $file->get_source() );
 		$this->assertNull( $file->get_rotation() );
-		$this->assertEquals( filemtime( $filename ), $file->get_created_timestamp() );
+		$this->assertEquals( filectime( $filename ), $file->get_created_timestamp() );
 		// On non-standard filenames, we can't determine what part of the name might be a hash.
 		$this->assertEquals( '', $file->get_hash() );
 	}
@@ -87,75 +152,108 @@ class FileTest extends WC_Unit_Test_Case {
 	/**
 	 * @testdox Check that all properties are populated correctly when a File instance receives a rotated filename in a non-standard format.
 	 */
-	public function test_initialize_file_non_standard_rotated() {
+	public function test_initialize_existing_file_non_standard_rotated() {
 		$filename = Constants::get_constant( 'WC_LOG_DIR' ) . 'test-Source_1-1-' . wp_hash( 'cheddar' ) . '.5.log';
-		$resource = fopen( $filename, 'a' );
-		fclose( $resource );
-		$file = new File( $filename );
+		$file     = new File( $filename );
+
+		// For non-standard files, file must exist to get the created timestamp.
+		$file->write( 'test' );
 
 		$this->assertEquals( 'test-Source_1-1-' . wp_hash( 'cheddar' ) . '.5.log', $file->get_basename() );
 		$this->assertEquals( 'test-Source_1-1-' . wp_hash( 'cheddar' ) . '.5', $file->get_file_id() );
 		$this->assertEquals( 'test-Source_1-1-' . wp_hash( 'cheddar' ), $file->get_source() );
 		$this->assertEquals( 5, $file->get_rotation() );
-		$this->assertEquals( filemtime( $filename ), $file->get_created_timestamp() );
+		$this->assertEquals( filectime( $filename ), $file->get_created_timestamp() );
 		// On non-standard filenames, we can't determine what part of the name might be a hash.
 		$this->assertEquals( '', $file->get_hash() );
-	}
-
-	/**
-	 * @testdox Check that is_readable and is_writable only return true for files.
-	 */
-	public function test_is_readable_writable() {
-		global $wp_filesystem;
-
-		$filename = Constants::get_constant( 'WC_LOG_DIR' ) . 'test-Source_1-1-2023-10-23-' . wp_hash( 'cheddar' ) . '.log';
-		$resource = fopen( $filename, 'a' );
-		fclose( $resource );
-		$file = new File( $filename );
-
-		$this->assertTrue( $file->is_readable() );
-		$this->assertTrue( $file->is_writable() );
-
-		$nonfilename = Constants::get_constant( 'WC_LOG_DIR' ) . 'test_dir';
-		$wp_filesystem->mkdir( $nonfilename );
-		$nonfile = new File( $nonfilename );
-
-		$this->assertFalse( $nonfile->is_readable() );
-		$this->assertFalse( $nonfile->is_writable() );
 	}
 
 	/**
 	 * @testdox Check that get_stream returns a PHP resource representation of the file.
 	 */
 	public function test_get_and_close_stream() {
-		$filename = Constants::get_constant( 'WC_LOG_DIR' ) . 'test-Source_1-1-2023-10-23-' . wp_hash( 'cheddar' ) . '.log';
-		$resource = fopen( $filename, 'a' );
-		fclose( $resource );
-		$file = new File( $filename );
+		$filename = Constants::get_constant( 'WC_LOG_DIR' ) . 'test-file.log';
+		$file     = new File( $filename );
+
+		// File doesn't exist yet.
+		$this->assertFalse( $file->get_stream() );
+
+		$file->write( 'test' );
 
 		$stream = $file->get_stream();
 
 		$this->assertTrue( is_resource( $stream ) );
 
-		$file->close_stream();
+		$result = $file->close_stream();
 
+		$this->assertTrue( $result );
 		$this->assertFalse( is_resource( $stream ) );
+	}
+
+	/**
+	 * @testdox Check that rotating a file without a rotation market will rename it to include a rotation marker.
+	 */
+	public function test_rotate_current_file() {
+		$filename = Constants::get_constant( 'WC_LOG_DIR' ) . 'test-file.log';
+		$file     = new File( $filename );
+		$file->write( 'test' );
+
+		$this->assertNull( $file->get_rotation() );
+
+		$result = $file->rotate();
+
+		$this->assertTrue( $result );
+
+		$expected_filename = 'test-file.0.log';
+
+		$this->assertEquals( $expected_filename, $file->get_basename() );
+		$this->assertTrue( $file->is_readable() );
+
+		$old_file = new File( $filename );
+
+		$this->assertFalse( $old_file->is_readable() );
+	}
+
+	/**
+	 * @testdox Check that rotating a file with a rotation market will rename it to increment the rotation marker.
+	 */
+	public function test_rotate_older_file() {
+		$filename = Constants::get_constant( 'WC_LOG_DIR' ) . 'test-file.2.log';
+		$file     = new File( $filename );
+		$file->write( 'test' );
+
+		$this->assertEquals( 2, $file->get_rotation() );
+
+		$result = $file->rotate();
+
+		$this->assertTrue( $result );
+
+		$expected_filename = 'test-file.3.log';
+
+		$this->assertEquals( $expected_filename, $file->get_basename() );
+		$this->assertTrue( $file->is_readable() );
+
+		$old_file = new File( $filename );
+
+		$this->assertFalse( $old_file->is_readable() );
 	}
 
 	/**
 	 * @testdox The delete method should delete the file from the filesystem.
 	 */
-	public function test_delete() {
-		$filename = Constants::get_constant( 'WC_LOG_DIR' ) . 'test-Source_1-1-' . wp_hash( 'cheddar' ) . '.5.log';
-		$resource = fopen( $filename, 'a' );
-		fclose( $resource );
-		$file = new File( $filename );
+	public function test_delete_existing_file() {
+		$filename = Constants::get_constant( 'WC_LOG_DIR' ) . 'test-file.log';
+		$file     = new File( $filename );
+		$file->write( 'test' );
 
+		$this->assertTrue( $file->is_readable() );
 		$files = glob( trailingslashit( realpath( Constants::get_constant( 'WC_LOG_DIR' ) ) ) . '*.log' );
 		$this->assertCount( 1, $files );
 
-		$file->delete();
+		$result = $file->delete();
 
+		$this->assertTrue( $result );
+		$this->assertFalse( $file->is_readable() );
 		$files = glob( trailingslashit( realpath( Constants::get_constant( 'WC_LOG_DIR' ) ) ) . '*.log' );
 		$this->assertCount( 0, $files );
 	}

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileTest.php
@@ -169,6 +169,20 @@ class FileTest extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Check that the has_standard_filename method correctly identifies standard and nonstandard filenames.
+	 */
+	public function test_has_standard_filename() {
+		$standard    = Constants::get_constant( 'WC_LOG_DIR' ) . 'test-Source_1-1.3-2023-10-23-' . wp_hash( 'cheddar' ) . '.log';
+		$nonstandard = Constants::get_constant( 'WC_LOG_DIR' ) . 'test-Source_1-1-' . wp_hash( 'cheddar' ) . '.5.log';
+
+		$file = new File( $standard );
+		$this->assertTrue( $file->has_standard_filename() );
+
+		$file = new File( $nonstandard );
+		$this->assertFalse( $file->has_standard_filename() );
+	}
+
+	/**
 	 * @testdox Check that get_stream returns a PHP resource representation of the file.
 	 */
 	public function test_get_and_close_stream() {

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileTest.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/FileV2/FileTest.php
@@ -80,7 +80,8 @@ class FileTest extends WC_Unit_Test_Case {
 		$this->assertEquals( 'test-Source_1-1-' . wp_hash( 'cheddar' ), $file->get_source() );
 		$this->assertNull( $file->get_rotation() );
 		$this->assertEquals( filemtime( $filename ), $file->get_created_timestamp() );
-		$this->assertEquals( 'test-Source_1-1-' . wp_hash( 'cheddar' ), $file->get_hash() );
+		// On non-standard filenames, we can't determine what part of the name might be a hash.
+		$this->assertEquals( '', $file->get_hash() );
 	}
 
 	/**
@@ -97,7 +98,8 @@ class FileTest extends WC_Unit_Test_Case {
 		$this->assertEquals( 'test-Source_1-1-' . wp_hash( 'cheddar' ), $file->get_source() );
 		$this->assertEquals( 5, $file->get_rotation() );
 		$this->assertEquals( filemtime( $filename ), $file->get_created_timestamp() );
-		$this->assertEquals( 'test-Source_1-1-' . wp_hash( 'cheddar' ), $file->get_hash() );
+		// On non-standard filenames, we can't determine what part of the name might be a hash.
+		$this->assertEquals( '', $file->get_hash() );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/LogHandlerFileV2Test.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/LogHandlerFileV2Test.php
@@ -76,21 +76,21 @@ class LogHandlerFileV2Test extends WC_Unit_Test_Case {
 				'timestamp' => $current_time,
 				'context'   => array(),
 			),
-			'plugin-woocommerce-' . gmdate( 'Y-m-d', $current_time )
+			'plugin-woocommerce-' . gmdate( 'Y-m-d', $current_time ),
 		);
 		yield 'custom source, past time' => array(
 			array(
 				'timestamp' => $past_time,
 				'context'   => array( 'source' => 'tater_tots' ),
 			),
-			'tater_tots-' . gmdate( 'Y-m-d', $past_time )
+			'tater_tots-' . gmdate( 'Y-m-d', $past_time ),
 		);
 		yield 'custom source with formatting issues, current time' => array(
 			array(
 				'timestamp' => $current_time,
 				'context'   => array( 'source' => 'MACARONI & chEEse_Puffs' ),
 			),
-			'macaroni-cheese_puffs-' . gmdate( 'Y-m-d', $current_time )
+			'macaroni-cheese_puffs-' . gmdate( 'Y-m-d', $current_time ),
 		);
 	}
 
@@ -143,7 +143,7 @@ MESSAGE;
 
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		$actual_content   = file_get_contents( reset( $paths ) );
-		$expected_content = date( 'c', $time ) . ' DEBUG How to win 1. Bake cookies 2. ??? 3. Profit' . "\n";
+		$expected_content = gmdate( 'c', $time ) . ' DEBUG How to win 1. Bake cookies 2. ??? 3. Profit' . "\n";
 
 		$this->assertEquals( $expected_content, $actual_content );
 	}
@@ -158,7 +158,7 @@ MESSAGE;
 			array(
 				'file'     => 'foo.bar',
 				'line'     => 1337,
-				'function' => 'baz'
+				'function' => 'baz',
 			),
 		);
 	}
@@ -180,7 +180,11 @@ MESSAGE;
 			'',
 		);
 		yield 'source and custom keys' => array(
-			array( 'source' => 'frootloops', 'yin' => 'yang', 'apple' => 'orange' ),
+			array(
+				'source' => 'frootloops',
+				'yin'    => 'yang',
+				'apple'  => 'orange',
+			),
 			$context_delineator . '{"yin":"yang","apple":"orange"}',
 		);
 		yield 'backtrace boolean only' => array(
@@ -204,18 +208,21 @@ MESSAGE;
 	public function test_handle_context_output( array $input, string $expected ): void {
 		// Mock the backtrace output.
 		$handler = new class() extends LogHandlerFileV2 {
+			// phpcs:ignore Squiz.Commenting.VariableComment.Missing
 			protected $backtrace_data;
 
+			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
 			public function set_backtrace_data( $data ) {
 				$this->backtrace_data = $data;
 			}
 
+			// phpcs:ignore Squiz.Commenting.FunctionComment.Missing
 			protected static function get_backtrace() {
 				return array(
 					array(
 						'file'     => 'foo.bar',
 						'line'     => 1337,
-						'function' => 'baz'
+						'function' => 'baz',
 					),
 				);
 			}
@@ -229,7 +236,7 @@ MESSAGE;
 			$time,
 			'debug',
 			$message,
-			$input
+			$input,
 		);
 
 		$paths = glob( trailingslashit( realpath( Constants::get_constant( 'WC_LOG_DIR' ) ) ) . '*.log' );
@@ -237,7 +244,7 @@ MESSAGE;
 
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		$actual_content  = file_get_contents( reset( $paths ) );
-		$expected_prefix = date( 'c', $time ) . ' DEBUG ' . $message;
+		$expected_prefix = gmdate( 'c', $time ) . ' DEBUG ' . $message;
 
 		$this->assertEquals( $expected_prefix . $expected . "\n", $actual_content );
 	}
@@ -270,7 +277,7 @@ MESSAGE;
 
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		$actual_content  = file_get_contents( reset( $paths ) );
-		$expected_string = "4 expired log files were deleted.";
+		$expected_string = '4 expired log files were deleted.';
 		$this->assertStringContainsString( $expected_string, $actual_content );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/LogHandlerFileV2Test.php
+++ b/plugins/woocommerce/tests/php/src/Internal/Admin/Logging/LogHandlerFileV2Test.php
@@ -1,0 +1,276 @@
+<?php
+declare( strict_types = 1 );
+
+namespace Automattic\WooCommerce\Tests\Internal\Admin\Logging;
+
+use Automattic\Jetpack\Constants;
+use Automattic\WooCommerce\Internal\Admin\Logging\LogHandlerFileV2;
+use Automattic\WooCommerce\Internal\Admin\Logging\FileV2\File;
+use WC_Unit_Test_Case;
+
+/**
+ * LogHandlerFileV2Test class.
+ */
+class LogHandlerFileV2Test extends WC_Unit_Test_Case {
+	/**
+	 * "System Under Test", an instance of the class to be tested.
+	 *
+	 * @var LogHandlerFileV2
+	 */
+	private $sut;
+
+	/**
+	 * Set up to do before running any of these tests.
+	 *
+	 * @return void
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		self::delete_all_log_files();
+	}
+
+	/**
+	 * Set up before each test.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->sut = new LogHandlerFileV2();
+	}
+
+	/**
+	 * Tear down after each test.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		self::delete_all_log_files();
+		parent::tearDown();
+	}
+
+	/**
+	 * Delete all existing log files.
+	 *
+	 * @return void
+	 */
+	private static function delete_all_log_files(): void {
+		$files = glob( trailingslashit( realpath( Constants::get_constant( 'WC_LOG_DIR' ) ) ) . '*.log' );
+		foreach ( $files as $file ) {
+			unlink( $file );
+		}
+	}
+
+	/**
+	 * Data provider for test_handle_created_filenames.
+	 *
+	 * @return iterable
+	 */
+	public function provide_created_filenames_data(): iterable {
+		$current_time = time();
+		$past_time    = strtotime( '-2 days' );
+
+		yield 'no source, current time' => array(
+			array(
+				'timestamp' => $current_time,
+				'context'   => array(),
+			),
+			'plugin-woocommerce-' . gmdate( 'Y-m-d', $current_time )
+		);
+		yield 'custom source, past time' => array(
+			array(
+				'timestamp' => $past_time,
+				'context'   => array( 'source' => 'tater_tots' ),
+			),
+			'tater_tots-' . gmdate( 'Y-m-d', $past_time )
+		);
+		yield 'custom source with formatting issues, current time' => array(
+			array(
+				'timestamp' => $current_time,
+				'context'   => array( 'source' => 'MACARONI & chEEse_Puffs' ),
+			),
+			'macaroni-cheese_puffs-' . gmdate( 'Y-m-d', $current_time )
+		);
+	}
+
+	/**
+	 * @testdox Check that the handle method creates consistent filenames.
+	 *
+	 * @dataProvider provide_created_filenames_data
+	 *
+	 * @param array  $input    Arguments for the handle method.
+	 * @param string $expected The expected first part of the created filename.
+	 */
+	public function test_handle_created_filenames( array $input, string $expected ): void {
+		$this->sut->handle(
+			$input['timestamp'],
+			'debug',
+			'test',
+			$input['context']
+		);
+
+		$paths = glob( trailingslashit( realpath( Constants::get_constant( 'WC_LOG_DIR' ) ) ) . '*.log' );
+		$this->assertCount( 1, $paths );
+
+		$parsed = File::parse_path( reset( $paths ) );
+
+		$this->assertStringStartsWith( $expected, $parsed['basename'] );
+	}
+
+	/**
+	 * @testdox Check that the handle method formats the message content correctly.
+	 */
+	public function test_handle_message_formatting() {
+		$time    = time();
+		$message = <<<MESSAGE
+How to win
+1. Bake cookies
+2. ???
+3. Profit
+MESSAGE;
+		$message = trim( $message );
+
+		$this->sut->handle(
+			$time,
+			'debug',
+			$message,
+			array()
+		);
+
+		$paths = glob( trailingslashit( realpath( Constants::get_constant( 'WC_LOG_DIR' ) ) ) . '*.log' );
+		$this->assertCount( 1, $paths );
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$actual_content   = file_get_contents( reset( $paths ) );
+		$expected_content = date( 'c', $time ) . ' DEBUG How to win 1. Bake cookies 2. ??? 3. Profit' . "\n";
+
+		$this->assertEquals( $expected_content, $actual_content );
+	}
+
+	/**
+	 * Mock backtrace data.
+	 *
+	 * @return array[]
+	 */
+	private function get_mock_backtrace() {
+		return array(
+			array(
+				'file'     => 'foo.bar',
+				'line'     => 1337,
+				'function' => 'baz'
+			),
+		);
+	}
+
+	/**
+	 * Data provider for test_handle_context_output.
+	 *
+	 * @return iterable
+	 */
+	public function provide_context(): iterable {
+		$context_delineator = ' CONTEXT: ';
+
+		yield 'no context' => array(
+			array(),
+			'',
+		);
+		yield 'source only' => array(
+			array( 'source' => 'frootloops' ),
+			'',
+		);
+		yield 'source and custom keys' => array(
+			array( 'source' => 'frootloops', 'yin' => 'yang', 'apple' => 'orange' ),
+			$context_delineator . '{"yin":"yang","apple":"orange"}',
+		);
+		yield 'backtrace boolean only' => array(
+			array( 'backtrace' => true ),
+			$context_delineator . wp_json_encode( array( 'backtrace' => $this->get_mock_backtrace() ) ),
+		);
+		yield 'backtrace custom value' => array(
+			array( 'backtrace' => 'Not actually a backtrace' ),
+			$context_delineator . '{"backtrace":"Not actually a backtrace"}',
+		);
+	}
+
+	/**
+	 * @testdox Check that various data provided to the handler in the context arg is rendered correctly.
+	 *
+	 * @dataProvider provide_context
+	 *
+	 * @param array  $input    Arguments for the handle method.
+	 * @param string $expected The expected content appended to the log entry.
+	 */
+	public function test_handle_context_output( array $input, string $expected ): void {
+		// Mock the backtrace output.
+		$handler = new class() extends LogHandlerFileV2 {
+			protected $backtrace_data;
+
+			public function set_backtrace_data( $data ) {
+				$this->backtrace_data = $data;
+			}
+
+			protected static function get_backtrace() {
+				return array(
+					array(
+						'file'     => 'foo.bar',
+						'line'     => 1337,
+						'function' => 'baz'
+					),
+				);
+			}
+		};
+		$handler->set_backtrace_data( $this->get_mock_backtrace() );
+
+		$time    = time();
+		$message = 'Schmaltz';
+
+		$handler->handle(
+			$time,
+			'debug',
+			$message,
+			$input
+		);
+
+		$paths = glob( trailingslashit( realpath( Constants::get_constant( 'WC_LOG_DIR' ) ) ) . '*.log' );
+		$this->assertCount( 1, $paths );
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$actual_content  = file_get_contents( reset( $paths ) );
+		$expected_prefix = date( 'c', $time ) . ' DEBUG ' . $message;
+
+		$this->assertEquals( $expected_prefix . $expected . "\n", $actual_content );
+	}
+
+	/**
+	 * @testdox Check that the delete_logs_before_timestamp method deletes files based on their created date.
+	 */
+	public function test_delete_logs() {
+		$current_time = time();
+		$past_time    = strtotime( '-5 days' );
+
+		$this->sut->handle( $past_time, 'debug', 'old.', array( 'source' => 'source1' ) );
+		$this->sut->handle( $past_time, 'debug', 'old.', array( 'source' => 'source2' ) );
+		$this->sut->handle( $past_time, 'debug', 'old.', array( 'source' => 'source3' ) );
+		$this->sut->handle( $past_time, 'debug', 'old.', array( 'source' => 'source4' ) );
+		$this->sut->handle( $current_time, 'debug', 'new!', array( 'source' => 'source5' ) );
+		$this->sut->handle( $current_time, 'debug', 'new!', array( 'source' => 'source6' ) );
+
+		$paths = glob( trailingslashit( realpath( Constants::get_constant( 'WC_LOG_DIR' ) ) ) . '*.log' );
+		$this->assertCount( 6, $paths );
+
+		$result = $this->sut->delete_logs_before_timestamp( strtotime( '-3 days' ) );
+		$this->assertEquals( 4, $result );
+
+		$paths = glob( trailingslashit( realpath( Constants::get_constant( 'WC_LOG_DIR' ) ) ) . '*.log' );
+		$this->assertCount( 3, $paths ); // New log gets created when old logs are deleted!
+
+		$paths = glob( trailingslashit( realpath( Constants::get_constant( 'WC_LOG_DIR' ) ) ) . 'wc_logger*.log' );
+		$this->assertCount( 1, $paths );
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$actual_content  = file_get_contents( reset( $paths ) );
+		$expected_string = "4 expired log files were deleted.";
+		$this->assertStringContainsString( $expected_string, $actual_content );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This fleshes out the `LogHandlerFileV2` class that was introduced back in #40662. It no longer extends the original file log handler, but works as a standalone. To realize the improvements in the handler class, lots of improvements are also made to the `File` and `FileController` classes.

Notable enhancements in this handler class vs the original one:

* Better algorithm for determining the "source" of a log entry when none is provided.
* Normalizes the source property of a log entry so that variations in capitalization will still result in the same value.
* Improves file rotation behavior so that it will consistently increment each rotation up by one.
* Formats log messages to remove line breaks, so that each line of a log file is an entire entry.
* To complement this, data from the `$context` parameter is added to the log entries, and displayed in the log file viewer as prettified JSON, hidden behind a `<details>` element. Thus, each log entry can be expanded to show the context data, but it won't dominate the screen in the log viewer by default.

Fixes #41561

| 1 | 2 |
|--------|--------|
| ![Screen Shot 2023-12-14 at 16 28 28](https://github.com/woocommerce/woocommerce/assets/916023/b54985bb-de9f-4d59-8eec-aa23e6d09c5b) | ![Screen Shot 2023-12-14 at 16 28 49](https://github.com/woocommerce/woocommerce/assets/916023/9e29cc81-2e8a-456b-aa8e-5f44870ad84b) | 

### How to test the changes in this Pull Request:

#### Setup

1. After checking out this branch, you may need to update the autoloader. From the **plugins/woocommerce** directory, run `composer dump-autoload`. You also will probably need to rebuild the stylesheet for the Logs screen. For this, run `pnpm --filter=@woocommerce/plugin-woocommerce build`.
1. In your test site's **wp-config.php** file, add this line: `define( 'WC_LOG_HANDLER', 'Automattic\\WooCommerce\\Internal\\Admin\\Logging\\LogHandlerFileV2' );`. This is what allows you to see the new log file functionality.
2. Install [this plugin](https://gist.github.com/coreymckrill/2968911c8b63c556e7787f2cdc65f966) on your test site for generating test log files. Probably easiest to copy the file into the mu-plugins directory. **Note:** if you already have this plugin from reviewing a previous logging PR, delete that and re-download from this link again. The plugin has been updated with some new logging data.
3. Open two browser tabs: the Logs screen (WP Admin > WooCommerce > Status > Logs) and the WooCommerce Tools screen (WP Admin > WooCommerce > Status > Tools). On the Tools screen you should see the **Debug Log Generator** tool at the top of the list. Click the button to Generate some log entries.

#### Tests

1. Back on the Logs screen, there should be a list table of log files. One of the files should be called `debug-log-generator`. If you click to open this file, you should see messages saying that two different source values were used, where the difference is a variation in case. Since those entries are in the same file, it indicates that the source value has been normalized.
2. Return to the list table of log files. Now click on the logging tool file. If you installed the log generator plugin in the mu-plugins directory, the source should be called `mu-plugin-logging-tool`.
3. In this file, you'll see a NOTICE level entry with a basic stack trace included. It should all be on one line. Further down, there should be a DEBUG level entry that says "This entry has a backtrace in the context". Included on that entry line should be a `<details>` element that says "Additional context" with a small arrow. Clicking on that should reveal a backtrace as formatted JSON.

Other functionality is covered by the included unit tests, but if you want, you can manually test file rotations by generating several batches of logs until the size threshold is reached. The default threshold is 5 MB, but you can add this snippet to change it to 5 KB:

```php
// Make the file size threshold low for testing log file rotation.
add_filter(
	'woocommerce_log_file_size_limit',
	function() {
		return 5 * KB_IN_BYTES;
	}
);
```
