### PR TITLE
[Product Block Editor]: minor Summary block enhancements

### DIFF
--- a/packages/js/product-editor/changelog/update-product-editor-tweak-summary-block
+++ b/packages/js/product-editor/changelog/update-product-editor-tweak-summary-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+[Product Block Editor]: minor Summary block enhancements

--- a/packages/js/product-editor/src/blocks/product-fields/summary/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/summary/block.json
@@ -34,12 +34,10 @@
 			"enum": [ "ltr", "rtl" ]
 		},
 		"label": {
-			"type": "string",
-			"default": "Summary"
+			"type": "string"
 		},
 		"helpText": {
-			"type": "string",
-			"default": "Summarize this product in 1-2 short sentences. We'll show it at the top of the page."
+			"type": "string"
 		},
 		"content": {
 			"type": "string",

--- a/packages/js/product-editor/src/blocks/product-fields/summary/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/summary/block.json
@@ -34,7 +34,8 @@
 			"enum": [ "ltr", "rtl" ]
 		},
 		"label": {
-			"type": "string"
+			"type": "string",
+			"default": "Summary"
 		},
 		"helpText": {
 			"type": "string",

--- a/packages/js/product-editor/src/blocks/product-fields/summary/block.json
+++ b/packages/js/product-editor/src/blocks/product-fields/summary/block.json
@@ -37,7 +37,8 @@
 			"type": "string"
 		},
 		"helpText": {
-			"type": "string"
+			"type": "string",
+			"default": "Summarize this product in 1-2 short sentences. We'll show it at the top of the page."
 		},
 		"content": {
 			"type": "string",

--- a/packages/js/product-editor/src/blocks/product-fields/summary/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/summary/edit.tsx
@@ -26,7 +26,7 @@ import { SummaryAttributes } from './types';
 import { ALIGNMENT_CONTROLS } from './constants';
 import { ProductEditorBlockEditProps } from '../../../types';
 
-export function Edit( {
+export function SummaryBlockEdit( {
 	attributes,
 	setAttributes,
 	context,
@@ -36,7 +36,7 @@ export function Edit( {
 		style: { direction },
 	} );
 	const contentId = useInstanceId(
-		Edit,
+		SummaryBlockEdit,
 		'wp-block-woocommerce-product-summary-field__content'
 	);
 	const [ summary, setSummary ] = useEntityProp< string >(
@@ -88,24 +88,18 @@ export function Edit( {
 
 			<BaseControl
 				id={ contentId.toString() }
-				label={ createInterpolateElement(
-					label || __( 'Summary', 'woocommerce' ),
-					{
-						optional: (
-							<span className="woocommerce-product-form__optional-input">
-								{ __( '(OPTIONAL)', 'woocommerce' ) }
-							</span>
-						),
-					}
-				) }
-				help={
-					typeof helpText === 'string'
-						? helpText
-						: __(
-								"Summarize this product in 1-2 short sentences. We'll show it at the top of the page.",
-								'woocommerce'
-						  )
+				label={
+					label
+						? createInterpolateElement( label, {
+								optional: (
+									<span className="woocommerce-product-form__optional-input">
+										{ __( '(OPTIONAL)', 'woocommerce' ) }
+									</span>
+								),
+						  } )
+						: null
 				}
+				help={ helpText }
 			>
 				<div { ...blockProps }>
 					<RichText

--- a/packages/js/product-editor/src/blocks/product-fields/summary/edit.tsx
+++ b/packages/js/product-editor/src/blocks/product-fields/summary/edit.tsx
@@ -89,17 +89,30 @@ export function SummaryBlockEdit( {
 			<BaseControl
 				id={ contentId.toString() }
 				label={
-					label
-						? createInterpolateElement( label, {
-								optional: (
-									<span className="woocommerce-product-form__optional-input">
-										{ __( '(OPTIONAL)', 'woocommerce' ) }
-									</span>
-								),
-						  } )
-						: null
+					typeof label === 'undefined'
+						? createInterpolateElement(
+								__( 'Summary', 'woocommerce' ),
+								{
+									optional: (
+										<span className="woocommerce-product-form__optional-input">
+											{ __(
+												'(OPTIONAL)',
+												'woocommerce'
+											) }
+										</span>
+									),
+								}
+						  )
+						: label
 				}
-				help={ helpText }
+				help={
+					typeof helpText === 'undefined'
+						? __(
+								"Summarize this product in 1-2 short sentences. We'll show it at the top of the page.",
+								'woocommerce'
+						  )
+						: helpText
+				}
 			>
 				<div { ...blockProps }>
 					<RichText

--- a/packages/js/product-editor/src/blocks/product-fields/summary/index.ts
+++ b/packages/js/product-editor/src/blocks/product-fields/summary/index.ts
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import blockConfiguration from './block.json';
-import { Edit } from './edit';
+import { SummaryBlockEdit } from './edit';
 import { registerProductEditorBlockType } from '../../../utils';
 
 const { name, ...metadata } = blockConfiguration;
@@ -11,7 +11,7 @@ export { name, metadata };
 
 export const settings = {
 	example: {},
-	edit: Edit,
+	edit: SummaryBlockEdit,
 };
 
 export function init() {


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR introduces minor enhancements in the Summary block:

* Rename the edit function: `SummaryBlockEdit`
* Set the default value of `label` and `helpText` attributes at the block definition level

Closes # .

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to the Product Editor
2. Select the `General` tab
3. Confirm the Summary block looks as usual:

<img width="725" alt="Screenshot 2023-12-01 at 09 50 48" src="https://github.com/woocommerce/woocommerce/assets/77539/3aacf372-169c-409c-ae94-3615e7dab3f0">

Additionally:

4. Open the React dev tool
5. Search the Summary block
6. Identify the block properties
7. Confirm it's possible to remove the `label` and `helpText` attributes

<img width="1726" alt="Screenshot 2023-12-01 at 10 03 25" src="https://github.com/woocommerce/woocommerce/assets/77539/aa7ea70d-0931-40e4-8f59-5a25c10038c8">

4. Open the 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
