### PR TITLE
Template API: Registration of custom block types

### DIFF
--- a/plugins/woocommerce/changelog/add-register_product_editor_block_type
+++ b/plugins/woocommerce/changelog/add-register_product_editor_block_type
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Support registering of custom block types for the new product editor.

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
@@ -65,6 +65,32 @@ class BlockRegistry {
 	);
 
 	/**
+	 * Singleton instance.
+	 *
+	 * @var BlockRegistry
+	 */
+	private static $instance = null;
+
+	/**
+	 * Get the singleton instance.
+	 */
+	public static function get_instance(): BlockRegistry {
+		if ( ! self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Constructor
+	 */
+	protected function __construct() {
+		add_filter( 'block_categories_all', array( $this, 'register_categories' ), 10, 2 );
+		$this->register_product_blocks();
+	}
+
+	/**
 	 * Get a file path for a given block file.
 	 *
 	 * @param string $path File path.
@@ -72,14 +98,6 @@ class BlockRegistry {
 	 */
 	private function get_file_path( $path, $dir ) {
 		return WC_ABSPATH . WCAdminAssets::get_path( 'js' ) . trailingslashit( $dir ) . $path;
-	}
-
-	/**
-	 * Initialize all blocks.
-	 */
-	public function init() {
-		add_filter( 'block_categories_all', array( $this, 'register_categories' ), 10, 2 );
-		$this->register_product_blocks();
 	}
 
 	/**

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
@@ -241,7 +241,7 @@ class BlockRegistry {
 	 * @param string $file_or_folder Path to the JSON file with metadata definition for the block or
 	 * path to the folder where the `block.json` file is located.
 	 *
-	 * @return WP_Block_Type|false The registered block type on success, or false on failure.
+	 * @return \WP_Block_Type|false The registered block type on success, or false on failure.
 	 */
 	public function register_block_type_from_metadata( $file_or_folder ) {
 		$metadata_file = ( ! str_ends_with( $file_or_folder, 'block.json' ) )

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
@@ -228,6 +228,7 @@ class BlockRegistry {
 			return false;
 		}
 
+		// We are dealing with a local file, so we can use file_get_contents.
 		// phpcs:disable WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		$metadata = json_decode( file_get_contents( $metadata_file ), true );
 		if ( ! is_array( $metadata ) || ! $metadata['name'] ) {

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
@@ -208,12 +208,28 @@ class BlockRegistry {
 		$block_name      = $this->remove_block_prefix( $block_name );
 		$block_json_file = $this->get_file_path( $block_name . '/block.json', $block_dir );
 
-		if ( ! file_exists( $block_json_file ) ) {
+		return $this->register_block_type_from_metadata( $block_json_file );
+	}
+
+	/**
+	 * Register a block type from metadata stored in the block.json file.
+	 *
+	 * @param string $file_or_folder Path to the JSON file with metadata definition for the block or
+	 * path to the folder where the `block.json` file is located.
+	 *
+	 * @return WP_Block_Type|false The registered block type on success, or false on failure.
+	 */
+	public function register_block_type_from_metadata( $file_or_folder ) {
+		$metadata_file = ( ! str_ends_with( $file_or_folder, 'block.json' ) )
+			? trailingslashit( $file_or_folder ) . 'block.json'
+			: $file_or_folder;
+
+		if ( ! file_exists( $metadata_file ) ) {
 			return false;
 		}
 
 		// phpcs:disable WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-		$metadata = json_decode( file_get_contents( $block_json_file ), true );
+		$metadata = json_decode( file_get_contents( $metadata_file ), true );
 		if ( ! is_array( $metadata ) || ! $metadata['name'] ) {
 			return false;
 		}
@@ -225,12 +241,11 @@ class BlockRegistry {
 		}
 
 		return register_block_type_from_metadata(
-			$block_json_file,
+			$metadata_file,
 			array(
 				'attributes'   => $this->augment_attributes( isset( $metadata['attributes'] ) ? $metadata['attributes'] : array() ),
 				'uses_context' => $this->augment_uses_context( isset( $metadata['usesContext'] ) ? $metadata['usesContext'] : array() ),
 			)
 		);
 	}
-
 }

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/BlockRegistry.php
@@ -212,6 +212,30 @@ class BlockRegistry {
 	}
 
 	/**
+	 * Check if a block is registered.
+	 *
+	 * @param string $block_name Block name.
+	 */
+	public function is_registered( $block_name ): bool {
+		$registry = \WP_Block_Type_Registry::get_instance();
+
+		return $registry->is_registered( $block_name );
+	}
+
+	/**
+	 * Unregister a block.
+	 *
+	 * @param string $block_name Block name.
+	 */
+	public function unregister( $block_name ) {
+		$registry = \WP_Block_Type_Registry::get_instance();
+
+		if ( $registry->is_registered( $block_name ) ) {
+			$registry->unregister( $block_name );
+		}
+	}
+
+	/**
 	 * Register a block type from metadata stored in the block.json file.
 	 *
 	 * @param string $file_or_folder Path to the JSON file with metadata definition for the block or
@@ -235,11 +259,7 @@ class BlockRegistry {
 			return false;
 		}
 
-		$registry = \WP_Block_Type_Registry::get_instance();
-
-		if ( $registry->is_registered( $metadata['name'] ) ) {
-			$registry->unregister( $metadata['name'] );
-		}
+		$this->unregister( $metadata['name'] );
 
 		return register_block_type_from_metadata(
 			$metadata_file,

--- a/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
+++ b/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/Init.php
@@ -67,8 +67,8 @@ class Init {
 
 			add_action( 'current_screen', array( $this, 'set_current_screen_to_block_editor_if_wc_admin' ) );
 
-			$block_registry = new BlockRegistry();
-			$block_registry->init();
+			// Make sure the block registry is initialized so that core blocks are registered.
+			BlockRegistry::get_instance();
 
 			$tracks = new Tracks();
 			$tracks->init();

--- a/plugins/woocommerce/tests/php/src/Admin/ProductBlockEditor/BlockRegistryTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/ProductBlockEditor/BlockRegistryTest.php
@@ -64,9 +64,28 @@ class BlockRegistryTest extends WC_Unit_Test_Case {
 
 		$this->assertFalse( $block_registry->is_registered( 'woocommerce-test/test-block' ), 'Block type already registered.' );
 
-		$block_registry->register_block_type_from_metadata( trailingslashit( __DIR__ ) . 'test-block' );
+		$block_type = $block_registry->register_block_type_from_metadata( trailingslashit( __DIR__ ) . 'test-block' );
 
 		$this->assertTrue( $block_registry->is_registered( 'woocommerce-test/test-block' ), 'Block type not registered.' );
+
+		$this->assertInstanceOf( \WP_Block_Type::class, $block_type, 'Block type not an instance of WP_Block_Type.' );
+
+		// Make sure basic properties are set.
+		$this->assertEquals( 'woocommerce-test/test-block', $block_type->name, 'Block type name not correct.' );
+		$this->assertEquals( 'Test Block', $block_type->title, 'Block type title not correct.' );
+
+		// Make sure defined attributes are set.
+		$this->assertArrayHasKey( 'label', $block_type->attributes, 'Block type missing label attribute.' );
+
+		// Make sure augmented template attributes are set.
+		$this->assertArrayHasKey( '_templateBlockId', $block_type->attributes, 'Block type missing _templateBlockId attribute.' );
+		$this->assertArrayHasKey( '_templateBlockOrder', $block_type->attributes, 'Block type missing _templateBlockOrder attribute.' );
+		$this->assertArrayHasKey( '_templateBlockHideConditions', $block_type->attributes, 'Block type missing _templateBlockHideConditions attribute.' );
+		$this->assertArrayHasKey( '_templateBlockDisableConditions', $block_type->attributes, 'Block type missing _templateBlockDisableConditions attribute.' );
+		$this->assertArrayHasKey( 'disabled', $block_type->attributes, 'Block type missing disabled attribute.' );
+
+		// Make sure usesContext is set.
+		$this->assertContains( 'postType', $block_type->uses_context, 'Block type uses_context missing postType.' );
 	}
 
 	/**

--- a/plugins/woocommerce/tests/php/src/Admin/ProductBlockEditor/BlockRegistryTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/ProductBlockEditor/BlockRegistryTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Automattic\WooCommerce\Tests\Admin\ProductBlockEditor;
+
+use WC_Unit_Test_Case;
+use Automattic\WooCommerce\Admin\Features\ProductBlockEditor\BlockRegistry;
+
+/**
+ * Tests for the BlockRegistry class.
+ */
+class BlockRegistryTest extends WC_Unit_Test_Case {
+	/**
+	 * Test registering a block type.
+	 */
+	public function test_register_block_type_from_metadata() {
+		$core_registry = \WP_Block_Type_Registry::get_instance();
+
+		$block_registry = BlockRegistry::get_instance();
+
+		$block_registry->register_block_type_from_metadata( trailingslashit( __DIR__ ) . 'test-block' );
+
+		$this->assertTrue( $core_registry->is_registered( 'woocommerce-test/test-block' ), 'Block type not registered.' );
+	}
+}

--- a/plugins/woocommerce/tests/php/src/Admin/ProductBlockEditor/BlockRegistryTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/ProductBlockEditor/BlockRegistryTest.php
@@ -13,12 +13,12 @@ class BlockRegistryTest extends WC_Unit_Test_Case {
 	 * Test registering a block type.
 	 */
 	public function test_register_block_type_from_metadata() {
-		$core_registry = \WP_Block_Type_Registry::get_instance();
-
 		$block_registry = BlockRegistry::get_instance();
+
+		$this->assertFalse( $block_registry->is_registered( 'woocommerce-test/test-block' ), 'Block type already registered.' );
 
 		$block_registry->register_block_type_from_metadata( trailingslashit( __DIR__ ) . 'test-block' );
 
-		$this->assertTrue( $core_registry->is_registered( 'woocommerce-test/test-block' ), 'Block type not registered.' );
+		$this->assertTrue( $block_registry->is_registered( 'woocommerce-test/test-block' ), 'Block type not registered.' );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Admin/ProductBlockEditor/BlockRegistryTest.php
+++ b/plugins/woocommerce/tests/php/src/Admin/ProductBlockEditor/BlockRegistryTest.php
@@ -10,6 +10,53 @@ use Automattic\WooCommerce\Admin\Features\ProductBlockEditor\BlockRegistry;
  */
 class BlockRegistryTest extends WC_Unit_Test_Case {
 	/**
+	 * Test that generic blocks are registered.
+	 */
+	public function test_generic_blocks_registered() {
+		$block_registry = BlockRegistry::get_instance();
+
+		$this->assertTrue( $block_registry->is_registered( 'woocommerce/conditional' ), 'Conditional component not registered.' );
+		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-checkbox-field' ), 'Checkbox field not registered.' );
+		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-collapsible' ), 'Collapsible component not registered.' );
+		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-radio-field' ), 'Radio field not registered.' );
+		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-pricing-field' ), 'Pricing field not registered.' );
+		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-section' ), 'Section component not registered.' );
+		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-tab' ), 'Tab component not registered.' );
+		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-toggle-field' ), 'Toggle field not registered.' );
+		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-taxonomy-field' ), 'Taxonomy field not registered.' );
+		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-text-field' ), 'Text field not registered.' );
+		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-number-field' ), 'Number field not registered.' );
+	}
+
+	/**
+	 * Test that product fields blocks are registered.
+	 */
+	public function test_product_fields_blocks_registered() {
+		$block_registry = BlockRegistry::get_instance();
+
+		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-catalog-visibility-field' ), 'Catalog visibility field not registered.' );
+		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-description-field' ), 'Description field not registered.' );
+		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-downloads-field' ), 'Downloads field not registered.' );
+		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-images-field' ), 'Images field not registered.' );
+		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-inventory-email-field' ), 'Inventory email field not registered.' );
+		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-sku-field' ), 'SKU field not registered.' );
+		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-name-field' ), 'Name field not registered.' );
+		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-regular-price-field' ), 'Regular price not registered.' );
+		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-schedule-sale-fields' ), 'Schedule sale fields not registered.' );
+		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-shipping-class-field' ), 'Shipping class field not registered.' );
+		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-shipping-dimensions-fields' ), 'Shipping dimensions not registered.' );
+		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-summary-field' ), 'Summary field not registered.' );
+		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-tag-field' ), 'Tag field not registered.' );
+		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-inventory-quantity-field' ), 'Inventory quantity field not registered.' );
+		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-variation-items-field' ), 'Variation items field not registered.' );
+		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-variations-fields' ), 'Variation fields not registered.' );
+		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-password-field', 'Password field not registered.' ) );
+		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-list-field', 'List field not registered.' ) );
+		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-has-variations-notice', 'Has variation notice not registered.' ) );
+		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-single-variation-notice', 'Single variation notice not registered.' ) );
+	}
+
+	/**
 	 * Test registering a block type.
 	 */
 	public function test_register_block_type_from_metadata() {
@@ -20,5 +67,18 @@ class BlockRegistryTest extends WC_Unit_Test_Case {
 		$block_registry->register_block_type_from_metadata( trailingslashit( __DIR__ ) . 'test-block' );
 
 		$this->assertTrue( $block_registry->is_registered( 'woocommerce-test/test-block' ), 'Block type not registered.' );
+	}
+
+	/**
+	 * Test unregistering a block type.
+	 */
+	public function test_unregister() {
+		$block_registry = BlockRegistry::get_instance();
+
+		$this->assertTrue( $block_registry->is_registered( 'woocommerce/product-checkbox-field' ), 'Checkbox field not registered.' );
+
+		$block_registry->unregister( 'woocommerce/product-checkbox-field' );
+
+		$this->assertFalse( $block_registry->is_registered( 'woocommerce/product-checkbox-field' ), 'Checkbox field still registered.' );
 	}
 }

--- a/plugins/woocommerce/tests/php/src/Admin/ProductBlockEditor/test-block/block.json
+++ b/plugins/woocommerce/tests/php/src/Admin/ProductBlockEditor/test-block/block.json
@@ -1,0 +1,13 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "woocommerce-test/test-block",
+	"version": "0.1.0",
+	"title": "Test Block",
+	"category": "widgets",
+	"attributes": {
+		"label": {
+			"type": "string"
+		}
+	}
+}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR implements the following:

- Custom block types for use in the new product editor can be registered, with the necessary template attributes and usesContext auto-added to the type. 
    - This allows custom block types to use conditional visibility/disabling
- Unit tests for block registration

Moving forward, all block types to be used in the product editor should be registered via:

```php
$registry = \Automattic\WooCommerce\Admin\Features\ProductBlockEditor\BlockRegistry::get_instance();
$registry->register_block_type_from_metadata( $file_or_folder_with_block_json );
```

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

#### Automated unit tests (run locally or just verify they pass in GH on this PR):

1. PHP unit tests:

```bash
pnpm --filter=woocommerce env:test
pnpm test:unit:env --filter 'Automattic\\WooCommerce\\Tests\\Admin\\ProductBlockEditor'
```

#### Manual testing:

1. Enable the **Product Block Editor** under **WooCommerce** > **Settings** > **Advanced** > **Features** > **Experimental features**.
2. Go to **Products** > **Add New**
3. Verify fields display as expected (no regression)
    - You don't need to go deep on this... either the fields will display or they won't

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
