### PR TITLE
Accessibility improvements for (classic) add new product page.

### DIFF
--- a/plugins/woocommerce/changelog/fix-38506
+++ b/plugins/woocommerce/changelog/fix-38506
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Adds missing aria-label and tabindex HTML attributes to the Help tip element for "Product data" on "Add new product" page

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -178,7 +178,7 @@ jQuery( function ( $ ) {
 		$( '#tiptip_arrow' ).removeAttr( 'style' );
 		$( '.woocommerce-product-type-tip' )
 		.attr( 'tabindex', '0' )
-		.attr( 'aria-label', $( '<div />' ).html( content ).text() ) // Escape HTML tags.
+		.attr( 'aria-label', $( '<div />' ).html( content ).text() ) // Remove HTML tags.
 		.tipTip( {
 			attribute: 'data-tip',
 			content: content,

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -176,7 +176,10 @@ jQuery( function ( $ ) {
 	function change_product_type_tip( content ) {
 		$( '#tiptip_holder' ).removeAttr( 'style' );
 		$( '#tiptip_arrow' ).removeAttr( 'style' );
-		$( '.woocommerce-product-type-tip' ).tipTip( {
+		$( '.woocommerce-product-type-tip' )
+		.attr( 'tabindex', '0' )
+		.attr( 'aria-label', content)
+		.tipTip( {
 			attribute: 'data-tip',
 			content: content,
 			fadeIn: 50,

--- a/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
+++ b/plugins/woocommerce/client/legacy/js/admin/meta-boxes-product.js
@@ -178,7 +178,7 @@ jQuery( function ( $ ) {
 		$( '#tiptip_arrow' ).removeAttr( 'style' );
 		$( '.woocommerce-product-type-tip' )
 		.attr( 'tabindex', '0' )
-		.attr( 'aria-label', content)
+		.attr( 'aria-label', $( '<div />' ).html( content ).text() ) // Escape HTML tags.
 		.tipTip( {
 			attribute: 'data-tip',
 			content: content,


### PR DESCRIPTION
Accessibility improvements. This is essentially a "re-play" of https://github.com/woocommerce/woocommerce/pull/40726 (interested to see if we can get CI passing via this approach).

Closes https://github.com/woocommerce/woocommerce/issues/38506.

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to `Products > Add New` (/wp-admin/post-new.php?post_type=product)
2. Search for the class `.woocommerce-help-tip` on the new product page using the Inspector tool on the trunk branch.
3. Observe that some matched elements don't have the `aria-label` and `tabindex` attribute set.
4. Switch to the fix branch and repeat step (1)
5. Observe matched elements have missing attributes from step (2)
6. Enable screen readers such as VoiceOver
7. Confirm you can navigate to help tip elements using the keyboard and the screen reader can read the text.
