### PR TITLE
Logging: Fix pagination and filtering on DB log list table

### DIFF
--- a/plugins/woocommerce/changelog/fix-39359-db-log-pagination
+++ b/plugins/woocommerce/changelog/fix-39359-db-log-pagination
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix problems with pagination and filtering for the database logger list table view

--- a/plugins/woocommerce/includes/admin/class-wc-admin-log-table-list.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-log-table-list.php
@@ -17,6 +17,12 @@ if ( ! class_exists( 'WP_List_Table' ) ) {
 }
 
 class WC_Admin_Log_Table_List extends WP_List_Table {
+	/**
+	 * The key for the user option of how many list table items to display per page.
+	 *
+	 * @const string
+	 */
+	public const PER_PAGE_USER_OPTION_KEY = 'woocommerce_status_log_items_per_page';
 
 	/**
 	 * Initialize the log table list.
@@ -330,7 +336,10 @@ class WC_Admin_Log_Table_List extends WP_List_Table {
 
 		$this->prepare_column_headers();
 
-		$per_page = $this->get_items_per_page( 'woocommerce_status_log_items_per_page', 10 );
+		$per_page = $this->get_items_per_page(
+			self::PER_PAGE_USER_OPTION_KEY,
+			$this->get_per_page_default()
+		);
 
 		$where  = $this->get_items_query_where();
 		$order  = $this->get_items_query_order();
@@ -367,7 +376,11 @@ class WC_Admin_Log_Table_List extends WP_List_Table {
 	protected function get_items_query_limit() {
 		global $wpdb;
 
-		$per_page = $this->get_items_per_page( 'woocommerce_status_log_items_per_page', 10 );
+		$per_page = $this->get_items_per_page(
+			self::PER_PAGE_USER_OPTION_KEY,
+			$this->get_per_page_default()
+		);
+
 		return $wpdb->prepare( 'LIMIT %d', $per_page );
 	}
 
@@ -381,7 +394,10 @@ class WC_Admin_Log_Table_List extends WP_List_Table {
 	protected function get_items_query_offset() {
 		global $wpdb;
 
-		$per_page     = $this->get_items_per_page( 'woocommerce_status_log_items_per_page', 10 );
+		$per_page     = $this->get_items_per_page(
+			self::PER_PAGE_USER_OPTION_KEY,
+			$this->get_per_page_default()
+		);
 		$current_page = $this->get_pagenum();
 		if ( 1 < $current_page ) {
 			$offset = $per_page * ( $current_page - 1 );
@@ -456,5 +472,14 @@ class WC_Admin_Log_Table_List extends WP_List_Table {
 			array(),
 			$this->get_sortable_columns(),
 		);
+	}
+
+	/**
+	 * Helper to get the default value for the per_page arg.
+	 *
+	 * @return int
+	 */
+	public function get_per_page_default(): int {
+		return 20;
 	}
 }

