### PR TITLE
Force marketing menu items order.

### DIFF
--- a/plugins/woocommerce/changelog/update-force-marketing-menu-items-order
+++ b/plugins/woocommerce/changelog/update-force-marketing-menu-items-order
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Force Marketing menu items order.

--- a/plugins/woocommerce/src/Internal/Admin/Marketing.php
+++ b/plugins/woocommerce/src/Internal/Admin/Marketing.php
@@ -223,7 +223,6 @@ class Marketing {
 		$new_menu_order = array_merge( $new_menu_order, $marketing_submenu );
 
 		$submenu['woocommerce-marketing'] = $new_menu_order;  //phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Marketing.php
+++ b/plugins/woocommerce/src/Internal/Admin/Marketing.php
@@ -44,6 +44,9 @@ class Marketing {
 		add_action( 'admin_menu', array( $this, 'register_pages' ), 5 );
 		add_action( 'admin_menu', array( $this, 'add_parent_menu_item' ), 6 );
 
+		// Overwrite submenu defualt ordering for marketing menu. Hight priority gives plugins chance to register their own menu items.
+		add_action( 'admin_menu', array( $this, 'reorder_marketing_submenu' ), 99 );
+
 		add_filter( 'woocommerce_admin_shared_settings', array( $this, 'component_settings' ), 30 );
 	}
 
@@ -138,6 +141,43 @@ class Marketing {
 				$item[2] = 'admin.php?page=' . $item[2];
 			}
 		}
