### PR TITLE
Manually apply changes from #41833 that were omitted

### DIFF
--- a/plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js
+++ b/plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js
@@ -632,17 +632,6 @@
 						}
 					} else if ( target === 'wc-modal-shipping-method-settings' ) {
 						event.data.view.possiblyHideFreeShippingRequirements( data );
-						const requiredFields = [ 'woocommerce_free_shipping_title', 'woocommerce_flat_rate_title', 'woocommerce_local_pickup_title' ];
-						const requiredFieldPresent = requiredFields.find( ( field ) => {
-							return data.hasOwnProperty( field ) && field;
-						} );
-						
-						if ( requiredFieldPresent ) {
-							const shouldDisable = data[ requiredFieldPresent ].length === 0;
-							const saveButton = document.getElementById( 'btn-ok' );
-							saveButton.disabled = shouldDisable;
-							saveButton.classList.toggle( 'disabled', shouldDisable );
-						} 
 					}
 				},
 				onCloseConfigureShippingMethod: function( event, target, post_data, addButtonCalled ) {

--- a/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
+++ b/plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
@@ -149,7 +149,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				</article>
 				<footer>
 					<div class="inner">
-						<button id="btn-ok" data-status='{{ data.status }}' disabled='{{ data.status === "new" ? "disabled" : "" }}' class="button button-primary button-large {{ data.status === 'new' ? 'disabled' : '' }}">
+						<button id="btn-ok" data-status='{{ data.status }}' class="button button-primary button-large">
 							<div class="wc-backbone-modal-action-{{ data.status === 'new' ? 'active' : 'inactive' }}"><?php esc_html_e( 'Create', 'woocommerce' ); ?></div>
 							<div class="wc-backbone-modal-action-{{ data.status === 'existing' ? 'active' : 'inactive' }}"><?php esc_html_e( 'Save', 'woocommerce' ); ?></div>
 						</button>


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

https://github.com/woocommerce/woocommerce/pull/41889 cherry picks https://github.com/woocommerce/woocommerce/pull/41833 into the `release/8.4` branch. It looks like two files' changes were overwritten somehow.

This PR makes sure those changes are present in the release branch.

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Add a new Shipping Zone `/wp-admin/admin.php?page=wc-settings&tab=shipping&zone_id=new`
2. Add "Free Shipping" method
3. When the configuration modal appears, be sure not to change any values or focus any fields. Confirm the name field is populated with the default value of "Free shipping".
4. Confirm the "Create" button has active styles and you are able to click it.
5. Confirm the code changes in the following files are the same found in the [original changeset](https://github.com/woocommerce/woocommerce/pull/41833/files).
* `plugins/woocommerce/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php`
* `plugins/woocommerce/client/legacy/js/admin/wc-shipping-zone-methods.js`

<!-- End testing instructions -->
