### PR TITLE
Update WooCommerce Blocks to 11.7.0

### DIFF
--- a/plugins/woocommerce/bin/composer/mozart/composer.lock
+++ b/plugins/woocommerce/bin/composer/mozart/composer.lock
@@ -268,16 +268,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.4.31",
+            "version": "v5.4.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "11ac5f154e0e5c4c77af83ad11ead9165280b92a"
+                "reference": "c70df1ffaf23a8d340bded3cfab1b86752ad6ed7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/11ac5f154e0e5c4c77af83ad11ead9165280b92a",
-                "reference": "11ac5f154e0e5c4c77af83ad11ead9165280b92a",
+                "url": "https://api.github.com/repos/symfony/console/zipball/c70df1ffaf23a8d340bded3cfab1b86752ad6ed7",
+                "reference": "c70df1ffaf23a8d340bded3cfab1b86752ad6ed7",
                 "shasum": ""
             },
             "require": {
@@ -347,7 +347,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.31"
+                "source": "https://github.com/symfony/console/tree/v5.4.32"
             },
             "funding": [
                 {
@@ -363,7 +363,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-10-31T07:58:33+00:00"
+            "time": "2023-11-18T18:23:04+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -1072,16 +1072,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v5.4.31",
+            "version": "v5.4.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "2765096c03f39ddf54f6af532166e42aaa05b24b"
+                "reference": "91bf4453d65d8231688a04376c3a40efe0770f04"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/2765096c03f39ddf54f6af532166e42aaa05b24b",
-                "reference": "2765096c03f39ddf54f6af532166e42aaa05b24b",
+                "url": "https://api.github.com/repos/symfony/string/zipball/91bf4453d65d8231688a04376c3a40efe0770f04",
+                "reference": "91bf4453d65d8231688a04376c3a40efe0770f04",
                 "shasum": ""
             },
             "require": {
@@ -1138,7 +1138,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.4.31"
+                "source": "https://github.com/symfony/string/tree/v5.4.32"
             },
             "funding": [
                 {
@@ -1154,7 +1154,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-11-09T08:19:44+00:00"
+            "time": "2023-11-26T13:43:46+00:00"
         }
     ],
     "aliases": [],

--- a/plugins/woocommerce/changelog/update-woocommerce-blocks-11.7.0
+++ b/plugins/woocommerce/changelog/update-woocommerce-blocks-11.7.0
@@ -1,0 +1,4 @@
+Significance: minor
+Type: update
+
+Update WooCommerce Blocks to 11.7.0

--- a/plugins/woocommerce/composer.json
+++ b/plugins/woocommerce/composer.json
@@ -23,7 +23,7 @@
 		"maxmind-db/reader": "^1.11",
 		"pelago/emogrifier": "^6.0",
 		"woocommerce/action-scheduler": "3.7.0",
-		"woocommerce/woocommerce-blocks": "11.6.1"
+		"woocommerce/woocommerce-blocks": "11.7.0"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "^3.3.0",

--- a/plugins/woocommerce/composer.lock
+++ b/plugins/woocommerce/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9aa8e31b166b09f29650e80f47481281",
+    "content-hash": "b6acb0cb84f1203222c10e9a337f2963",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1004,16 +1004,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "11.6.1",
+            "version": "11.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-blocks.git",
-                "reference": "3c6be3fbb5a3d7745864fd0ee2ea40c620c16330"
+                "reference": "a26a94d13d9f21fe673f37a14aa1bb17adf7ead6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/3c6be3fbb5a3d7745864fd0ee2ea40c620c16330",
-                "reference": "3c6be3fbb5a3d7745864fd0ee2ea40c620c16330",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-blocks/zipball/a26a94d13d9f21fe673f37a14aa1bb17adf7ead6",
+                "reference": "a26a94d13d9f21fe673f37a14aa1bb17adf7ead6",
                 "shasum": ""
             },
             "require": {
@@ -1064,9 +1064,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-blocks/issues",
-                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v11.6.1"
+                "source": "https://github.com/woocommerce/woocommerce-blocks/tree/v11.7.0"
             },
