### PR TITLE
Shipping Settings: Add filter for currency context

### DIFF
--- a/plugins/woocommerce-admin/client/wp-admin-scripts/shipping-settings-region-picker/currency-context.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/shipping-settings-region-picker/currency-context.js
@@ -11,7 +11,11 @@ export const ShippingCurrencyContext = () => {
 
 	useEffect( () => {
 		window.wc.ShippingCurrencyContext =
-			window.wc.ShippingCurrencyContext || applyFilters( 'woocommerce_shipping_zone_method_currency_context', context );
+			window.wc.ShippingCurrencyContext ||
+			applyFilters(
+				'woocommerce_shipping_zone_method_currency_context',
+				context
+			);
 		window.wc.ShippingCurrencyNumberFormat =
 			window.wc.ShippingCurrencyNumberFormat || numberFormat;
 	}, [ context ] );

--- a/plugins/woocommerce-admin/client/wp-admin-scripts/shipping-settings-region-picker/currency-context.js
+++ b/plugins/woocommerce-admin/client/wp-admin-scripts/shipping-settings-region-picker/currency-context.js
@@ -4,13 +4,14 @@
 import { useContext, useEffect } from '@wordpress/element';
 import { CurrencyContext } from '@woocommerce/currency';
 import { numberFormat } from '@woocommerce/number';
+import { applyFilters } from '@wordpress/hooks';
 
 export const ShippingCurrencyContext = () => {
 	const context = useContext( CurrencyContext );
 
 	useEffect( () => {
 		window.wc.ShippingCurrencyContext =
-			window.wc.ShippingCurrencyContext || context;
+			window.wc.ShippingCurrencyContext || applyFilters( 'woocommerce_shipping_zone_method_currency_context', context );
 		window.wc.ShippingCurrencyNumberFormat =
 			window.wc.ShippingCurrencyNumberFormat || numberFormat;
 	}, [ context ] );

--- a/plugins/woocommerce/changelog/41871-add-shipping-settings-js-currency-filter
+++ b/plugins/woocommerce/changelog/41871-add-shipping-settings-js-currency-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: add
+
+Add a filter `woocommerce_shipping_zone_method_currency_context` for manipulating currency context in Shipping Method modals.


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In order to manipulate currencies in the Shipping Settings modals, a filter is added: `woocommerce_shipping_zone_method_currency_context`

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a plugin to modify the currency filter context for Shipping method modals. Here is one ready to go:
[shipping-modal-currency.zip](https://github.com/woocommerce/woocommerce/files/13553734/shipping-modal-currency.zip)
2. Activate the plugin and create a new Shipping Zone at `/wp-admin/admin.php?page=wc-settings&tab=shipping&zone_id=1`
3. Add a method and note the currency symbol.
<img width="588" alt="image" src="https://github.com/woocommerce/woocommerce/assets/1922453/458f1044-eea3-41e1-9d79-dfe3f2559b69">

Here is the relevant sample code:

```php
function add_shipping_modal_currency( $hook_suffix ) {
	wp_register_script(
		'shipping-modal-currency',
		plugins_url( 'index.js', __FILE__ ),
		array( 'wc-admin-app' ),
		'1.0.0',
		true
	);

	wp_enqueue_script( 'shipping-modal-currency' );
}

add_action( 'admin_enqueue_scripts', 'add_shipping_modal_currency' );
```
```js
wp.hooks.addFilter( 'woocommerce_shipping_zone_method_currency_context', 'shipping-modal-currency', function ( currency ) {
    var config = currency.getCurrencyConfig();
	config.symbol = '$$$';
    
    currency.setCurrency( config );
    
    return currency;
} );
```



<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [x] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

 Add a filter `woocommerce_shipping_zone_method_currency_context` for manipulating currency context in Shipping Method modals.

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
