### PR TITLE
Grouped product field is being shown on non-grouped product types

### DIFF
--- a/plugins/woocommerce/changelog/add-41945
+++ b/plugins/woocommerce/changelog/add-41945
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Hide Variations tab, stock status and product list for specific product types

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -344,6 +344,11 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 						'title'       => __( 'Products in this group', 'woocommerce' ),
 						'description' => __( 'Make a collection of related products, enabling customers to purchase multiple items together.', 'woocommerce' ),
 					),
+					'hideConditions' => array(
+						array(
+							'expression' => 'editedProduct.type !== "grouped"',
+						),
+					),
 				)
 			);
 

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -346,9 +346,9 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 		if ( Features::is_enabled( 'product-grouped' ) ) {
 			$product_list_section = $general_group->add_section(
 				array(
-					'id'         => 'product-list-section',
-					'order'      => 35,
-					'attributes' => array(
+					'id'             => 'product-list-section',
+					'order'          => 35,
+					'attributes'     => array(
 						'title'       => __( 'Products in this group', 'woocommerce' ),
 						'description' => __( 'Make a collection of related products, enabling customers to purchase multiple items together.', 'woocommerce' ),
 					),
@@ -783,10 +783,10 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 		);
 		$product_stock_status_conditional = $product_inventory_section->add_block(
 			array(
-				'id'         => 'product-stock-status-conditional-wrapper',
-				'blockName'  => 'woocommerce/conditional',
-				'order'      => 20,
-				'attributes' => array(
+				'id'             => 'product-stock-status-conditional-wrapper',
+				'blockName'      => 'woocommerce/conditional',
+				'order'          => 20,
+				'attributes'     => array(
 					'mustMatch' => array(
 						'manage_stock' => array( false ),
 					),
@@ -825,10 +825,10 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 		);
 		$product_inventory_advanced         = $product_inventory_section->add_block(
 			array(
-				'id'         => 'product-inventory-advanced',
-				'blockName'  => 'woocommerce/product-collapsible',
-				'order'      => 30,
-				'attributes' => array(
+				'id'             => 'product-inventory-advanced',
+				'blockName'      => 'woocommerce/product-collapsible',
+				'order'          => 30,
+				'attributes'     => array(
 					'toggleText'       => __( 'Advanced', 'woocommerce' ),
 					'initialCollapsed' => true,
 					'persistRender'    => true,

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -783,6 +783,11 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 						'manage_stock' => array( false ),
 					),
 				),
+				'hideConditions' => Features::is_enabled( 'product-grouped' ) ? array(
+					array(
+						'expression' => 'editedProduct.type === "grouped"',
+					),
+				) : null,
 			)
 		);
 		$product_stock_status_conditional->add_block(
@@ -820,6 +825,11 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 					'initialCollapsed' => true,
 					'persistRender'    => true,
 				),
+				'hideConditions' => Features::is_enabled( 'product-grouped' ) ? array(
+					array(
+						'expression' => 'editedProduct.type === "grouped"',
+					),
+				) : null,
 			)
 		);
 		$product_inventory_advanced_wrapper = $product_inventory_advanced->add_block(

--- a/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
+++ b/plugins/woocommerce/src/Internal/Features/ProductBlockEditor/ProductTemplates/SimpleProductTemplate.php
@@ -126,6 +126,18 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 			)
 		);
 		if ( Features::is_enabled( 'product-variation-management' ) ) {
+			$variations_hide_conditions = array();
+			if ( Features::is_enabled( 'product-grouped' ) ) {
+				$variations_hide_conditions[] = array(
+					'expression' => 'editedProduct.type === "grouped"',
+				);
+			}
+			if ( Features::is_enabled( 'product-external-affiliate' ) ) {
+				$variations_hide_conditions[] = array(
+					'expression' => 'editedProduct.type === "external"',
+				);
+			}
+
 			$this->add_group(
 				array(
 					'id'             => $this::GROUP_IDS['VARIATIONS'],
@@ -133,11 +145,7 @@ class SimpleProductTemplate extends AbstractProductFormTemplate implements Produ
 					'attributes'     => array(
 						'title' => __( 'Variations', 'woocommerce' ),
 					),
-					'hideConditions' => Features::is_enabled( 'product-external-affiliate' ) ? array(
-						array(
-							'expression' => 'editedProduct.type === "external"',
-						),
-					) : null,
+					'hideConditions' => $variations_hide_conditions,
 				)
 			);
 		}


### PR DESCRIPTION
### Submission Review Guidelines:

-   I have followed the [WooCommerce Contributing Guidelines](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md) and the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-   I have checked to ensure there aren't other open [Pull Requests](https://github.com/woocommerce/woocommerce/pulls) for the same update/change.
-   I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
-   Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- If necessary, indicate if this PR is part of a bigger feature. Add a label with the format `focus: name of the feature [team:name of the team]`. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #41945
Closes #41943
Closes #41944

<!-- Begin testing instructions -->

### How to test the changes in this Pull Request:

<!-- Include detailed instructions on how these changes can be tested. Review and follow the guide for how to write high-quality testing instructions. -->

Using the [WooCommerce Testing Instructions Guide](https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions), include your detailed testing instructions:

1. Create a `Grouped` product from the classic editor
2. Make sure feature `New product editor` is enabled under `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`
3. Make sure feature `product-grouped` is enabled under `Features` tab from `/wp-admin/tools.php?page=woocommerce-admin-test-helper` (WooCommerce Beta Tester plugin) is required
4. If you try to edit the product created in point 1 you should be redirected to the new product editor.
5. From there under the `General` tab, a new `Products in this group` section should be shown
6. Make sure this section is only shown for grouped products and not for other type of products
7. Also from the `Inventory` tab only the SKU field should be shown and nothing else.
8. And `Variations` tab should not longer be visible.

<!-- End testing instructions -->

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<details>

#### Significance

<!-- Choose only one -->

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality

#### Message <!-- Add a changelog message here -->

#### Comment <!-- If the changes in this pull request don't warrant a changelog entry, you can alternatively supply a comment here. Note that comments are only accepted with a significance of "Patch" -->

</details>
