### PR TITLE
Logging: Prevent fatal type error when submitting empty search

### DIFF
--- a/plugins/woocommerce/changelog/fix-log-search-fatal
+++ b/plugins/woocommerce/changelog/fix-log-search-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent fatal error when submitting an empty search query on the log files screen.

--- a/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/FileV2/FileController.php
@@ -421,7 +421,7 @@ class FileController {
 	 */
 	public function search_within_files( string $search, array $args = array(), array $file_args = array(), bool $count_only = false ) {
 		if ( '' === $search ) {
-			return array();
+			return $count_only ? 0 : array();
 		}
 
 		$search = esc_html( $search );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Ensures that if the "Search within these files" form is submitted with an empty input, it does not trigger a fatal error due to the search method returning an empty array at a time when it should be returning the integer `0`.

### How to test the changes in this Pull Request:

#### Setup

Do this before checking out the PR branch:

1. In your test site's **wp-config.php** file, add this line: `define( 'WC_LOG_HANDLER', 'Automattic\\WooCommerce\\Internal\\Admin\\Logging\\LogHandlerFileV2' );`. This is what allows you to see the new log file functionality.
2. Install [this plugin](https://gist.github.com/coreymckrill/2968911c8b63c556e7787f2cdc65f966) on your test site for generating test log files. Probably easiest to copy the file into the mu-plugins directory.
3. Open two browser tabs: the Logs screen (WP Admin > WooCommerce > Status > Logs) and the WooCommerce Tools screen (WP Admin > WooCommerce > Status > Tools). On the Tools screen you should see the **Debug Log Generator** tool at the top of the list.
4. On the Tools screen, click the button to generate some log entries, so that on the Logs screen, the list table is populated with some log files.

#### Test

1. On the Logs screen, find the "Search within these files" field in the upper right corner. Without entering anything into that field, click the nearby "Search" button to submit the form. On the trunk branch, this should give you a fatal error.
2. Now check out this PR's branch, and then try submitting the search form again. This time you should get the "Search results" screen, showing that there are no results.
