### PR TITLE
Logging: Update doc block to more accurate return value

### DIFF
--- a/plugins/woocommerce/changelog/fix-41256
+++ b/plugins/woocommerce/changelog/fix-41256
@@ -1,0 +1,5 @@
+Significance: patch
+Type: dev
+Comment: Simply changes a value in a doc block.
+
+

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -2003,9 +2003,7 @@ function wc_remove_number_precision_deep( $value ) {
  *     - an instance which will be used directly as the logger
  * In either case, the class or instance *must* implement WC_Logger_Interface.
  *
- * @see WC_Logger_Interface
- *
- * @return WC_Logger
+ * @return WC_Logger_Interface
  */
 function wc_get_logger() {
 	static $logger = null;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Improves the doc block of `wc_get_logger()` to reflect that the return value will be a class that implements `WC_Logger_Interface`, but may not actually be an instance of `WC_Logger`.

Fixes #41256

### How to test the changes in this Pull Request:

No testing needed since this only updates a value in a doc block.