+	}
+
+	/**
+	 * Order marketing menu items alphabeticaly.
+	 * Overview should be first.
+	 *
+	 * @return  void
+	 */
+	public function reorder_marketing_submenu( ) {
+		global $submenu;
+
+		if ( ! isset( $submenu['woocommerce-marketing'] ) ) {
+			return;
+		}
+
+		$marketing_submenu = $submenu['woocommerce-marketing'];
+
+		$new_order = array();
+
+		// Overview should be first.
+		$overview_key = array_search( 'Overview', array_column( $marketing_submenu, 0 ) );
+		$new_order[]  = $marketing_submenu[ $overview_key ];
+
+		// Remove Overview from the array.
+		unset( $marketing_submenu[ $overview_key ] );
+
+		// Sort the rest of the items alphabetically.
+		usort(
+			$marketing_submenu,
+			function( $a, $b ) {
+				return strcmp( $a[0], $b[0] );
+			}
+		);
+
+		$new_order = array_merge( $new_order, $marketing_submenu );
+
+		$submenu['woocommerce-marketing'] = $new_order;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Marketing.php
+++ b/plugins/woocommerce/src/Internal/Admin/Marketing.php
@@ -163,7 +163,7 @@ class Marketing {
 	 *
 	 * @return  void
 	 */
-	public function reorder_marketing_submenu( ) {
+	public function reorder_marketing_submenu() {
 		global $submenu;
 
 		if ( ! isset( $submenu['woocommerce-marketing'] ) ) {
@@ -174,18 +174,18 @@ class Marketing {
 		$new_menu_order    = array();
 
 		// Overview should be first.
-		$overview_key = array_search( 'Overview', array_column( $marketing_submenu, self::SUBMENU_NAME_KEY ) );
+		$overview_key = array_search( 'Overview', array_column( $marketing_submenu, self::SUBMENU_NAME_KEY ), true );
 		if ( false !== $overview_key ) {
 			$new_menu_order[] = $marketing_submenu[ $overview_key ];
 			array_splice( $marketing_submenu, $overview_key, 1 );
 		}
 
-		if ( $overview_key === false ) {
+		if ( false === $overview_key ) {
 			/*
 			 * If Overview is not found we may be on a site witha different language.
 			 * We can use a fallback and try to find the overview page by its path.
 			 */
-			$overview_key = array_search( 'admin.php?page=wc-admin&path=/marketing', array_column( $marketing_submenu, self::SUBMENU_LOCATION_KEY ) );
+			$overview_key = array_search( 'admin.php?page=wc-admin&path=/marketing', array_column( $marketing_submenu, self::SUBMENU_LOCATION_KEY ), true );
 			if ( false !== $overview_key ) {
 				$new_menu_order[] = $marketing_submenu[ $overview_key ];
 				array_splice( $marketing_submenu, $overview_key, 1 );
@@ -193,18 +193,18 @@ class Marketing {
 		}
 
 		// Coupons should be second.
-		$coupons_key = array_search( 'Coupons', array_column( $marketing_submenu, self::SUBMENU_NAME_KEY ) );
+		$coupons_key = array_search( 'Coupons', array_column( $marketing_submenu, self::SUBMENU_NAME_KEY ), true );
 		if ( false !== $coupons_key ) {
 			$new_menu_order[] = $marketing_submenu[ $coupons_key ];
 			array_splice( $marketing_submenu, $coupons_key, 1 );
 		}
 
-		if ( $coupons_key === false ) {
+		if ( false === $coupons_key ) {
 			/*
 			 * If Coupons is not found we may be on a site witha different language.
 			 * We can use a fallback and try to find the coupons page by its path.
 			 */
-			$coupons_key = array_search( 'edit.php?post_type=shop_coupon', array_column( $marketing_submenu, self::SUBMENU_LOCATION_KEY ) );
+			$coupons_key = array_search( 'edit.php?post_type=shop_coupon', array_column( $marketing_submenu, self::SUBMENU_LOCATION_KEY ), true );
 			if ( false !== $coupons_key ) {
 				$new_menu_order[] = $marketing_submenu[ $coupons_key ];
 				array_splice( $marketing_submenu, $coupons_key, 1 );
@@ -221,7 +221,8 @@ class Marketing {
 
 		$new_menu_order = array_merge( $new_menu_order, $marketing_submenu );
 
-		$submenu['woocommerce-marketing'] = $new_menu_order;
+		$submenu['woocommerce-marketing'] = $new_menu_order;  //phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Marketing.php
+++ b/plugins/woocommerce/src/Internal/Admin/Marketing.php
@@ -167,11 +167,35 @@ class Marketing {
 			array_splice( $marketing_submenu, $overview_key, 1 );
 		}
 
+		if ( $overview_key === false ) {
+			/*
+			 * If Overview is not found we may be on a site witha different language.
+			 * We can use a fallback and try to find the overview page by its path.
+			 */
+			$overview_key = array_search( 'admin.php?page=wc-admin&path=/marketing', array_column( $marketing_submenu, 2 ) );
+			if ( false !== $overview_key ) {
+				$new_order[] = $marketing_submenu[ $overview_key ];
+				array_splice( $marketing_submenu, $overview_key, 1 );
+			}
+		}
+
 		// Coupons should be second.
 		$coupons_key = array_search( 'Coupons', array_column( $marketing_submenu, 0 ) );
 		if ( false !== $coupons_key ) {
 			$new_order[] = $marketing_submenu[ $coupons_key ];
 			array_splice( $marketing_submenu, $coupons_key, 1 );
+		}
+
+		if ( $coupons_key === false ) {
+			/*
+			 * If Coupons is not found we may be on a site witha different language.
+			 * We can use a fallback and try to find the coupons page by its path.
+			 */
+			$coupons_key = array_search( 'admin.php?post_type=shop_coupon', array_column( $marketing_submenu, 2 ) );
+			if ( false !== $coupons_key ) {
+				$new_order[] = $marketing_submenu[ $coupons_key ];
+				array_splice( $marketing_submenu, $coupons_key, 1 );
+			}
 		}
 
 		// Sort the rest of the items alphabetically.

--- a/plugins/woocommerce/src/Internal/Admin/Marketing.php
+++ b/plugins/woocommerce/src/Internal/Admin/Marketing.php
@@ -44,7 +44,7 @@ class Marketing {
 		add_action( 'admin_menu', array( $this, 'register_pages' ), 5 );
 		add_action( 'admin_menu', array( $this, 'add_parent_menu_item' ), 6 );
 
-		// Overwrite submenu defualt ordering for marketing menu. Hight priority gives plugins chance to register their own menu items.
+		// Overwrite submenu default ordering for marketing menu. High priority gives plugins the chance to register their own menu items.
 		add_action( 'admin_menu', array( $this, 'reorder_marketing_submenu' ), 99 );
 
 		add_filter( 'woocommerce_admin_shared_settings', array( $this, 'component_settings' ), 30 );

--- a/plugins/woocommerce/src/Internal/Admin/Marketing.php
+++ b/plugins/woocommerce/src/Internal/Admin/Marketing.php
@@ -162,7 +162,12 @@ class Marketing {
 
 		// Overview should be first.
 		$overview_key = array_search( 'Overview', array_column( $marketing_submenu, 0 ) );
-		$new_order[]  = $marketing_submenu[ $overview_key ];
+
+		if ( false === $overview_key ) {
+			return;
+		}
+
+		$new_order[] = $marketing_submenu[ $overview_key ];
 
 		// Remove Overview from the array.
 		unset( $marketing_submenu[ $overview_key ] );

--- a/plugins/woocommerce/src/Internal/Admin/Marketing.php
+++ b/plugins/woocommerce/src/Internal/Admin/Marketing.php
@@ -17,6 +17,20 @@ class Marketing {
 	use CouponsMovedTrait;
 
 	/**
+	 * Constant representing the key for the submenu name value in the global $submenu array.
+	 *
+	 * @var int
+	 */
+	const SUBMENU_NAME_KEY = 0;
+
+	/**
+	 * Constant representing the key for the submenu location value in the global $submenu array.
+	 *
+	 * @var int
+	 */
+	const SUBMENU_LOCATION_KEY = 2;
+
+	/**
 	 * Class instance.
 	 *
 	 * @var Marketing instance
@@ -157,13 +171,12 @@ class Marketing {
 		}
 
 		$marketing_submenu = $submenu['woocommerce-marketing'];
-
-		$new_order = array();
+		$new_menu_order    = array();
 
 		// Overview should be first.
-		$overview_key = array_search( 'Overview', array_column( $marketing_submenu, 0 ) );
+		$overview_key = array_search( 'Overview', array_column( $marketing_submenu, self::SUBMENU_NAME_KEY ) );
 		if ( false !== $overview_key ) {
-			$new_order[] = $marketing_submenu[ $overview_key ];
+			$new_menu_order[] = $marketing_submenu[ $overview_key ];
 			array_splice( $marketing_submenu, $overview_key, 1 );
 		}
 
@@ -172,17 +185,17 @@ class Marketing {
 			 * If Overview is not found we may be on a site witha different language.
 			 * We can use a fallback and try to find the overview page by its path.
 			 */
-			$overview_key = array_search( 'admin.php?page=wc-admin&path=/marketing', array_column( $marketing_submenu, 2 ) );
+			$overview_key = array_search( 'admin.php?page=wc-admin&path=/marketing', array_column( $marketing_submenu, self::SUBMENU_LOCATION_KEY ) );
 			if ( false !== $overview_key ) {
-				$new_order[] = $marketing_submenu[ $overview_key ];
+				$new_menu_order[] = $marketing_submenu[ $overview_key ];
 				array_splice( $marketing_submenu, $overview_key, 1 );
 			}
 		}
 
 		// Coupons should be second.
-		$coupons_key = array_search( 'Coupons', array_column( $marketing_submenu, 0 ) );
+		$coupons_key = array_search( 'Coupons', array_column( $marketing_submenu, self::SUBMENU_NAME_KEY ) );
 		if ( false !== $coupons_key ) {
-			$new_order[] = $marketing_submenu[ $coupons_key ];
+			$new_menu_order[] = $marketing_submenu[ $coupons_key ];
 			array_splice( $marketing_submenu, $coupons_key, 1 );
 		}
 
@@ -191,9 +204,9 @@ class Marketing {
 			 * If Coupons is not found we may be on a site witha different language.
 			 * We can use a fallback and try to find the coupons page by its path.
 			 */
-			$coupons_key = array_search( 'admin.php?post_type=shop_coupon', array_column( $marketing_submenu, 2 ) );
+			$coupons_key = array_search( 'edit.php?post_type=shop_coupon', array_column( $marketing_submenu, self::SUBMENU_LOCATION_KEY ) );
 			if ( false !== $coupons_key ) {
-				$new_order[] = $marketing_submenu[ $coupons_key ];
+				$new_menu_order[] = $marketing_submenu[ $coupons_key ];
 				array_splice( $marketing_submenu, $coupons_key, 1 );
 			}
 		}
@@ -206,9 +219,9 @@ class Marketing {
 			}
 		);
 
-		$new_order = array_merge( $new_order, $marketing_submenu );
+		$new_menu_order = array_merge( $new_menu_order, $marketing_submenu );
 
-		$submenu['woocommerce-marketing'] = $new_order;
+		$submenu['woocommerce-marketing'] = $new_menu_order;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Internal/Admin/Marketing.php
+++ b/plugins/woocommerce/src/Internal/Admin/Marketing.php
@@ -175,10 +175,6 @@ class Marketing {
 
 		// Overview should be first.
 		$overview_key = array_search( 'Overview', array_column( $marketing_submenu, self::SUBMENU_NAME_KEY ), true );
-		if ( false !== $overview_key ) {
-			$new_menu_order[] = $marketing_submenu[ $overview_key ];
-			array_splice( $marketing_submenu, $overview_key, 1 );
-		}
 
 		if ( false === $overview_key ) {
 			/*
@@ -186,18 +182,15 @@ class Marketing {
 			 * We can use a fallback and try to find the overview page by its path.
 			 */
 			$overview_key = array_search( 'admin.php?page=wc-admin&path=/marketing', array_column( $marketing_submenu, self::SUBMENU_LOCATION_KEY ), true );
-			if ( false !== $overview_key ) {
-				$new_menu_order[] = $marketing_submenu[ $overview_key ];
-				array_splice( $marketing_submenu, $overview_key, 1 );
-			}
+		}
+
+		if ( false !== $overview_key ) {
+			$new_menu_order[] = $marketing_submenu[ $overview_key ];
+			array_splice( $marketing_submenu, $overview_key, 1 );
 		}
 
 		// Coupons should be second.
 		$coupons_key = array_search( 'Coupons', array_column( $marketing_submenu, self::SUBMENU_NAME_KEY ), true );
-		if ( false !== $coupons_key ) {
-			$new_menu_order[] = $marketing_submenu[ $coupons_key ];
-			array_splice( $marketing_submenu, $coupons_key, 1 );
-		}
 
 		if ( false === $coupons_key ) {
 			/*
@@ -205,11 +198,19 @@ class Marketing {
 			 * We can use a fallback and try to find the coupons page by its path.
 			 */
 			$coupons_key = array_search( 'edit.php?post_type=shop_coupon', array_column( $marketing_submenu, self::SUBMENU_LOCATION_KEY ), true );
-			if ( false !== $coupons_key ) {
-				$new_menu_order[] = $marketing_submenu[ $coupons_key ];
-				array_splice( $marketing_submenu, $coupons_key, 1 );
-			}
 		}
+
+		if ( false !== $coupons_key ) {
+			$new_menu_order[] = $marketing_submenu[ $coupons_key ];
+			array_splice( $marketing_submenu, $coupons_key, 1 );
+		}
+
+
+		if ( false !== $coupons_key ) {
+			$new_menu_order[] = $marketing_submenu[ $coupons_key ];
+			array_splice( $marketing_submenu, $coupons_key, 1 );
+		}
+
 
 		// Sort the rest of the items alphabetically.
 		usort(

--- a/plugins/woocommerce/src/Internal/Admin/Marketing.php
+++ b/plugins/woocommerce/src/Internal/Admin/Marketing.php
@@ -205,13 +205,6 @@ class Marketing {
 			array_splice( $marketing_submenu, $coupons_key, 1 );
 		}
 
-
-		if ( false !== $coupons_key ) {
-			$new_menu_order[] = $marketing_submenu[ $coupons_key ];
-			array_splice( $marketing_submenu, $coupons_key, 1 );
-		}
-
-
 		// Sort the rest of the items alphabetically.
 		usort(
 			$marketing_submenu,

--- a/plugins/woocommerce/src/Internal/Admin/Marketing.php
+++ b/plugins/woocommerce/src/Internal/Admin/Marketing.php
@@ -145,7 +145,7 @@ class Marketing {
 
 	/**
 	 * Order marketing menu items alphabeticaly.
-	 * Overview should be first.
+	 * Overview should be first, and Coupons should be second, followed by other marketing menu items.
 	 *
 	 * @return  void
 	 */

--- a/plugins/woocommerce/src/Internal/Admin/Marketing.php
+++ b/plugins/woocommerce/src/Internal/Admin/Marketing.php
@@ -162,15 +162,17 @@ class Marketing {
 
 		// Overview should be first.
 		$overview_key = array_search( 'Overview', array_column( $marketing_submenu, 0 ) );
-
-		if ( false === $overview_key ) {
-			return;
+		if ( false !== $overview_key ) {
+			$new_order[] = $marketing_submenu[ $overview_key ];
+			array_splice( $marketing_submenu, $overview_key, 1 );
 		}
 
-		$new_order[] = $marketing_submenu[ $overview_key ];
-
-		// Remove Overview from the array.
-		unset( $marketing_submenu[ $overview_key ] );
+		// Coupons should be second.
+		$coupons_key = array_search( 'Coupons', array_column( $marketing_submenu, 0 ) );
+		if ( false !== $coupons_key ) {
+			$new_order[] = $marketing_submenu[ $coupons_key ];
+			array_splice( $marketing_submenu, $coupons_key, 1 );
+		}
 
 		// Sort the rest of the items alphabetically.
 		usort(


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The Marketing menu is often extended by 3rd party extensions with submenus. In order to provide consistency in how things are displayed we want to enforce alphabetical ordering of Marketing menu sub items. With one exception the `Overview` entry will always be first.

Before this PR:
![image](https://github.com/woocommerce/woocommerce/assets/17271089/92765ef2-0ef2-4b44-996d-99ef6b8c126d)

After this PR:
<img width="250" alt="image" src="https://github.com/woocommerce/woocommerce/assets/17271089/e85a68a9-d2e5-42f9-a53d-63b50af2d417">


<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. With this PR checked out:
2. Install plugins that extend the Marketing sumenu: Facebook For WooCommerce, Pinterest For WooCommerce, TikTok For Woocommerce, Google Listing and adds. ( not all are ofc required )
2. Activate them - setup is not required
3. Opem wp-admin and click on the `Marketing` menu item.
4. Make sure tha `Overwiev` is first `Coupons` is second and that the remaining items are added in alphabetical order.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