-            "time": "2023-11-23T15:22:10+00:00"
+            "time": "2023-12-05T09:40:55+00:00"
         }
     ],
     "packages-dev": [

--- a/plugins/woocommerce/tests/e2e-pw/tests/shopper/mini-cart.spec.js
+++ b/plugins/woocommerce/tests/e2e-pw/tests/shopper/mini-cart.spec.js
@@ -6,6 +6,7 @@ const wcApi = require( '@woocommerce/woocommerce-rest-api' ).default;
 const pageTitle = 'Mini Cart';
 const pageSlug = pageTitle.replace( / /gi, '-' ).toLowerCase();
 const miniCartButton = '.wc-block-mini-cart__button';
+const miniCartBadge = '.wc-block-mini-cart__badge';
 
 const simpleProductName = 'Single Hundred Product';
 const simpleProductDesc = 'Lorem ipsum dolor sit amet.';
@@ -192,9 +193,7 @@ test.describe( 'Mini Cart block page', () => {
 
 		// go to page with mini cart block and test with the product added
 		await page.goto( pageSlug );
-		await expect(
-			page.locator( '.wc-block-mini-cart__button' )
-		).toContainText( `$${ singleProductSalePrice }` );
+		await expect( page.locator( miniCartBadge ) ).toContainText( '1' );
 		await page.locator( miniCartButton ).click();
 		await expect(
 			page.getByRole( 'heading', { name: 'Your cart (1 item)' } )
@@ -210,9 +209,7 @@ test.describe( 'Mini Cart block page', () => {
 		await expect(
 			page.getByRole( 'heading', { name: 'Your cart (2 items)' } )
 		).toBeVisible();
-		await expect(
-			page.locator( '.wc-block-mini-cart__button' )
-		).toContainText( `$${ singleProductSalePrice * 2 }` );
+		await expect( page.locator( miniCartBadge ) ).toContainText( '2' );
 		await expect(
 			page.locator( '.wc-block-components-totals-item__value' )
 		).toContainText( `$${ singleProductSalePrice * 2 }` );
@@ -282,9 +279,7 @@ test.describe( 'Mini Cart block page', () => {
 		await expect(
 			page.getByRole( 'heading', { name: pageTitle } )
 		).toBeVisible();
-		await expect(
-			page.locator( '.wc-block-mini-cart__button' )
-		).toContainText( `$${ totalInclusiveTax }` );
+		await expect( page.locator( miniCartBadge ) ).toContainText( '1' );
 		await page.locator( miniCartButton ).click();
 		await expect(
 			page.locator( '.wc-block-components-totals-item__value' )


### PR DESCRIPTION
This PR updates the WooCommerce Blocks to 11.7.0. It is intended to target WooCommerce 8.5 for release.

Details from all the different releases included in this pull:

## WooCommerce Blocks 11.7.0

* https://github.com/woocommerce/woocommerce-blocks/pull/12024/
* [Testing instructions](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/1170.md)
* [Release post](https://developer.woo.com/2023/12/05/woocommerce-blocks-11-7-0-release-notes/)

## Changelog entry

The following changelog entries are only those that impact existing blocks and functionality surfaced to users:

### 11.7.0

#### Enhancements

- The Block Hooks API is implemented to auto-inject the Mini-Cart block in header patterns and template parts when the "Twenty Twenty-Four" theme is active. The Mini-Cart block also now defaults to not show the total for the items in the cart when inserted into content. ([11745](https://github.com/woocommerce/woocommerce-blocks/pull/11745))
- Decrease modal width. ([12003](https://github.com/woocommerce/woocommerce-blocks/pull/12003))
- [Store Customization] Update the default content in patterns. ([11997](https://github.com/woocommerce/woocommerce-blocks/pull/11997))
- [Store Customization] Update the "Footer with 3 Menus" pattern to remove the last 2 menus. ([11980](https://github.com/woocommerce/woocommerce-blocks/pull/11980))
- Limit number of visible incompatible extensions in sidebar notice. ([11972](https://github.com/woocommerce/woocommerce-blocks/pull/11972))
- Improve readability of order note. ([11944](https://github.com/woocommerce/woocommerce-blocks/pull/11944))
- Reorganise Columns controls and fix undefined problem in Product Collection settings. ([11937](https://github.com/woocommerce/woocommerce-blocks/pull/11937))
- Switch to NoticeBanner component inside Store Notices Block placeholder. ([11920](https://github.com/woocommerce/woocommerce-blocks/pull/11920))
- Preserve shrinkColumns value when switching the layout type of Product Collection. ([11905](https://github.com/woocommerce/woocommerce-blocks/pull/11905))
- Tweak the product prompt. ([11903](https://github.com/woocommerce/woocommerce-blocks/pull/11903))
- Add DELETE `private/ai/pattern` endpoint. ([11890](https://github.com/woocommerce/woocommerce-blocks/pull/11890))
- Update notice for default cart and checkout. ([11861](https://github.com/woocommerce/woocommerce-blocks/pull/11861))
- Enable shrink columns option in Product Collection by default. ([11821](https://github.com/woocommerce/woocommerce-blocks/pull/11821))
- Move `Combobox` to components package. ([11353](https://github.com/woocommerce/woocommerce-blocks/pull/11353))
- Interactivity API: Implement the new `store()` API. ([11071](https://github.com/woocommerce/woocommerce-blocks/pull/11071))

#### Bug Fixes

- [CYS] Fix regression and ensure AI-generated content is assigned to products after the third attempt. ([12016](https://github.com/woocommerce/woocommerce-blocks/pull/12016))
- [Product Collection] Fix: HTML Entity Decoding in Taxonomy Controls. ([11982](https://github.com/woocommerce/woocommerce-blocks/pull/11982))
- Product Gallery: Add a Product Image fallback. ([11978](https://github.com/woocommerce/woocommerce-blocks/pull/11978))
- Reviews by Product: Fix reviews count not appearing in product selector. ([11976](https://github.com/woocommerce/woocommerce-blocks/pull/11976))
- Hook `woocommerce_single_product_summary` action to `core/post-excerpt` block. ([11953](https://github.com/woocommerce/woocommerce-blocks/pull/11953))
- fix: Store notices always shows as an error type #11768. ([11932](https://github.com/woocommerce/woocommerce-blocks/pull/11932))
- [Product Collection] Fix: HTML entity decoding for product names in Hand-Picked Products. ([11927](https://github.com/woocommerce/woocommerce-blocks/pull/11927))
- Validate coupon usage against customer id AND emails. ([11860](https://github.com/woocommerce/woocommerce-blocks/pull/11860))
- Pass order ID to woocommerce_before_thankyou hook. ([11852](https://github.com/woocommerce/woocommerce-blocks/pull/11852))
- Translate the prefixes passed to post-terms in product-meta. ([11811](https://github.com/woocommerce/woocommerce-blocks/pull/11811))
- Prevent fatal errors when using Cart Tokens and creating new accounts on checkout. ([11785](https://github.com/woocommerce/woocommerce-blocks/pull/11785))
- Product Gallery Thumbnails: Add support for cropping. ([11718](https://github.com/woocommerce/woocommerce-blocks/pull/11718))
- Fix: Product Collection show products with correct stock statuses. ([11708](https://github.com/woocommerce/woocommerce-blocks/pull/11708))
- Product Gallery Thumbnails: Fix overflow issues and improve responsiveness. ([11665](https://github.com/woocommerce/woocommerce-blocks/pull/11665))

#### Various

- Update extensibility doc. ([11924](https://github.com/woocommerce/woocommerce-blocks/pull/11924))
- Move `CheckboxControl` to components package and leave alias in checkout package. ([11662](https://github.com/woocommerce/woocommerce-blocks/pull/11662))