--- a/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-menus.php
@@ -326,6 +326,7 @@ class WC_Admin_Menus {
 			'woocommerce_webhooks_per_page',
 			FileListTable::PER_PAGE_USER_OPTION_KEY,
 			SearchListTable::PER_PAGE_USER_OPTION_KEY,
+			WC_Admin_Log_Table_List::PER_PAGE_USER_OPTION_KEY,
 		);
 
 		if ( in_array( $option, $screen_options, true ) ) {

--- a/plugins/woocommerce/includes/admin/class-wc-admin-status.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-status.php
@@ -342,7 +342,7 @@ class WC_Admin_Status {
 
 		WC_Log_Handler_DB::flush();
 
-		$sendback = remove_query_arg( array( 'action', 'action2', 'flush-logs', '_wpnonce', '_wp_http_referer' ), wp_get_referer() );
+		$sendback = wp_sanitize_redirect( admin_url( 'admin.php?page=wc-status&tab=logs' ) );
 
 		wp_safe_redirect( $sendback );
 		exit;

--- a/plugins/woocommerce/includes/admin/class-wc-admin-status.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-status.php
@@ -15,6 +15,12 @@ defined( 'ABSPATH' ) || exit;
  * WC_Admin_Status Class.
  */
 class WC_Admin_Status {
+	/**
+	 * An instance of the DB log handler list table.
+	 *
+	 * @var WC_Admin_Log_Table_List
+	 */
+	private static $db_log_list_table;
 
 	/**
 	 * Handles output of the reports page in admin.
@@ -133,15 +139,17 @@ class WC_Admin_Status {
 	 * Show the log page contents for db log handler.
 	 */
 	public static function status_logs_db() {
-		if ( ! empty( $_REQUEST['flush-logs'] ) ) { // WPCS: input var ok, CSRF ok.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce handled in flush_db_logs().
+		if ( isset( $_REQUEST['flush-logs'] ) ) {
 			self::flush_db_logs();
 		}
 
-		if ( isset( $_REQUEST['action'] ) && isset( $_REQUEST['log'] ) ) { // WPCS: input var ok, CSRF ok.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce handled in log_table_bulk_actions().
+		if ( isset( $_REQUEST['action'] ) && isset( $_REQUEST['log'] ) ) {
 			self::log_table_bulk_actions();
 		}
 
-		$log_table_list = new WC_Admin_Log_Table_List();
+		$log_table_list = self::get_db_log_list_table();
 		$log_table_list->prepare_items();
 
 		include_once __DIR__ . '/views/html-admin-page-status-logs-db.php';
@@ -307,19 +315,37 @@ class WC_Admin_Status {
 	}
 
 	/**
+	 * Return a stored instance of the DB log list table class.
+	 *
+	 * @return WC_Admin_Log_Table_List
+	 */
+	private static function get_db_log_list_table() {
+		if ( is_null( self::$db_log_list_table ) ) {
+			self::$db_log_list_table = new WC_Admin_Log_Table_List();
+		}
+
+		return self::$db_log_list_table;
+	}
+
+
+	/**
 	 * Clear DB log table.
 	 *
 	 * @since 3.0.0
 	 */
 	private static function flush_db_logs() {
-		if ( empty( $_REQUEST['_wpnonce'] ) || ! wp_verify_nonce( $_REQUEST['_wpnonce'], 'woocommerce-status-logs' ) ) { // WPCS: input var ok, sanitization ok.
-			wp_die( esc_html__( 'Action failed. Please refresh the page and retry.', 'woocommerce' ) );
+		check_admin_referer( 'bulk-logs' );
+
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			wp_die( esc_html__( 'You do not have permission to manage log entries.', 'woocommerce' ) );
 		}
 
 		WC_Log_Handler_DB::flush();
 
-		wp_safe_redirect( esc_url_raw( admin_url( 'admin.php?page=wc-status&tab=logs' ) ) );
-		exit();
+		$sendback = remove_query_arg( array( 'action', 'action2', 'flush-logs', '_wpnonce', '_wp_http_referer' ), wp_get_referer() );
+
+		wp_safe_redirect( $sendback );
+		exit;
 	}
 
 	/**
@@ -328,15 +354,29 @@ class WC_Admin_Status {
 	 * @since 3.0.0
 	 */
 	private static function log_table_bulk_actions() {
-		if ( empty( $_REQUEST['_wpnonce'] ) || ! wp_verify_nonce( $_REQUEST['_wpnonce'], 'woocommerce-status-logs' ) ) { // WPCS: input var ok, sanitization ok.
-			wp_die( esc_html__( 'Action failed. Please refresh the page and retry.', 'woocommerce' ) );
+		check_admin_referer( 'bulk-logs' );
+
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			wp_die( esc_html__( 'You do not have permission to manage log entries.', 'woocommerce' ) );
 		}
 
-		$log_ids = array_map( 'absint', (array) isset( $_REQUEST['log'] ) ? wp_unslash( $_REQUEST['log'] ) : array() ); // WPCS: input var ok, sanitization ok.
+		$log_ids = filter_input(
+			INPUT_GET,
+			'log',
+			FILTER_CALLBACK,
+			array(
+				'options' => fn( $log ) => absint( $log ),
+			)
+		);
 
-		if ( ( isset( $_REQUEST['action'] ) && 'delete' === $_REQUEST['action'] ) || ( isset( $_REQUEST['action2'] ) && 'delete' === $_REQUEST['action2'] ) ) { // WPCS: input var ok, sanitization ok.
+		$action = self::get_db_log_list_table()->current_action();
+
+		if ( 'delete' === $action ) {
 			WC_Log_Handler_DB::delete( $log_ids );
-			wp_safe_redirect( esc_url_raw( admin_url( 'admin.php?page=wc-status&tab=logs' ) ) );
+
+			$sendback = remove_query_arg( array( 'action', 'action2', 'log', '_wpnonce', '_wp_http_referer' ), wp_get_referer() );
+
+			wp_safe_redirect( $sendback );
 			exit();
 		}
 	}

--- a/plugins/woocommerce/includes/admin/class-wc-admin-status.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-status.php
@@ -360,14 +360,7 @@ class WC_Admin_Status {
 			wp_die( esc_html__( 'You do not have permission to manage log entries.', 'woocommerce' ) );
 		}
 
-		$log_ids = filter_input(
-			INPUT_GET,
-			'log',
-			FILTER_CALLBACK,
-			array(
-				'options' => fn( $log ) => absint( $log ),
-			)
-		);
+		$log_ids = (array) filter_input( INPUT_GET, 'log', FILTER_VALIDATE_INT, FILTER_REQUIRE_ARRAY );
 
 		$action = self::get_db_log_list_table()->current_action();
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-status.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-status.php
@@ -360,7 +360,7 @@ class WC_Admin_Status {
 			wp_die( esc_html__( 'You do not have permission to manage log entries.', 'woocommerce' ) );
 		}
 
-		$log_ids = (array) filter_input( INPUT_GET, 'log', FILTER_VALIDATE_INT, FILTER_REQUIRE_ARRAY );
+		$log_ids = (array) filter_input( INPUT_GET, 'log', FILTER_CALLBACK, array( 'options' => 'absint' ) );
 
 		$action = self::get_db_log_list_table()->current_action();
 

--- a/plugins/woocommerce/includes/admin/class-wc-admin-status.php
+++ b/plugins/woocommerce/includes/admin/class-wc-admin-status.php
@@ -319,7 +319,7 @@ class WC_Admin_Status {
 	 *
 	 * @return WC_Admin_Log_Table_List
 	 */
-	private static function get_db_log_list_table() {
+	public static function get_db_log_list_table() {
 		if ( is_null( self::$db_log_list_table ) ) {
 			self::$db_log_list_table = new WC_Admin_Log_Table_List();
 		}

--- a/plugins/woocommerce/includes/admin/views/html-admin-page-status-logs-db.php
+++ b/plugins/woocommerce/includes/admin/views/html-admin-page-status-logs-db.php
@@ -9,16 +9,29 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+$delete_confirmation_js = sprintf(
+	"return window.confirm( '%s' )",
+	esc_js( __( 'Are you sure you want to clear all logs from the database?', 'woocommerce' ) )
+);
 ?>
-<form method="post" id="mainform" action="">
-	<?php $log_table_list->search_box( __( 'Search logs', 'woocommerce' ), 'log' ); ?>
-	<?php $log_table_list->display(); ?>
-
+<form method="get" id="mainform">
 	<input type="hidden" name="page" value="wc-status" />
 	<input type="hidden" name="tab" value="logs" />
 
-	<?php submit_button( __( 'Flush all logs', 'woocommerce' ), 'delete', 'flush-logs' ); ?>
-	<?php wp_nonce_field( 'woocommerce-status-logs' ); ?>
+	<?php $log_table_list->search_box( __( 'Search logs', 'woocommerce' ), 'log' ); ?>
+	<?php $log_table_list->display(); ?>
+
+	<?php
+	submit_button(
+		__( 'Flush all logs', 'woocommerce' ),
+		'delete',
+		'flush-logs',
+		true,
+		array(
+			'onclick' => esc_attr( $delete_confirmation_js ),
+		)
+	);
+	?>
 </form>
 <script>
 	document.addEventListener( 'DOMContentLoaded', function() {
@@ -49,12 +62,3 @@ if ( ! defined( 'ABSPATH' ) ) {
 		} );
 	} );
 </script>
-<?php
-wc_enqueue_js(
-	"jQuery( '#flush-logs' ).on( 'click', function() {
-		if ( window.confirm('" . esc_js( __( 'Are you sure you want to clear all logs from the database?', 'woocommerce' ) ) . "') ) {
-			return true;
-		}
-		return false;
-	});"
-);

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -8,8 +8,9 @@ use Automattic\WooCommerce\Internal\Admin\Logging\LogHandlerFileV2;
 use Automattic\WooCommerce\Internal\Admin\Logging\FileV2\{ FileController, FileListTable, SearchListTable };
 use Automattic\WooCommerce\Internal\Traits\AccessiblePrivateMethods;
 use WC_Admin_Status;
-use WP_List_Table;
+use WC_Log_Handler_File, WC_Log_Handler_DB;
 use WC_Log_Levels;
+use WP_List_Table;
 
 /**
  * PageController class.
@@ -83,7 +84,7 @@ class PageController {
 		$handler = Constants::get_constant( 'WC_LOG_HANDLER' );
 
 		if ( is_null( $handler ) || ! class_exists( $handler ) ) {
-			$handler = \WC_Log_Handler_File::class;
+			$handler = WC_Log_Handler_File::class;
 		}
 
 		return $handler;
@@ -425,11 +426,22 @@ class PageController {
 	 * @return void
 	 */
 	private function setup_screen_options(): void {
-		$params = $this->get_query_params( array( 'view' ) );
+		$params     = $this->get_query_params( array( 'view' ) );
+		$handler    = $this->get_default_handler();
+		$list_table = null;
 
-		if ( in_array( $params['view'], array( 'list_files', 'search_results' ), true ) ) {
-			$list_table = $this->get_list_table( $params['view'] );
+		switch ( $handler ) {
+			case LogHandlerFileV2::class:
+				if ( in_array( $params['view'], array( 'list_files', 'search_results' ), true ) ) {
+					$list_table = $this->get_list_table( $params['view'] );
+				}
+				break;
+			case 'WC_Log_Handler_DB':
+					$list_table = WC_Admin_Status::get_db_log_list_table();
+				break;
+		}
 
+		if ( $list_table instanceof WP_List_Table ) {
 			// Ensure list table columns are initialized early enough to enable column hiding, if available.
 			$list_table->prepare_column_headers();
 

--- a/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
+++ b/plugins/woocommerce/src/Internal/Admin/Logging/PageController.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 namespace Automattic\WooCommerce\Internal\Admin\Logging;
 
 use Automattic\Jetpack\Constants;
+use Automattic\WooCommerce\Internal\Admin\Logging\LogHandlerFileV2;
 use Automattic\WooCommerce\Internal\Admin\Logging\FileV2\{ FileController, FileListTable, SearchListTable };
 use Automattic\WooCommerce\Internal\Traits\AccessiblePrivateMethods;
 use WC_Admin_Status;
@@ -448,6 +449,11 @@ class PageController {
 	 * @return void
 	 */
 	private function handle_list_table_bulk_actions(): void {
+		// Bail if we're not using the file handler.
+		if ( LogHandlerFileV2::class !== $this->get_default_handler() ) {
+			return;
+		}
+
 		$params = $this->get_query_params( array( 'file_id', 'view' ) );
 
 		// Bail if this is not the list table view.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This fixes some long-standing issues (and also some maybe introduced by recent work on the file handler) where pagination and filters were not persisting in the DB log list table view after running a bulk action. Furthermore, there was not a way to customize the number of log entries shown per page.

Fixes #39359

### How to test the changes in this Pull Request:

#### Setup

1. In your test site's **wp-config.php** file, add this line: `define( 'WC_LOG_HANDLER', 'WC_Log_Handler_DB' );`. This is what enables the DB log list table view.
2. Install [this plugin](https://gist.github.com/coreymckrill/2968911c8b63c556e7787f2cdc65f966) on your test site for generating test log files. Probably easiest to copy the file into the mu-plugins directory.
3. Open two browser tabs: the Logs screen (WP Admin > WooCommerce > Status > Logs) and the WooCommerce Tools screen (WP Admin > WooCommerce > Status > Tools). On the Tools screen you should see the **Debug Log Generator** tool at the top of the list.

#### Tests

1. On the Tools screen, run the Debug Log Generator tool several times (should generate about 10 entries each time) so that you have at least 30 entries.
2. On the Logs screen, you should see the list table with all the log entries. The list table UI should include page navigation, and tell you how many total log entries there are. Try navigating to another page of log entries.
3. Up at the top of the screen is a "Screen Options" tab. Click on this and change the "Number of items per page" setting to a low number like 5, and click "Apply". This should reload the screen and now the list table should show fewer entries, but have more pages available.
4. While on a subsequent page (e.g. Page 2), check the box next to one or more entries, click the Bulk Actions dropdown, select "Delete", and click "Apply". The entries you selected should go away, but you should still be on the same page you were on before.
5. Now click on the "All sources" dropdown and select a log source, then click "Filter". The list table should now only show you log entries from that particular source.
6. While the list table is still filtered, try using the Bulk delete action again. After the entries have been deleted, you should still be seeing the filtered list table view.
7. At the bottom of the list table is a button labeled "Flush all logs". Click it! You should get a confirmation dialog. If you click "Cancel", nothing should happen. If you click "Ok", all log entries should be deleted, and the list table should now be empty.
