### PR TITLE
Update order attribution default cookie lifetime.

### DIFF
--- a/plugins/woocommerce/changelog/update-order-attribution-session-length
+++ b/plugins/woocommerce/changelog/update-order-attribution-session-length
@@ -1,4 +1,4 @@
 Significance: minor
 Type: tweak
 
-Change the default cookie lifetime from 6 months to the lenght of the session.
+Change the default cookie lifetime from 6 months to the length of the session.

--- a/plugins/woocommerce/changelog/update-order-attribution-session-length
+++ b/plugins/woocommerce/changelog/update-order-attribution-session-length
@@ -1,0 +1,4 @@
+Significance: minor
+Type: tweak
+
+Change the default cookie lifetime from 6 months to the lenght of the session.

--- a/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
@@ -200,9 +200,12 @@ class OrderAttributionController implements RegisterHooksInterface {
 		 *
 		 * @since 8.5.0
 		 *
-		 * @param int $lifetime The lifetime of the cookie in months.
+		 * @param float $lifetime The lifetime of the cookie in months.
+		 *
+		 * Fractional values are supported.
+		 * The defualt value tricks sourcebuster into using cookie valid for session only.
 		 */
-		$lifetime = (int) apply_filters( 'wc_order_attribution_cookie_lifetime_months', 6 );
+		$lifetime = (float) apply_filters( 'wc_order_attribution_cookie_lifetime_months', 0.00001 );
 
 		/**
 		 * Filter the session length for source tracking.

--- a/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
@@ -202,7 +202,6 @@ class OrderAttributionController implements RegisterHooksInterface {
 		 *
 		 * @param float $lifetime The lifetime of the Sourcebuster cookies in months.
 		 *
-		 * Fractional values are supported.
 		 * The default value forces Sourcebuster into making the cookies valid for the current session only.
 		 */
 		$lifetime = (float) apply_filters( 'wc_order_attribution_cookie_lifetime_months', 0.00001 );

--- a/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
@@ -200,7 +200,7 @@ class OrderAttributionController implements RegisterHooksInterface {
 		 *
 		 * @since 8.5.0
 		 *
-		 * @param float $lifetime The lifetime of the cookie in months.
+		 * @param float $lifetime The lifetime of the Sourcebuster cookies in months.
 		 *
 		 * Fractional values are supported.
 		 * The defualt value tricks sourcebuster into using cookie valid for session only.

--- a/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
+++ b/plugins/woocommerce/src/Internal/Orders/OrderAttributionController.php
@@ -203,7 +203,7 @@ class OrderAttributionController implements RegisterHooksInterface {
 		 * @param float $lifetime The lifetime of the Sourcebuster cookies in months.
 		 *
 		 * Fractional values are supported.
-		 * The defualt value tricks sourcebuster into using cookie valid for session only.
+		 * The default value forces Sourcebuster into making the cookies valid for the current session only.
 		 */
 		$lifetime = (float) apply_filters( 'wc_order_attribution_cookie_lifetime_months', 0.00001 );
 


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The default lifetime for order attribution cookie was 6 months. This needs to be changed to session length lifetime.
This parameter is used by the sourcebuster library. This library is using an initial check of the value passed as lifetime. If it detects 0 it reverts to the default value. Fortunately it supports flot parameters so we can pass a very small but non zero value. The proposed value will be calculated internally into minutes as:

`lifetime * 30 * 24. * 60`

If we select the value `0.0001` this will result in `0.432` which will be parsed via `paresInt` into `0`. And sourcebuster will assume no sesion time set and it will use session based cookie lifetime.


<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Checkout this PR.
2. Set a breakpoint at cookies.set in sourcebuster
3. Verify that `expires` parameter is not passed into `documen.cookie

Alternatively open a new woocommerce page, verify that the sourcebusters cookies are present. Close the session ( all tabs and browser ), open the page again - cookies should be gone. Compare to the scenario when lifetime is set to 1 ( make that change manually )

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
