### PR TITLE
Create section description block

### DIFF
--- a/packages/js/product-editor/changelog/add-41586-section-description
+++ b/packages/js/product-editor/changelog/add-41586-section-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Create section description block

--- a/packages/js/product-editor/src/blocks/generic/section-description/block.json
+++ b/packages/js/product-editor/src/blocks/generic/section-description/block.json
@@ -8,7 +8,7 @@
 	"keywords": [ "products", "section", "description" ],
 	"textdomain": "default",
 	"attributes": {
-		"name": {
+		"content": {
 			"type": "string",
 			"__experimentalRole": "content"
 		}

--- a/packages/js/product-editor/src/blocks/generic/section-description/block.json
+++ b/packages/js/product-editor/src/blocks/generic/section-description/block.json
@@ -1,0 +1,25 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "woocommerce/product-section-description",
+	"title": "Product section description",
+	"category": "woocommerce",
+	"description": "The product section description.",
+	"keywords": [ "products", "section", "description" ],
+	"textdomain": "default",
+	"attributes": {
+		"name": {
+			"type": "string",
+			"__experimentalRole": "content"
+		}
+	},
+	"supports": {
+		"align": false,
+		"html": false,
+		"multiple": true,
+		"reusable": false,
+		"inserter": false,
+		"lock": false,
+		"__experimentalToolbar": false
+	}
+}

--- a/packages/js/product-editor/src/blocks/generic/section-description/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/section-description/edit.tsx
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { Fill } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { createElement } from '@wordpress/element';
+import { useWooBlockProps } from '@woocommerce/block-templates';
+import {
+	// @ts-expect-error no exported member.
+	useInnerBlocksProps,
+} from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { ProductEditorBlockEditProps } from '../../../types';
+import { SectionDescriptionBlockAttributes } from './types';
+
+export function SectionDescriptionBlockEdit( {
+	attributes,
+	clientId,
+}: ProductEditorBlockEditProps< SectionDescriptionBlockAttributes > ) {
+	const blockProps = useWooBlockProps( attributes );
+	const innerBlockProps = useInnerBlocksProps( blockProps, {
+		templateLock: 'all',
+	} );
+
+	const rootClientId = useSelect(
+		( select ) => {
+			const { getBlockRootClientId } = select( 'core/block-editor' );
+			return getBlockRootClientId( clientId );
+		},
+		[ clientId ]
+	);
+
+	if ( ! rootClientId ) return;
+
+	return <Fill { ...innerBlockProps } name={ rootClientId } />;
+}

--- a/packages/js/product-editor/src/blocks/generic/section-description/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/section-description/edit.tsx
@@ -5,10 +5,6 @@ import { Fill } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { createElement } from '@wordpress/element';
 import { useWooBlockProps } from '@woocommerce/block-templates';
-import {
-	// @ts-expect-error no exported member.
-	useInnerBlocksProps,
-} from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -20,10 +16,8 @@ export function SectionDescriptionBlockEdit( {
 	attributes,
 	clientId,
 }: ProductEditorBlockEditProps< SectionDescriptionBlockAttributes > ) {
+	const { content } = attributes;
 	const blockProps = useWooBlockProps( attributes );
-	const innerBlockProps = useInnerBlocksProps( blockProps, {
-		templateLock: 'all',
-	} );
 
 	const rootClientId = useSelect(
 		( select ) => {
@@ -35,5 +29,9 @@ export function SectionDescriptionBlockEdit( {
 
 	if ( ! rootClientId ) return;
 
-	return <Fill { ...innerBlockProps } name={ rootClientId } />;
+	return (
+		<Fill { ...blockProps } name={ rootClientId }>
+			<div>{ content }</div>
+		</Fill>
+	);
 }

--- a/packages/js/product-editor/src/blocks/generic/section-description/index.ts
+++ b/packages/js/product-editor/src/blocks/generic/section-description/index.ts
@@ -1,0 +1,27 @@
+/**
+ * Internal dependencies
+ */
+import { registerProductEditorBlockType } from '../../../utils';
+
+/**
+ * Internal dependencies
+ */
+import blockConfiguration from './block.json';
+import { SectionDescriptionBlockEdit } from './edit';
+
+const { name, ...metadata } = blockConfiguration;
+
+export { metadata, name };
+
+export const settings = {
+	example: {},
+	edit: SectionDescriptionBlockEdit,
+};
+
+export function init() {
+	return registerProductEditorBlockType( {
+		name,
+		metadata: metadata as never,
+		settings: settings as never,
+	} );
+}

--- a/packages/js/product-editor/src/blocks/generic/section-description/types.ts
+++ b/packages/js/product-editor/src/blocks/generic/section-description/types.ts
@@ -1,0 +1,8 @@
+/**
+ * External dependencies
+ */
+import { BlockAttributes } from '@wordpress/blocks';
+
+export interface SectionDescriptionBlockAttributes extends BlockAttributes {
+	name: string;
+}

--- a/packages/js/product-editor/src/blocks/generic/section-description/types.ts
+++ b/packages/js/product-editor/src/blocks/generic/section-description/types.ts
@@ -4,5 +4,5 @@
 import { BlockAttributes } from '@wordpress/blocks';
 
 export interface SectionDescriptionBlockAttributes extends BlockAttributes {
-	name: string;
+	content: string;
 }

--- a/packages/js/product-editor/src/blocks/generic/section/edit.tsx
+++ b/packages/js/product-editor/src/blocks/generic/section/edit.tsx
@@ -1,9 +1,10 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
 import classNames from 'classnames';
+import { Slot } from '@wordpress/components';
 import { createElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import { useWooBlockProps } from '@woocommerce/block-templates';
 import { __experimentalTooltip as Tooltip } from '@woocommerce/components';
 import {
@@ -63,6 +64,8 @@ export function SectionBlockEdit( {
 							/>
 						) }
 					</h2>
+
+					<Slot name={ clientId } />
 				</HeadingTagName>
 			) }
 

--- a/packages/js/product-editor/src/blocks/index.ts
+++ b/packages/js/product-editor/src/blocks/index.ts
@@ -14,6 +14,7 @@ export { init as initRegularPrice } from './product-fields/regular-price';
 export { init as initSalePrice } from './product-fields/sale-price';
 export { init as initScheduleSale } from './product-fields/schedule-sale';
 export { init as initSection } from './generic/section';
+export { init as initSectionDescription } from './generic/section-description';
 export { init as initShippingClass } from './product-fields/shipping-class';
 export { init as initShippingDimensions } from './product-fields/shipping-dimensions';
 export { init as initSummary } from './product-fields/summary';

--- a/plugins/woocommerce/changelog/add-41586-section-description
+++ b/plugins/woocommerce/changelog/add-41586-section-description
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Create section description block

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
@@ -30,6 +30,7 @@ class BlockRegistry {
 		'woocommerce/product-radio-field',
 		'woocommerce/product-pricing-field',
 		'woocommerce/product-section',
+		'woocommerce/product-section-description',
 		'woocommerce/product-tab',
 		'woocommerce/product-toggle-field',
 		'woocommerce/product-taxonomy-field',


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Partially closes #41586

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Go to this php class plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
2. Add as part of the basic details section
```php
$basic_details->add_block(
	array(
		'id'         => 'basic-details-description-block',
		'blockName'  => 'woocommerce/product-section-description',
		'order'      => 10,
		'attributes' => array(
			'content' => __( 'This info will be displayed on the product page, category pages, social media, and search results.', 'woocommerce' ),
		),
	)
);
```
3. Make sure you have the new product editor feature flag activated under the Woo Settings.
4. Try to add a new product from the left menu.
5. Under the `General` tab, The `Basic details` section should has the description text below the title that reads: `This info will be displayed on the product page, category pages, social media, and search results.`
<img width="697" alt="image" src="https://github.com/woocommerce/woocommerce/assets/13334210/2ecbb571-c042-4af6-b643-242e96f66bd6">
 

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
