### PR TITLE
New woocommerce_cart_totals_after_table action

### DIFF
--- a/plugins/woocommerce/templates/cart/cart-totals.php
+++ b/plugins/woocommerce/templates/cart/cart-totals.php
@@ -103,6 +103,8 @@ defined( 'ABSPATH' ) || exit;
 
 	</table>
 
+	<?php do_action( 'woocommerce_cart_totals_after_table' ); ?>
+
 	<div class="wc-proceed-to-checkout">
 		<?php do_action( 'woocommerce_proceed_to_checkout' ); ?>
 	</div>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

A new, nice-to-have hook on the cart-totals.php template, just after the table and before the "Proceed to checkout". Helpful for displaying extra content in there.

### How to test the changes in this Pull Request:

1. add a product to cart
2. go to the Cart page and scroll to the cart totals area
3. if this new hook is present, the following code should display the "test" string between the cart totals table and the Proceed to checkout section:

`add_action( 'woocommerce_cart_totals_after_table', function() { echo 'test' } );
`

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
