### PR TITLE
Shipping Settings: Revert removal of default method names

### DIFF
--- a/plugins/woocommerce/changelog/41833-fix-shipping-settings-no-defaults
+++ b/plugins/woocommerce/changelog/41833-fix-shipping-settings-no-defaults
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+Comment: Fixes a bug found in unreleased feature. No changelog needed.
+

--- a/plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js
@@ -629,17 +629,6 @@
 						}
 					} else if ( target === 'wc-modal-shipping-method-settings' ) {
 						event.data.view.possiblyHideFreeShippingRequirements( data );
-						const requiredFields = [ 'woocommerce_free_shipping_title', 'woocommerce_flat_rate_title', 'woocommerce_local_pickup_title' ];
-						const requiredFieldPresent = requiredFields.find( ( field ) => {
-							return data.hasOwnProperty( field ) && field;
-						} );
-						
-						if ( requiredFieldPresent ) {
-							const shouldDisable = data[ requiredFieldPresent ].length === 0;
-							const saveButton = document.getElementById( 'btn-ok' );
-							saveButton.disabled = shouldDisable;
-							saveButton.classList.toggle( 'disabled', shouldDisable );
-						} 
 					}
 				},
 				onCloseConfigureShippingMethod: function( event, target, post_data, addButtonCalled ) {

--- a/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
+++ b/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
@@ -149,7 +149,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				</article>
 				<footer>
 					<div class="inner">
-						<button id="btn-ok" data-status='{{ data.status }}' disabled='{{ data.status === "new" ? "disabled" : "" }}' class="button button-primary button-large {{ data.status === 'new' ? 'disabled' : '' }}">
+						<button id="btn-ok" data-status='{{ data.status }}' class="button button-primary button-large">
 							<div class="wc-backbone-modal-action-{{ data.status === 'new' ? 'active' : 'inactive' }}"><?php esc_html_e( 'Create', 'woocommerce' ); ?></div>
 							<div class="wc-backbone-modal-action-{{ data.status === 'existing' ? 'active' : 'inactive' }}"><?php esc_html_e( 'Save', 'woocommerce' ); ?></div>
 						</button>

--- a/plugins/woocommerce/includes/shipping/flat-rate/includes/settings-flat-rate.php
+++ b/plugins/woocommerce/includes/shipping/flat-rate/includes/settings-flat-rate.php
@@ -15,7 +15,7 @@ $settings = array(
 		'title'       => __( 'Name', 'woocommerce' ),
 		'type'        => 'text',
 		'description' => __( 'Your customers will see the name of this shipping method during checkout.', 'woocommerce' ),
-		'default'     => '',
+		'default'     => __( 'Flat rate', 'woocommerce' ),
 		'placeholder' => __( 'e.g. Standard national', 'woocommerce' ),
 		'desc_tip'    => true,
 	),

--- a/plugins/woocommerce/includes/shipping/free-shipping/class-wc-shipping-free-shipping.php
+++ b/plugins/woocommerce/includes/shipping/free-shipping/class-wc-shipping-free-shipping.php
@@ -112,7 +112,7 @@ class WC_Shipping_Free_Shipping extends WC_Shipping_Method {
 				'title'       => __( 'Name', 'woocommerce' ),
 				'type'        => 'text',
 				'description' => __( 'Your customers will see the name of this shipping method during checkout.', 'woocommerce' ),
-				'default'     => '',
+				'default'     => $this->method_title,
 				'placeholder' => __( 'e.g. Free shipping', 'woocommerce' ),
 				'desc_tip'    => true,
 			),

--- a/plugins/woocommerce/includes/shipping/local-pickup/class-wc-shipping-local-pickup.php
+++ b/plugins/woocommerce/includes/shipping/local-pickup/class-wc-shipping-local-pickup.php
@@ -108,7 +108,7 @@ class WC_Shipping_Local_Pickup extends WC_Shipping_Method {
 				'title'       => __( 'Name', 'woocommerce' ),
 				'type'        => 'text',
 				'description' => __( 'Your customers will see the name of this shipping method during checkout.', 'woocommerce' ),
-				'default'     => '',
+				'default'     => __( 'Local pickup', 'woocommerce' ),
 				'placeholder' => __( 'e.g. Local pickup', 'woocommerce' ),
 				'desc_tip'    => true,
 			),

--- a/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-shipping-zones.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/merchant/create-shipping-zones.spec.js
@@ -67,28 +67,36 @@ test.describe( 'WooCommerce Shipping Settings - Add new shipping zone', () => {
 				.getByPlaceholder( 'Zone name' )
 				.fill( shippingZoneNameLocalPickup );
 
-			const input = await page.getByPlaceholder( 'Start typing to filter zones' );
+			const input = await page.getByPlaceholder(
+				'Start typing to filter zones'
+			);
 			input.click();
 			input.type( 'British Columbia, Canada' );
-			
-			await page
-				.getByText( 'British Columbia, Canada' ).last()
-				.click();
-			
-			// Close dropdown
-			await page.keyboard.press('Escape');
-			
-			await page.getByRole( 'link', { name: 'Limit to specific ZIP/postcodes' } ).click();
-			await page.getByPlaceholder( 'List 1 postcode per line' ).fill( maynePostal );
 
-			await page.getByRole( 'button', { name: 'Add shipping method' } ).click();
-			await page.getByText( 'Local pickup', { exact: true } ).click();
-			await page.getByRole('button', { name: 'Continue' } ).last().click();
-			await page.waitForLoadState( 'networkidle' );
-			
+			await page.getByText( 'British Columbia, Canada' ).last().click();
+
+			// Close dropdown
+			await page.keyboard.press( 'Escape' );
+
 			await page
-				.getByPlaceholder( 'e.g. Local pickup' )
-				.fill( 'Local pickup' );
+				.getByRole( 'link', {
+					name: 'Limit to specific ZIP/postcodes',
+				} )
+				.click();
+			await page
+				.getByPlaceholder( 'List 1 postcode per line' )
+				.fill( maynePostal );
+
+			await page
+				.getByRole( 'button', { name: 'Add shipping method' } )
+				.click();
+			await page.getByText( 'Local pickup', { exact: true } ).click();
+			await page
+				.getByRole( 'button', { name: 'Continue' } )
+				.last()
+				.click();
+			await page.waitForLoadState( 'networkidle' );
+
 			await page.locator( '#btn-ok' ).click();
 			await page.waitForLoadState( 'networkidle' );
 
@@ -130,28 +138,32 @@ test.describe( 'WooCommerce Shipping Settings - Add new shipping zone', () => {
 				'wp-admin/admin.php?page=wc-settings&tab=shipping&zone_id=new',
 				{ waitUntil: 'networkidle' }
 			);
-			await page.getByPlaceholder( 'Zone name' ).fill( shippingZoneNameFreeShip );
+			await page
+				.getByPlaceholder( 'Zone name' )
+				.fill( shippingZoneNameFreeShip );
 
-			const input = await page.getByPlaceholder( 'Start typing to filter zones' );
+			const input = await page.getByPlaceholder(
+				'Start typing to filter zones'
+			);
 			input.click();
 			input.type( 'British Columbia, Canada' );
-			
-			await page
-				.getByText( 'British Columbia, Canada' ).last()
-				.click();
-			
+
+			await page.getByText( 'British Columbia, Canada' ).last().click();
+
 			// Close dropdown
-			await page.keyboard.press('Escape');
-			
-			await page.getByRole( 'button', { name: 'Add shipping method' } ).click();
+			await page.keyboard.press( 'Escape' );
+
+			await page
+				.getByRole( 'button', { name: 'Add shipping method' } )
+				.click();
 
 			await page.getByText( 'Free shipping', { exact: true } ).click();
-			await page.getByRole('button', { name: 'Continue' } ).last().click();
-			await page.waitForLoadState( 'networkidle' );
-			
 			await page
-				.getByPlaceholder( 'e.g. Free shipping' )
-				.fill( 'Free shipping' );
+				.getByRole( 'button', { name: 'Continue' } )
+				.last()
+				.click();
+			await page.waitForLoadState( 'networkidle' );
+
 			await page.locator( '#btn-ok' ).click();
 			await page.waitForLoadState( 'networkidle' );
 
@@ -190,27 +202,31 @@ test.describe( 'WooCommerce Shipping Settings - Add new shipping zone', () => {
 				'wp-admin/admin.php?page=wc-settings&tab=shipping&zone_id=new',
 				{ waitUntil: 'networkidle' }
 			);
-			await page.getByPlaceholder( 'Zone name' ).fill( shippingZoneNameFlatRate );
+			await page
+				.getByPlaceholder( 'Zone name' )
+				.fill( shippingZoneNameFlatRate );
 
-			const input = await page.getByPlaceholder( 'Start typing to filter zones' );
+			const input = await page.getByPlaceholder(
+				'Start typing to filter zones'
+			);
 			input.click();
 			input.type( 'Canada' );
 
-			await page
-				.getByText('Canada').last()
-				.click();
-			
-				// Close dropdown
-			await page.keyboard.press('Escape');
+			await page.getByText( 'Canada' ).last().click();
 
-			await page.getByRole( 'button', { name: 'Add shipping method' } ).click();
+			// Close dropdown
+			await page.keyboard.press( 'Escape' );
+
+			await page
+				.getByRole( 'button', { name: 'Add shipping method' } )
+				.click();
 			await page.getByText( 'Flat rate', { exact: true } ).click();
-			await page.getByRole('button', { name: 'Continue' } ).last().click();
+			await page
+				.getByRole( 'button', { name: 'Continue' } )
+				.last()
+				.click();
 			await page.waitForLoadState( 'networkidle' );
 
-			await page
-				.getByPlaceholder( 'e.g. Standard national' )
-				.fill( 'Flat rate' );
 			await page.locator( '#btn-ok' ).click();
 			await page.waitForLoadState( 'networkidle' );
 
@@ -220,7 +236,11 @@ test.describe( 'WooCommerce Shipping Settings - Add new shipping zone', () => {
 					.filter( { hasText: 'Flat rate' } )
 			).toBeVisible();
 
-			await page.locator( 'td:has-text("Flat rate") ~ td.wc-shipping-zone-actions a.wc-shipping-zone-action-edit' ).click();
+			await page
+				.locator(
+					'td:has-text("Flat rate") ~ td.wc-shipping-zone-actions a.wc-shipping-zone-action-edit'
+				)
+				.click();
 			await page.getByLabel( 'Cost', { exact: true } ).fill( '10' );
 			await page.getByRole( 'button', { name: 'Save' } ).last().click();
 			await page.waitForLoadState( 'networkidle' );
@@ -257,16 +277,16 @@ test.describe( 'WooCommerce Shipping Settings - Add new shipping zone', () => {
 			);
 			await page.locator( '#zone_name' ).fill( shippingZoneNameUSRegion );
 
-			const input = await page.getByPlaceholder( 'Start typing to filter zones' );
+			const input = await page.getByPlaceholder(
+				'Start typing to filter zones'
+			);
 			input.click();
 			input.type( 'United States' );
 
-			await page
-				.getByText( 'United States' ).last()
-				.click();
-			
-				// Close dropdown
-			await page.keyboard.press('Escape');
+			await page.getByText( 'United States' ).last().click();
+
+			// Close dropdown
+			await page.keyboard.press( 'Escape' );
 
 			await page.locator( '#submit' ).click();
 			await page.waitForFunction( () => {
@@ -286,7 +306,11 @@ test.describe( 'WooCommerce Shipping Settings - Add new shipping zone', () => {
 		//delete created shipping zone region after confirmation it exists
 		await page.goto( 'wp-admin/admin.php?page=wc-settings&tab=shipping' );
 
-		await page.locator( 'td:has-text("USA Zone") ~ td.wc-shipping-zone-actions a.wc-shipping-zone-action-edit' ).click();
+		await page
+			.locator(
+				'td:has-text("USA Zone") ~ td.wc-shipping-zone-actions a.wc-shipping-zone-action-edit'
+			)
+			.click();
 
 		//delete
 		await page.getByRole( 'button', { name: 'Remove' } ).click();
@@ -319,37 +343,41 @@ test.describe( 'WooCommerce Shipping Settings - Add new shipping zone', () => {
 			);
 			await page.locator( '#zone_name' ).fill( shippingZoneNameFlatRate );
 
-			const input = await page.getByPlaceholder( 'Start typing to filter zones' );
+			const input = await page.getByPlaceholder(
+				'Start typing to filter zones'
+			);
 			input.click();
 			input.type( 'Canada' );
 
-			await page
-				.getByText( 'Canada' ).last()
-				.click();
-			
-				// Close dropdown
-			await page.keyboard.press('Escape');
+			await page.getByText( 'Canada' ).last().click();
+
+			// Close dropdown
+			await page.keyboard.press( 'Escape' );
 
 			await page.locator( 'text=Add shipping method' ).click();
 
 			await page.getByText( 'Flat rate', { exact: true } ).click();
-			await page.getByRole('button', { name: 'Continue' } ).last().click();
+			await page
+				.getByRole( 'button', { name: 'Continue' } )
+				.last()
+				.click();
 
 			await page.waitForLoadState( 'networkidle' );
 
-			await page
-				.getByPlaceholder( 'e.g. Standard national' )
-				.fill( 'Flat rate' );
 			await page.locator( '#btn-ok' ).click();
 			await page.waitForLoadState( 'networkidle' );
-			
+
 			await expect(
 				page
 					.locator( '.wc-shipping-zone-method-title' )
 					.filter( { hasText: 'Flat rate' } )
 			).toBeVisible();
 
-			await page.locator( 'td:has-text("Flat rate") ~ td.wc-shipping-zone-actions a.wc-shipping-zone-action-edit' ).click();
+			await page
+				.locator(
+					'td:has-text("Flat rate") ~ td.wc-shipping-zone-actions a.wc-shipping-zone-action-edit'
+				)
+				.click();
 			await page.locator( '#woocommerce_flat_rate_cost' ).fill( '10' );
 			await page.locator( '#btn-ok' ).click();
 			await page.waitForLoadState( 'networkidle' );
@@ -435,20 +463,13 @@ test.describe( 'Verifies shipping options from customer perspective', () => {
 			method_id: 'flat_rate',
 			settings: {
 				cost: '10.00',
-				title: 'Flat rate',
 			},
 		} );
 		await api.post( `shipping/zones/${ shippingFreeId }/methods`, {
 			method_id: 'free_shipping',
-			settings: {
-				title: 'Free shipping',
-			}
 		} );
 		await api.post( `shipping/zones/${ shippingLocalId }/methods`, {
 			method_id: 'local_pickup',
-			settings: {
-				title: 'Local pickup',
-			}
 		} );
 	} );
 

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-calculate-shipping.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/cart-calculate-shipping.spec.js
@@ -78,22 +78,15 @@ test.describe( 'Cart Calculate Shipping', () => {
 		// set shipping zone methods
 		await api.post( `shipping/zones/${ shippingZoneDEId }/methods`, {
 			method_id: 'free_shipping',
-			settings: {
-				title: 'Free shipping',
-			},
 		} );
 		await api.post( `shipping/zones/${ shippingZoneFRId }/methods`, {
 			method_id: 'flat_rate',
 			settings: {
-				title: 'Flat rate',
 				cost: '5.00',
 			},
 		} );
 		await api.post( `shipping/zones/${ shippingZoneFRId }/methods`, {
 			method_id: 'local_pickup',
-			settings: {
-				title: 'Local pickup',
-			},
 		} );
 		// confirm that we allow shipping to any country
 		await api.put( 'settings/general/woocommerce_allowed_countries', {
@@ -174,9 +167,9 @@ test.describe( 'Cart Calculate Shipping', () => {
 		await page.locator( 'text=Local pickup' ).click();
 
 		// Verify updated shipping costs
-		await expect( page.locator( '.order-total .amount' ).first() ).toContainText(
-			`$${ firstProductPrice }`
-		);
+		await expect(
+			page.locator( '.order-total .amount' ).first()
+		).toContainText( `$${ firstProductPrice }` );
 	} );
 
 	test( 'should show correct total cart price after updating quantity', async ( {

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-create-account.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-create-account.spec.js
@@ -66,9 +66,6 @@ test.describe( 'Shopper Checkout Create Account', () => {
 		] );
 		await api.post( `shipping/zones/${ shippingZoneId }/methods`, {
 			method_id: 'free_shipping',
-			settings: {
-				title: 'Free shipping',
-			}
 		} );
 		await api.put( 'payment_gateways/cod', {
 			enabled: true,

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-login.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout-login.spec.js
@@ -62,9 +62,6 @@ test.describe( 'Shopper Checkout Login Account', () => {
 		] );
 		await api.post( `shipping/zones/${ shippingZoneId }/methods`, {
 			method_id: 'free_shipping',
-			settings: {
-				title: 'Free shipping',
-			}
 		} );
 		// create customer and save its id
 		await api
@@ -175,6 +172,8 @@ test.describe( 'Shopper Checkout Login Account', () => {
 		// check my account page
 		await page.goto( '/my-account/' );
 		await expect( page.url() ).toContain( 'my-account/' );
-		await expect( page.getByRole( 'heading', { name: 'My account' } ) ).toBeVisible();
+		await expect(
+			page.getByRole( 'heading', { name: 'My account' } )
+		).toBeVisible();
 	} );
 } );

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/checkout.spec.js
@@ -67,9 +67,6 @@ test.describe( 'Checkout page', () => {
 		] );
 		await api.post( `shipping/zones/${ shippingZoneId }/methods`, {
 			method_id: 'free_shipping',
-			settings: {
-				title: 'Free shipping',
-			}
 		} );
 	} );
 
@@ -117,7 +114,6 @@ test.describe( 'Checkout page', () => {
 		await api.put( 'payment_gateways/cod', {
 			enabled: true,
 		} );
-
 	} );
 
 	test( 'should display cart items in order review', async ( { page } ) => {
@@ -132,7 +128,11 @@ test.describe( 'Checkout page', () => {
 		await expect( page.locator( 'strong.product-quantity' ) ).toContainText(
 			'1'
 		);
-		let totalPrice = await page.getByRole( 'row', { name: 'Total' } ).last().locator( 'td' ).textContent();
+		let totalPrice = await page
+			.getByRole( 'row', { name: 'Total' } )
+			.last()
+			.locator( 'td' )
+			.textContent();
 		console.log( `Total Price: ${ totalPrice }` );
 		totalPrice = Number( totalPrice.replace( /[^\d.-]/g, '' ) );
 		console.log( `Number: ${ totalPrice }` );
@@ -154,7 +154,11 @@ test.describe( 'Checkout page', () => {
 		await expect( page.locator( 'strong.product-quantity' ) ).toContainText(
 			'2'
 		);
-		let totalPrice = await page.getByRole( 'row', { name: 'Total' } ).last().locator( 'td' ).textContent();
+		let totalPrice = await page
+			.getByRole( 'row', { name: 'Total' } )
+			.last()
+			.locator( 'td' )
+			.textContent();
 		console.log( `Total Price: ${ totalPrice }` );
 		totalPrice = Number( totalPrice.replace( /[^\d.-]/g, '' ) );
 		console.log( `Number: ${ totalPrice }` );
@@ -178,7 +182,11 @@ test.describe( 'Checkout page', () => {
 		await expect( page.locator( 'strong.product-quantity' ) ).toContainText(
 			'3'
 		);
-		let totalPrice = await page.getByRole( 'row', { name: 'Total' } ).last().locator( 'td' ).textContent();
+		let totalPrice = await page
+			.getByRole( 'row', { name: 'Total' } )
+			.last()
+			.locator( 'td' )
+			.textContent();
 		console.log( `Total Price: ${ totalPrice }` );
 		totalPrice = Number( totalPrice.replace( /[^\d.-]/g, '' ) );
 		console.log( `Number: ${ totalPrice }` );
@@ -200,24 +208,44 @@ test.describe( 'Checkout page', () => {
 		await expect( page.locator( '#billing_email' ) ).toBeEditable();
 	} );
 
-	test( 'warn when customer is missing required details', async ( { page } ) => {
-		await page.goto( `/shop/?add-to-cart=${ productId }`, { waitUntil: 'networkidle' } );
+	test( 'warn when customer is missing required details', async ( {
+		page,
+	} ) => {
+		await page.goto( `/shop/?add-to-cart=${ productId }`, {
+			waitUntil: 'networkidle',
+		} );
 
 		await page.goto( '/checkout/' );
 
 		// first try submitting the form with no fields complete
-		await page.getByRole('button', { name: 'Place order' }).click();
-		await expect( page.locator('form[name="checkout"]').getByRole('alert') ).toBeVisible();
-		await expect( page.getByText( 'Billing First name is a required field.' ) ).toBeVisible();
-		await expect( page.getByText( 'Billing Last name is a required field.' ) ).toBeVisible();
-		await expect( page.getByText( 'Billing Street address is a required field.' ) ).toBeVisible();
-		await expect( page.getByText( 'Billing Town / City is a required field.' ) ).toBeVisible();
-		await expect( page.getByText( 'Billing ZIP Code is a required field.' ) ).toBeVisible();
-		await expect( page.getByText( 'Billing Phone is a required field.' ) ).toBeVisible();
-		await expect( page.getByText( 'Billing Email address is a required field.' ) ).toBeVisible();
+		await page.getByRole( 'button', { name: 'Place order' } ).click();
+		await expect(
+			page.locator( 'form[name="checkout"]' ).getByRole( 'alert' )
+		).toBeVisible();
+		await expect(
+			page.getByText( 'Billing First name is a required field.' )
+		).toBeVisible();
+		await expect(
+			page.getByText( 'Billing Last name is a required field.' )
+		).toBeVisible();
+		await expect(
+			page.getByText( 'Billing Street address is a required field.' )
+		).toBeVisible();
+		await expect(
+			page.getByText( 'Billing Town / City is a required field.' )
+		).toBeVisible();
+		await expect(
+			page.getByText( 'Billing ZIP Code is a required field.' )
+		).toBeVisible();
+		await expect(
+			page.getByText( 'Billing Phone is a required field.' )
+		).toBeVisible();
+		await expect(
+			page.getByText( 'Billing Email address is a required field.' )
+		).toBeVisible();
 
 		// toggle ship to different address, fill out billing info and confirm error shown
-		await page.getByText('Ship to a different address?').click();
+		await page.getByText( 'Ship to a different address?' ).click();
 		await page.locator( '#billing_first_name' ).fill( 'Homer' );
 		await page.locator( '#billing_last_name' ).fill( 'Simpson' );
 		await page
@@ -229,14 +257,24 @@ test.describe( 'Checkout page', () => {
 		await page.locator( '#billing_postcode' ).fill( '97403' );
 		await page.locator( '#billing_phone' ).fill( '555 555-5555' );
 		await page.locator( '#billing_email' ).fill( customer.email );
-		await page.getByRole('button', { name: 'Place order' }).click();
+		await page.getByRole( 'button', { name: 'Place order' } ).click();
 
 		await expect( page.locator( 'ul.woocommerce-error' ) ).toBeVisible();
-		await expect( page.getByText( 'Shipping First name is a required field.' ) ).toBeVisible();
-		await expect( page.getByText( 'Shipping Last name is a required field.' ) ).toBeVisible();
-		await expect( page.getByText( 'Shipping Street address is a required field.' ) ).toBeVisible();
-		await expect( page.getByText( 'Shipping Town / City is a required field.' ) ).toBeVisible();
-		await expect( page.getByText( 'Shipping ZIP Code is a required field.' ) ).toBeVisible();
+		await expect(
+			page.getByText( 'Shipping First name is a required field.' )
+		).toBeVisible();
+		await expect(
+			page.getByText( 'Shipping Last name is a required field.' )
+		).toBeVisible();
+		await expect(
+			page.getByText( 'Shipping Street address is a required field.' )
+		).toBeVisible();
+		await expect(
+			page.getByText( 'Shipping Town / City is a required field.' )
+		).toBeVisible();
+		await expect(
+			page.getByText( 'Shipping ZIP Code is a required field.' )
+		).toBeVisible();
 	} );
 
 	test( 'allows customer to fill shipping details', async ( { page } ) => {
@@ -249,7 +287,11 @@ test.describe( 'Checkout page', () => {
 		await expect( page.locator( 'strong.product-quantity' ) ).toContainText(
 			'2'
 		);
-		let totalPrice = await page.getByRole( 'row', { name: 'Total' } ).last().locator( 'td' ).textContent();
+		let totalPrice = await page
+			.getByRole( 'row', { name: 'Total' } )
+			.last()
+			.locator( 'td' )
+			.textContent();
 		console.log( `Total Price: ${ totalPrice }` );
 		totalPrice = Number( totalPrice.replace( /[^\d.-]/g, '' ) );
 		console.log( `Number: ${ totalPrice }` );
@@ -281,7 +323,11 @@ test.describe( 'Checkout page', () => {
 		await expect( page.locator( 'strong.product-quantity' ) ).toContainText(
 			'2'
 		);
-		let totalPrice = await page.getByRole( 'row', { name: 'Total' } ).last().locator( 'td' ).textContent();
+		let totalPrice = await page
+			.getByRole( 'row', { name: 'Total' } )
+			.last()
+			.locator( 'td' )
+			.textContent();
 		console.log( `Total Price: ${ totalPrice }` );
 		totalPrice = Number( totalPrice.replace( /[^\d.-]/g, '' ) );
 		console.log( `Number: ${ totalPrice }` );
@@ -315,7 +361,6 @@ test.describe( 'Checkout page', () => {
 			.textContent();
 		guestOrderId = await orderReceivedText.split( /(\s+)/ )[ 6 ].toString();
 
-
 		// Let's simulate a new browser context (by dropping all cookies), and reload the page. This approximates a
 		// scenario where the server can no longer identify the shopper. However, so long as we are within the 10 minute
 		// grace period following initial order placement, the 'order received' page should still be rendered.
@@ -327,19 +372,23 @@ test.describe( 'Checkout page', () => {
 
 		// Let's simulate a scenario where the 10 minute grace period has expired. This time, we expect the shopper to
 		// be presented with a request to verify their email address.
-		await setFilterValue( page, 'woocommerce_order_email_verification_grace_period', 0 );
-		await page.reload();
-		await expect( page.locator( 'form.woocommerce-verify-email p:nth-child(3)' ) ).toContainText(
-			/verify the email address associated with the order/
+		await setFilterValue(
+			page,
+			'woocommerce_order_email_verification_grace_period',
+			0
 		);
+		await page.reload();
+		await expect(
+			page.locator( 'form.woocommerce-verify-email p:nth-child(3)' )
+		).toContainText( /verify the email address associated with the order/ );
 
 		// Supplying an email address other than the actual order billing email address will take them back to the same
 		// page with an error message.
 		await page.fill( '#email', 'incorrect@email.address' );
 		await page.locator( 'form.woocommerce-verify-email button' ).click();
-		await expect( page.locator( 'form.woocommerce-verify-email p:nth-child(4)' ) ).toContainText(
-			/verify the email address associated with the order/
-		);
+		await expect(
+			page.locator( 'form.woocommerce-verify-email p:nth-child(4)' )
+		).toContainText( /verify the email address associated with the order/ );
 		await expect( page.locator( 'ul.woocommerce-error li' ) ).toContainText(
 			/We were unable to verify the email address you provided/
 		);
@@ -362,7 +411,9 @@ test.describe( 'Checkout page', () => {
 		);
 
 		await expect(
-			page.getByRole( 'heading', { name: `Order #${ guestOrderId } details` } )
+			page.getByRole( 'heading', {
+				name: `Order #${ guestOrderId } details`,
+			} )
 		).toBeVisible();
 		await expect( page.locator( '.wc-order-item-name' ) ).toContainText(
 			simpleProductName
@@ -381,8 +432,12 @@ test.describe( 'Checkout page', () => {
 
 	test( 'allows existing customer to place order', async ( { page } ) => {
 		await page.goto( 'my-account/' );
-		await page.locator( 'input[name="username"]' ).fill( customer.username );
-		await page.locator( 'input[name="password"]' ).fill( customer.password );
+		await page
+			.locator( 'input[name="username"]' )
+			.fill( customer.username );
+		await page
+			.locator( 'input[name="password"]' )
+			.fill( customer.password );
 		await page.locator( 'text=Log In' ).click();
 		await page.waitForLoadState( 'networkidle' );
 		for ( let i = 1; i < 3; i++ ) {
@@ -394,7 +449,11 @@ test.describe( 'Checkout page', () => {
 		await expect( page.locator( 'strong.product-quantity' ) ).toContainText(
 			'2'
 		);
-		let totalPrice = await page.getByRole( 'row', { name: 'Total' } ).last().locator( 'td' ).textContent();
+		let totalPrice = await page
+			.getByRole( 'row', { name: 'Total' } )
+			.last()
+			.locator( 'td' )
+			.textContent();
 		console.log( `Total Price: ${ totalPrice }` );
 		totalPrice = Number( totalPrice.replace( /[^\d.-]/g, '' ) );
 		console.log( `Number: ${ totalPrice }` );

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/shipping-zones.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/shipping-zones.php
@@ -691,7 +691,7 @@ class WC_Tests_API_Shipping_Zones_V2 extends WC_REST_Unit_Test_Case {
 		$request->set_body_params(
 			array(
 				'settings' => array(
-					'cost'  => 5,
+					'cost' => 5,
 				),
 			)
 		);

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/shipping-zones.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version2/shipping-zones.php
@@ -680,7 +680,7 @@ class WC_Tests_API_Shipping_Zones_V2 extends WC_REST_Unit_Test_Case {
 		$data     = $response->get_data();
 
 		$this->assertArrayHasKey( 'title', $data['settings'] );
-		$this->assertEquals( '', $data['settings']['title']['value'] );
+		$this->assertEquals( 'Flat rate', $data['settings']['title']['value'] );
 		$this->assertArrayHasKey( 'tax_status', $data['settings'] );
 		$this->assertEquals( 'taxable', $data['settings']['tax_status']['value'] );
 		$this->assertArrayHasKey( 'cost', $data['settings'] );
@@ -692,7 +692,6 @@ class WC_Tests_API_Shipping_Zones_V2 extends WC_REST_Unit_Test_Case {
 			array(
 				'settings' => array(
 					'cost'  => 5,
-					'title' => 'Flat rate',
 				),
 			)
 		);

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/shipping-zones.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/shipping-zones.php
@@ -714,7 +714,7 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 		$request->set_body_params(
 			array(
 				'settings' => array(
-					'cost'  => 5,
+					'cost' => 5,
 				),
 			)
 		);

--- a/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/shipping-zones.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/rest-api/Tests/Version3/shipping-zones.php
@@ -703,7 +703,7 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 		$data     = $response->get_data();
 
 		$this->assertArrayHasKey( 'title', $data['settings'] );
-		$this->assertEquals( '', $data['settings']['title']['value'] );
+		$this->assertEquals( 'Flat rate', $data['settings']['title']['value'] );
 		$this->assertArrayHasKey( 'tax_status', $data['settings'] );
 		$this->assertEquals( 'taxable', $data['settings']['tax_status']['value'] );
 		$this->assertArrayHasKey( 'cost', $data['settings'] );
@@ -715,7 +715,6 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 			array(
 				'settings' => array(
 					'cost'  => 5,
-					'title' => 'Flat rate',
 				),
 			)
 		);


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In https://github.com/woocommerce/woocommerce/pull/40838 default names for WooCommerce Shipping Zone methods was removed in favour of displaying a placeholder. In the case below `e.g. Free shipping`. The removal of the default is causing issues with previously configured methods that relied on there being a default.

![image](https://github.com/woocommerce/woocommerce/assets/1922453/de122282-1af1-4561-aa21-06a18ce00662)

It appears to have been a mistake to remove the default names of methods because systems interacting with shipping zone methods work under the assumption the default exists, and so this was a backwards incompatible change. This PR revert that changes and resets some unit and e2e tests back to their original state.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->


Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a new JN site, but not from this branch. Make sure it includes the lastest WCX 8.3 release. You will see the old shipping zone method dialog which will allow you to enter a method without a name.
2. Add a shipping zone for the US, and add a free shipping method. Be sure to leave the name field as is.
3. Try adding a shippable product to the cart, and try to calculate shipping fees for an address in the US (it should work).
4. Now update WooCommerce to a zip of this branch. You can [download it here](https://betadownload.jetpack.me/data/woocommerce/fix_shipping-settings-no-defaults/woocommerce-dev.zip).
5. Visit the shipping zone setting page, `/wp-admin/admin.php?page=wc-settings&tab=shipping` and see the "Shipping method(s)" column have names underneath.
6. Now go back to the checkout screen and refresh. You should see the shipping method available. 
7. Finally, try adding a new shipping method. See the name field show the default values "Free shipping", "Flat rate", or "Local pickup" depending on the type.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

Fixes a bug found in unreleased feature. No changelog needed.

</details>
