### PR TITLE
Add new hook: woocommerce_before_cart_totals_table

### DIFF
--- a/plugins/woocommerce/changelog/41890-add-woocommerce_before_cart_totals_table
+++ b/plugins/woocommerce/changelog/41890-add-woocommerce_before_cart_totals_table
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Introduces new hooks to customize the cart totals table (classic storefront).

--- a/plugins/woocommerce/templates/cart/cart-totals.php
+++ b/plugins/woocommerce/templates/cart/cart-totals.php
@@ -103,6 +103,8 @@ defined( 'ABSPATH' ) || exit;
 
 	</table>
 
+	<?php do_action( 'woocommerce_cart_totals_after_table' ); ?>
+
 	<div class="wc-proceed-to-checkout">
 		<?php do_action( 'woocommerce_proceed_to_checkout' ); ?>
 	</div>

--- a/plugins/woocommerce/templates/cart/cart-totals.php
+++ b/plugins/woocommerce/templates/cart/cart-totals.php
@@ -24,6 +24,8 @@ defined( 'ABSPATH' ) || exit;
 
 	<h2><?php esc_html_e( 'Cart totals', 'woocommerce' ); ?></h2>
 
+	<?php do_action( 'woocommerce_before_cart_totals_table' ); ?>
+
 	<table cellspacing="0" class="shop_table shop_table_responsive">
 
 		<tr class="cart-subtotal">


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).

### Changes proposed in this Pull Request:

I'd like to add a new hook to print some content BEFORE the cart totals table and AFTER the cart totals heading. Currently there is no way to place content in there.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

1. add a product to cart
2. scroll to the Cart totals table
3. use something like this, and the "test" string should appear between the heading and the table:

`add_action( 'woocommerce_before_cart_totals_table', function () { echo 'test'; } );
`
<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [x] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [x] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

Introduces new hooks to customize the cart totals table (classic storefront).

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
